### PR TITLE
Added in a model loaders ant task.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -193,6 +193,21 @@
 			<reference refid="classpath"/>
 		</ant>
 	</target>
+
+   <!-- model loaders -->
+   <target name="gdx-model-loaders" depends="gdx-core,gdx-backend-jogl">
+      <path id="classpath">
+         <pathelement location="${distDir}/gdx.jar"/>
+         <pathelement location="${distDir}/extensions/gdx-jnigen.jar"/>
+         <pathelement location="${distDir}/gdx-backend-jogl.jar"/>
+      </path>
+      <ant antfile="../../../build-template.xml" dir="extensions/model-loaders/model-loaders">
+         <property name="distDir" value="${distDir}/extensions/model-loaders/model-loaders"/>
+         <property name="jar" value="gdx-model-loaders"/>
+         <reference refid="classpath"/>
+      </ant>
+   </target>
+
 	
 	<!-- generates the javadoc for the core api and the application implementations -->
 	<target name="docs" depends="clean">


### PR DESCRIPTION
I have added in a model loaders ant task but I have not added it to the list of projects that
automatically get built. To run the task just type in:

```
ant gdx-model-loaders
```

I think that this would be pretty handy to have around for people that want the model loaders jar. (Like I did)

Is there supposed to be some other way that we add it to our projects?
