### PR TITLE
Matrix3/4 Mul Documentation Fixup

### DIFF
--- a/gdx/src/com/badlogic/gdx/math/Matrix3.java
+++ b/gdx/src/com/badlogic/gdx/math/Matrix3.java
@@ -61,8 +61,13 @@ public class Matrix3 implements Serializable {
 		return this;
 	}
 
-	/** Multiplies this matrix with the other matrix in the order this * m.
-	 * @return this matrix */
+	/** Multiplies this matrix with the provided matrix and stores the result in this matrix. For example:
+	 * 
+	 * <pre>
+	 * A.mul(B) results in A := AB
+	 * </pre>
+	 * @param m Matrix to multiply by.
+	 * @return This matrix for the purpose of chaining operations together. */
 	public Matrix3 mul (Matrix3 m) {
 		float v00 = val[M00] * m.val[M00] + val[M01] * m.val[M10] + val[M02] * m.val[M20];
 		float v01 = val[M00] * m.val[M01] + val[M01] * m.val[M11] + val[M02] * m.val[M21];

--- a/gdx/src/com/badlogic/gdx/math/Matrix4.java
+++ b/gdx/src/com/badlogic/gdx/math/Matrix4.java
@@ -183,10 +183,14 @@ public class Matrix4 implements Serializable {
 		return val;
 	}
 
-	/** (Pre-)Multiplies this matrix with the given matrix, storing the result in this matrix. E.g. A.mul(B) results in A := BA.
+	/** Multiplies this matrix with the given matrix, storing the result in this matrix. For example:
 	 * 
-	 * @param matrix The other matrix
-	 * @return This matrix for chaining. */
+	 * <pre>
+	 * A.mul(B) results in A := AB.
+	 * </pre>
+	 * 
+	 * @param matrix The other matrix to multiply by.
+	 * @return This matrix for the purpose of chaining operations together. */
 	public Matrix4 mul (Matrix4 matrix) {
 		tmp[M00] = val[M00] * matrix.val[M00] + val[M01] * matrix.val[M10] + val[M02] * matrix.val[M20] + val[M03]
 			* matrix.val[M30];


### PR DESCRIPTION
Minor fix. It was my mistake. The matricies actually perform A.mul(B) ==> A := AB not A := BA. This should fix that right up before it can make it into the next release. More documentation fixes coming.

I attempted to keep the documentation as short as possible. Did I manage it? Or go shorter again?

P.S. There are many merge commits in here. I am going to try and keep them down in the future but I don't think it matters.
