### PR TITLE
added method removedFromActor to Action to be called when the Actor is r...

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/Action.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/Action.java
@@ -53,13 +53,16 @@ abstract public class Action implements Poolable {
 	 * {@link #act(float)}. For a {@link TemporalAction}, use TemporalAction#initialize(). */
 	public void setActor (Actor actor) {
 		this.actor = actor;
-		if (actor == null) {
-			if (pool != null) {
-				pool.free(this);
-				pool = null;
-			} else
-				reset();
-		}
+	}
+
+	/** Called when the Action was removed from its Actor. */
+	public void removedFromActor () {
+		if (pool != null) {
+			pool.free(this);
+			pool = null;
+		} else
+			reset();
+		this.actor = null;
 	}
 
 	/** Resets the optional state of this action to as if it were newly created, allowing the action to be pooled and reused. State

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/Actor.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/Actor.java
@@ -71,7 +71,7 @@ public class Actor {
 			Action action = actions.get(i);
 			if (action.act(delta)) {
 				actions.removeIndex(i);
-				action.setActor(null);
+				action.removedFromActor();
 				i--;
 				n--;
 			}
@@ -217,7 +217,7 @@ public class Actor {
 	}
 
 	public void removeAction (Action action) {
-		if (actions.removeValue(action, true)) action.setActor(null);
+		if (actions.removeValue(action, true)) action.removedFromActor();
 	}
 
 	public Array<Action> getActions () {
@@ -227,7 +227,7 @@ public class Actor {
 	/** Removes all actions on this actor. */
 	public void clearActions () {
 		for (int i = actions.size - 1; i >= 0; i--)
-			actions.get(i).setActor(null);
+			actions.get(i).removedFromActor();
 		actions.clear();
 	}
 

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/DelegateAction.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/DelegateAction.java
@@ -43,8 +43,13 @@ abstract public class DelegateAction extends Action {
 	}
 
 	public void setActor (Actor actor) {
-		if (action != null) action.setActor(actor);
+		action.setActor(actor);
 		super.setActor(actor);
+	}
+
+	public void removedFromActor () {
+		action.removedFromActor();
+		super.removedFromActor();
 	}
 
 	public String toString () {

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/ParallelAction.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/ParallelAction.java
@@ -58,6 +58,14 @@ public class ParallelAction extends Action {
 			actions.get(i).setActor(actor);
 		super.setActor(actor);
 	}
+	
+	@Override
+	public void removedFromActor () {
+		Array<Action> actions = this.actions;
+		for (int i = 0, n = actions.size; i < n; i++)
+			actions.get(i).removedFromActor();
+		super.removedFromActor();
+	}
 
 	public Array<Action> getActions () {
 		return actions;


### PR DESCRIPTION
The pull request is to separate the event of removing an Action from an Actor from the setActor method by adding another method named removedFromActor() that is called in case the action was removed, and setActor doesnt receives null anymore. 

Feel free to change the method name if you want, just apply this pull request (if you agree with it) and then in a separated commit modify the name, that will be the easiest way I believe.
