### PR TITLE
Added loader for animated collada models

### DIFF
--- a/extensions/model-loaders/model-loaders-android/assets/data/models/cube.dae
+++ b/extensions/model-loaders/model-loaders-android/assets/data/models/cube.dae
@@ -1,0 +1,196 @@
+<?xml version="1.0" encoding="utf-8"?>
+<COLLADA xmlns="http://www.collada.org/2005/11/COLLADASchema" version="1.4.1">
+  <asset>
+    <contributor>
+      <author>Blender User</author>
+      <authoring_tool>Blender 2.63.0 r46461:46487M</authoring_tool>
+    </contributor>
+    <created>2012-08-16T12:03:53</created>
+    <modified>2012-08-16T12:03:53</modified>
+    <unit name="meter" meter="1"/>
+    <up_axis>Z_UP</up_axis>
+  </asset>
+  <library_geometries>
+    <geometry id="Cube-mesh" name="Cube">
+      <mesh>
+        <source id="Cube-mesh-positions">
+          <float_array id="Cube-mesh-positions-array" count="24">-1 -1 -1 -1 1 -1 1 1 -1 1 -1 -1 -1 -1 1 -1 1 1 1 1 1 1 -1 1</float_array>
+          <technique_common>
+            <accessor source="#Cube-mesh-positions-array" count="8" stride="3">
+              <param name="X" type="float"/>
+              <param name="Y" type="float"/>
+              <param name="Z" type="float"/>
+            </accessor>
+          </technique_common>
+        </source>
+        <source id="Cube-mesh-normals">
+          <float_array id="Cube-mesh-normals-array" count="18">-1 0 0 0 1 0 1 0 0 0 -1 0 0 0 -1 0 0 1</float_array>
+          <technique_common>
+            <accessor source="#Cube-mesh-normals-array" count="6" stride="3">
+              <param name="X" type="float"/>
+              <param name="Y" type="float"/>
+              <param name="Z" type="float"/>
+            </accessor>
+          </technique_common>
+        </source>
+        <source id="Cube-mesh-map-0">
+          <float_array id="Cube-mesh-map-0-array" count="48">0.3333334 0.001019418 0.6656472 0 0.6666667 0.3323138 0.3343529 0.3333333 0.001019477 0.3333334 0 0.001019477 0.3323138 0 0.3333334 0.3323138 0.3333333 0.6656473 0.001019418 0.6666668 0 0.3343529 0.3323138 0.3333334 0.6656472 0.3333333 0.6666667 0.6656472 0.3343529 0.6666667 0.3333334 0.3343528 1 0.3323138 0.6676862 0.3333333 0.6666667 0.001019477 0.9989805 0 0.3333334 0.6676862 0.6656472 0.6666667 0.6666667 0.9989805 0.3343529 1</float_array>
+          <technique_common>
+            <accessor source="#Cube-mesh-map-0-array" count="24" stride="2">
+              <param name="S" type="float"/>
+              <param name="T" type="float"/>
+            </accessor>
+          </technique_common>
+        </source>
+        <vertices id="Cube-mesh-vertices">
+          <input semantic="POSITION" source="#Cube-mesh-positions"/>
+        </vertices>
+        <polylist count="6">
+          <input semantic="VERTEX" source="#Cube-mesh-vertices" offset="0"/>
+          <input semantic="NORMAL" source="#Cube-mesh-normals" offset="1"/>
+          <input semantic="TEXCOORD" source="#Cube-mesh-map-0" offset="2" set="0"/>
+          <vcount>4 4 4 4 4 4 </vcount>
+          <p>1 0 0 0 0 1 4 0 2 5 0 3 5 1 4 6 1 5 2 1 6 1 1 7 6 2 8 7 2 9 3 2 10 2 2 11 0 3 12 3 3 13 7 3 14 4 3 15 0 4 16 1 4 17 2 4 18 3 4 19 7 5 20 6 5 21 5 5 22 4 5 23</p>
+        </polylist>
+      </mesh>
+      <extra><technique profile="MAYA"><double_sided>1</double_sided></technique></extra>
+    </geometry>
+  </library_geometries>
+  <library_animations>
+    <animation id="Armature_Bone_pose_matrix">
+      <source id="Armature_Bone_pose_matrix-input">
+        <float_array id="Armature_Bone_pose_matrix-input-array" count="4">0.04166662 0.4166666 0.8333333 1.25</float_array>
+        <technique_common>
+          <accessor source="#Armature_Bone_pose_matrix-input-array" count="4" stride="1">
+            <param name="TIME" type="float"/>
+          </accessor>
+        </technique_common>
+      </source>
+      <source id="Armature_Bone_pose_matrix-output">
+        <float_array id="Armature_Bone_pose_matrix-output-array" count="64">1 0 0 -2.38419e-7 0 0 -1 0 0 1 0 1.19209e-7 0 0 0 1 1 0 0 -2.38419e-7 0 0 -1 0 0 1 0 1.19209e-7 0 0 0 1 1 0 0 -2.38419e-7 0 0 -1 0 0 1 0 1.19209e-7 0 0 0 1 1 0 0 -2.38419e-7 0 0 -1 0 0 1 0 1.19209e-7 0 0 0 1</float_array>
+        <technique_common>
+          <accessor source="#Armature_Bone_pose_matrix-output-array" count="4" stride="16">
+            <param name="TRANSFORM" type="float4x4"/>
+          </accessor>
+        </technique_common>
+      </source>
+      <source id="Armature_Bone_pose_matrix-interpolation">
+        <Name_array id="Armature_Bone_pose_matrix-interpolation-array" count="4">LINEAR LINEAR LINEAR LINEAR</Name_array>
+        <technique_common>
+          <accessor source="#Armature_Bone_pose_matrix-interpolation-array" count="4" stride="1">
+            <param name="INTERPOLATION" type="name"/>
+          </accessor>
+        </technique_common>
+      </source>
+      <sampler id="Armature_Bone_pose_matrix-sampler">
+        <input semantic="INPUT" source="#Armature_Bone_pose_matrix-input"/>
+        <input semantic="OUTPUT" source="#Armature_Bone_pose_matrix-output"/>
+        <input semantic="INTERPOLATION" source="#Armature_Bone_pose_matrix-interpolation"/>
+      </sampler>
+      <channel source="#Armature_Bone_pose_matrix-sampler" target="Bone/transform"/>
+    </animation>
+    <animation id="Armature_Bone_001_pose_matrix">
+      <source id="Armature_Bone_001_pose_matrix-input">
+        <float_array id="Armature_Bone_001_pose_matrix-input-array" count="4">0.04166662 0.4166666 0.8333333 1.25</float_array>
+        <technique_common>
+          <accessor source="#Armature_Bone_001_pose_matrix-input-array" count="4" stride="1">
+            <param name="TIME" type="float"/>
+          </accessor>
+        </technique_common>
+      </source>
+      <source id="Armature_Bone_001_pose_matrix-output">
+        <float_array id="Armature_Bone_001_pose_matrix-output-array" count="64">-1 0 -1.50996e-7 0 0 1 1.50996e-7 1 1.50996e-7 1.50996e-7 -1 0 0 0 0 1 0.2361423 0.953189 -0.1888589 0 0.8805032 -0.2921077 -0.3733463 1 -0.4110367 -0.07812798 -0.9082647 0 0 0 0 1 0.005432963 0.7937502 -0.6082198 0 0.340026 -0.5734534 -0.7453414 1 -0.9404004 -0.2027611 -0.2730112 0 0 0 0 1 -1 0 -1.50996e-7 0 0 1 1.50996e-7 1 1.50996e-7 1.50996e-7 -1 0 0 0 0 1</float_array>
+        <technique_common>
+          <accessor source="#Armature_Bone_001_pose_matrix-output-array" count="4" stride="16">
+            <param name="TRANSFORM" type="float4x4"/>
+          </accessor>
+        </technique_common>
+      </source>
+      <source id="Armature_Bone_001_pose_matrix-interpolation">
+        <Name_array id="Armature_Bone_001_pose_matrix-interpolation-array" count="4">LINEAR LINEAR LINEAR LINEAR</Name_array>
+        <technique_common>
+          <accessor source="#Armature_Bone_001_pose_matrix-interpolation-array" count="4" stride="1">
+            <param name="INTERPOLATION" type="name"/>
+          </accessor>
+        </technique_common>
+      </source>
+      <sampler id="Armature_Bone_001_pose_matrix-sampler">
+        <input semantic="INPUT" source="#Armature_Bone_001_pose_matrix-input"/>
+        <input semantic="OUTPUT" source="#Armature_Bone_001_pose_matrix-output"/>
+        <input semantic="INTERPOLATION" source="#Armature_Bone_001_pose_matrix-interpolation"/>
+      </sampler>
+      <channel source="#Armature_Bone_001_pose_matrix-sampler" target="Bone_001/transform"/>
+    </animation>
+  </library_animations>
+  <library_controllers>
+    <controller id="Armature_Cube-skin" name="Armature">
+      <skin source="#Cube-mesh">
+        <bind_shape_matrix>1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1</bind_shape_matrix>
+        <source id="Armature_Cube-skin-joints">
+          <Name_array id="Armature_Cube-skin-joints-array" count="2">Bone Bone_001</Name_array>
+          <technique_common>
+            <accessor source="#Armature_Cube-skin-joints-array" count="2" stride="1">
+              <param name="JOINT" type="name"/>
+            </accessor>
+          </technique_common>
+        </source>
+        <source id="Armature_Cube-skin-bind_poses">
+          <float_array id="Armature_Cube-skin-bind_poses-array" count="32">1 0 0 2.38419e-7 0 0 1 -1.19209e-7 0 -1 0 0 0 0 0 1 -1 -1.50996e-7 0 -2.38419e-7 0 0 1 -1 -1.50996e-7 1 0 -1.50996e-7 0 0 0 1</float_array>
+          <technique_common>
+            <accessor source="#Armature_Cube-skin-bind_poses-array" count="2" stride="16">
+              <param name="TRANSFORM" type="float4x4"/>
+            </accessor>
+          </technique_common>
+        </source>
+        <source id="Armature_Cube-skin-weights">
+          <float_array id="Armature_Cube-skin-weights-array" count="16">0.9042961 0.09570389 0.9039745 0.09602546 0.9042962 0.09570378 0.9039745 0.09602546 0.5360631 0.4639369 0.5405094 0.4594907 0.5360632 0.4639368 0.5405092 0.4594907</float_array>
+          <technique_common>
+            <accessor source="#Armature_Cube-skin-weights-array" count="16" stride="1">
+              <param name="WEIGHT" type="float"/>
+            </accessor>
+          </technique_common>
+        </source>
+        <joints>
+          <input semantic="JOINT" source="#Armature_Cube-skin-joints"/>
+          <input semantic="INV_BIND_MATRIX" source="#Armature_Cube-skin-bind_poses"/>
+        </joints>
+        <vertex_weights count="8">
+          <input semantic="JOINT" source="#Armature_Cube-skin-joints" offset="0"/>
+          <input semantic="WEIGHT" source="#Armature_Cube-skin-weights" offset="1"/>
+          <vcount>2 2 2 2 2 2 2 2 </vcount>
+          <v>0 0 1 1 0 2 1 3 0 4 1 5 0 6 1 7 0 8 1 9 0 10 1 11 0 12 1 13 0 14 1 15</v>
+        </vertex_weights>
+      </skin>
+    </controller>
+  </library_controllers>
+  <library_visual_scenes>
+    <visual_scene id="Scene" name="Scene">
+      <node id="Armature" type="NODE">
+        <translate sid="location">0 0 0</translate>
+        <rotate sid="rotationZ">0 0 1 0</rotate>
+        <rotate sid="rotationY">0 1 0 0</rotate>
+        <rotate sid="rotationX">1 0 0 0</rotate>
+        <scale sid="scale">1 1 1</scale>
+        <node id="Bone" name="Bone" sid="Bone" type="JOINT">
+          <matrix sid="transform">1 0 0 -2.38419e-7 0 7.54979e-8 -1 0 0 1 7.54979e-8 1.19209e-7 0 0 0 1</matrix>
+          <node id="Bone_001" name="Bone.001" sid="Bone_001" type="JOINT">
+            <matrix sid="transform">-1 1.13999e-14 -1.50996e-7 0 -1.13999e-14 1 1.50996e-7 1 1.50996e-7 1.50996e-7 -1 -1.89462e-15 0 0 0 1</matrix>
+          </node>
+        </node>
+      </node>
+      <node id="Cube" type="NODE">
+        <translate sid="location">0 0 0</translate>
+        <rotate sid="rotationZ">0 0 1 0</rotate>
+        <rotate sid="rotationY">0 1 0 0</rotate>
+        <rotate sid="rotationX">1 0 0 0</rotate>
+        <scale sid="scale">1 1 1</scale>
+        <instance_controller url="#Armature_Cube-skin">
+          <skeleton>#Bone</skeleton>
+        </instance_controller>
+      </node>
+    </visual_scene>
+  </library_visual_scenes>
+  <scene>
+    <instance_visual_scene url="#Scene"/>
+  </scene>
+</COLLADA>

--- a/extensions/model-loaders/model-loaders/src/com/badlogic/gdx/graphics/g3d/experimental/SkeletonModelGpuSkinningTest.java
+++ b/extensions/model-loaders/model-loaders/src/com/badlogic/gdx/graphics/g3d/experimental/SkeletonModelGpuSkinningTest.java
@@ -94,7 +94,7 @@ public class SkeletonModelGpuSkinningTest implements ApplicationListener {
 		}
 
 		Gdx.gl.glEnable(GL10.GL_CULL_FACE);
-		Gdx.gl.glFrontFace(GL10.GL_CCW);
+		Gdx.gl.glFrontFace(GL10.GL_CW);
 		Gdx.gl.glCullFace(GL10.GL_FRONT);
 
 		Gdx.gl.glEnable(GL10.GL_DEPTH_TEST);
@@ -149,21 +149,24 @@ public class SkeletonModelGpuSkinningTest implements ApplicationListener {
 
 		texture = new Texture(Gdx.files.internal("data/models/robot.jpg"), Format.RGB565, true);
 		texture.setFilter(TextureFilter.MipMapLinearNearest, TextureFilter.Linear);
-
-		//model = ModelLoaderRegistry.loadSkeletonModel(Gdx.files.internal("data/models/robot-mesh.xml"));
 		
-		String fileName = "data/models/robot-mesh.xml.g3d";
+		//String fileName = "data/models/robot-mesh.xml.g3d";
+		
+		String fileName = "data/models/cube.dae";
 		
 		if (!fileName.endsWith(".g3d") && Gdx.app.getType() == ApplicationType.Desktop) {
-			model = new OgreXmlLoader().load(Gdx.files.internal(fileName),
-				Gdx.files.internal(fileName.replace("mesh.xml", "skeleton.xml")));
+			model = ModelLoaderRegistry.loadSkeletonModel(Gdx.files.internal(fileName));
+			if(model == null){
+				model = new OgreXmlLoader().load(Gdx.files.internal(fileName),
+					Gdx.files.internal(fileName.replace("mesh.xml", "skeleton.xml")));
+			}
 		
 			G3dExporter.export(model, Gdx.files.absolute(fileName + ".g3d"));
 			model = G3dLoader.loadSkeletonModel(Gdx.files.absolute(fileName + ".g3d"));
 		}
 		else
 		{
-			model = G3dLoader.loadSkeletonModel(Gdx.files.internal(fileName));
+			model = ModelLoaderRegistry.loadSkeletonModel(Gdx.files.internal(fileName));
 		}
 		
 		if(useGpuSkinning){
@@ -194,7 +197,7 @@ public class SkeletonModelGpuSkinningTest implements ApplicationListener {
 				model.getBoundingBox(box);
 				
 				instance.matrix.trn(-1.75f, 0f, -5.5f);
-				instance.matrix.scale(0.02f, 0.02f, 0.02f);
+				instance.matrix.scale(0.4f, 0.4f, 0.4f);
 				box.mul(instance.matrix);
 				
 				instance.radius = (box.getDimensions().len() / 2);
@@ -232,7 +235,7 @@ public class SkeletonModelGpuSkinningTest implements ApplicationListener {
 		config.width = 800;
 		config.height = 480;
 		config.samples = 8;
-		config.vSyncEnabled = false;
+		config.vSyncEnabled = true;
 		config.useGL20 = true;
 		new JoglApplication(new SkeletonModelGpuSkinningTest(), config);
 	}

--- a/extensions/model-loaders/model-loaders/src/com/badlogic/gdx/graphics/g3d/loaders/ModelLoaderRegistry.java
+++ b/extensions/model-loaders/model-loaders/src/com/badlogic/gdx/graphics/g3d/loaders/ModelLoaderRegistry.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.g3d.ModelLoaderHints;
 import com.badlogic.gdx.graphics.g3d.loaders.collada.ColladaLoader;
+import com.badlogic.gdx.graphics.g3d.loaders.collada.ColladaLoaderSkeleton;
 import com.badlogic.gdx.graphics.g3d.loaders.g3d.G3dLoader.G3dKeyframedModelLoader;
 import com.badlogic.gdx.graphics.g3d.loaders.g3d.G3dLoader.G3dStillModelLoader;
 import com.badlogic.gdx.graphics.g3d.loaders.g3d.G3dLoader.G3dSkeletonModelLoader;
@@ -51,6 +52,7 @@ public class ModelLoaderRegistry {
 	// registering the default loaders here
 	static {
 		registerLoader("dae", new ColladaLoader(), new ModelLoaderHints(false));
+		registerLoader("dae", new ColladaLoaderSkeleton(), new ModelLoaderHints(false));
 		registerLoader("obj", new ObjLoader(), new ModelLoaderHints(false));
 		registerLoader("md2", new MD2Loader(), new MD2LoaderHints(0.2f));
 		registerLoader("g3dt", new G3dtStillModelLoader(), new ModelLoaderHints(true));

--- a/extensions/model-loaders/model-loaders/src/com/badlogic/gdx/graphics/g3d/loaders/collada/Animation.java
+++ b/extensions/model-loaders/model-loaders/src/com/badlogic/gdx/graphics/g3d/loaders/collada/Animation.java
@@ -1,0 +1,85 @@
+package com.badlogic.gdx.graphics.g3d.loaders.collada;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.badlogic.gdx.graphics.g3d.model.skeleton.SkeletonKeyframe;
+import com.badlogic.gdx.math.Matrix4;
+import com.badlogic.gdx.utils.Array;
+import com.badlogic.gdx.utils.GdxRuntimeException;
+import com.badlogic.gdx.utils.ObjectMap;
+import com.badlogic.gdx.utils.XmlReader.Element;
+
+public class Animation {
+	ObjectMap<String, float[]> inputMap = new ObjectMap<String, float[]>();
+	ObjectMap<String, float[]> outputMap = new ObjectMap<String, float[]>();
+	
+	//TODO: replace this with the bone name/index read in skin data
+	Array<String> channels = new Array<String>(); 
+	
+	SkeletonKeyframe[][] keyFrames;
+	
+	public Animation(Element libAnimElement){
+		Array<Element> animElements = libAnimElement.getChildrenByName("animation");
+		for(int i=0;i<animElements.size;i++){
+			Element animElement = animElements.get(i);
+			Array<Element> colladaSources = animElement.getChildrenByName("source");
+			Map<String, Source> sources = new HashMap<String, Source>();
+			for (int j = 0; j < colladaSources.size; j++) {
+				Element colladaSource = colladaSources.get(j);
+				//TODO: fix this so source can load more then just floats
+				if(colladaSource.getChildrenByName("float_array").size != 0){
+					sources.put(colladaSource.getAttribute("id"), new Source(colladaSource));
+				}
+			}
+			
+			ObjectMap<String , String> mapping = new ObjectMap<String, String>();
+			
+			Element samplerElement = animElement.getChildByName("sampler");
+			if(samplerElement ==null)
+				throw new GdxRuntimeException("no sampler in animation element in scene");
+			
+			Array<Element> inputs = samplerElement.getChildrenByName("input");
+			for(int k = 0;k<inputs.size;k++){
+				mapping.put(inputs.get(k).getAttribute("semantic"),inputs.get(k).getAttribute("source").replaceFirst("#", ""));
+			}
+			
+			Element channelElement = animElement.getChildByName("channel");
+			if(channelElement ==null)
+				throw new GdxRuntimeException("no sampler in animation element in scene");
+			
+			String channelName = channelElement.getAttribute("target");
+			
+			channels.add(channelName);
+			inputMap.put(channelName,sources.get(mapping.get("INPUT")).data);
+			outputMap.put(channelName,sources.get(mapping.get("OUTPUT")).data);
+		}
+		
+		keyFrames = new SkeletonKeyframe[channels.size][];
+		for(int i=0;i<channels.size;i++){
+			String channel = channels.get(i);
+			float[] input = inputMap.get(channel);
+			float[] output = outputMap.get(channel);
+			keyFrames[i] = new SkeletonKeyframe[input.length];
+			for(int j=0;j<input.length;j++){
+				SkeletonKeyframe frame = new SkeletonKeyframe();
+				keyFrames[i][j] = frame;
+				Matrix4 m = getMatrix(output, j*16);
+				m.getTranslation(frame.position);
+				m.getRotation(frame.rotation);
+				//TODO: get Scale from matrix
+				frame.timeStamp = input[j];
+				//TODO:set parent index joint data
+			}
+		}
+	}
+	
+	private Matrix4 getMatrix(float[] val, int offset){
+		Matrix4 m = new Matrix4();
+		for(int i=0;i<16;i++){
+			m.val[i] = val[i+offset];
+		}
+		m.tra();
+		return m;
+	}
+}

--- a/extensions/model-loaders/model-loaders/src/com/badlogic/gdx/graphics/g3d/loaders/collada/ColladaLoader.java
+++ b/extensions/model-loaders/model-loaders/src/com/badlogic/gdx/graphics/g3d/loaders/collada/ColladaLoader.java
@@ -55,7 +55,7 @@ public class ColladaLoader implements StillModelLoader {
 		return model;
 	}
 
-	private static Array<Geometry> readGeometries (Element root) {
+	public static Array<Geometry> readGeometries (Element root) {
 		// check whether the library_geometries element is there
 		Element colladaGeoLibrary = root.getChildByName("library_geometries");
 		if (colladaGeoLibrary == null) throw new GdxRuntimeException("not <library_geometries> element in file");

--- a/extensions/model-loaders/model-loaders/src/com/badlogic/gdx/graphics/g3d/loaders/collada/ColladaLoaderSkeleton.java
+++ b/extensions/model-loaders/model-loaders/src/com/badlogic/gdx/graphics/g3d/loaders/collada/ColladaLoaderSkeleton.java
@@ -1,0 +1,124 @@
+package com.badlogic.gdx.graphics.g3d.loaders.collada;
+
+import java.io.InputStream;
+
+import com.badlogic.gdx.files.FileHandle;
+import com.badlogic.gdx.graphics.g3d.ModelLoaderHints;
+import com.badlogic.gdx.graphics.g3d.loaders.SkeletonModelLoader;
+import com.badlogic.gdx.graphics.g3d.model.skeleton.Skeleton;
+import com.badlogic.gdx.graphics.g3d.model.skeleton.SkeletonAnimation;
+import com.badlogic.gdx.graphics.g3d.model.skeleton.SkeletonJoint;
+import com.badlogic.gdx.graphics.g3d.model.skeleton.SkeletonModel;
+import com.badlogic.gdx.graphics.g3d.model.skeleton.SkeletonSubMesh;
+import com.badlogic.gdx.utils.Array;
+import com.badlogic.gdx.utils.GdxRuntimeException;
+import com.badlogic.gdx.utils.XmlReader;
+import com.badlogic.gdx.utils.XmlReader.Element;
+
+public class ColladaLoaderSkeleton  implements SkeletonModelLoader {
+	@Override
+	public SkeletonModel load(FileHandle handle, ModelLoaderHints hints) {
+		return loadSkeletonModel(handle);
+	}
+	
+	public static SkeletonModel loadSkeletonModel (FileHandle handle) {
+		return loadSkeletonModel(handle.read());
+	}
+	
+	public static SkeletonModel loadSkeletonModel (InputStream in) {
+		XmlReader xml = new XmlReader();
+		Element root = null;
+		try {
+			root = xml.parse(in);
+		} catch (Exception e) {
+			throw new GdxRuntimeException("Couldn't load Collada model", e);
+		}
+
+		// get geometries
+		Array<Geometry> geos = ColladaLoader.readGeometries(root);
+		
+		Array<Skin> skins = readSkins(root);
+		
+		Joint joint = readJoint(root);
+		
+		Animation anim = readAnim(root);
+
+		// convert geometries to meshes
+		SkeletonSubMesh[] meshes = createSkeletonSubMeshes(geos, skins);
+		
+		Skeleton skeleton = createSkeleton(skins, joint.joint,anim);
+
+		// create SkeletonModel
+		SkeletonModel model = new SkeletonModel(skeleton,meshes);
+		return model;
+	}
+	
+	private static Array<Skin> readSkins (Element root) {
+		// check whether the library_controllers element is there
+		Element colladaGeoLibrary = root.getChildByName("library_controllers");
+		if (colladaGeoLibrary == null) throw new GdxRuntimeException("not <library_controllers> element in file");
+
+		// check for controller
+		Element colladaController = colladaGeoLibrary.getChildByName("controller");
+		if (colladaController == null) throw new GdxRuntimeException("no <controller> elements in file");
+
+		// check for controller
+		Array<Element> colladaSkin = colladaController.getChildrenByName("skin");
+		if (colladaController == null) throw new GdxRuntimeException("no <controller> elements in file");
+		
+		Array<Skin> skins = new Array<Skin>();
+		
+		for (int i = 0; i < colladaSkin.size; i++) {
+			skins.add(new Skin(colladaSkin.get(i)));
+		}
+		
+		return skins;
+	}
+	
+	private static Joint readJoint (Element root) {
+		// check whether the library_controllers element is there
+		Element colladaLibrary = root.getChildByName("library_visual_scenes");
+		if (colladaLibrary == null) throw new GdxRuntimeException("not <library_visual_scenes> element in file");
+
+		// check for controller
+		Element colladaScene = colladaLibrary.getChildByName("visual_scene");
+		if (colladaScene == null) throw new GdxRuntimeException("no <controller> elements in file");
+
+		return new Joint(colladaScene);
+	}
+	
+	private static Animation readAnim (Element root) {
+		// check whether the library_controllers element is there
+		Element colladaAnimationLib = root.getChildByName("library_animations");
+		if (colladaAnimationLib == null) throw new GdxRuntimeException("not <library_animations> element in file");
+
+		return new Animation(colladaAnimationLib);
+	}
+	
+	private static Skeleton createSkeleton(Array<Skin> skins, SkeletonJoint joint, Animation anim)
+	{
+		Skeleton skeleton = new Skeleton();
+		
+		for(int i=0;i<joint.children.size;i++){
+			skeleton.hierarchy.add(joint.children.get(i));
+		}
+		
+		skeleton.buildFromHierarchy();
+		
+		float[] times = anim.inputMap.values().next();
+		float totalDuration = times[times.length-1];
+
+		
+		skeleton.animations.put("My Animation", new SkeletonAnimation("My Animation", totalDuration, anim.keyFrames));
+		
+		return skeleton;
+	}
+	
+	private static SkeletonSubMesh[] createSkeletonSubMeshes (Array<Geometry> geos, Array<Skin> skins) {
+		SkeletonSubMesh[] meshes = new SkeletonSubMesh[geos.size];
+		for (int i = 0; i < geos.size; i++) {
+			meshes[i] = geos.get(i).getSkeletonSubMesh(skins.get(i));
+		}
+		return meshes;
+	}
+}

--- a/extensions/model-loaders/model-loaders/src/com/badlogic/gdx/graphics/g3d/loaders/collada/Geometry.java
+++ b/extensions/model-loaders/model-loaders/src/com/badlogic/gdx/graphics/g3d/loaders/collada/Geometry.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import com.badlogic.gdx.graphics.Mesh;
+import com.badlogic.gdx.graphics.g3d.model.skeleton.SkeletonSubMesh;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.GdxRuntimeException;
 import com.badlogic.gdx.utils.XmlReader.Element;
@@ -68,5 +69,9 @@ public class Geometry {
 
 	public Mesh getMesh () {
 		return faces.getMesh();
+	}
+	
+	public SkeletonSubMesh getSkeletonSubMesh (Skin skin){
+		return faces.getSkeletonSubMesh(skin);
 	}
 }

--- a/extensions/model-loaders/model-loaders/src/com/badlogic/gdx/graphics/g3d/loaders/collada/Joint.java
+++ b/extensions/model-loaders/model-loaders/src/com/badlogic/gdx/graphics/g3d/loaders/collada/Joint.java
@@ -1,0 +1,72 @@
+package com.badlogic.gdx.graphics.g3d.loaders.collada;
+
+import com.badlogic.gdx.graphics.g3d.model.skeleton.SkeletonJoint;
+import com.badlogic.gdx.math.Matrix4;
+import com.badlogic.gdx.utils.Array;
+import com.badlogic.gdx.utils.GdxRuntimeException;
+import com.badlogic.gdx.utils.XmlReader.Element;
+
+public class Joint {
+	SkeletonJoint joint;
+	
+	public Joint(Element animationElement) {
+		Array<Element> nodes = animationElement.getChildrenByName("node");
+		
+		Element jointNode = null;
+		for(int i=0;i<nodes.size;i++){
+			Element e = nodes.get(i);
+			Array<Element> subNodes = e.getChildrenByName("node");
+			if(subNodes.size > 0 && subNodes.get(0).getAttribute("type").equalsIgnoreCase("JOINT"))
+			{
+				jointNode = e;
+				break;
+			}
+		}
+		
+		if(jointNode==null){
+			throw new GdxRuntimeException("no Joint element in scene");
+		}
+		
+		
+		joint = getJoint(jointNode,true);
+		
+	}
+	
+	SkeletonJoint getJoint(Element jointNode, boolean isRootNode){
+		SkeletonJoint joint = new SkeletonJoint();
+		joint.name = jointNode.getAttribute("id");
+		if(!isRootNode){
+			Element matrixElement = jointNode.getChildByName("matrix");
+			if(matrixElement != null)
+			{
+				Matrix4 m = getMatrix(matrixElement);
+				m.getTranslation(joint.position);
+				m.getRotation(joint.rotation);
+				//TODO: get scale from matrix
+			}
+		}
+		
+		Array<Element> nodes = jointNode.getChildrenByName("node");
+		for(int i=0;i<nodes.size;i++){
+			SkeletonJoint child = getJoint(nodes.get(i),false);
+			if(!isRootNode){
+				child.parent = joint;
+			}
+			joint.children.add(child);
+		}
+		
+		return joint;
+	}
+	
+	public Matrix4 getMatrix(Element matrix){
+		Matrix4 m = new Matrix4();
+		
+		// read elements into data[]
+		String[] tokens = matrix.getText().split("\\s+");
+		for (int i = 0; i < tokens.length; i++) {
+			m.val[i] = Float.parseFloat(tokens[i]);
+		}
+		m.tra();
+		return m;
+	}
+}

--- a/extensions/model-loaders/model-loaders/src/com/badlogic/gdx/graphics/g3d/loaders/collada/Skin.java
+++ b/extensions/model-loaders/model-loaders/src/com/badlogic/gdx/graphics/g3d/loaders/collada/Skin.java
@@ -1,0 +1,66 @@
+package com.badlogic.gdx.graphics.g3d.loaders.collada;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.badlogic.gdx.utils.Array;
+import com.badlogic.gdx.utils.GdxRuntimeException;
+import com.badlogic.gdx.utils.ObjectMap;
+import com.badlogic.gdx.utils.XmlReader.Element;
+
+public class Skin {
+	public float[][] boneWeight;
+	public int[][] boneIndex;
+	
+	public Skin(Element skinElement){
+		Array<Element> colladaSources = skinElement.getChildrenByName("source");
+		Map<String, Source> sources = new HashMap<String, Source>();
+		for (int j = 0; j < colladaSources.size; j++) {
+			Element colladaSource = colladaSources.get(j);
+			//TODO: fix this so source can load more then just floats
+			if(colladaSource.getChildrenByName("float_array").size != 0){
+				sources.put(colladaSource.getAttribute("id"), new Source(colladaSource));
+			}
+		}
+			
+		Element vertexWeights = skinElement.getChildByName("vertex_weights");
+		
+		// read vertexCount
+		String[] countTokens = vertexWeights.getChildByName("vcount").getText().split("\\s+");
+		int[] vertexCount = new int[countTokens.length];
+		for (int i = 0; i < countTokens.length; i++) {
+			vertexCount[i] = Integer.parseInt(countTokens[i]);
+		}
+		
+		String[] indexTokens = vertexWeights.getChildByName("v").getText().split("\\s+");
+		int[] vertexWeightIndex = new int[indexTokens.length];
+		for (int i = 0; i < indexTokens.length; i++) {
+			vertexWeightIndex[i] = Integer.parseInt(indexTokens[i]);
+		}
+		
+		ObjectMap<String , String> mapping = new ObjectMap<String, String>();
+		
+		Array<Element> inputs = vertexWeights.getChildrenByName("input");
+		for(int i = 0;i<inputs.size;i++){
+			mapping.put(inputs.get(i).getAttribute("semantic"),inputs.get(i).getAttribute("source").replaceFirst("#", ""));
+		}
+		
+		boneWeight = new float[vertexCount.length][];
+		boneIndex = new int[vertexCount.length][];
+		
+		int index = 0;
+		
+		for(int i=0;i<vertexCount.length;i++){
+			int count = vertexCount[i];
+			boneWeight[i] = new float[count];
+			boneIndex[i] = new int[count];
+			
+			float[] weights = sources.get(mapping.get("WEIGHT")).data;
+			
+			for(int k=0;k<count;k++){
+				boneIndex[i][k] = vertexWeightIndex[index++];
+				boneWeight[i][k] = weights[vertexWeightIndex[index++]];
+			}
+		}
+	}
+}


### PR DESCRIPTION
Here is a Collada loader that can load skeleton models in libgdx, (and works on android too).
It is based on the existing still model loader.

It needs tiding up a bit and there are a couple of TODO's still in there, like bone scaling. But it does work for the blender models I have made and animated.

I have modified the SkeletonModelGpuSkinningTest to load cube.dae which is a simple cube with 2 bones and animated.

I have only tried collada models generated with blender as I don't have any other software to generate models.
