### PR TITLE
Enables Hiero tool to read effect values again when loading a .hiero file

### DIFF
--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/hiero/unicodefont/HieroSettings.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/hiero/unicodefont/HieroSettings.java
@@ -89,16 +89,16 @@ public class HieroSettings {
 				} else if (name.startsWith("effect.")) {
 					// Set an effect value on the last added effect.
 					name = name.substring(7);
-					// ConfigurableEffect effect = (ConfigurableEffect)effects.get(effects.size() - 1);
-					// List values = effect.getValues();
-					// for (Iterator iter = values.iterator(); iter.hasNext();) {
-					// Value effectValue = (Value)iter.next();
-					// if (effectValue.getName().equals(name)) {
-					// effectValue.setString(value);
-					// break;
-					// }
-					// }
-					// effect.setValues(values);
+					ConfigurableEffect effect = (ConfigurableEffect)effects.get(effects.size() - 1);
+					List values = effect.getValues();
+					for (Iterator iter = values.iterator(); iter.hasNext();) {
+						Value effectValue = (Value)iter.next();
+						if (effectValue.getName().equals(name)) {
+							effectValue.setString(value);
+							break;
+						}
+					}
+					effect.setValues(values);
 				}
 			}
 			reader.close();


### PR DESCRIPTION
For some reason the code was commented out, but after trying a few save/loads everything seems to work fine. Also, a simple blame shown some commits, but i found issue [#804](http://code.google.com/p/libgdx/issues/detail?id=804) on Google Code, this describes the same problem and the same solution :)
