### PR TITLE
The comparison should include the extreme limits rather than exclude them

### DIFF
--- a/extensions/gdx-tiled-preprocessor/src/com/badlogic/gdx/tiledmappacker/TileSetLayout.java
+++ b/extensions/gdx-tiled-preprocessor/src/com/badlogic/gdx/tiledmappacker/TileSetLayout.java
@@ -55,8 +55,8 @@ public class TileSetLayout extends TileSet {
 		int stopWidth = image.getWidth() - tileSet.tileWidth;
 		int stopHeight = image.getHeight() - tileSet.tileHeight;
 		
-		for (y = tileSet.margin; y < stopHeight; y += tileSet.tileHeight + tileSet.spacing) {
-			for (x = tileSet.margin; x < stopWidth; x += tileSet.tileWidth + tileSet.spacing) {
+		for (y = tileSet.margin; y <= stopHeight; y += tileSet.tileHeight + tileSet.spacing) {
+			for (x = tileSet.margin; x <= stopWidth; x += tileSet.tileWidth + tileSet.spacing) {
 				if (y == tileSet.margin) numCols++;
 				imageTilePositions.put(tile, new Vector2(x, y));
 				tile++;


### PR DESCRIPTION
Else [bad things](https://github.com/libgdx/libgdx/commit/ab507d723e9003558092d0ebf383f79fe7bef355#commitcomment-1777674) can happen to both the indices and the atlas :)
