### PR TITLE
Added a null check for the stage of the scrollpane, in case that stage has been removed

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ScrollPane.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ScrollPane.java
@@ -220,7 +220,7 @@ public class ScrollPane extends WidgetGroup {
 
 	void cancelTouchFocusedChild (InputEvent event) {
 		Stage stage = getStage();
-		stage.cancelTouchFocus(gestureListener, this);
+		if(stage != null) stage.cancelTouchFocus(gestureListener, this);
 	}
 
 	void clamp () {


### PR DESCRIPTION
The issue can be reproduced by having a scollpane within a Table, and (while flinging the scrollpane up/down) replace the contents of that table with some other stuff (table.clear()). The scrollpane reference to its stage in cancelTouchFocusedChild will then be 'null', and an exception will emerge.
