### PR TITLE
Changed native lib build files to skip a build if the necessary compiler is missing

### DIFF
--- a/extensions/gdx-audio/jni/build-linux32.xml
+++ b/extensions/gdx-audio/jni/build-linux32.xml
@@ -16,8 +16,8 @@
 	<property name="gcc" value="${compilerPrefix}gcc"/>	
 	<property name="gcc-opts" value="-c -Wall -O2 -mfpmath=sse -msse -fmessage-length=0 -m32 -fPIC -DFIXED_POINT -DMPG123_NO_CONFIGURE -DOPT_GENERIC -DHAVE_STRERROR -DMPG123_NO_LARGENAME"/>
 	<fileset id="gcc-files" dir="./">
-		<exclude name="target/"/>		
-				<include name="kissfft/*.c"/>
+		<exclude name="target/"/>
+		<include name="kissfft/*.c"/>
 		<include name="vorbis/*.c"/>
 		<include name="libmpg123/equalizer.c"/>
 		<include name="libmpg123/index.c"/>
@@ -43,7 +43,6 @@
 		<include name="libmpg123/synth_8bit.c"/>
 		<include name="libmpg123/synth_real.c"/>
 		<include name="libmpg123/synth_s32.c"/>
-
 		
 	</fileset>
 	
@@ -52,14 +51,13 @@
 	<property name="g++-opts" value="-c -Wall -O2 -mfpmath=sse -msse -fmessage-length=0 -m32 -fPIC -DFIXED_POINT -DMPG123_NO_CONFIGURE -DOPT_GENERIC -DHAVE_STRERROR -DMPG123_NO_LARGENAME"/>
 	<fileset id="g++-files" dir="./">
 		<exclude name="target/"/>
-				<include name="**/*AudioTools.cpp"/>
+		<include name="**/*AudioTools.cpp"/>
 		<include name="**/*KissFFT.cpp"/>
 		<include name="**/*VorbisDecoder.cpp"/>
 		<include name="**/*SoundTouch.cpp"/>
 		<include name="**/*Mpg123Decoder.cpp"/>
 		<include name="soundtouch/source/SoundTouch/*.cpp"/>
-
-				<exclude name="**/cpu_detect_x86_win.cpp"/>
+		<exclude name="**/cpu_detect_x86_win.cpp"/>
 
 	</fileset>
 
@@ -76,10 +74,27 @@
 	</target>
 	
 	<target name="precompile">
+                <condition property="compiler-found">
+                        <and>
+                                <or>
+                                        <!-- Windows might be either; Linux the first -->
+                                        <available file="${g++}" filepath="${env.PATH}"/>
+                                        <available file="${g++}" filepath="${env.Path}"/>
+                                </or>
+                                <or>
+                                        <!-- Windows might be either; Linux the first -->
+                                        <available file="${gcc}" filepath="${env.PATH}"/>
+                                        <available file="${gcc}" filepath="${env.Path}"/>
+                                </or>
+                        </and>
+                </condition>
+                <condition property="has-compiler">
+                        <equals arg1="${compiler-found}" arg2="true"/>
+                </condition>
 		<copy failonerror="true" tofile="soundtouch/include/STTypes.h" verbose="true" overwrite="true" file="STTypes.h.patched"/>
 	</target>
 	
-	<target name="create-build-dir" depends="precompile">
+	<target name="create-build-dir" depends="precompile" if="has-compiler">
 		<!-- FIXME this is pretty nasty :/ -->
 		<copy todir="${buildDir}">
 			<fileset refid="g++-files"/>
@@ -94,7 +109,7 @@
 	</target>
 
 	<!-- compiles all C and C++ files to object files in the build directory -->
-	<target name="compile" depends="create-build-dir" >
+	<target name="compile" depends="create-build-dir" if="has-compiler">
 		<mkdir dir="${buildDir}"/>
 		<apply failonerror="true" executable="${g++}" dest="${buildDir}" verbose="true">
 			<arg line="${g++-opts}"/>
@@ -135,7 +150,7 @@
 	</target>	
 
 	<!-- links the shared library based on the previously compiled object files -->	
-	<target name="link" depends="compile">
+	<target name="link" depends="compile" if="has-compiler">
 		<mkdir dir="${libsDir}"/>
 		<apply failonerror="true" executable="${linker}" parallel="true" dir="${buildDir}">
 			<arg line="${linker-opts}"/>

--- a/extensions/gdx-audio/jni/build-linux64.xml
+++ b/extensions/gdx-audio/jni/build-linux64.xml
@@ -16,8 +16,8 @@
 	<property name="gcc" value="${compilerPrefix}gcc"/>	
 	<property name="gcc-opts" value="-c -Wall -O2 -mfpmath=sse -msse -fmessage-length=0 -m64 -fPIC -DFIXED_POINT -DMPG123_NO_CONFIGURE -DOPT_GENERIC -DHAVE_STRERROR -DMPG123_NO_LARGENAME"/>
 	<fileset id="gcc-files" dir="./">
-		<exclude name="target/"/>		
-				<include name="kissfft/*.c"/>
+		<exclude name="target/"/>
+		<include name="kissfft/*.c"/>
 		<include name="vorbis/*.c"/>
 		<include name="libmpg123/equalizer.c"/>
 		<include name="libmpg123/index.c"/>
@@ -43,7 +43,6 @@
 		<include name="libmpg123/synth_8bit.c"/>
 		<include name="libmpg123/synth_real.c"/>
 		<include name="libmpg123/synth_s32.c"/>
-
 		
 	</fileset>
 	
@@ -52,14 +51,13 @@
 	<property name="g++-opts" value="-c -Wall -O2 -mfpmath=sse -msse -fmessage-length=0 -m64 -fPIC -DFIXED_POINT -DMPG123_NO_CONFIGURE -DOPT_GENERIC -DHAVE_STRERROR -DMPG123_NO_LARGENAME"/>
 	<fileset id="g++-files" dir="./">
 		<exclude name="target/"/>
-				<include name="**/*AudioTools.cpp"/>
+		<include name="**/*AudioTools.cpp"/>
 		<include name="**/*KissFFT.cpp"/>
 		<include name="**/*VorbisDecoder.cpp"/>
 		<include name="**/*SoundTouch.cpp"/>
 		<include name="**/*Mpg123Decoder.cpp"/>
 		<include name="soundtouch/source/SoundTouch/*.cpp"/>
-
-				<exclude name="**/cpu_detect_x86_win.cpp"/>
+		<exclude name="**/cpu_detect_x86_win.cpp"/>
 
 	</fileset>
 
@@ -76,10 +74,27 @@
 	</target>
 	
 	<target name="precompile">
+                <condition property="compiler-found">
+                        <and>
+                                <or>
+                                        <!-- Windows might be either; Linux the first -->
+                                        <available file="${g++}" filepath="${env.PATH}"/>
+                                        <available file="${g++}" filepath="${env.Path}"/>
+                                </or>
+                                <or>
+                                        <!-- Windows might be either; Linux the first -->
+                                        <available file="${gcc}" filepath="${env.PATH}"/>
+                                        <available file="${gcc}" filepath="${env.Path}"/>
+                                </or>
+                        </and>
+                </condition>
+                <condition property="has-compiler">
+                        <equals arg1="${compiler-found}" arg2="true"/>
+                </condition>
 		<copy failonerror="true" tofile="soundtouch/include/STTypes.h" verbose="true" overwrite="true" file="STTypes.h.patched"/>
 	</target>
 	
-	<target name="create-build-dir" depends="precompile">
+	<target name="create-build-dir" depends="precompile" if="has-compiler">
 		<!-- FIXME this is pretty nasty :/ -->
 		<copy todir="${buildDir}">
 			<fileset refid="g++-files"/>
@@ -94,7 +109,7 @@
 	</target>
 
 	<!-- compiles all C and C++ files to object files in the build directory -->
-	<target name="compile" depends="create-build-dir" >
+	<target name="compile" depends="create-build-dir" if="has-compiler">
 		<mkdir dir="${buildDir}"/>
 		<apply failonerror="true" executable="${g++}" dest="${buildDir}" verbose="true">
 			<arg line="${g++-opts}"/>
@@ -135,7 +150,7 @@
 	</target>	
 
 	<!-- links the shared library based on the previously compiled object files -->	
-	<target name="link" depends="compile">
+	<target name="link" depends="compile" if="has-compiler">
 		<mkdir dir="${libsDir}"/>
 		<apply failonerror="true" executable="${linker}" parallel="true" dir="${buildDir}">
 			<arg line="${linker-opts}"/>

--- a/extensions/gdx-audio/jni/build-macosx32.xml
+++ b/extensions/gdx-audio/jni/build-macosx32.xml
@@ -16,8 +16,8 @@
 	<property name="gcc" value="${compilerPrefix}gcc"/>	
 	<property name="gcc-opts" value="-c -Wall -O2 -arch i386 -arch x86_64 -DFIXED_POINT -fmessage-length=0 -fPIC -mmacosx-version-min=10.5 -DFIXED_POINT -DMPG123_NO_CONFIGURE -DOPT_GENERIC -DHAVE_STRERROR -DMPG123_NO_LARGENAME"/>
 	<fileset id="gcc-files" dir="./">
-		<exclude name="target/"/>		
-				<include name="kissfft/*.c"/>
+		<exclude name="target/"/>
+		<include name="kissfft/*.c"/>
 		<include name="vorbis/*.c"/>
 		<include name="libmpg123/equalizer.c"/>
 		<include name="libmpg123/index.c"/>
@@ -43,7 +43,6 @@
 		<include name="libmpg123/synth_8bit.c"/>
 		<include name="libmpg123/synth_real.c"/>
 		<include name="libmpg123/synth_s32.c"/>
-
 		
 	</fileset>
 	
@@ -52,7 +51,7 @@
 	<property name="g++-opts" value="-c -Wall -O2 -arch i386 -arch x86_64 -DFIXED_POINT -fmessage-length=0 -fPIC -mmacosx-version-min=10.5 -DFIXED_POINT -DMPG123_NO_CONFIGURE -DOPT_GENERIC -DHAVE_STRERROR -DMPG123_NO_LARGENAME"/>
 	<fileset id="g++-files" dir="./">
 		<exclude name="target/"/>
-				<include name="**/*AudioTools.cpp"/>
+		<include name="**/*AudioTools.cpp"/>
 		<include name="**/*KissFFT.cpp"/>
 		<include name="**/*VorbisDecoder.cpp"/>
 		<include name="**/*SoundTouch.cpp"/>
@@ -76,10 +75,27 @@
 	</target>
 	
 	<target name="precompile">
+                <condition property="compiler-found">
+                        <and>
+                                <or>
+                                        <!-- Windows might be either; Linux the first -->
+                                        <available file="${g++}" filepath="${env.PATH}"/>
+                                        <available file="${g++}" filepath="${env.Path}"/>
+                                </or>
+                                <or>
+                                        <!-- Windows might be either; Linux the first -->
+                                        <available file="${gcc}" filepath="${env.PATH}"/>
+                                        <available file="${gcc}" filepath="${env.Path}"/>
+                                </or>
+                        </and>
+                </condition>
+                <condition property="has-compiler">
+                        <equals arg1="${compiler-found}" arg2="true"/>
+                </condition>
 		<copy failonerror="true" tofile="soundtouch/include/STTypes.h" verbose="true" overwrite="true" file="STTypes.h.patched"/>
 	</target>
 	
-	<target name="create-build-dir" depends="precompile">
+	<target name="create-build-dir" depends="precompile" if="has-compiler">
 		<!-- FIXME this is pretty nasty :/ -->
 		<copy todir="${buildDir}">
 			<fileset refid="g++-files"/>
@@ -94,7 +110,7 @@
 	</target>
 
 	<!-- compiles all C and C++ files to object files in the build directory -->
-	<target name="compile" depends="create-build-dir" >
+	<target name="compile" depends="create-build-dir" if="has-compiler">
 		<mkdir dir="${buildDir}"/>
 		<apply failonerror="true" executable="${g++}" dest="${buildDir}" verbose="true">
 			<arg line="${g++-opts}"/>
@@ -135,7 +151,7 @@
 	</target>	
 
 	<!-- links the shared library based on the previously compiled object files -->	
-	<target name="link" depends="compile">
+	<target name="link" depends="compile" if="has-compiler">
 		<mkdir dir="${libsDir}"/>
 		<apply failonerror="true" executable="${linker}" parallel="true" dir="${buildDir}">
 			<arg line="${linker-opts}"/>

--- a/extensions/gdx-audio/jni/build-windows32.xml
+++ b/extensions/gdx-audio/jni/build-windows32.xml
@@ -16,8 +16,8 @@
 	<property name="gcc" value="${compilerPrefix}gcc"/>	
 	<property name="gcc-opts" value="-c -Wall -O2 -mfpmath=sse -msse2 -fmessage-length=0 -m32 -DFIXED_POINT -DMPG123_NO_CONFIGURE -DOPT_GENERIC -DHAVE_STRERROR -DMPG123_NO_LARGENAME"/>
 	<fileset id="gcc-files" dir="./">
-		<exclude name="target/"/>		
-				<include name="kissfft/*.c"/>
+		<exclude name="target/"/>
+		<include name="kissfft/*.c"/>
 		<include name="vorbis/*.c"/>
 		<include name="libmpg123/equalizer.c"/>
 		<include name="libmpg123/index.c"/>
@@ -44,7 +44,6 @@
 		<include name="libmpg123/synth_real.c"/>
 		<include name="libmpg123/synth_s32.c"/>
 
-		
 	</fileset>
 	
 	<!-- define g++ compiler, options and files to compile -->
@@ -52,14 +51,13 @@
 	<property name="g++-opts" value="-c -Wall -O2 -mfpmath=sse -msse2 -fmessage-length=0 -m32 -DFIXED_POINT -DMPG123_NO_CONFIGURE -DOPT_GENERIC -DHAVE_STRERROR -DMPG123_NO_LARGENAME"/>
 	<fileset id="g++-files" dir="./">
 		<exclude name="target/"/>
-				<include name="**/*AudioTools.cpp"/>
+		<include name="**/*AudioTools.cpp"/>
 		<include name="**/*KissFFT.cpp"/>
 		<include name="**/*VorbisDecoder.cpp"/>
 		<include name="**/*SoundTouch.cpp"/>
 		<include name="**/*Mpg123Decoder.cpp"/>
 		<include name="soundtouch/source/SoundTouch/*.cpp"/>
-
-				<exclude name="**/cpu_detect_x86_win.cpp"/>
+		<exclude name="**/cpu_detect_x86_win.cpp"/>
 
 	</fileset>
 
@@ -76,10 +74,27 @@
 	</target>
 	
 	<target name="precompile">
+                <condition property="compiler-found">
+                        <and>
+                                <or>
+                                        <!-- Windows might be either; Linux the first -->
+                                        <available file="${g++}" filepath="${env.PATH}"/>
+                                        <available file="${g++}" filepath="${env.Path}"/>
+                                </or>
+                                <or>
+                                        <!-- Windows might be either; Linux the first -->
+                                        <available file="${gcc}" filepath="${env.PATH}"/>
+                                        <available file="${gcc}" filepath="${env.Path}"/>
+                                </or>
+                        </and>
+                </condition>
+                <condition property="has-compiler">
+                        <equals arg1="${compiler-found}" arg2="true"/>
+                </condition>
 		<copy failonerror="true" tofile="soundtouch/include/STTypes.h" verbose="true" overwrite="true" file="STTypes.h.patched"/>
 	</target>
 	
-	<target name="create-build-dir" depends="precompile">
+	<target name="create-build-dir" depends="precompile" if="has-compiler">
 		<!-- FIXME this is pretty nasty :/ -->
 		<copy todir="${buildDir}">
 			<fileset refid="g++-files"/>
@@ -94,7 +109,7 @@
 	</target>
 
 	<!-- compiles all C and C++ files to object files in the build directory -->
-	<target name="compile" depends="create-build-dir" >
+	<target name="compile" depends="create-build-dir" if="has-compiler">
 		<mkdir dir="${buildDir}"/>
 		<apply failonerror="true" executable="${g++}" dest="${buildDir}" verbose="true">
 			<arg line="${g++-opts}"/>
@@ -135,7 +150,7 @@
 	</target>	
 
 	<!-- links the shared library based on the previously compiled object files -->	
-	<target name="link" depends="compile">
+	<target name="link" depends="compile" if="has-compiler">
 		<mkdir dir="${libsDir}"/>
 		<apply failonerror="true" executable="${linker}" parallel="true" dir="${buildDir}">
 			<arg line="${linker-opts}"/>

--- a/extensions/gdx-audio/jni/build-windows64.xml
+++ b/extensions/gdx-audio/jni/build-windows64.xml
@@ -16,8 +16,8 @@
 	<property name="gcc" value="${compilerPrefix}gcc"/>	
 	<property name="gcc-opts" value="-c -Wall -O2 -mfpmath=sse -msse2 -fmessage-length=0 -m64 -DFIXED_POINT -DMPG123_NO_CONFIGURE -DOPT_GENERIC -DHAVE_STRERROR -DMPG123_NO_LARGENAME"/>
 	<fileset id="gcc-files" dir="./">
-		<exclude name="target/"/>		
-				<include name="kissfft/*.c"/>
+		<exclude name="target/"/>
+		<include name="kissfft/*.c"/>
 		<include name="vorbis/*.c"/>
 		<include name="libmpg123/equalizer.c"/>
 		<include name="libmpg123/index.c"/>
@@ -43,7 +43,6 @@
 		<include name="libmpg123/synth_8bit.c"/>
 		<include name="libmpg123/synth_real.c"/>
 		<include name="libmpg123/synth_s32.c"/>
-
 		
 	</fileset>
 	
@@ -52,14 +51,13 @@
 	<property name="g++-opts" value="-c -Wall -O2 -mfpmath=sse -msse2 -fmessage-length=0 -m64 -DFIXED_POINT -DMPG123_NO_CONFIGURE -DOPT_GENERIC -DHAVE_STRERROR -DMPG123_NO_LARGENAME"/>
 	<fileset id="g++-files" dir="./">
 		<exclude name="target/"/>
-				<include name="**/*AudioTools.cpp"/>
+		<include name="**/*AudioTools.cpp"/>
 		<include name="**/*KissFFT.cpp"/>
 		<include name="**/*VorbisDecoder.cpp"/>
 		<include name="**/*SoundTouch.cpp"/>
 		<include name="**/*Mpg123Decoder.cpp"/>
 		<include name="soundtouch/source/SoundTouch/*.cpp"/>
-
-				<exclude name="**/cpu_detect_x86_win.cpp"/>
+		<exclude name="**/cpu_detect_x86_win.cpp"/>
 
 	</fileset>
 
@@ -76,10 +74,27 @@
 	</target>
 	
 	<target name="precompile">
+                <condition property="compiler-found">
+                        <and>
+                                <or>
+                                        <!-- Windows might be either; Linux the first -->
+                                        <available file="${g++}" filepath="${env.PATH}"/>
+                                        <available file="${g++}" filepath="${env.Path}"/>
+                                </or>
+                                <or>
+                                        <!-- Windows might be either; Linux the first -->
+                                        <available file="${gcc}" filepath="${env.PATH}"/>
+                                        <available file="${gcc}" filepath="${env.Path}"/>
+                                </or>
+                        </and>
+                </condition>
+                <condition property="has-compiler">
+                        <equals arg1="${compiler-found}" arg2="true"/>
+                </condition>
 		<copy failonerror="true" tofile="soundtouch/include/STTypes.h" verbose="true" overwrite="true" file="STTypes.h.patched"/>
 	</target>
 	
-	<target name="create-build-dir" depends="precompile">
+	<target name="create-build-dir" depends="precompile" if="has-compiler">
 		<!-- FIXME this is pretty nasty :/ -->
 		<copy todir="${buildDir}">
 			<fileset refid="g++-files"/>
@@ -94,18 +109,17 @@
 	</target>
 
 	<!-- compiles all C and C++ files to object files in the build directory -->
-	<target name="compile" depends="create-build-dir" >
+	<target name="compile" depends="create-build-dir" if="has-compiler">
 		<mkdir dir="${buildDir}"/>
 		<apply failonerror="true" executable="${g++}" dest="${buildDir}" verbose="true">
 			<arg line="${g++-opts}"/>
 			<arg value="-Ijni-headers"/>
 			<arg value="-Ijni-headers/${jniPlatform}"/>
 			<arg value="-I."/>
-						<arg value="-Ikissfft"/>
+			<arg value="-Ikissfft"/>
 			<arg value="-Ivorbis"/>
 			<arg value="-Isoundtouch/include"/>
 			<arg value="-Isoundtouch/source/SoundTouch/"/>
-
 			<srcfile/>
 			<arg value="-o"/>
 			<targetfile/>
@@ -119,11 +133,10 @@
 			<arg value="-Ijni-headers"/>
 			<arg value="-Ijni-headers/${jniPlatform}"/>
 			<arg value="-I."/>
-						<arg value="-Ikissfft"/>
+			<arg value="-Ikissfft"/>
 			<arg value="-Ivorbis"/>
 			<arg value="-Isoundtouch/include"/>
 			<arg value="-Isoundtouch/source/SoundTouch/"/>
-
 			<srcfile/>
 			<arg value="-o"/>
 			<targetfile/>
@@ -135,7 +148,7 @@
 	</target>	
 
 	<!-- links the shared library based on the previously compiled object files -->	
-	<target name="link" depends="compile">
+	<target name="link" depends="compile" if="has-compiler">
 		<mkdir dir="${libsDir}"/>
 		<apply failonerror="true" executable="${linker}" parallel="true" dir="${buildDir}">
 			<arg line="${linker-opts}"/>

--- a/extensions/gdx-bullet/jni/build-linux32.xml
+++ b/extensions/gdx-bullet/jni/build-linux32.xml
@@ -17,9 +17,8 @@
 	<property name="gcc-opts" value="-c -Wall -O2 -mfpmath=sse -msse -fmessage-length=0 -m32 -fPIC"/>
 	<fileset id="gcc-files" dir="./">
 		<exclude name="target/"/>		
-				<include name="**/*.c"/>
-
-				<exclude name="src/BulletMultiThreaded/GpuSoftBodySolvers/**"/>
+		<include name="**/*.c"/>
+		<exclude name="src/BulletMultiThreaded/GpuSoftBodySolvers/**"/>
 
 	</fileset>
 	
@@ -28,9 +27,8 @@
 	<property name="g++-opts" value="-c -Wall -O2 -mfpmath=sse -msse -fmessage-length=0 -m32 -fPIC -fno-strict-aliasing -fno-rtti -DBT_NO_PROFILE"/>
 	<fileset id="g++-files" dir="./">
 		<exclude name="target/"/>
-				<include name="**/*.cpp"/>
-
-				<exclude name="src/BulletMultiThreaded/GpuSoftBodySolvers/**"/>
+		<include name="**/*.cpp"/>
+		<exclude name="src/BulletMultiThreaded/GpuSoftBodySolvers/**"/>
 
 	</fileset>
 
@@ -47,10 +45,26 @@
 	</target>
 	
 	<target name="precompile">
-		
+                <condition property="compiler-found">
+                        <and>
+                                <or>
+                                        <!-- Windows might be either; Linux the first -->
+                                        <available file="${g++}" filepath="${env.PATH}"/>
+                                        <available file="${g++}" filepath="${env.Path}"/>
+                                </or>
+                                <or>
+                                        <!-- Windows might be either; Linux the first -->
+                                        <available file="${gcc}" filepath="${env.PATH}"/>
+                                        <available file="${gcc}" filepath="${env.Path}"/>
+                                </or>
+                        </and>
+                </condition>
+                <condition property="has-compiler">
+                        <equals arg1="${compiler-found}" arg2="true"/>
+                </condition>
 	</target>
 	
-	<target name="create-build-dir" depends="precompile">
+	<target name="create-build-dir" depends="precompile" if="has-compiler">
 		<!-- FIXME this is pretty nasty :/ -->
 		<copy todir="${buildDir}">
 			<fileset refid="g++-files"/>
@@ -65,15 +79,14 @@
 	</target>
 
 	<!-- compiles all C and C++ files to object files in the build directory -->
-	<target name="compile" depends="create-build-dir" >
+	<target name="compile" depends="create-build-dir" if="has-compiler">
 		<mkdir dir="${buildDir}"/>
 		<apply failonerror="true" executable="${g++}" dest="${buildDir}" verbose="true">
 			<arg line="${g++-opts}"/>
 			<arg value="-Ijni-headers"/>
 			<arg value="-Ijni-headers/${jniPlatform}"/>
 			<arg value="-I."/>
-						<arg value="-Isrc/"/>
-
+			<arg value="-Isrc/"/>
 			<srcfile/>
 			<arg value="-o"/>
 			<targetfile/>
@@ -87,8 +100,7 @@
 			<arg value="-Ijni-headers"/>
 			<arg value="-Ijni-headers/${jniPlatform}"/>
 			<arg value="-I."/>
-						<arg value="-Isrc/"/>
-
+			<arg value="-Isrc/"/>
 			<srcfile/>
 			<arg value="-o"/>
 			<targetfile/>
@@ -100,7 +112,7 @@
 	</target>	
 
 	<!-- links the shared library based on the previously compiled object files -->	
-	<target name="link" depends="compile">
+	<target name="link" depends="compile" if="has-compiler">
 		<mkdir dir="${libsDir}"/>
 		<apply failonerror="true" executable="${linker}" parallel="true" dir="${buildDir}">
 			<arg line="${linker-opts}"/>

--- a/extensions/gdx-bullet/jni/build-linux64.xml
+++ b/extensions/gdx-bullet/jni/build-linux64.xml
@@ -17,9 +17,8 @@
 	<property name="gcc-opts" value="-c -Wall -O2 -mfpmath=sse -msse -fmessage-length=0 -m64 -fPIC"/>
 	<fileset id="gcc-files" dir="./">
 		<exclude name="target/"/>		
-				<include name="**/*.c"/>
-
-				<exclude name="src/BulletMultiThreaded/GpuSoftBodySolvers/**"/>
+		<include name="**/*.c"/>
+		<exclude name="src/BulletMultiThreaded/GpuSoftBodySolvers/**"/>
 
 	</fileset>
 	
@@ -28,9 +27,8 @@
 	<property name="g++-opts" value="-c -Wall -O2 -mfpmath=sse -msse -fmessage-length=0 -m64 -fPIC -fno-strict-aliasing -fno-rtti -DBT_NO_PROFILE"/>
 	<fileset id="g++-files" dir="./">
 		<exclude name="target/"/>
-				<include name="**/*.cpp"/>
-
-				<exclude name="src/BulletMultiThreaded/GpuSoftBodySolvers/**"/>
+		<include name="**/*.cpp"/>
+		<exclude name="src/BulletMultiThreaded/GpuSoftBodySolvers/**"/>
 
 	</fileset>
 
@@ -47,10 +45,26 @@
 	</target>
 	
 	<target name="precompile">
-		
+                <condition property="compiler-found">
+                        <and>
+                                <or>
+                                        <!-- Windows might be either; Linux the first -->
+                                        <available file="${g++}" filepath="${env.PATH}"/>
+                                        <available file="${g++}" filepath="${env.Path}"/>
+                                </or>
+                                <or>
+                                        <!-- Windows might be either; Linux the first -->
+                                        <available file="${gcc}" filepath="${env.PATH}"/>
+                                        <available file="${gcc}" filepath="${env.Path}"/>
+                                </or>
+                        </and>
+                </condition>
+                <condition property="has-compiler">
+                        <equals arg1="${compiler-found}" arg2="true"/>
+                </condition>
 	</target>
 	
-	<target name="create-build-dir" depends="precompile">
+	<target name="create-build-dir" depends="precompile" if="has-compiler">
 		<!-- FIXME this is pretty nasty :/ -->
 		<copy todir="${buildDir}">
 			<fileset refid="g++-files"/>
@@ -65,15 +79,14 @@
 	</target>
 
 	<!-- compiles all C and C++ files to object files in the build directory -->
-	<target name="compile" depends="create-build-dir" >
+	<target name="compile" depends="create-build-dir" if="has-compiler">
 		<mkdir dir="${buildDir}"/>
 		<apply failonerror="true" executable="${g++}" dest="${buildDir}" verbose="true">
 			<arg line="${g++-opts}"/>
 			<arg value="-Ijni-headers"/>
 			<arg value="-Ijni-headers/${jniPlatform}"/>
 			<arg value="-I."/>
-						<arg value="-Isrc/"/>
-
+			<arg value="-Isrc/"/>
 			<srcfile/>
 			<arg value="-o"/>
 			<targetfile/>
@@ -87,8 +100,7 @@
 			<arg value="-Ijni-headers"/>
 			<arg value="-Ijni-headers/${jniPlatform}"/>
 			<arg value="-I."/>
-						<arg value="-Isrc/"/>
-
+			<arg value="-Isrc/"/>
 			<srcfile/>
 			<arg value="-o"/>
 			<targetfile/>
@@ -100,7 +112,7 @@
 	</target>	
 
 	<!-- links the shared library based on the previously compiled object files -->	
-	<target name="link" depends="compile">
+	<target name="link" depends="compile" if="has-compiler">
 		<mkdir dir="${libsDir}"/>
 		<apply failonerror="true" executable="${linker}" parallel="true" dir="${buildDir}">
 			<arg line="${linker-opts}"/>

--- a/extensions/gdx-bullet/jni/build-macosx32.xml
+++ b/extensions/gdx-bullet/jni/build-macosx32.xml
@@ -17,9 +17,8 @@
 	<property name="gcc-opts" value="-c -Wall -O2 -arch i386 -arch x86_64 -DFIXED_POINT -fmessage-length=0 -fPIC -mmacosx-version-min=10.5"/>
 	<fileset id="gcc-files" dir="./">
 		<exclude name="target/"/>		
-				<include name="**/*.c"/>
-
-				<exclude name="src/BulletMultiThreaded/GpuSoftBodySolvers/**"/>
+		<include name="**/*.c"/>
+		<exclude name="src/BulletMultiThreaded/GpuSoftBodySolvers/**"/>
 
 	</fileset>
 	
@@ -28,9 +27,8 @@
 	<property name="g++-opts" value="-c -Wall -O2 -arch i386 -arch x86_64 -DFIXED_POINT -fmessage-length=0 -fPIC -mmacosx-version-min=10.5 -fno-strict-aliasing -fno-rtti -DBT_NO_PROFILE"/>
 	<fileset id="g++-files" dir="./">
 		<exclude name="target/"/>
-				<include name="**/*.cpp"/>
-
-				<exclude name="src/BulletMultiThreaded/GpuSoftBodySolvers/**"/>
+		<include name="**/*.cpp"/>
+		<exclude name="src/BulletMultiThreaded/GpuSoftBodySolvers/**"/>
 
 	</fileset>
 
@@ -47,10 +45,26 @@
 	</target>
 	
 	<target name="precompile">
-		
+                <condition property="compiler-found">
+                        <and>
+                                <or>
+                                        <!-- Windows might be either; Linux the first -->
+                                        <available file="${g++}" filepath="${env.PATH}"/>
+                                        <available file="${g++}" filepath="${env.Path}"/>
+                                </or>
+                                <or>
+                                        <!-- Windows might be either; Linux the first -->
+                                        <available file="${gcc}" filepath="${env.PATH}"/>
+                                        <available file="${gcc}" filepath="${env.Path}"/>
+                                </or>
+                        </and>
+                </condition>
+                <condition property="has-compiler">
+                        <equals arg1="${compiler-found}" arg2="true"/>
+                </condition>
 	</target>
 	
-	<target name="create-build-dir" depends="precompile">
+	<target name="create-build-dir" depends="precompile" if="has-compiler">
 		<!-- FIXME this is pretty nasty :/ -->
 		<copy todir="${buildDir}">
 			<fileset refid="g++-files"/>
@@ -65,15 +79,14 @@
 	</target>
 
 	<!-- compiles all C and C++ files to object files in the build directory -->
-	<target name="compile" depends="create-build-dir" >
+	<target name="compile" depends="create-build-dir" if="has-compiler">
 		<mkdir dir="${buildDir}"/>
 		<apply failonerror="true" executable="${g++}" dest="${buildDir}" verbose="true">
 			<arg line="${g++-opts}"/>
 			<arg value="-Ijni-headers"/>
 			<arg value="-Ijni-headers/${jniPlatform}"/>
 			<arg value="-I."/>
-						<arg value="-Isrc/"/>
-
+			<arg value="-Isrc/"/>
 			<srcfile/>
 			<arg value="-o"/>
 			<targetfile/>
@@ -87,8 +100,7 @@
 			<arg value="-Ijni-headers"/>
 			<arg value="-Ijni-headers/${jniPlatform}"/>
 			<arg value="-I."/>
-						<arg value="-Isrc/"/>
-
+			<arg value="-Isrc/"/>
 			<srcfile/>
 			<arg value="-o"/>
 			<targetfile/>
@@ -100,7 +112,7 @@
 	</target>	
 
 	<!-- links the shared library based on the previously compiled object files -->	
-	<target name="link" depends="compile">
+	<target name="link" depends="compile" if="has-compiler">
 		<mkdir dir="${libsDir}"/>
 		<apply failonerror="true" executable="${linker}" parallel="true" dir="${buildDir}">
 			<arg line="${linker-opts}"/>

--- a/extensions/gdx-bullet/jni/build-windows32.xml
+++ b/extensions/gdx-bullet/jni/build-windows32.xml
@@ -17,9 +17,8 @@
 	<property name="gcc-opts" value="-c -Wall -O2 -mfpmath=sse -msse2 -fmessage-length=0 -m32"/>
 	<fileset id="gcc-files" dir="./">
 		<exclude name="target/"/>		
-				<include name="**/*.c"/>
-
-				<exclude name="src/BulletMultiThreaded/GpuSoftBodySolvers/**"/>
+		<include name="**/*.c"/>
+		<exclude name="src/BulletMultiThreaded/GpuSoftBodySolvers/**"/>
 
 	</fileset>
 	
@@ -28,9 +27,8 @@
 	<property name="g++-opts" value="-c -Wall -O2 -mfpmath=sse -msse2 -fmessage-length=0 -m32 -fno-strict-aliasing -fno-rtti -DBT_NO_PROFILE"/>
 	<fileset id="g++-files" dir="./">
 		<exclude name="target/"/>
-				<include name="**/*.cpp"/>
-
-				<exclude name="src/BulletMultiThreaded/GpuSoftBodySolvers/**"/>
+		<include name="**/*.cpp"/>
+		<exclude name="src/BulletMultiThreaded/GpuSoftBodySolvers/**"/>
 
 	</fileset>
 
@@ -47,10 +45,26 @@
 	</target>
 	
 	<target name="precompile">
-		
+                <condition property="compiler-found">
+                        <and>
+                                <or>
+                                        <!-- Windows might be either; Linux the first -->
+                                        <available file="${g++}" filepath="${env.PATH}"/>
+                                        <available file="${g++}" filepath="${env.Path}"/>
+                                </or>
+                                <or>
+                                        <!-- Windows might be either; Linux the first -->
+                                        <available file="${gcc}" filepath="${env.PATH}"/>
+                                        <available file="${gcc}" filepath="${env.Path}"/>
+                                </or>
+                        </and>
+                </condition>
+                <condition property="has-compiler">
+                        <equals arg1="${compiler-found}" arg2="true"/>
+                </condition>
 	</target>
 	
-	<target name="create-build-dir" depends="precompile">
+	<target name="create-build-dir" depends="precompile" if="has-compiler">
 		<!-- FIXME this is pretty nasty :/ -->
 		<copy todir="${buildDir}">
 			<fileset refid="g++-files"/>
@@ -65,15 +79,14 @@
 	</target>
 
 	<!-- compiles all C and C++ files to object files in the build directory -->
-	<target name="compile" depends="create-build-dir" >
+	<target name="compile" depends="create-build-dir" if="has-compiler">
 		<mkdir dir="${buildDir}"/>
 		<apply failonerror="true" executable="${g++}" dest="${buildDir}" verbose="true">
 			<arg line="${g++-opts}"/>
 			<arg value="-Ijni-headers"/>
 			<arg value="-Ijni-headers/${jniPlatform}"/>
 			<arg value="-I."/>
-						<arg value="-Isrc/"/>
-
+			<arg value="-Isrc/"/>
 			<srcfile/>
 			<arg value="-o"/>
 			<targetfile/>
@@ -87,8 +100,7 @@
 			<arg value="-Ijni-headers"/>
 			<arg value="-Ijni-headers/${jniPlatform}"/>
 			<arg value="-I."/>
-						<arg value="-Isrc/"/>
-
+			<arg value="-Isrc/"/>
 			<srcfile/>
 			<arg value="-o"/>
 			<targetfile/>
@@ -100,7 +112,7 @@
 	</target>	
 
 	<!-- links the shared library based on the previously compiled object files -->	
-	<target name="link" depends="compile">
+	<target name="link" depends="compile" if="has-compiler">
 		<mkdir dir="${libsDir}"/>
 		<apply failonerror="true" executable="${linker}" parallel="true" dir="${buildDir}">
 			<arg line="${linker-opts}"/>

--- a/extensions/gdx-bullet/jni/build-windows64.xml
+++ b/extensions/gdx-bullet/jni/build-windows64.xml
@@ -16,10 +16,9 @@
 	<property name="gcc" value="${compilerPrefix}gcc"/>	
 	<property name="gcc-opts" value="-c -Wall -O2 -mfpmath=sse -msse2 -fmessage-length=0 -m64"/>
 	<fileset id="gcc-files" dir="./">
-		<exclude name="target/"/>		
-				<include name="**/*.c"/>
-
-				<exclude name="src/BulletMultiThreaded/GpuSoftBodySolvers/**"/>
+		<exclude name="target/"/>
+		<include name="**/*.c"/>
+		<exclude name="src/BulletMultiThreaded/GpuSoftBodySolvers/**"/>
 
 	</fileset>
 	
@@ -28,9 +27,8 @@
 	<property name="g++-opts" value="-c -Wall -O2 -mfpmath=sse -msse2 -fmessage-length=0 -m64 -fno-strict-aliasing -fno-rtti -DBT_NO_PROFILE"/>
 	<fileset id="g++-files" dir="./">
 		<exclude name="target/"/>
-				<include name="**/*.cpp"/>
-
-				<exclude name="src/BulletMultiThreaded/GpuSoftBodySolvers/**"/>
+		<include name="**/*.cpp"/>
+		<exclude name="src/BulletMultiThreaded/GpuSoftBodySolvers/**"/>
 
 	</fileset>
 
@@ -47,10 +45,27 @@
 	</target>
 	
 	<target name="precompile">
+                <condition property="compiler-found">
+                        <and>
+                                <or>
+                                        <!-- Windows might be either; Linux the first -->
+                                        <available file="${g++}" filepath="${env.PATH}"/>
+                                        <available file="${g++}" filepath="${env.Path}"/>
+                                </or>
+                                <or>
+                                        <!-- Windows might be either; Linux the first -->
+                                        <available file="${gcc}" filepath="${env.PATH}"/>
+                                        <available file="${gcc}" filepath="${env.Path}"/>
+                                </or>
+                        </and>
+                </condition>
+                <condition property="has-compiler">
+                        <equals arg1="${compiler-found}" arg2="true"/>
+                </condition>
 		<copy todir="src" verbose="true" overwrite="true"><fileset dir="../patched"/></copy>
 	</target>
 	
-	<target name="create-build-dir" depends="precompile">
+	<target name="create-build-dir" depends="precompile" if="has-compiler">
 		<!-- FIXME this is pretty nasty :/ -->
 		<copy todir="${buildDir}">
 			<fileset refid="g++-files"/>
@@ -65,15 +80,14 @@
 	</target>
 
 	<!-- compiles all C and C++ files to object files in the build directory -->
-	<target name="compile" depends="create-build-dir" >
+	<target name="compile" depends="create-build-dir" if="has-compiler">
 		<mkdir dir="${buildDir}"/>
 		<apply failonerror="true" executable="${g++}" dest="${buildDir}" verbose="true">
 			<arg line="${g++-opts}"/>
 			<arg value="-Ijni-headers"/>
 			<arg value="-Ijni-headers/${jniPlatform}"/>
 			<arg value="-I."/>
-						<arg value="-Isrc/"/>
-
+			<arg value="-Isrc/"/>
 			<srcfile/>
 			<arg value="-o"/>
 			<targetfile/>
@@ -87,8 +101,7 @@
 			<arg value="-Ijni-headers"/>
 			<arg value="-Ijni-headers/${jniPlatform}"/>
 			<arg value="-I."/>
-						<arg value="-Isrc/"/>
-
+			<arg value="-Isrc/"/>
 			<srcfile/>
 			<arg value="-o"/>
 			<targetfile/>
@@ -100,7 +113,7 @@
 	</target>	
 
 	<!-- links the shared library based on the previously compiled object files -->	
-	<target name="link" depends="compile">
+	<target name="link" depends="compile" if="has-compiler">
 		<mkdir dir="${libsDir}"/>
 		<apply failonerror="true" executable="${linker}" parallel="true" dir="${buildDir}">
 			<arg line="${linker-opts}"/>

--- a/extensions/gdx-freetype/jni/build-linux32.xml
+++ b/extensions/gdx-freetype/jni/build-linux32.xml
@@ -17,7 +17,7 @@
 	<property name="gcc-opts" value="-c -Wall -O2 -mfpmath=sse -msse -fmessage-length=0 -m32 -fPIC -std=c99 -DFT2_BUILD_LIBRARY"/>
 	<fileset id="gcc-files" dir="./">
 		<exclude name="target/"/>		
-				<include name="freetype-2.4.8/src/base/ftsystem.c"/>
+		<include name="freetype-2.4.8/src/base/ftsystem.c"/>
 		<include name="freetype-2.4.8/src/base/ftinit.c"/>
 		<include name="freetype-2.4.8/src/base/ftdebug.c"/>
 		<include name="freetype-2.4.8/src/base/ftbase.c"/>
@@ -62,7 +62,6 @@
 		<include name="freetype-2.4.8/src/pshinter/pshinter.c"/>
 		<include name="freetype-2.4.8/src/psnames/psnames.c"/>
 
-		
 	</fileset>
 	
 	<!-- define g++ compiler, options and files to compile -->
@@ -70,8 +69,7 @@
 	<property name="g++-opts" value="-c -Wall -O2 -mfpmath=sse -msse -fmessage-length=0 -m32 -fPIC -std=c99 -DFT2_BUILD_LIBRARY"/>
 	<fileset id="g++-files" dir="./">
 		<exclude name="target/"/>
-				<include name="**/*.cpp"/>
-
+		<include name="**/*.cpp"/>
 		
 	</fileset>
 
@@ -88,10 +86,26 @@
 	</target>
 	
 	<target name="precompile">
-		
+                <condition property="compiler-found">
+                        <and>
+                                <or>
+                                        <!-- Windows might be either; Linux the first -->
+                                        <available file="${g++}" filepath="${env.PATH}"/>
+                                        <available file="${g++}" filepath="${env.Path}"/>
+                                </or>
+                                <or>
+                                        <!-- Windows might be either; Linux the first -->
+                                        <available file="${gcc}" filepath="${env.PATH}"/>
+                                        <available file="${gcc}" filepath="${env.Path}"/>
+                                </or>
+                        </and>
+                </condition>
+                <condition property="has-compiler">
+                        <equals arg1="${compiler-found}" arg2="true"/>
+                </condition>
 	</target>
 	
-	<target name="create-build-dir" depends="precompile">
+	<target name="create-build-dir" depends="precompile" if="has-compiler">
 		<!-- FIXME this is pretty nasty :/ -->
 		<copy todir="${buildDir}">
 			<fileset refid="g++-files"/>
@@ -106,15 +120,14 @@
 	</target>
 
 	<!-- compiles all C and C++ files to object files in the build directory -->
-	<target name="compile" depends="create-build-dir" >
+	<target name="compile" depends="create-build-dir" if="has-compiler">
 		<mkdir dir="${buildDir}"/>
 		<apply failonerror="true" executable="${g++}" dest="${buildDir}" verbose="true">
 			<arg line="${g++-opts}"/>
 			<arg value="-Ijni-headers"/>
 			<arg value="-Ijni-headers/${jniPlatform}"/>
 			<arg value="-I."/>
-						<arg value="-Ifreetype-2.4.8/include"/>
-
+			<arg value="-Ifreetype-2.4.8/include"/>
 			<srcfile/>
 			<arg value="-o"/>
 			<targetfile/>
@@ -128,8 +141,7 @@
 			<arg value="-Ijni-headers"/>
 			<arg value="-Ijni-headers/${jniPlatform}"/>
 			<arg value="-I."/>
-						<arg value="-Ifreetype-2.4.8/include"/>
-
+			<arg value="-Ifreetype-2.4.8/include"/>
 			<srcfile/>
 			<arg value="-o"/>
 			<targetfile/>
@@ -141,7 +153,7 @@
 	</target>	
 
 	<!-- links the shared library based on the previously compiled object files -->	
-	<target name="link" depends="compile">
+	<target name="link" depends="compile" if="has-compiler">
 		<mkdir dir="${libsDir}"/>
 		<apply failonerror="true" executable="${linker}" parallel="true" dir="${buildDir}">
 			<arg line="${linker-opts}"/>

--- a/extensions/gdx-freetype/jni/build-linux64.xml
+++ b/extensions/gdx-freetype/jni/build-linux64.xml
@@ -17,7 +17,7 @@
 	<property name="gcc-opts" value="-c -Wall -O2 -mfpmath=sse -msse -fmessage-length=0 -m64 -fPIC -std=c99 -DFT2_BUILD_LIBRARY"/>
 	<fileset id="gcc-files" dir="./">
 		<exclude name="target/"/>		
-				<include name="freetype-2.4.8/src/base/ftsystem.c"/>
+		<include name="freetype-2.4.8/src/base/ftsystem.c"/>
 		<include name="freetype-2.4.8/src/base/ftinit.c"/>
 		<include name="freetype-2.4.8/src/base/ftdebug.c"/>
 		<include name="freetype-2.4.8/src/base/ftbase.c"/>
@@ -62,7 +62,6 @@
 		<include name="freetype-2.4.8/src/pshinter/pshinter.c"/>
 		<include name="freetype-2.4.8/src/psnames/psnames.c"/>
 
-		
 	</fileset>
 	
 	<!-- define g++ compiler, options and files to compile -->
@@ -70,8 +69,7 @@
 	<property name="g++-opts" value="-c -Wall -O2 -mfpmath=sse -msse -fmessage-length=0 -m64 -fPIC -std=c99 -DFT2_BUILD_LIBRARY"/>
 	<fileset id="g++-files" dir="./">
 		<exclude name="target/"/>
-				<include name="**/*.cpp"/>
-
+		<include name="**/*.cpp"/>
 		
 	</fileset>
 
@@ -88,10 +86,26 @@
 	</target>
 	
 	<target name="precompile">
-		
+                <condition property="compiler-found">
+                        <and>
+                                <or>
+                                        <!-- Windows might be either; Linux the first -->
+                                        <available file="${g++}" filepath="${env.PATH}"/>
+                                        <available file="${g++}" filepath="${env.Path}"/>
+                                </or>
+                                <or>
+                                        <!-- Windows might be either; Linux the first -->
+                                        <available file="${gcc}" filepath="${env.PATH}"/>
+                                        <available file="${gcc}" filepath="${env.Path}"/>
+                                </or>
+                        </and>
+                </condition>
+                <condition property="has-compiler">
+                        <equals arg1="${compiler-found}" arg2="true"/>
+                </condition>
 	</target>
 	
-	<target name="create-build-dir" depends="precompile">
+	<target name="create-build-dir" depends="precompile" if="has-compiler">
 		<!-- FIXME this is pretty nasty :/ -->
 		<copy todir="${buildDir}">
 			<fileset refid="g++-files"/>
@@ -106,15 +120,14 @@
 	</target>
 
 	<!-- compiles all C and C++ files to object files in the build directory -->
-	<target name="compile" depends="create-build-dir" >
+	<target name="compile" depends="create-build-dir" if="has-compiler">
 		<mkdir dir="${buildDir}"/>
 		<apply failonerror="true" executable="${g++}" dest="${buildDir}" verbose="true">
 			<arg line="${g++-opts}"/>
 			<arg value="-Ijni-headers"/>
 			<arg value="-Ijni-headers/${jniPlatform}"/>
 			<arg value="-I."/>
-						<arg value="-Ifreetype-2.4.8/include"/>
-
+			<arg value="-Ifreetype-2.4.8/include"/>
 			<srcfile/>
 			<arg value="-o"/>
 			<targetfile/>
@@ -128,8 +141,7 @@
 			<arg value="-Ijni-headers"/>
 			<arg value="-Ijni-headers/${jniPlatform}"/>
 			<arg value="-I."/>
-						<arg value="-Ifreetype-2.4.8/include"/>
-
+			<arg value="-Ifreetype-2.4.8/include"/>
 			<srcfile/>
 			<arg value="-o"/>
 			<targetfile/>
@@ -141,7 +153,7 @@
 	</target>	
 
 	<!-- links the shared library based on the previously compiled object files -->	
-	<target name="link" depends="compile">
+	<target name="link" depends="compile" if="has-compiler">
 		<mkdir dir="${libsDir}"/>
 		<apply failonerror="true" executable="${linker}" parallel="true" dir="${buildDir}">
 			<arg line="${linker-opts}"/>

--- a/extensions/gdx-freetype/jni/build-macosx32.xml
+++ b/extensions/gdx-freetype/jni/build-macosx32.xml
@@ -17,7 +17,7 @@
 	<property name="gcc-opts" value="-c -Wall -O2 -arch i386 -arch x86_64 -DFIXED_POINT -fmessage-length=0 -fPIC -mmacosx-version-min=10.5 -std=c99 -DFT2_BUILD_LIBRARY"/>
 	<fileset id="gcc-files" dir="./">
 		<exclude name="target/"/>		
-				<include name="freetype-2.4.8/src/base/ftsystem.c"/>
+		<include name="freetype-2.4.8/src/base/ftsystem.c"/>
 		<include name="freetype-2.4.8/src/base/ftinit.c"/>
 		<include name="freetype-2.4.8/src/base/ftdebug.c"/>
 		<include name="freetype-2.4.8/src/base/ftbase.c"/>
@@ -62,7 +62,6 @@
 		<include name="freetype-2.4.8/src/pshinter/pshinter.c"/>
 		<include name="freetype-2.4.8/src/psnames/psnames.c"/>
 
-		
 	</fileset>
 	
 	<!-- define g++ compiler, options and files to compile -->
@@ -70,8 +69,7 @@
 	<property name="g++-opts" value="-c -Wall -O2 -arch i386 -arch x86_64 -DFIXED_POINT -fmessage-length=0 -fPIC -mmacosx-version-min=10.5 -std=c99 -DFT2_BUILD_LIBRARY"/>
 	<fileset id="g++-files" dir="./">
 		<exclude name="target/"/>
-				<include name="**/*.cpp"/>
-
+		<include name="**/*.cpp"/>
 		
 	</fileset>
 
@@ -88,10 +86,26 @@
 	</target>
 	
 	<target name="precompile">
-		
+                <condition property="compiler-found">
+                        <and>
+                                <or>
+                                        <!-- Windows might be either; Linux the first -->
+                                        <available file="${g++}" filepath="${env.PATH}"/>
+                                        <available file="${g++}" filepath="${env.Path}"/>
+                                </or>
+                                <or>
+                                        <!-- Windows might be either; Linux the first -->
+                                        <available file="${gcc}" filepath="${env.PATH}"/>
+                                        <available file="${gcc}" filepath="${env.Path}"/>
+                                </or>
+                        </and>
+                </condition>
+                <condition property="has-compiler">
+                        <equals arg1="${compiler-found}" arg2="true"/>
+                </condition>
 	</target>
 	
-	<target name="create-build-dir" depends="precompile">
+	<target name="create-build-dir" depends="precompile" if="has-compiler">
 		<!-- FIXME this is pretty nasty :/ -->
 		<copy todir="${buildDir}">
 			<fileset refid="g++-files"/>
@@ -106,15 +120,14 @@
 	</target>
 
 	<!-- compiles all C and C++ files to object files in the build directory -->
-	<target name="compile" depends="create-build-dir" >
+	<target name="compile" depends="create-build-dir" if="has-compiler">
 		<mkdir dir="${buildDir}"/>
 		<apply failonerror="true" executable="${g++}" dest="${buildDir}" verbose="true">
 			<arg line="${g++-opts}"/>
 			<arg value="-Ijni-headers"/>
 			<arg value="-Ijni-headers/${jniPlatform}"/>
 			<arg value="-I."/>
-						<arg value="-Ifreetype-2.4.8/include"/>
-
+			<arg value="-Ifreetype-2.4.8/include"/>
 			<srcfile/>
 			<arg value="-o"/>
 			<targetfile/>
@@ -128,8 +141,7 @@
 			<arg value="-Ijni-headers"/>
 			<arg value="-Ijni-headers/${jniPlatform}"/>
 			<arg value="-I."/>
-						<arg value="-Ifreetype-2.4.8/include"/>
-
+			<arg value="-Ifreetype-2.4.8/include"/>
 			<srcfile/>
 			<arg value="-o"/>
 			<targetfile/>
@@ -141,7 +153,7 @@
 	</target>	
 
 	<!-- links the shared library based on the previously compiled object files -->	
-	<target name="link" depends="compile">
+	<target name="link" depends="compile" if="has-compiler">
 		<mkdir dir="${libsDir}"/>
 		<apply failonerror="true" executable="${linker}" parallel="true" dir="${buildDir}">
 			<arg line="${linker-opts}"/>

--- a/extensions/gdx-freetype/jni/build-windows32.xml
+++ b/extensions/gdx-freetype/jni/build-windows32.xml
@@ -17,7 +17,7 @@
 	<property name="gcc-opts" value="-c -Wall -O2 -mfpmath=sse -msse2 -fmessage-length=0 -m32 -std=c99 -DFT2_BUILD_LIBRARY"/>
 	<fileset id="gcc-files" dir="./">
 		<exclude name="target/"/>		
-				<include name="freetype-2.4.8/src/base/ftsystem.c"/>
+		<include name="freetype-2.4.8/src/base/ftsystem.c"/>
 		<include name="freetype-2.4.8/src/base/ftinit.c"/>
 		<include name="freetype-2.4.8/src/base/ftdebug.c"/>
 		<include name="freetype-2.4.8/src/base/ftbase.c"/>
@@ -62,7 +62,6 @@
 		<include name="freetype-2.4.8/src/pshinter/pshinter.c"/>
 		<include name="freetype-2.4.8/src/psnames/psnames.c"/>
 
-		
 	</fileset>
 	
 	<!-- define g++ compiler, options and files to compile -->
@@ -70,8 +69,7 @@
 	<property name="g++-opts" value="-c -Wall -O2 -mfpmath=sse -msse2 -fmessage-length=0 -m32 -std=c99 -DFT2_BUILD_LIBRARY"/>
 	<fileset id="g++-files" dir="./">
 		<exclude name="target/"/>
-				<include name="**/*.cpp"/>
-
+		<include name="**/*.cpp"/>
 		
 	</fileset>
 
@@ -88,10 +86,26 @@
 	</target>
 	
 	<target name="precompile">
-		
+                <condition property="compiler-found">
+                        <and>
+                                <or>
+                                        <!-- Windows might be either; Linux the first -->
+                                        <available file="${g++}" filepath="${env.PATH}"/>
+                                        <available file="${g++}" filepath="${env.Path}"/>
+                                </or>
+                                <or>
+                                        <!-- Windows might be either; Linux the first -->
+                                        <available file="${gcc}" filepath="${env.PATH}"/>
+                                        <available file="${gcc}" filepath="${env.Path}"/>
+                                </or>
+                        </and>
+                </condition>
+                <condition property="has-compiler">
+                        <equals arg1="${compiler-found}" arg2="true"/>
+                </condition>
 	</target>
 	
-	<target name="create-build-dir" depends="precompile">
+	<target name="create-build-dir" depends="precompile" if="has-compiler">
 		<!-- FIXME this is pretty nasty :/ -->
 		<copy todir="${buildDir}">
 			<fileset refid="g++-files"/>
@@ -106,15 +120,14 @@
 	</target>
 
 	<!-- compiles all C and C++ files to object files in the build directory -->
-	<target name="compile" depends="create-build-dir" >
+	<target name="compile" depends="create-build-dir" if="has-compiler">
 		<mkdir dir="${buildDir}"/>
 		<apply failonerror="true" executable="${g++}" dest="${buildDir}" verbose="true">
 			<arg line="${g++-opts}"/>
 			<arg value="-Ijni-headers"/>
 			<arg value="-Ijni-headers/${jniPlatform}"/>
 			<arg value="-I."/>
-						<arg value="-Ifreetype-2.4.8/include"/>
-
+			<arg value="-Ifreetype-2.4.8/include"/>
 			<srcfile/>
 			<arg value="-o"/>
 			<targetfile/>
@@ -128,8 +141,7 @@
 			<arg value="-Ijni-headers"/>
 			<arg value="-Ijni-headers/${jniPlatform}"/>
 			<arg value="-I."/>
-						<arg value="-Ifreetype-2.4.8/include"/>
-
+			<arg value="-Ifreetype-2.4.8/include"/>
 			<srcfile/>
 			<arg value="-o"/>
 			<targetfile/>
@@ -141,7 +153,7 @@
 	</target>	
 
 	<!-- links the shared library based on the previously compiled object files -->	
-	<target name="link" depends="compile">
+	<target name="link" depends="compile" if="has-compiler">
 		<mkdir dir="${libsDir}"/>
 		<apply failonerror="true" executable="${linker}" parallel="true" dir="${buildDir}">
 			<arg line="${linker-opts}"/>

--- a/extensions/gdx-freetype/jni/build-windows64.xml
+++ b/extensions/gdx-freetype/jni/build-windows64.xml
@@ -17,7 +17,7 @@
 	<property name="gcc-opts" value="-c -Wall -O2 -mfpmath=sse -msse2 -fmessage-length=0 -m64 -std=c99 -DFT2_BUILD_LIBRARY"/>
 	<fileset id="gcc-files" dir="./">
 		<exclude name="target/"/>		
-				<include name="freetype-2.4.8/src/base/ftsystem.c"/>
+		<include name="freetype-2.4.8/src/base/ftsystem.c"/>
 		<include name="freetype-2.4.8/src/base/ftinit.c"/>
 		<include name="freetype-2.4.8/src/base/ftdebug.c"/>
 		<include name="freetype-2.4.8/src/base/ftbase.c"/>
@@ -62,7 +62,6 @@
 		<include name="freetype-2.4.8/src/pshinter/pshinter.c"/>
 		<include name="freetype-2.4.8/src/psnames/psnames.c"/>
 
-		
 	</fileset>
 	
 	<!-- define g++ compiler, options and files to compile -->
@@ -70,8 +69,7 @@
 	<property name="g++-opts" value="-c -Wall -O2 -mfpmath=sse -msse2 -fmessage-length=0 -m64 -std=c99 -DFT2_BUILD_LIBRARY"/>
 	<fileset id="g++-files" dir="./">
 		<exclude name="target/"/>
-				<include name="**/*.cpp"/>
-
+		<include name="**/*.cpp"/>
 		
 	</fileset>
 
@@ -88,10 +86,26 @@
 	</target>
 	
 	<target name="precompile">
-		
+                <condition property="compiler-found">
+                        <and>
+                                <or>
+                                        <!-- Windows might be either; Linux the first -->
+                                        <available file="${g++}" filepath="${env.PATH}"/>
+                                        <available file="${g++}" filepath="${env.Path}"/>
+                                </or>
+                                <or>
+                                        <!-- Windows might be either; Linux the first -->
+                                        <available file="${gcc}" filepath="${env.PATH}"/>
+                                        <available file="${gcc}" filepath="${env.Path}"/>
+                                </or>
+                        </and>
+                </condition>
+                <condition property="has-compiler">
+                        <equals arg1="${compiler-found}" arg2="true"/>
+                </condition>
 	</target>
 	
-	<target name="create-build-dir" depends="precompile">
+	<target name="create-build-dir" depends="precompile" if="has-compiler">
 		<!-- FIXME this is pretty nasty :/ -->
 		<copy todir="${buildDir}">
 			<fileset refid="g++-files"/>
@@ -106,15 +120,14 @@
 	</target>
 
 	<!-- compiles all C and C++ files to object files in the build directory -->
-	<target name="compile" depends="create-build-dir" >
+	<target name="compile" depends="create-build-dir" if="has-compiler">
 		<mkdir dir="${buildDir}"/>
 		<apply failonerror="true" executable="${g++}" dest="${buildDir}" verbose="true">
 			<arg line="${g++-opts}"/>
 			<arg value="-Ijni-headers"/>
 			<arg value="-Ijni-headers/${jniPlatform}"/>
 			<arg value="-I."/>
-						<arg value="-Ifreetype-2.4.8/include"/>
-
+			<arg value="-Ifreetype-2.4.8/include"/>
 			<srcfile/>
 			<arg value="-o"/>
 			<targetfile/>
@@ -128,8 +141,7 @@
 			<arg value="-Ijni-headers"/>
 			<arg value="-Ijni-headers/${jniPlatform}"/>
 			<arg value="-I."/>
-						<arg value="-Ifreetype-2.4.8/include"/>
-
+			<arg value="-Ifreetype-2.4.8/include"/>
 			<srcfile/>
 			<arg value="-o"/>
 			<targetfile/>
@@ -141,7 +153,7 @@
 	</target>	
 
 	<!-- links the shared library based on the previously compiled object files -->	
-	<target name="link" depends="compile">
+	<target name="link" depends="compile" if="has-compiler">
 		<mkdir dir="${libsDir}"/>
 		<apply failonerror="true" executable="${linker}" parallel="true" dir="${buildDir}">
 			<arg line="${linker-opts}"/>

--- a/extensions/gdx-image/jni/build-linux32.xml
+++ b/extensions/gdx-image/jni/build-linux32.xml
@@ -17,8 +17,7 @@
 	<property name="gcc-opts" value="-c -Wall -O2 -mfpmath=sse -msse -fmessage-length=0 -m32 -fPIC -DHAVE_CONFIG_H"/>
 	<fileset id="gcc-files" dir="./">
 		<exclude name="target/"/>		
-				<include name="**/*.c"/>
-
+		<include name="**/*.c"/>
 		
 	</fileset>
 	
@@ -27,8 +26,7 @@
 	<property name="g++-opts" value="-c -Wall -O2 -mfpmath=sse -msse -fmessage-length=0 -m32 -fPIC"/>
 	<fileset id="g++-files" dir="./">
 		<exclude name="target/"/>
-				<include name="**/*.cpp"/>
-
+		<include name="**/*.cpp"/>
 		
 	</fileset>
 
@@ -45,10 +43,26 @@
 	</target>
 	
 	<target name="precompile">
-		
+                <condition property="compiler-found">
+                        <and>
+                                <or>
+                                        <!-- Windows might be either; Linux the first -->
+                                        <available file="${g++}" filepath="${env.PATH}"/>
+                                        <available file="${g++}" filepath="${env.Path}"/>
+                                </or>
+                                <or>
+                                        <!-- Windows might be either; Linux the first -->
+                                        <available file="${gcc}" filepath="${env.PATH}"/>
+                                        <available file="${gcc}" filepath="${env.Path}"/>
+                                </or>
+                        </and>
+                </condition>
+                <condition property="has-compiler">
+                        <equals arg1="${compiler-found}" arg2="true"/>
+                </condition>
 	</target>
 	
-	<target name="create-build-dir" depends="precompile">
+	<target name="create-build-dir" depends="precompile" if="has-compiler">
 		<!-- FIXME this is pretty nasty :/ -->
 		<copy todir="${buildDir}">
 			<fileset refid="g++-files"/>
@@ -63,17 +77,16 @@
 	</target>
 
 	<!-- compiles all C and C++ files to object files in the build directory -->
-	<target name="compile" depends="create-build-dir" >
+	<target name="compile" depends="create-build-dir" if="has-compiler">
 		<mkdir dir="${buildDir}"/>
 		<apply failonerror="true" executable="${g++}" dest="${buildDir}" verbose="true">
 			<arg line="${g++-opts}"/>
 			<arg value="-Ijni-headers"/>
 			<arg value="-Ijni-headers/${jniPlatform}"/>
 			<arg value="-I."/>
-						<arg value="-Ilibjpeg/"/>
+			<arg value="-Ilibjpeg/"/>
 			<arg value="-Igiflib/"/>
 			<arg value="-I../../../gdx/jni/gdx2d/"/>
-
 			<srcfile/>
 			<arg value="-o"/>
 			<targetfile/>
@@ -102,7 +115,7 @@
 	</target>	
 
 	<!-- links the shared library based on the previously compiled object files -->	
-	<target name="link" depends="compile">
+	<target name="link" depends="compile" if="has-compiler">
 		<mkdir dir="${libsDir}"/>
 		<apply failonerror="true" executable="${linker}" parallel="true" dir="${buildDir}">
 			<arg line="${linker-opts}"/>

--- a/extensions/gdx-image/jni/build-linux64.xml
+++ b/extensions/gdx-image/jni/build-linux64.xml
@@ -17,8 +17,7 @@
 	<property name="gcc-opts" value="-c -Wall -O2 -mfpmath=sse -msse -fmessage-length=0 -m64 -fPIC -DHAVE_CONFIG_H"/>
 	<fileset id="gcc-files" dir="./">
 		<exclude name="target/"/>		
-				<include name="**/*.c"/>
-
+		<include name="**/*.c"/>
 		
 	</fileset>
 	
@@ -27,8 +26,7 @@
 	<property name="g++-opts" value="-c -Wall -O2 -mfpmath=sse -msse -fmessage-length=0 -m64 -fPIC"/>
 	<fileset id="g++-files" dir="./">
 		<exclude name="target/"/>
-				<include name="**/*.cpp"/>
-
+		<include name="**/*.cpp"/>
 		
 	</fileset>
 
@@ -45,10 +43,26 @@
 	</target>
 	
 	<target name="precompile">
-		
+                <condition property="compiler-found">
+                        <and>
+                                <or>
+                                        <!-- Windows might be either; Linux the first -->
+                                        <available file="${g++}" filepath="${env.PATH}"/>
+                                        <available file="${g++}" filepath="${env.Path}"/>
+                                </or>
+                                <or>
+                                        <!-- Windows might be either; Linux the first -->
+                                        <available file="${gcc}" filepath="${env.PATH}"/>
+                                        <available file="${gcc}" filepath="${env.Path}"/>
+                                </or>
+                        </and>
+                </condition>
+                <condition property="has-compiler">
+                        <equals arg1="${compiler-found}" arg2="true"/>
+                </condition>
 	</target>
 	
-	<target name="create-build-dir" depends="precompile">
+	<target name="create-build-dir" depends="precompile" if="has-compiler">
 		<!-- FIXME this is pretty nasty :/ -->
 		<copy todir="${buildDir}">
 			<fileset refid="g++-files"/>
@@ -63,17 +77,16 @@
 	</target>
 
 	<!-- compiles all C and C++ files to object files in the build directory -->
-	<target name="compile" depends="create-build-dir" >
+	<target name="compile" depends="create-build-dir" if="has-compiler">
 		<mkdir dir="${buildDir}"/>
 		<apply failonerror="true" executable="${g++}" dest="${buildDir}" verbose="true">
 			<arg line="${g++-opts}"/>
 			<arg value="-Ijni-headers"/>
 			<arg value="-Ijni-headers/${jniPlatform}"/>
 			<arg value="-I."/>
-						<arg value="-Ilibjpeg/"/>
+			<arg value="-Ilibjpeg/"/>
 			<arg value="-Igiflib/"/>
 			<arg value="-I../../../gdx/jni/gdx2d/"/>
-
 			<srcfile/>
 			<arg value="-o"/>
 			<targetfile/>
@@ -87,10 +100,9 @@
 			<arg value="-Ijni-headers"/>
 			<arg value="-Ijni-headers/${jniPlatform}"/>
 			<arg value="-I."/>
-						<arg value="-Ilibjpeg/"/>
+			<arg value="-Ilibjpeg/"/>
 			<arg value="-Igiflib/"/>
 			<arg value="-I../../../gdx/jni/gdx2d/"/>
-
 			<srcfile/>
 			<arg value="-o"/>
 			<targetfile/>
@@ -102,7 +114,7 @@
 	</target>	
 
 	<!-- links the shared library based on the previously compiled object files -->	
-	<target name="link" depends="compile">
+	<target name="link" depends="compile" if="has-compiler">
 		<mkdir dir="${libsDir}"/>
 		<apply failonerror="true" executable="${linker}" parallel="true" dir="${buildDir}">
 			<arg line="${linker-opts}"/>

--- a/extensions/gdx-image/jni/build-macosx32.xml
+++ b/extensions/gdx-image/jni/build-macosx32.xml
@@ -17,8 +17,7 @@
 	<property name="gcc-opts" value="-c -Wall -O2 -arch i386 -arch x86_64 -DFIXED_POINT -fmessage-length=0 -fPIC -mmacosx-version-min=10.5 -DHAVE_CONFIG_H"/>
 	<fileset id="gcc-files" dir="./">
 		<exclude name="target/"/>		
-				<include name="**/*.c"/>
-
+		<include name="**/*.c"/>
 		
 	</fileset>
 	
@@ -27,8 +26,7 @@
 	<property name="g++-opts" value="-c -Wall -O2 -arch i386 -arch x86_64 -DFIXED_POINT -fmessage-length=0 -fPIC -mmacosx-version-min=10.5"/>
 	<fileset id="g++-files" dir="./">
 		<exclude name="target/"/>
-				<include name="**/*.cpp"/>
-
+		<include name="**/*.cpp"/>
 		
 	</fileset>
 
@@ -45,10 +43,26 @@
 	</target>
 	
 	<target name="precompile">
-		
+                <condition property="compiler-found">
+                        <and>
+                                <or>
+                                        <!-- Windows might be either; Linux the first -->
+                                        <available file="${g++}" filepath="${env.PATH}"/>
+                                        <available file="${g++}" filepath="${env.Path}"/>
+                                </or>
+                                <or>
+                                        <!-- Windows might be either; Linux the first -->
+                                        <available file="${gcc}" filepath="${env.PATH}"/>
+                                        <available file="${gcc}" filepath="${env.Path}"/>
+                                </or>
+                        </and>
+                </condition>
+                <condition property="has-compiler">
+                        <equals arg1="${compiler-found}" arg2="true"/>
+                </condition>
 	</target>
 	
-	<target name="create-build-dir" depends="precompile">
+	<target name="create-build-dir" depends="precompile" if="has-compiler">
 		<!-- FIXME this is pretty nasty :/ -->
 		<copy todir="${buildDir}">
 			<fileset refid="g++-files"/>
@@ -63,17 +77,16 @@
 	</target>
 
 	<!-- compiles all C and C++ files to object files in the build directory -->
-	<target name="compile" depends="create-build-dir" >
+	<target name="compile" depends="create-build-dir" if="has-compiler">
 		<mkdir dir="${buildDir}"/>
 		<apply failonerror="true" executable="${g++}" dest="${buildDir}" verbose="true">
 			<arg line="${g++-opts}"/>
 			<arg value="-Ijni-headers"/>
 			<arg value="-Ijni-headers/${jniPlatform}"/>
 			<arg value="-I."/>
-						<arg value="-Ilibjpeg/"/>
+			<arg value="-Ilibjpeg/"/>
 			<arg value="-Igiflib/"/>
 			<arg value="-I../../../gdx/jni/gdx2d/"/>
-
 			<srcfile/>
 			<arg value="-o"/>
 			<targetfile/>
@@ -87,10 +100,9 @@
 			<arg value="-Ijni-headers"/>
 			<arg value="-Ijni-headers/${jniPlatform}"/>
 			<arg value="-I."/>
-						<arg value="-Ilibjpeg/"/>
+			<arg value="-Ilibjpeg/"/>
 			<arg value="-Igiflib/"/>
 			<arg value="-I../../../gdx/jni/gdx2d/"/>
-
 			<srcfile/>
 			<arg value="-o"/>
 			<targetfile/>
@@ -102,7 +114,7 @@
 	</target>	
 
 	<!-- links the shared library based on the previously compiled object files -->	
-	<target name="link" depends="compile">
+	<target name="link" depends="compile" if="has-compiler">
 		<mkdir dir="${libsDir}"/>
 		<apply failonerror="true" executable="${linker}" parallel="true" dir="${buildDir}">
 			<arg line="${linker-opts}"/>

--- a/extensions/gdx-image/jni/build-windows32.xml
+++ b/extensions/gdx-image/jni/build-windows32.xml
@@ -17,8 +17,7 @@
 	<property name="gcc-opts" value="-c -Wall -O2 -mfpmath=sse -msse2 -fmessage-length=0 -m32 -DHAVE_CONFIG_H"/>
 	<fileset id="gcc-files" dir="./">
 		<exclude name="target/"/>		
-				<include name="**/*.c"/>
-
+		<include name="**/*.c"/>
 		
 	</fileset>
 	
@@ -27,8 +26,7 @@
 	<property name="g++-opts" value="-c -Wall -O2 -mfpmath=sse -msse2 -fmessage-length=0 -m32"/>
 	<fileset id="g++-files" dir="./">
 		<exclude name="target/"/>
-				<include name="**/*.cpp"/>
-
+		<include name="**/*.cpp"/>
 		
 	</fileset>
 
@@ -45,10 +43,26 @@
 	</target>
 	
 	<target name="precompile">
-		
+                <condition property="compiler-found">
+                        <and>
+                                <or>
+                                        <!-- Windows might be either; Linux the first -->
+                                        <available file="${g++}" filepath="${env.PATH}"/>
+                                        <available file="${g++}" filepath="${env.Path}"/>
+                                </or>
+                                <or>
+                                        <!-- Windows might be either; Linux the first -->
+                                        <available file="${gcc}" filepath="${env.PATH}"/>
+                                        <available file="${gcc}" filepath="${env.Path}"/>
+                                </or>
+                        </and>
+                </condition>
+                <condition property="has-compiler">
+                        <equals arg1="${compiler-found}" arg2="true"/>
+                </condition>
 	</target>
 	
-	<target name="create-build-dir" depends="precompile">
+	<target name="create-build-dir" depends="precompile" if="has-compiler">
 		<!-- FIXME this is pretty nasty :/ -->
 		<copy todir="${buildDir}">
 			<fileset refid="g++-files"/>
@@ -63,17 +77,16 @@
 	</target>
 
 	<!-- compiles all C and C++ files to object files in the build directory -->
-	<target name="compile" depends="create-build-dir" >
+	<target name="compile" depends="create-build-dir" if="has-compiler">
 		<mkdir dir="${buildDir}"/>
 		<apply failonerror="true" executable="${g++}" dest="${buildDir}" verbose="true">
 			<arg line="${g++-opts}"/>
 			<arg value="-Ijni-headers"/>
 			<arg value="-Ijni-headers/${jniPlatform}"/>
 			<arg value="-I."/>
-						<arg value="-Ilibjpeg/"/>
+			<arg value="-Ilibjpeg/"/>
 			<arg value="-Igiflib/"/>
 			<arg value="-I../../../gdx/jni/gdx2d/"/>
-
 			<srcfile/>
 			<arg value="-o"/>
 			<targetfile/>
@@ -102,7 +115,7 @@
 	</target>	
 
 	<!-- links the shared library based on the previously compiled object files -->	
-	<target name="link" depends="compile">
+	<target name="link" depends="compile" if="has-compiler">
 		<mkdir dir="${libsDir}"/>
 		<apply failonerror="true" executable="${linker}" parallel="true" dir="${buildDir}">
 			<arg line="${linker-opts}"/>

--- a/extensions/gdx-image/jni/build-windows64.xml
+++ b/extensions/gdx-image/jni/build-windows64.xml
@@ -17,8 +17,7 @@
 	<property name="gcc-opts" value="-c -Wall -O2 -mfpmath=sse -msse2 -fmessage-length=0 -m64 -DHAVE_CONFIG_H"/>
 	<fileset id="gcc-files" dir="./">
 		<exclude name="target/"/>		
-				<include name="**/*.c"/>
-
+		<include name="**/*.c"/>
 		
 	</fileset>
 	
@@ -27,8 +26,7 @@
 	<property name="g++-opts" value="-c -Wall -O2 -mfpmath=sse -msse2 -fmessage-length=0 -m64"/>
 	<fileset id="g++-files" dir="./">
 		<exclude name="target/"/>
-				<include name="**/*.cpp"/>
-
+		<include name="**/*.cpp"/>
 		
 	</fileset>
 
@@ -45,10 +43,26 @@
 	</target>
 	
 	<target name="precompile">
-		
+                <condition property="compiler-found">
+                        <and>
+                                <or>
+                                        <!-- Windows might be either; Linux the first -->
+                                        <available file="${g++}" filepath="${env.PATH}"/>
+                                        <available file="${g++}" filepath="${env.Path}"/>
+                                </or>
+                                <or>
+                                        <!-- Windows might be either; Linux the first -->
+                                        <available file="${gcc}" filepath="${env.PATH}"/>
+                                        <available file="${gcc}" filepath="${env.Path}"/>
+                                </or>
+                        </and>
+                </condition>
+                <condition property="has-compiler">
+                        <equals arg1="${compiler-found}" arg2="true"/>
+                </condition>
 	</target>
 	
-	<target name="create-build-dir" depends="precompile">
+	<target name="create-build-dir" depends="precompile" if="has-compiler">
 		<!-- FIXME this is pretty nasty :/ -->
 		<copy todir="${buildDir}">
 			<fileset refid="g++-files"/>
@@ -63,17 +77,16 @@
 	</target>
 
 	<!-- compiles all C and C++ files to object files in the build directory -->
-	<target name="compile" depends="create-build-dir" >
+	<target name="compile" depends="create-build-dir" if="has-compiler">
 		<mkdir dir="${buildDir}"/>
 		<apply failonerror="true" executable="${g++}" dest="${buildDir}" verbose="true">
 			<arg line="${g++-opts}"/>
 			<arg value="-Ijni-headers"/>
 			<arg value="-Ijni-headers/${jniPlatform}"/>
 			<arg value="-I."/>
-						<arg value="-Ilibjpeg/"/>
+			<arg value="-Ilibjpeg/"/>
 			<arg value="-Igiflib/"/>
 			<arg value="-I../../../gdx/jni/gdx2d/"/>
-
 			<srcfile/>
 			<arg value="-o"/>
 			<targetfile/>
@@ -87,10 +100,9 @@
 			<arg value="-Ijni-headers"/>
 			<arg value="-Ijni-headers/${jniPlatform}"/>
 			<arg value="-I."/>
-						<arg value="-Ilibjpeg/"/>
+			<arg value="-Ilibjpeg/"/>
 			<arg value="-Igiflib/"/>
 			<arg value="-I../../../gdx/jni/gdx2d/"/>
-
 			<srcfile/>
 			<arg value="-o"/>
 			<targetfile/>
@@ -102,7 +114,7 @@
 	</target>	
 
 	<!-- links the shared library based on the previously compiled object files -->	
-	<target name="link" depends="compile">
+	<target name="link" depends="compile" if="has-compiler">
 		<mkdir dir="${libsDir}"/>
 		<apply failonerror="true" executable="${linker}" parallel="true" dir="${buildDir}">
 			<arg line="${linker-opts}"/>

--- a/extensions/gdx-tokamak/jni/build-linux32.xml
+++ b/extensions/gdx-tokamak/jni/build-linux32.xml
@@ -17,8 +17,7 @@
 	<property name="gcc-opts" value="-c -Wall -O2 -mfpmath=sse -msse -fmessage-length=0 -m32 -fPIC"/>
 	<fileset id="gcc-files" dir="./">
 		<exclude name="target/"/>		
-				<include name="**/*.c"/>
-
+		<include name="**/*.c"/>
 		
 	</fileset>
 	
@@ -27,9 +26,8 @@
 	<property name="g++-opts" value="-c -Wall -O2 -mfpmath=sse -msse -fmessage-length=0 -m32 -fPIC"/>
 	<fileset id="g++-files" dir="./">
 		<exclude name="target/"/>
-				<include name="**/*.cpp"/>
-
-				<exclude name="**/perfwin32.cpp"/>
+		<include name="**/*.cpp"/>
+		<exclude name="**/perfwin32.cpp"/>
 
 	</fileset>
 
@@ -46,10 +44,26 @@
 	</target>
 	
 	<target name="precompile">
-		
+                <condition property="compiler-found">
+                        <and>
+                                <or>
+                                        <!-- Windows might be either; Linux the first -->
+                                        <available file="${g++}" filepath="${env.PATH}"/>
+                                        <available file="${g++}" filepath="${env.Path}"/>
+                                </or>
+                                <or>
+                                        <!-- Windows might be either; Linux the first -->
+                                        <available file="${gcc}" filepath="${env.PATH}"/>
+                                        <available file="${gcc}" filepath="${env.Path}"/>
+                                </or>
+                        </and>
+                </condition>
+                <condition property="has-compiler">
+                        <equals arg1="${compiler-found}" arg2="true"/>
+                </condition>
 	</target>
 	
-	<target name="create-build-dir" depends="precompile">
+	<target name="create-build-dir" depends="precompile" if="has-compiler">
 		<!-- FIXME this is pretty nasty :/ -->
 		<copy todir="${buildDir}">
 			<fileset refid="g++-files"/>
@@ -64,16 +78,15 @@
 	</target>
 
 	<!-- compiles all C and C++ files to object files in the build directory -->
-	<target name="compile" depends="create-build-dir" >
+	<target name="compile" depends="create-build-dir" if="has-compiler">
 		<mkdir dir="${buildDir}"/>
 		<apply failonerror="true" executable="${g++}" dest="${buildDir}" verbose="true">
 			<arg line="${g++-opts}"/>
 			<arg value="-Ijni-headers"/>
 			<arg value="-Ijni-headers/${jniPlatform}"/>
 			<arg value="-I."/>
-						<arg value="-I."/>
+			<arg value="-I."/>
 			<arg value="-Itokamak/include"/>
-
 			<srcfile/>
 			<arg value="-o"/>
 			<targetfile/>
@@ -87,9 +100,8 @@
 			<arg value="-Ijni-headers"/>
 			<arg value="-Ijni-headers/${jniPlatform}"/>
 			<arg value="-I."/>
-						<arg value="-I."/>
+			<arg value="-I."/>
 			<arg value="-Itokamak/include"/>
-
 			<srcfile/>
 			<arg value="-o"/>
 			<targetfile/>
@@ -101,7 +113,7 @@
 	</target>	
 
 	<!-- links the shared library based on the previously compiled object files -->	
-	<target name="link" depends="compile">
+	<target name="link" depends="compile" if="has-compiler">
 		<mkdir dir="${libsDir}"/>
 		<apply failonerror="true" executable="${linker}" parallel="true" dir="${buildDir}">
 			<arg line="${linker-opts}"/>

--- a/extensions/gdx-tokamak/jni/build-linux64.xml
+++ b/extensions/gdx-tokamak/jni/build-linux64.xml
@@ -17,8 +17,7 @@
 	<property name="gcc-opts" value="-c -Wall -O2 -mfpmath=sse -msse -fmessage-length=0 -m64 -fPIC"/>
 	<fileset id="gcc-files" dir="./">
 		<exclude name="target/"/>		
-				<include name="**/*.c"/>
-
+		<include name="**/*.c"/>
 		
 	</fileset>
 	
@@ -27,9 +26,8 @@
 	<property name="g++-opts" value="-c -Wall -O2 -mfpmath=sse -msse -fmessage-length=0 -m64 -fPIC"/>
 	<fileset id="g++-files" dir="./">
 		<exclude name="target/"/>
-				<include name="**/*.cpp"/>
-
-				<exclude name="**/perfwin32.cpp"/>
+		<include name="**/*.cpp"/>
+		<exclude name="**/perfwin32.cpp"/>
 
 	</fileset>
 
@@ -46,10 +44,26 @@
 	</target>
 	
 	<target name="precompile">
-		
+                <condition property="compiler-found">
+                        <and>
+                                <or>
+                                        <!-- Windows might be either; Linux the first -->
+                                        <available file="${g++}" filepath="${env.PATH}"/>
+                                        <available file="${g++}" filepath="${env.Path}"/>
+                                </or>
+                                <or>
+                                        <!-- Windows might be either; Linux the first -->
+                                        <available file="${gcc}" filepath="${env.PATH}"/>
+                                        <available file="${gcc}" filepath="${env.Path}"/>
+                                </or>
+                        </and>
+                </condition>
+                <condition property="has-compiler">
+                        <equals arg1="${compiler-found}" arg2="true"/>
+                </condition>
 	</target>
 	
-	<target name="create-build-dir" depends="precompile">
+	<target name="create-build-dir" depends="precompile" if="has-compiler">
 		<!-- FIXME this is pretty nasty :/ -->
 		<copy todir="${buildDir}">
 			<fileset refid="g++-files"/>
@@ -64,16 +78,15 @@
 	</target>
 
 	<!-- compiles all C and C++ files to object files in the build directory -->
-	<target name="compile" depends="create-build-dir" >
+	<target name="compile" depends="create-build-dir" if="has-compiler">
 		<mkdir dir="${buildDir}"/>
 		<apply failonerror="true" executable="${g++}" dest="${buildDir}" verbose="true">
 			<arg line="${g++-opts}"/>
 			<arg value="-Ijni-headers"/>
 			<arg value="-Ijni-headers/${jniPlatform}"/>
 			<arg value="-I."/>
-						<arg value="-I."/>
+			<arg value="-I."/>
 			<arg value="-Itokamak/include"/>
-
 			<srcfile/>
 			<arg value="-o"/>
 			<targetfile/>
@@ -87,9 +100,8 @@
 			<arg value="-Ijni-headers"/>
 			<arg value="-Ijni-headers/${jniPlatform}"/>
 			<arg value="-I."/>
-						<arg value="-I."/>
+			<arg value="-I."/>
 			<arg value="-Itokamak/include"/>
-
 			<srcfile/>
 			<arg value="-o"/>
 			<targetfile/>
@@ -101,7 +113,7 @@
 	</target>	
 
 	<!-- links the shared library based on the previously compiled object files -->	
-	<target name="link" depends="compile">
+	<target name="link" depends="compile" if="has-compiler">
 		<mkdir dir="${libsDir}"/>
 		<apply failonerror="true" executable="${linker}" parallel="true" dir="${buildDir}">
 			<arg line="${linker-opts}"/>

--- a/extensions/gdx-tokamak/jni/build-macosx32.xml
+++ b/extensions/gdx-tokamak/jni/build-macosx32.xml
@@ -17,8 +17,7 @@
 	<property name="gcc-opts" value="-c -Wall -O2 -arch i386 -arch x86_64 -DFIXED_POINT -fmessage-length=0 -fPIC -mmacosx-version-min=10.5"/>
 	<fileset id="gcc-files" dir="./">
 		<exclude name="target/"/>		
-				<include name="**/*.c"/>
-
+		<include name="**/*.c"/>
 		
 	</fileset>
 	
@@ -27,9 +26,8 @@
 	<property name="g++-opts" value="-c -Wall -O2 -arch i386 -arch x86_64 -DFIXED_POINT -fmessage-length=0 -fPIC -mmacosx-version-min=10.5"/>
 	<fileset id="g++-files" dir="./">
 		<exclude name="target/"/>
-				<include name="**/*.cpp"/>
-
-				<exclude name="**/perfwin32.cpp"/>
+		<include name="**/*.cpp"/>
+		<exclude name="**/perfwin32.cpp"/>
 
 	</fileset>
 
@@ -46,10 +44,26 @@
 	</target>
 	
 	<target name="precompile">
-		
+                <condition property="compiler-found">
+                        <and>
+                                <or>
+                                        <!-- Windows might be either; Linux the first -->
+                                        <available file="${g++}" filepath="${env.PATH}"/>
+                                        <available file="${g++}" filepath="${env.Path}"/>
+                                </or>
+                                <or>
+                                        <!-- Windows might be either; Linux the first -->
+                                        <available file="${gcc}" filepath="${env.PATH}"/>
+                                        <available file="${gcc}" filepath="${env.Path}"/>
+                                </or>
+                        </and>
+                </condition>
+                <condition property="has-compiler">
+                        <equals arg1="${compiler-found}" arg2="true"/>
+                </condition>
 	</target>
 	
-	<target name="create-build-dir" depends="precompile">
+	<target name="create-build-dir" depends="precompile" if="has-compiler">
 		<!-- FIXME this is pretty nasty :/ -->
 		<copy todir="${buildDir}">
 			<fileset refid="g++-files"/>
@@ -64,16 +78,15 @@
 	</target>
 
 	<!-- compiles all C and C++ files to object files in the build directory -->
-	<target name="compile" depends="create-build-dir" >
+	<target name="compile" depends="create-build-dir" if="has-compiler">
 		<mkdir dir="${buildDir}"/>
 		<apply failonerror="true" executable="${g++}" dest="${buildDir}" verbose="true">
 			<arg line="${g++-opts}"/>
 			<arg value="-Ijni-headers"/>
 			<arg value="-Ijni-headers/${jniPlatform}"/>
 			<arg value="-I."/>
-						<arg value="-I."/>
+			<arg value="-I."/>
 			<arg value="-Itokamak/include"/>
-
 			<srcfile/>
 			<arg value="-o"/>
 			<targetfile/>
@@ -87,9 +100,8 @@
 			<arg value="-Ijni-headers"/>
 			<arg value="-Ijni-headers/${jniPlatform}"/>
 			<arg value="-I."/>
-						<arg value="-I."/>
+			<arg value="-I."/>
 			<arg value="-Itokamak/include"/>
-
 			<srcfile/>
 			<arg value="-o"/>
 			<targetfile/>
@@ -101,7 +113,7 @@
 	</target>	
 
 	<!-- links the shared library based on the previously compiled object files -->	
-	<target name="link" depends="compile">
+	<target name="link" depends="compile" if="has-compiler">
 		<mkdir dir="${libsDir}"/>
 		<apply failonerror="true" executable="${linker}" parallel="true" dir="${buildDir}">
 			<arg line="${linker-opts}"/>

--- a/extensions/gdx-tokamak/jni/build-windows32.xml
+++ b/extensions/gdx-tokamak/jni/build-windows32.xml
@@ -17,8 +17,7 @@
 	<property name="gcc-opts" value="-c -Wall -O2 -mfpmath=sse -msse2 -fmessage-length=0 -m32"/>
 	<fileset id="gcc-files" dir="./">
 		<exclude name="target/"/>		
-				<include name="**/*.c"/>
-
+		<include name="**/*.c"/>
 		
 	</fileset>
 	
@@ -27,9 +26,8 @@
 	<property name="g++-opts" value="-c -Wall -O2 -mfpmath=sse -msse2 -fmessage-length=0 -m32"/>
 	<fileset id="g++-files" dir="./">
 		<exclude name="target/"/>
-				<include name="**/*.cpp"/>
-
-				<exclude name="**/perflinux.cpp"/>
+		<include name="**/*.cpp"/>
+		<exclude name="**/perflinux.cpp"/>
 
 	</fileset>
 
@@ -46,10 +44,26 @@
 	</target>
 	
 	<target name="precompile">
-		
+                <condition property="compiler-found">
+                        <and>
+                                <or>
+                                        <!-- Windows might be either; Linux the first -->
+                                        <available file="${g++}" filepath="${env.PATH}"/>
+                                        <available file="${g++}" filepath="${env.Path}"/>
+                                </or>
+                                <or>
+                                        <!-- Windows might be either; Linux the first -->
+                                        <available file="${gcc}" filepath="${env.PATH}"/>
+                                        <available file="${gcc}" filepath="${env.Path}"/>
+                                </or>
+                        </and>
+                </condition>
+                <condition property="has-compiler">
+                        <equals arg1="${compiler-found}" arg2="true"/>
+                </condition>
 	</target>
 	
-	<target name="create-build-dir" depends="precompile">
+	<target name="create-build-dir" depends="precompile" if="has-compiler">
 		<!-- FIXME this is pretty nasty :/ -->
 		<copy todir="${buildDir}">
 			<fileset refid="g++-files"/>
@@ -64,16 +78,15 @@
 	</target>
 
 	<!-- compiles all C and C++ files to object files in the build directory -->
-	<target name="compile" depends="create-build-dir" >
+	<target name="compile" depends="create-build-dir" if="has-compiler">
 		<mkdir dir="${buildDir}"/>
 		<apply failonerror="true" executable="${g++}" dest="${buildDir}" verbose="true">
 			<arg line="${g++-opts}"/>
 			<arg value="-Ijni-headers"/>
 			<arg value="-Ijni-headers/${jniPlatform}"/>
 			<arg value="-I."/>
-						<arg value="-I."/>
+			<arg value="-I."/>
 			<arg value="-Itokamak/include"/>
-
 			<srcfile/>
 			<arg value="-o"/>
 			<targetfile/>
@@ -87,9 +100,8 @@
 			<arg value="-Ijni-headers"/>
 			<arg value="-Ijni-headers/${jniPlatform}"/>
 			<arg value="-I."/>
-						<arg value="-I."/>
+			<arg value="-I."/>
 			<arg value="-Itokamak/include"/>
-
 			<srcfile/>
 			<arg value="-o"/>
 			<targetfile/>
@@ -101,7 +113,7 @@
 	</target>	
 
 	<!-- links the shared library based on the previously compiled object files -->	
-	<target name="link" depends="compile">
+	<target name="link" depends="compile" if="has-compiler">
 		<mkdir dir="${libsDir}"/>
 		<apply failonerror="true" executable="${linker}" parallel="true" dir="${buildDir}">
 			<arg line="${linker-opts}"/>

--- a/extensions/gdx-tokamak/jni/build-windows64.xml
+++ b/extensions/gdx-tokamak/jni/build-windows64.xml
@@ -17,8 +17,7 @@
 	<property name="gcc-opts" value="-c -Wall -O2 -mfpmath=sse -msse2 -fmessage-length=0 -m64"/>
 	<fileset id="gcc-files" dir="./">
 		<exclude name="target/"/>		
-				<include name="**/*.c"/>
-
+		<include name="**/*.c"/>
 		
 	</fileset>
 	
@@ -27,9 +26,8 @@
 	<property name="g++-opts" value="-c -Wall -O2 -mfpmath=sse -msse2 -fmessage-length=0 -m64"/>
 	<fileset id="g++-files" dir="./">
 		<exclude name="target/"/>
-				<include name="**/*.cpp"/>
-
-				<exclude name="**/perflinux.cpp"/>
+		<include name="**/*.cpp"/>
+		<exclude name="**/perflinux.cpp"/>
 
 	</fileset>
 
@@ -46,10 +44,26 @@
 	</target>
 	
 	<target name="precompile">
-		
+                <condition property="compiler-found">
+                        <and>
+                                <or>
+                                        <!-- Windows might be either; Linux the first -->
+                                        <available file="${g++}" filepath="${env.PATH}"/>
+                                        <available file="${g++}" filepath="${env.Path}"/>
+                                </or>
+                                <or>
+                                        <!-- Windows might be either; Linux the first -->
+                                        <available file="${gcc}" filepath="${env.PATH}"/>
+                                        <available file="${gcc}" filepath="${env.Path}"/>
+                                </or>
+                        </and>
+                </condition>
+                <condition property="has-compiler">
+                        <equals arg1="${compiler-found}" arg2="true"/>
+                </condition>
 	</target>
 	
-	<target name="create-build-dir" depends="precompile">
+	<target name="create-build-dir" depends="precompile" if="has-compiler">
 		<!-- FIXME this is pretty nasty :/ -->
 		<copy todir="${buildDir}">
 			<fileset refid="g++-files"/>
@@ -64,16 +78,15 @@
 	</target>
 
 	<!-- compiles all C and C++ files to object files in the build directory -->
-	<target name="compile" depends="create-build-dir" >
+	<target name="compile" depends="create-build-dir" if="has-compiler">
 		<mkdir dir="${buildDir}"/>
 		<apply failonerror="true" executable="${g++}" dest="${buildDir}" verbose="true">
 			<arg line="${g++-opts}"/>
 			<arg value="-Ijni-headers"/>
 			<arg value="-Ijni-headers/${jniPlatform}"/>
 			<arg value="-I."/>
-						<arg value="-I."/>
+			<arg value="-I."/>
 			<arg value="-Itokamak/include"/>
-
 			<srcfile/>
 			<arg value="-o"/>
 			<targetfile/>
@@ -87,9 +100,8 @@
 			<arg value="-Ijni-headers"/>
 			<arg value="-Ijni-headers/${jniPlatform}"/>
 			<arg value="-I."/>
-						<arg value="-I."/>
+			<arg value="-I."/>
 			<arg value="-Itokamak/include"/>
-
 			<srcfile/>
 			<arg value="-o"/>
 			<targetfile/>
@@ -101,7 +113,7 @@
 	</target>	
 
 	<!-- links the shared library based on the previously compiled object files -->	
-	<target name="link" depends="compile">
+	<target name="link" depends="compile" if="has-compiler">
 		<mkdir dir="${libsDir}"/>
 		<apply failonerror="true" executable="${linker}" parallel="true" dir="${buildDir}">
 			<arg line="${linker-opts}"/>

--- a/gdx/jni/build-linux32.xml
+++ b/gdx/jni/build-linux32.xml
@@ -16,10 +16,8 @@
 	<property name="gcc" value="${compilerPrefix}gcc"/>	
 	<property name="gcc-opts" value="-c -Wall -O2 -mfpmath=sse -msse -fmessage-length=0 -m32 -fPIC"/>
 	<fileset id="gcc-files" dir="./">
-		<exclude name="target/"/>		
-				<include name="**/*.c"/>
-
-		
+		<exclude name="target/"/>
+		<include name="**/*.c"/>		
 	</fileset>
 	
 	<!-- define g++ compiler, options and files to compile -->
@@ -27,9 +25,7 @@
 	<property name="g++-opts" value="-c -Wall -O2 -mfpmath=sse -msse -fmessage-length=0 -m32 -fPIC"/>
 	<fileset id="g++-files" dir="./">
 		<exclude name="target/"/>
-				<include name="**/*.cpp"/>
-
-		
+		<include name="**/*.cpp"/>
 	</fileset>
 
 	<!-- define linker and options -->
@@ -45,10 +41,26 @@
 	</target>
 	
 	<target name="precompile">
-		
+                <condition property="compiler-found">
+                        <and>
+                                <or>
+                                        <!-- Windows might be either; Linux the first -->
+                                        <available file="${g++}" filepath="${env.PATH}"/>
+                                        <available file="${g++}" filepath="${env.Path}"/>
+                                </or>
+                                <or>
+                                        <!-- Windows might be either; Linux the first -->
+                                        <available file="${gcc}" filepath="${env.PATH}"/>
+                                        <available file="${gcc}" filepath="${env.Path}"/>
+                                </or>
+                        </and>
+                </condition>
+                <condition property="has-compiler">
+                        <equals arg1="${compiler-found}" arg2="true"/>
+                </condition>
 	</target>
 	
-	<target name="create-build-dir" depends="precompile">
+	<target name="create-build-dir" depends="precompile" if="has-compiler">
 		<!-- FIXME this is pretty nasty :/ -->
 		<copy todir="${buildDir}">
 			<fileset refid="g++-files"/>
@@ -63,7 +75,7 @@
 	</target>
 
 	<!-- compiles all C and C++ files to object files in the build directory -->
-	<target name="compile" depends="create-build-dir" >
+	<target name="compile" depends="create-build-dir" if="has-compiler">
 		<mkdir dir="${buildDir}"/>
 		<apply failonerror="true" executable="${g++}" dest="${buildDir}" verbose="true">
 			<arg line="${g++-opts}"/>
@@ -96,7 +108,7 @@
 	</target>	
 
 	<!-- links the shared library based on the previously compiled object files -->	
-	<target name="link" depends="compile">
+	<target name="link" depends="compile" if="has-compiler">
 		<mkdir dir="${libsDir}"/>
 		<apply failonerror="true" executable="${linker}" parallel="true" dir="${buildDir}">
 			<arg line="${linker-opts}"/>

--- a/gdx/jni/build-linux64.xml
+++ b/gdx/jni/build-linux64.xml
@@ -16,10 +16,8 @@
 	<property name="gcc" value="${compilerPrefix}gcc"/>	
 	<property name="gcc-opts" value="-c -Wall -O2 -mfpmath=sse -msse -fmessage-length=0 -m64 -fPIC"/>
 	<fileset id="gcc-files" dir="./">
-		<exclude name="target/"/>		
-				<include name="**/*.c"/>
-
-		
+		<exclude name="target/"/>
+		<include name="**/*.c"/>
 	</fileset>
 	
 	<!-- define g++ compiler, options and files to compile -->
@@ -27,9 +25,7 @@
 	<property name="g++-opts" value="-c -Wall -O2 -mfpmath=sse -msse -fmessage-length=0 -m64 -fPIC"/>
 	<fileset id="g++-files" dir="./">
 		<exclude name="target/"/>
-				<include name="**/*.cpp"/>
-
-		
+		<include name="**/*.cpp"/>
 	</fileset>
 
 	<!-- define linker and options -->
@@ -45,10 +41,26 @@
 	</target>
 	
 	<target name="precompile">
-		
+                <condition property="compiler-found">
+                        <and>
+                                <or>
+                                        <!-- Windows might be either; Linux the first -->
+                                        <available file="${g++}" filepath="${env.PATH}"/>
+                                        <available file="${g++}" filepath="${env.Path}"/>
+                                </or>
+                                <or>
+                                        <!-- Windows might be either; Linux the first -->
+                                        <available file="${gcc}" filepath="${env.PATH}"/>
+                                        <available file="${gcc}" filepath="${env.Path}"/>
+                                </or>
+                        </and>
+                </condition>
+                <condition property="has-compiler">
+                        <equals arg1="${compiler-found}" arg2="true"/>
+                </condition>
 	</target>
 	
-	<target name="create-build-dir" depends="precompile">
+	<target name="create-build-dir" depends="precompile" if="has-compiler">
 		<!-- FIXME this is pretty nasty :/ -->
 		<copy todir="${buildDir}">
 			<fileset refid="g++-files"/>
@@ -63,7 +75,7 @@
 	</target>
 
 	<!-- compiles all C and C++ files to object files in the build directory -->
-	<target name="compile" depends="create-build-dir" >
+	<target name="compile" depends="create-build-dir" if="has-compiler">
 		<mkdir dir="${buildDir}"/>
 		<apply failonerror="true" executable="${g++}" dest="${buildDir}" verbose="true">
 			<arg line="${g++-opts}"/>
@@ -96,7 +108,7 @@
 	</target>	
 
 	<!-- links the shared library based on the previously compiled object files -->	
-	<target name="link" depends="compile">
+	<target name="link" depends="compile" if="has-compiler">
 		<mkdir dir="${libsDir}"/>
 		<apply failonerror="true" executable="${linker}" parallel="true" dir="${buildDir}">
 			<arg line="${linker-opts}"/>

--- a/gdx/jni/build-macosx32.xml
+++ b/gdx/jni/build-macosx32.xml
@@ -16,10 +16,8 @@
 	<property name="gcc" value="${compilerPrefix}gcc"/>	
 	<property name="gcc-opts" value="-c -Wall -O2 -arch i386 -arch x86_64 -DFIXED_POINT -fmessage-length=0 -fPIC -mmacosx-version-min=10.5"/>
 	<fileset id="gcc-files" dir="./">
-		<exclude name="target/"/>		
-				<include name="**/*.c"/>
-
-		
+		<exclude name="target/"/>
+		<include name="**/*.c"/>
 	</fileset>
 	
 	<!-- define g++ compiler, options and files to compile -->
@@ -27,9 +25,7 @@
 	<property name="g++-opts" value="-c -Wall -O2 -arch i386 -arch x86_64 -DFIXED_POINT -fmessage-length=0 -fPIC -mmacosx-version-min=10.5"/>
 	<fileset id="g++-files" dir="./">
 		<exclude name="target/"/>
-				<include name="**/*.cpp"/>
-
-		
+		<include name="**/*.cpp"/>		
 	</fileset>
 
 	<!-- define linker and options -->
@@ -45,10 +41,26 @@
 	</target>
 	
 	<target name="precompile">
-		
+                <condition property="compiler-found">
+                        <and>
+                                <or>
+                                        <!-- Windows might be either; Linux the first -->
+                                        <available file="${g++}" filepath="${env.PATH}"/>
+                                        <available file="${g++}" filepath="${env.Path}"/>
+                                </or>
+                                <or>
+                                        <!-- Windows might be either; Linux the first -->
+                                        <available file="${gcc}" filepath="${env.PATH}"/>
+                                        <available file="${gcc}" filepath="${env.Path}"/>
+                                </or>
+                        </and>
+                </condition>
+                <condition property="has-compiler">
+                        <equals arg1="${compiler-found}" arg2="true"/>
+                </condition>
 	</target>
 	
-	<target name="create-build-dir" depends="precompile">
+	<target name="create-build-dir" depends="precompile" if="has-compiler">
 		<!-- FIXME this is pretty nasty :/ -->
 		<copy todir="${buildDir}">
 			<fileset refid="g++-files"/>
@@ -63,7 +75,7 @@
 	</target>
 
 	<!-- compiles all C and C++ files to object files in the build directory -->
-	<target name="compile" depends="create-build-dir" >
+	<target name="compile" depends="create-build-dir" if="has-compiler">
 		<mkdir dir="${buildDir}"/>
 		<apply failonerror="true" executable="${g++}" dest="${buildDir}" verbose="true">
 			<arg line="${g++-opts}"/>
@@ -96,7 +108,7 @@
 	</target>	
 
 	<!-- links the shared library based on the previously compiled object files -->	
-	<target name="link" depends="compile">
+	<target name="link" depends="compile" if="has-compiler">
 		<mkdir dir="${libsDir}"/>
 		<apply failonerror="true" executable="${linker}" parallel="true" dir="${buildDir}">
 			<arg line="${linker-opts}"/>

--- a/gdx/jni/build-windows32.xml
+++ b/gdx/jni/build-windows32.xml
@@ -16,10 +16,8 @@
 	<property name="gcc" value="${compilerPrefix}gcc"/>	
 	<property name="gcc-opts" value="-c -Wall -O2 -mfpmath=sse -msse2 -fmessage-length=0 -m32"/>
 	<fileset id="gcc-files" dir="./">
-		<exclude name="target/"/>		
-				<include name="**/*.c"/>
-
-		
+		<exclude name="target/"/>
+		<include name="**/*.c"/>
 	</fileset>
 	
 	<!-- define g++ compiler, options and files to compile -->
@@ -27,9 +25,7 @@
 	<property name="g++-opts" value="-c -Wall -O2 -mfpmath=sse -msse2 -fmessage-length=0 -m32"/>
 	<fileset id="g++-files" dir="./">
 		<exclude name="target/"/>
-				<include name="**/*.cpp"/>
-
-		
+		<include name="**/*.cpp"/>
 	</fileset>
 
 	<!-- define linker and options -->
@@ -45,10 +41,26 @@
 	</target>
 	
 	<target name="precompile">
-		
+                <condition property="compiler-found">
+                        <and>
+                                <or>
+                                        <!-- Windows might be either; Linux the first -->
+                                        <available file="${g++}" filepath="${env.PATH}"/>
+                                        <available file="${g++}" filepath="${env.Path}"/>
+                                </or>
+                                <or>
+                                        <!-- Windows might be either; Linux the first -->
+                                        <available file="${gcc}" filepath="${env.PATH}"/>
+                                        <available file="${gcc}" filepath="${env.Path}"/>
+                                </or>
+                        </and>
+                </condition>
+                <condition property="has-compiler">
+                        <equals arg1="${compiler-found}" arg2="true"/>
+                </condition>
 	</target>
 	
-	<target name="create-build-dir" depends="precompile">
+	<target name="create-build-dir" depends="precompile" if="has-compiler">
 		<!-- FIXME this is pretty nasty :/ -->
 		<copy todir="${buildDir}">
 			<fileset refid="g++-files"/>
@@ -63,7 +75,7 @@
 	</target>
 
 	<!-- compiles all C and C++ files to object files in the build directory -->
-	<target name="compile" depends="create-build-dir" >
+	<target name="compile" depends="create-build-dir" if="has-compiler">
 		<mkdir dir="${buildDir}"/>
 		<apply failonerror="true" executable="${g++}" dest="${buildDir}" verbose="true">
 			<arg line="${g++-opts}"/>
@@ -96,7 +108,7 @@
 	</target>	
 
 	<!-- links the shared library based on the previously compiled object files -->	
-	<target name="link" depends="compile">
+	<target name="link" depends="compile" if="has-compiler">
 		<mkdir dir="${libsDir}"/>
 		<apply failonerror="true" executable="${linker}" parallel="true" dir="${buildDir}">
 			<arg line="${linker-opts}"/>

--- a/gdx/jni/build-windows64.xml
+++ b/gdx/jni/build-windows64.xml
@@ -16,10 +16,8 @@
 	<property name="gcc" value="${compilerPrefix}gcc"/>	
 	<property name="gcc-opts" value="-c -Wall -O2 -mfpmath=sse -msse2 -fmessage-length=0 -m64"/>
 	<fileset id="gcc-files" dir="./">
-		<exclude name="target/"/>		
-				<include name="**/*.c"/>
-
-		
+		<exclude name="target/"/>
+		<include name="**/*.c"/>
 	</fileset>
 	
 	<!-- define g++ compiler, options and files to compile -->
@@ -27,9 +25,7 @@
 	<property name="g++-opts" value="-c -Wall -O2 -mfpmath=sse -msse2 -fmessage-length=0 -m64"/>
 	<fileset id="g++-files" dir="./">
 		<exclude name="target/"/>
-				<include name="**/*.cpp"/>
-
-		
+		<include name="**/*.cpp"/>
 	</fileset>
 
 	<!-- define linker and options -->
@@ -45,10 +41,26 @@
 	</target>
 	
 	<target name="precompile">
-		
+                <condition property="compiler-found">
+                        <and>
+                                <or>
+                                        <!-- Windows might be either; Linux the first -->
+                                        <available file="${g++}" filepath="${env.PATH}"/>
+                                        <available file="${g++}" filepath="${env.Path}"/>
+                                </or>
+                                <or>
+                                        <!-- Windows might be either; Linux the first -->
+                                        <available file="${gcc}" filepath="${env.PATH}"/>
+                                        <available file="${gcc}" filepath="${env.Path}"/>
+                                </or>
+                        </and>
+                </condition>
+                <condition property="has-compiler">
+                        <equals arg1="${compiler-found}" arg2="true"/>
+                </condition>
 	</target>
 	
-	<target name="create-build-dir" depends="precompile">
+	<target name="create-build-dir" depends="precompile" if="has-compiler">
 		<!-- FIXME this is pretty nasty :/ -->
 		<copy todir="${buildDir}">
 			<fileset refid="g++-files"/>
@@ -63,7 +75,7 @@
 	</target>
 
 	<!-- compiles all C and C++ files to object files in the build directory -->
-	<target name="compile" depends="create-build-dir" >
+	<target name="compile" depends="create-build-dir" if="has-compiler">
 		<mkdir dir="${buildDir}"/>
 		<apply failonerror="true" executable="${g++}" dest="${buildDir}" verbose="true">
 			<arg line="${g++-opts}"/>
@@ -96,7 +108,7 @@
 	</target>	
 
 	<!-- links the shared library based on the previously compiled object files -->	
-	<target name="link" depends="compile">
+	<target name="link" depends="compile" if="has-compiler">
 		<mkdir dir="${libsDir}"/>
 		<apply failonerror="true" executable="${linker}" parallel="true" dir="${buildDir}">
 			<arg line="${linker-opts}"/>


### PR DESCRIPTION
The native libraries have their own build.xml files for each platform (Windows 64, Windows 32, Linux 32, etc.)  When I tried to run the native lib build using:

ant -Denv.NDK_HOME=/opt/android-ndk-r8b -Dbuild-natives=true

the build failed when it reached a compiler I didn't have available/configured to cross-compile on my machine.

What I decided to do was to change all the native lib build files to check for the existence of the compiler (i586-mingw32msvc-gcc, etc.) and to skip that particular part of the build if it couldn't find that compiler on the system.  This shouldn't cause problems for systems that have a compiler configured, but should just avoid unnecessary failures when trying to build for only a particular platform.  It seems like a good idea to me, but I'm completely new to libgdx (just finding my way) so may be missing some particular nuance of the build. Fwiw, thought I'd pass it back upstream for review.

I also made some minor formatting tweaks in the build files' XML (removed unusual formatting in the XML just out of habit -- sorry that pollutes the patch a bit).  Overall, it's the same pattern applied to each of the native/jni build files.
