### PR TITLE
Changed build templates to skip a native build if the necessary compiler is missing

### DIFF
--- a/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/resources/scripts/build-android.xml.template
+++ b/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/resources/scripts/build-android.xml.template
@@ -1,22 +1,31 @@
 <project name="android-natives" basedir="." default="postcompile">
 	<property environment="env" />
 
-	<target name="clean">
+	<target name="clean" depends="check-for-ndk" if="has-ndk-build">
 		<exec executable="${env.NDK_HOME}/ndk-build" failonerror="true">
 			<arg value="clean"/>
 		</exec>
 	</target>
 
-	<target name="precompile">
+	<target name="precompile" depends="check-for-ndk">
 		%precompile%
 	</target>
 
-	<target name="compile-natives" depends="precompile">
+	<target name="compile-natives" depends="precompile" if="has-ndk-build">
 		<echo>ndk_home: ${env.NDK_HOME}</echo>
 		<exec executable="${env.NDK_HOME}/ndk-build" failonerror="true"/>
 	</target>
 	
 	<target name="postcompile" depends="compile-natives">
 		%postcompile%
+	</target>
+
+	<target name="check-for-ndk">
+		<condition property="ndk-build-found">
+			<available file="ndk_build" filepath="${env.NDK_HOME}"/>
+		</condition>
+		<condition property="has-ndk-build">
+			<equals arg1="${ndk-build-found}" arg2="true"/>
+		</condition>
 	</target>
 </project>

--- a/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/resources/scripts/build-target.xml.template
+++ b/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/resources/scripts/build-target.xml.template
@@ -43,10 +43,27 @@
 	</target>
 	
 	<target name="precompile">
+		<condition property="compiler-found">
+			<and>
+				<or>
+					<!-- Include both b/c Windows might be either -->
+					<available file="${g++}" filepath="${env.PATH}"/>
+					<available file="${g++}" filepath="${env.Path}"/>
+				</or>
+				<or>
+					<!-- Include both b/c Windows might be either -->
+					<available file="${gcc}" filepath="${env.PATH}"/>
+					<available file="${gcc}" filepath="${env.Path}"/>
+				</or>
+			</and>
+		</condition>
+		<condition property="has-compiler">
+			<equals arg1="${compiler-found}" arg2="true"/>
+		</condition>
 		%precompile%
 	</target>
 	
-	<target name="create-build-dir" depends="precompile">
+	<target name="create-build-dir" depends="precompile" if="has-compiler">
 		<!-- FIXME this is pretty nasty :/ -->
 		<copy todir="${buildDir}">
 			<fileset refid="g++-files"/>
@@ -61,7 +78,7 @@
 	</target>
 
 	<!-- compiles all C and C++ files to object files in the build directory -->
-	<target name="compile" depends="create-build-dir" >
+	<target name="compile" depends="create-build-dir" if="has-compiler">
 		<mkdir dir="${buildDir}"/>
 		<apply failonerror="true" executable="${g++}" dest="${buildDir}" verbose="true">
 			<arg line="${g++-opts}"/>
@@ -94,7 +111,7 @@
 	</target>	
 
 	<!-- links the shared library based on the previously compiled object files -->	
-	<target name="link" depends="compile">
+	<target name="link" depends="compile" if="has-compiler">
 		<mkdir dir="${libsDir}"/>
 		<apply failonerror="true" executable="${linker}" parallel="true" dir="${buildDir}">
 			<arg line="${linker-opts}"/>


### PR DESCRIPTION
Modifications to the native build templates that will allow the build process to skip any build that depends on a compiler that isn't present on the system. These are just the changed template files, not the changed build files that are generated as a result of running the GdxBuild (and related) scripts.  We'll see if the build server blows up?
