### PR TITLE
Fixed Decal setRotation.

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g3d/decals/Decal.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/decals/Decal.java
@@ -107,7 +107,7 @@ public class Decal {
 	public void setRotation (Vector3 dir, Vector3 up) {
 		tmp.set(up).crs(dir).nor();
 		tmp2.set(dir).crs(tmp).nor();
-		rotation.setFromAxes(tmp.x, tmp.y, tmp.z, tmp2.x, tmp2.y, tmp2.z, dir.x, dir.y, dir.z);
+		rotation.setFromAxes(tmp.x, tmp2.x, dir.x, tmp.y, tmp2.y, dir.y, tmp.z, tmp2.z, dir.z);
 		updated = false;
 	}
 


### PR DESCRIPTION
Changed due to fix in Quaternion#setFromAxis.
