### PR TITLE
Use accessor methods in Button#draw and TextButton#draw

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Button.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Button.java
@@ -175,11 +175,11 @@ public class Button extends Table {
 			offsetX = style.pressedOffsetX;
 			offsetY = style.pressedOffsetY;
 		} else {
-			if (isDisabled && style.disabled != null)
+			if (isDisabled() && style.disabled != null)
 				background = style.disabled;
-			else if (isChecked && style.checked != null)
+			else if (isChecked() && style.checked != null)
 				background = style.checked;
-			else if (clickListener.isOver() && style.over != null)
+			else if (isOver() && style.over != null)
 				background = style.over;
 			else
 				background = style.up;

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextButton.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextButton.java
@@ -69,11 +69,11 @@ public class TextButton extends Button {
 
 	public void draw (SpriteBatch batch, float parentAlpha) {
 		Color fontColor;
-		if (isDisabled && style.disabledFontColor != null)
+		if (isDisabled() && style.disabledFontColor != null)
 			fontColor = style.disabledFontColor;
 		else if (isPressed() && style.downFontColor != null)
 			fontColor = style.downFontColor;
-		else if (isChecked && style.checkedFontColor != null)
+		else if (isChecked() && style.checkedFontColor != null)
 			fontColor = style.checkedFontColor;
 		else if (isOver() && style.overFontColor != null)
 			fontColor = style.overFontColor;


### PR DESCRIPTION
I wanted to disable the isOver style for a single TextButton. The easiest way seems to be by overwriting #isOver to always return false. However this was ignored in #draw.

Even if this is not the preferred usage there is currently some inconsistency in using either the private field or the accessor, or the accessor of the clicklistener.
