### PR TITLE
gdx.net: first set of changes!

### DIFF
--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglNet.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglNet.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *	 http://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,6 +23,7 @@ import com.badlogic.gdx.net.Socket;
 import com.badlogic.gdx.net.SocketHints;
 
 public class LwjglNet implements Net {
+	
 	@Override
 	public HttpResult httpGet (String url, String... parameters) {
 		throw new UnsupportedOperationException("Not implemented");
@@ -35,11 +36,11 @@ public class LwjglNet implements Net {
 
 	@Override
 	public ServerSocket newServerSocket (Protocol protocol, int port, ServerSocketHints hints) {
-		throw new UnsupportedOperationException("Not implemented");
+		return new LwjglServerSocket(protocol, port, hints);
 	}
-
+	
 	@Override
 	public Socket newClientSocket (Protocol protocol, String host, int port, SocketHints hints) {
-		throw new UnsupportedOperationException("Not implemented");
+		return new LwjglSocket(protocol, host, port, hints);
 	}
 }

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglServerSocket.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglServerSocket.java
@@ -1,0 +1,84 @@
+package com.badlogic.gdx.backends.lwjgl;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+
+import com.badlogic.gdx.Net.Protocol;
+import com.badlogic.gdx.net.ServerSocket;
+import com.badlogic.gdx.net.ServerSocketHints;
+import com.badlogic.gdx.net.Socket;
+import com.badlogic.gdx.net.SocketHints;
+import com.badlogic.gdx.utils.GdxRuntimeException;
+
+/**
+ * Server socket implementation using java.net.ServerSocket.
+ * 
+ * @author noblemaster
+ */
+public class LwjglServerSocket implements ServerSocket {
+
+	private Protocol protocol;
+	
+	/** Our server or null for disposed, aka closed. */
+	private java.net.ServerSocket server;
+	
+	
+	public LwjglServerSocket(Protocol protocol, int port, ServerSocketHints hints) {
+		this.protocol = protocol;
+		
+		// create the server socket
+		try {
+			// initialize
+			server = new java.net.ServerSocket();
+			if (hints != null) {
+				server.setPerformancePreferences(hints.performancePrefConnectionTime, 
+															hints.performancePrefLatency, 
+															hints.performancePrefBandwidth);
+				server.setReuseAddress(hints.reuseAddress);
+				server.setSoTimeout(hints.acceptTimeout);
+				server.setReceiveBufferSize(hints.receiveBufferSize);
+			}
+			
+			// and bind the server...
+			InetSocketAddress address = new InetSocketAddress(port);
+			if (hints != null) {
+				server.bind(address, hints.backlog);
+			}
+			else {
+				server.bind(address);
+			}
+		}
+		catch (Exception e) {
+			throw new GdxRuntimeException("Cannot create a server socket at port " + port + ".", e);
+		}
+	}
+
+	@Override
+	public Protocol getProtocol () {
+		return protocol;
+	}
+
+	@Override
+	public Socket accept(SocketHints hints) {
+		try {
+			return new LwjglSocket(server.accept(), hints);
+		}
+		catch (Exception e) {
+			throw new GdxRuntimeException("Error accepting socket.", e);
+		}
+	}
+
+	@Override
+	public void dispose() {
+		if (server != null) {
+			try {
+				server.close();
+				server = null;
+			}
+			catch (Exception e) {
+				throw new GdxRuntimeException("Error closing server.", e);
+			}
+		}
+	}
+}

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglSocket.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglSocket.java
@@ -1,0 +1,110 @@
+package com.badlogic.gdx.backends.lwjgl;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+
+import com.badlogic.gdx.Net.Protocol;
+import com.badlogic.gdx.net.ServerSocketHints;
+import com.badlogic.gdx.net.Socket;
+import com.badlogic.gdx.net.SocketHints;
+import com.badlogic.gdx.utils.GdxRuntimeException;
+
+/**
+ * Socket implementation using java.net.Socket.
+ * 
+ * @author noblemaster
+ */
+public class LwjglSocket implements Socket {
+
+	/** Our socket or null for disposed, aka closed. */
+	private java.net.Socket socket;
+	
+	
+	public LwjglSocket(Protocol protocol, String host, int port, SocketHints hints) {
+		try {
+			// create the socket
+			socket = new java.net.Socket();
+			applyHints(hints);  // better to call BEFORE socket is connected!
+			
+			// and connect...
+			InetSocketAddress address = new InetSocketAddress(host, port);
+			if (hints != null) {
+				socket.connect(address, hints.connectTimeout);
+			}
+			else {
+				socket.connect(address);
+			}
+		}
+		catch (Exception e) {
+			throw new GdxRuntimeException("Error making a socket connection to " + host + ":" + port, e);
+		}
+	}
+	
+	public LwjglSocket(java.net.Socket socket, SocketHints hints) {
+		this.socket = socket;
+		applyHints(hints);
+	}
+	
+	private void applyHints(SocketHints hints) {
+		if (hints != null) {
+			try {	
+				socket.setPerformancePreferences(hints.performancePrefConnectionTime, 
+					 										hints.performancePrefLatency, 
+					 										hints.performancePrefBandwidth);
+				socket.setTrafficClass(hints.trafficClass);
+				socket.setTcpNoDelay(hints.tcpNoDelay);
+				socket.setKeepAlive(hints.keepAlive);
+				socket.setSendBufferSize(hints.sendBufferSize);
+				socket.setReceiveBufferSize(hints.receiveBufferSize);
+				socket.setSoLinger(hints.linger, hints.lingerDuration);
+			}
+			catch (Exception e) {
+				throw new GdxRuntimeException("Error setting socket hints." , e);
+			}
+		}
+	}
+	
+	@Override
+	public boolean isConnected () {
+		if (socket != null) {
+			return socket.isConnected();
+		}
+		else {
+			return false;
+		}
+	}
+
+	@Override
+	public InputStream getInputStream () {
+		try {
+			return socket.getInputStream();
+		}
+		catch (Exception e) {
+			throw new GdxRuntimeException("Error getting input stream from socket.", e);
+		}
+	}
+
+	@Override
+	public OutputStream getOutputStream () {
+		try {
+			return socket.getOutputStream();
+		}
+		catch (Exception e) {
+			throw new GdxRuntimeException("Error getting output stream from socket.", e);
+		}
+	}
+
+	@Override
+	public void dispose() {
+		if (socket != null) {
+			try {
+				socket.close();
+				socket = null;
+			}
+			catch (Exception e) {
+				throw new GdxRuntimeException("Error closing socket.", e);
+			}
+		}
+	}
+}

--- a/gdx/src/com/badlogic/gdx/Net.java
+++ b/gdx/src/com/badlogic/gdx/Net.java
@@ -44,9 +44,10 @@ import com.badlogic.gdx.utils.GdxRuntimeException;
  * that waits for an incoming connection.
  * 
  * @author mzechner
- *
+ * @author noblemaster
  */
 public interface Net {
+	
 	/**
 	 * {@link Future} like interface used with the HTTP get
 	 * and post methods. Allows to cancel the operation, 
@@ -130,7 +131,8 @@ public interface Net {
 	 * waiting for incoming connections.
 	 * 
 	 * @param port the port to listen on
-	 * @param hints additional {@link ServerSocketHints} used to create the socket
+	 * @param hints additional {@link ServerSocketHints} used to create the socket. Input null to
+	 *        use the default setting provided by the system.
 	 * @return the {@link ServerSocket}
 	 * @throws GdxRuntimeException in case the socket couldn't be opened
 	 */
@@ -141,7 +143,8 @@ public interface Net {
 	 * 
 	 * @param host the host address
 	 * @param port the port
-	 * @param hints additional {@link SocketHints} used to create the socket
+	 * @param hints additional {@link SocketHints} used to create the socket. Input null to
+	 *        use the default setting provided by the system.
 	 * @return GdxRuntimeException in case the socket couldn't be opened
 	 */
 	public Socket newClientSocket(Protocol protocol, String host, int port, SocketHints hints);

--- a/gdx/src/com/badlogic/gdx/net/ServerSocket.java
+++ b/gdx/src/com/badlogic/gdx/net/ServerSocket.java
@@ -16,6 +16,7 @@
 package com.badlogic.gdx.net;
 
 import com.badlogic.gdx.Net.Protocol;
+import com.badlogic.gdx.utils.Disposable;
 import com.badlogic.gdx.utils.GdxRuntimeException;
 
 /**
@@ -24,9 +25,10 @@ import com.badlogic.gdx.utils.GdxRuntimeException;
  * should preferably be called in a separate thread as it is blocking.
  * 
  * @author mzechner
- *
+ * @author noblemaster
  */
-public interface ServerSocket {
+public interface ServerSocket extends Disposable {
+	
 	/**
 	 * @return the Protocol used by this socket
 	 */
@@ -37,7 +39,8 @@ public interface ServerSocket {
 	 * given hints will be applied to the accepted socket. Blocking, call
 	 * on a separate thread.
 	 * 
-	 * @param hints additional {@link SocketHints} applied to the accepted {@link Socket}
+	 * @param hints additional {@link SocketHints} applied to the accepted {@link Socket}. Input null to
+	 *        use the default setting provided by the system.
 	 * @return the accepted {@link Socket}
 	 * @throws GdxRuntimeException in case an error ocurred
 	 */

--- a/gdx/src/com/badlogic/gdx/net/ServerSocketHints.java
+++ b/gdx/src/com/badlogic/gdx/net/ServerSocketHints.java
@@ -17,9 +17,33 @@ package com.badlogic.gdx.net;
 
 /**
  * Options for {@link ServerSocket} instances.
+ * 
  * @author mzechner
- *
+ * @author noblemaster 
  */
 public class ServerSocketHints {
 
+	/** The listen backlog length. Needs to be greater than 0, otherwise the default is used. */
+	public int backlog = 16;
+	
+	/**
+	 * Performance preferences are described by three integers whose values indicate the relative 
+	 * importance of short connection time, low latency, and high bandwidth. The absolute 
+	 * values of the integers are irrelevant; in order to choose a protocol the values are 
+	 * simply compared, with larger values indicating stronger preferences. 
+	 * Negative values represent a lower priority than positive values. If the application 
+	 * prefers short connection time over both low latency and high bandwidth, for example, 
+	 * then it could invoke this method with the values (1, 0, 0). If the application 
+	 * prefers high bandwidth above low latency, and low latency above short connection 
+	 * time, then it could invoke this method with the values (0, 1, 2).
+	 */
+	public int performancePrefConnectionTime = 0;
+	public int performancePrefLatency = 1;   // low latency
+	public int performancePrefBandwidth = 0;
+	/** Enable/disable the SO_REUSEADDR socket option. */
+	public boolean reuseAddress = true;
+	/** The SO_TIMEOUT in milliseconds for how long to wait during server.accept(). Enter 0 for infinite wait. */
+	public int acceptTimeout = 5000;
+	/** The SO_RCVBUF (receive buffer) size in bytes for server.accept(). */
+	public int receiveBufferSize = 4096;
 }

--- a/gdx/src/com/badlogic/gdx/net/SocketHints.java
+++ b/gdx/src/com/badlogic/gdx/net/SocketHints.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *	 http://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,9 +17,52 @@ package com.badlogic.gdx.net;
 
 /**
  * Options for {@link Socket} instances.
+ * 
  * @author mzechner
- *
+ * @author noblemaster
  */
 public class SocketHints {
 
+	/** The connection timeout in milliseconds. Not used for sockets created via server.accept(). */
+	public int connectTimeout = 5000;
+	
+	/**
+	 * Performance preferences are described by three integers whose values indicate the relative 
+	 * importance of short connection time, low latency, and high bandwidth. The absolute 
+	 * values of the integers are irrelevant; in order to choose a protocol the values are 
+	 * simply compared, with larger values indicating stronger preferences. 
+	 * Negative values represent a lower priority than positive values. If the application 
+	 * prefers short connection time over both low latency and high bandwidth, for example, 
+	 * then it could invoke this method with the values (1, 0, 0). If the application 
+	 * prefers high bandwidth above low latency, and low latency above short connection 
+	 * time, then it could invoke this method with the values (0, 1, 2).
+	 */
+	public int performancePrefConnectionTime = 0;
+	public int performancePrefLatency = 1;   // low latency
+	public int performancePrefBandwidth = 0;
+	/**
+	 * The traffic class describes the type of connection that shall be established.  
+	 * The traffic class must be in the range 0 <= trafficClass <= 255.
+	 * <p>
+	 * The traffic class is bitset created by bitwise-or'ing values such the following :
+ 	 *  <ul>
+	 *    <li>IPTOS_LOWCOST (0x02) - cheap!
+	 *    <li>IPTOS_RELIABILITY (0x04) - reliable connection with little package loss.
+	 *    <li>IPTOS_THROUGHPUT (0x08) - lots of data being sent.
+	 *    <li>IPTOS_LOWDELAY (0x10) - low delay.
+	 *  </ul>
+	 */
+	public int trafficClass = 0x14;   // low delay + reliable
+	/** True to enable  SO_KEEPALIVE. */
+	public boolean keepAlive = true;
+	/** True to enable TCP_NODELAY (disable/enable Nagle's algorithm). */ 
+	public boolean tcpNoDelay = true;
+	/** The SO_SNDBUF (send buffer) size in bytes. */
+	public int sendBufferSize = 4096;
+	/** The SO_RCVBUF (receive buffer) size in bytes. */
+	public int receiveBufferSize = 4096;
+	/** Enable/disable SO_LINGER with the specified linger time in seconds. Only affects socket close. */
+	public boolean linger = false;
+	/** The linger duration in seconds (NOT milliseconds!). Only used if linger is true! */
+	public int lingerDuration = 0;
 }


### PR DESCRIPTION
Here are my first set of changes for cross-platform networking on libgdx. I implemented the socket connection functionality over java.net.*. 

Request for feedback:

1) not sure about naming all those hint variables. I wonder what Mono uses? My naming matches what Java offers though but they seem quite inconsistent with the TCP specs. Sometimes following the TCP specs naming convention, other times not? Sometimes it's called "soTimeout", sometimes just "timeout". Anyhow, I followed the Java naming, the only thing I didn't follow was the soTimeout (server hints). I think calling it "acceptTimeout" is a lot clearer? 

2) I implemented the classes for the LWJGL backend. This will be the exact same for Android. How would I go about that without producing duplicate code? 

3) we should add a newServerSocket/newClientSocket without the hints? No hints meaning to use the platform defaults. I already check if hints if null and if it is null it will simply use the defaults on the platform.

4) not sure what "backlog" means (server hints)?

Please note I haven't tested it at all (sorry, didn't have time yet). It should compile just fine. Not sure if you should merge it just yet? I am mainly posting it to gather some feedback.
