### PR TITLE
Stop LwjglApplication when not running

### DIFF
--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglApplication.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglApplication.java
@@ -151,6 +151,11 @@ public class LwjglApplication implements Application {
 					}
 				}
 			}
+			
+			// if one of the runnables set running in false, for example after an exit().
+			if (!running)
+				break;
+			
 			input.update();
 			shouldRender |= graphics.shouldRender();
 


### PR DESCRIPTION
Just a modification inside the main loop, if running is false after the runnables were processed then the while should stop. In some cases, if the loop is not stopped it could lead to errors since the application could be in a non stable state.

The commit is mainly a suggestion, could be implemented in other nicer ways.
