### PR TITLE
Avoid unnecesary calls to renderMesh() in both enableBlending and disableBlending if blending was already enabled/disabled.

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g2d/SpriteBatch.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/SpriteBatch.java
@@ -1068,12 +1068,16 @@ public class SpriteBatch implements Disposable {
 
 	/** Disables blending for drawing sprites. */
 	public void disableBlending () {
+		if (blendingDisabled)
+			return;
 		renderMesh();
 		blendingDisabled = true;
 	}
 
 	/** Enables blending for sprites */
 	public void enableBlending () {
+		if (!blendingDisabled)
+			return;
 		renderMesh();
 		blendingDisabled = false;
 	}


### PR DESCRIPTION
The commit log says the idea:

"modified SpriteBatch enableBlending() and disableBlending() methods to check if blendingDisabled was disabled or enabled, respectively, to perform the renderMesh() or not, so two consecutive calls to enableBlending/disableBlending will not perform a renderMesh() call"
