### PR TITLE
Fixed infinite loop in GWTApplication postRunnable 

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplication.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplication.java
@@ -65,6 +65,7 @@ public abstract class GwtApplication implements EntryPoint, Application {
 	private TextArea log = null;
 	private int logLevel = LOG_ERROR;
 	private Array<Runnable> runnables = new Array<Runnable>();
+	private Array<Runnable> runnablesHelper = new Array<Runnable>();
 	private int lastWidth, lastHeight;
 	private Preloader preloader;
 	private static AgentInfo agentInfo;
@@ -187,10 +188,12 @@ public abstract class GwtApplication implements EntryPoint, Application {
 						lastHeight = graphics.getHeight();
 						Gdx.gl.glViewport(0, 0, lastWidth, lastHeight);
 					}
-					for (int i = 0; i < runnables.size; i++) {
-						runnables.get(i).run();
-					}
+					runnablesHelper.addAll(runnables);
 					runnables.clear();
+					for (int i = 0; i < runnablesHelper.size; i++) {
+						runnablesHelper.get(i).run();
+					}
+					runnablesHelper.clear();					
 					listener.render();
 					input.justTouched = false;
 				} catch (Throwable t) {


### PR DESCRIPTION
GWTApplication fell into an infinite loop whenever postRunnable was called from a Runnable (the runnable queue never ended)
