### PR TITLE
Deprecated Android SDK constant

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplication.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplication.java
@@ -282,7 +282,7 @@ public class AndroidApplication extends Activity implements Application {
 	/** {@inheritDoc} */
 	@Override
 	public int getVersion () {
-		return Integer.parseInt(android.os.Build.VERSION.SDK);
+		return Integer.parseInt(android.os.Build.VERSION.SDK_INT);
 	}
 
 	@Override


### PR DESCRIPTION
SDK_INT available since API 4 (Android 1.6), so, it's not a problem for compatibility (as i know libgdx is not support android less than 1.6)
