### PR TITLE
added missing SetMaxLength wrapper for b2RopeJoint

### DIFF
--- a/gdx/jni/com.badlogic.gdx.physics.box2d.joints.RopeJoint.cpp
+++ b/gdx/jni/com.badlogic.gdx.physics.box2d.joints.RopeJoint.cpp
@@ -14,3 +14,14 @@
 
 }
 
+JNIEXPORT jfloat JNICALL Java_com_badlogic_gdx_physics_box2d_joints_RopeJoint_jniSetMaxLength(JNIEnv* env, jobject object, jlong addr, jfloat length) {
+
+
+//@line:51
+
+		b2RopeJoint* rope = (b2RopeJoint*)addr;
+		rope->SetMaxLength(length);
+	
+
+}
+

--- a/gdx/jni/com.badlogic.gdx.physics.box2d.joints.RopeJoint.h
+++ b/gdx/jni/com.badlogic.gdx.physics.box2d.joints.RopeJoint.h
@@ -15,6 +15,14 @@ extern "C" {
 JNIEXPORT jfloat JNICALL Java_com_badlogic_gdx_physics_box2d_joints_RopeJoint_jniGetMaxLength
   (JNIEnv *, jobject, jlong);
 
+/*
+ * Class:     com_badlogic_gdx_physics_box2d_joints_RopeJoint
+ * Method:    jniSetMaxLength
+ * Signature: (JF)F
+ */
+JNIEXPORT jfloat JNICALL Java_com_badlogic_gdx_physics_box2d_joints_RopeJoint_jniSetMaxLength
+  (JNIEnv *, jobject, jlong, jfloat);
+
 #ifdef __cplusplus
 }
 #endif

--- a/gdx/src/com/badlogic/gdx/physics/box2d/joints/RopeJoint.java
+++ b/gdx/src/com/badlogic/gdx/physics/box2d/joints/RopeJoint.java
@@ -42,4 +42,14 @@ public class RopeJoint extends Joint {
 		b2RopeJoint* rope = (b2RopeJoint*)addr;
 		return rope->GetMaxLength();
 	*/
+
+	/** Set the maximum length of the rope. */
+	public void setMaxLength (float length) {
+		jniSetMaxLength(addr, length);
+	}
+
+	private native float jniSetMaxLength (long addr, float length); /*
+		b2RopeJoint* rope = (b2RopeJoint*)addr;
+		rope->SetMaxLength(length);
+	*/
 }


### PR DESCRIPTION
After some tinkering, I managed to build this by running the "gdx" project from Eclipse choosing GdxBuild for the main class, then running "ant -DbuildNatives=true". It appears to work, even!
