### PR TITLE
spelling error: Simultanious -> Simultaneous

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplicationConfiguration.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplicationConfiguration.java
@@ -53,13 +53,13 @@ public class AndroidApplicationConfiguration {
 	 * to your manifest file. default: false */
 	public boolean useWakelock = false;
 
-	/** hide status bar buttons on Android 4.x and higher (API 14+). Doesn't work if "android:targetSdkVersion" less 11 or if
-	 * API less 14. default: false **/
+	/** hide status bar buttons on Android 4.x and higher (API 14+). Doesn't work if "android:targetSdkVersion" less 11 or if API
+	 * less 14. default: false **/
 	public boolean hideStatusBar = false;
 
-	/** the maximum number of {@link Sound} instances that can be played simultaniously, sets the corresponding {@link SoundPool}
+	/** the maximum number of {@link Sound} instances that can be played simultaneously, sets the corresponding {@link SoundPool}
 	 * constructor argument. */
-	public int maxSimultaniousSounds = 16;
+	public int maxSimultaneousSounds = 16;
 
 	/** the {@link ResolutionStrategy}. default: {@link FillResolutionStrategy} **/
 	public ResolutionStrategy resolutionStrategy = new FillResolutionStrategy();

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidAudio.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidAudio.java
@@ -40,12 +40,12 @@ import com.badlogic.gdx.utils.GdxRuntimeException;
  * 
  * @author mzechner */
 public final class AndroidAudio implements Audio {
-	private SoundPool soundPool;
+	private final SoundPool soundPool;
 	private final AudioManager manager;
 	protected final List<AndroidMusic> musics = new ArrayList<AndroidMusic>();
 
 	public AndroidAudio (Activity context, AndroidApplicationConfiguration config) {
-		soundPool = new SoundPool(config.maxSimultaniousSounds, AudioManager.STREAM_MUSIC, 100);
+		soundPool = new SoundPool(config.maxSimultaneousSounds, AudioManager.STREAM_MUSIC, 100);
 		manager = (AudioManager)context.getSystemService(Context.AUDIO_SERVICE);
 		context.setVolumeControlStream(AudioManager.STREAM_MUSIC);
 	}


### PR DESCRIPTION
A simple spelling error, but it is visible in the public API.
