### PR TITLE
Issue 1091: Render on resize, half fix

### DIFF
--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGraphics.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGraphics.java
@@ -444,7 +444,7 @@ public class LwjglGraphics implements Graphics {
 		synchronized (this) {
 			boolean rq = requestRendering;
 			requestRendering = false;
-			return rq || isContinuous;
+			return rq || isContinuous || Display.isDirty();
 		}
 	}
 


### PR DESCRIPTION
...jglGraphics.java

Half fix of Issue 1091:    Render on resize.
Will now render when the window becomes dirty, usually when the window gets moved or when the window gets resized bigger.

I am not too sure how to get the condition for resizing without calling Display.update constantly, as that method updates Display.wasResized()
