### PR TITLE
Proposed fix for issue 1099.

### DIFF
--- a/gdx/src/com/badlogic/gdx/utils/Pools.java
+++ b/gdx/src/com/badlogic/gdx/utils/Pools.java
@@ -34,7 +34,7 @@ public class Pools {
 
 	/** Obtains an object from the {@link #get(Class) pool}. */
 	static public <T> T obtain (Class<T> type) {
-		return (T)get(type).obtain();
+		return get(type).obtain();
 	}
 
 	/** Frees an object from the {@link #get(Class) pool}. */


### PR DESCRIPTION
Remove the method Pools#free(Array) since the method is currently unused (accept by accident).
If you do want to keep this method around it could be renamed to Pools#freeAll(Array) or similar.
