### PR TITLE
Rename Array#free(Array) to Array#freeAll() (Fix for issue 1099)

### DIFF
--- a/gdx/src/com/badlogic/gdx/utils/Pools.java
+++ b/gdx/src/com/badlogic/gdx/utils/Pools.java
@@ -46,8 +46,8 @@ public class Pools {
 		pool.free(object);
 	}
 
-	/** Frees the specified objects from the {@link #get(Class) pool}. */
-	static public void free (Array objects) {
+	/** Frees the contained objects from the {@link #get(Class) pool}. */
+	static public void freeAll (Array objects) {
 		if (objects == null) throw new IllegalArgumentException("objects cannot be null.");
 		for (int i = 0, n = objects.size; i < n; i++) {
 			Object object = objects.get(i);


### PR DESCRIPTION
Alright, if the method is deemed useful, can we rename it?
