### PR TITLE
Fixed scene2d Group to avoid calling begin/end when not needed

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/Group.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/Group.java
@@ -180,9 +180,7 @@ public class Group extends Actor implements Cullable {
 	/** Restores the SpriteBatch transform to what it was before {@link #applyTransform(SpriteBatch, Matrix4)}. Note this causes the
 	 * batch to be flushed. */
 	protected void resetTransform (SpriteBatch batch) {
-		batch.end();
 		batch.setTransformMatrix(oldBatchTransform);
-		batch.begin();
 	}
 
 	/** Children completely outside of this rectangle will not be drawn. This is only valid for use with unrotated and unscaled


### PR DESCRIPTION
Group was calling batch.begin() and batch.end() when applying a transform or reseting a transform. That wasn't needed since batch.setTransform() already calls flush() and renders everything that was waiting to be rendered. 

Also, we get an improvement since a lot of bind/unbind of the current shader of the batch and changes of the opengl state is avoided. 

Already tested, but please give it a second review if you can. 

Thanks.
