### PR TITLE
!B - Fixes broken references between level XML and atlas

### DIFF
--- a/tests/gdx-tests-android/assets/data/gleedtest.xml
+++ b/tests/gdx-tests-android/assets/data/gleedtest.xml
@@ -455,7 +455,7 @@
             <string>data/braid</string>
         </Property>
         <Property Name="atlas" Type="string" Description="">
-            <string>data/tiles.txt</string>
+            <string>data/gleedtiles.txt</string>
         </Property>
     </CustomProperties>
     <EditorRelated>

--- a/tests/gdx-tests-android/assets/data/gleedtiles.txt
+++ b/tests/gdx-tests-android/assets/data/gleedtiles.txt
@@ -1,4 +1,4 @@
-tiles.png
+gleed.png
 format: RGBA8888
 filter: Linear,Linear
 repeat: none

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/extensions/GLEEDTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/extensions/GLEEDTest.java
@@ -35,6 +35,7 @@ public class GLEEDTest extends GdxTest {
 		manager = new AssetManager();
 		camera = new OrthographicCamera(640, 480);
 		camera.setToOrtho(false, 640, 480);
+		camera.zoom = 2.0f;
 		LevelLoader.setLoggingLevel(Logger.INFO);
 		manager.setLoader(Level.class, new LevelLoader(new InternalFileHandleResolver()));
 		manager.load("data/gleedtest.xml", Level.class);
@@ -54,24 +55,24 @@ public class GLEEDTest extends GdxTest {
 			renderer.render(camera);
 			
 			if (Gdx.input.isKeyPressed(Keys.UP)) {
-				camera.position.y += 0.2f;
+				camera.position.y += 5.0f;
 			}
 			else if (Gdx.input.isKeyPressed(Keys.DOWN)) {
-				camera.position.y -= 0.2f;
+				camera.position.y -= 5.0f;
 			}
 			
 			if (Gdx.input.isKeyPressed(Keys.RIGHT)) {
-				camera.position.x += 0.2f;
+				camera.position.x += 5.0f;
 			}
 			else if (Gdx.input.isKeyPressed(Keys.LEFT)) {
-				camera.position.x -= 0.2f;
+				camera.position.x -= 5.0f;
 			}
 			
 			if (Gdx.input.isKeyPressed(Keys.A)) {
-				camera.zoom += 0.2f;
+				camera.zoom += 0.05f;
 			}
 			else if (Gdx.input.isKeyPressed(Keys.S)) {
-				camera.zoom -= 0.2f;
+				camera.zoom -= 0.05f;
 			}
 		}
 	}


### PR DESCRIPTION
Don't worry about the absolute paths in the GLEED XML file, the tool does that. That's why you need to specify the atlas file or the textures folder as a custom property. The problem, as you can see, is that I messed up in the naming.

Sorry about that, it's working nicely now.
