### PR TITLE
getRotation for livewallpaper

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidInput.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidInput.java
@@ -701,12 +701,7 @@ public class AndroidInput implements Input, OnKeyListener, OnTouchListener {
 		if (context instanceof Activity) {
 			orientation = ((Activity) context).getWindowManager().getDefaultDisplay().getOrientation();
 		} else {
-			final DisplayMetrics metrics = new DisplayMetrics();
-			final Display display = ((WindowManager) context.getSystemService(Context.WINDOW_SERVICE)).getDefaultDisplay();
-
-			display.getMetrics(metrics);
-
-			orientation = display.getOrientation();
+			orientation = ((WindowManager) context.getSystemService(Context.WINDOW_SERVICE)).getDefaultDisplay().getOrientation();
 		}
 
 		switch (orientation) {


### PR DESCRIPTION
But it's little bit buggy, don't know why.
If you place your device to 0 degrees position (portraite orientation) 
and rotate to 180 degrees, nothing be detected, or from 90 to 270 and 
versa. But if you rotate your device from 0 to 90 or 270, or from 90 
to 180 and 0 and so on - all is fine (different orientations).
