### PR TITLE
Fix touch events for LWP on Android API <9

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidLiveWallpaperService.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidLiveWallpaperService.java
@@ -85,11 +85,9 @@ public abstract class AndroidLiveWallpaperService extends WallpaperService {
 			this.app.initialize(listener, config);
 			this.listener = listener;
 			this.view = ((AndroidGraphicsLiveWallpaper)app.getGraphics()).getView();
-			// FIXME this seems to crash on ICS, and is unnecessary it seems if you
-			// overwrite onTouchEvent
-//			if(config.getTouchEventsForLiveWallpaper) {
-//				this.setTouchEventsEnabled(true);
-//			}
+
+			if (config.getTouchEventsForLiveWallpaper && Integer.parseInt(android.os.Build.VERSION.SDK) < 9)
+				this.setTouchEventsEnabled(true);
 		}
 
 		@Override


### PR DESCRIPTION
Without this fix HTC Hero with 2.2.1 does not respond touch events.
In removed "FIXME" comment stated about crash on ICS - i check it on the ICS 4.0.3 and all works, but anyway - i add SDK check. On the LG P990 with 2.3.5 no problems without SDK check. And works on the Samsung S5670 with 2.3.6. So, hope it's usefull.
