### PR TITLE
Make Game#setScreen accept null

### DIFF
--- a/gdx/src/com/badlogic/gdx/Game.java
+++ b/gdx/src/com/badlogic/gdx/Game.java
@@ -59,8 +59,8 @@ public abstract class Game implements ApplicationListener {
 		if (this.screen != null) this.screen.hide();
 		this.screen = screen;
 		if (this.screen != null) {
-			screen.show();
-			screen.resize(Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+			this.screen.show();
+			this.screen.resize(Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
 		}
 	}
 


### PR DESCRIPTION
It starts out with screen == null, so it's silly that it's not possible to get back to that state.

Use case: I have a method that cleans up (disposes) a Screen without knowing which Screen will be next. Naturally, I don't want any references lying around to a disposed screen.
