### PR TITLE
Fixed bug that broke ScrollPane.setupFadeScrollBars

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ScrollPane.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ScrollPane.java
@@ -260,8 +260,8 @@ public class ScrollPane extends WidgetGroup {
 		boolean panning = flickScrollListener.getGestureDetector().isPanning();
 
 		if (fadeAlpha > 0 && fadeScrollBars && !panning && !touchScrollH && !touchScrollV) {
-			fadeDelay -= fadeDelaySeconds * delta;
-			if (fadeDelay <= 0) fadeAlpha = Math.max(0, fadeAlpha - fadeAlphaSeconds * delta);
+			fadeDelay -= delta;
+			if (fadeDelay <= 0) fadeAlpha = Math.max(0, fadeAlpha - delta);
 		}
 
 		if (flingTimer > 0) {


### PR DESCRIPTION
ScrollPane contains a small bug in its act method which effectively forces the fade delay and fade alpha to 1 second regardless of their intended values.
