### PR TITLE
Convenience methods for Dialog

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Dialog.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Dialog.java
@@ -119,6 +119,11 @@ public class Dialog extends Window {
 		return button(new TextButton(text, buttonStyle), object);
 	}
 
+	/** Adds the given button to the button table. */
+	public Dialog button (Button button) {
+		return button(button, null);
+	}
+
 	/** Adds the given button to the button table.
 	 * @param object The object that will be passed to {@link #result(Object)} if this button is clicked. May be null. */
 	public Dialog button (Button button, Object object) {


### PR DESCRIPTION
I wanted to add ImageButtons and a Label with Align.center to the dialog. It's possible to do this by using #getContentTable() and #getButtonTable() but I suspect this is common enough to warrant an additional method.
