### PR TITLE
Simple typo fixed in Color Colour

### DIFF
--- a/extensions/model-loaders/model-loaders/src/com/badlogic/gdx/graphics/g3d/materials/ColorAttribute.java
+++ b/extensions/model-loaders/model-loaders/src/com/badlogic/gdx/graphics/g3d/materials/ColorAttribute.java
@@ -37,7 +37,7 @@ public class ColorAttribute extends MaterialAttribute {
 
 	/** Creates a {@link MaterialAttribute} that is a pure {@link Color}.
 	 * 
-	 * @param color The {@link Colour} that you wish the attribute to represent.
+	 * @param color The {@link Color} that you wish the attribute to represent.
 	 * @param name The name of the uniform in the {@link ShaderProgram} that will have its value set to this color. (A 'name' does
 	 *           not matter for a game that uses {@link GL10}). */
 	public ColorAttribute (Color color, String name) {


### PR DESCRIPTION
The link doesn't work because colour doesn't exist, however Color does.

I know they are both valid names for colour, however the existing @link doesn't work with Colour
