### PR TITLE
Just added dispose() code to WaterRipples example

### DIFF
--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/WaterRipples.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/WaterRipples.java
@@ -60,6 +60,17 @@ public class WaterRipples extends GdxTest implements InputProcessor {
 	float[] vertices;
 
 	@Override
+	public void dispose () {
+		super.dispose();
+		mesh.dispose();
+		mesh = null;
+		batch.dispose();
+		batch = null;
+		texture.dispose();
+		texture = null;
+	}
+
+	@Override
 	public void create () {
 
 		camera = new PerspectiveCamera(90, Gdx.graphics.getWidth(), Gdx.graphics.getWidth());


### PR DESCRIPTION
Added dispose() code to WaterRipples example to dispose the mesh, texture and batch (not) used.
