### PR TITLE
Matrix4/Quaternion saving some cpu cycles on rotations

### DIFF
--- a/gdx/src/com/badlogic/gdx/math/Matrix4.java
+++ b/gdx/src/com/badlogic/gdx/math/Matrix4.java
@@ -506,8 +506,10 @@ public class Matrix4 implements Serializable {
 	 * @param angle The angle in degrees
 	 * @return This matrix for the purpose of chaining methods together. */
 	public Matrix4 setToRotation (Vector3 axis, float angle) {
-		idt();
-		if (angle == 0) return this;
+		if (angle == 0) {
+			idt();
+			return this;
+		}
 		return set(quat.set(axis, angle));
 	}
 
@@ -519,8 +521,10 @@ public class Matrix4 implements Serializable {
 	 * @param angle The angle in degrees
 	 * @return This matrix for the purpose of chaining methods together. */
 	public Matrix4 setToRotation (float axisX, float axisY, float axisZ, float angle) {
-		idt();
-		if (angle == 0) return this;
+		if (angle == 0) {
+			idt();
+			return this;
+		}
 		return set(quat.set(tmpV.set(axisX, axisY, axisZ), angle));
 	}
 
@@ -533,7 +537,7 @@ public class Matrix4 implements Serializable {
 	 * @return This matrix */
 	public Matrix4 setFromEulerAngles (float yaw, float pitch, float roll) {
 		quat.setEulerAngles(yaw, pitch, roll);
-		return idt().set(quat);
+		return set(quat);
 	}
 
 	/** Sets this matrix to a scaling matrix

--- a/gdx/src/com/badlogic/gdx/math/Quaternion.java
+++ b/gdx/src/com/badlogic/gdx/math/Quaternion.java
@@ -127,10 +127,15 @@ public class Quaternion implements Serializable {
 		float num7 = yaw * 0.5f;
 		float num2 = (float)Math.sin(num7);
 		float num = (float)Math.cos(num7);
-		x = ((num * num4) * num5) + ((num2 * num3) * num6);
-		y = ((num2 * num3) * num5) - ((num * num4) * num6);
-		z = ((num * num3) * num6) - ((num2 * num4) * num5);
-		w = ((num * num3) * num5) + ((num2 * num4) * num6);
+		float f1 = num * num4;
+		float f2 = num2 * num3;
+		float f3 = num * num3;
+		float f4 = num2 * num4;
+
+		x = (f1 * num5) + (f2 * num6);
+		y = (f2 * num5) - (f1 * num6);
+		z = (f3 * num6) - (f4 * num5);
+		w = (f3 * num5) + (f4 * num6);
 		return this;
 	}
 


### PR DESCRIPTION
1. Setting identity first on Matrix4.setToRotation/setFromEulerAngles is redundant because values are overwritten when setting from quaternion.
2. Some multiplications can be saved on Quaternion.setEulerAngles
