### PR TITLE
Fix for a bug when calling isPreview() inside the Engine constructor

### DIFF
--- a/tests/gdx-tests-android/src/com/badlogic/gdx/tests/android/LiveWallpaper.java
+++ b/tests/gdx-tests-android/src/com/badlogic/gdx/tests/android/LiveWallpaper.java
@@ -1,19 +1,15 @@
 package com.badlogic.gdx.tests.android;
 
-import com.badlogic.gdx.ApplicationAdapter;
 import com.badlogic.gdx.ApplicationListener;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.backends.android.AndroidApplicationConfiguration;
 import com.badlogic.gdx.backends.android.AndroidLiveWallpaperService;
-import com.badlogic.gdx.graphics.GL10;
-import com.badlogic.gdx.math.MathUtils;
-import com.badlogic.gdx.tests.Box2DTest;
 import com.badlogic.gdx.tests.MeshShaderTest;
-import com.badlogic.gdx.tests.WaterRipples;
 
 public class LiveWallpaper extends AndroidLiveWallpaperService {
+	
 	@Override
-	public ApplicationListener createListener (boolean isPreview) {
+	public ApplicationListener createListener () {
 		return new MeshShaderTest();
 	}
 


### PR DESCRIPTION
It seems that isPreview() cant be called inside the Engine constructor since some stuff wasn't initialized yet. The pull request suggest another way by implementing an optional interface PreviewListener (not the best name I know) so if the listener implements it, then it is called by the Service after Engine was created.
