### PR TITLE
Custom Onscreen keyboard must know current focused TextField.

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextField.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextField.java
@@ -129,13 +129,13 @@ public class TextField extends Widget {
 			public boolean touchDown (InputEvent event, float x, float y, int pointer, int button) {
 				if (!super.touchDown(event, x, y, pointer, button)) return false;
 				if (pointer == 0 && button != 0) return false;
-				if (disabled) return true;
-				keyboard.show(true);
+				if (disabled) return true;				
 				clearSelection();
 				setCursorPosition(x);
 				selectionStart = cursor;
 				Stage stage = getStage();
 				if (stage != null) stage.setKeyboardFocus(TextField.this);
+				keyboard.show(true);
 				return true;
 			}
 


### PR DESCRIPTION
When onscreen keyboard show it must know current focused TextField.
