### PR TITLE
Adds missing ParticleEffect.flipY() to GWT backend, issue #1163

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/graphics/g2d/ParticleEffect.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/graphics/g2d/ParticleEffect.java
@@ -99,6 +99,11 @@ public class ParticleEffect implements Disposable {
 			emitters.get(i).setFlip(flipX, flipY);
 	}
 
+	public void flipY () {
+		for (int i = 0, n = emitters.size; i < n; i++)
+			emitters.get(i).flipY();
+	}
+
 	public Array<ParticleEmitter> getEmitters () {
 		return emitters;
 	}


### PR DESCRIPTION
ParticlEffect.flipY() is not implemented in the gwt backend, this commit adds it.

http://code.google.com/p/libgdx/issues/detail?id=1163
