### PR TITLE
Docu update: glReadPixel(…) for GWT backend

### DIFF
--- a/backends/gdx-backends-gwt/issues.txt
+++ b/backends/gdx-backends-gwt/issues.txt
@@ -5,7 +5,6 @@ DIFFERENCES TO MAIN APIs/UNSUSPECTED BEHAVIOUR
 - getters are not implemented, some are not supported by WebGL
 - uniform location id allocation returns multiple ids if one queries for one uniform multiple times. Not an issue as long
   as you don't start comparing those ids to each other.
-- glReadPixels does not work.
 
 [GwtInput]
 - mapping of a couple of (minor) keys is bad, see FIXMEs

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtGL20.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtGL20.java
@@ -360,10 +360,10 @@ public class GwtGL20 implements GL20 {
 	public void glReadPixels (int x, int y, int width, int height, int format, int type, Buffer pixels) {
 		// verify request
 		if ((format != WebGLRenderingContext.RGBA) || (type != WebGLRenderingContext.UNSIGNED_BYTE)) {
-			throw new GdxRuntimeException("Only format UNSIGNED_BYTE for type RGBA is currently supported.");
+			throw new GdxRuntimeException("Only format RGBA and type UNSIGNED_BYTE are currently supported for glReadPixels(...).");
 		}
 		if (!(pixels instanceof ByteBuffer)) {
-			throw new GdxRuntimeException("Inputed pixels buffer needs to be of type ByteBuffer.");
+			throw new GdxRuntimeException("Inputed pixels buffer needs to be of type ByteBuffer for glReadPixels(...).");
 		}
 		
 		// create new ArrayBufferView (4 bytes per pixel)


### PR DESCRIPTION
I have tested glReadPixel(...) for the GWT backend. Fully working :-D

Anyhow, this is just some minor documentation update. Thanks.
