### PR TITLE
Enhance WindowedMean performance

### DIFF
--- a/gdx/src/com/badlogic/gdx/math/WindowedMean.java
+++ b/gdx/src/com/badlogic/gdx/math/WindowedMean.java
@@ -55,9 +55,9 @@ public final class WindowedMean {
 	 * @param value The value to add */
 	public void addValue (float value) {
 		added_values++;
+		mean += (value - values[last_value]) / values.length;
 		values[last_value++] = value;
 		if (last_value > values.length - 1) last_value = 0;
-		dirty = true;
 	}
 
 	/** returns the mean of the samples added to this instance. only returns meaningfull results when at least window_size samples


### PR DESCRIPTION
calculate mean incremental in addValue to avoid going through all values to update the mean on each getMean() after a value was added.
