### PR TITLE
Added getFailureReason to Gdx2DPixmap

### DIFF
--- a/gdx/jni/com.badlogic.gdx.graphics.g2d.Gdx2DPixmap.cpp
+++ b/gdx/jni/com.badlogic.gdx.graphics.g2d.Gdx2DPixmap.cpp
@@ -167,3 +167,10 @@ JNIEXPORT void JNICALL Java_com_badlogic_gdx_graphics_g2d_Gdx2DPixmap_setScale(J
 
 }
 
+JNIEXPORT jstring JNICALL Java_com_badlogic_gdx_graphics_g2d_Gdx2DPixmap_getFailureReason(JNIEnv* env, jclass clazz) {
+
+  //@line:325
+  
+                return env->NewStringUTF8(env, gdx2d_get_failure_reason(void));
+
+}

--- a/gdx/jni/com.badlogic.gdx.graphics.g2d.Gdx2DPixmap.h
+++ b/gdx/jni/com.badlogic.gdx.graphics.g2d.Gdx2DPixmap.h
@@ -139,6 +139,14 @@ JNIEXPORT void JNICALL Java_com_badlogic_gdx_graphics_g2d_Gdx2DPixmap_setBlend
 JNIEXPORT void JNICALL Java_com_badlogic_gdx_graphics_g2d_Gdx2DPixmap_setScale
   (JNIEnv *, jclass, jint);
 
+  /*
+   * Class:     com_badlogic_gdx_graphics_g2d_Gdx2DPixmap
+   * Method:    getFailureReason
+   * Signature: (V)S
+   */
+JNIEXPORT jstring JNICALL Java_com_badlogic_gdx_graphics_g2d_Gdx2DPixmap_getFailureReason
+  (JNIEnv *, jclass);
+
 #ifdef __cplusplus
 }
 #endif

--- a/gdx/jni/gdx2d/gdx2d.c
+++ b/gdx/jni/gdx2d/gdx2d.c
@@ -274,6 +274,10 @@ void gdx2d_set_scale (uint32_t scale) {
 	gdx2d_scale = scale;
 }
 
+const char *gdx2d_get_failure_reason(void) {
+  return stbi_failure_reason(void);
+}
+
 static inline void clear_alpha(const gdx2d_pixmap* pixmap, uint32_t col) {
 	int pixels = pixmap->width * pixmap->height;
 	memset((void*)pixmap->pixels, col, pixels);

--- a/gdx/jni/gdx2d/gdx2d.h
+++ b/gdx/jni/gdx2d/gdx2d.h
@@ -73,6 +73,7 @@ JNIEXPORT void 		 gdx2d_free (const gdx2d_pixmap* pixmap);
 JNIEXPORT void gdx2d_set_blend	  (uint32_t blend);
 JNIEXPORT void gdx2d_set_scale	  (uint32_t scale);
 
+JNIEXPORT const char*   gdx2d_get_failure_reason(void);
 JNIEXPORT void		gdx2d_clear	   	  (const gdx2d_pixmap* pixmap, uint32_t col);
 JNIEXPORT void		gdx2d_set_pixel   (const gdx2d_pixmap* pixmap, int32_t x, int32_t y, uint32_t col);
 JNIEXPORT uint32_t gdx2d_get_pixel	  (const gdx2d_pixmap* pixmap, int32_t x, int32_t y);

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/Gdx2DPixmap.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/Gdx2DPixmap.java
@@ -54,7 +54,7 @@ public class Gdx2DPixmap implements Disposable {
 
 	public Gdx2DPixmap (byte[] encodedData, int offset, int len, int requestedFormat) throws IOException {
 		pixelPtr = load(nativeData, encodedData, offset, len, requestedFormat);
-		if (pixelPtr == null) throw new IOException("couldn't load pixmap");
+		if (pixelPtr == null) throw new IOException("couldn't load pixmap " + getFailureReason());
 
 		basePtr = nativeData[0];
 		width = (int)nativeData[1];
@@ -73,7 +73,7 @@ public class Gdx2DPixmap implements Disposable {
 
 		buffer = bytes.toByteArray();
 		pixelPtr = load(nativeData, buffer, 0, buffer.length, requestedFormat);
-		if (pixelPtr == null) throw new IOException("couldn't load pixmap");
+		if (pixelPtr == null) throw new IOException("couldn't load pixmap " + getFailureReason());
 
 		basePtr = nativeData[0];
 		width = (int)nativeData[1];
@@ -321,4 +321,8 @@ public class Gdx2DPixmap implements Disposable {
 	public static native void setScale (int scale); /*
 		gdx2d_set_scale(scale);
 	*/
+
+        public static native String getFailureReason (); /*
+	        gdx2d_get_failure_reason(void);
+        */
 }


### PR DESCRIPTION
Looks like my fork was several commits behind :) Try now. 

This adds getFailureReason to Gdx2DPixmap to display the contents of const char *failure_reason in stb_image.c if it fails to load an image. I originally had an issue loading a progressive jpeg which isn't supported by stb_image.c. For new comers like myself, we can now see why stb_image failed to load an image.
