### PR TITLE
Corrected method name NewStringUTF instead of NewStringUTF8

### DIFF
--- a/gdx/jni/com.badlogic.gdx.graphics.g2d.Gdx2DPixmap.cpp
+++ b/gdx/jni/com.badlogic.gdx.graphics.g2d.Gdx2DPixmap.cpp
@@ -171,6 +171,5 @@ JNIEXPORT jstring JNICALL Java_com_badlogic_gdx_graphics_g2d_Gdx2DPixmap_getFail
 
   //@line:325
   
-                return env->NewStringUTF8(env, gdx2d_get_failure_reason(void));
-
+                return env->NewStringUTF(gdx2d_get_failure_reason());
 }

--- a/gdx/jni/gdx2d/gdx2d.c
+++ b/gdx/jni/gdx2d/gdx2d.c
@@ -275,7 +275,7 @@ void gdx2d_set_scale (uint32_t scale) {
 }
 
 const char *gdx2d_get_failure_reason(void) {
-  return stbi_failure_reason(void);
+  return stbi_failure_reason();
 }
 
 static inline void clear_alpha(const gdx2d_pixmap* pixmap, uint32_t col) {


### PR DESCRIPTION
Corrected spelling. Built and tested this go around.
