### PR TITLE
IOSServerSocket Bugfix: Local IP Address Resolution

### DIFF
--- a/backends/gdx-backend-iosmonotouch/src/com/badlogic/gdx/backends/ios/IOSServerSocket.java
+++ b/backends/gdx-backend-iosmonotouch/src/com/badlogic/gdx/backends/ios/IOSServerSocket.java
@@ -10,6 +10,8 @@ import cli.System.AsyncCallback;
 import cli.System.IAsyncResult;
 import cli.System.Net.Dns;
 import cli.System.Net.IPAddress;
+import cli.System.Net.NetworkInformation.NetworkInterface;
+import cli.System.Net.NetworkInformation.NetworkInterfaceType;
 import cli.System.Net.Sockets.AddressFamily;
 import cli.System.Net.Sockets.TcpClient;
 import cli.System.Net.Sockets.TcpListener;
@@ -59,17 +61,17 @@ public class IOSServerSocket implements ServerSocket {
 				if (listeners.get(port) == null) {
 					// get local IP to connect with
 					IPAddress ipAddress = null;
-					String host = Dns.GetHostName(); 
-					if (cli.MonoTouch.ObjCRuntime.Runtime.Arch.Value == Arch.DEVICE) {
-						// the ".local" is not added on the simulator!
-						host = host + ".local"; 
-					}
-					IPAddress[] ips = Dns.GetHostAddresses(host);
-					for (int i = 0; i < ips.length; i++) {
-						IPAddress ip = ips[i];
-						if (ip.get_AddressFamily().Value == AddressFamily.InterNetwork) {
-							ipAddress = ip;
-							break;
+					NetworkInterface netInterfaces[] = NetworkInterface.GetAllNetworkInterfaces();
+					for (int i = 0; i < netInterfaces.length; i++) {
+						NetworkInterface netInterface = netInterfaces[i];
+						if (netInterface.get_NetworkInterfaceType().Value == NetworkInterfaceType.Wireless80211 ||
+						    netInterface.get_NetworkInterfaceType().Value == NetworkInterfaceType.Ethernet) {
+							for (int k = 0; k < netInterface.GetIPProperties().get_UnicastAddresses().get_Count(); k++) {
+								IPAddress address = netInterface.GetIPProperties().get_UnicastAddresses().get_Item(k).get_Address();
+								if (address.get_AddressFamily().Value == AddressFamily.InterNetwork) {
+									ipAddress = address;
+								}
+							}
 						}
 					}
 					Gdx.app.debug("IOSServerSocket", "Binding server to " + ipAddress.ToString() + ":" + port);


### PR DESCRIPTION
The old way to obtain the local IP address on iOS does not work anymore. It will produce crashes on iOS 6+. This fixes the problem.
