### PR TITLE
Fix #1186: GdxNativesLoader.extractLibrary overwriting existing .so

### DIFF
--- a/gdx/src/com/badlogic/gdx/utils/GdxNativesLoader.java
+++ b/gdx/src/com/badlogic/gdx/utils/GdxNativesLoader.java
@@ -65,7 +65,7 @@ public class GdxNativesLoader {
 	static public String extractLibrary (String native32, String native64) {
 		String nativeFileName = is64Bit ? native64 : native32;
 		File nativeFile = new File(nativesDir, nativeFileName);
-                if (!nativeFile.exists()) {
+		if (!nativeFile.exists()) {
 		    try {
 			// Extract native from classpath to temp dir.
 			InputStream input = GdxNativesLoader.class.getResourceAsStream("/" + nativeFileName);


### PR DESCRIPTION
Fix for [issue 1186](http://code.google.com/p/libgdx/issues/detail?id=1186) by only extracting a native library into /tmp if it doesn't already exist.
