### PR TITLE
Fix edge case where PixmapPacker eats all memory in infinite recursion

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g2d/PixmapPacker.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/PixmapPacker.java
@@ -158,10 +158,10 @@ public class PixmapPacker implements Disposable {
 		int borderPixels = padding + (duplicateBorder ? 1 : 0);
 		borderPixels <<= 1;
 
-		if (image.getWidth() >= pageWidth + borderPixels || image.getHeight() >= pageHeight + borderPixels)
-			throw new GdxRuntimeException("page size for '" + name + "' to small");
-
 		Rectangle rect = new Rectangle(0, 0, image.getWidth() + borderPixels, image.getHeight() + borderPixels);
+		if (rect.getWidth() > pageWidth || rect.getHeight() > pageHeight)
+			throw new GdxRuntimeException("page size for '" + name + "' to small");
+		
 		Node node = insert(currPage.root, rect);
 
 		if (node == null) {


### PR DESCRIPTION
Please check if I got this right; there is no test for it, and I can't seem to use my own libgdx build in my game right now.
