### PR TITLE
Let unchecked exceptions thrown in a Runnable kill the app do not just eat them.

### DIFF
--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglApplication.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglApplication.java
@@ -168,18 +168,14 @@ public class LwjglApplication implements Application {
 				executedRunnables.clear();
 				executedRunnables.addAll(runnables);
 				runnables.clear();
-
-				for (int i = 0; i < executedRunnables.size; i++) {
-					shouldRender = true;
-					try {
-						executedRunnables.get(i).run();
-					} catch (Throwable t) {
-						t.printStackTrace();
-					}
-				}
 			}
 
-			// If one of the runnables set running in false, for example after an exit().
+			for (int i = 0; i < executedRunnables.size; i++) {
+				shouldRender = true;
+				executedRunnables.get(i).run(); // calls out to random app code that could do anything ...
+			}
+
+			// If one of the runnables set running to false, for example after an exit().
 			if (!running) break;
 
 			input.update();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/RunnablePostTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/RunnablePostTest.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+			
+package com.badlogic.gdx.tests;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.tests.utils.GdxTest;
+
+/** Test that unchecked exceptions thrown from a runnable get posted and terminate the app. */
+public class RunnablePostTest extends GdxTest {
+	
+	private static final String TAG = "RunnablePostTest";
+	static boolean expectIt = false;
+	
+	static private Thread.UncaughtExceptionHandler exHandler = new Thread.UncaughtExceptionHandler() {
+		@Override
+		public void uncaughtException(Thread t, Throwable e) {
+			if (expectIt) {
+				Gdx.app.log(TAG, "PASSED: " + e.getMessage());
+			} else {
+				Gdx.app.log(TAG, "FAILED!  Unexpected exception received.");				
+				e.printStackTrace(System.err);
+			}
+		}
+	};
+	
+	@Override
+	public boolean needsGL20 () {
+		return false;
+	}
+	
+	public void create () {
+		Thread.setDefaultUncaughtExceptionHandler(exHandler);		
+	}
+
+	@Override
+	public void render () {
+		if (Gdx.input.justTouched()) {
+			expectIt = true;
+			Gdx.app.postRunnable(new Runnable() {
+				@Override
+				public void run () {
+					throw new RuntimeException("This is a test of the uncaught exception handler.");
+				}
+			});
+		}
+	}
+}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
@@ -75,7 +75,8 @@ public class GdxTests {
 		// InternationalFontsTest.class, VorbisTest.class
 		TextButtonTest.class, TextButtonTestGL2.class, TextureBindTest.class, SortedSpriteTest.class,
 		ExternalMusicTest.class, SoftKeyboardTest.class, DirtyRenderingTest.class, YDownTest.class,
-		ScreenCaptureTest.class, BitmapFontTest.class, LabelScaleTest.class, GLEEDTest.class, GamepadTest.class, NetAPITest.class));
+		ScreenCaptureTest.class, BitmapFontTest.class, LabelScaleTest.class, GLEEDTest.class, GamepadTest.class, NetAPITest.class,
+		RunnablePostTest.class));
 	
 	public static List<String> getNames () {
 		List<String> names = new ArrayList<String>(tests.size());


### PR DESCRIPTION
Also, do not hold the lock on runnables across invocation of the callbacks. 
Its fine to add more runnables while the executed runnables list is
being run through.

Add a test case too.
