### PR TITLE
LWJGL: Allowing "null" for Gl20.glTexImage (already in Gl10!)

### DIFF
--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGL20.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGL20.java
@@ -528,7 +528,9 @@ final class LwjglGL20 implements com.badlogic.gdx.graphics.GL20 {
 
 	public void glTexImage2D (int target, int level, int internalformat, int width, int height, int border, int format, int type,
 		Buffer pixels) {
-		if (pixels instanceof ByteBuffer)
+		if (pixels == null)
+			GL11.glTexImage2D(target, level, internalformat, width, height, border, format, type, (ByteBuffer)null);
+		else if (pixels instanceof ByteBuffer)
 			GL11.glTexImage2D(target, level, internalformat, width, height, border, format, type, (ByteBuffer)pixels);
 		else if (pixels instanceof ShortBuffer)
 			GL11.glTexImage2D(target, level, internalformat, width, height, border, format, type, (ShortBuffer)pixels);


### PR DESCRIPTION
on a side note: any idea how to get glTexSubImage to work on the GWT backend? Is this supposed to work? All I get is INVALID_VALUE. Works on all the other backends.
