### PR TITLE
Javadoc fixes for Math

### DIFF
--- a/gdx/src/com/badlogic/gdx/math/CatmullRomSpline.java
+++ b/gdx/src/com/badlogic/gdx/math/CatmullRomSpline.java
@@ -19,9 +19,10 @@ package com.badlogic.gdx.math;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Vector;
 
-/** Encapsulates a catmull rom spline with n control points, n >= 4. For more information on this type of spline see
- * http://www.mvps.org/directx/articles/catmull/.
+/** Encapsulates a Catmull-Rom spline with n control points, n >= 4. For more information on this type of spline see
+ * <a href="http://www.mvps.org/directx/articles/catmull/">http://www.mvps.org/directx/articles/catmull/</a>
  * 
  * @author badlogicgames@gmail.com */
 public class CatmullRomSpline implements Serializable {
@@ -42,8 +43,12 @@ public class CatmullRomSpline implements Serializable {
 		return controlPoints;
 	}
 
-	/** Returns a path, between every two control points numPoints are generated and the control points themselves are added too.
-	 * The first and the last controlpoint are omitted. if there's less than 4 controlpoints an empty path is returned.
+	/** Returns a path.  Between every pair of consecutive control points numPoints are generated along the path.
+	 * The control points themselves are added to the path too.
+	 * The first and the last control point are omitted.  
+	 * If there are fewer than four control points an empty path is returned.
+	 * 
+	 * <p>This method is not thread-safe.  It uses the global {@link Vector3#tmp()}.  
 	 * 
 	 * @param numPoints number of points returned for a segment
 	 * @return the path */
@@ -86,8 +91,14 @@ public class CatmullRomSpline implements Serializable {
 		return points;
 	}
 
-	/** Returns a path, between every two control points numPoints are generated and the control points themselves are added too.
-	 * The first and the last controlpoint are omitted. if there's less than 4 controlpoints an empty path is returned.
+	/** Returns a path.  Between every pair of consecutive control points numPoints are generated along the path.
+	 * The control points themselves are added to the path too.
+	 * The first and the last control point are omitted.  
+	 * If there are fewer than four control points an empty path is returned.
+	 * 
+	 * <p>The points array must be large enough for all the path points or an exception will be thrown.
+	 * 
+	 * <p>This method is not thread-safe.  It uses the global {@link Vector3#tmp()}.  
 	 * 
 	 * @param points the array of Vector3 instances to store the path in
 	 * @param numPoints number of points returned for a segment */
@@ -125,6 +136,8 @@ public class CatmullRomSpline implements Serializable {
 
 	/** Returns all tangents for the points in a path. Same semantics as getPath.
 	 * 
+	 * <p>This method is not thread-safe.  It uses the global {@link Vector3#tmp()}.
+	 *  
 	 * @param numPoints number of points returned for a segment
 	 * @return the tangents of the points in the path */
 	public List<Vector3> getTangents (int numPoints) {
@@ -169,6 +182,8 @@ public class CatmullRomSpline implements Serializable {
 	/** Returns all tangent's normals in 2D space for the points in a path. The controlpoints have to lie in the x/y plane for this
 	 * to work. Same semantics as getPath.
 	 * 
+	 * <p>This method is not thread-safe.  It uses the global {@link Vector3#tmp()}.
+	 *  
 	 * @param numPoints number of points returned for a segment
 	 * @return the tangents of the points in the path */
 	public List<Vector3> getTangentNormals2D (int numPoints) {

--- a/gdx/src/com/badlogic/gdx/math/EarClippingTriangulator.java
+++ b/gdx/src/com/badlogic/gdx/math/EarClippingTriangulator.java
@@ -21,8 +21,10 @@ import java.util.Collections;
 import java.util.List;
 
 /** A simple implementation of the ear cutting algorithm to triangulate simple polygons without holes. For more information:
- * http://cgm.cs.mcgill.ca/~godfried/teaching/cg-projects/97/Ian/algorithm2.html
- * http://www.geometrictools.com/Documentation/TriangulationByEarClipping.pdf
+ * <ul>
+ * <li><a href="http://cgm.cs.mcgill.ca/~godfried/teaching/cg-projects/97/Ian/algorithm2.html">http://cgm.cs.mcgill.ca/~godfried/teaching/cg-projects/97/Ian/algorithm2.html</a></li>
+ * <li><a href="http://www.geometrictools.com/Documentation/TriangulationByEarClipping.pdf">http://www.geometrictools.com/Documentation/TriangulationByEarClipping.pdf</a></li>
+ * </ul>
  * 
  * @author badlogicgames@gmail.com
  * @author Nicolas Gramlich (Improved performance. Collinear edges are now supported.)

--- a/gdx/src/com/badlogic/gdx/math/FloatCounter.java
+++ b/gdx/src/com/badlogic/gdx/math/FloatCounter.java
@@ -18,7 +18,11 @@ package com.badlogic.gdx.math;
 
 import com.badlogic.gdx.utils.StringBuilder;
 
-/** @author xoppa */
+/** 
+ * Track properties of a stream of float values.  The properties (total value, minimum, etc) are updated as
+ * values are {@link #put(float)} into the stream.
+ * 
+ * @author xoppa */
 public class FloatCounter {	
 	/** The amount of values added */
 	public int count;

--- a/gdx/src/com/badlogic/gdx/math/Frustum.java
+++ b/gdx/src/com/badlogic/gdx/math/Frustum.java
@@ -16,11 +16,16 @@
 
 package com.badlogic.gdx.math;
 
+import com.badlogic.gdx.graphics.Camera;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.graphics.PerspectiveCamera;
 import com.badlogic.gdx.math.Plane.PlaneSide;
 import com.badlogic.gdx.math.collision.BoundingBox;
 
+/**
+ * A truncated rectangular pyramid.  Used to define the viewable region and its projection onto the screen.  
+ * See {@link Camera#frustum}.
+ */
 public class Frustum {
 	protected static final Vector3[] clipSpacePlanePoints = {new Vector3(-1, -1, -1), new Vector3(1, -1, -1),
 		new Vector3(1, 1, -1), new Vector3(-1, 1, -1), // near clip

--- a/gdx/src/com/badlogic/gdx/math/Polygon.java
+++ b/gdx/src/com/badlogic/gdx/math/Polygon.java
@@ -143,6 +143,13 @@ public class Polygon {
 		return area;
 	}
 
+	/** Returns an axis-aligned bounding box of this polygon.  
+	 * 
+	 * Note the returned Rectangle is cached in this polygon, and will
+	 * be reused if this Polygon is changed.
+	 * 
+	 * @return this polygon's bounding box Rectangle
+	 */
 	public Rectangle getBoundingRectangle () {
 		float[] vertices = getTransformedVertices();
 

--- a/gdx/src/com/badlogic/gdx/math/Quaternion.java
+++ b/gdx/src/com/badlogic/gdx/math/Quaternion.java
@@ -18,7 +18,9 @@ package com.badlogic.gdx.math;
 
 import java.io.Serializable;
 
-/** A simple quaternion class. See http://en.wikipedia.org/wiki/Quaternion for more information.
+/** A simple quaternion class. See 
+ * <a href="http://en.wikipedia.org/wiki/Quaternion">http://en.wikipedia.org/wiki/Quaternion</a>
+ * for more information.
  * 
  * @author badlogicgames@gmail.com
  * @author vesuvio */


### PR DESCRIPTION
Make URLs into real links in generated javadoc.  Improve the wording on
a bunch of functions.  Add thread-safety warnings to a bunch (but not
yet all) methods that use Vector3.tmp().
