### PR TITLE
!F - Adds Polyline support to GleedMapLoader

### DIFF
--- a/gdx/src/com/badlogic/gdx/maps/loaders/GleedMapLoader.java
+++ b/gdx/src/com/badlogic/gdx/maps/loaders/GleedMapLoader.java
@@ -32,6 +32,7 @@ import com.badlogic.gdx.maps.MapObject;
 import com.badlogic.gdx.maps.MapProperties;
 import com.badlogic.gdx.maps.objects.CircleMapObject;
 import com.badlogic.gdx.maps.objects.PolygonMapObject;
+import com.badlogic.gdx.maps.objects.PolylineMapObject;
 import com.badlogic.gdx.maps.objects.RectangleMapObject;
 import com.badlogic.gdx.maps.objects.TextureMapObject;
 import com.badlogic.gdx.math.Polygon;
@@ -249,7 +250,12 @@ public class GleedMapLoader  extends AsynchronousAssetLoader<Map, GleedMapLoader
 				mapObject = loadTexture(item);
 			}
 			else if (type.equals("PathItem")) {
-				mapObject = loadPolygon(item);
+				if (isPolygon(item)) {
+					mapObject = loadPolygon(item);
+				}
+				else {
+					mapObject = loadPolyline(item);
+				}
 			}
 			else if (type.equals("RectangleItem")) {
 				mapObject = loadRectangle(item);
@@ -366,5 +372,29 @@ public class GleedMapLoader  extends AsynchronousAssetLoader<Map, GleedMapLoader
 		polygon.setColor(loadColor(item.getChildByName("LineColor")));
 		
 		return polygon;
+	}
+	
+	private PolylineMapObject loadPolyline(Element item) {
+		PolylineMapObject polyline = new PolylineMapObject();
+		
+		loadObject(item, polyline);
+		
+		Array<Element> pointElements = item.getChildByName("WorldPoints").getChildrenByName("Vector2");
+		float[] vertices = new float[pointElements.size * 2];
+		
+		for (int j = 0; j < pointElements.size; ++j) {
+			Element pointElement = pointElements.get(j);
+			vertices[j * 2] = Float.parseFloat(pointElement.getChildByName("X").getText());
+			vertices[j * 2 + 1] = -Float.parseFloat(pointElement.getChildByName("Y").getText());
+		}
+		
+		polyline.setPolygon(new Polygon(vertices));
+		polyline.setColor(loadColor(item.getChildByName("LineColor")));
+		
+		return polyline;
+	}
+	
+	private boolean isPolygon(Element item) {
+		return Boolean.parseBoolean(item.getChildByName("IsPolygon").getText());
 	}
 }


### PR DESCRIPTION
Until now, I was treating every path item as a Polygon. Polylines are highly helpful to generate ChainShapes which makes static level collisions easy.
