### PR TITLE
Allow RepeatAction to be finished

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/RepeatAction.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/RepeatAction.java
@@ -25,7 +25,7 @@ public class RepeatAction extends DelegateAction {
 	private boolean finished;
 
 	public boolean act (float delta) {
-		if (executedCount == repeatCount) return true;
+		if (executedCount == repeatCount || finished) return true;
 		if (action.act(delta)) {
 			if (repeatCount > 0) executedCount++;
 			if (executedCount == repeatCount) return true;


### PR DESCRIPTION
The finish() method has no effect.
the private boolean finished is never used.
