### PR TITLE
Add 'includeantruntime="false"' to javac

### DIFF
--- a/build-template.xml
+++ b/build-template.xml
@@ -49,7 +49,7 @@ zipfileset id="jarfiles" -> the jar files to be merged with the project's classe
 
 	<!-- compiles the java code -->
 	<target name="compile" depends="init">
-		<javac debug="on" encoding="utf-8" source="1.6" target="1.6" destdir="${target}/java">
+		<javac debug="on" encoding="utf-8" source="1.6" target="1.6" destdir="${target}/java" includeantruntime="false">
 			<src>
 				<path refid="src"/>
 			</src>


### PR DESCRIPTION
Newer versions of ANT warn about the fact that the ANT runtime is
included on a javac compile.  Since this is not generally what is
wanted (but is backwards compatible with older versions of ANT), a new
flag
    includeantruntime="false"
will disable it.

This will clear up the Jenkins warnings like this:

```
[javac] /var/lib/jenkins/workspace/libgdx/build-template.xml:51: warning: 'includeantruntime' was not set, defaulting to build.sysclasspath=last; set to false for repeatable builds
```

AFAICT, this is backwards compatible with older versions of ANT.

(Let me know if you'd rather have small fixes like this batched up into a larger pull request,  or not.)
