### PR TITLE
Ios socket exception bugfix

### DIFF
--- a/backends/gdx-backend-iosmonotouch/src/com/badlogic/gdx/backends/ios/IOSSocket.java
+++ b/backends/gdx-backend-iosmonotouch/src/com/badlogic/gdx/backends/ios/IOSSocket.java
@@ -54,9 +54,9 @@ public class IOSSocket implements Socket {
 				client = new TcpClient(host, port);
 				setupConnection(hints);
 				
-			  // Hack to catch socket exception
-			  // Keep compiler happy and catch the Mono SocketException explicitly.
-			  // This Mono exception is not caught by the java Exception catch.
+			   // Hack to catch socket exception
+			   // Keep compiler happy and catch the Mono SocketException explicitly.
+			   // This Mono exception is not caught by the java Exception catch.
 			    if (false) throw new cli.System.Net.Sockets.SocketException();
 			  } catch(cli.System.Net.Sockets.SocketException e) {
 			    throw new GdxRuntimeException("Error making a socket connection to " + host + ":" + port, e);


### PR DESCRIPTION
While creating a network socket when there is not network, IOS Socket exception is thrown by the Mono framework. However, this is not caught by Java Exception.
Couple of lines of code added to catch the Mono exception and to keep the Java compiler happy.
