### PR TITLE
Add isCurrent() method to LwjglAWTCanvas.

### DIFF
--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglAWTCanvas.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglAWTCanvas.java
@@ -393,6 +393,15 @@ public class LwjglAWTCanvas implements Application {
 		}
 	}
 
+	/** Test whether the canvas' context is current. */
+	public boolean isCurrent() {
+		try {
+			return canvas.isCurrent();
+		} catch (LWJGLException ex) {
+			throw new GdxRuntimeException(ex);
+		}
+	}
+
 	/** @param cursor May be null. */
 	public void setCursor (Cursor cursor) {
 		this.cursor = cursor;


### PR DESCRIPTION
...ainly useful for cases where you have multiple canvas contexts, and you want to know if any of them are current before loading a resource that requires an active context.
