### PR TITLE
Don't allow simultaneous drags in DragAndDrop class

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/DragAndDrop.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/DragAndDrop.java
@@ -40,22 +40,17 @@ public class DragAndDrop {
 	float dragActorX = 14, dragActorY = -20;
 	long dragStartTime;
 	int dragTime = 250;
-	boolean isDragging = false;
-	Object dragSyncObj = new Object();
-	int activePointer;
+	int activePointer = -1;
 
 	public void addSource (final Source source) {
 		DragListener listener = new DragListener() {
 			public void dragStart (InputEvent event, float x, float y, int pointer) {
-				synchronized (dragSyncObj) {
-					if (isDragging) {
-						event.stop();
-						return;
-					}
-
-					isDragging = true;
-					activePointer = pointer;
+				if (activePointer != -1) {
+					event.stop();
+					return;
 				}
+
+				activePointer = pointer;
 
 				dragStartTime = System.currentTimeMillis();
 				payload = source.dragStart(event, getTouchDownX(), getTouchDownY(), pointer);
@@ -119,9 +114,7 @@ public class DragAndDrop {
 				if (payload == null) return;
 				if (pointer != activePointer) return;
 
-				synchronized (dragSyncObj) {
-					isDragging = false;
-				}
+				activePointer = -1;
 
 				if (System.currentTimeMillis() - dragStartTime < dragTime) isValidTarget = false;
 				if (dragActor != null) dragActor.remove();


### PR DESCRIPTION
The DragAndDrop class only manages one payload and drag actor, so we
need to stop several drag events from happening at the same time.

I have several DragAndDrop.Source objects managed by the DragAndDrop class, when I'm trying to drag two Source objects simultaneously the drag actor and payload isn't handled correctly (since you can only have one payload/drag actor in DragAndDrop).

My workaround is to make sure only one drag is recognized at a time. Not sure if this is how it should be solved though.
