### PR TITLE
Have to set the coordinates before you can transform them

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/SelectBox.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/SelectBox.java
@@ -207,7 +207,7 @@ public class SelectBox extends Widget {
 		InputListener stageListener = new InputListener() {
 			public boolean touchDown (InputEvent event, float x, float y, int pointer, int button) {
 				if (pointer == 0 && button != 0) return false;
-				stageToLocalCoordinates(Vector2.tmp);
+				stageToLocalCoordinates(Vector2.tmp.set(x, y));
 				x = Vector2.tmp.x;
 				y = Vector2.tmp.y;
 				if (x > 0 && x < getWidth() && y > 0 && y < getHeight()) {
@@ -230,7 +230,7 @@ public class SelectBox extends Widget {
 			}
 
 			public boolean mouseMoved (InputEvent event, float x, float y) {
-				stageToLocalCoordinates(Vector2.tmp);
+				stageToLocalCoordinates(Vector2.tmp.set(x, y));
 				x = Vector2.tmp.x;
 				y = Vector2.tmp.y;
 				if (x > 0 && x < getWidth() && y > 0 && y < getHeight()) {


### PR DESCRIPTION
I found this while looking closely at uses of temporary variables in scene2d.  I'm not exactly sure what was broken before, but I'm pretty confident this fixes it.

I ran the UITest and ShadowMappingTest, and both seem to work fine.  I wonder if they mostly worked before because the Vector2.tmp generally already had relatively similar screen coordinates in it?
