### PR TITLE
Remove Vector2.tmp() and its variations (.tmp{1,2,3})

### DIFF
--- a/demos/pax-britannica/pax-britannica/src/de/swagner/paxbritannica/Ship.java
+++ b/demos/pax-britannica/pax-britannica/src/de/swagner/paxbritannica/Ship.java
@@ -66,7 +66,7 @@ public class Ship extends Sprite {
 		collisionPoints.get(2).set( this.getVertices()[10], this.getVertices()[11]);
 		collisionPoints.get(3).set( this.getVertices()[15], this.getVertices()[16]);
 		
-		collisionCenter.set(collisionPoints.get(0).tmp().add(collisionPoints.get(2)).mul(0.5f));
+		collisionCenter.set(collisionPoints.get(2)).mul(0.5f).add(collisionPoints.get(0));
 
 		velocity.mul( (float) Math.pow(0.97f, delta * 30.f));
 		position.add(velocity.x * delta, velocity.y * delta);
@@ -105,8 +105,14 @@ public class Ship extends Sprite {
 				+ MathUtils.random(-this.getHeight() / 2, this.getHeight() / 2));
 	}
 
+	/*
+	 * Scratch space for computing a target's direction. This is safe (as a static) because
+	 * its only used in goTowardsOrAway which is only called on the render thread (via update).
+	 */
+	private static final Vector2 target_direction = new Vector2(); 
+
 	public void goTowardsOrAway(Vector2 targetPos, boolean forceThrust, boolean isAway) {
-		Vector2 target_direction = targetPos.tmp().sub(collisionCenter);
+		target_direction.set(targetPos).sub(collisionCenter);
 		if (isAway) {
 			target_direction.mul(-1);
 		}
@@ -144,7 +150,7 @@ public class Ship extends Sprite {
 
 	public void factoryDestruct() {
 		delta = Math.min(0.06f, Gdx.graphics.getDeltaTime());
-		
+
 		if (deathCounter > 0) {
 			((FactoryProduction) this).production.halt_production = true;
 			this.setColor(1, 1, 1, Math.min(1, opacity));

--- a/gdx/src/com/badlogic/gdx/math/Vector2.java
+++ b/gdx/src/com/badlogic/gdx/math/Vector2.java
@@ -25,10 +25,6 @@ import com.badlogic.gdx.utils.NumberUtils;
 public class Vector2 implements Serializable, Vector<Vector2> {
 	private static final long serialVersionUID = 913902788239530931L;
 
-	/** Static temporary vector. Use with care! Use only when sure other code will not also use this.
-	 * @see #tmp() **/
-	public final static Vector2 tmp = new Vector2(), tmp2 = new Vector2(), tmp3 = new Vector2();
-
 	public final static Vector2 X = new Vector2(1, 0);
 	public final static Vector2 Y = new Vector2(0, 1);
 	public final static Vector2 Zero = new Vector2(0, 0);
@@ -161,15 +157,15 @@ public class Vector2 implements Serializable, Vector<Vector2> {
 	}
 
 	public Vector2 div (float value) {
-		return this.mul(1/value);
+		return this.mul(1 / value);
 	}
 
 	public Vector2 div (float vx, float vy) {
-		return this.mul(1/vx, 1/vy);
+		return this.mul(1 / vx, 1 / vy);
 	}
 
 	public Vector2 div (Vector2 other) {
-		return this.mul(1/other.x, 1/other.y);
+		return this.mul(1 / other.x, 1 / other.y);
 	}
 
 	/** @param v The other vector
@@ -220,15 +216,6 @@ public class Vector2 implements Serializable, Vector<Vector2> {
 		return this;
 	}
 
-	/** NEVER EVER SAVE THIS REFERENCE! Do not use this unless you are aware of the side-effects, e.g. other methods might call this
-	 * as well.
-	 * 
-	 * @return a temporary copy of this vector. Use with care as this is backed by a single static Vector2 instance. v1.tmp().add(
-	 *         v2.tmp() ) will not work! */
-	public Vector2 tmp () {
-		return tmp.set(this);
-	}
-
 	/** Multiplies this vector by the given matrix
 	 * @param mat the matrix
 	 * @return this vector */
@@ -262,7 +249,7 @@ public class Vector2 implements Serializable, Vector<Vector2> {
 		if (angle < 0) angle += 360;
 		return angle;
 	}
-	
+
 	/** Sets the angle of the vector.
 	 * @param angle The angle to set. */
 	public void setAngle (float angle) {

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/InputListener.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/InputListener.java
@@ -33,6 +33,10 @@ import com.badlogic.gdx.math.Vector2;
  * </pre>
  */
 public class InputListener implements EventListener {
+	
+	/** Scratch object used by handle().  Event dispatch should only be invoked by the render thread. */
+	private static final Vector2 coords = new Vector2();
+	
 	public boolean handle (Event e) {
 		if (!(e instanceof InputEvent)) return false;
 		InputEvent event = (InputEvent)e;
@@ -46,7 +50,7 @@ public class InputListener implements EventListener {
 			return keyTyped(event, event.getCharacter());
 		}
 
-		Vector2 coords = Vector2.tmp.set(event.getStageX(), event.getStageY());
+		coords.set(event.getStageX(), event.getStageY());
 		event.getListenerActor().stageToLocalCoordinates(coords);
 
 		switch (event.getType()) {

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/SelectBox.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/SelectBox.java
@@ -52,6 +52,9 @@ public class SelectBox extends Widget {
 	private float prefWidth, prefHeight;
 	private ClickListener clickListener;
 
+	/** Scratch space for converting to/from stage coordinates. Only used in listener callbacks (so only on render thread). */
+	static final Vector2 tmpCoords = new Vector2();
+
 	public SelectBox (Object[] items, Skin skin) {
 		this(items, skin.get(SelectBoxStyle.class));
 	}
@@ -74,9 +77,8 @@ public class SelectBox extends Widget {
 					return true;
 				}
 				Stage stage = getStage();
-				Vector2 stageCoords = Vector2.tmp;
-				stage.screenToStageCoordinates(stageCoords.set(screenCoords.x, screenCoords.y));
-				list = new SelectList(stageCoords.x, stageCoords.y);
+				stage.screenToStageCoordinates(tmpCoords.set(screenCoords));
+				list = new SelectList(tmpCoords.x, tmpCoords.y);
 				stage.addActor(list);
 				return true;
 			}
@@ -207,9 +209,9 @@ public class SelectBox extends Widget {
 		InputListener stageListener = new InputListener() {
 			public boolean touchDown (InputEvent event, float x, float y, int pointer, int button) {
 				if (pointer == 0 && button != 0) return false;
-				stageToLocalCoordinates(Vector2.tmp.set(event.getStageX(), event.getStageY()));
-				x = Vector2.tmp.x;
-				y = Vector2.tmp.y;
+				stageToLocalCoordinates(tmpCoords.set(event.getStageX(), event.getStageY()));
+				x = tmpCoords.x;
+				y = tmpCoords.y;
 				if (x > 0 && x < getWidth() && y > 0 && y < getHeight()) {
 					listSelectedIndex = (int)((getHeight() - y) / itemHeight);
 					listSelectedIndex = Math.max(0, listSelectedIndex);
@@ -230,9 +232,9 @@ public class SelectBox extends Widget {
 			}
 
 			public boolean mouseMoved (InputEvent event, float x, float y) {
-				stageToLocalCoordinates(Vector2.tmp.set(event.getStageX(), event.getStageY()));
-				x = Vector2.tmp.x;
-				y = Vector2.tmp.y;
+				stageToLocalCoordinates(tmpCoords.set(event.getStageX(), event.getStageY()));
+				x = tmpCoords.x;
+				y = tmpCoords.y;
 				if (x > 0 && x < getWidth() && y > 0 && y < getHeight()) {
 					listSelectedIndex = (int)((getHeight() - style.listBackground.getTopHeight() - y) / itemHeight);
 					listSelectedIndex = Math.max(0, listSelectedIndex);

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextField.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextField.java
@@ -583,20 +583,28 @@ public class TextField extends Widget {
 		cursor = minIndex;
 		clearSelection();
 	}
+	
+	/*
+	 * Three hacks to work around the inability to stack allocate small scratch-space objects in Java.  
+	 * Used by #next() and #findNextTextField.
+	 */
+	private static final Vector2 tmp1 = new Vector2();
+	private static final Vector2 tmp2 = new Vector2();
+	private static final Vector2 tmp3 = new Vector2();
 
 	/** Focuses the next TextField. If none is found, the keyboard is hidden. Does nothing if the text field is not in a stage.
 	 * @param up If true, the TextField with the same or next smallest y coordinate is found, else the next highest. */
 	public void next (boolean up) {
 		Stage stage = getStage();
 		if (stage == null) return;
-		getParent().localToStageCoordinates(Vector2.tmp.set(getX(), getY()));
-		TextField textField = findNextTextField(stage.getActors(), null, Vector2.tmp2, Vector2.tmp, up);
+		getParent().localToStageCoordinates(tmp1.set(getX(), getY()));
+		TextField textField = findNextTextField(stage.getActors(), null, tmp2, tmp1, up);
 		if (textField == null) { // Try to wrap around.
 			if (up)
-				Vector2.tmp.set(Float.MIN_VALUE, Float.MIN_VALUE);
+				tmp1.set(Float.MIN_VALUE, Float.MIN_VALUE);
 			else
-				Vector2.tmp.set(Float.MAX_VALUE, Float.MAX_VALUE);
-			textField = findNextTextField(getStage().getActors(), null, Vector2.tmp2, Vector2.tmp, up);
+				tmp1.set(Float.MAX_VALUE, Float.MAX_VALUE);
+			textField = findNextTextField(getStage().getActors(), null, tmp2, tmp1, up);
 		}
 		if (textField != null)
 			stage.setKeyboardFocus(textField);
@@ -609,7 +617,7 @@ public class TextField extends Widget {
 			Actor actor = actors.get(i);
 			if (actor == this) continue;
 			if (actor instanceof TextField) {
-				Vector2 actorCoords = actor.getParent().localToStageCoordinates(Vector2.tmp3.set(actor.getX(), actor.getY()));
+				Vector2 actorCoords = actor.getParent().localToStageCoordinates(tmp3.set(actor.getX(), actor.getY()));
 				if ((actorCoords.y < currentCoords.y || (actorCoords.y == currentCoords.y && actorCoords.x > currentCoords.x)) ^ up) {
 					if (best == null
 						|| (actorCoords.y > bestCoords.y || (actorCoords.y == bestCoords.y && actorCoords.x < bestCoords.x)) ^ up) {

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Window.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Window.java
@@ -135,15 +135,22 @@ public class Window extends Table {
 		}
 		super.draw(batch, parentAlpha);
 	}
+	
+	/*
+	 * Hacks to work around the inability to stack allocate small scratch objects in Java.
+	 */
+	
+	private static final Vector2 tmpPosition = new Vector2();
+	private static final Vector2 tmpSize = new Vector2();
 
 	protected void drawBackground (SpriteBatch batch, float parentAlpha) {
 		if (style.stageBackground != null) {
 			Color color = getColor();
 			batch.setColor(color.r, color.g, color.b, color.a * parentAlpha);
 			Stage stage = getStage();
-			Vector2 position = stageToLocalCoordinates(Vector2.tmp.set(0, 0));
-			Vector2 size = stageToLocalCoordinates(Vector2.tmp2.set(stage.getWidth(), stage.getHeight()));
-			style.stageBackground.draw(batch, getX() + position.x, getY() + position.y, getX() + size.x, getY() + size.y);
+			stageToLocalCoordinates(/*in/out*/tmpPosition.set(0, 0));
+			stageToLocalCoordinates(/*in/out*/tmpSize.set(stage.getWidth(), stage.getHeight()));
+			style.stageBackground.draw(batch, getX() + tmpPosition.x, getY() + tmpPosition.y, getX() + tmpSize.x, getY() + tmpSize.y);
 		}
 
 		super.drawBackground(batch, parentAlpha);

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/ActorGestureListener.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/ActorGestureListener.java
@@ -32,7 +32,10 @@ public class ActorGestureListener implements EventListener {
 	private final GestureDetector detector;
 	InputEvent event;
 	Actor actor, touchDownTarget;
-
+	
+	/** Scratch coordinates used to convert event coordinates into local coordinates. */
+	static final Vector2 tmpCoords = new Vector2();
+	
 	/** @see GestureDetector#GestureDetector(com.badlogic.gdx.input.GestureDetector.GestureListener) */
 	public ActorGestureListener () {
 		this(20, 0.4f, 1.1f, 0.15f);
@@ -45,14 +48,14 @@ public class ActorGestureListener implements EventListener {
 			private final Vector2 pointer1 = new Vector2(), pointer2 = new Vector2();
 
 			public boolean tap (float stageX, float stageY, int count, int button) {
-				actor.stageToLocalCoordinates(Vector2.tmp.set(stageX, stageY));
-				ActorGestureListener.this.tap(event, Vector2.tmp.x, Vector2.tmp.y, count, button);
+				actor.stageToLocalCoordinates(tmpCoords.set(stageX, stageY));
+				ActorGestureListener.this.tap(event, tmpCoords.x, tmpCoords.y, count, button);
 				return true;
 			}
 
 			public boolean longPress (float stageX, float stageY) {
-				actor.stageToLocalCoordinates(Vector2.tmp.set(stageX, stageY));
-				return ActorGestureListener.this.longPress(actor, Vector2.tmp.x, Vector2.tmp.y);
+				actor.stageToLocalCoordinates(tmpCoords.set(stageX, stageY));
+				return ActorGestureListener.this.longPress(actor, tmpCoords.x, tmpCoords.y);
 			}
 
 			public boolean fling (float velocityX, float velocityY, int button) {
@@ -61,8 +64,8 @@ public class ActorGestureListener implements EventListener {
 			}
 
 			public boolean pan (float stageX, float stageY, float deltaX, float deltaY) {
-				actor.stageToLocalCoordinates(Vector2.tmp.set(stageX, stageY));
-				ActorGestureListener.this.pan(event, Vector2.tmp.x, Vector2.tmp.y, deltaX, deltaY);
+				actor.stageToLocalCoordinates(tmpCoords.set(stageX, stageY));
+				ActorGestureListener.this.pan(event, tmpCoords.x, tmpCoords.y, deltaX, deltaY);
 				return true;
 			}
 
@@ -92,15 +95,15 @@ public class ActorGestureListener implements EventListener {
 			actor = event.getListenerActor();
 			touchDownTarget = event.getTarget();
 			detector.touchDown(event.getStageX(), event.getStageY(), event.getPointer(), event.getButton());
-			actor.stageToLocalCoordinates(Vector2.tmp.set(event.getStageX(), event.getStageY()));
-			touchDown(event, Vector2.tmp.x, Vector2.tmp.y, event.getPointer(), event.getButton());
+			actor.stageToLocalCoordinates(tmpCoords.set(event.getStageX(), event.getStageY()));
+			touchDown(event, tmpCoords.x, tmpCoords.y, event.getPointer(), event.getButton());
 			return true;
 		case touchUp:
 			this.event = event;
 			actor = event.getListenerActor();
 			detector.touchUp(event.getStageX(), event.getStageY(), event.getPointer(), event.getButton());
-			actor.stageToLocalCoordinates(Vector2.tmp.set(event.getStageX(), event.getStageY()));
-			touchUp(event, Vector2.tmp.x, Vector2.tmp.y, event.getPointer(), event.getButton());
+			actor.stageToLocalCoordinates(tmpCoords.set(event.getStageX(), event.getStageY()));
+			touchUp(event, tmpCoords.x, tmpCoords.y, event.getPointer(), event.getButton());
 			return true;
 		case touchDragged:
 			this.event = event;

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/DragAndDrop.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/DragAndDrop.java
@@ -42,6 +42,9 @@ public class DragAndDrop {
 	int dragTime = 250;
 	int activePointer = -1;
 
+	/* Scratch vector used to convert event's stage coordinates to local coordinates. */
+	static final Vector2 tmpVector = new Vector2();
+
 	public void addSource (final Source source) {
 		DragListener listener = new DragListener() {
 			public void dragStart (InputEvent event, float x, float y, int pointer) {
@@ -79,8 +82,8 @@ public class DragAndDrop {
 						Target target = targets.get(i);
 						if (!target.actor.isAscendantOf(hit)) continue;
 						newTarget = target;
-						target.actor.stageToLocalCoordinates(Vector2.tmp.set(event.getStageX(), event.getStageY()));
-						isValidTarget = target.drag(source, payload, Vector2.tmp.x, Vector2.tmp.y, pointer);
+						target.actor.stageToLocalCoordinates(tmpVector.set(event.getStageX(), event.getStageY()));
+						isValidTarget = target.drag(source, payload, tmpVector.x, tmpVector.y, pointer);
 						break;
 					}
 				}
@@ -119,8 +122,8 @@ public class DragAndDrop {
 				if (System.currentTimeMillis() - dragStartTime < dragTime) isValidTarget = false;
 				if (dragActor != null) dragActor.remove();
 				if (isValidTarget) {
-					target.actor.stageToLocalCoordinates(Vector2.tmp.set(event.getStageX(), event.getStageY()));
-					target.drop(source, payload, Vector2.tmp.x, Vector2.tmp.y, pointer);
+					target.actor.stageToLocalCoordinates(tmpVector.set(event.getStageX(), event.getStageY()));
+					target.drop(source, payload, tmpVector.x, tmpVector.y, pointer);
 				}
 				source.dragStop(event, x, y, pointer, isValidTarget ? target : null);
 				if (target != null) target.reset(source, payload);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/PathTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/PathTest.java
@@ -100,8 +100,8 @@ public class PathTest extends GdxTest {
 		float val = 0f;
 		while (val <= 1f) {
 			renderer.color(0f, 0f, 0f, 1f);
-			paths.get(currentPath).valueAt(Vector2.tmp, val);
-			renderer.vertex(Vector2.tmp.x, Vector2.tmp.y, 0);
+			paths.get(currentPath).valueAt(/*out:*/tmpV, val);
+			renderer.vertex(tmpV.x, tmpV.y, 0);
 			val += SAMPLE_POINT_DISTANCE;
 		}
 		renderer.end();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/StageTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/StageTest.java
@@ -147,6 +147,8 @@ public class StageTest extends GdxTest implements InputProcessor {
 			}
 	}
 
+	private final Vector2 stageCoords = new Vector2();
+
 	@Override
 	public void render () {
 		Gdx.gl.glViewport(0, 0, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
@@ -154,7 +156,6 @@ public class StageTest extends GdxTest implements InputProcessor {
 		Gdx.gl.glClear(GL10.GL_COLOR_BUFFER_BIT);
 
 		if (Gdx.input.isTouched()) {
-			Vector2 stageCoords = Vector2.tmp;
 			stage.screenToStageCoordinates(stageCoords.set(Gdx.input.getX(), Gdx.input.getY()));
 			Actor actor = stage.hit(stageCoords.x, stageCoords.y, true);
 			if (actor instanceof Image)


### PR DESCRIPTION
This change removes the public static mutable "tmp" objects from `Vector2`.  Mostly they're replaced with _private_ static mutable tmp objects elsewhere in the code.  

I could probably reduce the number of scratch objects in the scene2d code, if anyone objects to the number created (I think its 10 new and 3 removed).

There is one free cleanup of a `Vector3` tmp usage while I was in Stage.

This breaks the API since `Vector2.tmp`\* were all public.

Some discussion on this topic: http://www.badlogicgames.com/forum/viewtopic.php?f=23&t=7814  Folks are free to change their opinions now that they've got a concrete example.  :)
