### PR TITLE
Adds padding to drawable width to account for a NinePatch's content area...

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/List.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/List.java
@@ -106,10 +106,10 @@ public class List extends Widget implements Cullable {
 
 		font.setColor(fontColorUnselected.r, fontColorUnselected.g, fontColorUnselected.b, fontColorUnselected.a * parentAlpha);
 		float itemY = getHeight();
+        float padding = selectedDrawable.getLeftWidth() + selectedDrawable.getRightWidth();
 		for (int i = 0; i < items.length; i++) {
 			if (cullingArea == null || (itemY - itemHeight <= cullingArea.y + cullingArea.height && itemY >= cullingArea.y)) {
 				if (selectedIndex == i) {
-                    float padding = selectedDrawable.getLeftWidth() + selectedDrawable.getRightWidth();
 					selectedDrawable.draw(batch, x, y + itemY - itemHeight, Math.max(prefWidth, getWidth() + padding), itemHeight);
 					font.setColor(fontColorSelected.r, fontColorSelected.g, fontColorSelected.b, fontColorSelected.a * parentAlpha);
 				}


### PR DESCRIPTION
It looks like when Lists are given a NinePatch with which to draw the selected element, they don't account for the padding in their width calculation. This means the font drawn inside the box is properly padded from the left, but since the box's width didn't increase, it causes the text to run off the right edge of the box.

My fix simply adds the left and right padding to the width while drawing.

Here's the incorrect padding calculation:
![IncorrectList](https://f.cloud.github.com/assets/30749/190235/381a6d1e-7ed8-11e2-9627-643f877f2b1d.PNG)

Here is what it should look like:
![CorrectList](https://f.cloud.github.com/assets/30749/190229/e566e1ec-7ed7-11e2-85d9-c55df29e9671.PNG)

And here is the configuration of the NinePatch using the android tool. Notice the bottom row of pixels signifying horizontal padding in the content area (also visible by the blue box on the right)
![NinePatchConfiguration](https://f.cloud.github.com/assets/30749/190230/ebb72f16-7ed7-11e2-85e6-0a233b00fa68.PNG)
