### PR TITLE
Add margin per pixmap to PixmapPacker, fix the FreeType extensions issues on rendering

### DIFF
--- a/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGenerator.java
+++ b/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGenerator.java
@@ -209,10 +209,11 @@ public class FreeTypeFontGenerator implements Disposable {
 
 		// generate the glyphs
 		int maxGlyphHeight = (int)Math.ceil(data.lineHeight);
-		int pageWidth = MathUtils.nextPowerOfTwo((int)Math.sqrt(maxGlyphHeight * maxGlyphHeight * characters.length()));
+		int pageWidth = MathUtils.nextPowerOfTwo((maxGlyphHeight + 4) * (int) Math.ceil(Math.sqrt(characters.length())));
 		PixmapPacker atlas = new PixmapPacker(pageWidth, pageWidth, Format.RGBA8888, 2, false);
 		for (int i = 0; i < characters.length(); i++) {
 			char c = characters.charAt(i);
+
 			if (!FreeType.loadChar(face, c, FreeType.FT_LOAD_DEFAULT)) {
 				Gdx.app.log("FreeTypeFontGenerator", "Couldn't load char '" + c + "'");
 				continue;
@@ -225,7 +226,7 @@ public class FreeTypeFontGenerator implements Disposable {
 			GlyphMetrics metrics = slot.getMetrics();
 			Bitmap bitmap = slot.getBitmap();
 			Pixmap pixmap = bitmap.getPixmap(Format.RGBA8888);
-			Rectangle rect = atlas.pack("" + c, pixmap);
+			Rectangle rect = atlas.pack("" + c, pixmap, Math.max(0, (maxGlyphHeight - pixmap.getWidth())), Math.max(0, (maxGlyphHeight - pixmap.getHeight())));
 			Glyph glyph = new Glyph();
 			glyph.width = pixmap.getWidth();
 			glyph.height = pixmap.getHeight();

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/PixmapPacker.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/PixmapPacker.java
@@ -153,12 +153,28 @@ public class PixmapPacker implements Disposable {
 	 * @return Rectangle describing the area the pixmap was rendered to or null.
 	 * @throws RuntimeException in case the image did not fit due to the page size being to small or providing a duplicate name */
 	public synchronized Rectangle pack (String name, Pixmap image) {
+		return this.pack(name, image, 0, 0);
+	}
+
+	/** <p>
+	 * Inserts the given {@link Pixmap} with paddings in the page for better pixmap alignment. You can later on retrieve the images position in the output image via the supplied name
+	 * and the method {@link #getRect(String)}.
+	 * </p>
+	 *
+	 * @param name the name of the image
+	 * @param image the image
+	 * @param marginRight The right margin for the pixmap drawing in the page of the packer.
+	 * @param marginBottom The bottom margin for the pixmap drawing in the page of the packer.
+	 * @return Rectangle describing the area the pixmap was rendered to or null.
+	 * @throws RuntimeException in case the image did not fit due to the page size being to small or providing a duplicate name */
+	public synchronized Rectangle pack (String name, Pixmap image, int marginRight, int marginBottom) {
 		if (disposed) return null;
 		if (getRect(name) != null) throw new RuntimeException("Key with name '" + name + "' is already in map");
+		if (marginRight < 0 || marginBottom < 0) throw new RuntimeException("Margin for the pixmap in the packer should be zero or positive");
 		int borderPixels = padding + (duplicateBorder ? 1 : 0);
 		borderPixels <<= 1;
 
-		Rectangle rect = new Rectangle(0, 0, image.getWidth() + borderPixels, image.getHeight() + borderPixels);
+		Rectangle rect = new Rectangle(0, 0, image.getWidth() + marginRight + borderPixels, image.getHeight() + marginBottom + borderPixels);
 		if (rect.getWidth() > pageWidth || rect.getHeight() > pageHeight)
 			throw new GdxRuntimeException("page size for '" + name + "' to small");
 		
@@ -171,8 +187,8 @@ public class PixmapPacker implements Disposable {
 
 		node.leaveName = name;
 		rect = new Rectangle(node.rect);
-		rect.width -= borderPixels;
-		rect.height -= borderPixels;
+		rect.width -= (marginRight + borderPixels);
+		rect.height -= (marginBottom + borderPixels);
 		borderPixels >>= 1;
 		rect.x += borderPixels;
 		rect.y += borderPixels;


### PR DESCRIPTION
Hi, I am littlebtc (Hsiao-Ting Yu) from the Briareus Network Techonology, a game engine startup in Taiwan. We are developing our commercial game engine and using libgdx in our Android client implementation. Libgdx is very great and we love it <3

However, we encountered some problems about the freetype extensions. Due to the large size of asian scripts, we use the Motoya Japanese font from Android Open Source Project ( [Font on GitHub Mirrors](https://github.com/android/platform_frameworks_base/blob/master/data/fonts/MTLmr3m.ttf) ), and dynamically generate the BitmapFont using the freetype extension.

However, Motoya fonts includes some punctuation mark with halt width and height (e.g. 22px font has 7x9 full-sized comma), the PixmapPacker cannot efficiently deal with that type of various glyph sizes, and the generator did not give the enought size for drawing to the page. So the glyphs will be drawn on the second page, and since BitmapFontCache will only use one texture, the font rendering will be simply broken.

![Result](http://i.imgur.com/hccEgBq.png)
The texture page when rendering "―ア最大級" with MTLmr3m, sized 22, where "級" is absent.

To fix it, I investigate the rendering part and the pull request is my solution:
1. Improve the calulation of the PixmapPacker size; consider the packer padding and use ceil(sqrt(text.length)) to ensure there will always be enough spaces to fill the texts.
2. Allow setting "margins" for every pixmaps on the packer, this will make PixmapPacker places every texts in gird and there will be no strange position anymore.

---

And about the CLA, I discussed with my employer and we decided to sign a Corporate CLA (from Briareus Network Technology) instead of Personal CLA. Can we make a modification from Apache's Corporate CLA and sign? :smile: 
