### PR TITLE
Fixed possible resource leak in AndroidFileHandle::length()

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidFileHandle.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidFileHandle.java
@@ -147,8 +147,17 @@ public class AndroidFileHandle extends FileHandle {
 
 	public long length () {
 		if (type == FileType.Internal) {
+			AssetFileDescriptor fileDescriptor = null;
 			try {
-				return assets.openFd(file.getPath()).getLength();
+				try {
+					fileDescriptor = assets.openFd(file.getPath());
+					return fileDescriptor.getLength();
+				}
+				finally {
+					if (fileDescriptor != null) {
+						fileDescriptor.close();
+					}
+				}
 			} catch (IOException ignored) {
 			}
 		}


### PR DESCRIPTION
This leak was reported by following exception when application was executed with Strict Mode enabled:

<pre>
E/StrictMode(9784): A resource was acquired at attached stack trace but never released. See java.io.Closeable for information on avoiding resource leaks.
E/StrictMode(9784): java.lang.Throwable: Explicit termination method 'close' not called
E/StrictMode(9784):     at dalvik.system.CloseGuard.open(CloseGuard.java:184)
E/StrictMode(9784):     at android.os.ParcelFileDescriptor.<init>(ParcelFileDescriptor.java:412)
E/StrictMode(9784):     at android.content.res.AssetManager.openAssetFd(Native Method)
E/StrictMode(9784):     at android.content.res.AssetManager.openFd(AssetManager.java:331)
E/StrictMode(9784):     at com.badlogic.gdx.backends.android.AndroidFileHandle.length(AndroidFileHandle.java:151)
E/StrictMode(9784):     at com.badlogic.gdx.files.FileHandle.readBytes(FileHandle.java:215)
E/StrictMode(9784):     at com.badlogic.gdx.graphics.Pixmap.<init>(Pixmap.java:137)
E/StrictMode(9784):     at com.kreymerman.alfred.graphics.loaders.TextureLoader.loadTextureData(TextureLoader.java:59)
E/StrictMode(9784):     at com.kreymerman.alfred.graphics.loaders.TextureLoader.load(TextureLoader.java:45)
E/StrictMode(9784):     at com.kreymerman.alfred.graphics.loaders.TextureLoader.load(TextureLoader.java:36)
E/StrictMode(9784):     at com.kreymerman.alfred.graphics.loaders.TextureLoader.loadOverlay(TextureLoader.java:30)
E/StrictMode(9784):     at com.kreymerman.alfred.game.LoadingScreen.createScreenResources(LoadingScreen.java:122)
E/StrictMode(9784):     at com.kreymerman.alfred.game.ScreenManager.finishResourceLoading(ScreenManager.java:222)
E/StrictMode(9784):     at com.kreymerman.alfred.game.ScreenManager.switchToScreenAsync(ScreenManager.java:198)
E/StrictMode(9784):     at com.kreymerman.alfred.game.ScreenManager.switchToScreenAsync(ScreenManager.java:135)
E/StrictMode(9784):     at com.kreymerman.alfred.SplashScreen.render(SplashScreen.java:98)
E/StrictMode(9784):     at com.kreymerman.alfred.game.Game.render(Game.java:164)
E/StrictMode(9784):     at com.badlogic.gdx.backends.android.AndroidGraphics.onDrawFrame(AndroidGraphics.java:449)
E/StrictMode(9784):     at android.opengl.GLSurfaceView$GLThread.guardedRun(GLSurfaceView.java:1516)
E/StrictMode(9784):     at android.opengl.GLSurfaceView$GLThread.run(GLSurfaceView.java:1240)
</pre>
