### PR TITLE
Better foreign support for softKeyboard for Android backend

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidInput.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidInput.java
@@ -452,11 +452,25 @@ public class AndroidInput implements Input, OnKeyListener, OnTouchListener {
 			if(keyListeners.get(i).onKey(v, keyCode, e)) return true;
 
 		synchronized (this) {
+			KeyEvent event = null;
+			
+			if(e.getKeyCode() == android.view.KeyEvent.KEYCODE_UNKNOWN &&
+				e.getAction() == android.view.KeyEvent.ACTION_MULTIPLE) {
+					String chars = e.getCharacters();
+					for(int i = 0; i < chars.length(); i++) {
+						event = usedKeyEvents.obtain();
+						event.keyCode = 0;
+						event.keyChar = chars.charAt(i);
+						event.type = KeyEvent.KEY_TYPED;
+						keyEvents.add(event);
+					}
+					return false;
+			}
+			
 			char character = (char)e.getUnicodeChar();
 			// Android doesn't report a unicode char for back space. hrm...
 			if (keyCode == 67) character = '\b';
 
-			KeyEvent event = null;
 			switch (e.getAction()) {
 			case android.view.KeyEvent.ACTION_DOWN:
 				event = usedKeyEvents.obtain();


### PR DESCRIPTION
I noticed that the softKeyboard diden't catch ACTION_MULTIPLE which contained some important functionality for foregin characters and swype typing.

This commit triggets mulitple KEY_TYPE events when an ACTION_MULTIPLE onKey event is triggered. So far I haven't encountered any problems with the UI widgets that might follow from these changes. It should maybe be noted that the font needs to support the characters, but other than that any UNICODE character should be supported  from softKeyboards now.
