### PR TITLE
Fix issue 1231 for MathUtils.atan2()

### DIFF
--- a/gdx/src/com/badlogic/gdx/math/MathUtils.java
+++ b/gdx/src/com/badlogic/gdx/math/MathUtils.java
@@ -128,6 +128,10 @@ public class MathUtils {
 			add = 0;
 		}
 		float invDiv = 1 / ((x < y ? y : x) * INV_ATAN2_DIM_MINUS_1);
+		
+		if (invDiv == Float.POSITIVE_INFINITY)
+			return ((float)Math.atan2(y, x) + add) * mul;
+		
 		int xi = (int)(x * invDiv);
 		int yi = (int)(y * invDiv);
 		return (Atan2.table[yi * ATAN2_DIM + xi] + add) * mul;


### PR DESCRIPTION
If x and y are small enough, the MathUtils.atan2(y,x) will crash.
My fix detects this case and calls the Math.atan2(y,x) instead.

https://code.google.com/p/libgdx/issues/detail?id=1231
