### PR TITLE
Switched modifier to public

### DIFF
--- a/gdx/src/com/badlogic/gdx/maps/tiled/TiledMap.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/TiledMap.java
@@ -34,7 +34,7 @@ public class TiledMap extends Map {
 	 * {@link #dispose()}.
 	 * @param textures
 	 */
-	void setOwnedTextures(Array<Texture> textures) {
+	public void setOwnedTextures(Array<Texture> textures) {
 		this.ownedTextures = textures;
 	}
 	


### PR DESCRIPTION
Enable custom map loaders not residing in the *.tiled namespace to set owned textures
