### PR TITLE
Couple of small fixes in GWT backend

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplication.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplication.java
@@ -81,6 +81,7 @@ public abstract class GwtApplication implements EntryPoint, Application {
 		this.agentInfo = computeAgentInfo();
 		this.listener = getApplicationListener();
 		this.config = getConfig();
+		this.log = config.log;
 
 		if (config.rootPanel != null) {
 			this.root = config.rootPanel;

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtGraphics.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtGraphics.java
@@ -155,11 +155,11 @@ public class GwtGraphics implements Graphics {
 	}
 
 	private native int getScreenWidthJSNI () /*-{
-															return screen.width;
+															return $wnd.screen.width;
 															}-*/;
 
 	private native int getScreenHeightJSNI () /*-{
-															return screen.height;
+															return $wnd.screen.height;
 															}-*/;
 
 	private native boolean isFullscreenJSNI () /*-{
@@ -181,8 +181,8 @@ public class GwtGraphics implements Graphics {
 
 	private native boolean setFullscreenJSNI (GwtGraphics graphics, CanvasElement element) /*-{
 																														if(element.webkitRequestFullScreen) {
-																														element.width = screen.width;
-																														element.height = screen.height;
+																														element.width = $wnd.screen.width;
+																														element.height = $wnd.screen.height;
 																														element.webkitRequestFullScreen(Element.ALLOW_KEYBOARD_INPUT);
 																														$doc.addEventListener("webkitfullscreenchange", function() {
 																														graphics.@com.badlogic.gdx.backends.gwt.GwtGraphics::fullscreenChanged()();
@@ -190,8 +190,8 @@ public class GwtGraphics implements Graphics {
 																														return true;
 																														}
 																														if(element.mozRequestFullScreen) {
-																														element.width = screen.width;
-																														element.height = screen.height;
+																														element.width = $wnd.screen.width;
+																														element.height = $wnd.screen.height;
 																														element.mozRequestFullScreen();
 																														$doc.addEventListener("mozfullscreenchange", function() {
 																														graphics.@com.badlogic.gdx.backends.gwt.GwtGraphics::fullscreenChanged()();
@@ -264,7 +264,7 @@ public class GwtGraphics implements Graphics {
 
 	@Override
 	public float getDensity () {
-		return 96 / 160;
+		return 96.0 / 160;
 	}
 
 	@Override

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/scenes/scene2d/ui/Skin.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/scenes/scene2d/ui/Skin.java
@@ -194,8 +194,9 @@ public class Skin implements Disposable {
 		return region;
 	}
 
-	/** Returns a registered ninepatch. If no ninepatch is found but a region exists with the name, the region is returned as a
-	 * ninepatch. If the region is an {@link AtlasRegion} then the {@link AtlasRegion#splits} are used. */
+	/** Returns a registered ninepatch. If no ninepatch is found but a region exists with the name, a ninepatch is created from the
+	 * region and stored in the skin. If the region is an {@link AtlasRegion} then the {@link AtlasRegion#splits} are used,
+	 * otherwise the ninepatch will have the region as the center patch. */
 	public NinePatch getPatch (String name) {
 		NinePatch patch = optional(name, NinePatch.class);
 		if (patch != null) return patch;
@@ -204,7 +205,11 @@ public class Skin implements Disposable {
 			TextureRegion region = getRegion(name);
 			if (region instanceof AtlasRegion) {
 				int[] splits = ((AtlasRegion)region).splits;
-				if (splits != null) patch = new NinePatch(region, splits[0], splits[1], splits[2], splits[3]);
+				if (splits != null) {
+					patch = new NinePatch(region, splits[0], splits[1], splits[2], splits[3]);
+					int[] pads = ((AtlasRegion)region).pads;
+					if (pads != null) patch.setPadding(pads[0], pads[1], pads[2], pads[3]);
+				}
 			}
 			if (patch == null) patch = new NinePatch(region);
 			add(name, patch, NinePatch.class);

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/preloader/PreloaderBundleGenerator.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/preloader/PreloaderBundleGenerator.java
@@ -96,8 +96,7 @@ public class PreloaderBundleGenerator extends Generator {
 	}
 
 	private void copyFile (FileWrapper source, FileWrapper dest, AssetFilter filter, ArrayList<Asset> assets) {
-		if (filter.accept(dest.path(), false))
-		;
+		if (!filter.accept(dest.path(), false)) return;
 		try {
 			assets.add(new Asset(dest, filter.getType(dest.path())));
 			dest.write(source.read(), false);


### PR DESCRIPTION
And therefore combined into one pull request. I hope this is ok.
- added log configuration with GwtApplicationConfiguration.log
- more accurate value of GwtGraphics.getDensity()
- Skin emulation takes NinePatch padding into account (copy-paste from not emulated class)
- fixed filtering of asset files in PreloaderBundleGenerator

I also faced another issue, which is not included in the patch:

The style declaration

```
<inherits name='com.google.gwt.user.theme.chrome.Chrome'/>
```

in [gdx_backends_gwt.gwt.xml](https://github.com/libgdx/libgdx/blob/master/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gdx_backends_gwt.gwt.xml) is quite convenient, but if the application is embedded in a web page and the gwt module is loaded in the end, then this style overwrites page styles. To get rid of it is not easy (in fact I was not able to turn it off and use modified jar files). Maybe it makes sense to move this style from the library module to user application modules to allow better theme customization.
