### PR TITLE
Fixed SelectBox::hideList()

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/SelectBox.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/SelectBox.java
@@ -197,6 +197,8 @@ public class SelectBox extends Widget {
 
 	public void hideList () {
 		if (list.getParent() == null) return;
+		
+		getStage().removeCaptureListener(list.stageListener)
 		list.addAction(sequence(fadeOut(0.15f, Interpolation.fade), removeActor()));
 	}
 
@@ -228,7 +230,6 @@ public class SelectBox extends Widget {
 
 			public void touchUp (InputEvent event, float x, float y, int pointer, int button) {
 				hideList();
-				event.getStage().removeCaptureListener(stageListener);
 			}
 
 			public boolean mouseMoved (InputEvent event, float x, float y) {


### PR DESCRIPTION
stageListener of SelectList should be removed in hideList() (not only in touchUp method, where it was removed previously), because hideList() call be called without any touch input.
