### PR TITLE
issue #188

### DIFF
--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglApplicationConfiguration.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglApplicationConfiguration.java
@@ -61,8 +61,11 @@ public class LwjglApplicationConfiguration {
 	/** the audio device buffer count **/
 	public int audioDeviceBufferCount = 9;
 	public Color initialBackgroundColor = Color.BLACK;
-	/** whether the game should pause when minimized or not */
-	public boolean pauseWhenMinimized = false;
+	/** Target framerate when the window is in the foreground. The CPU sleeps as needed. Use 0 to never sleep. **/
+	public int foregroundFPS = 60;
+	/** Target framerate when the window not in the background. The CPU sleeps as needed. Use 0 to never sleep, -1 to not render. **/
+	public int hiddenFPS = 60;
+	
 
 	Array<String> iconPaths = new Array();
 	Array<FileType> iconFileTypes = new Array();


### PR DESCRIPTION
Addressing issue #188 at https://code.google.com/p/libgdx/issues/detail?id=188

Make `LwjglApplication` paused when minimized or not on focus, and call resume when back on focus. It configurable with `LwjglApplicationConfiguration.pauseWhenMinimized`. By default the value is `false`, which means it will not pause when the application minimized, and the application work like this code never added. When it set to `true`, the loop will call `listener.pause()` and skip every rendering parts when the application minimized, and call `listener.resume()` when it's back on focus.
