### PR TITLE
Minor mapsapi refactoring

### DIFF
--- a/gdx/src/com/badlogic/gdx/maps/MapLayers.java
+++ b/gdx/src/com/badlogic/gdx/maps/MapLayers.java
@@ -14,7 +14,7 @@ public class MapLayers implements Iterable<MapLayer> {
 	 * @param index
 	 * @return layer at index
 	 */
-	public MapLayer getLayer(int index) {
+	public MapLayer get(int index) {
 		return layers.get(index);
 	}
 	
@@ -22,7 +22,7 @@ public class MapLayers implements Iterable<MapLayer> {
 	 * @param name
 	 * @return first layer matching the name, null otherwise
 	 */
-	public MapLayer getLayer(String name) {
+	public MapLayer get(String name) {
 		for (MapLayer layer : layers) {
 			if (name.equals(layer.getName())) {
 				return layer;
@@ -39,21 +39,21 @@ public class MapLayers implements Iterable<MapLayer> {
 	/**
 	 * @param layer layer to be added to the set
 	 */
-	public void addLayer(MapLayer layer) {
+	public void add(MapLayer layer) {
 		this.layers.add(layer);
 	}
 	
 	/**
 	 * @param index removes layer at index
 	 */
-	public void removeLayer(int index) {
+	public void remove(int index) {
 		layers.removeIndex(index);
 	}
 	
 	/**
 	 * @param layer layer to be removed
 	 */
-	public void removeLayer(MapLayer layer) {
+	public void remove(MapLayer layer) {
 		layers.removeValue(layer, true);
 	}
 
@@ -61,8 +61,8 @@ public class MapLayers implements Iterable<MapLayer> {
 	 * @param type
 	 * @return array with all the layers matching type
 	 */
-	public <T extends MapLayer> Array<T> getLayersByType(Class<T> type) {
-		return getLayersByType(type, new Array<T>());	
+	public <T extends MapLayer> Array<T> getByType(Class<T> type) {
+		return getByType(type, new Array<T>());
 	}
 	
 	/**
@@ -71,7 +71,7 @@ public class MapLayers implements Iterable<MapLayer> {
 	 * @param fill array to be filled with the matching layers
 	 * @return array with all the layers matching type
 	 */
-	public <T extends MapLayer> Array<T> getLayersByType(Class<T> type, Array<T> fill) {
+	public <T extends MapLayer> Array<T> getByType(Class<T> type, Array<T> fill) {
 		fill.clear();
 		for (MapLayer layer : layers) {
 			if (type.isInstance(layer)) {

--- a/gdx/src/com/badlogic/gdx/maps/MapObjects.java
+++ b/gdx/src/com/badlogic/gdx/maps/MapObjects.java
@@ -15,14 +15,14 @@ public class MapObjects implements Iterable<MapObject> {
 	 * Creates and empty set of MapObject instances
 	 */
 	public MapObjects() {
-		objects = new Array<MapObject>();		
+		objects = new Array<MapObject>();
 	}
 	
 	/**
 	 * @param index
 	 * @return MapObject at index
 	 */
-	public MapObject getObject(int index) {
+	public MapObject get(int index) {
 		return objects.get(index);
 	}
 	
@@ -30,7 +30,7 @@ public class MapObjects implements Iterable<MapObject> {
 	 * @param name
 	 * @return name matching object, null if it´s not in the set
 	 */
-	public MapObject getObject(String name) {
+	public MapObject get(String name) {
 		for (MapObject object : objects) {
 			if (name.equals(object.getName())) {
 				return object;
@@ -42,28 +42,28 @@ public class MapObjects implements Iterable<MapObject> {
 	/**
 	 * @param object instance to be added to the collection
 	 */
-	public void addObject(MapObject object) {
+	public void add(MapObject object) {
 		this.objects.add(object);
 	}
 	
 	/**
 	 * @param index removes MapObject instance at index
 	 */
-	public void removeObject(int index) {
+	public void remove(int index) {
 		objects.removeIndex(index);
 	}
 	
 	/**
 	 * @param object instance to be removed
 	 */
-	public void removeObject(MapObject object) {
+	public void remove(MapObject object) {
 		objects.removeValue(object, true);
 	}
 	
 	/**
 	 * @return number of objects in the collection
 	 */
-	public int getNumObjects() {
+	public int getCount() {
 		return objects.size;
 	}
 
@@ -71,8 +71,8 @@ public class MapObjects implements Iterable<MapObject> {
 	 * @param type class of the objects we want to retrieve
 	 * @return array filled with all the objects in the collection matching type
 	 */
-	public <T extends MapObject> Array<T> getObjectsByType(Class<T> type) {
-		return getObjectsByType(type, new Array<T>());	
+	public <T extends MapObject> Array<T> getByType(Class<T> type) {
+		return getByType(type, new Array<T>());
 	}
 	
 	/**
@@ -80,7 +80,7 @@ public class MapObjects implements Iterable<MapObject> {
 	 * @param fill collection to put the returned objects in
 	 * @return array filled with all the objects in the collection matching type
 	 */
-	public <T extends MapObject> Array<T> getObjectsByType(Class<T> type, Array<T> fill) {
+	public <T extends MapObject> Array<T> getByType(Class<T> type, Array<T> fill) {
 		fill.clear();
 		for (MapObject object : objects) {
 			if (type.isInstance(object)) {

--- a/gdx/src/com/badlogic/gdx/maps/tiled/TideMapLoader.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/TideMapLoader.java
@@ -252,7 +252,7 @@ public class TideMapLoader extends SynchronousAssetLoader<TiledMap, TideMapLoade
 					}
 				}
 			}
-			map.getLayers().addLayer(layer);
+			map.getLayers().add(layer);
 		}
 	}
 	

--- a/gdx/src/com/badlogic/gdx/maps/tiled/TmxMapLoader.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/TmxMapLoader.java
@@ -555,7 +555,7 @@ public class TmxMapLoader extends SynchronousAssetLoader<TiledMap, TmxMapLoader.
 			if (properties != null) {
 				loadProperties(layer.getProperties(), properties);
 			}
-			map.getLayers().addLayer(layer);
+			map.getLayers().add(layer);
 		}		
 	}
 	
@@ -573,7 +573,7 @@ public class TmxMapLoader extends SynchronousAssetLoader<TiledMap, TmxMapLoader.
 				loadObject(layer, objectElement);
 			}
 
-			map.getLayers().addLayer(layer);
+			map.getLayers().add(layer);
 		}
 	}
 	
@@ -634,7 +634,7 @@ public class TmxMapLoader extends SynchronousAssetLoader<TiledMap, TmxMapLoader.
 			if (properties != null) {
 				loadProperties(object.getProperties(), properties);
 			}
-			layer.getObjects().addObject(object);
+			layer.getObjects().add(object);
 		}
 	}
 	

--- a/gdx/src/com/badlogic/gdx/maps/tiled/renderers/BatchTiledMapRenderer.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/renderers/BatchTiledMapRenderer.java
@@ -86,7 +86,7 @@ public abstract class BatchTiledMapRenderer implements TiledMapRenderer, Disposa
 	public void render (int[] layers) {
 		spriteBatch.begin();
 		for (int layerIdx : layers) {
-			MapLayer layer = map.getLayers().getLayer(layerIdx);
+			MapLayer layer = map.getLayers().get(layerIdx);
 			if (layer.isVisible()) {
 				if (layer instanceof TiledMapTileLayer) {
 					renderTileLayer((TiledMapTileLayer) layer);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/bench/TiledMapBench.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/bench/TiledMapBench.java
@@ -64,7 +64,7 @@ public class TiledMapBench extends GdxTest {
 						layer.setCell(x, y, cell);
 					}
 				}
-				layers.addLayer(layer);
+				layers.add(layer);
 			}
 		}
 		

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/superkoalio/SuperKoalio.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/superkoalio/SuperKoalio.java
@@ -213,7 +213,7 @@ public class SuperKoalio extends GdxTest {
 				if(koala.velocity.y > 0) {
 					koala.position.y = tile.y - Koala.HEIGHT;
 					// we hit a block jumping upwards, let's destroy it!
-					TiledMapTileLayer layer = (TiledMapTileLayer)map.getLayers().getLayer(1);
+					TiledMapTileLayer layer = (TiledMapTileLayer)map.getLayers().get(1);
 					layer.setCell((int)tile.x, (int)tile.y, null);
 				} else {
 					koala.position.y = tile.y + tile.height;
@@ -250,7 +250,7 @@ public class SuperKoalio extends GdxTest {
 	}
 	
 	private void getTiles(int startX, int startY, int endX, int endY, Array<Rectangle> tiles) {
-		TiledMapTileLayer layer = (TiledMapTileLayer)map.getLayers().getLayer(1);
+		TiledMapTileLayer layer = (TiledMapTileLayer)map.getLayers().get(1);
 		rectPool.freeAll(tiles);
 		tiles.clear();
 		for(int y = startY; y <= endY; y++) {


### PR DESCRIPTION
Remove suffixes such as Object and Layer from method names since the subject is clear from the context.

This patch depends from my previous changes, mainly because the same file is being edited twice for two very different reasons: sorry for the rebase, i did a quite stupid thingy ;/
