### PR TITLE
Fix float precision issues and mixed usage of Math.sin, MathUtils.sin

### DIFF
--- a/gdx/src/com/badlogic/gdx/math/Quaternion.java
+++ b/gdx/src/com/badlogic/gdx/math/Quaternion.java
@@ -276,8 +276,8 @@ public class Quaternion implements Serializable {
 			return idt();
 		d = 1f /d;
 		float l_ang = angle * MathUtils.degreesToRadians;
-		float l_sin = MathUtils.sin(l_ang / 2);
-		float l_cos = MathUtils.cos(l_ang / 2);
+		float l_sin = (float)Math.sin(l_ang / 2);
+		float l_cos = (float)Math.cos(l_ang / 2);
 		return this.set(d * x * l_sin, d * y * l_sin, d * z * l_sin, l_cos).nor();
 	}
 


### PR DESCRIPTION
The mixed usage of both the high-precision and the faster trig functions
can leads to very different results and problems due to the nature of the
faster methods.

Also, the MathUtils implementation produces some slightly different results
when, for example, rotating a matrix on an arbitrary axis.
