### PR TITLE
Camera: Fix incorrect order of arguments.

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/Camera.java
+++ b/gdx/src/com/badlogic/gdx/graphics/Camera.java
@@ -111,8 +111,8 @@ public abstract class Camera {
 	 * @param axisY the y-component of the axis
 	 * @param axisZ the z-component of the axis */
 	public void rotate (float angle, float axisX, float axisY, float axisZ) {
-		direction.rotate(axisX, axisY, axisZ, angle);
-		up.rotate(axisX, axisY, axisZ, angle);
+		direction.rotate(angle, axisX, axisY, axisZ);
+		up.rotate(angle, axisX, axisY, axisZ);
 	}
 
 	/** Rotates the direction and up vector of this camera by the given angle around the given axis. The direction and up vector


### PR DESCRIPTION
See: http://badlogicgames.com/forum/viewtopic.php?f=15&t=8291

Note that Matrix4 uses rotate(axisX, axisY, axisZ, angle) and camera/vector3 uses rotate(angle, axisX, axisY, axisZ). I would opt to have consistent rotate method and since openGL uses angle first, it makes sense to follow that.
