### PR TITLE
Fix OUYA controller mappings on newer firmwares

### DIFF
--- a/extensions/gdx-controllers/gdx-controllers/src/com/badlogic/gdx/controllers/mappings/Ouya.java
+++ b/extensions/gdx-controllers/gdx-controllers/src/com/badlogic/gdx/controllers/mappings/Ouya.java
@@ -39,7 +39,8 @@ public class Ouya {
 		try {
 			Class<?> buildClass = Class.forName("android.os.Build");
 			Field deviceField = buildClass.getDeclaredField("DEVICE");
-			isOuya = "cardhu".equals(deviceField.get(null));
+			Object device = deviceField.get(null);
+			isOuya = "ouya_1_1".equals(device) || "cardhu".equals(device);
 		} catch(Exception e) {
 		}
 		runningOnOuya = isOuya;


### PR DESCRIPTION
In one of our recent updates, we switched our device name to "ouya_1_1". Any games running on the new firmware with the old LibGDX code would have returned incorrect mappings (and possibly been rejected from the approval process :worried:).
