### PR TITLE
New3dapi: Remove static TestShader.lightsCount

### DIFF
--- a/demos/invaders/gdx-invaders/src/com/badlogic/gdxinvaders/Renderer.java
+++ b/demos/invaders/gdx-invaders/src/com/badlogic/gdxinvaders/Renderer.java
@@ -79,7 +79,6 @@ public class Renderer {
 			spriteBatch = new SpriteBatch();
 			modelBatch = new ModelBatch();
 			TestShader.ignoreUnimplemented = true;
-			TestShader.lightsCount = 0;
 
 			backgroundTexture = new Texture(Gdx.files.internal("data/planet.jpg"), Format.RGB565, true);
 			backgroundTexture.setFilter(TextureFilter.MipMap, TextureFilter.Linear);

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/test/GLES10Shader.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/test/GLES10Shader.java
@@ -27,7 +27,7 @@ public class GLES10Shader implements Shader{
 	private Material currentMaterial;
 	private Texture currentTexture0;
 	private Mesh currentMesh;
-	private Light lights[] = new Light[lightsCount];
+	private final Light lights[] = new Light[lightsCount];
 	
 	public GLES10Shader() {
 		if (Gdx.gl10 == null)
@@ -131,9 +131,14 @@ public class GLES10Shader implements Shader{
 			Gdx.gl10.glPushMatrix();
 			Gdx.gl10.glLoadMatrixf(currentTransform.val, 0);
 		}
-		for (int i = 0; i < lightsCount; i++) {
-			final Light light = (renderable.lights == null || renderable.lights.length <= i) ? null : renderable.lights[i];
-			bindLight(i, light);
+		if (renderable.lights == null)
+			Gdx.gl10.glDisable(GL10.GL_LIGHTING);
+		else {
+			Gdx.gl10.glEnable(GL10.GL_LIGHTING);
+			for (int i = 0; i < lightsCount; i++) {
+				final Light light = renderable.lights.length > i ? renderable.lights[i] : null;
+				bindLight(i, light);
+			}
 		}
 		if (currentMesh != renderable.mesh) {
 			if (currentMesh != null)

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/utils/DefaultShaderProvider.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/utils/DefaultShaderProvider.java
@@ -8,12 +8,14 @@ import com.badlogic.gdx.graphics.g3d.test.GLES10Shader;
 import com.badlogic.gdx.graphics.g3d.test.TestShader;
 import com.badlogic.gdx.utils.Array;
 
-public class DefaultShaderProvider extends BaseShaderProvider {	
+public class DefaultShaderProvider extends BaseShaderProvider {
+	public int maxLightsCount = 5;
+	
 	@Override
 	protected Shader createShader(final Renderable renderable) {
 		Gdx.app.log("DefaultShaderProvider", "Creating new shader");
 		if (Gdx.graphics.isGL20Available())
-			return new TestShader(renderable.material);
+			return new TestShader(renderable.material, renderable.lights == null ? 0 : maxLightsCount);
 		return new GLES10Shader();
 	}
 }

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/CullTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/CullTest.java
@@ -59,7 +59,6 @@ public class CullTest extends GdxTest implements ApplicationListener {
 
 	@Override
 	public void create () {
-		TestShader.lightsCount = 0;
 		ModelBuilder builder = new ModelBuilder();
 		sphere = builder.createSphere(2f, 2f, 2f, 16, 16, new Material(new ColorAttribute(ColorAttribute.Diffuse, Color.WHITE)), new VertexAttributes(new VertexAttribute(Usage.Position, 3, ShaderProgram.POSITION_ATTRIBUTE), new VertexAttribute(Usage.Normal, 3, ShaderProgram.NORMAL_ATTRIBUTE)));
 		// cam = new PerspectiveCamera(45, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/EdgeDetectionTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/EdgeDetectionTest.java
@@ -72,7 +72,6 @@ public class EdgeDetectionTest extends GdxTest {
 			Gdx.app.log("EdgeDetectionTest", "couldn't compile post-processing shader: " + batchShader.getLog());
 		}
 
-		TestShader.lightsCount = 0;
 		TestShader.ignoreUnimplemented = true;
 		ObjLoader objLoader = new ObjLoader();
 		scene = objLoader.loadObj(Gdx.files.internal("data/scene.obj"));

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/BaseBulletTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/BaseBulletTest.java
@@ -92,7 +92,6 @@ public class BaseBulletTest extends BulletTest {
 		init();
 		modelBatch = new ModelBatch();
 		TestShader.ignoreUnimplemented = true;
-		TestShader.lightsCount = 5;
 		
 		world = createWorld();
 		world.performanceCounter = performanceCounter;


### PR DESCRIPTION
Up until now we used a "hack" to enable/disable lighting. This PR better defines how lighting is enabled/disabled:

If Renderable#lights is null, lighting should be disabled for that renderable (think skyboxes etc.). TestShader#canRender now tests on this. GLES10Shader now simply enables/disables lighting if needed (could be optimized).

If Renderable#lights is an (empty) array (even if the items within that array are all null), lighting should be enabled for that renderable.

As for TestShader the maximum number of lights allowed is set by the ShaderProvider (which should be more than 0 for Renderable#light != null).

Still, the Light class some attention. We could also just add a Vector3 direction, float angle, etc. and call it a day for now.
