### PR TITLE
fix issue 1326 (Android backend resumes audio too soon on phone unlock)

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplication.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplication.java
@@ -74,6 +74,7 @@ public class AndroidApplication extends Activity implements Application {
 	protected final Array<LifecycleListener> lifecycleListeners = new Array<LifecycleListener>();
 	protected WakeLock wakeLock = null;
 	protected int logLevel = LOG_INFO;
+	protected boolean hasFocus = true;
 
 	/** This method has to be called in the {@link Activity#onCreate(Bundle)} method. It sets up all the things necessary to get
 	 * input, render via OpenGL and so on. If useGL20IfAvailable is set the AndroidApplication will try to create an OpenGL ES 2.0
@@ -254,7 +255,7 @@ public class AndroidApplication extends Activity implements Application {
 		}
 
 		if (!firstResume) {
-			graphics.resume();
+			graphics.resume(hasFocus);
 		} else
 			firstResume = false;
 		super.onResume();
@@ -263,6 +264,14 @@ public class AndroidApplication extends Activity implements Application {
 	@Override
 	protected void onDestroy () {
 		super.onDestroy();
+	}
+
+	@Override
+	public void onWindowFocusChanged(boolean hasFocus) {
+		this.hasFocus = hasFocus;
+		if (hasFocus) {
+			graphics.resumeAudio();
+		}
 	}
 
 	@Override

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphics.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphics.java
@@ -82,6 +82,7 @@ public final class AndroidGraphics implements Graphics, Renderer {
 	volatile boolean pause = false;
 	volatile boolean resume = false;
 	volatile boolean destroy = false;
+	volatile boolean resumeAudio = false;
 
 	private float ppiX = 0;
 	private float ppiY = 0;
@@ -387,10 +388,19 @@ public final class AndroidGraphics implements Graphics, Renderer {
 
 	Object synch = new Object();
 
-	void resume () {
+	void resume (boolean resumeAudio) {
 		synchronized (synch) {
 			running = true;
 			resume = true;
+			if (resumeAudio) {
+				this.resumeAudio = true;
+			}
+		}
+	}
+
+	void resumeAudio () {
+		synchronized (synch) {
+			resumeAudio = true;
 		}
 	}
 
@@ -435,15 +445,21 @@ public final class AndroidGraphics implements Graphics, Renderer {
 		boolean lpause = false;
 		boolean ldestroy = false;
 		boolean lresume = false;
+		boolean lresumeAudio = false;
 
 		synchronized (synch) {
 			lrunning = running;
 			lpause = pause;
 			ldestroy = destroy;
 			lresume = resume;
+			lresumeAudio = resumeAudio;
 
 			if (resume) {
 				resume = false;
+			}
+
+			if (resumeAudio) {
+				resumeAudio = false;
 			}
 
 			if (pause) {
@@ -457,8 +473,11 @@ public final class AndroidGraphics implements Graphics, Renderer {
 			}
 		}
 
-		if (lresume) {
+		if (lresumeAudio) {
 			((AndroidApplication)app).audio.resume();
+		}
+
+		if (lresume) {
 			Array<LifecycleListener> listeners = ((AndroidApplication)app).lifecycleListeners;
 			synchronized(listeners) {
 				for(LifecycleListener listener: listeners) {


### PR DESCRIPTION
Context:

https://code.google.com/p/libgdx/issues/detail?id=1326

This is a pretty literal implementation of the fix suggested in the blog post. I have tested it on various Android versions and it works, but obviously I couldn't cover all the possible scenarios, so proceed with caution.
