### PR TITLE
Issue #1376 Solution for ParticleEditor keyboard events handler.

### DIFF
--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/ParticleEditor.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/ParticleEditor.java
@@ -458,6 +458,9 @@ public class ParticleEditor extends JFrame {
 		}
 
 		public boolean touchUp (int x, int y, int pointer, int button) {
+			ParticleEditor.this.dispatchEvent(new WindowEvent(ParticleEditor.this, WindowEvent.WINDOW_LOST_FOCUS));
+			ParticleEditor.this.dispatchEvent(new WindowEvent(ParticleEditor.this, WindowEvent.WINDOW_GAINED_FOCUS));
+			ParticleEditor.this.requestFocusInWindow();
 			return false;
 		}
 


### PR DESCRIPTION
https://code.google.com/p/libgdx/issues/detail?id=1376

Particle Editor doesn't handle key events after clicking on particle panel (lwjglCanvas).
Here is the simple solution.
