### PR TITLE
Update ParticleEmitterBox2D.java

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g2d/ParticleEmitterBox2D.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/ParticleEmitterBox2D.java
@@ -113,7 +113,7 @@ public class ParticleEmitterBox2D extends ParticleEmitter {
 			if (world != null) world.rayCast(rayCallBack, startPoint, endPoint);
 
 			/** If ray collided boolean has set to true at rayCallBack */
-			if (!particleCollided) {
+			if (particleCollided) {
 				// perfect reflection
 				angle = 2f * normalAngle - angle - 180f;
 				angleCos = MathUtils.cosDeg(angle);


### PR DESCRIPTION
The particleCollided check is just plain wrong and is making the whole particleemitter to react to the collisions happening instead of the single particle that collided.
