### PR TITLE
New3dapi: small changes

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/Camera.java
+++ b/gdx/src/com/badlogic/gdx/graphics/Camera.java
@@ -21,6 +21,7 @@ import com.badlogic.gdx.Graphics;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.math.Frustum;
+import com.badlogic.gdx.math.Matrix3;
 import com.badlogic.gdx.math.Matrix4;
 import com.badlogic.gdx.math.Quaternion;
 import com.badlogic.gdx.math.Vector3;
@@ -86,21 +87,21 @@ public abstract class Camera {
 	 * @param z the x-coordinate of the point to look at */
 	public void lookAt (float x, float y, float z) {
 		direction.set(x, y, z).sub(position).nor();
+		normalizeUp();
 	}
 	
 	/** Recalculates the direction of the camera to look at the point (x, y, z).
 	 * @param target the point to look at */
 	public void lookAt (Vector3 target) {
 		direction.set(target).sub(position).nor();
+		normalizeUp();
 	}
 
 	/** Normalizes the up vector by first calculating the right vector via a cross product between direction and up, and then
 	 * recalculating the up vector via a cross product between right and direction. */
-	final Vector3 right = new Vector3();
-
 	public void normalizeUp () {
-		right.set(direction).crs(up).nor();
-		up.set(right).crs(direction).nor();
+		tmpVec.set(direction).crs(up).nor();
+		up.set(tmpVec).crs(direction).nor();
 	}
 
 	/** Rotates the direction and up vector of this camera by the given angle around the given axis. The direction and up vector

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/Model.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/Model.java
@@ -189,15 +189,20 @@ public class Model implements Disposable {
 	private Material convertMaterial(ModelMaterial mtl, TextureProvider textureProvider) {
 		Material result = new Material();
 		result.id = mtl.id;
-		result.add(new ColorAttribute(ColorAttribute.Ambient, mtl.ambient));
-		result.add(new ColorAttribute(ColorAttribute.Diffuse, mtl.diffuse));
-		result.add(new ColorAttribute(ColorAttribute.Specular, mtl.specular));
-		result.add(new ColorAttribute(ColorAttribute.Emissive, mtl.emissive));
-		result.add(new FloatAttribute(FloatAttribute.Shininess, mtl.shininess));
+		if (mtl.ambient != null)
+			result.add(new ColorAttribute(ColorAttribute.Ambient, mtl.ambient));
+		if (mtl.diffuse != null)
+			result.add(new ColorAttribute(ColorAttribute.Diffuse, mtl.diffuse));
+		if (mtl.specular != null)
+			result.add(new ColorAttribute(ColorAttribute.Specular, mtl.specular));
+		if (mtl.emissive != null)
+			result.add(new ColorAttribute(ColorAttribute.Emissive, mtl.emissive));
+		if (mtl.shininess > 0f)
+			result.add(new FloatAttribute(FloatAttribute.Shininess, mtl.shininess));
 		
 		ObjectMap<String, Texture> textures = new ObjectMap<String, Texture>();
 		
-		// FIXME mipmapping totally ignored, filters totally ignored
+		// FIXME mipmapping totally ignored, filters totally ignored, uvScaling/uvTranslation totally ignored
 		if(mtl.diffuseTextures != null) {
 			for(ModelTexture tex: mtl.diffuseTextures) {
 				if(textures.containsKey(tex.fileName)) continue;

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/utils/CameraInputController.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/utils/CameraInputController.java
@@ -1,0 +1,128 @@
+package com.badlogic.gdx.graphics.g3d.utils;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.InputAdapter;
+import com.badlogic.gdx.Input.Buttons;
+import com.badlogic.gdx.graphics.Camera;
+import com.badlogic.gdx.math.Vector3;
+
+public class CameraInputController extends InputAdapter {
+	/** The button for rotating the camera. */ 
+	public int rotateButton = Buttons.LEFT;
+	/** The angle to rotate when moved the full width or height of the screen. */
+	public float rotateAngle = 360f;
+	/** The button for translating the camera along the up/right plane */
+	public int translateButton = Buttons.RIGHT;
+	/** The units to translate the camera when moved the full width or height of the screen. */
+	public float translateUnits = 10f; // FIXME auto calculate this based on the target
+	/** The button for translating the camera along the direction axis */
+	public int forwardButton = Buttons.MIDDLE;
+	/** The key which must be pressed to activate rotate, translate and forward or 0 to always activate. */ 
+	public int activateKey = 0;
+	/** Indices if the activateKey is currently being pressed. */
+	protected boolean activatePressed;
+	/** Whether scrolling requires the activeKey to be pressed (false) or always allow scrolling (true). */
+	public boolean alwaysScroll = true;
+	/** The weight for each scrolled amount. */
+	public float scrollFactor = -0.1f;
+	/** Whether to update the camera after it has been changed. */
+	public boolean autoUpdate = true;
+	/** The target to rotating around. */
+	public Vector3 target = new Vector3();
+	/** Whether to update the target on translation */ 
+	public boolean translateTarget = true;
+	/** Whether to update the target on forward */
+	public boolean forwardTarget = true;
+	/** Whether to update the target on scroll */
+	public boolean scrollTarget = false;
+	/** The camera. */
+	public Camera camera;
+	/** The current (first) button being pressed. */
+	protected int button = -1;
+	
+	private float startX, startY;
+	private final Vector3 tmpV1 = new Vector3();
+	private final Vector3 tmpV2 = new Vector3();
+	
+	public CameraInputController(final Camera camera) {
+		this.camera = camera;
+	}
+	
+	@Override
+	public boolean touchDown (int screenX, int screenY, int pointer, int button) {
+		if (this.button < 0 && activateKey == 0 || activatePressed) {
+			startX = screenX;
+			startY = screenY;
+			this.button = button;
+		}
+		return false;
+	}
+	
+	@Override
+	public boolean touchUp (int screenX, int screenY, int pointer, int button) {
+		if (button == this.button)
+			this.button = -1;
+		return false;
+	}
+	
+	protected boolean process(float deltaX, float deltaY, int button) {
+		deltaX = (deltaX + 1f) * 0.5f;
+		deltaY = (deltaY + 1f) * 0.5f;
+		if (button == rotateButton) {
+			tmpV1.set(camera.direction).crs(camera.up).y = 0f;
+			camera.rotateAround(target, tmpV1.nor(), deltaY * rotateAngle);
+			camera.rotateAround(target, Vector3.Y, deltaX * -rotateAngle);
+		} else if (button == translateButton) {
+			camera.translate(tmpV1.set(camera.direction).crs(camera.up).nor().scl(-deltaX * translateUnits));
+			camera.translate(tmpV2.set(camera.up).scl(-deltaY * translateUnits));
+			if (translateTarget)
+				target.add(tmpV1).add(tmpV2);				
+		} else if (button == forwardButton) {
+			camera.translate(tmpV1.set(camera.direction).scl(deltaY * translateUnits));
+			if (forwardTarget)
+				target.add(tmpV1);
+		}
+		if (autoUpdate)
+			camera.update();
+		return true;
+	}
+	
+	@Override
+	public boolean touchDragged (int screenX, int screenY, int pointer) {
+		if (this.button < 0)
+			return false;
+		final float deltaX = -1f + 2f * (screenX - startX) / Gdx.graphics.getWidth();
+		final float deltaY = -1f + 2f * (startY - screenY) / Gdx.graphics.getHeight();
+		startX = screenX;
+		startY = screenY;
+		return process(deltaX, deltaY, button);
+	}
+	
+	@Override
+	public boolean scrolled (int amount) {
+		if (!alwaysScroll && activateKey != 0 && !activatePressed)
+			return false;
+		camera.translate(tmpV1.set(camera.direction).scl(amount * scrollFactor * translateUnits));
+		if (scrollTarget)
+			target.add(tmpV1);
+		if (autoUpdate)
+			camera.update();
+		return true;
+	}
+	
+	@Override
+	public boolean keyDown (int keycode) {
+		if (keycode == activateKey)
+			activatePressed = true;
+		return false;
+	}
+	
+	@Override
+	public boolean keyUp (int keycode) {
+		if (keycode == activateKey) {
+			activatePressed = false;
+			button = -1;
+		}
+		return false;
+	}
+}

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/utils/DefaultTextureBinder.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/utils/DefaultTextureBinder.java
@@ -16,7 +16,7 @@ public final class DefaultTextureBinder implements TextureBinder {
 	public final static int ROUNDROBIN = 0;
 	public final static int WEIGHTED = 1;
 	/** GLES only supports up to 32 textures */
-	public final static int MAX_GLES_UNITS = 4;
+	public final static int MAX_GLES_UNITS = 32;
 	/** The index of the first exclusive texture unit */
 	private final int offset;
 	/** The amount of exclusive textures that may be used */
@@ -51,8 +51,7 @@ public final class DefaultTextureBinder implements TextureBinder {
 	}
 	
 	public DefaultTextureBinder(final int method, final int offset, final int count, final int reuseWeight) {
-		// FIXME this is wrong, GL_MATRX_TEXTURE_UNITS is a constant, doesn't return the #units for the current GPU
-		int max = Math.max(getMaxTextureUnits(), MAX_GLES_UNITS - offset);
+		final int max = Math.min(getMaxTextureUnits(), MAX_GLES_UNITS - offset);
 		if (offset < 0 || count < 0 || (offset + count) > max || reuseWeight < 1)
 			throw new GdxRuntimeException("Illegal arguments");
 		this.method = method;
@@ -84,10 +83,12 @@ public final class DefaultTextureBinder implements TextureBinder {
 
 	@Override
 	public void end () {
-		// FIXME only unbind textures that are bound
 		for(int i = 0; i < count; i++) {
-			Gdx.gl.glActiveTexture(GL20.GL_TEXTURE0 + i);
-			Gdx.gl.glBindTexture(GL20.GL_TEXTURE_2D, 0);
+			if (textures[i].texture != null) {
+				Gdx.gl.glActiveTexture(GL20.GL_TEXTURE0 + i);
+				Gdx.gl.glBindTexture(GL20.GL_TEXTURE_2D, 0);
+				textures[i].texture = null;
+			}
 		}
 		Gdx.gl.glActiveTexture(GL20.GL_TEXTURE0);
 	}

--- a/gdx/src/com/badlogic/gdx/math/collision/Ray.java
+++ b/gdx/src/com/badlogic/gdx/math/collision/Ray.java
@@ -43,12 +43,20 @@ public class Ray implements Serializable {
 		return new Ray(this.origin, this.direction);
 	}
 
-	/** Returns and endpoint given the distance. This is calculated as startpoint + distance * direction.
-	 * 
+	/** @deprecated Use {@link #getEndPoint(Vector3, float)} instead.
+	 * Returns the endpoint given the distance. This is calculated as startpoint + distance * direction.
 	 * @param distance The distance from the end point to the start point.
 	 * @return The end point */
 	public Vector3 getEndPoint (float distance) {
-		return new Vector3(origin).add(direction.tmp().mul(distance));
+		return getEndPoint(new Vector3(), distance);
+	}
+
+	/** Returns the endpoint given the distance. This is calculated as startpoint + distance * direction.
+	 * @param out The vector to set to the result
+	 * @param distance The distance from the end point to the start point.
+	 * @return The out param */
+	public Vector3 getEndPoint(final Vector3 out, final float distance) {
+		return out.set(direction).scl(distance).add(origin);
 	}
 
 	static Vector3 tmp = new Vector3();
@@ -101,7 +109,6 @@ public class Ray implements Serializable {
 	 * @param ray The ray
 	 * @return This ray for chaining */
 	public Ray set (Ray ray) {
-
 		this.origin.set(ray.origin);
 		this.direction.set(ray.direction);
 		return this;

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/BulletEntity.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/BulletEntity.java
@@ -47,7 +47,7 @@ public class BulletEntity extends BaseEntity {
 	}
 	
 	public BulletEntity (final Model model, final btCollisionObject body, final Matrix4 transform) {
-		this.modelInstance = new ModelInstance(model, transform);
+		this.modelInstance = new ModelInstance(model, transform.cpy());
 		this.transform = this.modelInstance.transform;
 		this.body = body;
 		

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/SoftBodyTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/SoftBodyTest.java
@@ -26,6 +26,7 @@ import com.badlogic.gdx.graphics.VertexAttributes.Usage;
 import com.badlogic.gdx.graphics.g3d.Model;
 import com.badlogic.gdx.graphics.g3d.ModelInstance;
 import com.badlogic.gdx.graphics.g3d.materials.ColorAttribute;
+import com.badlogic.gdx.graphics.g3d.materials.FloatAttribute;
 import com.badlogic.gdx.graphics.g3d.materials.Material;
 import com.badlogic.gdx.graphics.g3d.materials.TextureAttribute;
 import com.badlogic.gdx.graphics.g3d.utils.ModelBuilder;
@@ -118,7 +119,7 @@ public class SoftBodyTest extends BaseBulletTest {
 		texture = new Texture(Gdx.files.internal("data/badlogic.jpg"));
 		
 		model = ModelBuilder.createFromMesh(mesh, GL10.GL_TRIANGLES, 
-			new Material(TextureAttribute.createDiffuse(texture), ColorAttribute.createSpecular(Color.WHITE)));
+			new Material(TextureAttribute.createDiffuse(texture), ColorAttribute.createSpecular(Color.WHITE), FloatAttribute.createShininess(1f)));
 		instance = new ModelInstance(model);
 	}
 	

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/BatchRenderTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/BatchRenderTest.java
@@ -13,6 +13,7 @@ import com.badlogic.gdx.graphics.g3d.ModelInstance;
 import com.badlogic.gdx.graphics.g3d.loader.JsonModelLoader;
 import com.badlogic.gdx.graphics.g3d.loader.ObjLoader;
 import com.badlogic.gdx.graphics.g3d.shaders.DefaultShader;
+import com.badlogic.gdx.graphics.g3d.utils.CameraInputController;
 import com.badlogic.gdx.graphics.g3d.utils.DefaultTextureBinder;
 import com.badlogic.gdx.math.Matrix4;
 import com.badlogic.gdx.math.Vector3;
@@ -84,7 +85,7 @@ public class BatchRenderTest extends GdxTest {
 			new Light(0f, 1f, 0f, 1f, 0f, 10f, 50f, 0f, -1f, 0f, 15f, 1f, 0f, 0f)
 		};
 		
-		Gdx.input.setInputProcessor(this);
+		Gdx.input.setInputProcessor(new CameraInputController(cam));
 	}
 	
 	public void createScene1() {
@@ -128,30 +129,6 @@ public class BatchRenderTest extends GdxTest {
 				renderBatch.render(instances.get(i), lights);
 		}
 		renderBatch.end();		
-	}
-	
-	@Override
-	public boolean touchDown (int x, int y, int pointer, int newParam) {
-		touchStartX = x;
-		touchStartY = y;
-		return false;
-	}
-
-	@Override
-	public boolean touchDragged (int x, int y, int pointer) {
-		cam.rotateAround(Vector3.Zero, Vector3.X, (x - touchStartX));
-		cam.rotateAround(Vector3.Zero, Vector3.Y, (y - touchStartY));
-		touchStartX = x;
-		touchStartY = y;
-		cam.update();
-		return false;
-	}
-
-	@Override
-	public boolean scrolled (int amount) {
-		cam.fieldOfView -= -amount * Gdx.graphics.getDeltaTime() * 100;
-		cam.update();
-		return false;
 	}
 
 	@Override

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/NewModelTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/NewModelTest.java
@@ -11,8 +11,10 @@ import com.badlogic.gdx.graphics.g3d.ModelBatch;
 import com.badlogic.gdx.graphics.g3d.ModelInstance;
 import com.badlogic.gdx.graphics.g3d.loader.JsonModelLoader;
 import com.badlogic.gdx.graphics.g3d.shaders.DefaultShader;
+import com.badlogic.gdx.graphics.g3d.utils.CameraInputController;
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer.ShapeType;
+import com.badlogic.gdx.math.Matrix3;
 import com.badlogic.gdx.math.Matrix4;
 import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.tests.utils.GdxTest;
@@ -37,29 +39,40 @@ public class NewModelTest extends GdxTest {
 	public void create () {
 		if (assets == null)
 			assets = new AssetManager();
-		assets.load("data/cube.obj", Model.class);
+		assets.load("data/g3d/head.g3dj", Model.class);
 		assets.finishLoading();
-		model = assets.get("data/cube.obj", Model.class);
+		model = assets.get("data/g3d/head.g3dj", Model.class);
+
 		instance = new ModelInstance(model);
+		instance.transform.scale(5f, 5f, 5f);
 		modelBatch = new ModelBatch();
 		shapeRenderer = new ShapeRenderer();
 		
 		cam = new PerspectiveCamera(67, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
 		cam.position.set(10f, 10f, 10f);
-		cam.direction.set(-1, -1, -1);
+		cam.lookAt(0,0,0);
 		cam.near = 0.1f;
 		cam.far = 300f;
-		Gdx.input.setInputProcessor(this);
+		cam.update();
+
+		Gdx.input.setInputProcessor(new CameraInputController(cam));
 	}
 
+	final float GRID_MIN = -10f;
+	final float GRID_MAX = 10f;
+	final float GRID_STEP = 1f;
 	@Override
 	public void render () {
 		Gdx.gl.glViewport(0, 0, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
 		Gdx.gl.glClear(GL10.GL_COLOR_BUFFER_BIT | GL10.GL_DEPTH_BUFFER_BIT);
 
-		cam.update();
 		shapeRenderer.setProjectionMatrix(cam.combined);
 		shapeRenderer.begin(ShapeType.Line);
+		shapeRenderer.setColor(Color.LIGHT_GRAY);
+		for (float t = GRID_MIN; t <= GRID_MAX; t+=GRID_STEP) {
+			shapeRenderer.line(t, 0, GRID_MIN, t, 0, GRID_MAX);
+			shapeRenderer.line(GRID_MIN, 0, t, GRID_MAX, 0, t);
+		}
 		shapeRenderer.setColor(Color.RED);
 		shapeRenderer.line(0, 0, 0, 100, 0, 0);
 		shapeRenderer.setColor(Color.GREEN);
@@ -67,9 +80,6 @@ public class NewModelTest extends GdxTest {
 		shapeRenderer.setColor(Color.BLUE);
 		shapeRenderer.line(0, 0, 0, 0, 0, 100);
 		shapeRenderer.end();
-
-		instance.transform.idt();
-		instance.transform.translate(0, 0, 3);
 		
 		modelBatch.begin(cam);
 		modelBatch.render(instance, lights);
@@ -81,28 +91,6 @@ public class NewModelTest extends GdxTest {
 		modelBatch.dispose();
 		assets.dispose();
 		assets = null;
-	}
-
-	@Override
-	public boolean touchDown (int x, int y, int pointer, int newParam) {
-		touchStartX = x;
-		touchStartY = y;
-		return false;
-	}
-
-	@Override
-	public boolean touchDragged (int x, int y, int pointer) {
-		cam.rotateAround(new Vector3(), Vector3.X, y - touchStartY);
-		cam.rotateAround(new Vector3(), Vector3.Y, x - touchStartX);
-		touchStartX = x;
-		touchStartY = y;
-		return false;
-	}
-
-	@Override
-	public boolean scrolled (int amount) {
-		cam.fieldOfView -= -amount * Gdx.graphics.getDeltaTime() * 100;
-		return false;
 	}
 
 	@Override


### PR DESCRIPTION
Camera: 
set up vector when using lookAt and remove temp vector right.

Model: 
only set material attributes if they aren't null

ModelInstance: 
add calculateBoundingBox
reference instead of copy the specified matrix (useful for mvc, entity system, etc.)

CameraInputController:
class to easier control the camera (somewhat like the cam in modelling software), the default:
- Left button: rotate around a target vector, horizontal around Y axis, vertical around the right axis (recalculated to be perpendicular to the Y axis).
- Middle button: vertical: move the camera along the direction axis and translate the (rotation) target vector along with it (keeping the same distance).
- Scoll: move the camera along the direction axis, but not translate the (rotation) target vector.
- Right button: move the camera on the up/right plane and translate the (rotation) target vector also.

DefaultTextureBinder:
fix the max texture units (cannot bind more textures than GL_TEXTURE0+31)
only unbind textures that are bound

Mesh:
add calculateBoundingBox for a specific meshpart
add transformUV to translate/scale/rotate uv coordinates

Ray:
avoid creating objects

Change the tests accordingly
