### PR TITLE
Fixed Live Wallpaper crash on Android 2.2

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidLiveWallpaperService.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidLiveWallpaperService.java
@@ -338,10 +338,10 @@ public abstract class AndroidLiveWallpaperService extends WallpaperService {
 				onCreateApplication();
 				if (app.graphics == null)
 					throw new Error("You must override 'AndroidLiveWallpaperService.onCreateApplication' method and call 'initialize' from its body.");
-				
-				view = (SurfaceHolder.Callback)app.graphics.view;
-				this.getSurfaceHolder().removeCallback(view);	// we are going to call this events manually
 			}
+
+			view = (SurfaceHolder.Callback)app.graphics.view;
+			this.getSurfaceHolder().removeCallback(view);	// we are going to call this events manually
 
 			// inherit format from shared surface view
 			engineFormat = viewFormat;


### PR DESCRIPTION
Maybe not only on 2.2, but i have 2 "engines" on HTC Hero with 2.2.1 and have a crash because view is not initialized, because can't be initialized if have more than 1 engine (see line 331).
So, i think it's just a typo.
