### PR TITLE
Fixed forceVBO in Mesh

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/Mesh.java
+++ b/gdx/src/com/badlogic/gdx/graphics/Mesh.java
@@ -176,7 +176,7 @@ public class Mesh implements Disposable {
 	public Mesh (VertexDataType type, boolean isStatic, int maxVertices, int maxIndices, VertexAttribute... attributes) {
 // if (type == VertexDataType.VertexArray && Gdx.graphics.isGL20Available()) type = VertexDataType.VertexBufferObject;
 
-		if (type == VertexDataType.VertexBufferObject) {
+		if (type == VertexDataType.VertexBufferObject || Mesh.forceVBO) {
 			vertices = new VertexBufferObject(isStatic, maxVertices, attributes);
 			indices = new IndexBufferObject(isStatic, maxIndices);
 			isVertexArray = false;


### PR DESCRIPTION
At least one recent commit https://github.com/libgdx/libgdx/commit/7020231ca8b1e14995d398603de525581e3d1282 has completely disabled VBO support in the SpriteBatch class for not so clear reasons. 
My project uses GL20 for now only and I would like to use/test VBOs, so at least there's a way to bring back VBOs in spritebatch by using the forceVBO flag.

If someone could clarify why SpriteBatch was changed I would appreciate as well. 
Reason being is that setting a new texture for every draw can be the cause of the slow down instead of the vbo itself. 
Eg: Some engines can sort the meshes by material before drawing, minimizing state changes for performance reasons.

Also one thing not taken into account in the SpriteBatch class is culling with GL_CULL_FACE which could theoretically help with performance. Spritebatch uses a (non default) CW front face order (default is CCW as front face), which makes things a little bit uneasy if you have mixed usage with other custom CCW meshes, but that's a non issue.
