### PR TITLE
Fix for issue #1397

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextField.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextField.java
@@ -382,7 +382,7 @@ public class TextField extends Widget {
 	/** Sets the password character for the text field. The character must be present in the {@link BitmapFont} */
 	public void setPasswordCharacter (char passwordCharacter) {
 		this.passwordCharacter = passwordCharacter;
-		updateDisplayText();
+		if(passwordMode) updateDisplayText();
 	}
 
 	/** Returns the text field's style. Modifying the returned style may not have an effect until {@link #setStyle(TextFieldStyle)}


### PR DESCRIPTION
This will update the displayed text in TextField after password has been enabled. I would assume that the textfield immediately gets obfuscated/de-obfuscated when setPassowordMode is enabled/disabled. This is a fix for issue #1397.
