### PR TITLE
Update TiledMapTileSet - get TileSet tiles when TiledMapTile ID is unknown

### DIFF
--- a/gdx/src/com/badlogic/gdx/maps/tiled/TiledMapTileSet.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/TiledMapTileSet.java
@@ -1,12 +1,13 @@
 package com.badlogic.gdx.maps.tiled;
 
+import java.util.Iterator;
 import com.badlogic.gdx.maps.MapProperties;
 import com.badlogic.gdx.utils.IntMap;
 
 /**
  * @brief Set of TiledMapTile instances used to compose a TiledMapLayer
  */
-public class TiledMapTileSet {
+public class TiledMapTileSet implements Iterable<TiledMapTile> {
 	
 	private String name;
 	
@@ -52,11 +53,13 @@ public class TiledMapTileSet {
 	}
 	
 	/**
-	 *  Get TiledMapTiles used by this TileSet (in case you don't know the exact ID)
+	 * @return iterator to tiles in this tileset
 	 */
-	public Values<TiledMapTile> getTiles() {
-     		return tiles.values();
+	@Override
+	public Iterator<TiledMapTile> iterator() {
+		return tiles.values().iterator();
 	}
+	
 	/**
 	 * Adds or replaces tile with that id
 	 * 


### PR DESCRIPTION
Premise:
I am using Tiled Map Editor and giving properties, such as friction, to individual TileSet tiles as a template so that I may lay down 20 'ice' tiles and 20 'road' tiles without having to individually specify their respective properties (friction) for each tile laid as that would get cumbersome. 

TileSets support properties for their Tiles, and libgdx allows access to these TileSets, however the TileSet class only allows access to their respective Tiles (and their respective properties) if you know the exact id of said Tile.

Current State:
- You may iterate through all the TiledMapTileSets for a given TileMap.
- For each TileSet, if you DO know the TiledMapTile's id, you may get TiledMapTile's from the TileSet using TileSet.getId(id). 
- If you DO NOT know the id of the TiledMapTile, there is no way to iterate through all of its TiledMapTile's - such is my case since the user may make their own levels and the ids they may use are unknown to me
