### PR TITLE
Fix for HTTP error responses being handled as failed requests

### DIFF
--- a/gdx/src/com/badlogic/gdx/net/NetJavaImpl.java
+++ b/gdx/src/com/badlogic/gdx/net/NetJavaImpl.java
@@ -36,7 +36,11 @@ public class NetJavaImpl {
 
 		public HttpClientResponse (HttpURLConnection connection) throws IOException {
 			this.connection = connection;
-			this.inputStream = connection.getInputStream();
+			try {
+				this.inputStream = connection.getInputStream();
+			} catch (IOException e) {
+				this.inputStream = connection.getErrorStream();
+			}
 
 			try {
 				this.status = new HttpStatus(connection.getResponseCode());


### PR DESCRIPTION
The documentation for the Net.HttpResponseListener.failed method states:
"Called if the Net.HttpRequest failed because an exception when processing the HTTP request, could be a timeout any other reason (not an HTTP error)."

However, HTTP errors are currently being treated as failures. This makes it impossible to get at the error body the server sends. For example a server may give a JSON response on 400-level status that the client has to parse and take action on.

The proposed fix does the following:
On HTTP errors, set the HttpClientResponse input stream to the error stream. This continues the response processing and allows for reading the server's error response in the handleHttpResponse callback instead of invoking the failed method (which is now used for connection-level failures like the timeouts, the server not being reachable etc).
