### PR TITLE
Adding support for the HTTP verbs PUT and DELETE

### DIFF
--- a/backends/gdx-backend-iosmonotouch/src/com/badlogic/gdx/backends/ios/IOSNet.java
+++ b/backends/gdx-backend-iosmonotouch/src/com/badlogic/gdx/backends/ios/IOSNet.java
@@ -149,7 +149,7 @@ public class IOSNet implements Net {
 						webHeaderCollection.Add(key, headers.get(key));
 					httpWebRequest.set_Headers(webHeaderCollection);
 
-					if (method.equalsIgnoreCase(HttpMethods.POST)) {
+					if (method.equalsIgnoreCase(HttpMethods.POST) || method.equalsIgnoreCase(HttpMethods.PUT)) {
 						InputStream contentAsStream = httpRequest.getContentStream();
 						String contentAsString = httpRequest.getContent();
 

--- a/gdx/src/com/badlogic/gdx/Net.java
+++ b/gdx/src/com/badlogic/gdx/Net.java
@@ -80,11 +80,15 @@ public interface Net {
 	 * <ul>
 	 * <li>GET</li>
 	 * <li>POST</li>
+	 * <li>PUT</li>
+	 * <li>DELETE</li>
 	 * </ul> */
 	public static interface HttpMethods {
 
 		public static final String GET = "GET";
 		public static final String POST = "POST";
+		public static final String PUT = "PUT";
+		public static final String DELETE = "DELETE";
 
 	}
 

--- a/gdx/src/com/badlogic/gdx/net/NetJavaImpl.java
+++ b/gdx/src/com/badlogic/gdx/net/NetJavaImpl.java
@@ -117,7 +117,8 @@ public class NetJavaImpl {
 
 			final HttpURLConnection connection = (HttpURLConnection)url.openConnection();
 			// should be enabled to upload data.
-			connection.setDoOutput(method.equalsIgnoreCase(HttpMethods.POST));
+			final boolean doingOutPut = method.equalsIgnoreCase(HttpMethods.POST) || method.equalsIgnoreCase(HttpMethods.PUT); 
+			connection.setDoOutput(doingOutPut);
 			connection.setDoInput(true);
 			connection.setRequestMethod(method);
 
@@ -136,8 +137,8 @@ public class NetJavaImpl {
 				public void run () {
 					try {
 
-						// Set the content for POST (GET has the information embedded in the URL)
-						if (method.equalsIgnoreCase(HttpMethods.POST)) {
+						// Set the content for POST and PUT (GET has the information embedded in the URL)
+						if (doingOutPut) {
 							// we probably need to use the content as stream here instead of using it as a string.
 							String contentAsString = httpRequest.getContent();
 							InputStream contentAsStream = httpRequest.getContentStream();


### PR DESCRIPTION
This adds the support for the PUT and DELETE HttpMethods to Net.HttpRequest.

Tested on Android and desktop, iOS not tested but should be OK.
