### PR TITLE
Fix for get (int key, int defaultValue) method in IntIntMap.java

### DIFF
--- a/gdx/src/com/badlogic/gdx/utils/IntIntMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/IntIntMap.java
@@ -282,7 +282,10 @@ public class IntIntMap {
 
 	/** @param defaultValue Returned if the key was not associated with a value. */
 	public int get (int key, int defaultValue) {
-		if (key == 0) return zeroValue;
+		if (key == 0) {
+			if (!hasZeroValue) return defaultValue;
+			return zeroValue;
+		}
 		int index = key & mask;
 		if (keyTable[index] != key) {
 			index = hash2(key);


### PR DESCRIPTION
Method get is broken.
Ex : Using get(0, -1) on a new IntIntMap would return 0 (zeroValue) instead of that -1 (defaultValue) because there isn't the hasZeroValue check like in the remove method.
