### PR TITLE
iOS Bugfix: playing music files that are not in the assets folder!

### DIFF
--- a/backends/gdx-backend-iosmonotouch/src/com/badlogic/gdx/backends/ios/IOSAudio.java
+++ b/backends/gdx-backend-iosmonotouch/src/com/badlogic/gdx/backends/ios/IOSAudio.java
@@ -102,14 +102,15 @@ public class IOSAudio implements Audio {
 		verify(fileHandle);
 
 		// create audio player - from file path
+		String path = fileHandle.file().getPath().replace('\\', '/');
 		NSError[] error = new NSError[1];
-		AVAudioPlayer player = AVAudioPlayer.FromUrl(NSUrl.FromFilename(fileHandle.path()), error);
+		AVAudioPlayer player = AVAudioPlayer.FromUrl(NSUrl.FromFilename(path), error);
 		if (error[0] == null) {
 			// no error: return the music object
 			return new IOSMusic(player);
 		} else {
 			// throw an exception
-			throw new GdxRuntimeException("Error opening music file at " + fileHandle.path() + ": " + error[0].ToString());
+			throw new GdxRuntimeException("Error opening music file at " + path + ": " + error[0].ToString());
 		}
 	}
 }


### PR DESCRIPTION
On a side note: I noted in the iOS Wiki there is a mention to convert sounds to CAF or OGG. I added a comment below. I wonder, what are the benefits of using CAF or OGG besides probably (?) better compression?

Wiki ("Sound" section at bottom):
http://code.google.com/p/libgdx/wiki/IOSWIP?ts=1367735126&updated=IOSWIP
