### PR TITLE
Stage. Add clear() in dispose()

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/Stage.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/Stage.java
@@ -677,6 +677,7 @@ public class Stage extends InputAdapter implements Disposable {
 	}
 
 	public void dispose () {
+		clear();
 		if (ownsBatch) batch.dispose();
 	}
 


### PR DESCRIPTION
Without clear() even after "stage = null;" click listeners still work even on another screens.
