### PR TITLE
Add support for ImageProcessor to accept BufferedImage objects as input

### DIFF
--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/imagepacker/ImageProcessor.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/imagepacker/ImageProcessor.java
@@ -46,8 +46,14 @@ public class ImageProcessor {
 	public ImageProcessor (File rootDir, Settings settings) {
 		this.settings = settings;
 
-		rootPath = rootDir.getAbsolutePath().replace('\\', '/');
-		if (!rootPath.endsWith("/")) rootPath += "/";
+		if (rootDir != null) {
+			rootPath = rootDir.getAbsolutePath().replace('\\', '/');
+			if (!rootPath.endsWith("/")) rootPath += "/";
+		}
+	}
+
+	public ImageProcessor (Settings settings) {
+		this(null, settings);
 	}
 
 	public void addImage (File file) {
@@ -68,6 +74,10 @@ public class ImageProcessor {
 		int dotIndex = name.lastIndexOf('.');
 		if (dotIndex != -1) name = name.substring(0, dotIndex);
 
+		addImage(image, name);
+	}
+
+	public void addImage (BufferedImage image, String name) {
 		Rect rect = null;
 
 		// Strip ".9" from file name, read ninepatch split pixels, and strip ninepatch split pixels.

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/imagepacker/TexturePacker2.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/imagepacker/TexturePacker2.java
@@ -65,8 +65,16 @@ public class TexturePacker2 {
 		imageProcessor = new ImageProcessor(rootDir, settings);
 	}
 
+	public TexturePacker2 (Settings settings) {
+		this(null, settings);
+	}
+
 	public void addImage (File file) {
 		imageProcessor.addImage(file);
+	}
+
+	public void addImage (BufferedImage image, String name) {
+		imageProcessor.addImage(image, name);
 	}
 
 	public void pack (File outputDir, String packFileName) {


### PR DESCRIPTION
Update TexturePacker2 to accommodate ImageProcessor changes and exposes new
constructor and method.
