### PR TITLE
Make LwjglAWTCanvas clean up its created resources on exit

### DIFF
--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglAWTCanvas.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglAWTCanvas.java
@@ -149,7 +149,7 @@ public class LwjglAWTCanvas implements Application {
 
 	protected void setTitle (String title) {
 	}
-	
+
 	@Override
 	public ApplicationListener getApplicationListener () {
 		return listener;
@@ -273,22 +273,22 @@ public class LwjglAWTCanvas implements Application {
 		running = false;
 		setGlobals();
 		Array<LifecycleListener> listeners = lifecycleListeners;
-		synchronized(listeners) {
-			for(LifecycleListener listener: listeners) {
+		synchronized (listeners) {
+			for (LifecycleListener listener : listeners) {
 				listener.pause();
 				listener.dispose();
 			}
 		}
 		listener.pause();
 		listener.dispose();
-		
+
 		if (audio != null) {
 			audio.dispose();
 			Gdx.audio = null;
 		}
-		
+
 		if (files != null) Gdx.files = null;
-		
+
 		if (net != null) Gdx.net = null;
 	}
 
@@ -399,7 +399,7 @@ public class LwjglAWTCanvas implements Application {
 	}
 
 	/** Test whether the canvas' context is current. */
-	public boolean isCurrent() {
+	public boolean isCurrent () {
 		try {
 			return canvas.isCurrent();
 		} catch (LWJGLException ex) {
@@ -411,18 +411,18 @@ public class LwjglAWTCanvas implements Application {
 	public void setCursor (Cursor cursor) {
 		this.cursor = cursor;
 	}
-	
+
 	@Override
 	public void addLifecycleListener (LifecycleListener listener) {
-		synchronized(lifecycleListeners) {
+		synchronized (lifecycleListeners) {
 			lifecycleListeners.add(listener);
 		}
 	}
 
 	@Override
 	public void removeLifecycleListener (LifecycleListener listener) {
-		synchronized(lifecycleListeners) {
+		synchronized (lifecycleListeners) {
 			lifecycleListeners.removeValue(listener, true);
-		}		
+		}
 	}
 }


### PR DESCRIPTION
LwjglAWTCanvas doesn't clean up after itself on stop() or exit(), and so subsequently created ones misbehave. Swing apps will also report that the OpenAL devices have not been properly closed.

This fixes that (I hope).
