### PR TITLE
new3dapi remove normal mapping / phong support

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/DefaultShader.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/DefaultShader.java
@@ -159,9 +159,11 @@ public class DefaultShader extends BaseShader {
 		pointLightsSize 				= loc(u_pointLights1color)- pointLightsLoc;
 	}
 	
+	protected final static long tangentAttribute = Usage.Generic << 1;
+	protected final static long binormalAttribute = Usage.Generic << 2;
 	protected final static long blendAttributes[] = {
-		Usage.Generic << 1, Usage.Generic << 2, Usage.Generic << 3, Usage.Generic << 4, 
-		Usage.Generic << 5, Usage.Generic << 6, Usage.Generic << 7, Usage.Generic << 8
+		Usage.Generic << 3, Usage.Generic << 4, Usage.Generic << 5, Usage.Generic << 6, 
+		Usage.Generic << 7, Usage.Generic << 8, Usage.Generic << 9, Usage.Generic << 10
 	}; // FIXME this is a temporary, quick and dirty fix and should be changed
 	protected static long getAttributesMask(final VertexAttributes attributes) {
 		long result = 0;
@@ -172,6 +174,10 @@ public class DefaultShader extends BaseShader {
 			if (a == Usage.Generic) { 
 				if (attributes.get(i).alias.startsWith("a_boneWeight"))
 					a = blendAttributes[Integer.parseInt(attributes.get(i).alias.substring(12))];
+				else if (attributes.get(i).alias.equals(ShaderProgram.TANGENT_ATTRIBUTE))
+					a = tangentAttribute;
+				else if (attributes.get(i).alias.equals(ShaderProgram.BINORMAL_ATTRIBUTE))
+					a = binormalAttribute;
 			}
 			result |= a;
 		}
@@ -195,6 +201,10 @@ public class DefaultShader extends BaseShader {
 			if ((attributes & blendAttributes[i]) == blendAttributes[i])
 				prefix += "#define boneWeight"+i+"Flag\n";
 		}
+		if ((attributes & tangentAttribute) == tangentAttribute)
+			prefix += "#define tangentFlag\n";
+		if ((attributes & binormalAttribute) == binormalAttribute)
+			prefix += "#define binormalFlag\n";
 		if ((mask & BlendingAttribute.Type) == BlendingAttribute.Type)
 			prefix += "#define "+BlendingAttribute.Alias+"Flag\n";
 		if ((mask & TextureAttribute.Diffuse) == TextureAttribute.Diffuse)

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/default.fragment.glsl
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/default.fragment.glsl
@@ -8,30 +8,19 @@ precision mediump float;
 #define LOWP
 #endif
 
-#if defined(normalTextureFlag)
-#define phongFlag
-#endif
-
 #if defined(specularTextureFlag) || defined(specularColorFlag)
 #define specularFlag
 #endif
 
 #ifdef normalFlag
-
 varying vec3 v_normal;
-
-#if defined(binormalFlag) || defined(tangentFlag) || defined(normalTextureFlag)
-varying vec3 v_binormal;
-varying vec3 v_tangent;
-#endif //binormalFlag || tangentFlag
-
 #endif //normalFlag
 
 #if defined(colorFlag)
 varying vec4 v_color;
 #endif
 
-#if defined(diffuseTextureFlag) || defined(specularTextureFlag) || defined(normalTextureFlag)
+#if defined(diffuseTextureFlag) || defined(specularTextureFlag)
 #define textureFlag
 varying MED vec2 v_texCoords0;
 #endif
@@ -57,57 +46,16 @@ uniform sampler2D u_normalTexture;
 #endif
 
 #ifdef lightingFlag
-
 varying vec3 v_lightDiffuse;
-
-#ifdef phongFlag
-
-varying vec3 v_viewVec;
-varying vec3 v_pos;
-
-#ifdef shininessFlag
-uniform float u_shininess;
-#else
-const float u_shininess = 20.0;
-#endif // shininessFlag
-
-#if defined(numDirectionalLights) && (numDirectionalLights > 0)
-struct DirectionalLight
-{
-	vec3 color;
-	vec3 direction;
-};
-uniform DirectionalLight u_dirLights[numDirectionalLights];
-#endif // numDirectionalLights
-
-#if defined(numPointLights) && (numPointLights > 0)
-struct PointLight
-{
-	vec3 color;
-	vec3 position;
-	float intensity;
-};
-uniform PointLight u_pointLights[numPointLights];
-#endif // numPointLights
-
-#else //phongFlag
 
 #ifdef specularFlag
 varying vec3 v_lightSpecular;
 #endif //specularFlag
-
-#endif //phongFlag	
 #endif //lightingFlag
-	
 
 void main() {
-	#if defined(normalFlag) && defined(normalTextureFlag)
-		vec3 normal = normalize(2.0 + texture2D(u_normalTexture, v_texCoords0).xyz - 1.0);
-		normal = normalize((v_tangent * normal.x) + (v_binormal * normal.y) + (v_normal * normal.z));
-	#elif defined(normalFlag) 
+	#if defined(normalFlag) 
 		vec3 normal = v_normal;
-	#elif defined(normalTextureFlag)
-		vec3 normal = normalize(texture2D(u_normalTexture, v_texCoords0).xyz);
 	#endif // normalFlag
 		
 	#if defined(diffuseTextureFlag) && defined(diffuseColorFlag) && defined(colorFlag)
@@ -132,53 +80,7 @@ void main() {
 		gl_FragColor.rgb = diffuse.rgb;
 	#elif (!defined(specularFlag))
 		gl_FragColor.rgb = (diffuse.rgb * v_lightDiffuse);
-		
-	#elif defined(phongFlag)
-		vec3 lightDiffuse = v_lightDiffuse;
-		
-		#ifdef specularFlag
-			vec3 lightSpecular = vec3(0.0);
-			#if defined(specularTextureFlag) && defined(specularColorFlag)
-				vec3 specular = texture2D(u_specularTexture, v_texCoords0).rgb * u_specularColor.rgb;
-			#elif defined(specularTextureFlag)
-				vec3 specular = texture2D(u_specularTexture, v_texCoords0).rgb;
-			#elif defined(specularColorFlag)
-				vec3 specular = u_specularColor.rgb;
-			#else //if defined(lightingFlag)
-				vec3 specular = vec3(0.0);
-			#endif
-		#endif
-			
-		#if defined(numDirectionalLights) && (numDirectionalLights > 0) && (defined(normalFlag) || defined(normalTextureFlag))
-			for (int i = 0; i < numDirectionalLights; i++) {
-				vec3 lightDir = -u_dirLights[i].direction;
-				float NdotL = clamp(dot(normal, lightDir), 0.0, 1.0);
-				lightDiffuse.rgb += u_dirLights[i].color * NdotL;
-				#ifdef specularFlag
-					float halfDotView = dot(normal, normalize(lightDir + v_viewVec));
-					lightSpecular += u_dirLights[i].color * clamp(NdotL * pow(halfDotView, u_shininess), 0.0, 1.0);
-				#endif // specularFlag
-			}
-		#endif // numDirectionalLights
-			
-		#if defined(numPointLights) && (numPointLights > 0) && (defined(normalFlag) || defined(normalTextureFlag))
-			for (int i = 0; i < numPointLights; i++) {
-				vec3 lightDir = u_pointLights[i].position - v_pos;
-				float dist2 = dot(lightDir, lightDir);
-				lightDir *= inversesqrt(dist2);
-				float NdotL = clamp(dot(normal, lightDir), 0.0, 2.0);
-				float falloff = clamp(u_pointLights[i].intensity / (1.0 + dist2), 0.0, 2.0); // FIXME mul intensity on cpu
-				lightDiffuse += u_pointLights[i].color * (NdotL * falloff);
-				#ifdef specularFlag
-					float halfDotView = clamp(dot(normal, normalize(lightDir + v_viewVec)), 0.0, 2.0);
-					lightSpecular += u_pointLights[i].color * clamp(NdotL * pow(halfDotView, u_shininess) * falloff, 0.0, 2.0);
-				#endif // specularFlag
-			}
-		#endif // numPointLights
-		
-		gl_FragColor.rgb = (diffuse.rgb * lightDiffuse) + (specular * lightSpecular);
-		
-	#else //!phongFlag
+	#else
 		#if defined(specularTextureFlag) && defined(specularColorFlag)
 			vec3 specular = texture2D(u_specularTexture, v_texCoords0).rgb * u_specularColor.rgb * v_lightSpecular;
 		#elif defined(specularTextureFlag)
@@ -188,8 +90,9 @@ void main() {
 		#else //if defined(lightingFlag)
 			vec3 specular = v_lightSpecular;
 		#endif
+			
 		gl_FragColor.rgb = (diffuse.rgb * v_lightDiffuse) + specular;
-	#endif //phongFlag
+	#endif //lightingFlag
 
 	#ifdef blendedFlag
 		gl_FragColor.a = diffuse.a;


### PR DESCRIPTION
So normal mapping and phong shading works. Let's not include it within default shader to keep things manageble. This PR removes phong and normalmap support, but allows you to add your own shader if needed (all required uniforms/attributes are set).
