### PR TITLE
Add font name to hiero settings file

### DIFF
--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/hiero/Hiero.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/hiero/Hiero.java
@@ -268,6 +268,7 @@ public class Hiero extends JFrame {
 
 	void save (File file) throws IOException {
 		HieroSettings settings = new HieroSettings();
+		settings.setFontName((String)fontList.getSelectedValue());
 		settings.setFontSize(((Integer)fontSizeSpinner.getValue()).intValue());
 		settings.setBold(boldCheckBox.isSelected());
 		settings.setItalic(italicCheckBox.isSelected());
@@ -293,6 +294,7 @@ public class Hiero extends JFrame {
 			panels[i].remove();
 
 		HieroSettings settings = new HieroSettings(file.getAbsolutePath());
+		fontList.setSelectedValue(settings.getFontName(), true);
 		fontSizeSpinner.setValue(new Integer(settings.getFontSize()));
 		boldCheckBox.setSelected(settings.isBold());
 		italicCheckBox.setSelected(settings.isItalic());

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/hiero/unicodefont/HieroSettings.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/hiero/unicodefont/HieroSettings.java
@@ -34,6 +34,7 @@ import com.badlogic.gdx.utils.GdxRuntimeException;
 /** Holds the settings needed to configure a UnicodeFont.
  * @author Nathan Sweet */
 public class HieroSettings {
+	private String fontName = "Arial";
 	private int fontSize = 12;
 	private boolean bold = false, italic = false;
 	private int paddingTop, paddingLeft, paddingBottom, paddingRight, paddingAdvanceX, paddingAdvanceY;
@@ -57,7 +58,9 @@ public class HieroSettings {
 				String[] pieces = line.split("=", 2);
 				String name = pieces[0].trim();
 				String value = pieces[1];
-				if (name.equals("font.size")) {
+				if (name.equals("font.name")) {
+					fontName = value;
+				} else if (name.equals("font.size")) {
 					fontSize = Integer.parseInt(value);
 				} else if (name.equals("font.bold")) {
 					bold = Boolean.parseBoolean(value);
@@ -189,6 +192,18 @@ public class HieroSettings {
 	public void setGlyphPageHeight (int glyphPageHeight) {
 		this.glyphPageHeight = glyphPageHeight;
 	}
+	
+	/** @see UnicodeFont#UnicodeFont(String, int, boolean, boolean)
+	 * @see UnicodeFont#UnicodeFont(java.awt.Font, int, boolean, boolean) */
+	public String getFontName() {
+		return fontName;
+	}
+	
+	/** @see UnicodeFont#UnicodeFont(String, int, boolean, boolean)
+	 * @see UnicodeFont#UnicodeFont(java.awt.Font, int, boolean, boolean) */
+	public void setFontName(String fontName) {
+		this.fontName = fontName;
+	}
 
 	/** @see UnicodeFont#UnicodeFont(String, int, boolean, boolean)
 	 * @see UnicodeFont#UnicodeFont(java.awt.Font, int, boolean, boolean) */
@@ -251,6 +266,7 @@ public class HieroSettings {
 	 * @throws IOException if the file could not be saved. */
 	public void save (File file) throws IOException {
 		PrintStream out = new PrintStream(new FileOutputStream(file));
+		out.println("font.name=" + fontName);
 		out.println("font.size=" + fontSize);
 		out.println("font.bold=" + bold);
 		out.println("font.italic=" + italic);


### PR DESCRIPTION
When loading my Hiero font settings, the font name was not stored.
Re-generating the font atlas obviously resulted in the wrong font atlas. (it was a while ago when I lastly generated the atlas).

This can be prevented by storing the font name in the settings file as well, which is done by this commit.
