### PR TITLE
Add support for 0-alpha pixel to TexturePacker2

### DIFF
--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/imagepacker/TexturePacker2.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/imagepacker/TexturePacker2.java
@@ -139,42 +139,58 @@ public class TexturePacker2 {
 			System.out.println("Writing " + canvas.getWidth() + "x" + canvas.getHeight() + ": " + outputFile);
 
 			for (Rect rect : page.outputRects) {
-				int rectX = page.x + rect.x, rectY = page.y + page.height - rect.y - rect.height;
-				if (rect.rotated) {
-					g.translate(rectX, rectY);
-					g.rotate(-90 * MathUtils.degreesToRadians);
-					g.translate(-rectX, -rectY);
-					g.translate(-(rect.height - settings.paddingY), 0);
-				}
 				BufferedImage image = rect.image;
+				int iw = image.getWidth();
+				int ih = image.getHeight();
+				int rectX = page.x + rect.x, rectY = page.y + page.height - rect.y - rect.height;
 				if (settings.duplicatePadding) {
 					int amountX = settings.paddingX / 2;
 					int amountY = settings.paddingY / 2;
-					int imageWidth = image.getWidth();
-					int imageHeight = image.getHeight();
-					// Copy corner pixels to fill corners of the padding.
-					g.drawImage(image, rectX - amountX, rectY - amountY, rectX, rectY, 0, 0, 1, 1, null);
-					g.drawImage(image, rectX + imageWidth, rectY - amountY, rectX + imageWidth + amountX, rectY, imageWidth - 1, 0,
-						imageWidth, 1, null);
-					g.drawImage(image, rectX - amountX, rectY + imageHeight, rectX, rectY + imageHeight + amountY, 0, imageHeight - 1,
-						1, imageHeight, null);
-					g.drawImage(image, rectX + imageWidth, rectY + imageHeight, rectX + imageWidth + amountX, rectY + imageHeight
-						+ amountY, imageWidth - 1, imageHeight - 1, imageWidth, imageHeight, null);
-					// Copy edge pixels into padding.
-					g.drawImage(image, rectX, rectY - amountY, rectX + imageWidth, rectY, 0, 0, imageWidth, 1, null);
-					g.drawImage(image, rectX, rectY + imageHeight, rectX + imageWidth, rectY + imageHeight + amountY, 0,
-						imageHeight - 1, imageWidth, imageHeight, null);
-					g.drawImage(image, rectX - amountX, rectY, rectX, rectY + imageHeight, 0, 0, 1, imageHeight, null);
-					g.drawImage(image, rectX + imageWidth, rectY, rectX + imageWidth + amountX, rectY + imageHeight, imageWidth - 1,
-						0, imageWidth, imageHeight, null);
+					if (rect.rotated) {
+						// Copy corner pixels to fill corners of the padding.
+						for (int i = 1; i <= amountX; i++) {
+							for (int j = 1; j <= amountY; j++) {
+								plot(canvas, rectX - j, rectY + iw - 1 + i, image.getRGB(0, 0));
+								plot(canvas, rectX + ih - 1 + j, rectY + iw - 1 + i, image.getRGB(0, ih - 1));
+								plot(canvas, rectX - j, rectY - i, image.getRGB(iw - 1, 0));
+								plot(canvas, rectX + ih - 1 + j, rectY - i, image.getRGB(iw - 1, ih - 1));
+							}
+						}
+						// Copy edge pixels into padding.
+						for (int i = 1; i <= amountY; i++) {
+							for (int j = 0; j < iw; j++) {
+								plot(canvas, rectX - i, rectY + iw - 1 - j, image.getRGB(j, 0));
+								plot(canvas, rectX + ih - 1 + i, rectY + iw - 1 - j, image.getRGB(j, ih - 1));
+							}
+						}
+						for (int i = 1; i <= amountX; i++) {
+							for (int j = 0; j < ih; j++) {
+								plot(canvas, rectX + j, rectY - i, image.getRGB(iw - 1, j));
+								plot(canvas, rectX + j, rectY + iw - 1 + i, image.getRGB(0, j));
+							}
+						}
+					} else {
+						// Copy corner pixels to fill corners of the padding.
+						for (int i = 1; i <= amountX; i++) {
+							for (int j = 1; j <= amountY; j++) {
+								canvas.setRGB(rectX - i, rectY - j, image.getRGB(0, 0));
+								canvas.setRGB(rectX - i, rectY + ih - 1 + j, image.getRGB(0, ih - 1));
+								canvas.setRGB(rectX + iw - 1 + i, rectY - j, image.getRGB(iw - 1, 0));
+								canvas.setRGB(rectX + iw - 1 + i, rectY + ih - 1 + j, image.getRGB(iw - 1, ih - 1));
+							}
+						}
+						// Copy edge pixels into padding.
+						for (int i = 1; i <= amountY; i++) {
+							copy(image, 0, 0, iw, 1, canvas, rectX, rectY - i, rect.rotated);
+							copy(image, 0, ih - 1, iw, 1, canvas, rectX, rectY + ih - 1 + i, rect.rotated);
+						}
+						for (int i = 1; i <= amountX; i++) {
+							copy(image, 0, 0, 1, ih, canvas, rectX - i, rectY, rect.rotated);
+							copy(image, iw - 1, 0, 1, ih, canvas, rectX + iw - 1 + i, rectY, rect.rotated);
+						}
+					}
 				}
-				g.drawImage(image, rectX, rectY, null);
-				if (rect.rotated) {
-					g.translate(rect.height - settings.paddingY, 0);
-					g.translate(rectX, rectY);
-					g.rotate(90 * MathUtils.degreesToRadians);
-					g.translate(-rectX, -rectY);
-				}
+				copy(image, 0, 0, iw, ih, canvas, rectX, rectY, rect.rotated);
 				if (settings.debug) {
 					g.setColor(Color.magenta);
 					g.drawRect(rectX, rectY, rect.width - settings.paddingX - 1, rect.height - settings.paddingY - 1);
@@ -202,6 +218,28 @@ public class TexturePacker2 {
 				}
 			} catch (IOException ex) {
 				throw new RuntimeException("Error writing file: " + outputFile, ex);
+			}
+		}
+	}
+
+	private static void plot (BufferedImage dst, int x, int y, int argb) {
+		if (0 <= x && x < dst.getWidth() && 0 <= y && y < dst.getHeight()) {
+			dst.setRGB(x, y, argb);
+		}
+	}
+
+	private static void copy (BufferedImage src, int x, int y, int w, int h, BufferedImage dst, int dx, int dy, boolean rotated) {
+		if (rotated) {
+			for (int i = 0; i < w; i++) {
+				for (int j = 0; j < h; j++) {
+					dst.setRGB(dx + j, dy + w - i - 1, src.getRGB(x + i, y + j));
+				}
+			}
+		} else {
+			for (int i = 0; i < w; i++) {
+				for (int j = 0; j < h; j++) {
+					dst.setRGB(dx + i, dy + j, src.getRGB(x + i, y + j));
+				}
 			}
 		}
 	}


### PR DESCRIPTION
The current implementation uses Graphics2d to render image when creating atlas texture.
Graphics2d will not preserve the color of pixel with 0 alpha. This can be seen when  scaling down the texture with linear filtering ; blending will be performed using black pixels for the 0 alpha pixel instead of the initial color.

This modification use direct ARGB copy to preserve color when alpha is 0, leading to correct filtering.

I performed some testing comparing results between the current implementation and this one, not finding unexpected changes. There are some situations where the current implementation will behave "strangely" (at least, I don't fully understand), like using rotation, different padding on X and Y axis with non even padding, all of this in the same time. Not sure of the use case of this type of situation ; anyway, the result with this implementation should be satisfying as well.

I have read the sticky post from the forum (http://www.badlogicgames.com/forum/viewtopic.php?f=11&t=635) and I think this is different.  
This change will only help if you produce sprite with color over fully transparent area (like in this post : http://www.badlogicgames.com/forum/viewtopic.php?f=11&t=635&p=27934)

Edit : sorry, I made it wrong with git. Please use ?w=1 to have a readable pull ; https://github.com/libgdx/libgdx/pull/414/files?w=1
