### PR TITLE
draw substring of BitmapFontCache

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFontCache.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFontCache.java
@@ -113,6 +113,10 @@ public class BitmapFontCache {
 	public void draw (SpriteBatch spriteBatch) {
 		spriteBatch.draw(font.getRegion().getTexture(), vertices, 0, idx);
 	}
+	
+	public void draw(SpriteBatch spriteBatch, int start, int end) {
+            spriteBatch.draw(font.getRegion().getTexture(), vertices, start*20, end*20);
+        }
 
 	public void draw (SpriteBatch spriteBatch, float alphaModulation) {
 		if (alphaModulation == 1) {


### PR DESCRIPTION
Allows for drawing a substring of the cache for letter-by-letter text scrolling. I didn't see any other/better way of accomplishing this than adding this method.
