### PR TITLE
AndroidSound#play/loop now returns -1 on failure, to match other backends

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -38,6 +38,7 @@
 - ScrollBar#setForceOverscroll renamed to setForceScroll, as it affects more than just overscroll.
 - ArrayMap#addAll renamed to putAll to match the other maps.
 - Added ObjectSet and IntSet.
+- Sound#play and Sound#loop on Android now return -1 on failure, to match other backends.
 
 [0.9.8]
 - see http://www.badlogicgames.com/wordpress/?p=2791

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidSound.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidSound.java
@@ -48,6 +48,9 @@ final class AndroidSound implements Sound {
 	public long play (float volume) {
 		if (streamIds.size == 8) streamIds.pop();
 		int streamId = soundPool.play(soundId, volume, volume, 1, 0, 1);
+		//standardise error code with other backends
+		if (streamId == 0)
+			return -1;
 		streamIds.add(streamId);
 		return streamId;
 	}
@@ -81,6 +84,9 @@ final class AndroidSound implements Sound {
 	public long loop (float volume) {
 		if (streamIds.size == 8) streamIds.pop();
 		int streamId = soundPool.play(soundId, volume, volume, 1, -1, 1);
+		//standardise error code with other backends
+		if (streamId == 0)
+			return -1;
 		streamIds.add(streamId);
 		return streamId;
 	}
@@ -115,6 +121,9 @@ final class AndroidSound implements Sound {
 			leftVolume *= (1 - Math.abs(pan));
 		}
 		int streamId = soundPool.play(soundId, leftVolume, rightVolume, 1, 0, pitch);
+		//standardise error code with other backends
+		if (streamId == 0)
+			return -1;
 		streamIds.add(streamId);
 		return streamId;
 	}
@@ -130,6 +139,9 @@ final class AndroidSound implements Sound {
 			leftVolume *= (1 - Math.abs(pan));
 		}
 		int streamId = soundPool.play(soundId, leftVolume, rightVolume, 1, -1, pitch);
+		//standardise error code with other backends
+		if (streamId == 0)
+			return -1;
 		streamIds.add(streamId);
 		return streamId;
 	}

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtSound.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtSound.java
@@ -45,12 +45,12 @@ public class GwtSound implements Sound {
 
 	@Override
 	public long loop () {
-		return 0;
+		return -1;
 	}
 
 	@Override
 	public long loop (float volume) {
-		return 0;
+		return -1;
 	}
 
 	@Override

--- a/gdx/src/com/badlogic/gdx/audio/Sound.java
+++ b/gdx/src/com/badlogic/gdx/audio/Sound.java
@@ -37,29 +37,29 @@ import com.badlogic.gdx.utils.Disposable;
  * @author badlogicgames@gmail.com */
 public interface Sound extends Disposable {
 	/** Plays the sound. If the sound is already playing, it will be played again, concurrently.
-	 * @return the id of the sound instance. */
+	 * @return the id of the sound instance if successful, or -1 on failure. */
 	public long play ();
 
 	/** Plays the sound. If the sound is already playing, it will be played again, concurrently.
 	 * @param volume the volume in the range [0,1]
-	 * @return the id of the sound instance */
+	 * @return the id of the sound instance if successful, or -1 on failure. */
 	public long play (float volume);
 
 	/** Plays the sound. If the sound is already playing, it will be played again, concurrently.
 	 * @param volume the volume in the range [0,1]
 	 * @param pitch the pitch multiplier, 1 == default, >1 == faster, <1 == slower, the value has to be between 0.5 and 2.0
 	 * @param pan panning in the range -1 (full right) to 1 (full left). 0 is center position.
-	 * @return the id of the sound instance */
+	 * @return the id of the sound instance if successful, or -1 on failure. */
 	public long play (float volume, float pitch, float pan);
 
 	/** Plays the sound, looping. If the sound is already playing, it will be played again, concurrently.
-	 * @return the id of the sound instance */
+	 * @return the id of the sound instance if successful, or -1 on failure. */
 	public long loop ();
 
 	/** Plays the sound, looping. If the sound is already playing, it will be played again, concurrently. You need to stop the sound
 	 * via a call to {@link #stop(long)} using the returned id.
 	 * @param volume the volume in the range [0, 1]
-	 * @return the id of the sound instance */
+	 * @return the id of the sound instance if successful, or -1 on failure. */
 	public long loop (float volume);
 
 	/** Plays the sound, looping. If the sound is already playing, it will be played again, concurrently. You need to stop the sound
@@ -67,7 +67,7 @@ public interface Sound extends Disposable {
 	 * @param volume the volume in the range [0,1]
 	 * @param pitch the pitch multiplier, 1 == default, >1 == faster, <1 == slower, the value has to be between 0.5 and 2.0
 	 * @param pan panning in the range -1 (full right) to 1 (full left). 0 is center position.
-	 * @return the id of the sound instance */
+	 * @return the id of the sound instance if successful, or -1 on failure. */
 	public long loop (float volume, float pitch, float pan);
 
 	/** Stops playing all instances of this sound. */


### PR DESCRIPTION
There is currently an inconsistency in the backends; OpenALSound#play and IOSSound#play both return -1 on failure, while AndroidSound returns 0. This is because of the Android [SoundPool](http://developer.android.com/reference/android/media/SoundPool.html#play(int, float, float, int, int, float)).
This fix simply modifies AndroidSound to match the other backends.
