### PR TITLE
Fix for Issue 1470: On OS X TextField deletes symbols from the right side

### DIFF
--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglInput.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglInput.java
@@ -798,6 +798,9 @@ final class LwjglInput implements Input {
 					long timeStamp = Keyboard.getEventNanoseconds();
 
 					switch (keyCode) {
+					case Keys.DEL:
+						keyChar = 8;
+						break;
 					case Keys.FORWARD_DEL:
 						keyChar = 127;
 						break;


### PR DESCRIPTION
ref: https://code.google.com/p/libgdx/issues/detail?id=1470

This pull request fixes the behavior of the backspace key in TextField on OS X.

On OS X, the KeyEvent.keyChar field on a Backspace press contains 127, not 8 as expected. This is what is reported by org.lwjgl.input.Keyboard.getEventCharacter().  

org.lwjgl.input.Keyboard.getEventKey() is distinguishing correctly between Backspace and Delete, so keyCode can be used to fix keyChar.
