### PR TITLE
Fixed long presses being handled incorrectly.

### DIFF
--- a/gdx/src/com/badlogic/gdx/input/GestureDetector.java
+++ b/gdx/src/com/badlogic/gdx/input/GestureDetector.java
@@ -54,7 +54,7 @@ public class GestureDetector extends InputAdapter {
 	private final Task longPressTask = new Task() {
 		@Override
 		public void run () {
-			if (listener.longPress(pointer1.x, pointer1.y)) longPressFired = true;
+			longPressFired = listener.longPress(pointer1.x, pointer1.y);
 		}
 	};
 
@@ -128,7 +128,7 @@ public class GestureDetector extends InputAdapter {
 
 	public boolean touchDragged (float x, float y, int pointer) {
 		if (pointer > 1) return false;
-		if (longPressFired) return false;
+		if (longPressFired) return true;
 
 		if (pointer == 0)
 			pointer1.set(x, y);
@@ -175,7 +175,7 @@ public class GestureDetector extends InputAdapter {
 
 		longPressTask.cancel();
 		panning = false;
-		if (longPressFired) return false;
+		if (longPressFired) return true;
 		if (inTapSquare) {
 			// handle taps
 			if (lastTapButton != button || lastTapPointer != pointer || TimeUtils.nanoTime() - lastTapTime > tapCountInterval


### PR DESCRIPTION
Fixed long presses causing events not to be consumed by the
GestureDetector. This issue was causing the GestureDetector to return
false in touchDragged and touchUp whenever a longPress returned true
resulting in unexpected behavior which one would likely only notice when
chaining InputProcessors in an InputMultiplexer.
