### PR TITLE
List: select 'nothing', and disable item selection

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/List.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/List.java
@@ -43,6 +43,7 @@ public class List extends Widget implements Cullable {
 	private float prefWidth, prefHeight;
 	private float itemHeight;
 	private float textOffsetX, textOffsetY;
+	private boolean selectable;
 
 	public List (Object[] items, Skin skin) {
 		this(items, skin.get(ListStyle.class));
@@ -57,14 +58,32 @@ public class List extends Widget implements Cullable {
 		setItems(items);
 		setWidth(getPrefWidth());
 		setHeight(getPrefHeight());
+		setSelectable(true);
 
 		addListener(new InputListener() {
 			public boolean touchDown (InputEvent event, float x, float y, int pointer, int button) {
 				if (pointer == 0 && button != 0) return false;
+				if (!List.this.isSelectable()) return false; // don't eat touch event when NOT selectable
 				List.this.touchDown(y);
 				return true;
 			}
 		});
+	}
+	
+	/**
+	 * Sets whether or not this List's items are selectable.
+	 *
+	 * *NOTE*
+	 * If the List is NOT selectable, it will NOT eat its touch events meaning they will still propagate down.
+	 * Please be aware of this behavior change.
+	 */
+	public void setSelectable(boolean s) {
+		selectable = s;
+	}
+	
+	/** @return Whether or not the List's items are selectable. */
+	public boolean isSelectable() {
+		return selectable;
 	}
 
 	void touchDown (float y) {
@@ -126,7 +145,7 @@ public class List extends Widget implements Cullable {
 		}
 	}
 
-	/** @return The index of the currently selected item. The top item has an index of 0. */
+	/** @return The index of the currently selected item. The top item has an index of 0. Nothing selected has an index of -1. */
 	public int getSelectedIndex () {
 		return selectedIndex;
 	}
@@ -137,15 +156,19 @@ public class List extends Widget implements Cullable {
 		selectedIndex = index;
 	}
 
-	/** @return The text of the currently selected item or null if the list is empty. */
+	/** @return The text of the currently selected item, else null if the list is empty or nothing is selected. */
 	public String getSelection () {
-		if (items.length == 0) return null;
+		if (items.length == 0 || isNothingSelected()) return null;
 		return items[selectedIndex];
 	}
 
-	/** @return The index of the item that was selected, or -1. */
+	/**
+	 * Sets the selection to the item if found, else sets the selection to nothing.
+	 * @return The new index of the list selection
+	 */
 	public int setSelection (String item) {
-		selectedIndex = -1;
+		setSelectionToNothing();
+		
 		for (int i = 0, n = items.length; i < n; i++) {
 			if (items[i].equals(item)) {
 				selectedIndex = i;
@@ -154,6 +177,17 @@ public class List extends Widget implements Cullable {
 		}
 		return selectedIndex;
 	}
+
+	/** Sets the list item selection to nothing with selection index value -1. */
+	public void setSelectionToNothing() {
+		selectedIndex = -1;
+	}
+	
+	/** @return Whether or not the list has an item selected. */
+	public boolean isNothingSelected() {
+		return selectedIndex == -1;
+	}
+	
 
 	public void setItems (Object[] objects) {
 		if (objects == null) throw new IllegalArgumentException("items cannot be null.");


### PR DESCRIPTION
This adds functionality to the List Actor so it may behave like that of a ListView akin to Android's.  This is backwards compatible.

This is essential in situations where you may not always want to have an item selected (like a touch-based file browser), or where you may not want items even selectable at all (like during a tutorial).

Also this fixes a bug/defect fix where if you look in the old setSelection(String name) method, you'll see it sets the selectedIndex to -1, then tries to find an item with that name.  When it doesn't, it leaves the selectedIndex not pointing to an item, -1, which isn't intended allowable behavior in the current version.

_Note_
When the List is NOT selectable, it will no longer eat its touch event meaning they will still propagate down.

I'm not 100% sure if that is the behavior you want versus the contrary where it eats the touch event despite not doing anything.  Regardless, I have a note of this behavior change in the setSelectable comment.
