### PR TITLE
Update Shape.java

### DIFF
--- a/gdx/src/com/badlogic/gdx/physics/box2d/Shape.java
+++ b/gdx/src/com/badlogic/gdx/physics/box2d/Shape.java
@@ -30,7 +30,7 @@ public abstract class Shape {
 	/** Enum describing the type of a shape
 	 * @author mzechner */
 	public enum Type {
-		Circle, Polygon, Edge, Chain,
+		Circle, Edge, Polygon, Chain,
 	};
 
 	/** the address of the shape **/


### PR DESCRIPTION
Small ordinal fix in shape as per jniGetType(). 
Now Shape.Type.Polygon.ordinal() returns 2 as expected.
