### PR TITLE
TextField bug: DELETE char not notifying listener

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextField.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextField.java
@@ -330,7 +330,6 @@ public class TextField extends Widget {
 								delete();
 							}
 						}
-						return true;
 					}
 					if (character != ENTER_DESKTOP && character != ENTER_ANDROID) {
 						if (filter != null && !filter.acceptChar(TextField.this, character)) return true;


### PR DESCRIPTION
Quick fix.

When the DELETE key was pressed, it was returning before notifying the attached TextFieldListener that its respective TextField was changed.

If this is intended behavior (which I pray it isn't...), then we should at least be consistent and handle the BACKSPACE case the same way as well.
