### PR TITLE
SelectBox: maxListCount off-by-one bug quick fix

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/SelectBox.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/SelectBox.java
@@ -282,13 +282,6 @@ public class SelectBox extends Widget {
 					height = heightBelow;
 			}
 
-			// Fit items evenly.
-			float itemHeight = list.getItemHeight();
-			float backgroundPadding = getStyle().background.getTopHeight() + getStyle().background.getBottomHeight();
-			height -= backgroundPadding;
-			height -= height % itemHeight;
-			height += backgroundPadding;
-
 			if (below)
 				setY(tmpCoords.y - height);
 			else
@@ -296,6 +289,8 @@ public class SelectBox extends Widget {
 			setX(tmpCoords.x);
 			setWidth(SelectBox.this.getWidth());
 			setHeight(height);
+
+			float itemHeight = list.getItemHeight();
 
 			scrollToCenter(0, list.getHeight() - selectedIndex * itemHeight - itemHeight / 2, 0, 0);
 			updateVisualScroll();


### PR DESCRIPTION
The obsolete height-fitting code wasn't removed and is creating a chance to cause an off-by-one-item bug in the drop down box due to a possible precision loss from [ height -=  height % itemHeight ].

The problematic height fitting code is obsolete and unncessary as of the patch implementing maxListCount where the height is now calculated off the desired number of items and not prefHeight().  This fix simply removes the old code.
