### PR TITLE
Check for GL_FRAMEBUFFER_UNSUPPORTED error from glCheckFramebufferStatus

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/glutils/FrameBuffer.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/FrameBuffer.java
@@ -84,11 +84,12 @@ public class FrameBuffer implements Disposable {
 
 	/** Creates a new FrameBuffer having the given dimensions and potentially a depth buffer attached.
 	 * 
-	 * @param format the format of the color buffer
+	 * @param format the format of the color buffer; according to the OpenGL ES 2.0 spec, only
+   * RGB565, RGBA4444 and RGB5_A1 are color-renderable
 	 * @param width the width of the framebuffer in pixels
 	 * @param height the height of the framebuffer in pixels
 	 * @param hasDepth whether to attach a depth buffer
-	 * @throws GdxRuntimeException in case the FraeBuffer could not be created */
+	 * @throws GdxRuntimeException in case the FrameBuffer could not be created */
 	public FrameBuffer (Pixmap.Format format, int width, int height, boolean hasDepth) {
 		this.width = width;
 		this.height = height;
@@ -179,6 +180,9 @@ public class FrameBuffer implements Disposable {
 				throw new IllegalStateException("frame buffer couldn't be constructed: incomplete dimensions");
 			if (result == GL20.GL_FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT)
 				throw new IllegalStateException("frame buffer couldn't be constructed: missing attachment");
+			if (result == GL20.GL_FRAMEBUFFER_UNSUPPORTED)
+				throw new IllegalStateException("frame buffer couldn't be constructed: unsupported combination of formats");
+      throw new IllegalStateException(String.format("frame buffer couldn't be constructed: unknown error 0x%04x", result));
 		}
 	}
 


### PR DESCRIPTION
According to the OpenGL ES 2.0 spec
(http://www.khronos.org/registry/gles/specs/2.0/es_cm_spec_2.0.24.pdf),
CheckFramebufferStatus can return FRAMEBUFFER_UNSUPPORTED if e.g. the
texture isn't a color-renderable format. We should throw in that case,
not silently fail to work. Also throw for any other cases that aren't
FRAMEBUFFER_COMPLETE; according to the spec there shouldn't be any.

Also add some documentation about officially supported formats. In
particular, RGB888 and RGBA8888 do work on many devices, but aren't
listed in the spec as color-renderable formats.
