### PR TITLE
TexturePacker2 : make Page & Rect public to allow reuse in other projects

### DIFF
--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/imagepacker/TexturePacker2.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/imagepacker/TexturePacker2.java
@@ -324,7 +324,7 @@ public class TexturePacker2 {
 	}
 
 	/** @author Nathan Sweet */
-	static class Page {
+	public static class Page {
 		public String imageName;
 		public Array<Rect> outputRects, remainingRects;
 		public float occupancy;
@@ -332,7 +332,7 @@ public class TexturePacker2 {
 	}
 
 	/** @author Nathan Sweet */
-	static class Rect {
+	public static class Rect {
 		public String name;
 		public BufferedImage image;
 		public int offsetX, offsetY, originalWidth, originalHeight;


### PR DESCRIPTION
Just as the title says ; to avoid rewriting or copy pasting most of the code, this is needed to allow reuse (like in the ant task i proposed a few days ago).
