### PR TITLE
Fix SequenceAction skipping first action under certain circumstance

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/SequenceAction.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/SequenceAction.java
@@ -59,8 +59,9 @@ public class SequenceAction extends ParallelAction {
 	public boolean act (float delta) {
 		if (index >= actions.size) return true;
 		if (actions.get(index).act(delta)) {
-			if (index >= actions.size) return true;
+			if (actions.size == 0) return true;
 			index++;
+			if (index >= actions.size) return true;
 		}
 		return false;
 	}


### PR DESCRIPTION
If this SequenceAction is freed during Line 61: actions.get(index).act(delta), next time this SequenceAction being obtained, index will start from 1.
