### PR TITLE
FileHandle.moveTo() Update

### DIFF
--- a/gdx/src/com/badlogic/gdx/files/FileHandle.java
+++ b/gdx/src/com/badlogic/gdx/files/FileHandle.java
@@ -576,6 +576,7 @@ public class FileHandle {
 		if (type == FileType.Internal) throw new GdxRuntimeException("Cannot move an internal file: " + file);
 		copyTo(dest);
 		delete();
+		if (exists () && isDirectory()) deleteDirectory();
 	}
 
 	/** Returns the length in bytes of this file, or 0 if this file is a directory, does not exist, or the size cannot otherwise be


### PR DESCRIPTION
delete() only deletes files and empty directories.  As such, moveTo() would leave the old directory after a moveTo() opperation.  By adding deleteDirectory(), this ensures the old copy is removed.

The test "if (exists () && isDirectory())" may not be needed, but is added for safety.
