### PR TITLE
G3DModelLoader puts a '/' in front of the texture's name

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g3d/loader/G3dModelLoader.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/loader/G3dModelLoader.java
@@ -210,7 +210,7 @@ public class G3dModelLoader extends ModelLoader<AssetLoaderParameters<Model>> {
 						String fileName = texture.getString("filename", null);
 						if(fileName == null)
 							throw new GdxRuntimeException("Texture needs filename.");
-						jsonTexture.fileName = materialDir + (materialDir.endsWith("/") ? "" : "/") + fileName;
+						jsonTexture.fileName = materialDir + (materialDir.length() == 0 || materialDir.endsWith("/") ? "" : "/") + fileName;
 						
 						jsonTexture.uvTranslation = readVector2(texture.get("uvTranslation"), 0f, 0f);
 						jsonTexture.uvScaling = readVector2(texture.get("uvScaling"), 1f, 1f);


### PR DESCRIPTION
I was trying to load a very basic model, with a single texture named "floor.png", and I was getting an exception telling me that it couldn't find the file "/floor.png".

Maybe I missed something important, but I hope it would be useful in case we don't set a material directory at all.
