### PR TITLE
BaseShader various changes

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g3d/Shader.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/Shader.java
@@ -5,9 +5,16 @@ import com.badlogic.gdx.graphics.g3d.utils.RenderContext;
 import com.badlogic.gdx.utils.Disposable;
 
 public interface Shader extends Disposable {
+	/** Initializes the Shader, must be called before the Shader can be used */
+	void init();
+	/** Compare this shader against the other, used for sorting, light weight shaders are rendered first. */
 	int compareTo(Shader other); // TODO: probably better to add some weight value to sort on
+	/** Whether this shader is intended to render the {@link Renderable} */
 	boolean canRender(Renderable instance);
+	/** Initializes the context for exclusive rendering by this shader */
 	void begin(Camera camera, RenderContext context);
+	/** Renders the {@link Renderable} must be called between {@link #begin(Camera, RenderContext)} and {@link #end()} */
 	void render(final Renderable renderable);
+	/** Cleanup the context so other shaders can render */
 	void end();
 }

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/BaseShader.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/BaseShader.java
@@ -1,139 +1,285 @@
 package com.badlogic.gdx.graphics.g3d.shaders;
 
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.Camera;
 import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.VertexAttributes;
+import com.badlogic.gdx.graphics.g3d.Renderable;
 import com.badlogic.gdx.graphics.g3d.Shader;
+import com.badlogic.gdx.graphics.g3d.materials.Material;
+import com.badlogic.gdx.graphics.g3d.utils.RenderContext;
 import com.badlogic.gdx.graphics.glutils.ShaderProgram;
 import com.badlogic.gdx.math.Matrix3;
 import com.badlogic.gdx.math.Matrix4;
+import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.GdxRuntimeException;
 import com.badlogic.gdx.utils.Pool;
 
+/** @author Xoppa
+ * A BaseShader is a wrapper around a ShaderProgram that keeps track of the uniform and attribute locations.
+ * It does not manage the ShaderPogram, you are still responsible for disposing the ShaderProgram. */
 public abstract class BaseShader implements Shader {
-	private static class UniformEntry {
-		public UniformEntry () {}
-		public String name;
-		public long material;
-		public long attribute;
-		public long userFlag;
-		public final static Pool<UniformEntry> pool = new Pool<UniformEntry>() {
-			@Override
-			protected UniformEntry newObject () {
-				return new UniformEntry();
-			}
-		};
-	}
-	private final Array<UniformEntry> uniformEntries = new Array<UniformEntry>();
-	private int uniformLocations[];
-	private ShaderProgram program;
+	/** the Input is a vertex attribute */ 
+	public final static int VERTEX_ATTRIBUTE = 1;
+	/** the Input is a global uniform (independent of the renderable) */
+	public final static int GLOBAL_UNIFORM = 2; // FIXME rename to something better
+	/** the Input is a local uniform (depends on the renderable) */
+	public final static int LOCAL_UNIFORM = 3; // FIXME rename to something better
+	
+	public static class Input {
+		public interface Setter {
+			void set(BaseShader shader, ShaderProgram program, Input input, Camera camera, RenderContext context, Renderable renderable);
+		}
+		
+		/** The scope of the input: VERTEX_ATTRIBUTE, GLOBAL_UNIFORM or LOCAL_UNIFORM */
+		public final int scope;
+		/** The name of the input. */
+		public final String name;
+		/** The flags the materialMask must contain for this Input to be applicable */
+		public final long materialFlags;
+		/** The flags the vertexMask must contain for this Input to be applicable */
+		public final long vertexFlags;
+		/** The flags the userMask must contain for this Input to be applicable */
+		public final long userFlags;
+		/** The setter (if any, null otherwise) is responsible for setting the input with the appropriate value */ 
+		public final Setter setter;
+		/** The location within the ShaderProgram of this input */ 
+		public int location = -1;
+		
+		public boolean compare(final long materialMask, final long vertexMask, final long userMask) {
+			return (((materialMask & this.materialFlags) == this.materialFlags) && 
+				((vertexMask & this.vertexFlags) == this.vertexFlags) && 
+				((userMask & this.userFlags) == this.userFlags)); 
+		}
+		
+		public Input(final int scope, final String name, final long materialFlags, final long vertexFlags, final long userFlags, final Setter setter) {
+			this.scope = scope;
+			this.name = name;
+			this.materialFlags = materialFlags;
+			this.vertexFlags = vertexFlags;
+			this.userFlags = userFlags;
+			this.setter = setter;
+		}
+		
+		public Input(final int scope, final String name, final long materialFlags, final long vertexFlags, final long userFlags) {
+			this(scope, name, materialFlags, vertexFlags, userFlags, null);
+		}
 
-	/** Register a uniform which might be used by this shader. Only possible before the call to init().
-	 * @return The ID of the uniform to use in this shader. */
-	protected int registerUniform(final UniformEntry entry) {
+		public Input(final int scope, final String name, final long materialFlags, final long vertexFlags, final Setter setter) {
+			this(scope, name, materialFlags, vertexFlags, 0, setter);
+		}
+		
+		public Input(final int scope, final String name, final long materialFlags, final long vertexFlags) {
+			this(scope, name, materialFlags, vertexFlags, 0);
+		}
+
+		public Input(final int scope, final String name, final long materialFlags, final Setter setter) {
+			this(scope, name, materialFlags, 0, 0, setter);
+		}
+		
+		public Input(final int scope, final String name, final long materialFlags) {
+			this(scope, name, materialFlags, 0, 0);
+		}
+
+		public Input(final int scope, final String name, final Setter setter) {
+			this(scope, name, 0, 0, 0, setter);
+		}
+		
+		public Input(final int scope, final String name) {
+			this(scope, name, 0, 0, 0);
+		}
+	}
+	
+	private final Array<Input> inputs = new Array<Input>();
+	public final Array<Input> vertexAttributes = new Array<Input>();
+	public final Array<Input> globalUniforms = new Array<Input>();
+	public final Array<Input> localUniforms = new Array<Input>();
+	
+	public ShaderProgram program;
+	public RenderContext context;
+	public Camera camera;
+	
+	/** Register an input which might be used by this shader. Only possible before the call to init().
+	 * @return The ID of the input to use in this shader. */
+	public Input register(final Input input) {
 		if (program != null)
-			throw new GdxRuntimeException("Cannot register uniforms after initialization");
-		uniformEntries.add(entry);
-		return uniformEntries.size - 1;
+			throw new GdxRuntimeException("Cannot register input after initialization");
+		final Input existing = getInput(input.name);
+		if (existing != null) {
+			if (existing.scope != input.scope)
+				throw new GdxRuntimeException(input.name+": An input with the same name but different scope is already registered.");
+			return existing;
+		}
+		inputs.add(input);
+		return input;
 	}
 	
-	protected int registerUniform(final String name, final long material, final long attribute, final long userFlag) {
-		UniformEntry entry = UniformEntry.pool.obtain();
-		entry.name = name;
-		entry.material = material;
-		entry.attribute = attribute;
-		entry.userFlag = userFlag;
-		return registerUniform(entry);
+	public Iterable<Input> getInputs() {
+		return inputs;
 	}
 	
-	protected int registerUniform(final String name, final long material, final long attribute) {
-		return registerUniform(name, material, attribute, 0);
+	/** @return The input or null if not found. */
+	public Input getInput(final String alias) {
+		for (final Input input : inputs)
+			if (alias.equals(input.name))
+				return input;
+		return null;
 	}
-	
-	protected int registerUniform(final String name, final long material) {
-		return registerUniform(name, material, 0, 0);
-	}
-	
-	protected int registerUniform(final String name) {
-		return registerUniform(name, 0, 0, 0);
-	}
-	
+
 	/** Initialize this shader, causing all registered uniforms/attributes to be fetched. */
-	protected void init(final ShaderProgram program, final long material, final long attributes, final long userMask) {
+	public void init(final ShaderProgram program, final long materialMask, final long vertexMask, final long userMask) {
 		if (this.program != null)
 			throw new GdxRuntimeException("Already initialized");
 		if (!program.isCompiled())
 			throw new GdxRuntimeException(program.getLog());
 		this.program = program;
-		uniformLocations = new int[uniformEntries.size];
-		for (int i = 0; i < uniformLocations.length; i++) {
-			UniformEntry entry = uniformEntries.get(i);
-			if (((material & entry.material) == entry.material) && 
-				((attributes & entry.attribute) == entry.attribute) && 
-				((userMask & entry.userFlag) == entry.userFlag))  {
-				uniformLocations[i] = program.fetchUniformLocation(entry.name, false);
+		for (Input input : inputs) {
+			if (input.compare(materialMask, vertexMask, userMask))  {
+				if (input.scope == GLOBAL_UNIFORM) {
+					input.location = program.fetchUniformLocation(input.name, false);
+					if (input.location >= 0 && input.setter != null)
+						globalUniforms.add(input);
+				} else if (input.scope == LOCAL_UNIFORM) {
+					input.location = program.fetchUniformLocation(input.name, false);
+					if (input.location >= 0 && input.setter != null)
+						localUniforms.add(input);
+				} else if (input.scope == VERTEX_ATTRIBUTE) {
+					input.location = program.getAttributeLocation(input.name);
+					if (input.location >= 0)
+						vertexAttributes.add(input);
+				} else
+					input.location = -1;
 			} else
-				uniformLocations[i] = -1;
+				input.location = -1;
 		}
-		UniformEntry.pool.freeAll(uniformEntries);
-		uniformEntries.clear();
+	}
+	
+	@Override
+	public void begin (Camera camera, RenderContext context) {
+		this.camera = camera;
+		this.context = context;
+		program.begin();
+		for (final Input input : globalUniforms)
+			input.setter.set(this, program, input, camera, context, null);
+	}
+
+	@Override
+	public void render (Renderable renderable) {
+		for (final Input input : localUniforms)
+			input.setter.set(this, program, input, camera, context, renderable);
+		renderable.mesh.render(program, renderable.primitiveType, renderable.meshPartOffset, renderable.meshPartSize);
+		// FIXME Use vertexAttributes to bind and render the mesh
+	}
+
+	@Override
+	public void end () {
+		program.end();
 	}
 	
 	@Override
 	public void dispose () {
 		program = null;
-		uniformLocations = null;
+		inputs.clear();
+		vertexAttributes.clear();
+		localUniforms.clear();
+		globalUniforms.clear();
 	}
 	
-	/** Whether this Shader instance contains the specified uniform. */
-	protected boolean hasUniform(int what) {
-		return uniformLocations[what] >= 0;
+	/** Whether this Shader instance implements the specified attribute or uniform, only valid after a call to init(). */
+	public final boolean has(final Input input) {
+		return input.location >= 0;
 	}
 	
-	/** The location of the specified attribute or uniform, or negative if not available. */
-	protected int loc(int what) {
-		return uniformLocations[what];
-	}
-	
-	protected boolean set(int what, final Matrix4 value) {
-		if (uniformLocations[what] < 0)
+	public final boolean set(final Input uniform, final Matrix4 value) {
+		if (uniform.location < 0)
 			return false;
-		program.setUniformMatrix(uniformLocations[what], value);
+		program.setUniformMatrix(uniform.location, value);
 		return true;
 	}
 	
-	protected boolean set(int what, final Matrix3 value) {
-		if (uniformLocations[what] < 0)
+	public final boolean set(final Input uniform, final Matrix3 value) {
+		if (uniform.location < 0)
 			return false;
-		program.setUniformMatrix(uniformLocations[what], value);
+		program.setUniformMatrix(uniform.location, value);
 		return true;
 	}
 	
-	protected boolean set(int what, final Vector3 value) {
-		if (uniformLocations[what] < 0)
+	public final boolean set(final Input uniform, final Vector3 value) {
+		if (uniform.location < 0)
 			return false;
-		program.setUniformf(uniformLocations[what], value);
-		return true;
-	}
-
-    protected boolean set(int what, final float v1, final float v2, final float v3, final float v4) {
-        if (uniformLocations[what] < 0)
-            return false;
-        program.setUniformf(uniformLocations[what], v1, v2, v3, v4);
-        return true;
-    }
-	
-	protected boolean set(int what, final Color value) {
-		if (uniformLocations[what] < 0)
-			return false;
-		program.setUniformf(uniformLocations[what], value);
+		program.setUniformf(uniform.location, value);
 		return true;
 	}
 	
-	protected boolean set(int what, final float value) {
-		if (uniformLocations[what] < 0)
+	public final boolean set(final Input uniform, final Vector2 value) {
+		if (uniform.location < 0)
 			return false;
-		program.setUniformf(uniformLocations[what], value);
+		program.setUniformf(uniform.location, value);
+		return true;
+	}
+	
+	public final boolean set(final Input uniform, final Color value) {
+		if (uniform.location < 0)
+			return false;
+		program.setUniformf(uniform.location, value);
+		return true;
+	}
+	
+	public final boolean set(final Input uniform, final float value) {
+		if (uniform.location < 0)
+			return false;
+		program.setUniformf(uniform.location, value);
+		return true;
+	}
+	
+	public final boolean set(final Input uniform, final float v1, final float v2) {
+		if (uniform.location < 0)
+			return false;
+		program.setUniformf(uniform.location, v1, v2);
+		return true;
+	}
+	
+	public final boolean set(final Input uniform, final float v1, final float v2, final float v3) {
+		if (uniform.location < 0)
+			return false;
+		program.setUniformf(uniform.location, v1, v2, v3);
+		return true;
+	}
+	
+	public final boolean set(final Input uniform, final float v1, final float v2, final float v3, final float v4) {
+		if (uniform.location < 0)
+			return false;
+		program.setUniformf(uniform.location, v1, v2, v3, v4);
+		return true;
+	}
+	
+	public final boolean set(final Input uniform, final int value) {
+		if (uniform.location < 0)
+			return false;
+		program.setUniformi(uniform.location, value);
+		return true;
+	}
+	
+	public final boolean set(final Input uniform, final int v1, final int v2) {
+		if (uniform.location < 0)
+			return false;
+		program.setUniformi(uniform.location, v1, v2);
+		return true;
+	}
+	
+	public final boolean set(final Input uniform, final int v1, final int v2, final int v3) {
+		if (uniform.location < 0)
+			return false;
+		program.setUniformi(uniform.location, v1, v2, v3);
+		return true;
+	}
+	
+	public final boolean set(final Input uniform, final int v1, final int v2, final int v3, final int v4) {
+		if (uniform.location < 0)
+			return false;
+		program.setUniformi(uniform.location, v1, v2, v3, v4);
 		return true;
 	}
 }

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/DefaultShader.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/DefaultShader.java
@@ -62,34 +62,34 @@ public class DefaultShader extends BaseShader {
 	public static int defaultDepthFunc = GL10.GL_LEQUAL;
 	
 	// Global uniforms
-	protected final int u_projTrans					= registerUniform("u_projTrans");
-	protected final int u_cameraPosition			= registerUniform("u_cameraPosition");
-	protected final int u_cameraDirection			= registerUniform("u_cameraDirection");
-	protected final int u_cameraUp					= registerUniform("u_cameraUp");
+	protected final Input u_projTrans				= register(new Input(GLOBAL_UNIFORM, "u_projTrans"));
+	protected final Input u_cameraPosition			= register(new Input(GLOBAL_UNIFORM, "u_cameraPosition"));
+	protected final Input u_cameraDirection		= register(new Input(GLOBAL_UNIFORM, "u_cameraDirection"));
+	protected final Input u_cameraUp					= register(new Input(GLOBAL_UNIFORM, "u_cameraUp"));
 	// Object uniforms
-	protected final int u_worldTrans					= registerUniform("u_worldTrans");
-	protected final int u_normalMatrix				= registerUniform("u_normalMatrix", 0, Usage.Normal);
-	protected final int u_bones						= registerUniform("u_bones");
+	protected final Input u_worldTrans				= register(new Input(LOCAL_UNIFORM, "u_worldTrans"));
+	protected final Input u_normalMatrix			= register(new Input(LOCAL_UNIFORM, "u_normalMatrix", 0, Usage.Normal));
+	protected final Input u_bones						= register(new Input(LOCAL_UNIFORM, "u_bones"));
 	// Material uniforms
-	protected final int u_shininess					= registerUniform("u_shininess", FloatAttribute.Shininess);
-	protected final int u_opacity					= registerUniform("u_opacity", BlendingAttribute.Type);
-	protected final int u_diffuseColor				= registerUniform("u_diffuseColor", ColorAttribute.Diffuse);
-	protected final int u_diffuseTexture			= registerUniform("u_diffuseTexture", TextureAttribute.Diffuse);
-	protected final int u_specularColor				= registerUniform("u_specularColor", ColorAttribute.Specular);
-	protected final int u_specularTexture			= registerUniform("u_specularTexture", TextureAttribute.Specular);
-	protected final int u_normalTexture				= registerUniform("u_normalTexture", TextureAttribute.Normal);
-	protected final int u_alphaTest					= registerUniform("u_alphaTest", FloatAttribute.AlphaTest);
+	protected final Input u_shininess				= register(new Input(LOCAL_UNIFORM, "u_shininess", FloatAttribute.Shininess));
+	protected final Input u_opacity					= register(new Input(LOCAL_UNIFORM, "u_opacity", BlendingAttribute.Type));
+	protected final Input u_diffuseColor			= register(new Input(LOCAL_UNIFORM, "u_diffuseColor", ColorAttribute.Diffuse));
+	protected final Input u_diffuseTexture			= register(new Input(LOCAL_UNIFORM, "u_diffuseTexture", TextureAttribute.Diffuse));
+	protected final Input u_specularColor			= register(new Input(LOCAL_UNIFORM, "u_specularColor", ColorAttribute.Specular));
+	protected final Input u_specularTexture		= register(new Input(LOCAL_UNIFORM, "u_specularTexture", TextureAttribute.Specular));
+	protected final Input u_normalTexture			= register(new Input(LOCAL_UNIFORM, "u_normalTexture", TextureAttribute.Normal));
+	protected final Input u_alphaTest				= register(new Input(LOCAL_UNIFORM, "u_alphaTest", FloatAttribute.AlphaTest));
 	// Lighting uniforms
-	protected final int u_ambientLight				= registerUniform("u_ambientLight");
-	protected final int u_ambientCubemap			= registerUniform("u_ambientCubemap");
-	protected final int u_dirLights0color			= registerUniform("u_dirLights[0].color");
-	protected final int u_dirLights0direction		= registerUniform("u_dirLights[0].direction");
-	protected final int u_dirLights1color			= registerUniform("u_dirLights[1].color");
-	protected final int u_pointLights0color		    = registerUniform("u_pointLights[0].color");
-	protected final int u_pointLights0position	    = registerUniform("u_pointLights[0].position");
-	protected final int u_pointLights0intensity	    = registerUniform("u_pointLights[0].intensity");
-	protected final int u_pointLights1color		    = registerUniform("u_pointLights[1].color");
-    protected final int u_fogColor				    = registerUniform("u_fogColor");
+	protected final Input u_ambientLight			= register(new Input(LOCAL_UNIFORM, "u_ambientLight"));
+	protected final Input u_ambientCubemap			= register(new Input(LOCAL_UNIFORM, "u_ambientCubemap"));
+	protected final Input u_dirLights0color		= register(new Input(LOCAL_UNIFORM, "u_dirLights[0].color"));
+	protected final Input u_dirLights0direction	= register(new Input(LOCAL_UNIFORM, "u_dirLights[0].direction"));
+	protected final Input u_dirLights1color		= register(new Input(LOCAL_UNIFORM, "u_dirLights[1].color"));
+	protected final Input u_pointLights0color		= register(new Input(LOCAL_UNIFORM, "u_pointLights[0].color"));
+	protected final Input u_pointLights0position	= register(new Input(LOCAL_UNIFORM, "u_pointLights[0].position"));
+	protected final Input u_pointLights0intensity= register(new Input(LOCAL_UNIFORM, "u_pointLights[0].intensity"));
+	protected final Input u_pointLights1color		= register(new Input(LOCAL_UNIFORM, "u_pointLights[1].color"));
+	protected final Input u_fogColor				   = register(new Input(LOCAL_UNIFORM, "u_fogColor"));
 	// FIXME Cache vertex attribute locations...
 	
 	protected int dirLightsLoc;
@@ -103,40 +103,44 @@ public class DefaultShader extends BaseShader {
 	protected int pointLightsSize;
 
 	protected boolean lighting;
-    protected boolean fog;
+	protected boolean fog;
 	protected final AmbientCubemap ambientCubemap = new AmbientCubemap();
 	protected final DirectionalLight directionalLights[];
 	protected final PointLight pointLights[];
 	
 	protected final float bones[];
 	
-	protected RenderContext context;
-	protected long mask;
-	protected long attributes;
-	
-	protected final ShaderProgram program;
-	
+	protected long materialMask;
+	protected long vertexMask;
+
 	public DefaultShader(final Material material, final VertexAttributes attributes, boolean lighting, boolean fog, int numDirectional, int numPoint, int numSpot, int numBones) {
 		this(getDefaultVertexShader(), getDefaultFragmentShader(), material, attributes, lighting, fog, numDirectional, numPoint, numSpot, numBones);
 	}
 	
-	public DefaultShader(final long mask, final long attributes, boolean lighting, boolean fog, int numDirectional, int numPoint, int numSpot, int numBones) {
-		this(getDefaultVertexShader(), getDefaultFragmentShader(), mask, attributes, lighting, fog, numDirectional, numPoint, numSpot, numBones);
+	public DefaultShader(final long materialMask, final long vertexMask, boolean lighting, boolean fog, int numDirectional, int numPoint, int numSpot, int numBones) {
+		this(getDefaultVertexShader(), getDefaultFragmentShader(), materialMask, vertexMask, lighting, fog, numDirectional, numPoint, numSpot, numBones);
 	}
 
 	public DefaultShader(final String vertexShader, final String fragmentShader, final Material material, final VertexAttributes attributes, boolean lighting, boolean fog, int numDirectional, int numPoint, int numSpot, int numBones) {
 		this(vertexShader, fragmentShader, material.getMask(), getAttributesMask(attributes), lighting, fog, numDirectional, numPoint, numSpot, numBones);
 	}
+	
+	public DefaultShader(final String vertexShader, final String fragmentShader, final long materialMask, final long vertexMask, boolean lighting, boolean fog, int numDirectional, int numPoint, int numSpot, int numBones) {
+		this(createPrefix(materialMask, vertexMask, lighting, fog, numDirectional, numPoint, numSpot, numBones), 
+			vertexShader, fragmentShader, materialMask, vertexMask, lighting, fog, numDirectional, numPoint, numSpot, numBones);
+	}
 
-	public DefaultShader(final String vertexShader, final String fragmentShader, final long mask, final long attributes, boolean lighting, boolean fog, int numDirectional, int numPoint, int numSpot, int numBones) {
-		final String prefix = createPrefix(mask, attributes, lighting, fog, numDirectional, numPoint, numSpot, numBones);
-		program = new ShaderProgram(prefix + vertexShader, prefix + fragmentShader);
-		if(!program.isCompiled()) {
-			throw new GdxRuntimeException("Couldn't compile shader " + program.getLog());
-		}
-		init(program, mask, attributes, 0);
+	public DefaultShader(final String prefix, final String vertexShader, final String fragmentShader, final long materialMask, final long vertexMask, boolean lighting, boolean fog, int numDirectional, int numPoint, int numSpot, int numBones) {
+		this(new ShaderProgram(prefix + vertexShader, prefix + fragmentShader), materialMask, vertexMask, lighting, fog, numDirectional, numPoint, numSpot, numBones);
+	}
+	
+	public DefaultShader(final ShaderProgram shaderProgram, final long materialMask, final long vertexMask, boolean lighting, boolean fog, int numDirectional, int numPoint, int numSpot, int numBones) {
+		this.program = shaderProgram;
 		this.lighting = lighting;
-        this.fog = fog;
+		this.fog = fog;
+		this.materialMask = materialMask;
+		this.vertexMask = vertexMask;
+		
 		this.directionalLights = new DirectionalLight[lighting && numDirectional > 0 ? numDirectional : 0];
 		for (int i = 0; i < directionalLights.length; i++)
 			directionalLights[i] = new DirectionalLight();
@@ -144,23 +148,27 @@ public class DefaultShader extends BaseShader {
 		for (int i = 0; i < pointLights.length; i++)
 			pointLights[i] = new PointLight();
 		bones = new float[numBones > 0 ? numBones * 16 : 0];
-		
-		this.mask = mask;
-		this.attributes = attributes;
 				
-		if (!ignoreUnimplemented && (implementedFlags & mask) != mask)
-			throw new GdxRuntimeException("Some attributes not implemented yet ("+mask+")");
+		if (!ignoreUnimplemented && (implementedFlags & materialMask) != materialMask)
+			throw new GdxRuntimeException("Some attributes not implemented yet ("+materialMask+")");
+	}
+	
+	@Override
+	public void init () {
+		final ShaderProgram program = this.program;
+		this.program = null;
+		init(program, materialMask, vertexMask, 0);
 		
-		dirLightsLoc 				= loc(u_dirLights0color);
-		dirLightsColorOffset		= loc(u_dirLights0color) - dirLightsLoc;
-		dirLightsDirectionOffset 	= loc(u_dirLights0direction) - dirLightsLoc;
-		dirLightsSize 				= loc(u_dirLights1color) - dirLightsLoc;
+		dirLightsLoc 					= u_dirLights0color.location;
+		dirLightsColorOffset			= u_dirLights0color.location - dirLightsLoc;
+		dirLightsDirectionOffset 	= u_dirLights0direction.location - dirLightsLoc;
+		dirLightsSize 					= u_dirLights1color.location - dirLightsLoc;
 		
-		pointLightsLoc 				= loc(u_pointLights0color);
-		pointLightsColorOffset 		= loc(u_pointLights0color) - pointLightsLoc;
-		pointLightsPositionOffset 	= loc(u_pointLights0position) - pointLightsLoc;
-		pointLightsIntensityOffset  = loc(u_pointLights0intensity) - pointLightsLoc;
-		pointLightsSize 			= loc(u_pointLights1color)- pointLightsLoc;
+		pointLightsLoc 				= u_pointLights0color.location;
+		pointLightsColorOffset 		= u_pointLights0color.location - pointLightsLoc;
+		pointLightsPositionOffset 	= u_pointLights0position.location - pointLightsLoc;
+		pointLightsIntensityOffset = u_pointLights0intensity.location - pointLightsLoc;
+		pointLightsSize 				= u_pointLights1color.location - pointLightsLoc;
 	}
 	
 	protected final static long tangentAttribute = Usage.Generic << 1;
@@ -183,7 +191,7 @@ public class DefaultShader extends BaseShader {
 		return result;
 	}
 	
-	private String createPrefix(final long mask, final long attributes, boolean lighting, boolean fog, int numDirectional, int numPoint, int numSpot, int numBones) {
+	private static String createPrefix(final long mask, final long attributes, boolean lighting, boolean fog, int numDirectional, int numPoint, int numSpot, int numBones) {
 		String prefix = "";
 		if (((attributes & Usage.Color) == Usage.Color) || ((attributes & Usage.ColorPacked) == Usage.ColorPacked))
 			prefix += "#define colorFlag\n";
@@ -230,14 +238,14 @@ public class DefaultShader extends BaseShader {
 	
 	@Override
 	public boolean canRender(final Renderable renderable) {
-		return mask == renderable.material.getMask() && 
-			attributes == getAttributesMask(renderable.mesh.getVertexAttributes()) && 
+		return materialMask == renderable.material.getMask() && 
+			vertexMask == getAttributesMask(renderable.mesh.getVertexAttributes()) && 
 			(renderable.lights != null) == lighting &&
             ((renderable.lights != null && renderable.lights.fog != null) == fog);
 	}
 	
 	private final boolean can(final long flag) {
-		return (mask & flag) == flag;
+		return (materialMask & flag) == flag;
 	}
 	
 	@Override
@@ -263,17 +271,15 @@ public class DefaultShader extends BaseShader {
 	
 	@Override
 	public void begin (final Camera camera, final RenderContext context) {
-		this.context = context;
-		this.camera = camera;
-		program.begin();
+		super.begin(camera, context);
 		// FIXME add DepthTest Material Attribute ?
 		if (defaultDepthFunc == 0)
 			context.setDepthTest(false, GL10.GL_LEQUAL);
 		else
 			context.setDepthTest(true, defaultDepthFunc);
 
-        float fogDist  = 1.09f / camera.far;
-              fogDist *= fogDist;
+		float fogDist  = 1.09f / camera.far;
+			fogDist *= fogDist;
 
 		set(u_projTrans, camera.combined);
 		set(u_cameraPosition, camera.position.x, camera.position.y, camera.position.z, fogDist);
@@ -307,15 +313,15 @@ public class DefaultShader extends BaseShader {
 			renderable.mesh.setAutoBind(false); // FIXME this doesn't belong here
 			(currentMesh = renderable.mesh).bind(program);
 		}
-		if (hasUniform(u_bones)) {
+		if (has(u_bones)) {
 			for (int i = 0; i < bones.length; i++) {
 				final int idx = i/16;
 				bones[i] = (renderable.bones == null || idx >= renderable.bones.length || renderable.bones[idx] == null) ? 
 					idtMatrix.val[i%16] : renderable.bones[idx].val[i%16];
 			}
-			program.setUniformMatrix4fv(loc(u_bones), bones, 0, bones.length);
+			program.setUniformMatrix4fv(u_bones.location, bones, 0, bones.length);
 		}
-		renderable.mesh.render(program, renderable.primitiveType, renderable.meshPartOffset, renderable.meshPartSize);
+		super.render(renderable);
 	}
 
 	@Override
@@ -326,7 +332,7 @@ public class DefaultShader extends BaseShader {
 		}
 		currentTextureAttribute = null;
 		currentMaterial = null;
-		program.end();
+		super.end();
 	}
 	
 	Material currentMaterial;
@@ -349,10 +355,10 @@ public class DefaultShader extends BaseShader {
 			}
 			else if (TextureAttribute.is(t)) {
 				final TextureAttribute tex = (TextureAttribute)attr;
-				if ((t & TextureAttribute.Diffuse) == TextureAttribute.Diffuse && hasUniform(u_diffuseTexture))
-					bindTextureAttribute(loc(u_diffuseTexture), tex);
-				if ((t & TextureAttribute.Normal) == TextureAttribute.Normal && hasUniform(u_normalTexture))
-					bindTextureAttribute(loc(u_normalTexture), tex);
+				if ((t & TextureAttribute.Diffuse) == TextureAttribute.Diffuse && has(u_diffuseTexture))
+					bindTextureAttribute(u_diffuseTexture.location, tex);
+				if ((t & TextureAttribute.Normal) == TextureAttribute.Normal && has(u_normalTexture))
+					bindTextureAttribute(u_normalTexture.location, tex);
 				// TODO else if (..)
 			}
 			else if ((t & FloatAttribute.Shininess) == FloatAttribute.Shininess)
@@ -380,7 +386,7 @@ public class DefaultShader extends BaseShader {
 		final Array<DirectionalLight> dirs = lights.directionalLights; 
 		final Array<PointLight> points = lights.pointLights;
 		
-		if (hasUniform(u_ambientCubemap)) {
+		if (has(u_ambientCubemap)) {
 			renderable.worldTransform.getTranslation(tmpV1);
 			ambientCubemap.set(lights.ambientLight);
 			
@@ -392,7 +398,7 @@ public class DefaultShader extends BaseShader {
 			
 			ambientCubemap.clamp();
 			
-			program.setUniform3fv(loc(u_ambientCubemap), ambientCubemap.data, 0, ambientCubemap.data.length);
+			program.setUniform3fv(u_ambientCubemap.location, ambientCubemap.data, 0, ambientCubemap.data.length);
 		}
 		
 		if (dirLightsLoc >= 0) {
@@ -432,7 +438,7 @@ public class DefaultShader extends BaseShader {
 		}
 
         if (lights.fog != null) {
-            program.setUniformf(loc(u_fogColor), lights.fog);
+            program.setUniformf(u_fogColor.location, lights.fog);
         }
 	}
 

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/GLES10Shader.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/GLES10Shader.java
@@ -40,6 +40,10 @@ public class GLES10Shader implements Shader{
 	}
 	
 	@Override
+	public void init () {
+	}
+	
+	@Override
 	public boolean canRender(final Renderable renderable) {
 		return true;
 	}

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/utils/BaseShaderProvider.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/utils/BaseShaderProvider.java
@@ -13,14 +13,14 @@ public abstract class BaseShaderProvider implements ShaderProvider {
 		Shader suggestedShader = renderable.shader;
 		if (suggestedShader != null && suggestedShader.canRender(renderable))
 			return suggestedShader;
-		for (int i = 0; i < shaders.size; i++) {
-			final Shader shader = shaders.get(i);
+		for (Shader shader : shaders) {
 			if (shader.canRender(renderable))
 				return shader;
 		}
-		final Shader result = createShader(renderable);
-		shaders.add(result);
-		return result;
+		final Shader shader = createShader(renderable);
+		shader.init();
+		shaders.add(shader);
+		return shader;
 	}
 	
 	protected abstract Shader createShader(final Renderable renderable);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/ShaderTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/ShaderTest.java
@@ -16,6 +16,7 @@ import com.badlogic.gdx.graphics.g3d.lights.Lights;
 import com.badlogic.gdx.graphics.g3d.materials.Material;
 import com.badlogic.gdx.graphics.g3d.materials.Material.Attribute;
 import com.badlogic.gdx.graphics.g3d.shaders.BaseShader;
+import com.badlogic.gdx.graphics.g3d.shaders.BaseShader.Input;
 import com.badlogic.gdx.graphics.g3d.utils.BaseShaderProvider;
 import com.badlogic.gdx.graphics.g3d.utils.CameraInputController;
 import com.badlogic.gdx.graphics.g3d.utils.ModelBuilder;
@@ -65,9 +66,9 @@ public class ShaderTest extends GdxTest {
 			"	gl_FragColor.rgb = vec3(v_test);\n" +
 			"}\n";
 		
-		protected final int u_projTrans	= registerUniform("u_projTrans");
-		protected final int u_worldTrans	= registerUniform("u_worldTrans");
-		protected final int u_test			= registerUniform("u_test");
+		protected final Input u_projTrans	= register(new Input(GLOBAL_UNIFORM, "u_projTrans"));
+		protected final Input u_worldTrans	= register(new Input(GLOBAL_UNIFORM, "u_worldTrans"));
+		protected final Input u_test			= register(new Input(GLOBAL_UNIFORM, "u_test"));
 		
 		protected final ShaderProgram program;
 		
@@ -76,7 +77,11 @@ public class ShaderTest extends GdxTest {
 			program = new ShaderProgram(vertexShader, fragmentShader);
 			if (!program.isCompiled())
 				throw new GdxRuntimeException("Couldn't compile shader " + program.getLog());
-			init(program, 0, 0, 0);
+		}
+		
+		@Override
+		public void init () {
+			super.init(program, 0, 0, 0);
 		}
 		
 		@Override


### PR DESCRIPTION
Add Shader#init() and separate it from the constructor. This allows to easier extend a shader.

Introduce BaseShader#Input:
Input replaces the previous int to identify an uniform/attribute. This allows to extend the Input to add user definable data. It also accepts a Input.Setter which (if set) gets called by default when the uniform needs to be set. This allows to keep the code needed to set an uniform together. Input also has a scope, being either:
- VERTEX_ATTRIBUTE: obviously a vertex attribute, they are added to the public vertexAttributes array
- GLOBAL_UNIFORM: a uniform that only needs to be set once per render pass
- LOCAL_UNIFORM: a uniform that needs to be set for every renderable.

Using an Input in this way is optional, you can still use it to simply reference an uniform (like DefaultShader does). However for a more flexible Shader, it allows to better define who is responsible and when an uniform must be set. I hope to soon PR an improved CompositeShader, which relies on the change.
