### PR TITLE
Array: add Iterable and Iterator.allowRemove

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g3d/materials/Material.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/materials/Material.java
@@ -71,7 +71,6 @@ public class Material implements Iterable<Material.Attribute>, Comparator<Materi
 	public String id;
 	protected long mask;
 	protected final Array<Attribute> attributes = new Array<Attribute>();
-	protected final Array.ArrayIterator<Attribute> readOnlyIterator = new Array.ArrayIterator<Material.Attribute>(attributes, false);
 	protected boolean sorted = true;
 	
 	/** Create an empty material */
@@ -161,7 +160,7 @@ public class Material implements Iterable<Material.Attribute>, Comparator<Materi
 
 	/** Add an array of attributes to this material.
 	 * If the material already contains an attribute of the same type it is overwritten. */
-	public final void set(final Iterable<Attribute> attributes) {
+	public final void set(final Array<Attribute> attributes) {
 		for (final Attribute attr : attributes)
 			set(attr);
 	}
@@ -256,7 +255,6 @@ public class Material implements Iterable<Material.Attribute>, Comparator<Materi
 	/** Used for iterating through the attributes */
 	@Override
 	public final Iterator<Attribute> iterator () {
-		readOnlyIterator.reset();
-		return readOnlyIterator;
+		return attributes.iterator();
 	}
 }

--- a/gdx/src/com/badlogic/gdx/utils/Array.java
+++ b/gdx/src/com/badlogic/gdx/utils/Array.java
@@ -34,7 +34,7 @@ public class Array<T> implements Iterable<T> {
 	public int size;
 	public boolean ordered;
 
-	private ArrayIterator iterator1, iterator2;
+	private ArrayIterable iterable;
 	private Predicate.PredicateIterable<T> predicateIterable;
 
 	/** Creates an ordered array with a capacity of 16. */
@@ -353,20 +353,9 @@ public class Array<T> implements Iterable<T> {
 	/** Returns an iterator for the items in the array. Remove is supported. Note that the same iterator instance is returned each
 	 * time this method is called. Use the {@link ArrayIterator} constructor for nested or multithreaded iteration. */
 	public Iterator<T> iterator () {
-		if (iterator1 == null) {
-			iterator1 = new ArrayIterator(this);
-			iterator2 = new ArrayIterator(this);
-		}
-		if (!iterator1.valid) {
-			iterator1.index = 0;
-			iterator1.valid = true;
-			iterator2.valid = false;
-			return iterator1;
-		}
-		iterator2.index = 0;
-		iterator2.valid = true;
-		iterator1.valid = false;
-		return iterator2;
+		if (iterable == null) 
+			iterable = new ArrayIterable(this);
+		return iterable.iterator();
 	}
 
 	/** Returns an iterable for the selected items in the array. Remove is supported, but not between hasNext() and next(). Note


### PR DESCRIPTION
Add Array.ArrayIterable: E.g. both the Model and ModelInstance class internally use Array#iterator() a lot, which can lead to usage of nested iterators (note how I worked around that problem in Basic3DSceneTest by iterating on index). This change allows those classes to have an Iterable for internal usage, leaving the Array#iterator() valid for the user to use.

I also added a allowRemove to both ArrayIterator and ArrayIterable. As an example for this, I updated the Material class, where removing attributes using the iterator would make the material (mask) invalid.
