### PR TITLE
Issue 1451 Patch - Indexes and aliases can now work together

### DIFF
--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/imagepacker/ImageProcessor.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/imagepacker/ImageProcessor.java
@@ -16,6 +16,7 @@
 
 package com.badlogic.gdx.tools.imagepacker;
 
+import com.badlogic.gdx.tools.imagepacker.TexturePacker2.Alias;
 import com.badlogic.gdx.tools.imagepacker.TexturePacker2.Rect;
 import com.badlogic.gdx.tools.imagepacker.TexturePacker2.Settings;
 import com.badlogic.gdx.utils.Array;
@@ -126,7 +127,7 @@ public class ImageProcessor {
 			Rect existing = crcs.get(crc);
 			if (existing != null) {
 				System.out.println(rect.name + " (alias of " + existing.name + ")");
-				existing.aliases.add(rect.name);
+				existing.aliases.add(new Alias(rect.name, rect.index));
 				return;
 			}
 			crcs.put(crc, rect);

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/imagepacker/TexturePacker2.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/imagepacker/TexturePacker2.java
@@ -275,8 +275,10 @@ public class TexturePacker2 {
 
 			for (Rect rect : page.outputRects) {
 				writeRect(writer, page, rect, rect.name);
-				for (String alias : rect.aliases)
-					writeRect(writer, page, rect, alias);
+				for (Alias alias : rect.aliases) {
+					rect.index = alias.index;
+					writeRect(writer, page, rect, alias.name);
+				}
 			}
 		}
 // }
@@ -331,6 +333,17 @@ public class TexturePacker2 {
 		public int x, y, width, height;
 	}
 
+	/** @author Regnarock */
+	public static class Alias {
+		public String name;
+		public int index;
+		
+		public Alias(String name, int index) {
+			this.name = name;
+			this.index = index;
+		}
+	}
+	
 	/** @author Nathan Sweet */
 	public static class Rect {
 		public String name;
@@ -339,7 +352,7 @@ public class TexturePacker2 {
 		public int x, y, width, height;
 		public int index;
 		public boolean rotated;
-		public Set<String> aliases = new HashSet<String>();
+		public Set<Alias> aliases = new HashSet<Alias>();
 		public int[] splits;
 		public int[] pads;
 		public boolean canRotate = true;


### PR DESCRIPTION
I corrected the bug signaled in issue 1451 (http://code.google.com/p/libgdx/issues/detail?id=1451).

In fact, only the name was stored to remember aliases while the index was also necessary.
I decided to create a new type but to let the code almost the same by overwriting the current rect.index by its aliases indexes. This may be bad if someone decide to use the "rect" variable after the "for".

Also, it will have only a very tiny impact on the running time of the TexturePacker2 tool.
