### PR TITLE
Issue 1558: Unable to Rotate TiledDrawable in Image Actor Patch

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Image.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Image.java
@@ -124,7 +124,7 @@ public class Image extends Widget {
 		float scaleY = getScaleY();
 
 		if (drawable != null) {
-			if (drawable.getClass() == TextureRegionDrawable.class) {
+			if (drawable instanceof TextureRegionDrawable) {
 				TextureRegion region = ((TextureRegionDrawable)drawable).getRegion();
 				float rotation = getRotation();
 				if (scaleX == 1 && scaleY == 1 && rotation == 0)


### PR DESCRIPTION
Corrected the bug in Issue 1558. (http://code.google.com/p/libgdx/issues/detail?id=1558)
