### PR TITLE
Rectangle, add getPosition returns Vector2

### DIFF
--- a/gdx/src/com/badlogic/gdx/math/Rectangle.java
+++ b/gdx/src/com/badlogic/gdx/math/Rectangle.java
@@ -141,7 +141,8 @@ public class Rectangle implements Serializable {
 		this.height = sizeXY;
 	}
 
-	/** @return the Vector2 with size of this rectangle */
+	/** @return the Vector2 with size of this rectangle
+	 * @param size The Vector2 */
 	public Vector2 getSize (Vector2 size) {
 		return size.set(width, height);
 	}


### PR DESCRIPTION
Created private Vector2 to avoid creating new Vector2 with each call of getPosition method.
