### PR TITLE
allow Android `internal` to fall back to classpath (just like on Desktop!)

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidFileHandle.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidFileHandle.java
@@ -74,11 +74,10 @@ public class AndroidFileHandle extends FileHandle {
 	}
 
 	public InputStream read () {
-		if (type == FileType.Internal && existsAndroidAsset()) {
+		if (type == FileType.Internal) {
 			try {
 				return assets.open(file.getPath());
 			} catch (IOException ex) {
-				throw new GdxRuntimeException("Error reading file: " + file + " (" + type + ")", ex);
 			}
 		}
 		return super.read();
@@ -175,7 +174,7 @@ public class AndroidFileHandle extends FileHandle {
 	}
 
 	public long length () {
-		if (type == FileType.Internal && existsAndroidAsset()) {
+		if (type == FileType.Internal) {
 			AssetFileDescriptor fileDescriptor = null;
 			try {
 				fileDescriptor = assets.openFd(file.getPath());


### PR DESCRIPTION
libGDX loads `internal` from the working directory, then the classpath on Desktop (or did the last time I checked)

libGDX uses "just" assets on Android

This patch (should) mean that libGDX behaves the same way in these two places - falling back to classpath in both places
