### PR TITLE
Updated maven-download-plugin version to 1.1.0

### DIFF
--- a/gdx/jni/maven/pom.xml
+++ b/gdx/jni/maven/pom.xml
@@ -27,7 +27,7 @@
             <plugin>
                 <groupId>com.googlecode.maven-download-plugin</groupId>
                 <artifactId>maven-download-plugin</artifactId>
-                <version>1.0.0</version>
+                <version>1.1.0</version>
                 <executions>
                     <execution>
                         <id>desktop</id>


### PR DESCRIPTION
Update is necessary to build libgdx with maven behind a proxy. 
Using proxy in wget goal was added in maven-download-plugin two month ago in version 1.1.0.
Proof: https://github.com/maven-download-plugin/maven-download-plugin/pull/13
