### PR TITLE
Changed robovm.xml files for RoboVM sample games to turn off pngcrush

### DIFF
--- a/demos/invaders/gdx-invaders-iosrobovm/robovm.xml
+++ b/demos/invaders/gdx-invaders-iosrobovm/robovm.xml
@@ -6,7 +6,13 @@
   <target>ios</target>
   <iosInfoPList>Info.plist.xml</iosInfoPList>
   <resources>
-    <resource>../gdx-invaders-android/assets/data</resource>
+    <resource>
+      <directory>../gdx-invaders-android/assets</directory>
+      <includes>
+        <include>data/**</include>
+      </includes>
+      <skipPngCrush>true</skipPngCrush>
+    </resource>
   </resources>
   <libs>
     <lib>../../../gdx/libs/ios32/libgdx.a</lib>

--- a/demos/pax-britannica/pax-britannica-iosrobovm/robovm.xml
+++ b/demos/pax-britannica/pax-britannica-iosrobovm/robovm.xml
@@ -6,7 +6,13 @@
   <target>ios</target>
   <iosInfoPList>Info.plist.xml</iosInfoPList>
   <resources>
-    <resource>../pax-britannica-android/assets/data</resource>
+    <resource>
+      <directory>../pax-britannica-android/assets</directory>
+      <includes>
+        <include>data/**</include>
+      </includes>
+      <skipPngCrush>true</skipPngCrush>
+    </resource>
   </resources>
   <libs>
     <lib>../../../gdx/libs/ios32/libgdx.a</lib>

--- a/demos/superjumper/superjumper-iosrobovm/robovm.xml
+++ b/demos/superjumper/superjumper-iosrobovm/robovm.xml
@@ -6,7 +6,13 @@
   <target>ios</target>
   <iosInfoPList>Info.plist.xml</iosInfoPList>
   <resources>
-    <resource>../superjumper-android/assets/data</resource>
+    <resource>
+      <directory>../superjumper-android/assets</directory>
+      <includes>
+        <include>data/**</include>
+      </includes>
+      <skipPngCrush>true</skipPngCrush>
+    </resource>
   </resources>
   <libs>
     <lib>../../../gdx/libs/ios32/libgdx.a</lib>

--- a/demos/vector-pinball/gdx-vectorpinball-iosrobovm/robovm.xml
+++ b/demos/vector-pinball/gdx-vectorpinball-iosrobovm/robovm.xml
@@ -6,7 +6,13 @@
   <target>ios</target>
   <iosInfoPList>Info.plist.xml</iosInfoPList>
   <resources>
-    <resource>../gdx-vectorpinball/data/</resource>
+    <resource>
+      <directory>../gdx-vectorpinball</directory>
+      <includes>
+        <include>data/**</include>
+      </includes>
+      <skipPngCrush>true</skipPngCrush>
+    </resource>
   </resources>
   <libs>
     <lib>../../../gdx/libs/ios32/libgdx.a</lib>

--- a/tests/gdx-tests-iosrobovm/robovm.xml
+++ b/tests/gdx-tests-iosrobovm/robovm.xml
@@ -6,7 +6,13 @@
   <target>ios</target>
   <iosInfoPList>Info.plist.xml</iosInfoPList>
    <resources>
-    <resource>../gdx-tests-android/assets/data</resource>
+    <resource>
+      <directory>../gdx-tests-android/assets</directory>
+      <includes>
+        <include>data/**</include>
+      </includes>
+      <skipPngCrush>true</skipPngCrush>
+    </resource>
   </resources>
   <libs>
     <lib>../../gdx/libs/ios32/libgdx.a</lib>


### PR DESCRIPTION
In RoboVM 0.0.4 (not yet released) PNG files will by default be run through pngcrush. AFAIU libgdx doesn't support the Apple specific optimizations done by Xcode's pngcrush so this can be turned off by adding <skipPngCrush>true</skipPngCrush> to each <resource> in the app's robovm.xml. This patch fixes this for all of the demo games.
