### PR TITLE
setAngle in Vector2 now returns this for chaining.

### DIFF
--- a/gdx/src/com/badlogic/gdx/math/Vector2.java
+++ b/gdx/src/com/badlogic/gdx/math/Vector2.java
@@ -293,9 +293,11 @@ public class Vector2 implements Serializable, Vector<Vector2> {
 
 	/** Sets the angle of the vector in degrees.
 	 * @param angle The angle to set. */
-	public void setAngle (float angle) {
+	public Vector2 setAngle (float angle) {
 		this.set(len(), 0f);
 		this.rotate(angle);
+		
+		return this;
 	}
 
 	/** Rotates the Vector2 by the given angle, counter-clockwise.


### PR DESCRIPTION
setAngle returns "this" as with all over Vector2 functions that do not return another value.

First ever Pull Request, don't break my heart.
