### PR TITLE
Add user-configurable number of simultaneously playing audio sources

### DIFF
--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglApplication.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglApplication.java
@@ -16,6 +16,13 @@
 
 package com.badlogic.gdx.backends.lwjgl;
 
+import java.awt.Canvas;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.lwjgl.LWJGLException;
+import org.lwjgl.opengl.Display;
+
 import com.badlogic.gdx.Application;
 import com.badlogic.gdx.ApplicationListener;
 import com.badlogic.gdx.Audio;
@@ -29,13 +36,6 @@ import com.badlogic.gdx.backends.openal.OpenALAudio;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.Clipboard;
 import com.badlogic.gdx.utils.GdxRuntimeException;
-
-import java.awt.Canvas;
-import java.util.HashMap;
-import java.util.Map;
-
-import org.lwjgl.LWJGLException;
-import org.lwjgl.opengl.Display;
 
 /** An OpenGL surface fullscreen or in a lightweight window. */
 public class LwjglApplication implements Application {
@@ -79,7 +79,8 @@ public class LwjglApplication implements Application {
 
 		this.graphics = graphics;
 		if (!LwjglApplicationConfiguration.disableAudio)
-			audio = new OpenALAudio(16, config.audioDeviceBufferCount, config.audioDeviceBufferSize);
+			audio = new OpenALAudio(config.audioDeviceSimultaneousSources, config.audioDeviceBufferCount,
+				config.audioDeviceBufferSize);
 		files = new LwjglFiles();
 		input = new LwjglInput();
 		net = new LwjglNet();
@@ -106,6 +107,7 @@ public class LwjglApplication implements Application {
 
 	private void initialize () {
 		mainLoopThread = new Thread("LWJGL Application") {
+			@Override
 			public void run () {
 				graphics.setVSync(graphics.config.vSyncEnabled);
 				try {
@@ -334,6 +336,7 @@ public class LwjglApplication implements Application {
 		}
 	}
 
+	@Override
 	public void log (String tag, String message) {
 		if (logLevel >= LOG_INFO) {
 			System.out.println(tag + ": " + message);

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglApplicationConfiguration.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglApplicationConfiguration.java
@@ -16,16 +16,16 @@
 
 package com.badlogic.gdx.backends.lwjgl;
 
+import java.awt.GraphicsDevice;
+import java.awt.GraphicsEnvironment;
+import java.util.ArrayList;
+
 import com.badlogic.gdx.Application;
 import com.badlogic.gdx.Files.FileType;
 import com.badlogic.gdx.Graphics;
 import com.badlogic.gdx.Graphics.DisplayMode;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.utils.Array;
-
-import java.awt.GraphicsDevice;
-import java.awt.GraphicsEnvironment;
-import java.util.ArrayList;
 
 public class LwjglApplicationConfiguration {
 	/** If true, OpenAL will not be used. This means {@link Application#getAudio()} returns null and the gdx-openal.jar and OpenAL
@@ -54,6 +54,8 @@ public class LwjglApplicationConfiguration {
 	public boolean forceExit = true;
 	/** whether the window is resizable **/
 	public boolean resizable = true;
+	/** the maximum number of sources that can be played simultaneously */
+	public int audioDeviceSimultaneousSources = 16;
 	/** the audio device buffer size in samples **/
 	public int audioDeviceBufferSize = 512;
 	/** the audio device buffer count **/


### PR DESCRIPTION
Permits to configure the number of simultaneously playing audio sources in the Lwjgl backend, as it already happen in the Android one.

16 sources seems a reasonable default btw.
