### PR TITLE
Added getColor to Pixmap

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/Pixmap.java
+++ b/gdx/src/com/badlogic/gdx/graphics/Pixmap.java
@@ -169,6 +169,18 @@ public class Pixmap implements Disposable {
 		this.color = Color.rgba8888(color.r, color.g, color.b, color.a);
 	}
 
+	/**
+	 * Returns the color this Pixmap is set to use for drawing operations.
+	 * Manipulating the returned instance has no effect.
+	 * 
+	 * @return Color pixmap is using for drawing operations.
+	 */
+	public Color getColor() {
+		Color colorCopy = new Color();
+		Color.rgb888ToColor(colorCopy, color);
+		return colorCopy;
+	}
+
 	/** Fills the complete bitmap with the currently set color. */
 	public void fill () {
 		pixmap.clear(color);


### PR DESCRIPTION
Just added a simple getColor to the Pixmap so you can tell what Color it was set to for drawing. Someone on irc pointed out it wasn't exposed and I didn't see a reason it couldn't be exposed.
