### PR TITLE
Fix for the next(int) function in AtomicQueue.

### DIFF
--- a/gdx/src/com/badlogic/gdx/utils/AtomicQueue.java
+++ b/gdx/src/com/badlogic/gdx/utils/AtomicQueue.java
@@ -38,7 +38,7 @@ public class AtomicQueue<T> {
 	}
 
 	private int next (int idx) {
-		return idx + 1 & queue.length() - 1;
+		return (idx + 1) % queue.length();
 	}
 
 	public boolean put (T value) {


### PR DESCRIPTION
The calculation now uses remainder instead of bitwise AND.

The associated bug is [Issue 1630](https://code.google.com/p/libgdx/issues/detail?id=1630).
