### PR TITLE
Resurrect duplicate padding

### DIFF
--- a/extensions/gdx-tiled-preprocessor/src/com/badlogic/gdx/tiledmappacker/TiledMapPacker.java
+++ b/extensions/gdx-tiled-preprocessor/src/com/badlogic/gdx/tiledmappacker/TiledMapPacker.java
@@ -465,6 +465,8 @@ public class TiledMapPacker {
 		final Settings texturePackerSettings = new Settings();
 		texturePackerSettings.paddingX = 2;
 		texturePackerSettings.paddingY = 2;
+		texturePackerSettings.edgePadding = true;
+		texturePackerSettings.duplicatePadding = true;
 		texturePackerSettings.bleed = true;
 		texturePackerSettings.alias = true;
 		texturePackerSettings.useIndexes = true;

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/imagepacker/MaxRectsPacker.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/imagepacker/MaxRectsPacker.java
@@ -79,9 +79,11 @@ public class MaxRectsPacker {
 	}
 
 	private Page packPage (Array<Rect> inputRects) {
-		int edgePaddingX = settings.paddingX;
-		int edgePaddingY = settings.paddingY;
-
+		int edgePaddingX = 0, edgePaddingY = 0;
+		if (!settings.duplicatePadding) { // if duplicatePadding, edges get only half padding.
+			edgePaddingX = settings.paddingX;
+			edgePaddingY = settings.paddingY;
+		}
 		// Find min size.
 		int minWidth = Integer.MAX_VALUE;
 		int minHeight = Integer.MAX_VALUE;

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/imagepacker/TexturePacker2.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/imagepacker/TexturePacker2.java
@@ -99,6 +99,10 @@ public class TexturePacker2 {
 			int width = page.width, height = page.height;
 			int paddingX = settings.paddingX;
 			int paddingY = settings.paddingY;
+			if (settings.duplicatePadding) {
+				paddingX /= 2;
+				paddingY /= 2;
+			}
 			width -= settings.paddingX;
 			height -= settings.paddingY;
 			if (settings.edgePadding) {
@@ -139,6 +143,53 @@ public class TexturePacker2 {
 				int iw = image.getWidth();
 				int ih = image.getHeight();
 				int rectX = page.x + rect.x, rectY = page.y + page.height - rect.y - rect.height;
+				if (settings.duplicatePadding) {
+					int amountX = settings.paddingX / 2;
+					int amountY = settings.paddingY / 2;
+					if (rect.rotated) {
+						// Copy corner pixels to fill corners of the padding.
+						for (int i = 1; i <= amountX; i++) {
+							for (int j = 1; j <= amountY; j++) {
+								plot(canvas, rectX - j, rectY + iw - 1 + i, image.getRGB(0, 0));
+								plot(canvas, rectX + ih - 1 + j, rectY + iw - 1 + i, image.getRGB(0, ih - 1));
+								plot(canvas, rectX - j, rectY - i, image.getRGB(iw - 1, 0));
+								plot(canvas, rectX + ih - 1 + j, rectY - i, image.getRGB(iw - 1, ih - 1));
+							}
+						}
+						// Copy edge pixels into padding.
+						for (int i = 1; i <= amountY; i++) {
+							for (int j = 0; j < iw; j++) {
+								plot(canvas, rectX - i, rectY + iw - 1 - j, image.getRGB(j, 0));
+								plot(canvas, rectX + ih - 1 + i, rectY + iw - 1 - j, image.getRGB(j, ih - 1));
+							}
+						}
+						for (int i = 1; i <= amountX; i++) {
+							for (int j = 0; j < ih; j++) {
+								plot(canvas, rectX + j, rectY - i, image.getRGB(iw - 1, j));
+								plot(canvas, rectX + j, rectY + iw - 1 + i, image.getRGB(0, j));
+							}
+						}
+					} else {
+						// Copy corner pixels to fill corners of the padding.
+						for (int i = 1; i <= amountX; i++) {
+							for (int j = 1; j <= amountY; j++) {
+								canvas.setRGB(rectX - i, rectY - j, image.getRGB(0, 0));
+								canvas.setRGB(rectX - i, rectY + ih - 1 + j, image.getRGB(0, ih - 1));
+								canvas.setRGB(rectX + iw - 1 + i, rectY - j, image.getRGB(iw - 1, 0));
+								canvas.setRGB(rectX + iw - 1 + i, rectY + ih - 1 + j, image.getRGB(iw - 1, ih - 1));
+							}
+						}
+						// Copy edge pixels into padding.
+						for (int i = 1; i <= amountY; i++) {
+							copy(image, 0, 0, iw, 1, canvas, rectX, rectY - i, rect.rotated);
+							copy(image, 0, ih - 1, iw, 1, canvas, rectX, rectY + ih - 1 + i, rect.rotated);
+						}
+						for (int i = 1; i <= amountX; i++) {
+							copy(image, 0, 0, 1, ih, canvas, rectX - i, rectY, rect.rotated);
+							copy(image, iw - 1, 0, 1, ih, canvas, rectX + iw - 1 + i, rectY, rect.rotated);
+						}
+					}
+				}				
 				copy(image, 0, 0, iw, ih, canvas, rectX, rectY, rect.rotated);
 				if (settings.debug) {
 					g.setColor(Color.magenta);
@@ -405,6 +456,7 @@ public class TexturePacker2 {
 		public boolean pot = true;
 		public int paddingX = 2, paddingY = 2;
 		public boolean edgePadding = true;
+		public boolean duplicatePadding = false;
 		public boolean rotation;
 		public int minWidth = 16, minHeight = 16;
 		public int maxWidth = 1024, maxHeight = 1024;
@@ -440,6 +492,7 @@ public class TexturePacker2 {
 			paddingX = settings.paddingX;
 			paddingY = settings.paddingY;
 			edgePadding = settings.edgePadding;
+			duplicatePadding = settings.duplicatePadding;
 			alphaThreshold = settings.alphaThreshold;
 			ignoreBlankImages = settings.ignoreBlankImages;
 			stripWhitespaceX = settings.stripWhitespaceX;


### PR DESCRIPTION
When the bleed option was added, duplicate padding was removed. Unfortunately, the bleed effect is not a direct replacement for duplicate padding so I am adding it back in. It will be "off" by default, so the current behavior will remain unless it is specifically turned "on" by the user.
