### PR TITLE
ParticleEmitter now resets the active particles too.

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g2d/ParticleEmitter.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/ParticleEmitter.java
@@ -307,6 +307,10 @@ public class ParticleEmitter {
 	public void reset () {
 		emissionDelta = 0;
 		durationTimer = duration;
+		boolean[] active = this.active;
+		for (int i = 0, n = active.length; i < n; i++)
+			active[i] = false;
+		activeCount = 0;
 		start();
 	}
 


### PR DESCRIPTION
When reusing particle effects with the ParticleEffectPool, the currently active particles of the effect get not reset. This leads to artifacts when the effect is used somewhere else:

![image](https://f.cloud.github.com/assets/1545118/1101314/e09d4414-17be-11e3-87c7-3d4a06ee60ec.png)

The above picture contains a single particleEffect which is drawn at different positions with freeing/obtaining it between the position changes.

Here the test class from the above screenshot:

```
public class ParticleTest extends ApplicationAdapter {
    SpriteBatch batch;
    TextureAtlas atlas;
    OrthographicCamera cam = new OrthographicCamera();
    Vector2 position = new Vector2();
    ParticleEffectPool pool;
    PooledEffect pooledEffect;
    float lifeTime;
    int i;

    @Override
    public void create () {
        cam.setToOrtho(false);
        batch = new SpriteBatch();
        atlas = new TextureAtlas(Gdx.files.internal("tmp/packed.atlas"));

        ParticleEffect effect = new ParticleEffect();
        effect.load(Gdx.files.internal("tmp/rocket.p"), atlas);

        pool = new ParticleEffectPool(effect, 1, 10);
        pooledEffect = this.pool.obtain();
    }




    @Override
    public void render () {
        Gdx.gl.glClearColor(0, 0, 0, 1);
        Gdx.gl.glClear(GL10.GL_COLOR_BUFFER_BIT);

        float delta = Gdx.graphics.getDeltaTime();
        lifeTime -= delta;

        if (lifeTime < 0) {
            pooledEffect.free();
            pooledEffect = pool.obtain();
            position.set(50 + 50 * (i % 5), 0);
            i++;
            lifeTime = 0.9f;
        }

        int v = 200;
        position.add(0, v * delta);
        pooledEffect.setPosition(position.x, position.y);
        pooledEffect.update(delta);

        batch.setProjectionMatrix(cam.combined);
        batch.begin();
        pooledEffect.draw(batch);
        batch.end();
    }
}
```
