### PR TITLE
Fix for bug in RoboVM which may cause ClassCastException in IOSPreferences

### DIFF
--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSPreferences.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSPreferences.java
@@ -8,12 +8,21 @@ import org.robovm.cocoatouch.foundation.NSMutableDictionary;
 import org.robovm.cocoatouch.foundation.NSNumber;
 import org.robovm.cocoatouch.foundation.NSObject;
 import org.robovm.cocoatouch.foundation.NSString;
+import org.robovm.objc.ObjCClass;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Preferences;
 
 public class IOSPreferences implements Preferences {
 
+	static {
+		// FIXME: Work around for a bug in RoboVM (https://github.com/robovm/robovm/issues/155).
+		//        These calls make sure NSNumber and NSString have been registered properly with the
+		//        RoboVM Objective-C bridge. Without them the get-methods below may throw ClassCastException.
+		ObjCClass.getByType(NSNumber.class);
+		ObjCClass.getByType(NSString.class);
+	}
+	
 	NSMutableDictionary<NSString, NSObject> nsDictionary;
 	String filePath;
 


### PR DESCRIPTION
With this fix and the NSDictionary/NSMutableDictionary fixes (https://github.com/robovm/robovm/issues/154) which will be in the next RoboVM nightly IOSPreferences seems to work as expected (at least pax-britannica doesn't crash when turning on sound).
