### PR TITLE
all box2d classes refactored from java.util.ArrayList to badlogic Array class

### DIFF
--- a/gdx/src/com/badlogic/gdx/physics/box2d/Body.java
+++ b/gdx/src/com/badlogic/gdx/physics/box2d/Body.java
@@ -16,10 +16,9 @@
 
 package com.badlogic.gdx.physics.box2d;
 
-import java.util.ArrayList;
-
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.physics.box2d.BodyDef.BodyType;
+import com.badlogic.gdx.utils.Array;
 
 /** A rigid body. These are created via World.CreateBody.
  * @author mzechner */
@@ -39,10 +38,10 @@ public class Body {
 	private final World world;
 
 	/** Fixtures of this body **/
-	private ArrayList<Fixture> fixtures = new ArrayList<Fixture>(2);
+	private Array<Fixture> fixtures = new Array<Fixture>(2);
 
 	/** Joints of this body **/
-	protected ArrayList<JointEdge> joints = new ArrayList<JointEdge>(2);
+	protected Array<JointEdge> joints = new Array<JointEdge>(2);
 
 	/** user data **/
 	private Object userData;
@@ -59,7 +58,7 @@ public class Body {
 	protected void reset (long addr) {
 		this.addr = addr;
 		this.userData = null;
-		for (int i = 0; i < fixtures.size(); i++)
+		for (int i = 0; i < fixtures.size; i++)
 			this.world.freeFixtures.free(fixtures.get(i));
 		fixtures.clear();
 		this.joints.clear();
@@ -127,7 +126,7 @@ public class Body {
 	public void destroyFixture (Fixture fixture) {
 		jniDestroyFixture(addr, fixture.addr);
 		this.world.fixtures.remove(fixture.addr);
-		this.fixtures.remove(fixture);
+		this.fixtures.removeValue(fixture, true);
 		this.world.freeFixtures.free(fixture);
 	}
 
@@ -757,19 +756,19 @@ inline b2BodyType getBodyType( int type )
 	*/
 
 	/** Get the list of all fixtures attached to this body. Do not modify the list! */
-	public ArrayList<Fixture> getFixtureList () {
+	public Array<Fixture> getFixtureList () {
 		return fixtures;
 	}
 
 	/** Get the list of all joints attached to this body. Do not modify the list! */
-	public ArrayList<JointEdge> getJointList () {
+	public Array<JointEdge> getJointList () {
 		return joints;
 	}
 
 	/** Get the list of all contacts attached to this body.
 	 * @warning this list changes during the time step and you may miss some collisions if you don't use b2ContactListener. Do not
 	 *          modify the returned list! */
-// ArrayList<ContactEdge> getContactList()
+// Array<ContactEdge> getContactList()
 // {
 // return contacts;
 // }

--- a/gdx/src/com/badlogic/gdx/physics/box2d/Box2DDebugRenderer.java
+++ b/gdx/src/com/badlogic/gdx/physics/box2d/Box2DDebugRenderer.java
@@ -17,7 +17,6 @@
 package com.badlogic.gdx.physics.box2d;
 
 import java.util.Iterator;
-import java.util.List;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
@@ -110,7 +109,7 @@ public class Box2DDebugRenderer {
 		if (drawContacts) {
 			if (Gdx.gl10 != null) Gdx.gl10.glPointSize(3);
 			renderer.begin(ShapeType.Point);
-			int len = world.getContactList().size();
+			int len = world.getContactList().size;
 			for (int i = 0; i < len; i++)
 				drawContact(world.getContactList().get(i));
 			renderer.end();

--- a/gdx/src/com/badlogic/gdx/physics/box2d/World.java
+++ b/gdx/src/com/badlogic/gdx/physics/box2d/World.java
@@ -16,9 +16,7 @@
 
 package com.badlogic.gdx.physics.box2d;
 
-import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.List;
 
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.physics.box2d.JointDef.JointType;
@@ -311,12 +309,12 @@ b2ContactFilter defaultFilter;
 	public void destroyBody (Body body) {
 		body.setUserData(null);
 		this.bodies.remove(body.addr);
-		List<Fixture> fixtureList = body.getFixtureList();
-		while(!fixtureList.isEmpty()) {
-			this.fixtures.remove(fixtureList.remove(0).addr).setUserData(null);
+		Array<Fixture> fixtureList = body.getFixtureList();
+		while(fixtureList.size > 0) {
+			this.fixtures.remove(fixtureList.removeIndex(0).addr).setUserData(null);
 		}
-		List<JointEdge> jointList = body.getJointList();
-		while (!jointList.isEmpty())
+		Array<JointEdge> jointList = body.getJointList();
+		while (jointList.size > 0)
 			destroyJoint(body.getJointList().get(0).joint);
 		jniDestroyBody(addr, body.addr);
 		freeBodies.free(body);
@@ -590,8 +588,8 @@ b2ContactFilter defaultFilter;
 	public void destroyJoint (Joint joint) {
 		joint.setUserData(null);
 		joints.remove(joint.addr);
-		joint.jointEdgeA.other.joints.remove(joint.jointEdgeB);
-		joint.jointEdgeB.other.joints.remove(joint.jointEdgeA);
+		joint.jointEdgeA.other.joints.removeValue(joint.jointEdgeB, true);
+		joint.jointEdgeB.other.joints.removeValue(joint.jointEdgeA, true);
 		jniDestroyJoint(addr, joint.addr);
 	}
 
@@ -797,14 +795,14 @@ b2ContactFilter defaultFilter;
 // b2Contact* GetContactList();
 
 	private long[] contactAddrs = new long[200];
-	private final ArrayList<Contact> contacts = new ArrayList<Contact>();
-	private final ArrayList<Contact> freeContacts = new ArrayList<Contact>();
+	private final Array<Contact> contacts = new Array<Contact>();
+	private final Array<Contact> freeContacts = new Array<Contact>();
 
 	/** Returns the list of {@link Contact} instances produced by the last call to {@link #step(float, int, int)}. Note that the
 	 * returned list will have O(1) access times when using indexing. contacts are created and destroyed in the middle of a time
 	 * step. Use {@link ContactListener} to avoid missing contacts
 	 * @return the contact list */
-	public List<Contact> getContactList () {
+	public Array<Contact> getContactList () {
 		int numContacts = getContactCount();
 		if (numContacts > contactAddrs.length) {
 			int newSize = 2 * numContacts;
@@ -812,8 +810,8 @@ b2ContactFilter defaultFilter;
 			contacts.ensureCapacity(newSize);
 			freeContacts.ensureCapacity(newSize);
 		}
-		if (numContacts > freeContacts.size()) {
-			int freeConts = freeContacts.size();
+		if (numContacts > freeContacts.size) {
+			int freeConts = freeContacts.size;
 			for (int i = 0; i < numContacts - freeConts; i++)
 				freeContacts.add(new Contact(this, 0));
 		}


### PR DESCRIPTION
This does change the API slightly, but since box2d already has some API changes from 0.9.8 to 0.9.9 I figured, why not?
- methods that returned ArrayLists, such as body.getFixtureList(), now return Arrays
- method calls to these objects will need to be change from ArrayList API to Array API, i.e.
  - bodyFixtures.size() --> bodyFixures.size
  - bodyFixtures.isEmpty() --> (bodyFixtures.size == 0)

I built gdx-core from this patch and dropped it into my game for testing.  After changing to Array API, I did not have any errors.
