### PR TITLE
TexturePacker: forceSquareOutput is not handed down to subdirectories.

### DIFF
--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/imagepacker/TexturePacker2.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/imagepacker/TexturePacker2.java
@@ -518,6 +518,9 @@ public class TexturePacker2 {
 			combineSubdirectories = settings.combineSubdirectories;
 			flattenPaths = settings.flattenPaths;
 			premultiplyAlpha = settings.premultiplyAlpha;
+			forceSquareOutput = settings.forceSquareOutput;
+			useIndexes = settings.useIndexes;
+			bleed = settings.bleed;
 		}
 	}
 


### PR DESCRIPTION
Added assignments in copy constructor for:
- forceSquareOutput
- useIndexes
- bleed
