### PR TITLE
improve performance of setFromCross

### DIFF
--- a/gdx/src/com/badlogic/gdx/math/Quaternion.java
+++ b/gdx/src/com/badlogic/gdx/math/Quaternion.java
@@ -395,7 +395,7 @@ public class Quaternion implements Serializable {
 		float len1 = x1 * x1 + y1 * y1 + z1 * z1;
 		float len2 = x2 * x2 + y2 * y2 + z2 * z2;
 		
-		float norm = Math.sqrt(len1 * len2);
+		float norm = (float)Math.sqrt(len1 * len2);
     		
     		return setFromCross(norm, x1, y1, z1, x2, y2, z2);
 	}


### PR DESCRIPTION
Hi I quickly improved the method which is used to build a Quaternion from two Vectors.

An explanation why this works can be found on the following blog post:
http://lolengine.net/blog/2013/09/18/beautiful-maths-quaternion-from-vectors
