### PR TITLE
GWT Reflection: Fixed getSuperClass to return null for Object.class

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gwtref/client/Type.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gwtref/client/Type.java
@@ -61,7 +61,7 @@ public class Type {
 	/** @return the super class of this type or null */
 	public Type getSuperclass () {
 		try {
-			return ReflectionCache.forName(superClass.getName());
+			return superClass == null ? null : ReflectionCache.forName(superClass.getName());
 		} catch (ClassNotFoundException e) {
 			return null;
 		}


### PR DESCRIPTION
ClassReflection.getFields(c) returns an error in GWT:

```
Uncaught TypeError: Cannot read property 'java_lang_Class_typeName' of null 
```

This is because of an unchecked access to the superClass in the Type class.
