### PR TITLE
make lwjgl GL* classes non-final

### DIFF
--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGL10.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGL10.java
@@ -34,7 +34,7 @@ import com.badlogic.gdx.utils.GdxRuntimeException;
 /** An implementation of the {@link GL10} interface based on LWJGL. Fixed point vertex arrays are emulated.
  * 
  * @author mzechner */
-class LwjglGL10 implements GL10 {
+public class LwjglGL10 implements GL10 {
 	private IntBuffer tempInt;
 	private FloatBuffer tempFloat;
 

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGL11.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGL11.java
@@ -33,7 +33,7 @@ import org.lwjgl.opengl.GL15;
  * are not implemented.
  * 
  * @author mzechner */
-final class LwjglGL11 extends LwjglGL10 implements com.badlogic.gdx.graphics.GL11 {
+public class LwjglGL11 extends LwjglGL10 implements com.badlogic.gdx.graphics.GL11 {
 	private IntBuffer tempInt;
 	private FloatBuffer tempFloat;
 

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGL20.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGL20.java
@@ -39,7 +39,7 @@ import com.badlogic.gdx.utils.GdxRuntimeException;
  * compatible. Some glGetXXX methods are not implemented.
  * 
  * @author mzechner */
-final class LwjglGL20 implements com.badlogic.gdx.graphics.GL20 {
+public class LwjglGL20 implements com.badlogic.gdx.graphics.GL20 {
 	public void glActiveTexture (int texture) {
 		GL13.glActiveTexture(texture);
 	}


### PR DESCRIPTION
This patch makes makes the LwjglGL\* classes public, this is consistent with the other GL\* implementations. In my application I use the 'same' GL interface as libgdx but libgdx is only one possible backend. To add my interface the Implementation needs to be non-final:

```
    // wrap LwjglGL20 to add GL20 interface
static class GdxGL extends LwjglGL20 implements org.oscim.backend.GL20 {
    @Override
    public void glGetShaderSource(int shader, int bufsize, Buffer length, String source) {
        throw new IllegalArgumentException("not implemented");
    }
}
```
