### PR TITLE
AssetManager: Added get(AssetDescriptor)

### DIFF
--- a/gdx/src/com/badlogic/gdx/assets/AssetManager.java
+++ b/gdx/src/com/badlogic/gdx/assets/AssetManager.java
@@ -124,6 +124,12 @@ public class AssetManager implements Disposable {
 		return asset;
 	}
 
+	/** @param assetDescriptor the asset descriptor
+	 * @return the asset */
+	public synchronized <T> T get (AssetDescriptor<T> assetDescriptor) {
+		return get(assetDescriptor.fileName, assetDescriptor.type);
+	}
+
 	/** Removes the asset and all its dependencies if they are not used by other assets.
 	 * @param fileName the file name */
 	public synchronized void unload (String fileName) {


### PR DESCRIPTION
Quite often I see me writing things like:

```
assetManager.get(ad.fileName, ad.type).createSprite(name);
```

or

```
assetManager.get(ad.fileName, TextureAtlas.class).createSprite(name);
```

Using the AssetDescriptor directly in the get method can make this a little less verbose.
