### PR TITLE
Add x86 build

### DIFF
--- a/gdx/jni/maven/pom.xml
+++ b/gdx/jni/maven/pom.xml
@@ -43,6 +43,17 @@
                     
 
                     <execution>
+                        <id>x86-gdx</id>
+                        <phase>process-resources</phase>
+                        <goals><goal>wget</goal></goals>
+                        <configuration>
+                            <cacheDirectory>${project.build.directory}/download-cache/x86</cacheDirectory>
+                            <url>${base.url}/x86/libgdx.so</url>
+                            <outputDirectory>${project.build.directory}/x86</outputDirectory>
+                        </configuration>
+                    </execution>
+
+                    <execution>
                         <id>armeabi-gdx</id>
                         <phase>process-resources</phase>
                         <goals><goal>wget</goal></goals>
@@ -163,6 +174,7 @@
                 <configuration>
                     <descriptors>
                         <descriptor>desktop.xml</descriptor>
+                        <descriptor>x86.xml</descriptor>
                         <descriptor>armeabi.xml</descriptor>
                         <descriptor>armeabi-v7a.xml</descriptor>
                         <descriptor>ios.xml</descriptor>

--- a/gdx/jni/maven/x86.xml
+++ b/gdx/jni/maven/x86.xml
@@ -1,0 +1,18 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+  <id>natives-x86</id>
+  <formats>
+    <format>jar</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <fileSets>
+    <fileSet>
+      <directory>${project.build.directory}/x86</directory>
+      <outputDirectory>/</outputDirectory>
+      <includes>
+        <include>**</include>
+      </includes>
+    </fileSet>
+  </fileSets>
+</assembly>


### PR DESCRIPTION
It allows to execute application at near native performance on Android emulator
when using x86 system image, KVM enabled and GPU Acceleration.

It helps me a lot when recording screencast for my apps

gdx-bullet x86 build is not included
