### PR TITLE
Added a way to change the Assets loader base URL for some special cases

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplication.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplication.java
@@ -80,6 +80,12 @@ public abstract class GwtApplication implements EntryPoint, Application {
 	/** @return the configuration for the {@link GwtApplication}. */
 	public abstract GwtApplicationConfiguration getConfig ();
 
+	
+	public String getPreloaderBaseURL()
+	{
+		return GWT.getHostPageBaseURL() + "assets/";
+	}
+	
 	@Override
 	public void onModuleLoad () {
 		GwtApplication.agentInfo = computeAgentInfo();
@@ -215,7 +221,7 @@ public abstract class GwtApplication implements EntryPoint, Application {
 	long loadStart = TimeUtils.nanoTime();
 
 	public Preloader createPreloader() {
-		return new Preloader();
+		return new Preloader(getPreloaderBaseURL());
 	}
 
 	public PreloaderCallback getPreloaderCallback () {

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/preloader/Preloader.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/preloader/Preloader.java
@@ -100,8 +100,11 @@ public class Preloader {
 
 	public final String baseUrl;
 
-	public Preloader () {
-		baseUrl = GWT.getHostPageBaseURL() + "assets/";
+	
+	public Preloader (String newBaseURL) {
+		
+		baseUrl = newBaseURL;
+	
 		// trigger copying of assets and creation of assets.txt
 		GWT.create(PreloaderBundle.class);
 	}


### PR DESCRIPTION
Added a way to change the Assets loader base URL for some special cases overriding the getPreloaderBaseURL() method in the GWTLauncher.
To give the reason, we are working on a 3D view on a website in Ruby/Rails and we cannot put the assets folder at the root, so this change will allow a change on the way to get the assets folder in some advanced integration like this one.
Of course it won't change anything if the method is not overridden.
