### PR TITLE
ParticleEffect: Don't dispose external textures

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/graphics/g2d/ParticleEffect.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/graphics/g2d/ParticleEffect.java
@@ -35,6 +35,7 @@ import com.badlogic.gdx.utils.StreamUtils;
 public class ParticleEffect implements Disposable {
 	private final Array<ParticleEmitter> emitters;
 	private BoundingBox bounds;
+	private boolean ownsTexture;
 
 	public ParticleEffect () {
 		emitters = new Array(8);
@@ -170,6 +171,7 @@ public class ParticleEffect implements Disposable {
 	}
 
 	public void loadEmitterImages (FileHandle imagesDir) {
+		ownsTexture = true;
 		for (int i = 0, n = emitters.size; i < n; i++) {
 			ParticleEmitter emitter = emitters.get(i);
 			String imagePath = emitter.getImagePath();
@@ -186,6 +188,7 @@ public class ParticleEffect implements Disposable {
 	/** Disposes the texture for each sprite for each ParticleEmitter. */
 	@Override
 	public void dispose () {
+		if (!ownsTexture) return;
 		for (int i = 0, n = emitters.size; i < n; i++) {
 			ParticleEmitter emitter = emitters.get(i);
 			emitter.getSprite().getTexture().dispose();

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/ParticleEffect.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/ParticleEffect.java
@@ -37,6 +37,7 @@ import com.badlogic.gdx.utils.StreamUtils;
 public class ParticleEffect implements Disposable {
 	private final Array<ParticleEmitter> emitters;
 	private BoundingBox bounds;
+	private boolean ownsTexture;
 
 	public ParticleEffect () {
 		emitters = new Array(8);
@@ -188,6 +189,7 @@ public class ParticleEffect implements Disposable {
 	}
 
 	public void loadEmitterImages (FileHandle imagesDir) {
+		ownsTexture = true;
 		for (int i = 0, n = emitters.size; i < n; i++) {
 			ParticleEmitter emitter = emitters.get(i);
 			String imagePath = emitter.getImagePath();
@@ -203,6 +205,7 @@ public class ParticleEffect implements Disposable {
 
 	/** Disposes the texture for each sprite for each ParticleEmitter. */
 	public void dispose () {
+		if (!ownsTexture) return;
 		for (int i = 0, n = emitters.size; i < n; i++) {
 			ParticleEmitter emitter = emitters.get(i);
 			emitter.getSprite().getTexture().dispose();


### PR DESCRIPTION
ParticleEffect disposed textures loaded from the assetmanager. This PR should fix this.
