### PR TITLE
Scene2DUI scroll bars can change sides, implement scrollbar test, format tests list

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ScrollPane.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ScrollPane.java
@@ -464,7 +464,7 @@ public class ScrollPane extends WidgetGroup {
 				// bar on the top or bottom
 				if (hScrollOnBottom) {
 					boundsY = bgBottomHeight;
-				} else {					
+				} else {
 					boundsY = height - bgTopHeight - hScrollHeight;
 				}
 				hScrollBounds.set(boundsX, boundsY, areaWidth, hScrollHeight);
@@ -894,18 +894,12 @@ public class ScrollPane extends WidgetGroup {
 		this.clamp = clamp;
 	}
 
-	/** Put the vertical scroll bar and knob on the left or right side of the ScrollPane
-	 * @param atRight set to true to draw on the right, false to draw on the left (default : right)
-	 */
-	public void setVScrollBarAtRight(boolean atRight) {
-		vScrollOnRight = atRight;
-	}
-
-	/** Put the vertical scroll bar and knob on the top (y coords, not draw order) or bottom of the ScrollPane
-	 * @param atBottom set to true to draw on the bottom, false to draw on the top (default : bottom)
-	 */
-	public void setHScrollBarAtBottom(boolean atBottom) {
-		hScrollOnBottom = atBottom;
+	/** Set the position of the vertical and horizontal scroll bars (if they exist).
+	 * @param bottom sets horizontal scroll bar to be at the bottom or the top
+	 * @param right sets vertical scroll bar to be at the right or the left */
+	public void setScrollBarPositions (boolean bottom, boolean right) {
+		hScrollOnBottom = bottom;
+		vScrollOnRight = right;
 	}
 
 	/** When true the scroll bars fade out after some time of not being used. */

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ScrollPaneScrollBarsTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ScrollPaneScrollBarsTest.java
@@ -18,41 +18,78 @@ package com.badlogic.gdx.tests;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL10;
+import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.scenes.scene2d.ui.Label;
 import com.badlogic.gdx.scenes.scene2d.ui.ScrollPane;
 import com.badlogic.gdx.scenes.scene2d.ui.Skin;
 import com.badlogic.gdx.scenes.scene2d.ui.Table;
+import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
+import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
 import com.badlogic.gdx.tests.utils.GdxTest;
+import com.badlogic.gdx.utils.Array;
 
-/**
- * Test switch of scroll bars + knobs from right to left, and bottom to top
- */
+/** Test switch of scroll bars + knobs from right to left, and bottom to top */
 public class ScrollPaneScrollBarsTest extends GdxTest {
 	private Stage stage;
-	private Table bottomLeft, bottomRight, topLeft, topRight,
-			horizOnlyTop, horizOnlyBottom, vertOnlyLeft, vertOnlyRight;
+	private Array<ScrollPane> scrollPanes = new Array<ScrollPane>();
+	private boolean doFade = true;
+	private boolean doOnTop = true;
+	private Table bottomLeft, bottomRight, topLeft, topRight, horizOnlyTop, horizOnlyBottom, vertOnlyLeft, vertOnlyRight;
 
 	public void create () {
+		float width = Gdx.graphics.getWidth();
+		float height = Gdx.graphics.getHeight();
+		float btnWidth = 200;
+		float btnHeight = 40;
 		stage = new Stage(0, 0, false);
 		Skin skin = new Skin(Gdx.files.internal("data/uiskin.json"));
 		Gdx.input.setInputProcessor(stage);
 
+		final TextButton fadeBtn = new TextButton("Fade: " + doFade, skin);
+		fadeBtn.setSize(btnWidth, btnHeight);
+		fadeBtn.setPosition(0, height - fadeBtn.getHeight());
+		stage.addActor(fadeBtn);
+		fadeBtn.addListener(new ChangeListener() {
+			@Override
+			public void changed (ChangeEvent event, Actor actor) {
+				doFade = !doFade;
+				fadeBtn.setText("Fade: " + doFade);
+				for (ScrollPane pane : scrollPanes) {
+					pane.setFadeScrollBars(doFade);
+				}
+			}
+		});
+
+		final TextButton onTopBtn = new TextButton("ScrollbarsOnTop: " + doOnTop, skin);
+		onTopBtn.setSize(btnWidth, btnHeight);
+		onTopBtn.setPosition(0 + fadeBtn.getWidth() + 20, height - onTopBtn.getHeight());
+		stage.addActor(onTopBtn);
+		onTopBtn.addListener(new ChangeListener() {
+			@Override
+			public void changed (ChangeEvent event, Actor actor) {
+				doOnTop = !doOnTop;
+				onTopBtn.setText("ScrollbarOnTop: " + doOnTop);
+				onTopBtn.invalidate();
+				for (ScrollPane pane : scrollPanes) {
+					pane.setScrollbarsOnTop(doOnTop);
+				}
+			}
+		});
+
 		// Gdx.graphics.setVSync(false);
 
-		float width = Gdx.graphics.getWidth();
-		float height = Gdx.graphics.getHeight();
 		float gap = 8;
 		float x = gap;
 		float y = gap;
 		float contWidth = width / 2 - gap * 1.5f;
-		float contHeight = height / 4 - gap * 1.25f;
+		float contHeight = height / 4.5f - gap * 1.25f;
 
 		bottomLeft = new Table();
 		bottomLeft.setPosition(x, y);
 		bottomLeft.setSize(contWidth, contHeight);
 		stage.addActor(bottomLeft);
-		
+
 		bottomRight = new Table();
 		bottomRight.setSize(contWidth, contHeight);
 		x = bottomLeft.getX() + bottomLeft.getWidth() + gap;
@@ -72,14 +109,14 @@ public class ScrollPaneScrollBarsTest extends GdxTest {
 		y = topLeft.getY();
 		topRight.setPosition(x, y);
 		stage.addActor(topRight);
-		
+
 		horizOnlyTop = new Table();
 		horizOnlyTop.setSize(contWidth, contHeight);
 		x = topRight.getX();
 		y = topRight.getY() + topRight.getHeight() + gap;
 		horizOnlyTop.setPosition(x, y);
 		stage.addActor(horizOnlyTop);
-		
+
 		horizOnlyBottom = new Table();
 		horizOnlyBottom.setSize(contWidth, contHeight);
 		x = topLeft.getX();
@@ -111,72 +148,67 @@ public class ScrollPaneScrollBarsTest extends GdxTest {
 		Table vertOnlyRightTable = new Table();
 
 		final ScrollPane bottomLeftScroll = new ScrollPane(bottomLeftTable, skin);
-		bottomLeftScroll.setVScrollBarAtRight(false);
-		bottomLeftScroll.setHScrollBarAtBottom(true);
+		bottomLeftScroll.setScrollBarPositions(true, false);
 
 		final ScrollPane bottomRightScroll = new ScrollPane(bottomRightTable, skin);
-		bottomRightScroll.setVScrollBarAtRight(true);
-		bottomRightScroll.setHScrollBarAtBottom(true);
+		bottomRightScroll.setScrollBarPositions(true, true);
 
 		final ScrollPane topLeftScroll = new ScrollPane(topLeftTable, skin);
-		topLeftScroll.setVScrollBarAtRight(false);
-		topLeftScroll.setHScrollBarAtBottom(false);
+		topLeftScroll.setScrollBarPositions(false, false);
 
 		final ScrollPane topRightScroll = new ScrollPane(topRightTable, skin);
-		topRightScroll.setVScrollBarAtRight(true);
-		topRightScroll.setHScrollBarAtBottom(false);
-		
+		topRightScroll.setScrollBarPositions(false, true);
+
 		final ScrollPane horizOnlyTopScroll = new ScrollPane(horizOnlyTopTable, skin);
-		horizOnlyTopScroll.setHScrollBarAtBottom(false);
-		
+		horizOnlyTopScroll.setScrollBarPositions(false, true);
+
 		final ScrollPane horizOnlyBottomScroll = new ScrollPane(horizOnlyBottomTable, skin);
-		horizOnlyBottomScroll.setHScrollBarAtBottom(true);
+		horizOnlyBottomScroll.setScrollBarPositions(true, true);
 
 		final ScrollPane vertOnlyLeftScroll = new ScrollPane(vertOnlyLeftTable, skin);
-		vertOnlyLeftScroll.setVScrollBarAtRight(false);
+		vertOnlyLeftScroll.setScrollBarPositions(true, false);
 
 		final ScrollPane vertOnlyRightScroll = new ScrollPane(vertOnlyRightTable, skin);
-		vertOnlyRightScroll.setVScrollBarAtRight(true);
-		
-		ScrollPane[] scrollPanes = new ScrollPane[] {
-			bottomLeftScroll, bottomRightScroll, topLeftScroll, topRightScroll,
-			horizOnlyTopScroll, horizOnlyBottomScroll,
-			vertOnlyLeftScroll, vertOnlyRightScroll
-		};
-		// want to see all scroll bars all the time
-		for (ScrollPane pane : scrollPanes) {
-			pane.setFadeScrollBars(false);
+		vertOnlyRightScroll.setScrollBarPositions(true, true);
+
+		ScrollPane[] panes = new ScrollPane[] {bottomLeftScroll, bottomRightScroll, topLeftScroll, topRightScroll,
+			horizOnlyTopScroll, horizOnlyBottomScroll, vertOnlyLeftScroll, vertOnlyRightScroll};
+		for (ScrollPane pane : panes) {
+			scrollPanes.add(pane);
 		}
 
-		Table[] tables = new Table[] { 
-			bottomLeftTable, bottomRightTable, topLeftTable, topRightTable,
-			horizOnlyTopTable, horizOnlyBottomTable,
-			vertOnlyLeftTable, vertOnlyRightTable
-		};
+		Table[] tables = new Table[] {bottomLeftTable, bottomRightTable, topLeftTable, topRightTable, horizOnlyTopTable,
+			horizOnlyBottomTable, vertOnlyLeftTable, vertOnlyRightTable};
 		for (Table t : tables) {
 			t.pad(10).defaults().expandX().space(4);
 		}
-		
-		horizOnlyTopTable.add(new Label("HORIZONTAL-ONLY-TOP verify HORIZONTAL scroll bar is on the TOP and properly aligned", skin));
-		horizOnlyBottomTable.add(new Label("HORIZONTAL-ONLY-BOTTOM verify HORIZONTAL scroll bar is on the BOTTOM and properly aligned", skin));
-		
+
+		horizOnlyTopTable
+			.add(new Label("HORIZONTAL-ONLY-TOP verify HORIZONTAL scroll bar is on the TOP and properly aligned", skin));
+		horizOnlyBottomTable.add(new Label(
+			"HORIZONTAL-ONLY-BOTTOM verify HORIZONTAL scroll bar is on the BOTTOM and properly aligned", skin));
+
 		for (int i = 0; i < 12; i++) {
 			bottomLeftTable.row();
 			bottomRightTable.row();
 			topLeftTable.row();
-			topRightTable.row();			
+			topRightTable.row();
 
-			bottomLeftTable.add(new Label(i + " BOTTOM-LEFT verify scroll bars are on the BOTTOM and the LEFT, and are properly aligned", skin));
-			bottomRightTable.add(new Label(i + " BOTTOM-RIGHT verify scroll bars are on the BOTTOM and the RIGHT, and are properly aligned", skin));
-			topLeftTable.add(new Label(i + " TOP-LEFT verify scroll bars are on the TOP and the LEFT, and are properly aligned", skin));
-			topRightTable.add(new Label(i + " TOP-RIGHT verify scroll bars are on the TOP and the RIGHT, and are properly aligned", skin));
+			bottomLeftTable.add(new Label(i
+				+ " BOTTOM-LEFT verify scroll bars are on the BOTTOM and the LEFT, and are properly aligned", skin));
+			bottomRightTable.add(new Label(i
+				+ " BOTTOM-RIGHT verify scroll bars are on the BOTTOM and the RIGHT, and are properly aligned", skin));
+			topLeftTable.add(new Label(i + " TOP-LEFT verify scroll bars are on the TOP and the LEFT, and are properly aligned",
+				skin));
+			topRightTable.add(new Label(i + " TOP-RIGHT verify scroll bars are on the TOP and the RIGHT, and are properly aligned",
+				skin));
 
 			vertOnlyLeftTable.row();
 			vertOnlyRightTable.row();
 
 			vertOnlyLeftTable.add(new Label("VERT-ONLY-LEFT", skin));
 			vertOnlyRightTable.add(new Label("VERT-ONLY-RIGHT", skin));
-		}		
+		}
 
 		bottomLeft.add(bottomLeftScroll).expand().fill().colspan(4);
 		bottomRight.add(bottomRightScroll).expand().fill().colspan(4);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
@@ -55,6 +55,7 @@ import com.badlogic.gdx.tests.superkoalio.SuperKoalio;
  * @author badlogicgames@gmail.com */
 public class GdxTests {
 	public static final List<Class<? extends GdxTest>> tests = new ArrayList<Class<? extends GdxTest>>(Arrays.asList(
+		// @off
 		AccelerometerTest.class,
 		ActionSequenceTest.class,
 		ActionTest.class,
@@ -224,9 +225,11 @@ public class GdxTests {
 		VibratorTest.class,
 		WaterRipples.class,
 		YDownTest.class
+		// @on
+
 		// SoundTouchTest.class, Mpg123Test.class, WavTest.class, FreeTypeTest.class,
 		// InternationalFontsTest.class, VorbisTest.class
-	));
+		));
 
 	public static List<String> getNames () {
 		List<String> names = new ArrayList<String>(tests.size());
@@ -236,11 +239,9 @@ public class GdxTests {
 		return names;
 	}
 
-	private static Class<? extends GdxTest> forName (String name)
-	{
+	private static Class<? extends GdxTest> forName (String name) {
 		for (Class clazz : tests)
-			if (clazz.getSimpleName().equals(name))
-				return clazz;
+			if (clazz.getSimpleName().equals(name)) return clazz;
 		return null;
 	}
 


### PR DESCRIPTION
Three changes:
- vertical and horizontal scroll bars in scene2d ui can be set to left/right, or top/bottom respectively.
  ![2013-10-06-124525_642x509_scrot](https://f.cloud.github.com/assets/1393288/1276149/28b6db2c-2e42-11e3-9220-6d7fbb419277.png)
- implemented a test for scroll bars (ScrollPaneScrollBarsTest in above pic)
- formatted and alphabetized the list of tests in utils.GdxTests (better readability, easier to add new tests)

If anyone has a project/game with ScrollPane it would be nice if you could test changing the scroll bar locations with these two methods:
- setVScrollBarAtRight(false);
- setHScrollBarAtBottom(false);
