### PR TITLE
ObjectSet and IntSet: some shortcuts for empty sets

### DIFF
--- a/gdx/src/com/badlogic/gdx/utils/IntSet.java
+++ b/gdx/src/com/badlogic/gdx/utils/IntSet.java
@@ -244,6 +244,8 @@ public class IntSet {
 
 	/** Returns true if the key was removed. */
 	public boolean remove (int key) {
+		if (size == 0) return false;
+
 		if (key == 0) {
 			if (!hasZeroValue) return false;
 			hasZeroValue = false;
@@ -325,6 +327,7 @@ public class IntSet {
 	}
 
 	public boolean contains (int key) {
+		if (size == 0) return false;
 		if (key == 0) return hasZeroValue;
 		int index = key & mask;
 		if (keyTable[index] != key) {

--- a/gdx/src/com/badlogic/gdx/utils/ObjectSet.java
+++ b/gdx/src/com/badlogic/gdx/utils/ObjectSet.java
@@ -239,6 +239,8 @@ public class ObjectSet<T> implements Iterable<T> {
 
 	/** Returns true if the key was removed. */
 	public boolean remove (T key) {
+		if (size == 0) return false;
+
 		int hashCode = key.hashCode();
 		int index = hashCode & mask;
 		if (key.equals(keyTable[index])) {
@@ -312,6 +314,7 @@ public class ObjectSet<T> implements Iterable<T> {
 	}
 
 	public boolean contains (T key) {
+		if (size == 0) return false;
 		int hashCode = key.hashCode();
 		int index = hashCode & mask;
 		if (!key.equals(keyTable[index])) {


### PR DESCRIPTION
ObjectSet#contains will always perform the maximum amount of work if the set is empty, i.e. it goes through all  hashes and checks the stash. This can be shortened if the size is known to be zero.

Also added it to the remove method and IntSet.
