### PR TITLE
Override equals and hashCode on FileHandle

### DIFF
--- a/gdx/src/com/badlogic/gdx/files/FileHandle.java
+++ b/gdx/src/com/badlogic/gdx/files/FileHandle.java
@@ -579,6 +579,21 @@ public class FileHandle {
 		return file().lastModified();
 	}
 
+	@Override
+	public boolean equals (Object obj) {
+		if (!(obj instanceof FileHandle)) return false;
+		FileHandle other = (FileHandle)obj;
+		return type == other.type && path().equals(other.path());
+	}
+
+	@Override
+	public int hashCode () {
+		int hash = 1;
+		hash = hash * 37 + type.hashCode();
+		hash = hash * 67 + path().hashCode();
+		return hash;
+	}
+
 	public String toString () {
 		return file.getPath().replace('\\', '/');
 	}


### PR DESCRIPTION
I wanted to start a discussion around this commit, since I'm not sure we necessarily want to make this change.

Today, one cannot use `fileHandle.equals(otherFileHandle)` to determine if the two FIleHandle instances refer to the same file. While this is easy to get around by comparing the type and the path separately, this doesn't work in cases where one does not have control over the comparison (such as in a Collection#contains call).

I don't think this would cause problems for folks, but since I can't foresee every use case, I figured it best to discuss.

Thoughts?
