### PR TITLE
Possible fix for ParticleEffect shows unmodified sprite on the first run

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g2d/ParticleEmitter.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/ParticleEmitter.java
@@ -182,8 +182,44 @@ public class ParticleEmitter {
 		int deltaMillis = (int)accumulator;
 		accumulator -= deltaMillis;
 
+		if (delayTimer < delay) {
+			delayTimer += deltaMillis;
+		} else {
+			boolean done = false;
+			if (firstUpdate) {
+				firstUpdate = false;
+				addParticle();
+			}
+	
+			if (durationTimer < duration)
+				durationTimer += deltaMillis;
+			else {
+				if (!continuous || allowCompletion)
+					done = true;
+				else
+					restart();
+			}
+
+			if(!done) {
+				emissionDelta += deltaMillis;
+				float emissionTime = emission + emissionDiff * emissionValue.getScale(durationTimer / (float)duration);
+				if (emissionTime > 0) {
+					emissionTime = 1000 / emissionTime;
+					if (emissionDelta >= emissionTime) {
+						int emitCount = (int)(emissionDelta / emissionTime);
+						emitCount = Math.min(emitCount, maxParticleCount - activeCount);
+						emissionDelta -= emitCount * emissionTime;
+						emissionDelta %= emissionTime;
+						addParticles(emitCount);
+					}
+				}
+				if (activeCount < minParticleCount) addParticles(minParticleCount - activeCount);
+			}
+		}
+
 		boolean[] active = this.active;
 		int activeCount = this.activeCount;
+		Particle[] particles = this.particles;
 		for (int i = 0, n = active.length; i < n; i++) {
 			if (active[i] && !updateParticle(particles[i], delta, deltaMillis)) {
 				active[i] = false;
@@ -191,37 +227,6 @@ public class ParticleEmitter {
 			}
 		}
 		this.activeCount = activeCount;
-
-		if (delayTimer < delay) {
-			delayTimer += deltaMillis;
-			return;
-		}
-
-		if (firstUpdate) {
-			firstUpdate = false;
-			addParticle();
-		}
-
-		if (durationTimer < duration)
-			durationTimer += deltaMillis;
-		else {
-			if (!continuous || allowCompletion) return;
-			restart();
-		}
-
-		emissionDelta += deltaMillis;
-		float emissionTime = emission + emissionDiff * emissionValue.getScale(durationTimer / (float)duration);
-		if (emissionTime > 0) {
-			emissionTime = 1000 / emissionTime;
-			if (emissionDelta >= emissionTime) {
-				int emitCount = (int)(emissionDelta / emissionTime);
-				emitCount = Math.min(emitCount, maxParticleCount - activeCount);
-				emissionDelta -= emitCount * emissionTime;
-				emissionDelta %= emissionTime;
-				addParticles(emitCount);
-			}
-		}
-		if (activeCount < minParticleCount) addParticles(minParticleCount - activeCount);
 	}
 
 	public void draw (SpriteBatch spriteBatch) {
@@ -229,11 +234,9 @@ public class ParticleEmitter {
 
 		Particle[] particles = this.particles;
 		boolean[] active = this.active;
-		int activeCount = this.activeCount;
 
 		for (int i = 0, n = active.length; i < n; i++)
 			if (active[i]) particles[i].draw(spriteBatch);
-		this.activeCount = activeCount;
 
 		if (additive) spriteBatch.setBlendFunction(GL10.GL_SRC_ALPHA, GL10.GL_ONE_MINUS_SRC_ALPHA);
 	}


### PR DESCRIPTION
This is a possible fix for Issue #835

The problem seems to be that in ParticleEmitter#update the updateParticle method is called first for all active particles. Then new particles are emitted after that. Those new particle's update method has never been called when they are drawn the first time resulting in the Sprite being drawn as-is.

In this PR I moved the updateParticle calls to the end of the method and tried to keep the logic of the continuous /allowCompletion/emission the same.

Also removed an unnecessary variable in the draw method.
