### PR TITLE
Update ScrollPane.java

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ScrollPane.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ScrollPane.java
@@ -99,7 +99,7 @@ public class ScrollPane extends WidgetGroup {
 	public ScrollPane (Actor widget, ScrollPaneStyle style) {
 		if (style == null) throw new IllegalArgumentException("style cannot be null.");
 		this.style = style;
-		setWidget(widget);
+		if (widget != null) setWidget(widget);
 		setWidth(150);
 		setHeight(150);
 


### PR DESCRIPTION
Null validation, line 102 
if (widget != null) setWidget(widget);

If widget is null, UnsupportedOperationException is thrown.
