### PR TITLE
Fix for generating jni interface for native function with a Object[].

### DIFF
--- a/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/parsing/RobustJavaMethodParser.java
+++ b/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/parsing/RobustJavaMethodParser.java
@@ -162,7 +162,7 @@ public class RobustJavaMethodParser implements JavaMethodParser {
 			if (arrayDim > 1) return ArgumentType.ObjectArray;
 			ArgumentType arrayType = arrayTypes.get(type);
 			if (arrayType == null) {
-				throw new RuntimeException("Unknown array type " + type);
+				return ArgumentType.ObjectArray;
 			}
 			return arrayType;
 		}


### PR DESCRIPTION
Recently I reported a bug where the jnigen code generator would crash when a native function with an Object[] as parameter was included in the file. Since I had no reaction, and needed it fixed, I did it myself. 

It is a single line fix. The reason why instead of throwing an exception, the ObjectArray type can be returned, is as follows: The piece of code checks whether an array parameter has more than one dimension, and selects a ObjectArray as type. This is obviously the right choice, since arrays are objects in java. If it has one dimension, it will check for primitive type arrays. If it does not find one, it would throw this exception. However, if it is not a primitive type, this means, it is an object, just as when it contains an array in the array. Therefore, the exception is unnecessary and the ObjectType can be returned instead ;)
