### PR TITLE
fixed Sprite.set(Sprite) so that it now also copies regionWidth and regionHeight

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g2d/Sprite.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/Sprite.java
@@ -114,6 +114,8 @@ public class Sprite extends TextureRegion {
 		y = sprite.y;
 		width = sprite.width;
 		height = sprite.height;
+		regionWidth = sprite.regionWidth;
+		regionHeight = sprite.regionHeight;
 		originX = sprite.originX;
 		originY = sprite.originY;
 		rotation = sprite.rotation;


### PR DESCRIPTION
If the method's documentation declares that it will:

``` java
    /** Make this sprite a copy in every way of the specified sprite */
```

…then the critical fields regionWidth and regionHeight should also be
copied from the incoming sprite. Their absence makes Sprite's copy
constructor (which uses set) produce buggy, zero-width, zero-height
textures that are invisible when rendered.
