### PR TITLE
add isClip() method.

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Table.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Table.java
@@ -464,6 +464,10 @@ public class Table extends WidgetGroup {
 		this.skin = skin;
 	}
 
+	public void isClip () {
+		return clip;
+	}
+
 	/** If true (the default), positions and sizes are rounded to integers. */
 	public void setRound (boolean round) {
 		layout.round = round;


### PR DESCRIPTION
if you want to override hit() in regular way, you need "clip" variable, which is private and: getClip() or isClip() is missing.
