### PR TITLE
OpenAL: Close InputStream when loading Sound

### DIFF
--- a/backends/gdx-openal/src/com/badlogic/gdx/backends/openal/Ogg.java
+++ b/backends/gdx-openal/src/com/badlogic/gdx/backends/openal/Ogg.java
@@ -17,6 +17,7 @@
 package com.badlogic.gdx.backends.openal;
 
 import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
 
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.utils.StreamUtils;
@@ -51,15 +52,20 @@ public class Ogg {
 		public Sound (OpenALAudio audio, FileHandle file) {
 			super(audio);
 			if (audio.noDevice) return;
-			OggInputStream input = new OggInputStream(file.read());
-			ByteArrayOutputStream output = new ByteArrayOutputStream(4096);
-			byte[] buffer = new byte[2048];
-			while (!input.atEnd()) {
-				int length = input.read(buffer);
-				if (length == -1) break;
-				output.write(buffer, 0, length);
+        	InputStream inputStream = file.read();
+			try {
+				OggInputStream input = new OggInputStream(inputStream);
+				ByteArrayOutputStream output = new ByteArrayOutputStream(4096);
+				byte[] buffer = new byte[2048];
+				while (!input.atEnd()) {
+					int length = input.read(buffer);
+					if (length == -1) break;
+					output.write(buffer, 0, length);
+				}
+				setup(output.toByteArray(), input.getChannels(), input.getSampleRate());
+			} finally {
+				StreamUtils.closeQuietly(inputStream);
 			}
-			setup(output.toByteArray(), input.getChannels(), input.getSampleRate());
 		}
 	}
 }


### PR DESCRIPTION
I want the InputStream returned by file.read() to be closed.
Using try/finally to ensure it is closed in case of exceptions.
Construction of OggInputStream intentionally moved inside the try's scope.
