### PR TITLE
Update ArrayMap.java

### DIFF
--- a/gdx/src/com/badlogic/gdx/utils/ArrayMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/ArrayMap.java
@@ -470,12 +470,16 @@ public class ArrayMap<K, V> {
 
 	static public class Entries<K, V> implements Iterable<Entry<K, V>>, Iterator<Entry<K, V>> {
 		private final ArrayMap<K, V> map;
-		Entry<K, V> entry = new Entry();
+		private Array<Entry<K, V>> array;
 		int index;
 		boolean valid = true;
 
 		public Entries (ArrayMap<K, V> map) {
 			this.map = map;
+			array = new Array<Entry<K, V>>(map.size);
+			for (int i = 0; i < map.size; i++) {
+				array.items[i] = new Entry(map.keys[i], map.values[i]);
+			}
 		}
 
 		public boolean hasNext () {
@@ -489,14 +493,13 @@ public class ArrayMap<K, V> {
 		public Entry<K, V> next () {
 			if (index >= map.size) throw new NoSuchElementException(String.valueOf(index));
 			if (!valid) throw new GdxRuntimeException("#iterator() cannot be used nested.");
-			entry.key = map.keys[index];
-			entry.value = map.values[index++];
-			return entry;
+			return array.items[index++];
 		}
 
 		public void remove () {
 			index--;
 			map.removeIndex(index);
+			array.removeIndex(index);
 		}
 
 		public void reset () {


### PR DESCRIPTION
Came across an error when iterating over the entries of an ArrayMap. Used to point to the same Entry-Instance each time with updated values only. This results in unwanted changes in priorly assigned Entry-Instances. See example:

```
    private void testIterable() {

        TestIterable t = new TestIterable();
        for (Entry<Integer, String> e : t) {
            System.out.println(e.key + "=" + e.value);
        }

        Entry<Integer, String> first = null;
        Entry<Integer, String> second = null;
        Entry<Integer, String> third = null;
        int index = 0;

        for (Entry<Integer, String> e : t) {

            if (index == 0) {
                first = e;
            }
            if (index == 1) {
                second = e;
            }
            if (index == 2) {
                third = e;
            }
            index++;
        }

        System.out.println("FIRST: " + first + " SECOND: " + second + "THIRD: " + third);
        System.out.println("Should have been: ");
        System.out.println("FIRST: 1=aaa SECOND: 2=bbb THIRD: 3=ccc");
    }

    class TestIterable implements Iterable<Entry<Integer, String>> {

        com.badlogic.gdx.utils.ArrayMap<Integer, String> map = new com.badlogic.gdx.utils.ArrayMap<Integer, String>();
        int iterate = 0;

        public TestIterable() {

            map.put(0, "aaa");
            map.put(1, "bbb");
            map.put(3, "ccc");
        }

        @Override
        public Iterator<Entry<Integer, String>> iterator() {

            return map.entries();
        }
    }
```

PS: I am new to GitHub and wrote this (and the code) on the webpage. Hope it works though...
