### PR TITLE
Add setX and setY to TextureAtlas.AtlasSprite so that it matches expected whitespace behavior.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -87,6 +87,7 @@
 - Added panStop to GestureListener interface.
 - ScissorStack#calculateScissors changed to take viewport, enabling it to work with glViewport.
 - Added Bits#getAndClear, Bits#getAndSet and Bits#containsAll
+- Added setX and setY to TextureAtlas.AtlasSprite so it matches expected behavior
 
 [0.9.8]
 - see http://www.badlogicgames.com/wordpress/?p=2791

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -165,3 +165,4 @@ caniep https://github.com/caniep
 jrenner https://github.com/jrenner
 sinistersnare https://github.com/sinistersnare
 Ranzdo https://github.com/Ranzdo
+mbforbes https://github.com/mbforbes

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/TextureAtlas.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/TextureAtlas.java
@@ -561,6 +561,14 @@ public class TextureAtlas implements Disposable {
 			super.setPosition(x + region.offsetX, y + region.offsetY);
 		}
 
+		public void setX (float x) {
+			super.setX(x + region.offsetX);
+		}
+
+		public void setY (float y) {
+			super.setY(y + region.offetY);
+		}
+
 		public void setBounds (float x, float y, float width, float height) {
 			float widthRatio = width / region.originalWidth;
 			float heightRatio = height / region.originalHeight;


### PR DESCRIPTION
Currently the getters and setPosition have been overridden, but the setters still behave like normal sprites, which means the whitespace behavior of the AtlasSprite is screwed up when you use a setter. This fixes that.
