### PR TITLE
Adjust NinePatch texture coordinates to avoid bleeding linear-blended atlas

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g2d/NinePatch.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/NinePatch.java
@@ -223,47 +223,47 @@ public class NinePatch {
 		final float color = Color.WHITE.toFloatBits(); // placeholder color, overwritten at draw time
 
 		if (patches[BOTTOM_LEFT] != null) {
-			bottomLeft = add(patches[BOTTOM_LEFT], color);
+			bottomLeft = add(patches[BOTTOM_LEFT], color, false, false);
 			leftWidth = patches[BOTTOM_LEFT].getRegionWidth();
 			bottomHeight = patches[BOTTOM_LEFT].getRegionHeight();
 		}
 		if (patches[BOTTOM_CENTER] != null) {
-			bottomCenter = add(patches[BOTTOM_CENTER], color);
+			bottomCenter = add(patches[BOTTOM_CENTER], color, true, false);
 			middleWidth = Math.max(middleWidth, patches[BOTTOM_CENTER].getRegionWidth());
 			bottomHeight = Math.max(bottomHeight, patches[BOTTOM_CENTER].getRegionHeight());
 		}
 		if (patches[BOTTOM_RIGHT] != null) {
-			bottomRight = add(patches[BOTTOM_RIGHT], color);
+			bottomRight = add(patches[BOTTOM_RIGHT], color, false, false);
 			rightWidth = Math.max(rightWidth, patches[BOTTOM_RIGHT].getRegionWidth());
 			bottomHeight = Math.max(bottomHeight, patches[BOTTOM_RIGHT].getRegionHeight());
 		}
 		if (patches[MIDDLE_LEFT] != null) {
-			middleLeft = add(patches[MIDDLE_LEFT], color);
+			middleLeft = add(patches[MIDDLE_LEFT], color, false, true);
 			leftWidth = Math.max(leftWidth, patches[MIDDLE_LEFT].getRegionWidth());
 			middleHeight = Math.max(middleHeight, patches[MIDDLE_LEFT].getRegionHeight());
 		}
 		if (patches[MIDDLE_CENTER] != null) {
-			middleCenter = add(patches[MIDDLE_CENTER], color);
+			middleCenter = add(patches[MIDDLE_CENTER], color, true, true);
 			middleWidth = Math.max(middleWidth, patches[MIDDLE_CENTER].getRegionWidth());
 			middleHeight = Math.max(middleHeight, patches[MIDDLE_CENTER].getRegionHeight());
 		}
 		if (patches[MIDDLE_RIGHT] != null) {
-			middleRight = add(patches[MIDDLE_RIGHT], color);
+			middleRight = add(patches[MIDDLE_RIGHT], color, false, true);
 			rightWidth = Math.max(rightWidth, patches[MIDDLE_RIGHT].getRegionWidth());
 			middleHeight = Math.max(middleHeight, patches[MIDDLE_RIGHT].getRegionHeight());
 		}
 		if (patches[TOP_LEFT] != null) {
-			topLeft = add(patches[TOP_LEFT], color);
+			topLeft = add(patches[TOP_LEFT], color, false, false);
 			leftWidth = Math.max(leftWidth, patches[TOP_LEFT].getRegionWidth());
 			topHeight = Math.max(topHeight, patches[TOP_LEFT].getRegionHeight());
 		}
 		if (patches[TOP_CENTER] != null) {
-			topCenter = add(patches[TOP_CENTER], color);
+			topCenter = add(patches[TOP_CENTER], color, true, false);
 			middleWidth = Math.max(middleWidth, patches[TOP_CENTER].getRegionWidth());
 			topHeight = Math.max(topHeight, patches[TOP_CENTER].getRegionHeight());
 		}
 		if (patches[TOP_RIGHT] != null) {
-			topRight = add(patches[TOP_RIGHT], color);
+			topRight = add(patches[TOP_RIGHT], color, false, false);
 			rightWidth = Math.max(rightWidth, patches[TOP_RIGHT].getRegionWidth());
 			topHeight = Math.max(topHeight, patches[TOP_RIGHT].getRegionHeight());
 		}
@@ -274,16 +274,31 @@ public class NinePatch {
 		}
 	}
 
-	private int add (TextureRegion region, float color) {
+	private int add (TextureRegion region, float color, boolean isStretchW, boolean isStretchH) {
 		if (texture == null)
 			texture = region.getTexture();
 		else if (texture != region.getTexture()) //
 			throw new IllegalArgumentException("All regions must be from the same texture.");
 
-		final float u = region.u;
-		final float v = region.v2;
-		final float u2 = region.u2;
-		final float v2 = region.v;
+		float u = region.u;
+		float v = region.v2;
+		float u2 = region.u2;
+		float v2 = region.v;
+
+		// Add half pixel offsets on stretchable dimensions to avoid color bleeding when GL_LINEAR
+		// filtering is used for the texture. This nudges the texture coordinate to the center
+		// of the texel where the neighboring pixel has 0% contribution in linear blending mode.
+		if (isStretchW) {
+			float halfTexelWidth = 0.5f * 1.0f / texture.getWidth();
+			u += halfTexelWidth;
+			u2 -= halfTexelWidth;
+		}
+		if (isStretchH) {
+			float halfTexelHeight = 0.5f * 1.0f / texture.getHeight();
+			v -= halfTexelHeight;
+			v2 += halfTexelHeight;
+		}
+
 		final float[] vertices = this.vertices;
 
 		idx += 2;


### PR DESCRIPTION
Builds and tested in production. We've been using this change for months to allow us to use GL_LINEAR filtering on our UI atlas so that scaled sprites look nicer.
