### PR TITLE
Label: avoid double-modulation of color alpha

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Label.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Label.java
@@ -201,7 +201,7 @@ public class Label extends Widget {
 		}
 		cache.setColor(style.fontColor == null ? color : Color.tmp.set(color).mul(style.fontColor));
 		cache.setPosition(getX(), getY());
-		cache.draw(batch, color.a * parentAlpha);
+		cache.draw(batch, parentAlpha);
 	}
 
 	public float getPrefWidth () {


### PR DESCRIPTION
BitmapFontCache.draw(Batch, float) already multiplies in the color.a.
