### PR TITLE
Added elementTypes to gwt reflection

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/utils/reflect/ClassReflection.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/utils/reflect/ClassReflection.java
@@ -48,7 +48,7 @@ public final class ClassReflection {
 	static public boolean isAssignableFrom (Class c1, Class c2) {
 		Type c1Type = ReflectionCache.getType(c1);
 		Type c2Type = ReflectionCache.getType(c2);
-		return c2Type.isAssignableFrom(c1Type);
+		return c1Type.isAssignableFrom(c2Type);
 	}
 
 	/** Returns true if the class or interface represented by the supplied Class is a member class. */

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/utils/reflect/Field.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/utils/reflect/Field.java
@@ -20,110 +20,111 @@ import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 
+import com.badlogic.gwtref.client.ReflectionCache;
+
 /** Provides information about, and access to, a single field of a class or interface.
  * @author nexsoftware */
 public final class Field {
-	
+
 	private final com.badlogic.gwtref.client.Field field;
-	
-	Field(com.badlogic.gwtref.client.Field field) {
+
+	Field (com.badlogic.gwtref.client.Field field) {
 		this.field = field;
 	}
-	
+
 	/** Returns the name of the field. */
-	public String getName() {
+	public String getName () {
 		return field.getName();
 	}
-	
+
 	/** Returns a Class object that identifies the declared type for the field. */
-	public Class getType() {
+	public Class getType () {
 		return field.getType().getClassOfType();
 	}
-	
+
 	/** Returns the Class object representing the class or interface that declares the field. */
-	public Class getDeclaringClass() {
+	public Class getDeclaringClass () {
 		return field.getEnclosingType().getClassOfType();
 	}
-	
-	public boolean isAccessible() {
-		return field.isAccessible();		
+
+	public boolean isAccessible () {
+		return field.isAccessible();
 	}
-	
-	public void setAccessible(boolean accessible) {
+
+	public void setAccessible (boolean accessible) {
 		field.setAccessible(accessible);
 	}
 
 	/** Return true if the field does not include any of the {@code private}, {@code protected}, or {@code public} modifiers. */
-	public boolean isDefaultAccess() {
-		return !isPrivate() && ! isProtected() && ! isPublic();
+	public boolean isDefaultAccess () {
+		return !isPrivate() && !isProtected() && !isPublic();
 	}
-	
+
 	/** Return true if the field includes the {@code final} modifier. */
-	public boolean isFinal() {
+	public boolean isFinal () {
 		return field.isFinal();
 	}
-	
+
 	/** Return true if the field includes the {@code private} modifier. */
-	public boolean isPrivate() {
+	public boolean isPrivate () {
 		return field.isPrivate();
 	}
-	
+
 	/** Return true if the field includes the {@code protected} modifier. */
-	public boolean isProtected() {
+	public boolean isProtected () {
 		return field.isProtected();
 	}
-	
+
 	/** Return true if the field includes the {@code public} modifier. */
-	public boolean isPublic() {
+	public boolean isPublic () {
 		return field.isPublic();
 	}
-	
+
 	/** Return true if the field includes the {@code static} modifier. */
-	public boolean isStatic() {
+	public boolean isStatic () {
 		return field.isStatic();
 	}
 
 	/** Return true if the field includes the {@code transient} modifier. */
-	public boolean isTransient() {
+	public boolean isTransient () {
 		return field.isTransient();
 	}
-	
+
 	/** Return true if the field includes the {@code volatile} modifier. */
-	public boolean isVolatile() {
+	public boolean isVolatile () {
 		return field.isVolatile();
 	}
 
 	/** Return true if the field is a synthetic field. */
-	public boolean isSynthetic() {
+	public boolean isSynthetic () {
 		return field.isSynthetic();
 	}
-	
+
 	/** If the type of the field is parameterized, returns the Class object representing the parameter type at the specified index,
 	 * null otherwise. */
 	public Class getElementType (int index) {
-		return null;
+		return field.getElementType(index).getClassOfType();
 	}
-	
+
 	/** Returns the value of the field on the supplied object. */
-	public Object get(Object obj) throws ReflectionException {
+	public Object get (Object obj) throws ReflectionException {
 		try {
 			return field.get(obj);
 		} catch (IllegalArgumentException e) {
-			throw new ReflectionException("Object is not an instance of " + getDeclaringClass(), e);
+			throw new ReflectionException("Could not get " + getDeclaringClass() + "#" + getName() + ": " + e.getMessage(), e);
 		} catch (IllegalAccessException e) {
-			throw new ReflectionException("Illegal access to field: " + getName(), e);
-		}	
+			throw new ReflectionException("Illegal access to field " + getName() + ": " + e.getMessage(), e);
+		}
 	}
-	
+
 	/** Sets the value of the field on the supplied object. */
-	public void set(Object obj, Object value) throws ReflectionException {
+	public void set (Object obj, Object value) throws ReflectionException {
 		try {
 			field.set(obj, value);
 		} catch (IllegalArgumentException e) {
-			throw new ReflectionException("Argument not valid for field: " + getName(), e);
+			throw new ReflectionException("Could not set " + getDeclaringClass() + "#" + getName() + ": " + e.getMessage(), e);
 		} catch (IllegalAccessException e) {
-			throw new ReflectionException("Illegal access to field: " + getName(), e);
+			throw new ReflectionException("Illegal access to field " + getName() + ": " + e.getMessage(), e);
 		}
 	}
-	
 }

--- a/backends/gdx-backends-gwt/src/com/badlogic/gwtref/client/Field.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gwtref/client/Field.java
@@ -17,6 +17,7 @@
 package com.badlogic.gwtref.client;
 
 import java.security.AccessControlException;
+import java.util.Arrays;
 
 public class Field {
 	final String name;
@@ -33,10 +34,11 @@ public class Field {
 	boolean accessible;
 	final String getter;
 	final String setter;
+	final Class[] elementTypes;
 
 	Field (String name, Class enclosingType, Class type, boolean isFinal, boolean isDefaultAccess, boolean isPrivate,
 		boolean isProtected, boolean isPublic, boolean isStatic, boolean isTransient, boolean isVolatile, String getter,
-		String setter) {
+		String setter, Class[] elementTypes) {
 		this.name = name;
 		this.enclosingType = enclosingType;
 		this.type = type;
@@ -50,6 +52,7 @@ public class Field {
 		this.isVolatile = isVolatile;
 		this.getter = getter;
 		this.setter = setter;
+		this.elementTypes = elementTypes;
 		accessible = isPublic;
 	}
 
@@ -59,6 +62,11 @@ public class Field {
 
 	public void set (Object obj, Object value) throws IllegalAccessException {
 		ReflectionCache.instance.set(this, obj, value);
+	}
+
+	public Type getElementType (int index) {
+		if (elementTypes != null && index < elementTypes.length) return ReflectionCache.getType(elementTypes[index]);
+		return null;
 	}
 
 	public String getName () {
@@ -122,6 +130,6 @@ public class Field {
 		return "Field [name=" + name + ", enclosingType=" + enclosingType + ", type=" + type + ", isFinal=" + isFinal
 			+ ", isDefaultAccess=" + isDefaultAccess + ", isPrivate=" + isPrivate + ", isProtected=" + isProtected + ", isPublic="
 			+ isPublic + ", isStatic=" + isStatic + ", isTransient=" + isTransient + ", isVolatile=" + isVolatile + ", accessible="
-			+ accessible + ", getter=" + getter + ", setter=" + setter + "]";
+			+ accessible + ", getter=" + getter + ", setter=" + setter + ", elementTypes=" + Arrays.toString(elementTypes) + "]";
 	}
 }

--- a/backends/gdx-backends-gwt/src/com/badlogic/gwtref/client/Type.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gwtref/client/Type.java
@@ -70,7 +70,7 @@ public class Type {
 	/** @param otherType the other type
 	 * @return whether this type is assignable to the other type. */
 	public boolean isAssignableFrom (Type otherType) {
-		return assignables.contains(otherType.getClassOfType());
+		return otherType.assignables.contains(getClassOfType());
 	}
 
 	/** @param name the name of the field
@@ -117,7 +117,6 @@ public class Type {
 	 * @return the public method that matches the name and parameter types of this type or one of its super interfaces.
 	 * @throws NoSuchMethodException */
 	public Method getMethod (String name, Class... parameterTypes) throws NoSuchMethodException {
-		ArrayList<Method> allMethods = new ArrayList<Method>();
 		Type t = this;
 		while (t != null) {
 			Method[] declMethods = t.getDeclaredMethods();

--- a/backends/gdx-backends-gwt/src/com/badlogic/gwtref/gen/ReflectionCacheSourceCreator.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gwtref/gen/ReflectionCacheSourceCreator.java
@@ -18,11 +18,11 @@ package com.badlogic.gwtref.gen;
 
 import java.io.PrintWriter;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.Map.Entry;
 
 import com.google.gwt.core.ext.BadPropertyValueException;
@@ -39,6 +39,7 @@ import com.google.gwt.core.ext.typeinfo.JField;
 import com.google.gwt.core.ext.typeinfo.JMethod;
 import com.google.gwt.core.ext.typeinfo.JPackage;
 import com.google.gwt.core.ext.typeinfo.JParameter;
+import com.google.gwt.core.ext.typeinfo.JParameterizedType;
 import com.google.gwt.core.ext.typeinfo.JPrimitiveType;
 import com.google.gwt.core.ext.typeinfo.JType;
 import com.google.gwt.core.ext.typeinfo.NotFoundException;
@@ -54,7 +55,7 @@ public class ReflectionCacheSourceCreator {
 	final String packageName;
 	SourceWriter sw;
 	StringBuffer source = new StringBuffer();
-	Set<JType> types = new HashSet<JType>();
+	List<JType> types = new ArrayList<JType>();
 	List<SetterGetterStub> setterGetterStubs = new ArrayList<SetterGetterStub>();
 	List<MethodStub> methodStubs = new ArrayList<MethodStub>();
 	int nextStub = 0;
@@ -119,7 +120,6 @@ public class ReflectionCacheSourceCreator {
 
 		sw.commit(logger);
 		createProxy(type);
-//		System.out.println(source.toString());
 		return packageName + "." + simpleName;
 	}
 
@@ -162,6 +162,13 @@ public class ReflectionCacheSourceCreator {
 		gatherTypes(typeOracle.findType("java.lang.Double").getErasedType(), types);
 		gatherTypes(typeOracle.findType("java.lang.Object").getErasedType(), types);
 
+		// sort the types so the generated output will be stable between runs
+		Collections.sort(types, new Comparator<JType>() {
+			public int compare (JType o1, JType o2) {
+				return o1.getQualifiedSourceName().compareTo(o2.getQualifiedSourceName());
+			}
+		});
+
 		// generate Type lookup generator methods.
 		int id = 0;
 		for (JType t : types) {
@@ -179,6 +186,14 @@ public class ReflectionCacheSourceCreator {
 		}
 		p("}");
 
+		// sort the stubs so the generated output will be stable between runs
+		Collections.sort(setterGetterStubs, new Comparator<SetterGetterStub>() {
+			@Override
+			public int compare (SetterGetterStub o1, SetterGetterStub o2) {
+				return (o1.enclosingType + o1.name).compareTo(o2.enclosingType + o2.name);
+			}
+		});
+
 		// generate field setters/getters
 		for (SetterGetterStub stub : setterGetterStubs) {
 			String stubSource = generateSetterGetterStub(stub);
@@ -186,11 +201,19 @@ public class ReflectionCacheSourceCreator {
 			p(stubSource);
 		}
 
+		// sort the stubs so the generated output will be stable between runs
+		Collections.sort(methodStubs, new Comparator<MethodStub>() {
+			@Override
+			public int compare (MethodStub o1, MethodStub o2) {
+				return (o1.enclosingType + o1.name).compareTo(o2.enclosingType + o2.name);
+			}
+		});
+
 		// generate methods
 		for (MethodStub stub : methodStubs) {
 			String stubSource = generateMethodStub(stub);
 			if (stubSource.equals("")) stub.unused = true;
-				p(stubSource);
+			p(stubSource);
 		}
 		logger.log(Type.INFO, types.size() + " types reflected");
 	}
@@ -203,7 +226,7 @@ public class ReflectionCacheSourceCreator {
 
 	int nesting = 0;
 
-	private void gatherTypes (JType type, Set<JType> types) {
+	private void gatherTypes (JType type, List<JType> types) {
 		nesting++;
 		// came here from a type that has no super class
 		if (type == null) {
@@ -400,9 +423,10 @@ public class ReflectionCacheSourceCreator {
 		pb("}-*/;");
 
 		if (!stub.isFinal) {
-			String vType = stub.type.equals("int") || stub.type.equals("float") || stub.type.equals("double")
-					|| stub.type.equals("boolean") ? stub.type : "Object";
-			pb("public native void " + stub.setter + "(" + stub.enclosingType + " obj, " + vType + " value)  /*-{");
+			pb("public native void " + stub.setter + "(" + stub.enclosingType + " obj, Object value)  /*-{");
+			// TODO changes from PR #1005 break things
+//			String vType = isPrimitive(stub.type) ? stub.type : "Object";
+//			pb("public native void " + stub.setter + "(" + stub.enclosingType + " obj, " + vType + " value)  /*-{");
 			if (stub.isStatic)
 				pb("    @" + stub.enclosingType + "::" + stub.name + " = value");
 			else
@@ -466,11 +490,12 @@ public class ReflectionCacheSourceCreator {
 					String fieldType = getType(f.getType());
 					String setter = "s" + (nextStub++);
 					String getter = "g" + (nextStub++);
+					String elementType = getElementTypes(f);
 
 					pb("new Field(\"" + f.getName() + "\", " + enclosingType + ", " + fieldType + ", " + f.isFinal() + ", "
 						+ f.isDefaultAccess() + ", " + f.isPrivate() + ", " + f.isProtected() + ", " + f.isPublic() + ", "
 						+ f.isStatic() + ", " + f.isTransient() + ", " + f.isVolatile() + ", " + "\"" + getter + "\", " + "\"" + setter
-						+ "\" " + "), ");
+						+ "\", " + elementType + "), ");
 
 					SetterGetterStub stub = new SetterGetterStub();
 					stub.name = f.getName();
@@ -548,6 +573,31 @@ public class ReflectionCacheSourceCreator {
 		return buffer.toString();
 	}
 
+	private String getElementTypes (JField f) {
+		StringBuilder b = new StringBuilder();
+		JParameterizedType params = f.getType().isParameterized();
+		if (params != null) {
+			JClassType[] typeArgs = params.getTypeArgs();
+			b.append("new Class[] {");
+			for (JClassType typeArg : typeArgs) {
+				if (typeArg.isWildcard() != null)
+					b.append("Object.class");
+				else if(!isVisible(typeArg))
+					b.append("null");
+				else if (typeArg.isClassOrInterface() != null)
+					b.append(typeArg.isClassOrInterface().getQualifiedSourceName()).append(".class");
+				else if (typeArg.isParameterized() != null)
+					b.append(typeArg.isParameterized().getQualifiedBinaryName()).append(".class");
+				else
+					b.append("null");
+				b.append(", ");
+			}
+			b.append("}");
+			return b.toString();
+		}
+		return "null";
+	}
+	
 	private String getType (JType type) {
 		if (!isVisible(type)) return null;
 		return type.getErasedType().getQualifiedSourceName() + ".class";
@@ -642,17 +692,12 @@ public class ReflectionCacheSourceCreator {
 		SwitchedCodeBlocks pc = new SwitchedCodeBlocks();
 		for (SetterGetterStub stub : setterGetterStubs) {
 			if (stub.enclosingType == null || stub.type == null || stub.isFinal || stub.unused) continue;
-			if (stub.type.equals("float")){
-				pc.add(stub.setter, stub.setter + "((" + stub.enclosingType + ")obj, ((Number) value).floatValue());");
-			} else if (stub.type.equals("int")){
-				pc.add(stub.setter, stub.setter + "((" + stub.enclosingType + ")obj, ((Number) value).intValue());");
-			} else if (stub.type.equals("double")){
-				pc.add(stub.setter, stub.setter + "((" + stub.enclosingType + ")obj, ((Number) value).doubleValue());");
-			} else if (stub.type.equals("boolean")){
-				pc.add(stub.setter, stub.setter + "((" + stub.enclosingType + ")obj, ((Boolean) value).booleanValue());");
-			} else {
-				pc.add(stub.setter, stub.setter + "((" + stub.enclosingType + ")obj, value);");
-			}
+			 pc.add(stub.setter, stub.setter + "((" + stub.enclosingType + ")obj, value);");
+			 // TODO changes from PR #1005 break things
+//			if(isPrimitive(stub.type))
+//				pc.add(stub.setter, stub.setter + "((" + stub.enclosingType + ")obj, " + castPrimitive(stub.type, "value") + ");");
+//			else
+//				pc.add(stub.setter, stub.setter + "((" + stub.enclosingType + ")obj, value);");
 		}
 		pc.print();
 		p("}");
@@ -777,7 +822,7 @@ public class ReflectionCacheSourceCreator {
 		p("}");
 	}
 
-	private void p (String line) {
+	void p (String line) {
 		sw.println(line);
 		source.append(line);
 		source.append("\n");


### PR DESCRIPTION
- Added elementTypes to gwt reflection to support field.getElementType in GWT
- switched types form Set to List and added some sorting in ReflectionCacheSourceCreator so the generated code stays more stable between runs
- corrected Type.isAssignableFrom (the logic was switched)
- Reverted some changes form PR #1005 as they broke things for copying primitive fields using reflection.
  I am using something like:
  
   field.set(obj, field.get((other.obj));

Example generated JS code:

```
case 107837400:
  java_lang_String_$equals__Ljava_lang_String_2Ljava_lang_Object_2Z($intern_3466, param) && com_badlogic_gwtref_client_IReflectionCacheGenerated_$s5648__Lcom_badlogic_gwtref_client_IReflectionCacheGenerated_2Lcom_rustybyte_es_components_CMusic_2ZV(com_google_gwt_lang_Cast_dynamicCast__Ljava_lang_Object_2ILjava_lang_Object_2(obj, Q$com_rustybyte_es_components_CMusic), java_lang_Boolean_$booleanValue__Ljava_lang_Boolean_2Z(com_google_gwt_lang_Cast_dynamicCast__Ljava_lang_Object_2ILjava_lang_Object_2(value_0, Q$java_lang_Boolean)));
  break;
```

Results in the following exception for a boolean field:

```
com_google_gwt_core_client_impl_StackTraceCreator$Collector_$makeException__Lcom_google_gwt_core_client_impl_StackTraceCreator$Collector_2Lcom_google_gwt_core_client_JavaScriptObject_2 (ED3B5F9B05BF2C377D9AFF10441C4905.cache.html:76170)
com_google_gwt_core_client_impl_StackTraceCreator$CollectorMoz_$collect__Lcom_google_gwt_core_client_impl_StackTraceCreator$CollectorMoz_2Lcom_google_gwt_core_client_JsArrayString_2 (ED3B5F9B05BF2C377D9AFF10441C4905.cache.html:76238)
com_google_gwt_core_client_impl_StackTraceCreator$CollectorChrome_collect__Lcom_google_gwt_core_client_JsArrayString_2 (ED3B5F9B05BF2C377D9AFF10441C4905.cache.html:76330)
com_google_gwt_core_client_impl_StackTraceCreator_createStackTrace__Lcom_google_gwt_core_client_JsArrayString_2 (ED3B5F9B05BF2C377D9AFF10441C4905.cache.html:76108)
com_google_gwt_core_client_impl_StackTraceCreator$CollectorChrome_fillInStackTrace__Ljava_lang_Throwable_2V (ED3B5F9B05BF2C377D9AFF10441C4905.cache.html:76376)
com_google_gwt_core_client_impl_StackTraceCreator_fillInStackTrace__Ljava_lang_Throwable_2V (ED3B5F9B05BF2C377D9AFF10441C4905.cache.html:76130)
java_lang_Throwable_$fillInStackTrace__Ljava_lang_Throwable_2Ljava_lang_Throwable_2 (ED3B5F9B05BF2C377D9AFF10441C4905.cache.html:27136)
java_lang_Throwable_Throwable__V (ED3B5F9B05BF2C377D9AFF10441C4905.cache.html:27193)
java_lang_Exception_Exception__V (ED3B5F9B05BF2C377D9AFF10441C4905.cache.html:27232)
java_lang_RuntimeException_RuntimeException__V (ED3B5F9B05BF2C377D9AFF10441C4905.cache.html:27256)
java_lang_ClassCastException_ClassCastException__V (ED3B5F9B05BF2C377D9AFF10441C4905.cache.html:91223)
com_google_gwt_lang_Cast_dynamicCast__Ljava_lang_Object_2ILjava_lang_Object_2 (ED3B5F9B05BF2C377D9AFF10441C4905.cache.html:78877)
com_badlogic_gwtref_client_IReflectionCacheGenerated_set__Lcom_badlogic_gwtref_client_Field_2Ljava_lang_Object_2Ljava_lang_Object_2V (ED3B5F9B05BF2C377D9AFF10441C4905.cache.html:71927)
com_badlogic_gwtref_client_Field_$set__Lcom_badlogic_gwtref_client_Field_2Ljava_lang_Object_2Ljava_lang_Object_2V (ED3B5F9B05BF2C377D9AFF10441C4905.cache.html:33667)
com_badlogic_gdx_utils_reflect_Field_$set__Lcom_badlogic_gdx_utils_reflect_Field_2Ljava_lang_Object_2Ljava_lang_Object_2V (ED3B5F9B05BF2C377D9AFF10441C4905.cache.html:33575)
com_rustybyte_es_Component$ReflectionField_copyFrom__Lcom_rustybyte_es_ComponentField_2V (ED3B5F9B05BF2C377D9AFF10441C4905.cache.html:83143)
com_rustybyte_es_Component_$copyFrom__Lcom_rustybyte_es_Component_2Lcom_rustybyte_es_Component_2V (ED3B5F9B05BF2C377D9AFF10441C4905.cache.html:82983)
com_rustybyte_es_World_$instantiatePrototype__Lcom_rustybyte_es_World_2Lcom_rustybyte_es_prototyping_EntityPrototype_2ZLcom_rustybyte_es_Entity_2 (ED3B5F9B05BF2C377D9AFF10441C4905.cache.html:83878)
com_rustybyte_es_World_$instantiatePrototype__Lcom_rustybyte_es_World_2Lcom_rustybyte_es_prototyping_EntityPrototype_2Lcom_rustybyte_es_Entity_2 (ED3B5F9B05BF2C377D9AFF10441C4905.cache.html:83870)
com_rustybyte_steamtd_core_screens_MainScreen_initializeStage__V (ED3B5F9B05BF2C377D9AFF10441C4905.cache.html:89481)
com_rustybyte_steamtd_core_screens_AbstractScreenWithStage_$show__Lcom_rustybyte_steamtd_core_screens_AbstractScreenWithStage_2V (ED3B5F9B05BF2C377D9AFF10441C4905.cache.html:88809)
com_rustybyte_steamtd_core_screens_AbstractScreenWithStageAndWorld_show__V (ED3B5F9B05BF2C377D9AFF10441C4905.cache.html:88877)
com_rustybyte_steamtd_core_FooGame_render__V (ED3B5F9B05BF2C377D9AFF10441C4905.cache.html:86047)
com_badlogic_gdx_backends_gwt_GwtApplication_$mainLoop__Lcom_badlogic_gdx_backends_gwt_GwtApplication_2V (ED3B5F9B05BF2C377D9AFF10441C4905.cache.html:1674)
com_badlogic_gdx_backends_gwt_GwtApplication$2_run__V (ED3B5F9B05BF2C377D9AFF10441C4905.cache.html:1940)
com_google_gwt_user_client_Timer_fire__IV (ED3B5F9B05BF2C377D9AFF10441C4905.cache.html:1921)
(anonymous function) (ED3B5F9B05BF2C377D9AFF10441C4905.cache.html:1910)
com_google_gwt_core_client_impl_Impl_apply__Ljava_lang_Object_2Ljava_lang_Object_2Ljava_lang_Object_2Ljava_lang_Object_2 (ED3B5F9B05BF2C377D9AFF10441C4905.cache.html:75687)
com_google_gwt_core_client_impl_Impl_entry0__Ljava_lang_Object_2Ljava_lang_Object_2Ljava_lang_Object_2Ljava_lang_Object_2 (ED3B5F9B05BF2C377D9AFF10441C4905.cache.html:75764)
(anonymous function) (ED3B5F9B05BF2C377D9AFF10441C4905.cache.html:75732)
(anonymous function) (ED3B5F9B05BF2C377D9AFF10441C4905.cache.html:76501)
```
