### PR TITLE
Support 'size' as a json skin data value for BitmapFont

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,5 @@
 [1.0.0]
-- support 'size' as a json skin data value for BitmapFont
+- support 'scaledSize' as a json skin data value for BitmapFont
 - added setAlpha(float a) method to Sprite class
 - added Input.Keys.toString(int keycode) and Input.Keys.valueOf(String keyname) methods
 - added Immersive Mode support to Android backend

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Skin.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Skin.java
@@ -442,7 +442,7 @@ public class Skin implements Disposable {
 		json.setSerializer(BitmapFont.class, new ReadOnlySerializer<BitmapFont>() {
 			public BitmapFont read (Json json, JsonValue jsonData, Class type) {
 				String path = json.readValue("file", String.class, jsonData);
-				int size = json.readValue("size", int.class, -1, jsonData);
+				int scaledSize = json.readValue("scaledSize", int.class, -1, jsonData);
 				Boolean flip = json.readValue("flip", Boolean.class, false, jsonData);
 
 				FileHandle fontFile = skinFile.parent().child(path);
@@ -463,9 +463,9 @@ public class Skin implements Disposable {
 						else
 							font = new BitmapFont(fontFile, flip);
 					}
-					if (size != -1) {
+					if (scaledSize != -1) {
 						// Use scale factor based on lineHeight (as font size) to scale the font
-						font.setScale(size / font.getData().lineHeight);
+						font.setScale(scaledSize / font.getData().lineHeight);
 					}
 					return font;
 				} catch (RuntimeException ex) {


### PR DESCRIPTION
This change adds font size support to BitmapFont definitions in skin json files
