### PR TITLE
Add method to obtain the width of the Window title text

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Window.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Window.java
@@ -32,7 +32,7 @@ import com.badlogic.gdx.scenes.scene2d.utils.Drawable;
 
 /** A table that can be dragged and act as a modal window. The top padding is used as the window's title height.
  * <p>
- * The preferred size of a window is the preferred size of the title text and the children as layed out by the table. After adding
+ * The preferred size of a window is the preferred size of the title text and the children as laid out by the table. After adding
  * children to the window, it can be convenient to call {@link #pack()} to size the window to the size of the children.
  * @author Nathan Sweet */
 public class Window extends Table {
@@ -316,8 +316,12 @@ public class Window extends Table {
 		return dragging;
 	}
 
+	public float getTitleWidth () {
+		return titleCache.getBounds().width;
+	}
+
 	public float getPrefWidth () {
-		return Math.max(super.getPrefWidth(), titleCache.getBounds().width + getPadLeft() + getPadRight());
+		return Math.max(super.getPrefWidth(), getTitleWidth() + getPadLeft() + getPadRight());
 	}
 
 	public Table getButtonTable () {


### PR DESCRIPTION
To determine the minimum width of a Window (including buttons on the buttonBar), one needs to be able to obtain the width of the title text of the Window.
