### PR TITLE
Bug-fix: AssetManager loads ETC1 textures synchronously

### DIFF
--- a/gdx/src/com/badlogic/gdx/assets/loaders/TextureLoader.java
+++ b/gdx/src/com/badlogic/gdx/assets/loaders/TextureLoader.java
@@ -76,9 +76,9 @@ public class TextureLoader extends AsynchronousAssetLoader<Texture, TextureLoade
 			}
 		} else {
 			info.data = parameter.textureData;
-			if (!info.data.isPrepared()) info.data.prepare();
 			info.texture = parameter.texture;
 		}
+		if (!info.data.isPrepared()) info.data.prepare();
 	}
 
 	@Override


### PR DESCRIPTION
In it's loadAsync method TextureLoader calls ETC1TextureData and It only stores file handler for later loading with prepare() function which is only called in loadSync. So simple way to fix issue is to move this line:
if (!info.data.isPrepared()) info.data.prepare();
out of else clause to the end of loadAsync so it's always called. This also makes code on lines 69-72 redundant so it can be safely removed.

On a slightly related note, any thoughts on how asynchronous loading of ETC1 into Cubemap should be implemented? I don't see any solution that doesn't involve serious rewriting of AssetManager
Edit: Ok. I think I have found simple solution for this as well and that's to simply create TextureDataLoader class from TextureLoader.
