### PR TITLE
Fix PixmapPacker-generated TextureAtlas disposal.

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g2d/PixmapPacker.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/PixmapPacker.java
@@ -85,7 +85,7 @@ import com.badlogic.gdx.utils.OrderedMap;
  * packer.dispose();
  * </pre> */
 public class PixmapPacker implements Disposable {
-	
+
 	static final class Node {
 		public Node leftChild;
 		public Node rightChild;
@@ -162,7 +162,7 @@ public class PixmapPacker implements Disposable {
 		Rectangle rect = new Rectangle(0, 0, image.getWidth() + borderPixels, image.getHeight() + borderPixels);
 		if (rect.getWidth() > pageWidth || rect.getHeight() > pageHeight)
 			throw new GdxRuntimeException("page size for '" + name + "' to small");
-		
+
 		Node node = insert(currPage.root, rect);
 
 		if (node == null) {
@@ -190,16 +190,19 @@ public class PixmapPacker implements Disposable {
 			this.currPage.image.drawPixmap(image, 0, 0, 1, 1, (int)rect.x - 1, (int)rect.y - 1, 1, 1);
 			this.currPage.image.drawPixmap(image, imageWidth - 1, 0, 1, 1, (int)rect.x + (int)rect.width, (int)rect.y - 1, 1, 1);
 			this.currPage.image.drawPixmap(image, 0, imageHeight - 1, 1, 1, (int)rect.x - 1, (int)rect.y + (int)rect.height, 1, 1);
-			this.currPage.image.drawPixmap(image, imageWidth - 1, imageHeight - 1, 1, 1, (int)rect.x + (int)rect.width, (int)rect.y + (int)rect.height, 1, 1);
+			this.currPage.image.drawPixmap(image, imageWidth - 1, imageHeight - 1, 1, 1, (int)rect.x + (int)rect.width, (int)rect.y
+				+ (int)rect.height, 1, 1);
 			// Copy edge pixels into padding.
 			this.currPage.image.drawPixmap(image, 0, 0, imageWidth, 1, (int)rect.x, (int)rect.y - 1, (int)rect.width, 1);
-			this.currPage.image.drawPixmap(image, 0, imageHeight - 1, imageWidth, 1, (int)rect.x, (int)rect.y + (int)rect.height, (int)rect.width, 1);
+			this.currPage.image.drawPixmap(image, 0, imageHeight - 1, imageWidth, 1, (int)rect.x, (int)rect.y + (int)rect.height,
+				(int)rect.width, 1);
 			this.currPage.image.drawPixmap(image, 0, 0, 1, imageHeight, (int)rect.x - 1, (int)rect.y, 1, (int)rect.height);
-			this.currPage.image.drawPixmap(image, imageWidth - 1, 0, 1, imageHeight, (int)rect.x + (int)rect.width, (int)rect.y, 1, (int)rect.height);
+			this.currPage.image.drawPixmap(image, imageWidth - 1, 0, 1, imageHeight, (int)rect.x + (int)rect.width, (int)rect.y, 1,
+				(int)rect.height);
 		}
-		
+
 		Pixmap.setBlending(blending);
-		
+
 		currPage.addedRects.add(name);
 		return rect;
 	}
@@ -284,12 +287,12 @@ public class PixmapPacker implements Disposable {
 		}
 		return null;
 	}
-	
+
 	/** Returns the index of the page containing the given packed rectangle.
 	 * @param name the name of the image
 	 * @return the index of the page the image is stored in or -1 */
 	public synchronized int getPageIndex (String name) {
-		for (int i=0; i<pages.size; i++) {
+		for (int i = 0; i < pages.size; i++) {
 			Rectangle rect = pages.get(i).rects.get(name);
 			if (rect != null) return i;
 		}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/PixmapPackerTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/PixmapPackerTest.java
@@ -31,41 +31,41 @@ import com.badlogic.gdx.graphics.g2d.TextureAtlas;
 import com.badlogic.gdx.tests.utils.GdxTest;
 
 public class PixmapPackerTest extends GdxTest {
-	
+
 	OrthographicCamera camera;
 	SpriteBatch batch;
-	
+
 	Texture texture;
 	TextureAtlas atlas;
-	
+
 	@Override
 	public void create () {
 		batch = new SpriteBatch();
-		
+
 		camera = new OrthographicCamera(Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
 		camera.position.set(Gdx.graphics.getWidth() / 2, Gdx.graphics.getHeight() / 2, 0);
 		camera.update();
-		
+
 		Pixmap pixmap1 = new Pixmap(Gdx.files.internal("data/badlogic.jpg"));
 		Pixmap pixmap2 = new Pixmap(Gdx.files.internal("data/wheel.png"));
 		Pixmap pixmap3 = new Pixmap(Gdx.files.internal("data/egg.png"));
-		
-		PixmapPacker packer =  new PixmapPacker(1024, 1024, Format.RGBA8888, 2, true);
+
+		PixmapPacker packer = new PixmapPacker(1024, 1024, Format.RGBA8888, 2, true);
 		packer.pack("badlogic", pixmap1);
 		packer.pack("wheel", pixmap1);
 		packer.pack("egg", pixmap1);
-		
+
 		pixmap1.dispose();
 		pixmap2.dispose();
 		pixmap3.dispose();
-		
+
 		atlas = packer.generateTextureAtlas(TextureFilter.Nearest, TextureFilter.Nearest, false);
 		Gdx.app.log("PixmaPackerTest", "Number of textures: " + atlas.getTextures().size());
 	}
 
 	@Override
 	public void render () {
-		
+
 	}
 
 	@Override


### PR DESCRIPTION
Currently, PixmapPacker-generated TextureAtlas's don't correctly dispose. They are doubly-disposed because of a bug introduced in ddc853b124707171261ec5f5c89cafa648be7841.

This adds disposal to the unit test, fixes the bug, and also runs the eclipse formatter on the source files.
