### PR TITLE
glBufferData now correctly handles null as a value for data in LWJGL backend

### DIFF
--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGL20.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGL20.java
@@ -89,8 +89,8 @@ final class LwjglGL20 implements com.badlogic.gdx.graphics.GL20 {
 	}
 
 	public void glBufferData (int target, int size, Buffer data, int usage) {
-		if(data == null)
-			throw new GdxRuntimeException("Using null for the data not possible, blame LWJGL");
+		if (data == null)
+			GL15.glBufferData(target, size, usage);
 		else if (data instanceof ByteBuffer)
 			GL15.glBufferData(target, (ByteBuffer)data, usage);
 		else if (data instanceof IntBuffer)
@@ -105,7 +105,7 @@ final class LwjglGL20 implements com.badlogic.gdx.graphics.GL20 {
 
 	public void glBufferSubData (int target, int offset, int size, Buffer data) {
 		if(data == null)
-			throw new GdxRuntimeException("Using null for the data not possible, blame LWJGL");
+			throw new GdxRuntimeException("Using null for the data not possible");
 		else if (data instanceof ByteBuffer)
 			GL15.glBufferSubData(target, offset, (ByteBuffer)data);
 		else if (data instanceof IntBuffer)


### PR DESCRIPTION
An exception was previously thrown when calling glBufferData with null as a value for data due to a LWJGL not exposing the proper method. The method is now part of LWJGL hence the update.
Also, null for data has never been possible in glBufferSubData so I removed the "blame LWJGL" bit :)
