### PR TITLE
Prevented rare crash on Keyboard.isKeyDown

### DIFF
--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglInput.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglInput.java
@@ -224,6 +224,8 @@ final public class LwjglInput implements Input {
 	}
 
 	public boolean isKeyPressed (int key) {
+		if (!Keyboard.isCreated()) return false;
+		
 		if (key == Input.Keys.ANY_KEY)
 			return pressedKeys > 0;
 		else


### PR DESCRIPTION
Workaround for #1090

This prevents LibGDX from crashing and simply returns false in the rare event Keyboard.isKeyDown accesses an uncreated Keyboard. I'm not sure what causes this because a creation of a Display should trigger the keyboard. This is more of a fail-safe.
