### PR TITLE
Added FBO.end(x, y, width, height) method

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/glutils/FrameBuffer.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/FrameBuffer.java
@@ -217,6 +217,18 @@ public class FrameBuffer implements Disposable {
 		Gdx.graphics.getGL20().glViewport(0, 0, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
 		Gdx.graphics.getGL20().glBindFramebuffer(GL20.GL_FRAMEBUFFER, defaultFramebufferHandle);
 	}
+	
+	/** Unbinds the framebuffer and sets viewport sizes, all drawing will be performed to the normal framebuffer from here on.
+	 * 
+	 * @param x the x-axis position of the viewport in pixels
+	 * @param y the y-asis position of the viewport in pixels
+	 * @param width the width of the viewport in pixels
+	 * @param height the height of the viewport in pixels
+	 * */
+	public void end (int x, int y, int width, int height) {
+		Gdx.graphics.getGL20().glViewport(x, y, width, height);
+		Gdx.graphics.getGL20().glBindFramebuffer(GL20.GL_FRAMEBUFFER, defaultFramebufferHandle);
+	}
 
 	/** @return the color buffer texture */
 	public Texture getColorBufferTexture () {


### PR DESCRIPTION
Added parametrised FBO#end(...) method - do the same as end() but that restores the viewport with sizes passed as arguments.

This method will help to remove duplicate glViewport calls after usage of FBO when using non-default viewport.
