### PR TITLE
Add default button that set the particle sprite to 'particle.png'

### DIFF
--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/EffectPanel.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/EffectPanel.java
@@ -66,7 +66,7 @@ class EffectPanel extends JPanel {
 		emitter.getTransparency().setHigh(1);
 
 		emitter.setMaxParticleCount(25);
-		emitter.setImagePath("particle.png");
+		emitter.setImagePath(ParticleEditor.DEFAULT_PARTICLE);
 
 		addEmitter(name, select, emitter);
 		return emitter;
@@ -107,7 +107,7 @@ class EffectPanel extends JPanel {
 		emitter.getTransparency().setScaling(new float[] {0, 1, 0.75f, 0});
 		
 		emitter.setMaxParticleCount(200);
-		emitter.setImagePath("particle.png");
+		emitter.setImagePath(ParticleEditor.DEFAULT_PARTICLE);
 		
 		addEmitter(name, select, emitter);
 		return emitter;

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/ImagePanel.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/ImagePanel.java
@@ -73,7 +73,7 @@ class ImagePanel extends EditorPanel {
 				@Override
 				public void actionPerformed (ActionEvent e) {
 					final ParticleEmitter emitter = editor.getEmitter();
-					emitter.setImagePath("particle.png");
+					emitter.setImagePath(ParticleEditor.DEFAULT_PARTICLE);
 					emitter.setSprite(null);
 
 					editor.setIcon(emitter, null);

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/ParticleEditor.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/ParticleEditor.java
@@ -62,6 +62,7 @@ import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.utils.GdxRuntimeException;
 
 public class ParticleEditor extends JFrame {
+	public static final String DEFAULT_PARTICLE = "particle.png"; 
 	LwjglCanvas lwjglCanvas;
 	JPanel rowsPanel;
 	JPanel editRowsPanel;
@@ -428,7 +429,7 @@ public class ParticleEditor extends JFrame {
 			String imageName = new File(imagePath.replace('\\', '/')).getName();
 			try {
 				FileHandle file;
-				if (imagePath.equals("particle.png"))
+				if (imagePath.equals(ParticleEditor.DEFAULT_PARTICLE))
 					file = Gdx.files.classpath(imagePath);
 				else
 					file = Gdx.files.absolute(imagePath);


### PR DESCRIPTION
This patch adds a 'default' button to the editor which will set the particle sprite back to the default 'particle.png'
