### PR TITLE
Allow ImageTextButton to have image and label on separate rows

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ImageTextButton.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ImageTextButton.java
@@ -48,24 +48,32 @@ public class ImageTextButton extends Button {
 	}
 
 	public ImageTextButton (String text, ImageTextButtonStyle style) {
-		super(style);
-		this.style = style;
-
-		defaults().space(3);
-
-		image = new Image();
-		image.setScaling(Scaling.fit);
-		add(image);
-
-		label = new Label(text, new LabelStyle(style.font, style.fontColor));
-		label.setAlignment(Align.center);
-		add(label);
-
-		setStyle(style);
-
-		setWidth(getPrefWidth());
-		setHeight(getPrefHeight());
+        this(text, style, false);
 	}
+
+    public ImageTextButton (String text, ImageTextButtonStyle style, boolean vertical) {
+        super(style);
+        this.style = style;
+
+        defaults().space(3);
+
+        image = new Image();
+        image.setScaling(Scaling.fit);
+        add(image);
+
+        if (vertical) {
+            row();
+        }
+
+        label = new Label(text, new LabelStyle(style.font, style.fontColor));
+        label.setAlignment(Align.center);
+        add(label);
+
+        setStyle(style);
+
+        setWidth(getPrefWidth());
+        setHeight(getPrefHeight());
+    }
 
 	public void setStyle (ButtonStyle style) {
 		if (!(style instanceof ImageTextButtonStyle)) throw new IllegalArgumentException("style must be a ImageTextButtonStyle.");


### PR DESCRIPTION
`ImageTextButton` allows you to create button where the image and label are on the same row (image left, label right).

Added functionality to allow the image and label to be on separate rows (image top, label below)
