### PR TITLE
MipMapTest: added ui.act in render method

### DIFF
--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/MipMapTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/MipMapTest.java
@@ -131,6 +131,7 @@ public class MipMapTest extends GdxTest {
 		mesh.render(shader, GL10.GL_TRIANGLE_FAN);
 		shader.end();
 
+		ui.act();
 		ui.draw();
 	}
 


### PR DESCRIPTION
It was not possible to change the filter due to the missing call to ui.act.
