### PR TITLE
Fix for pause() not being called on iOS backend

### DIFF
--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
@@ -249,10 +249,32 @@ public class IOSGraphics extends NSObject implements Graphics, GLKViewDelegate,
 
 	public void resume() {
 		paused = false;
+		
+		if (wasPaused) {
+			Array<LifecycleListener> listeners = app.lifecycleListeners;
+			synchronized (listeners) {
+				for (LifecycleListener listener : listeners) {
+					listener.resume();
+				}
+			}
+			app.listener.resume();
+			wasPaused = false;
+		}
 	}
 
 	public void pause() {
 		paused = true;
+		
+		if (!wasPaused) {
+			Array<LifecycleListener> listeners = app.lifecycleListeners;
+			synchronized (listeners) {
+				for (LifecycleListener listener : listeners) {
+					listener.pause();
+				}
+			}
+			app.listener.pause();
+			wasPaused = true;
+		}
 	}
 
 	boolean created = false;
@@ -265,28 +287,7 @@ public class IOSGraphics extends NSObject implements Graphics, GLKViewDelegate,
 			created = true;
 		}
 		if (paused) {
-			if (!wasPaused) {
-				Array<LifecycleListener> listeners = app.lifecycleListeners;
-				synchronized (listeners) {
-					for (LifecycleListener listener : listeners) {
-						listener.pause();
-					}
-				}
-				app.listener.pause();
-				wasPaused = true;
-			}
 			return;
-		} else {
-			if (wasPaused) {
-				Array<LifecycleListener> listeners = app.lifecycleListeners;
-				synchronized (listeners) {
-					for (LifecycleListener listener : listeners) {
-						listener.resume();
-					}
-				}
-				app.listener.resume();
-				wasPaused = false;
-			}
 		}
 
 		long time = System.nanoTime();


### PR DESCRIPTION
Application pause() was not being called sometimes when there was no draw() call after the IOSGraphics pause() was called.

Moved most of the pause handling out of the draw method.

Described here: http://www.badlogicgames.com/forum/viewtopic.php?f=11&t=11481
