### PR TITLE
Fixes in IOSGraphics, + formatting

### DIFF
--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
@@ -260,7 +260,8 @@ public class IOSGraphics extends NSObject implements Graphics, GLKViewDelegate, 
 
 	public void pause () {
 		if (paused) return;
-
+		paused = true;
+		
 		Array<LifecycleListener> listeners = app.lifecycleListeners;
 		synchronized (listeners) {
 			for (LifecycleListener listener : listeners) {


### PR DESCRIPTION
Most of the changes are formatting.

Changes:
- Removed wasPaused, added sanity checks using the paused variable instead.
- Fix for double resume call 
- Fix for the resume before create call #1159

Please test this as I cannot test this atm. I just made sure it wouldn't cause errors, but there shouldn't be breakages. 
