### PR TITLE
Add gwt support for the gradle cli setup

### DIFF
--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetup.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetup.java
@@ -24,9 +24,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -35,15 +33,13 @@ import java.util.Map;
  *
  */
 public class GdxSetup {
-	final static String[] GDX_VERSIONS = {"0.9.9", "1.0-SNAPSHOT"};
-	
-	public void build (String outputDir, String appName, String packageName, String mainClass, String gdxVersion) {
+	public void build (String outputDir, String appName, String packageName, String mainClass) {
 		Project project = new Project();
 		
 		String packageDir = packageName.replace('.', '/');
-		
+
 		// root dir/gradle files
-		project.files.add(new ProjectFile("build.gradle"));
+		project.files.add(new ProjectFile("build.gradle", true));
 		project.files.add(new ProjectFile("settings.gradle"));
 		project.files.add(new ProjectFile("gradlew", false));
 		project.files.add(new ProjectFile("gradlew.bat", false));
@@ -53,11 +49,13 @@ public class GdxSetup {
 		// core project
 		project.files.add(new ProjectFile("core/build.gradle"));
 		project.files.add(new ProjectFile("core/src/MainClass", "core/src/" + packageDir + "/" + mainClass + ".java", true));
+        //core but gwt required
+        project.files.add(new ProjectFile("core/CoreGdxDefinition", "core/src/" + packageDir + "/" + mainClass + ".gwt.xml", true));
 		
 		// desktop project
 		project.files.add(new ProjectFile("desktop/build.gradle"));
 		project.files.add(new ProjectFile("desktop/src/DesktopLauncher", "desktop/src/" + packageDir + "/desktop/DesktopLauncher.java", true));
-		
+
 		// android project
 		project.files.add(new ProjectFile("android/assets/badlogic.jpg", false));
 		project.files.add(new ProjectFile("android/res/values/strings.xml", false));
@@ -72,18 +70,24 @@ public class GdxSetup {
 		project.files.add(new ProjectFile("android/ic_launcher-web.png", false));
 		project.files.add(new ProjectFile("android/proguard-project.txt", false));
 		project.files.add(new ProjectFile("android/project.properties", false));
-		
+
+        //gwt project
+        project.files.add(new ProjectFile("gwt/build.gradle"));
+        project.files.add(new ProjectFile("gwt/src/GwtLauncher", "gwt/src/" + packageDir + "/client/GwtLauncher.java", true));
+        project.files.add(new ProjectFile("gwt/GdxDefinition", "gwt/src/" + packageDir + "/GdxDefinition.gwt.xml", true));
+        project.files.add(new ProjectFile("gwt/war/index", "gwt/webapp/" + "index.html", true));
+        project.files.add(new ProjectFile("gwt/war/WEB-INF/web.xml", "gwt/webapp/WEB-INF/web.xml", true));
+
+
 		Map<String, String> values = new HashMap<String, String>();
 		values.put("%APP_NAME%", appName);
 		values.put("%PACKAGE%", packageName);
 		values.put("%MAIN_CLASS%", mainClass);
-		values.put("%GDX_VERSION%", gdxVersion);
 		
 		copyAndReplace(outputDir, project, values);
 		
 		// HACK executable flag isn't preserved for whatever reason...
 		new File(outputDir, "gradlew").setExecutable(true);
-		System.out.println("Done! project created in " + outputDir +" directory");
 	}
 
 	private void copyAndReplace (String outputDir, Project project, Map<String, String> values) {
@@ -170,8 +174,6 @@ public class GdxSetup {
 	
 	private static void printHelp() {
 		System.out.println("Usage: GdxSetup --dir <dir-name> --name <app-name> --package <package> --mainClass <mainClass>");
-		System.out.println("[OPTIONAL]");
-		System.out.println("--gdxVersion <version> defaults to " + GDX_VERSIONS[0] + " if not specified");
 	}
 	
 	private static Map<String, String> parseArgs(String[] args) {
@@ -195,19 +197,7 @@ public class GdxSetup {
 			printHelp();
 			System.exit(-1);
 		}
-		if(params.containsKey("gdxVersion")){
-			List<String> versions = Arrays.asList(GDX_VERSIONS);
-			if(!versions.contains(params.get("gdxVersion"))){
-				System.out.println("Invalid gdxVersion : use one of the following versions");
-				System.out.println(versions);
-				System.exit(-1);
-			}
-		}
-		if(!params.containsKey("gdxVersion")){
-			params.put("gdxVersion", GDX_VERSIONS[0]);
-			System.out.println("No gdxVersion specified: using default [" + GDX_VERSIONS[0] + "]");
-		}
 		
-		new GdxSetup().build(params.get("dir"), params.get("name"), params.get("package"), params.get("mainClass"), params.get("gdxVersion"));
+		new GdxSetup().build(params.get("dir"), params.get("name"), params.get("package"), params.get("mainClass"));
 	}
 }

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/android/build.gradle
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/android/build.gradle
@@ -34,13 +34,13 @@ task copyAndroidNatives() {
         def outputDir = null
         if(jar.name.endsWith("natives-armeabi-v7a.jar")) outputDir = file("libs/armeabi-v7a")
         if(jar.name.endsWith("natives-armeabi.jar")) outputDir = file("libs/armeabi")
-        if(jar.name.endsWith("natives-x86.jar")) outputDir = file("libs/x86")                  
-        if(outputDir != null) {            
+        if(jar.name.endsWith("natives-x86.jar")) outputDir = file("libs/x86")
+        if(outputDir != null) {
             copy {
-				from zipTree(jar)
-				into outputDir
-				include "*.so"
-			}
+                from zipTree(jar)
+                into outputDir
+                include "*.so"
+            }
         }
     }
 }

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/build.gradle
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/build.gradle
@@ -1,24 +1,29 @@
 buildscript {
-    repositories { mavenCentral() }
-    dependencies { classpath 'com.android.tools.build:gradle:0.5.+' }
+    repositories {
+        maven {
+            url 'https://github.com/steffenschaefer/gwt-gradle-plugin/raw/maven-repo/'
+        }
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.2'
+        classpath 'com.android.tools.build:gradle:0.6.1+'
+    }
 }
 
 allprojects {
+    apply plugin: "eclipse"
     apply plugin: "idea"
     
     version = "1.0"
     ext.appName = "%APP_NAME%"
-    ext.gdxVersion = "%GDX_VERSION%"
+    ext.gdxVersion = "1.0-SNAPSHOT"
     
     repositories {
         mavenCentral()
         maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
         mavenLocal();
     }
-}
-
-subprojects {
-    apply plugin: "eclipse"    
 }
 
 project(":core") {
@@ -47,8 +52,43 @@ project(":android") {
 
     dependencies {
         compile project(":core")
-        compile "com.badlogicgames.gdx:gdx-backend-android:$gdxVersion"
+        compile "com.badlogicgames.gdx:gdx-backend-android:$gdxVersion"        
         natives "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-armeabi"
         natives "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-armeabi-v7a"
     }
+}
+
+project(":gwt") {
+    apply plugin: "gwt"
+    apply plugin: "war"
+    webAppDirName = 'webapp'
+
+    dependencies {
+        compile project(":core")
+        compile "com.badlogicgames.gdx:gdx-backend-gwt:$gdxVersion"
+        compile "com.badlogicgames.gdx:gdx:$gdxVersion:sources"
+        compile "com.badlogicgames.gdx:gdx-backend-gwt:$gdxVersion:sources"
+    }
+
+    gwt {
+        gwtVersion='2.5.0' // Should match the gwt version used for building the gwt backend
+
+        maxHeapSize="1G" // Default 256m is not enough for gwt compiler. GWT is HUNGRY
+        minHeapSize="1G"
+
+        src = files(file("src/")) // Needs to be in front of "modules" below.
+        modules '%PACKAGE%.GdxDefinition'
+
+        compiler {
+            strict = true;
+            enableClosureCompiler = true;
+            disableClassMetadata = true;
+            disableCastChecking = true;
+        }
+    }
+}
+
+
+tasks.eclipse.doLast {
+	delete ".project"
 }

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/core/CoreGdxDefinition
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/core/CoreGdxDefinition
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit trunk//EN" "http://google-web-toolkit.googlecode.com/svn/trunk/distro-source/core/src/gwt-module.dtd">
+<module>
+	<source path="" />
+</module>

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/gradle/wrapper/gradle-wrapper.properties
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.7-bin.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-1.8-all.zip

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/gwt/GdxDefinition
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/gwt/GdxDefinition
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit trunk//EN" "http://google-web-toolkit.googlecode.com/svn/trunk/distro-source/core/src/gwt-module.dtd">
+<module>
+	<inherits name='com.badlogic.gdx.backends.gdx_backends_gwt' />
+	<inherits name='%PACKAGE%.%MAIN_CLASS%' />
+	<entry-point class='%PACKAGE%.client.GwtLauncher' />
+	<set-configuration-property name="gdx.assetpath" value="../android/assets" />
+</module>

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/gwt/build.gradle
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/gwt/build.gradle
@@ -1,0 +1,23 @@
+apply plugin: "java"
+apply plugin: "application"
+
+sourceCompatibility = 1.6
+mainClassName = "%PACKAGE%.client.GwtLauncher"
+sourceSets.main.java.srcDirs = [ "src/" ]
+sourceSets.main.resources.srcDirs = [file("../android/assets").getAbsolutePath()]
+
+// Helps gwt find the proper .gwt.xml files.
+sourceSets.main.compileClasspath += files(project(':core').sourceSets.main.allJava.srcDirs)
+
+// idea doesn't like relative paths outside of content root...
+tasks.ideaModule.doFirst {
+    sourceSets.main.resources.srcDirs = []
+}
+
+eclipse.project {
+    name = appName + "-gwt"
+}
+
+run {
+    ignoreExitValue = true
+}

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/gwt/src/GwtLauncher
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/gwt/src/GwtLauncher
@@ -1,0 +1,19 @@
+package %PACKAGE%.client;
+
+import com.badlogic.gdx.ApplicationListener;
+import com.badlogic.gdx.backends.gwt.GwtApplication;
+import com.badlogic.gdx.backends.gwt.GwtApplicationConfiguration;
+import %PACKAGE%.%MAIN_CLASS%;
+
+public class GwtLauncher extends GwtApplication {
+
+        @Override
+        public GwtApplicationConfiguration getConfig () {
+                return new GwtApplicationConfiguration(480, 320);
+        }
+
+        @Override
+        public ApplicationListener getApplicationListener () {
+                return new %MAIN_CLASS%();
+        }
+}

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/settings.gradle
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/settings.gradle
@@ -1,1 +1,1 @@
-include "core", "desktop", "android"
+include "core", "desktop", "android", "gwt"


### PR DESCRIPTION
Out of the box gwt module.  
Super dev is configurable, using the gwt plugin. 

(Might be nice to have this as an option when choosing what extensions you want in the final system.)
