### PR TITLE
Discourage the use of obj models

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g3d/loader/ObjLoader.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/loader/ObjLoader.java
@@ -38,6 +38,8 @@ import com.badlogic.gdx.graphics.VertexAttribute;
 import com.badlogic.gdx.graphics.VertexAttributes.Usage;
 import com.badlogic.gdx.graphics.g3d.attributes.ColorAttribute;
 import com.badlogic.gdx.graphics.g3d.attributes.TextureAttribute;
+import com.badlogic.gdx.graphics.g3d.Attribute;
+import com.badlogic.gdx.graphics.g3d.Attributes;
 import com.badlogic.gdx.graphics.g3d.Material;
 import com.badlogic.gdx.graphics.g3d.Model;
 import com.badlogic.gdx.graphics.g3d.model.data.ModelData;
@@ -54,10 +56,27 @@ import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.FloatArray;
 
-/** Loads Wavefront OBJ files.
+/** {@link ModelLoader} to load Wavefront OBJ files. Only intended for testing basic models/meshes and educational usage.
+ * The Wavefront specification is NOT fully implemented, only a subset of the specification is supported. Especially the
+ * {@link Material} ({@link Attributes}), e.g. the color or texture applied, might not or not correctly be loaded.</p>
  * 
- * @author mzechner, espitz */
+ * This {@link ModelLoader} can be used to load very basic models without having to convert them to a more suitable format.
+ * Therefore it can be used for educational purposes and to quickly test a basic model, but should not be used in production.
+ * Instead use {@link G3dModelLoader}.</p>
+ * 
+ * Because of above reasons, when an OBJ file is loaded using this loader, it will log and error. To prevent this error from
+ * being logged, set the {@link #logWarning} flag to false. However, it is advised not to do so.</p>
+ * 
+ * An OBJ file only contains the mesh (shape). It may link to a separate MTL file, which is used to describe one or more materials.
+ * In that case the MTL filename (might be case-sensitive) is expected to be located relative to the OBJ file. The MTL file might
+ * reference one or more texture files, in which case those filename(s) are expected to be located relative to the MTL file.</p> 
+ * @author mzechner, espitz, xoppa */
 public class ObjLoader extends ModelLoader<ObjLoader.ObjLoaderParameters> {
+	/** Set to false to prevent a warning from being logged when this class is used.
+	 * Do not change this value, unless you are absolutely sure what you are doing.
+	 * Consult the documentation for more information. */
+	public static boolean logWarning = false;
+	
 	public static class ObjLoaderParameters extends AssetLoaderParameters<Model> {
 		public boolean flipV;
 		public ObjLoaderParameters() {}
@@ -108,6 +127,8 @@ public class ObjLoader extends ModelLoader<ObjLoader.ObjLoaderParameters> {
 	}
 	
 	protected ModelData loadModelData (FileHandle file, boolean flipV) {
+		if (logWarning)
+			Gdx.app.error("ObjLoader", "Wavefront (OBJ) is not fully supported, consult the documentation for more information");
 		String line;
 		String[] tokens;
 		char firstChar;


### PR DESCRIPTION
A long long time ago we [discussed](http://echelog.com/logs/browse/libgdx/1363993200) (around 19:28 for me) the meaning of ObjLoader. My opinion was that obj might be useful for beginners. And, for example, I do use it in the tutorials so it doesn't overwhelm by diving straight into fbx-conv. Moreover, obj is supported by virtually every modeling application and it is currently the only path not requiring a conversion.

That being said, it should be noted that ObjLoader is currently not fully implemented (specifically materials). The specification itself is really basic and doesn't implement all features the 3d api supports. Not all modeling applications implement the obj specification the same. And the dependency of an additional mtl file can be a bit cumbersome for some.

Unfortunately it appears that quite a few are using obj files and (naturally) experiencing problems. So I thought it might be a good idea to do something about that. I see three options (all of which with (I think) obvious pros and cons):
- Fully implement the OBJ specification
- Completely remove OBJ support (out of the core)
- Discourage the use of OBJ files

This PR tries to do the last option by logging an (optional) error every time a model is loaded. But other options/opinions are welcome.
