### PR TITLE
choose starting x,y, of lwjgl window

### DIFF
--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglApplicationConfiguration.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglApplicationConfiguration.java
@@ -70,6 +70,9 @@ public class LwjglApplicationConfiguration {
 	public boolean allowSoftwareMode = false;
 	/** Preferences directory on the desktop. Default is ".prefs/". */
 	public String preferencesDirectory = ".prefs/";
+	/** Set window position at start */
+	public int windowX = -1;
+	public int windowY = -1;
 
 	Array<String> iconPaths = new Array();
 	Array<FileType> iconFileTypes = new Array();

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGraphics.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGraphics.java
@@ -171,6 +171,9 @@ public class LwjglGraphics implements Graphics {
 		Display.setResizable(config.resizable);
 		Display.setInitialBackground(config.initialBackgroundColor.r, config.initialBackgroundColor.g,
 			config.initialBackgroundColor.b);
+		if (config.windowX > -1 && config.windowY > -1) {
+			Display.setLocation(config.windowX, config.windowY);
+		}
 
 		if (config.x != -1 && config.y != -1) Display.setLocation(config.x, config.y);
 		createDisplayPixelFormat();


### PR DESCRIPTION
Not terribly useful for end users, but when I do server/client testing I like to have their two windows side by side, and setting their start position in the cfg saves me lots of trouble.
