### PR TITLE
Android: Cleanup of touch input clearing and wakelocks

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplication.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplication.java
@@ -266,10 +266,12 @@ public class AndroidApplication extends Activity implements Application {
 		graphics.pause();
 
 		input.unregisterSensorListeners();
-		// erase pointer ids + touch states
+
 		int[] realId = input.realId;
-		boolean[] touched = input.touched;
+		// erase pointer ids. this sucks donkeyballs...
 		Arrays.fill(realId, -1);
+		boolean[] touched = input.touched;
+		// erase touched state. this also sucks donkeyballs...
 		Arrays.fill(touched, false);
 
 		if (isFinishing()) {

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidDaydream.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidDaydream.java
@@ -208,10 +208,12 @@ public class AndroidDaydream extends DreamService implements Application {
 		graphics.pause();
 
 		input.unregisterSensorListeners();
-		// erase pointer ids + touch states
+
 		int[] realId = input.realId;
-		boolean[] touched = input.touched;
+		// erase pointer ids. this sucks donkeyballs...
 		Arrays.fill(realId, -1);
+		boolean[] touched = input.touched;
+		// erase touched state. this also sucks donkeyballs...
 		Arrays.fill(touched, false);
 		graphics.clearManagedCaches();
 		graphics.destroy();

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidLiveWallpaper.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidLiveWallpaper.java
@@ -132,10 +132,12 @@ public class AndroidLiveWallpaper implements Application {
 		audio.pause();
 
 		input.unregisterSensorListeners();
-		// erase pointer ids + touch states
+
 		int[] realId = input.realId;
-		boolean[] touched = input.touched;
+		// erase pointer ids. this sucks donkeyballs...
 		Arrays.fill(realId, -1);
+		boolean[] touched = input.touched;
+		// erase touched state. this also sucks donkeyballs...
 		Arrays.fill(touched, false);
 
 		if (graphics != null && graphics.view != null) {


### PR DESCRIPTION
- Removed unneeded variables
- Made touch state and pointer id much nicer.
- Very minor formatting
