### PR TITLE
Basic clipboard in GWT

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplication.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplication.java
@@ -42,8 +42,6 @@ import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.Style;
 import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.user.client.Timer;
-import com.google.gwt.user.client.ui.FlowPanel;
-import com.google.gwt.user.client.ui.HTMLPanel;
 import com.google.gwt.user.client.ui.HasHorizontalAlignment;
 import com.google.gwt.user.client.ui.HasVerticalAlignment;
 import com.google.gwt.user.client.ui.Image;
@@ -76,6 +74,7 @@ public abstract class GwtApplication implements EntryPoint, Application {
 	Preloader preloader;
 	private static AgentInfo agentInfo;
 	private ObjectMap<String, Preferences> prefs = new ObjectMap<String, Preferences>();
+	private Clipboard clipboard;
 
 	/** @return the configuration for the {@link GwtApplication}. */
 	public abstract GwtApplicationConfiguration getConfig ();
@@ -171,6 +170,7 @@ public abstract class GwtApplication implements EntryPoint, Application {
 		Gdx.input = this.input;
 		this.net = new GwtNet();
 		Gdx.net = this.net;
+		this.clipboard = new GwtClipboard();
 
 		// tell listener about app creation
 		try {
@@ -400,17 +400,8 @@ public abstract class GwtApplication implements EntryPoint, Application {
 	}
 
 	@Override
-	public Clipboard getClipboard() {
-		return new Clipboard() {
-			@Override
-			public String getContents () {
-				return null;
-			}
-
-			@Override
-			public void setContents (String content) {
-			}			
-		};		
+	public Clipboard getClipboard () {
+		return clipboard;
 	}
 	
 	@Override

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtClipboard.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtClipboard.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogic.gdx.backends.gwt;
+
+import com.badlogic.gdx.utils.Clipboard;
+
+/** Basic implementation of clipboard in GWT. Copy-paste only works inside the libgdx application. */
+public class GwtClipboard implements Clipboard {
+
+	private String content = "";
+
+	@Override
+	public String getContents () {
+		return content;
+	}
+
+	@Override
+	public void setContents (String content) {
+		this.content = content;
+	}
+}


### PR DESCRIPTION
Web browsers has some issues with copy-paste from javascript, and the usual way to solve it is to use Flash, but I've implemented a very simple Clipboard in GWT that works inside the libgdx application (for example, across textfields). It's better than nothing, I think.
