### PR TITLE
Update BufferUtils.java

### DIFF
--- a/gdx/src/com/badlogic/gdx/utils/BufferUtils.java
+++ b/gdx/src/com/badlogic/gdx/utils/BufferUtils.java
@@ -447,6 +447,7 @@ public class BufferUtils {
 	 * {@link #freeMemory(ByteBuffer)}.
 	 * @param numBytes */
 	public static ByteBuffer newUnsafeByteBuffer (int numBytes) {
+		if(numBytes < 1) numBytes = 1;
 		ByteBuffer buffer = newDisposableByteBuffer(numBytes);
 		buffer.order(ByteOrder.nativeOrder());
 		allocatedUnsafe += numBytes;


### PR DESCRIPTION
android devices(like nexus 5) change to ART mode, creating a zero size bytebuffer will cause a crash, and ShapeRenderer will need a zero size buffer

the logs:
"F/art     ( 5062): art/runtime/check_jni.cc:64] JNI DETECTED ERROR IN APPLICATION: capacity must be greater than 0: 0
F/art     ( 5062): art/runtime/check_jni.cc:64]     in call to NewDirectByteBuffer
F/art     ( 5062): art/runtime/check_jni.cc:64]     from java.nio.ByteBuffer com.badlogic.gdx.utils.BufferUtils.newDisposableB                                                                                  yteBuffer(int)
"
