### PR TITLE
Making StreamUtils.copyStream* methods usable for copying from ZipInputSteam

### DIFF
--- a/gdx/src/com/badlogic/gdx/net/NetJavaImpl.java
+++ b/gdx/src/com/badlogic/gdx/net/NetJavaImpl.java
@@ -55,19 +55,25 @@ public class NetJavaImpl {
 
 		@Override
 		public byte[] getResult () {
+			InputStream input = getInputStream();
 			try {
-				return StreamUtils.copyStreamToByteArray(getInputStream(), connection.getContentLength());
+				return StreamUtils.copyStreamToByteArray(input, connection.getContentLength());
 			} catch (IOException e) {
 				return StreamUtils.EMPTY_BYTES;
+			} finally {
+				StreamUtils.closeQuietly(input);
 			}
 		}
 
 		@Override
 		public String getResultAsString () {
+			InputStream input = getInputStream();
 			try {
-				return StreamUtils.copyStreamToString(getInputStream(), connection.getContentLength());
+				return StreamUtils.copyStreamToString(input, connection.getContentLength());
 			} catch (IOException e) {
 				return "";
+			} finally {
+				StreamUtils.closeQuietly(input);
 			}
 		}
 

--- a/gdx/src/com/badlogic/gdx/utils/StreamUtils.java
+++ b/gdx/src/com/badlogic/gdx/utils/StreamUtils.java
@@ -30,33 +30,29 @@ public class StreamUtils {
 	public static final int DEFAULT_BUFFER_SIZE = 8192;
 	public static final byte[] EMPTY_BYTES = new byte[0];
 
-	/** Copy the data from an {@link InputStream} to an {@link OutputStream}.
+	/** Copy the data from an {@link InputStream} to an {@link OutputStream} without closing the stream.
 	 * @throws IOException */
 	public static void copyStream (InputStream input, OutputStream output) throws IOException {
 		copyStream(input, output, DEFAULT_BUFFER_SIZE);
 	}
 
-	/** Copy the data from an {@link InputStream} to an {@link OutputStream}.
+	/** Copy the data from an {@link InputStream} to an {@link OutputStream} without closing the stream.
 	 * @throws IOException */
 	public static void copyStream (InputStream input, OutputStream output, int bufferSize) throws IOException {
-		try {
-			byte[] buffer = new byte[bufferSize];
-			int bytesRead;
-			while ((bytesRead = input.read(buffer)) != -1) {
-				output.write(buffer, 0, bytesRead);
-			}
-		} finally {
-			closeQuietly(input);
+		byte[] buffer = new byte[bufferSize];
+		int bytesRead;
+		while ((bytesRead = input.read(buffer)) != -1) {
+			output.write(buffer, 0, bytesRead);
 		}
 	}
 
-	/** Copy the data from an {@link InputStream} to a byte array.
+	/** Copy the data from an {@link InputStream} to a byte array without closing the stream.
 	 * @throws IOException */
 	public static byte[] copyStreamToByteArray (InputStream input) throws IOException {
 		return copyStreamToByteArray(input, input.available());
 	}
 
-	/** Copy the data from an {@link InputStream} to a byte array.
+	/** Copy the data from an {@link InputStream} to a byte array without closing the stream.
 	 * @param estimatedSize Used to preallocate a possibly correct sized byte array to avoid an array copy.
 	 * @throws IOException */
 	public static byte[] copyStreamToByteArray (InputStream input, int estimatedSize) throws IOException {
@@ -65,7 +61,7 @@ public class StreamUtils {
 		return baos.toByteArray();
 	}
 
-	/** Copy the data from an {@link InputStream} to a string using the default charset.
+	/** Copy the data from an {@link InputStream} to a string using the default charset without closing the stream.
 	 * @throws IOException */
 	public static String copyStreamToString (InputStream input) throws IOException {
 		return copyStreamToString(input, input.available());
@@ -76,19 +72,15 @@ public class StreamUtils {
 	 * @throws IOException */
 	public static String copyStreamToString (InputStream input, int approxStringLength) throws IOException {
 		BufferedReader reader = new BufferedReader(new InputStreamReader(input));
-		try {
-			StringWriter w = new StringWriter(Math.max(0, approxStringLength));
-			char[] buffer = new char[DEFAULT_BUFFER_SIZE];
+		StringWriter w = new StringWriter(Math.max(0, approxStringLength));
+		char[] buffer = new char[DEFAULT_BUFFER_SIZE];
 
-			int charsRead;
-			while ((charsRead = reader.read(buffer)) != -1) {
-				w.write(buffer, 0, charsRead);
-			}
-
-			return w.toString();
-		} finally {
-			StreamUtils.closeQuietly(reader);
+		int charsRead;
+		while ((charsRead = reader.read(buffer)) != -1) {
+			w.write(buffer, 0, charsRead);
 		}
+
+		return w.toString();
 	}
 
 	/** Close and ignore all errors. */


### PR DESCRIPTION
Current StreamUtils.copyStream\* methods do close input streams after copying. This behavior is unacceptable when reading entries from ZipInputStream, JarInputStream and stuff from other streams what doesn't need to be closed immediately.
So I've moved closing the streams out of copyStream\* methods, also added some docs to avoid confusion.
