### PR TITLE
Add JDK 8 ABI detection to ARM GNU/Linux shared library loading.

### DIFF
--- a/gdx/src/com/badlogic/gdx/utils/SharedLibraryLoader.java
+++ b/gdx/src/com/badlogic/gdx/utils/SharedLibraryLoader.java
@@ -38,7 +38,15 @@ public class SharedLibraryLoader {
 	static public boolean isMac = System.getProperty("os.name").contains("Mac");
 	static public boolean isIos = false;
 	static public boolean isAndroid = false;
+	static public boolean isARM = System.getProperty("os.arch").startsWith("arm");
 	static public boolean is64Bit = System.getProperty("os.arch").equals("amd64");
+	/** JDK 8 introduced sun.arch.abi
+	 * http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=8005545
+	 * Here are some ARM specific examples:
+	 * gnueabi 	GNU softfp EABI
+	 * gnueabihf	GNU hard float EABI
+	 * androideabi	Android EABI */
+	static public String abi = (System.getProperty("sun.arch.abi")!=null ? System.getProperty("sun.arch.abi") : "");
 	static {
 		String vm = System.getProperty("java.vm.name");
 		if (vm != null && vm.contains("Dalvik")) {
@@ -87,7 +95,7 @@ public class SharedLibraryLoader {
 	/** Maps a platform independent library name to a platform dependent name. */
 	public String mapLibraryName (String libraryName) {
 		if (isWindows) return libraryName + (is64Bit ? "64.dll" : ".dll");
-		if (isLinux) return "lib" + libraryName + (is64Bit ? "64.so" : ".so");
+		if (isLinux) return "lib" + libraryName + (isARM ? "arm"+abi : "" ) + (is64Bit ? "64.so" : ".so");
 		if (isMac) return "lib" + libraryName + ".dylib";
 		return libraryName;
 	}


### PR DESCRIPTION
This change will enable libgdx to load ARM specific native library’s on ARM GNU/Linux systems.
JDK 8 introduced sun.arch.abi that tell which ABI of the ARM library to be loaded.
JDK 6/7 users have to be careful to deploy the right ABI of the libgdx natives that match their ARM system.

JDK 8 ARM systems will try to load:
lib_armgnueabi.so -> 32bit ARM GNU softfp EABI
lib_armgnueabihf.so -> 32bit ARM GNU hard float EABI
lib*armandroideabi.so -> 32bit Android EABI

JDK 6/7 ARM systems will try to load:
lib*arm.so -> 32bit ARM unknown ABI.

Signed-off-by: Xerxes Rånby xerxes@zafena.se
