### PR TITLE
Avoid instantiation of non-static classes with enclosing types in GWT Reflection Cache

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gwtref/gen/ReflectionCacheSourceCreator.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gwtref/gen/ReflectionCacheSourceCreator.java
@@ -533,7 +533,11 @@ public class ReflectionCacheSourceCreator {
 			}
 
 			printMethods(c, varName, "Method", c.getMethods());
-			if (!c.isAbstract()) printMethods(c, varName, "Constructor", c.getConstructors());
+			if (!c.isAbstract() && ( c.getEnclosingType() == null || c.isStatic() )){
+				printMethods(c, varName, "Constructor", c.getConstructors());
+			} else {
+				logger.log(Type.INFO, c.getName() + " can't be instantiated. Constructors not generated");
+			}
 
 			if (c.isArray() != null) {
 				pb(varName + ".componentType = " + getType(c.isArray().getComponentType()) + ";");


### PR DESCRIPTION
After the addition of the TextArea, the ReflectionCacheSourceCreator was generating a method like:

``` java
return new TextAreaListener();
```

which is a java compile error, since TextAreaListener is not static, and has as enclosing type TextArea (and broke the GWT backend).
This pull request makes the ReflectionCacheSourceCreator ignores constructors for those type of classes.

I added a log message to see exactly what classes were ignored (abstract classes and non-static classes with enclosing type). This is the output:

```
[INFO]             Interpolation can't be instantiated. Constructors not generated
[INFO]             Path can't be instantiated. Constructors not generated
[INFO]             Vector can't be instantiated. Constructors not generated
[INFO]             Action can't be instantiated. Constructors not generated
[INFO]             EventListener can't be instantiated. Constructors not generated
[INFO]             DelegateAction can't be instantiated. Constructors not generated
[INFO]             RelativeTemporalAction can't be instantiated. Constructors not generated
[INFO]             TemporalAction can't be instantiated. Constructors not generated
[INFO]             TextArea.TextAreaListener can't be instantiated. Constructors not generated
[INFO]             TextField.OnscreenKeyboard can't be instantiated. Constructors not generated
[INFO]             TextField.TextFieldClickListener can't be instantiated. Constructors not generated
[INFO]             TextField.TextFieldFilter can't be instantiated. Constructors not generated
[INFO]             TextField.TextFieldListener can't be instantiated. Constructors not generated
[INFO]             ChangeListener can't be instantiated. Constructors not generated
[INFO]             Cullable can't be instantiated. Constructors not generated
[INFO]             Disableable can't be instantiated. Constructors not generated
[INFO]             DragAndDrop.Source can't be instantiated. Constructors not generated
[INFO]             DragAndDrop.Target can't be instantiated. Constructors not generated
[INFO]             Drawable can't be instantiated. Constructors not generated
[INFO]             FocusListener can't be instantiated. Constructors not generated
[INFO]             Layout can't be instantiated. Constructors not generated
[INFO]             Disposable can't be instantiated. Constructors not generated
[INFO]             CharSequence can't be instantiated. Constructors not generated
[INFO]             Enum can't be instantiated. Constructors not generated
[INFO]             List can't be instantiated. Constructors not generated
[INFO]             ListIterator can't be instantiated. Constructors not generated
[INFO]             Map can't be instantiated. Constructors not generated
```
