### PR TITLE
Fix ScreenUtils reading pixels outside the framebuffer

### DIFF
--- a/gdx/src/com/badlogic/gdx/utils/ScreenUtils.java
+++ b/gdx/src/com/badlogic/gdx/utils/ScreenUtils.java
@@ -53,22 +53,20 @@ public class ScreenUtils {
 	 * @param w the width of the framebuffer contents to capture
 	 * @param h the height of the framebuffer contents to capture */
 	public static TextureRegion getFrameBufferTexture (int x, int y, int w, int h) {
-		Gdx.gl.glPixelStorei(GL10.GL_PACK_ALIGNMENT, 1);
 		final int potW = MathUtils.nextPowerOfTwo(w);
 		final int potH = MathUtils.nextPowerOfTwo(h);
 
-		final Pixmap pixmap = new Pixmap(potW, potH, Format.RGBA8888);
-		ByteBuffer pixels = pixmap.getPixels();
-		Gdx.gl.glReadPixels(x, y, potW, potH, GL10.GL_RGBA, GL10.GL_UNSIGNED_BYTE, pixels);
-
-		Texture texture = new Texture(pixmap);
+		final Pixmap pixmap = getFrameBufferPixmap(x, y, w, h);
+		final Pixmap potPixmap = new Pixmap(potW, potH, Format.RGBA8888);
+		potPixmap.drawPixmap(pixmap, 0, 0);
+		Texture texture = new Texture(potPixmap);
 		TextureRegion textureRegion = new TextureRegion(texture, 0, h, w, -h);
 		pixmap.dispose();
 
 		return textureRegion;
 	}
-	
-	public static Pixmap getFrameBufferPixmap(int x, int y, int w, int h) {
+
+	public static Pixmap getFrameBufferPixmap (int x, int y, int w, int h) {
 		Gdx.gl.glPixelStorei(GL10.GL_PACK_ALIGNMENT, 1);
 
 		final Pixmap pixmap = new Pixmap(w, h, Format.RGBA8888);


### PR DESCRIPTION
Currently, getFrameBufferTexture calls glReadPixels to read pixels to a potted pixmap bigger than screen size, assuming what pixels laid outside the framebuffer will simply have values of 0.
It's true on desktop, but on some android devices, the pixel data is totally wrong.

FramebufferToTextureTest on HTC Desire C:
![Bug](https://f.cloud.github.com/assets/3694019/1934419/e9ca9d92-7ee9-11e3-84d1-faf540b08d5f.png)

And as noted in http://www.khronos.org/opengles/sdk/docs/man/xhtml/glReadPixels.xml, "Values for pixels that lie outside the window connected to the current GL context are undefined"

This fix fixes it.
![Fixed](https://f.cloud.github.com/assets/3694019/1934965/7a79b2a8-7ef2-11e3-9876-c58db52d608e.png)
