### PR TITLE
Change visibility of tmpV1 and tmpV2 to protected so other classes can

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g3d/utils/CameraInputController.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/utils/CameraInputController.java
@@ -71,8 +71,8 @@ public class CameraInputController extends GestureDetector {
 	protected int button = -1;
 	
 	private float startX, startY;
-	private final Vector3 tmpV1 = new Vector3();
-	private final Vector3 tmpV2 = new Vector3();
+	protected final Vector3 tmpV1 = new Vector3();
+	protected final Vector3 tmpV2 = new Vector3();
 	
 	protected static class CameraGestureListener extends GestureAdapter {
 		public CameraInputController controller;


### PR DESCRIPTION
My usecase is that I want to have the camera rotate around the z-axis but found that CameraInputController hardcodes a rotate around the y-axis. I don't really want to copy-paste the entire class so changing tmpV1 and tmpV2 to protected would make it easy to extend and override process() without breaking other methods like update(). It's really a quick-fix but it doesn't seem that bad.
