### PR TITLE
Added Texture to GwtReflect.gwt.xml

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gwtref/GwtReflect.gwt.xml
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gwtref/GwtReflect.gwt.xml
@@ -21,6 +21,8 @@
 	<extend-configuration-property name="gdx.reflect.include"
 		value="com.badlogic.gdx.graphics.Color" />
 	<extend-configuration-property name="gdx.reflect.include"
+		value="com.badlogic.gdx.graphics.Texture" />
+	<extend-configuration-property name="gdx.reflect.include"
 		value="com.badlogic.gdx.utils.Array" />
 	<extend-configuration-property name="gdx.reflect.include"
 		value="com.badlogic.gdx.utils.ObjectMap" />


### PR DESCRIPTION
SpriteCache does not work in GWT as it uses Array.toArray in the endCache-method which tries to create a Texture array using reflection.

This is testable with the IsometricTileTest in GWT test runner.
