### PR TITLE
Removed unneeded wakelock permission from tests

### DIFF
--- a/tests/gdx-tests-android/AndroidManifest.xml
+++ b/tests/gdx-tests-android/AndroidManifest.xml
@@ -8,7 +8,6 @@
 	<uses-permission android:name="android.permission.RECORD_AUDIO"/>
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.VIBRATE"/>
-	<uses-permission android:name="android.permission.WAKE_LOCK"/>
 	<uses-permission android:name="android.permission.INTERNET" />
 	<uses-feature android:name="android.software.live_wallpaper" />
 		


### PR DESCRIPTION
The new wakelock we use doesn't require this permission
