### PR TITLE
Updated AndroidManifest.xml to target API Level 19

### DIFF
--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/android/AndroidManifest.xml
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/android/AndroidManifest.xml
@@ -4,7 +4,7 @@
     android:versionCode="1"
     android:versionName="1.0" >
 
-    <uses-sdk android:minSdkVersion="8" android:targetSdkVersion="17" />
+    <uses-sdk android:minSdkVersion="8" android:targetSdkVersion="19" />
 
     <application
         android:allowBackup="true"


### PR DESCRIPTION
gdx-backend-android is compiled with KitKat's android.jar now.
