### PR TITLE
Adding flexibility to ParticleEffects

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g2d/ParticleEmitter.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/ParticleEmitter.java
@@ -178,7 +178,7 @@ public class ParticleEmitter {
 	}
 
 	public void update (float delta) {
-		accumulator += Math.min(delta * 1000, 250);
+		accumulator += delta * 1000;
 		if (accumulator < 1) return;
 		int deltaMillis = (int)accumulator;
 		accumulator -= deltaMillis;
@@ -245,7 +245,7 @@ public class ParticleEmitter {
 	/** Updates and draws the particles. This is slightly more efficient than calling {@link #update(float)} and
 	 * {@link #draw(Batch)} separately. */
 	public void draw (Batch batch, float delta) {
-		accumulator += Math.min(delta * 1000, 250);
+		accumulator += delta * 1000;
 		if (accumulator < 1) {
 			draw(batch);
 			return;


### PR DESCRIPTION
There is no need to force minimum time passed in these methods. The user can already set the time, when using ParticleEffect.draw(Batch spriteBatch, float delta). I would like this to be changed, because it ruins my way of recording game video frame by frame.
