### PR TITLE
Extend GWT ReflectionCache with types used for Array.of

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gwtref/GwtReflect.gwt.xml
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gwtref/GwtReflect.gwt.xml
@@ -11,6 +11,16 @@
 	<extend-configuration-property name="gdx.reflect.include"
 		value="com.badlogic.gdx.math" />
 	<extend-configuration-property name="gdx.reflect.include"
+		value="com.badlogic.gdx.assets.AssetDescriptor" />
+	<extend-configuration-property name="gdx.reflect.include"
+		value="com.badlogic.gdx.graphics.Mesh" />
+	<extend-configuration-property name="gdx.reflect.include"
+		value="com.badlogic.gdx.graphics.g3d.Material" />
+	<extend-configuration-property name="gdx.reflect.include"
+		value="com.badlogic.gdx.graphics.g2d.TextureAtlas" />
+	<extend-configuration-property name="gdx.reflect.include"
+		value="com.badlogic.gdx.graphics.g3d.decals.Decal" />
+	<extend-configuration-property name="gdx.reflect.include"
 		value="com.badlogic.gdx.graphics.g2d.TextureRegion" />
 	<extend-configuration-property name="gdx.reflect.include"
 		value="com.badlogic.gdx.graphics.g2d.BitmapFont" />

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/decals/Decal.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/decals/Decal.java
@@ -57,7 +57,7 @@ public class Decal {
 	protected DecalMaterial material = new DecalMaterial();
 	protected boolean updated = false;
 
-	protected Decal () {
+	public Decal () {
 	}
 
 	/** Sets the color of all four vertices to the specified color


### PR DESCRIPTION
Fixing error introduced with https://github.com/libgdx/libgdx/pull/1217
