### PR TITLE
Add FrameBuffer#bind/unbind

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/glutils/FrameBuffer.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/FrameBuffer.java
@@ -212,7 +212,7 @@ public class FrameBuffer implements Disposable {
 	}
 	
 	/** Unbinds the framebuffer, all drawing will be performed to the normal framebuffer from here on. */
-	public void unbind () {
+	public static void unbind () {
 		Gdx.graphics.getGL20().glBindFramebuffer(GL20.GL_FRAMEBUFFER, defaultFramebufferHandle);
 	}
 	


### PR DESCRIPTION
Related to PR #1094 and #1221, added two methods: FrameBuffer#bind() and FrameBuffer.unbind() (the latter being static), giving more control to the user.
