### PR TITLE
Fixed setting previousScrollFocus in Dialog class

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Dialog.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Dialog.java
@@ -82,7 +82,7 @@ public class Dialog extends Window {
 		contentTable.defaults().space(6);
 		buttonTable.defaults().space(6);
 
-		buttonTable.addCaptureListener(new ChangeListener() {
+		buttonTable.addListener(new ChangeListener() {
 			public void changed (ChangeEvent event, Actor actor) {
 				if (!values.containsKey(actor)) return;
 				while (actor.getParent() != buttonTable)


### PR DESCRIPTION
After dialog window has been shown, stage's scroll focus doesn't receive scroll events.
I have attached small fix for this.

Regarding case when some dialog's button creates (calls 'show') another dialog. 
Such behaviour leads to losing stage's scroll (and keyboard, actually) focus, because the new dialog is added before old dialog is removed. 

Also we need to restore scroll focus just when dialog begins to hide and not when animation is done.
Second commit fixes this issue.
