### PR TITLE
Removed the isTemplate value for 'android/res/values/strings.xml'

### DIFF
--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetup.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetup.java
@@ -58,7 +58,7 @@ public class GdxSetup {
 
 		// android project
 		project.files.add(new ProjectFile("android/assets/badlogic.jpg", false));
-		project.files.add(new ProjectFile("android/res/values/strings.xml", false));
+		project.files.add(new ProjectFile("android/res/values/strings.xml"));
 		project.files.add(new ProjectFile("android/res/values/styles.xml", false));
 		project.files.add(new ProjectFile("android/res/drawable-hdpi/ic_launcher.png", false));
 		project.files.add(new ProjectFile("android/res/drawable-mdpi/ic_launcher.png", false));


### PR DESCRIPTION
modified the bug that %APP_NAME% is not replaced in "android/res/values/strings.xml".
