### PR TITLE
Make VertexAttributes implement Iterable

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/VertexAttributes.java
+++ b/gdx/src/com/badlogic/gdx/graphics/VertexAttributes.java
@@ -190,7 +190,7 @@ public final class VertexAttributes implements Iterable<VertexAttribute> {
 		return iterable.iterator();
 	}
 	
-	static public class ReadonlyIterator<T> implements Iterator<T>, Iterable<T> {
+	static private class ReadonlyIterator<T> implements Iterator<T>, Iterable<T> {
 		private final T[] array;
 		int index;
 		boolean valid = true;
@@ -227,7 +227,7 @@ public final class VertexAttributes implements Iterable<VertexAttribute> {
 		}
 	}
 	
-	static public class ReadonlyIterable<T> implements Iterable<T> {
+	static private class ReadonlyIterable<T> implements Iterable<T> {
 		private final T[] array;
 		private ReadonlyIterator iterator1, iterator2;
 


### PR DESCRIPTION
Closes #1228
Basically includes a copy of Array.ArrayIterable (ReadonlyIterable) and Array.ArrayIterator (ReadonlyIterator), but with a backing fixed array T[] instead of an Array&lt;T&gt; instance. Currently I made them subclasses of the VertexAttributes class, but it's probably better to rename and move them. If you agree, let me know (including a better name) and I will change it accordingly.

Also a minor change: the checkValidity() method is only needed for GLES1.x, so changed the name and only call it when isGL20Available() returns false.
