### PR TITLE
better error handling of null style argument for TextButton

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextButton.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextButton.java
@@ -52,6 +52,9 @@ public class TextButton extends Button {
 	}
 
 	public void setStyle (ButtonStyle style) {
+		if (style == null) {
+			throw new NullPointerException("style cannot be null");
+		}
 		if (!(style instanceof TextButtonStyle)) throw new IllegalArgumentException("style must be a TextButtonStyle.");
 		super.setStyle(style);
 		this.style = (TextButtonStyle)style;


### PR DESCRIPTION
before this the error message on passing a null argument doesn't make it completely obvious what the problem is:

```
// pass null as style
Exception in thread "LWJGL Application" java.lang.IllegalArgumentException: style must be a TextButtonStyle.
```
