### PR TITLE
GWT Reflection: simplified generated code

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gwtref/client/Constructor.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gwtref/client/Constructor.java
@@ -21,7 +21,7 @@ package com.badlogic.gwtref.client;
 public class Constructor extends Method {
 	Constructor (String name, Class enclosingType, Class returnType, Parameter[] parameters, boolean isAbstract, boolean isFinal,
 		boolean isStatic, boolean isDefaultAccess, boolean isPrivate, boolean isProtected, boolean isPublic, boolean isNative,
-		boolean isVarArgs, boolean isMethod, boolean isConstructor, String methodId) {
+		boolean isVarArgs, boolean isMethod, boolean isConstructor, int methodId) {
 		super(name, enclosingType, returnType, parameters, isAbstract, isFinal, isStatic, isDefaultAccess, isPrivate, isProtected,
 			isPublic, isNative, isVarArgs, isMethod, isConstructor, methodId);
 	}

--- a/backends/gdx-backends-gwt/src/com/badlogic/gwtref/client/Field.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gwtref/client/Field.java
@@ -31,13 +31,13 @@ public class Field {
 	final boolean isStatic;
 	final boolean isTransient;
 	final boolean isVolatile;
-	final String getter;
-	final String setter;
+	final int getter;
+	final int setter;
 	final Class[] elementTypes;
 
 	Field (String name, Class enclosingType, Class type, boolean isFinal, boolean isDefaultAccess, boolean isPrivate,
-		boolean isProtected, boolean isPublic, boolean isStatic, boolean isTransient, boolean isVolatile, String getter,
-		String setter, Class[] elementTypes) {
+		boolean isProtected, boolean isPublic, boolean isStatic, boolean isTransient, boolean isVolatile, int getter, int setter,
+		Class[] elementTypes) {
 		this.name = name;
 		this.enclosingType = enclosingType;
 		this.type = type;

--- a/backends/gdx-backends-gwt/src/com/badlogic/gwtref/client/Method.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gwtref/client/Method.java
@@ -37,11 +37,11 @@ public class Method {
 	final boolean isMethod;
 	final boolean isConstructor;
 	final Parameter[] parameters;
-	final String methodId;
+	final int methodId;
 
 	public Method (String name, Class enclosingType, Class returnType, Parameter[] parameters, boolean isAbstract,
 		boolean isFinal, boolean isStatic, boolean isDefaultAccess, boolean isPrivate, boolean isProtected, boolean isPublic,
-		boolean isNative, boolean isVarArgs, boolean isMethod, boolean isConstructor, String methodId) {
+		boolean isNative, boolean isVarArgs, boolean isMethod, boolean isConstructor, int methodId) {
 		this.name = name;
 		this.enclosingType = enclosingType;
 		this.parameters = parameters != null ? parameters : EMPTY_PARAMS;

--- a/backends/gdx-backends-gwt/src/com/badlogic/gwtref/client/Type.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gwtref/client/Type.java
@@ -30,6 +30,7 @@ public class Type {
 	private static final Constructor[] EMPTY_CONSTRUCTORS = new Constructor[0];
 
 	String name;
+	int id;
 	Class clazz;
 	Class superClass;
 	Set<Class> assignables = new HashSet<Class>();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ProjectiveTextureTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ProjectiveTextureTest.java
@@ -81,7 +81,7 @@ public class ProjectiveTextureTest extends GdxTest {
 		multiplexer.addProcessor(controller);
 		Gdx.input.setInputProcessor(multiplexer);
 
-		renderer = new ImmediateModeRenderer20(false, true, 0);
+		//renderer = new ImmediateModeRenderer20(false, true, 0);
 	}
 
 	public void setupScene () {
@@ -171,6 +171,7 @@ public class ProjectiveTextureTest extends GdxTest {
 		projTexShader.end();
 
 		fps.setText("fps: " + Gdx.graphics.getFramesPerSecond());
+		ui.act();
 		ui.draw();
 		Table.drawDebug(ui);
 	}
@@ -198,6 +199,6 @@ public class ProjectiveTextureTest extends GdxTest {
 		projTexShader.dispose();
 		ui.dispose();
 		skin.dispose();
-		renderer.dispose();
+		//renderer.dispose();
 	}
 }

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ReflectionTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ReflectionTest.java
@@ -23,6 +23,7 @@ import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.tests.utils.GdxTest;
 import com.badlogic.gdx.utils.Json;
+import com.badlogic.gdx.utils.reflect.ArrayReflection;
 import com.badlogic.gdx.utils.reflect.ClassReflection;
 import com.badlogic.gdx.utils.reflect.Constructor;
 import com.badlogic.gdx.utils.reflect.Field;
@@ -73,6 +74,14 @@ public class ReflectionTest extends GdxTest {
 			fromJson.x += 1;
 			fromJson.y += 1;
 			println("JSON deserialized + 1/1: " + fromJson);
+
+			Object array = ArrayReflection.newInstance(int.class, 5);
+			ArrayReflection.set(array, 0, 42);
+			println("Array int: length=" + ArrayReflection.getLength(array) + ", access=" + ArrayReflection.get(array, 0));
+
+			array = ArrayReflection.newInstance(String.class, 5);
+			ArrayReflection.set(array, 0, "test string");
+			println("Array String: length=" + ArrayReflection.getLength(array) + ", access=" + ArrayReflection.get(array, 0));
 		} catch (Exception e) {
 			message = "FAILED: " + e.getMessage() + "\n";
 			message += e.getClass();


### PR DESCRIPTION
The Reflection Cache uses now integer ids instead of strings for type/method/constructor lookups. This greatly simplifies the generated code.
