### PR TITLE
NPE in ReflectionPool

### DIFF
--- a/gdx/src/com/badlogic/gdx/utils/ReflectionPool.java
+++ b/gdx/src/com/badlogic/gdx/utils/ReflectionPool.java
@@ -55,9 +55,7 @@ public class ReflectionPool<T> extends Pool<T> {
 	}
 
 	protected T newObject () {
-		if (constructor == null)
-			throw new RuntimeException("Class cannot be created (missing no-arg constructor): "
-				+ constructor.getDeclaringClass().getName());
+		if (constructor == null) throw new RuntimeException("Class cannot be created (missing no-arg constructor)");
 
 		try {
 			return (T)constructor.newInstance((Object[])null);


### PR DESCRIPTION
ReflectionPool.newObject may throw an NPE instead of the expected RuntimeException if no default constructor is found.
