### PR TITLE
Update FPSLogger to use nanoTime.

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/FPSLogger.java
+++ b/gdx/src/com/badlogic/gdx/graphics/FPSLogger.java
@@ -17,7 +17,7 @@
 package com.badlogic.gdx.graphics;
 
 import com.badlogic.gdx.Gdx;
-import com.badlogic.gdx.utils.TileUtils;
+import com.badlogic.gdx.utils.TimeUtils;
 
 /** A simple helper class to log the frames per seconds achieved. Just invoke the {@link #log()} method in your rendering method.
  * The output will be logged once per second.


### PR DESCRIPTION
"currentTimeMillsis" pulls time from the system clock and should not be used to measure elapsed time. Other processes like NTP, or the user, can alter the system clock and the time returned can unexpectedly shift and create bizarre and intermittent behavior.

"nanoTime" is a measure of nanoseconds from some arbitrary time point and is safe for measuring elapsed time.

The results of this bug are rather benign – worst case the time is changed back and you would not get a framerate log message for that time, or until the user restarts the program. However, this flavor of bug can cause significant intermittent issues if present in other areas if the user is unfortunate enough to have his clock changed while he is playing (this happens more than you may think thanks to NTP keeping our system clocks in sync.)

See: 
http://docs.oracle.com/javase/7/docs/api/java/lang/System.html#nanoTime%28%29
http://docs.oracle.com/javase/7/docs/api/java/lang/System.html#currentTimeMillis%28%29

BTW: This edit was done in the browser and is untested. I don't know the ramifications for this on platforms other than the desktop.
