### PR TITLE
Add support for iOS application types in the MipMapGenerator

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/glutils/MipMapGenerator.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/MipMapGenerator.java
@@ -53,7 +53,7 @@ public class MipMapGenerator {
 			return;
 		}
 
-		if (Gdx.app.getType() == ApplicationType.Android || Gdx.app.getType() == ApplicationType.WebGL) {
+		if (Gdx.app.getType() == ApplicationType.Android || Gdx.app.getType() == ApplicationType.WebGL || Gdx.app.getType() == ApplicationType.iOS) {
 			if (Gdx.graphics.isGL20Available())
 				generateMipMapGLES20(target, pixmap);
 			else


### PR DESCRIPTION
Added support for iOS application types in the MipMapGenerator utility class.  This tells libGDX to use the OGL ES2 glGenerateMipmap() call to create mipmaps, instead of the CPU-based code.  One major advantage to this fix is that you can now use non-square textures on iOS.

TESTED: built and ran on iOS simulator and on an iPknoe 4 using a small test app that applies a single-channel non-square (but POT, it was 1024 x 512) texture to the faces of a cube.
