### PR TITLE
Fix Matrix#set and other small changes

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g3d/Shader.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/Shader.java
@@ -17,20 +17,69 @@
 package com.badlogic.gdx.graphics.g3d;
 
 import com.badlogic.gdx.graphics.Camera;
+import com.badlogic.gdx.graphics.g3d.utils.BaseShaderProvider;
 import com.badlogic.gdx.graphics.g3d.utils.RenderContext;
+import com.badlogic.gdx.graphics.g3d.utils.ShaderProvider;
+import com.badlogic.gdx.graphics.glutils.ShaderProgram;
 import com.badlogic.gdx.utils.Disposable;
 
+/**
+ * Interface which is used to render one or more {@link Renderable}s.</p>
+ * 
+ * A Shader is responsible for the actual rendering of an {@link Renderable}. Typically, when using OpenGL ES 2.0 or higher,
+ * it encapsulates a {@link ShaderProgram} and takes care of all OpenGL calls necessary to render the {@link Renderable}.
+ * When using OpenGL ES 1.x it takes care of the fixed pipeline.</p>
+ * 
+ * To start rendering the {@link #begin(Camera, RenderContext)} method must be called. After which the {@link #end()} method
+ * must be called to stop rendering. In between one or more calls to the {@link #render(Renderable)} method can be made to
+ * render a {@link Renderable}. The {@link #render(Renderable)} method must not be called before a call to 
+ * {@link #begin(Camera, RenderContext)} or after a call to {@link #end()}. Each Shader needs exclusive access to the OpenGL
+ * state and {@link RenderContext} between the {@link #begin(Camera, RenderContext)} and {@link #end()} methods, therefore
+ * only one shader can be used at a time (they must not be nested).</p>
+ * 
+ * A specific Shader instance might be (and usually is) dedicated to a specific type of {@link Renderable}. For example it
+ * might use a {@link ShaderProgram} that is compiled with uniforms (shader input) for specific {@link Attribute} types.
+ * Therefore the {@link #canRender(Renderable)} method can be used to check if the Shader instance can be used for a specific
+ * {@link Renderable}. Rendering a {@link Renderable} using a Shader for which {@link #canRender(Renderable)} returns false
+ * might result in unpredicted behavior or crash the application.</p>
+ * 
+ * To manage multiple shaders and create a new shader when required, a {@link ShaderProvider} can be used. Therefore, in
+ * practice, a specific Shader implementation is usually accompanied by a specific {@link ShaderProvider} implementation
+ * (usually extending {@link BaseShaderProvider}).</p>
+ * 
+ * When a Shader is constructed, the {@link #init()} method must be called before it can be used. Most commonly, the 
+ * {@link #init()} method compiles the {@link ShaderProgram}, fetches uniform locations and performs other preparations for
+ * usage of the Shader. When the shader is no longer needed, it must disposed using the {@link Disposable#dispose()} method.
+ * This, for example, disposed (unloads for memory) the used {@link ShaderProgram}.</p>
+ * @author Xoppa
+ */
 public interface Shader extends Disposable {
-	/** Initializes the Shader, must be called before the Shader can be used */
+	/** Initializes the Shader, must be called before the Shader can be used. This typically compiles a {@link ShaderProgram},
+	 * fetches uniform locations and performs other preparations for usage of the Shader. */
 	void init();
 	/** Compare this shader against the other, used for sorting, light weight shaders are rendered first. */
 	int compareTo(Shader other); // TODO: probably better to add some weight value to sort on
-	/** Whether this shader is intended to render the {@link Renderable} */
+	/** Checks whether this shader is intended to render the {@link Renderable}. Use this to make sure a call to the
+	 * {@link #render(Renderable)} method will succeed. This is expected to be a fast, non-blocking method. Note that
+	 * this method will only return true if it is intended to be used. Even when it returns false the Shader might still be
+	 * capable of rendering, but it's not preferred to do so.
+	 * @oaram instance The renderable to check against this shader. 
+	 * @return true if this shader is intended to render the {@Renderable}, false otherwise. */
 	boolean canRender(Renderable instance);
-	/** Initializes the context for exclusive rendering by this shader */
+	/** Initializes the context for exclusive rendering by this shader. Use the {@link #render(Renderable)} method to render
+	 * a {@link Renderable}. When done rendering the {@link #end()} method must be called.
+	 * @param camera The camera to use when rendering
+	 * @param context The context to be used, which must be exclusive available for the shader until the call to the
+	 * {@link #end()} method. */
 	void begin(Camera camera, RenderContext context);
-	/** Renders the {@link Renderable} must be called between {@link #begin(Camera, RenderContext)} and {@link #end()} */
+	/** Renders the {@link Renderable}, must be called between {@link #begin(Camera, RenderContext)} and {@link #end()}. The
+	 * Shader instance might not be able to render every type of {@link Renderable}s. Use the {@link #canRender(Renderable)}
+	 * method to check if the Shader is capable of rendering a specific {@link Renderable}.
+	 * @param renderable The renderable to render, all required fields (e.g. {@link Renderable#mesh}, 
+	 * {@link Renderable#material} and others) must be set. The {@link Renderable#shader} field will be ignored. */
 	void render(final Renderable renderable);
-	/** Cleanup the context so other shaders can render */
+	/** Cleanup the context so other shaders can render. Must be called when done rendering using the {@link #render(Renderable)}
+	 * method, which must be preceded by a call to {@link #begin(Camera, RenderContext)}. After a call to this method an call
+	 * to the {@link #render(Renderable)} method will fail until the {@link #begin(Camera, RenderContext)} is called. */
 	void end();
 }

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/model/Node.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/model/Node.java
@@ -59,7 +59,7 @@ public class Node {
 	 */
 	public Matrix4 calculateLocalTransform() {
 		if (!isAnimated)
-			localTransform.idt().translate(translation).rotate(rotation).scale(scale.x, scale.y, scale.z);
+			localTransform.set(translation, rotation, scale);
 		return localTransform;
 	}
 

--- a/gdx/src/com/badlogic/gdx/math/Frustum.java
+++ b/gdx/src/com/badlogic/gdx/math/Frustum.java
@@ -24,7 +24,7 @@ import com.badlogic.gdx.math.collision.BoundingBox;
 
 /**
  * A truncated rectangular pyramid.  Used to define the viewable region and its projection onto the screen.  
- * See {@link Camera#frustum}.
+ * @see Camera#frustum
  */
 public class Frustum {
 	protected static final Vector3[] clipSpacePlanePoints = {new Vector3(-1, -1, -1), new Vector3(1, -1, -1),
@@ -41,7 +41,7 @@ public class Frustum {
 		}
 	}
 
-	/** the six clipping planes, near, far, left, right, top, bottm **/
+	/** the six clipping planes, near, far, left, right, top, bottom **/
 	public final Plane[] planes = new Plane[6];
 
 	/** eight points making up the near and far clipping "rectangles". order is counter clockwise, starting at bottom left **/
@@ -169,6 +169,30 @@ public class Frustum {
 				if (planes[i].testPoint(corners[j]) == PlaneSide.Back) out++;
 
 			if (out == 8) return false;
+		}
+
+		return true;
+	}
+	
+	/** Returns whether the given bounding box is in the frustum.
+	 * @return Whether the bounding box is in the frustum */
+	public boolean boundsInFrustum (Vector3 center, Vector3 dimensions) {
+		return boundsInFrustum(center.x, center.y, center.z, dimensions.x/2, dimensions.y/2, dimensions.z/2);
+	}
+	
+	/** Returns whether the given bounding box is in the frustum.
+	 * @return Whether the bounding box is in the frustum */
+	public boolean boundsInFrustum (float x, float y, float z, float halfWidth, float halfHeight, float halfDepth) {
+		for (int i = 0, len2 = planes.length; i < len2; i++) {
+			if (planes[i].testPoint(x+halfWidth, y+halfHeight, z+halfDepth) != PlaneSide.Back) continue;
+			if (planes[i].testPoint(x+halfWidth, y+halfHeight, z-halfDepth) != PlaneSide.Back) continue;
+			if (planes[i].testPoint(x+halfWidth, y-halfHeight, z+halfDepth) != PlaneSide.Back) continue;
+			if (planes[i].testPoint(x+halfWidth, y-halfHeight, z-halfDepth) != PlaneSide.Back) continue;
+			if (planes[i].testPoint(x-halfWidth, y+halfHeight, z+halfDepth) != PlaneSide.Back) continue;
+			if (planes[i].testPoint(x-halfWidth, y+halfHeight, z-halfDepth) != PlaneSide.Back) continue;
+			if (planes[i].testPoint(x-halfWidth, y-halfHeight, z+halfDepth) != PlaneSide.Back) continue;
+			if (planes[i].testPoint(x-halfWidth, y-halfHeight, z-halfDepth) != PlaneSide.Back) continue;
+			return false;
 		}
 
 		return true;

--- a/gdx/src/com/badlogic/gdx/math/Matrix4.java
+++ b/gdx/src/com/badlogic/gdx/math/Matrix4.java
@@ -28,22 +28,54 @@ import java.io.Serializable;
  * @author badlogicgames@gmail.com */
 public class Matrix4 implements Serializable {
 	private static final long serialVersionUID = -2717655254359579617L;
-	public static final int M00 = 0;// 0;
-	public static final int M01 = 4;// 1;
-	public static final int M02 = 8;// 2;
-	public static final int M03 = 12;// 3;
-	public static final int M10 = 1;// 4;
-	public static final int M11 = 5;// 5;
-	public static final int M12 = 9;// 6;
-	public static final int M13 = 13;// 7;
-	public static final int M20 = 2;// 8;
-	public static final int M21 = 6;// 9;
-	public static final int M22 = 10;// 10;
-	public static final int M23 = 14;// 11;
-	public static final int M30 = 3;// 12;
-	public static final int M31 = 7;// 13;
-	public static final int M32 = 11;// 14;
-	public static final int M33 = 15;// 15;
+	/** XX: Typically the unrotated X component for scaling, also the cosine of the angle when rotated on the Y and/or Z axis. 
+	 * On Vector3 multiplication this value is multiplied with the source X component and added to the target X component. */ 
+	public static final int M00 = 0;
+	/** XY: Typically the negative sine of the angle when rotated on the Z axis.
+	 * On Vector3 multiplication this value is multiplied with the source Y component and added to the target X component. */
+	public static final int M01 = 4;
+	/** XZ: Typically the sine of the angle when rotated on the Y axis.
+	 * On Vector3 multiplication this value is multiplied with the source Z component and added to the target X component. */
+	public static final int M02 = 8;
+	/** XW: Typically the translation of the X component.
+	 * On Vector3 multiplication this value is added to the target X component. */ 
+	public static final int M03 = 12;
+	/** YX: Typically the sine of the angle when rotated on the Z axis.
+	 * On Vector3 multiplication this value is multiplied with the source X component and added to the target Y component. */
+	public static final int M10 = 1;
+	/** YY: Typically the unrotated Y component for scaling, also the cosine of the angle when rotated on the X and/or Z axis.
+	 * On Vector3 multiplication this value is multiplied with the source Y component and added to the target Y component. */
+	public static final int M11 = 5;
+	/** YZ: Typically the negative sine of the angle when rotated on the X axis.
+	 * On Vector3 multiplication this value is multiplied with the source Z component and added to the target Y component. */
+	public static final int M12 = 9;
+	/** YW: Typically the translation of the Y component.
+	 * On Vector3 multiplication this value is added to the target Y component. */
+	public static final int M13 = 13;
+	/** ZX: Typically the negative sine of the angle when rotated on the Y axis.
+	 * On Vector3 multiplication this value is multiplied with the source X component and added to the target Z component. */
+	public static final int M20 = 2;
+	/** ZY: Typical the sine of the angle when rotated on the X axis.
+	 * On Vector3 multiplication this value is multiplied with the source Y component and added to the target Z component. */
+	public static final int M21 = 6;
+	/** ZZ: Typically the unrotated Z component for scaling, also the cosine of the angle when rotated on the X and/or Y axis.
+	 * On Vector3 multiplication this value is multiplied with the source Z component and added to the target Z component. */
+	public static final int M22 = 10;
+	/** ZW: Typically the translation of the Z component.
+	 * On Vector3 multiplication this value is added to the target Z component. */
+	public static final int M23 = 14;
+	/** WX: Typically the value zero.
+	 * On Vector3 multiplication this value is ignored. */
+	public static final int M30 = 3;
+	/** WY: Typically the value zero.
+	 * On Vector3 multiplication this value is ignored. */
+	public static final int M31 = 7;
+	/** WZ: Typically the value zero.
+	 * On Vector3 multiplication this value is ignored. */
+	public static final int M32 = 11;
+	/** WW: Typically the value one.
+	 * On Vector3 multiplication this value is ignored. */
+	public static final int M33 = 15;
 
 	public final float tmp[] = new float[16];
 	public final float val[] = new float[16];
@@ -114,38 +146,58 @@ public class Matrix4 implements Serializable {
 	
 	/** Sets the matrix to a rotation matrix representing the quaternion.
 	 * 
-	 * @param x The X component of the quaternion that is to be used to set this matrix.
-	 * @param y The Y component of the quaternion that is to be used to set this matrix.
-	 * @param z The Z component of the quaternion that is to be used to set this matrix.
-	 * @param w The W component of the quaternion that is to be used to set this matrix.
+	 * @param quaternionX The X component of the quaternion that is to be used to set this matrix.
+	 * @param quaternionY The Y component of the quaternion that is to be used to set this matrix.
+	 * @param quaternionZ The Z component of the quaternion that is to be used to set this matrix.
+	 * @param quaternionW The W component of the quaternion that is to be used to set this matrix.
 	 * @return This matrix for the purpose of chaining methods together. */
-	public Matrix4 set(float x, float y, float z, float w) {
-		float l_xx = x * x;
-		float l_xy = x * y;
-		float l_xz = x * z;
-		float l_xw = x * w;
-		float l_yy = y * y;
-		float l_yz = y * z;
-		float l_yw = y * w;
-		float l_zz = z * z;
-		float l_zw = z * w;
-		// Set matrix from quaternion
-		val[M00] = 1 - 2 * (l_yy + l_zz);
-		val[M01] = 2 * (l_xy - l_zw);
-		val[M02] = 2 * (l_xz + l_yw);
-		val[M03] = 0;
-		val[M10] = 2 * (l_xy + l_zw);
-		val[M11] = 1 - 2 * (l_xx + l_zz);
-		val[M12] = 2 * (l_yz - l_xw);
-		val[M13] = 0;
-		val[M20] = 2 * (l_xz - l_yw);
-		val[M21] = 2 * (l_yz + l_xw);
-		val[M22] = 1 - 2 * (l_xx + l_yy);
-		val[M23] = 0;
-		val[M30] = 0;
-		val[M31] = 0;
-		val[M32] = 0;
-		val[M33] = 1;
+	public Matrix4 set(float quaternionX, float quaternionY, float quaternionZ, float quaternionW) {
+		return set(0f, 0f, 0f, quaternionX, quaternionY, quaternionZ, quaternionW);
+	}
+	
+	/** Set this matrix to the specified translation and rotation.
+	 * @param position The translation
+	 * @param orientation The rotation, must be normalized
+	 * @return This matrix for chaining */
+	public Matrix4 set (Vector3 position, Quaternion orientation) {
+		return set(position.x, position.y, position.z, orientation.x, orientation.y, orientation.z, orientation.w);
+	}
+		
+	/** Sets the matrix to a rotation matrix representing the translation and quaternion.
+	 * 
+	 * @param translationX The X component of the translation that is to be used to set this matrix.
+	 * @param translationY The Y component of the translation that is to be used to set this matrix.
+	 * @param translationZ The Z component of the translation that is to be used to set this matrix.
+	 * @param quaternionX The X component of the quaternion that is to be used to set this matrix.
+	 * @param quaternionY The Y component of the quaternion that is to be used to set this matrix.
+	 * @param quaternionZ The Z component of the quaternion that is to be used to set this matrix.
+	 * @param quaternionW The W component of the quaternion that is to be used to set this matrix.
+	 * @return This matrix for the purpose of chaining methods together. */
+	public Matrix4 set(float translationX, float translationY, float translationZ, float quaternionX, float quaternionY, float quaternionZ, float quaternionW) {
+		final float xs = quaternionX * 2f,	ys = quaternionY * 2f,	zs = quaternionZ * 2f;
+		final float wx = quaternionW * xs,	wy = quaternionW * ys, 	wz = quaternionW * zs;
+		final float xx = quaternionX * xs,	xy = quaternionX * ys, 	xz = quaternionX * zs;
+		final float yy = quaternionY * ys,	yz = quaternionY * zs,	zz = quaternionZ * zs;
+
+		val[M00] = (1.0f - (yy + zz));
+		val[M01] = (xy - wz);
+		val[M02] = (xz + wy);
+		val[M03] = translationX;
+		
+		val[M10] = (xy + wz);
+		val[M11] = (1.0f - (xx + zz));
+		val[M12] = (yz - wx);
+		val[M13] = translationY;
+		
+		val[M20] = (xz - wy);
+		val[M21] = (yz + wx);
+		val[M22] = (1.0f - (xx + yy));
+		val[M23] = translationZ;
+		
+		val[M30] = 0.f;
+		val[M31] = 0.f;
+		val[M32] = 0.f;
+		val[M33] = 1.0f;
 		return this;
 	}
 	
@@ -155,31 +207,47 @@ public class Matrix4 implements Serializable {
 	 * @param scale The scale
 	 * @return This matrix for chaining */
 	public Matrix4 set (Vector3 position, Quaternion orientation, Vector3 scale) {
-		final float xs = orientation.x * 2f,	ys = orientation.y * 2f,	zs = orientation.z * 2f;
-		final float wx = orientation.w * xs,	wy = orientation.w * ys, 	wz = orientation.w * zs;
-		final float xx = orientation.x * xs,	xy = orientation.x * ys, 	xz = orientation.x * zs;
-		final float yy = orientation.y * ys,	yz = orientation.y * zs,	zz = orientation.z * zs;
+		return set(position.x, position.y, position.z, orientation.x, orientation.y, orientation.z, orientation.w, scale.x, scale.y, scale.z);
+	}
+	
+	/** Sets the matrix to a rotation matrix representing the translation and quaternion.
+	 * 
+	 * @param translationX The X component of the translation that is to be used to set this matrix.
+	 * @param translationY The Y component of the translation that is to be used to set this matrix.
+	 * @param translationZ The Z component of the translation that is to be used to set this matrix.
+	 * @param quaternionX The X component of the quaternion that is to be used to set this matrix.
+	 * @param quaternionY The Y component of the quaternion that is to be used to set this matrix.
+	 * @param quaternionZ The Z component of the quaternion that is to be used to set this matrix.
+	 * @param quaternionW The W component of the quaternion that is to be used to set this matrix.
+	 * @param scaleX The X component of the scaling that is to be used to set this matrix.
+	 * @param scaleY The Y component of the scaling that is to be used to set this matrix.
+	 * @param scaleZ The Z component of the scaling that is to be used to set this matrix. 
+	 * @return This matrix for the purpose of chaining methods together. */
+	public Matrix4 set(float translationX, float translationY, float translationZ, float quaternionX, float quaternionY, float quaternionZ, float quaternionW, float scaleX, float scaleY, float scaleZ) {
+		final float xs = quaternionX * 2f,	ys = quaternionY * 2f,	zs = quaternionZ * 2f;
+		final float wx = quaternionW * xs,	wy = quaternionW * ys, 	wz = quaternionW * zs;
+		final float xx = quaternionX * xs,	xy = quaternionX * ys, 	xz = quaternionX * zs;
+		final float yy = quaternionY * ys,	yz = quaternionY * zs,	zz = quaternionZ * zs;
 
-		val[M00] = scale.x * (1.0f - (yy + zz));
-		val[M01] = scale.x * (xy - wz);
-		val[M02] = scale.x * (xz + wy);
-		val[M03] = position.x;
+		val[M00] = scaleX * (1.0f - (yy + zz));
+		val[M01] = scaleY * (xy - wz);
+		val[M02] = scaleZ * (xz + wy);
+		val[M03] = translationX;
 		
-		val[M10] = scale.y * (xy + wz);
-		val[M11] = scale.y * (1.0f - (xx + zz));
-		val[M12] = scale.y * (yz - wx);
-		val[M13] = position.y;
+		val[M10] = scaleX * (xy + wz);
+		val[M11] = scaleY * (1.0f - (xx + zz));
+		val[M12] = scaleZ * (yz - wx);
+		val[M13] = translationY;
 		
-		val[M20] = scale.z * (xz - wy);
-		val[M21] = scale.z * (yz + wx);
-		val[M22] = scale.z * (1.0f - (xx + yy));
-		val[M23] = position.z;
+		val[M20] = scaleX * (xz - wy);
+		val[M21] = scaleY * (yz + wx);
+		val[M22] = scaleZ * (1.0f - (xx + yy));
+		val[M23] = translationZ;
 		
-		val[M30] = 0.0f;
-		val[M31] = 0.0f;
-		val[M32] = 0.0f;
+		val[M30] = 0.f;
+		val[M31] = 0.f;
+		val[M32] = 0.f;
 		val[M33] = 1.0f;
-		
 		return this;
 	}
 


### PR DESCRIPTION
Fix scaling in Matrix4#set(translation, quaternion, scale) to match FBX, see #1289.
Added Matrix4#set(translation, quaternion) and added the same methods with float arguments.
Slightly changed the existing Matrix4#set(quaternion) method to remove a few multiplications.
Added docs to the Matrix4#Mxx members with (where possible) a simple example of the value usage.
Also add some docs to the Shader interface
Add some convenience methods to Frustum.
