### PR TITLE
Android: Removed deprecated FILL_PARENT reference

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplication.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplication.java
@@ -145,8 +145,8 @@ public class AndroidApplication extends Activity implements Application {
 	}
 
 	protected FrameLayout.LayoutParams createLayoutParams () {
-		FrameLayout.LayoutParams layoutParams = new FrameLayout.LayoutParams(android.view.ViewGroup.LayoutParams.FILL_PARENT,
-			android.view.ViewGroup.LayoutParams.FILL_PARENT);
+		FrameLayout.LayoutParams layoutParams = new FrameLayout.LayoutParams(android.view.ViewGroup.LayoutParams.MATCH_PARENT,
+			android.view.ViewGroup.LayoutParams.MATCH_PARENT);
 		layoutParams.gravity = Gravity.CENTER;
 		return layoutParams;
 	}


### PR DESCRIPTION
Since we now target 2.2+ we get access to MATCH_PARENT the field that replaced FILL_PARENT.
See: http://developer.android.com/reference/android/view/ViewGroup.LayoutParams.html#MATCH_PARENT

This is just part of my effort to remove dependence on deprecated code.
