### PR TITLE
Android Backend: Deprecation cleanup

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplication.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplication.java
@@ -372,7 +372,7 @@ public class AndroidApplication extends Activity implements Application {
 
 	@Override
 	public int getVersion () {
-		return Integer.parseInt(android.os.Build.VERSION.SDK);
+		return android.os.Build.VERSION.SDK_INT;
 	}
 
 	@Override

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidAudioDevice.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidAudioDevice.java
@@ -40,10 +40,10 @@ class AndroidAudioDevice implements AudioDevice {
 
 	AndroidAudioDevice (int samplingRate, boolean isMono) {
 		this.isMono = isMono;
-		int minSize = AudioTrack.getMinBufferSize(samplingRate, isMono ? AudioFormat.CHANNEL_CONFIGURATION_MONO
-			: AudioFormat.CHANNEL_CONFIGURATION_STEREO, AudioFormat.ENCODING_PCM_16BIT);
-		track = new AudioTrack(AudioManager.STREAM_MUSIC, samplingRate, isMono ? AudioFormat.CHANNEL_CONFIGURATION_MONO
-			: AudioFormat.CHANNEL_CONFIGURATION_STEREO, AudioFormat.ENCODING_PCM_16BIT, minSize, AudioTrack.MODE_STREAM);
+		int minSize = AudioTrack.getMinBufferSize(samplingRate, isMono ? AudioFormat.CHANNEL_OUT_MONO
+			: AudioFormat.CHANNEL_OUT_STEREO, AudioFormat.ENCODING_PCM_16BIT);
+		track = new AudioTrack(AudioManager.STREAM_MUSIC, samplingRate, isMono ? AudioFormat.CHANNEL_OUT_MONO
+			: AudioFormat.CHANNEL_OUT_STEREO, AudioFormat.ENCODING_PCM_16BIT, minSize, AudioTrack.MODE_STREAM);
 		track.play();
 		latency = minSize / (isMono ? 1 : 2);
 	}

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidDaydream.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidDaydream.java
@@ -123,8 +123,8 @@ public class AndroidDaydream extends DreamService implements Application {
 	}
 
 	protected FrameLayout.LayoutParams createLayoutParams () {
-		FrameLayout.LayoutParams layoutParams = new FrameLayout.LayoutParams(android.view.ViewGroup.LayoutParams.FILL_PARENT,
-			android.view.ViewGroup.LayoutParams.FILL_PARENT);
+		FrameLayout.LayoutParams layoutParams = new FrameLayout.LayoutParams(android.view.ViewGroup.LayoutParams.MATCH_PARENT,
+			android.view.ViewGroup.LayoutParams.MATCH_PARENT);
 		layoutParams.gravity = Gravity.CENTER;
 		return layoutParams;
 	}
@@ -294,7 +294,7 @@ public class AndroidDaydream extends DreamService implements Application {
 
 	@Override
 	public int getVersion () {
-		return Integer.parseInt(android.os.Build.VERSION.SDK);
+		return android.os.Build.VERSION.SDK_INT;
 	}
 
 	@Override

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphics.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphics.java
@@ -105,7 +105,7 @@ public final class AndroidGraphics implements Graphics, Renderer {
 	}
 
 	private void setPreserveContext (View view) {
-		int sdkVersion = Integer.parseInt(android.os.Build.VERSION.SDK);
+		int sdkVersion = android.os.Build.VERSION.SDK_INT;
 		if (sdkVersion >= 11 && view instanceof GLSurfaceView20) {
 			try {
 				Method method = null;
@@ -137,7 +137,7 @@ public final class AndroidGraphics implements Graphics, Renderer {
 		} else {
 			config.useGL20 = false;
 			configChooser = getEglConfigChooser();
-			int sdkVersion = Integer.parseInt(android.os.Build.VERSION.SDK);
+			int sdkVersion = android.os.Build.VERSION.SDK_INT;
 
 			if (sdkVersion >= 11) {
 				GLSurfaceView view = new GLSurfaceView(activity) {
@@ -153,7 +153,7 @@ public final class AndroidGraphics implements Graphics, Renderer {
 						BaseInputConnection connection = new BaseInputConnection(this, false) {
 							@Override
 							public boolean deleteSurroundingText (int beforeLength, int afterLength) {
-								int sdkVersion = Integer.parseInt(android.os.Build.VERSION.SDK);
+								int sdkVersion = android.os.Build.VERSION.SDK_INT;
 								if (sdkVersion >= 16) {
 									/*
 									 * In Jelly Bean, they don't send key events for delete. Instead, they send beforeLength = 1,

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphicsDaydream.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphicsDaydream.java
@@ -146,7 +146,7 @@ public final class AndroidGraphicsDaydream implements Graphics, Renderer {
 		} else {
 			config.useGL20 = false;
 			configChooser = getEglConfigChooser();
-			int sdkVersion = Integer.parseInt(android.os.Build.VERSION.SDK);
+			int sdkVersion = android.os.Build.VERSION.SDK_INT;
 
 			if (sdkVersion >= 11) {
 				GLSurfaceView view = new GLSurfaceView(dream) {

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphicsLiveWallpaper.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphicsLiveWallpaper.java
@@ -106,7 +106,7 @@ public final class AndroidGraphicsLiveWallpaper implements Graphics, Renderer {
 	// will be replaced by subclass of original GLSurfaceView, i'm working on it:)
 	// <- ok it is in use now
 	private void setPreserveContext (Object view) {
-		int sdkVersion = Integer.parseInt(android.os.Build.VERSION.SDK);
+		int sdkVersion = android.os.Build.VERSION.SDK_INT;
 		if (sdkVersion >= 11 && view instanceof GLSurfaceView) {
 			try {
 				Method method = null;
@@ -166,7 +166,7 @@ public final class AndroidGraphicsLiveWallpaper implements Graphics, Renderer {
 		} else {
 			config.useGL20 = false;
 			configChooser = getEglConfigChooser();
-			int sdkVersion = Integer.parseInt(android.os.Build.VERSION.SDK);
+			int sdkVersion = android.os.Build.VERSION.SDK_INT;
 
 			if (sdkVersion >= 11) {
 				GLSurfaceView view = new GLSurfaceView(context) {

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidInput.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidInput.java
@@ -153,7 +153,7 @@ public class AndroidInput implements Input, OnKeyListener, OnTouchListener {
 		this.app = activity;
 		this.context = context;
 		this.sleepTime = config.touchSleepTime;
-		int sdkVersion = Integer.parseInt(android.os.Build.VERSION.SDK);
+		int sdkVersion = android.os.Build.VERSION.SDK_INT;
 		if (sdkVersion >= 5)
 			touchHandler = new AndroidMultiTouchHandler();
 		else
@@ -717,9 +717,9 @@ public class AndroidInput implements Input, OnKeyListener, OnTouchListener {
 		int orientation = 0;
 
 		if (context instanceof Activity) {
-			orientation = ((Activity)context).getWindowManager().getDefaultDisplay().getOrientation();
+			orientation = ((Activity)context).getWindowManager().getDefaultDisplay().getRotation();
 		} else {
-			orientation = ((WindowManager)context.getSystemService(Context.WINDOW_SERVICE)).getDefaultDisplay().getOrientation();
+			orientation = ((WindowManager)context.getSystemService(Context.WINDOW_SERVICE)).getDefaultDisplay().getRotation();
 		}
 
 		switch (orientation) {

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidLiveWallpaper.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidLiveWallpaper.java
@@ -287,7 +287,7 @@ public class AndroidLiveWallpaper implements Application {
 
 	@Override
 	public int getVersion () {
-		return Integer.parseInt(android.os.Build.VERSION.SDK);
+		return android.os.Build.VERSION.SDK_INT;
 	}
 
 	@Override

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidMultiTouchHandler.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidMultiTouchHandler.java
@@ -29,7 +29,7 @@ import com.badlogic.gdx.backends.android.AndroidInput.TouchEvent;
 public class AndroidMultiTouchHandler implements AndroidTouchHandler {
 	public void onTouch (MotionEvent event, AndroidInput input) {
 		final int action = event.getAction() & MotionEvent.ACTION_MASK;
-		int pointerIndex = (event.getAction() & MotionEvent.ACTION_POINTER_ID_MASK) >> MotionEvent.ACTION_POINTER_ID_SHIFT;
+		int pointerIndex = (event.getAction() & MotionEvent.ACTION_POINTER_INDEX_MASK) >> MotionEvent.ACTION_POINTER_INDEX_SHIFT;
 		int pointerId = event.getPointerId(pointerIndex);
 
 		int x = 0, y = 0;

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidOnscreenKeyboard.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidOnscreenKeyboard.java
@@ -65,7 +65,7 @@ class AndroidOnscreenKeyboard implements OnKeyListener, OnTouchListener {
 	Dialog createDialog () {
 		textView = createView(context);
 		textView.setOnKeyListener(this);
-		FrameLayout.LayoutParams textBoxLayoutParams = new FrameLayout.LayoutParams(FrameLayout.LayoutParams.FILL_PARENT,
+		FrameLayout.LayoutParams textBoxLayoutParams = new FrameLayout.LayoutParams(FrameLayout.LayoutParams.MATCH_PARENT,
 			FrameLayout.LayoutParams.WRAP_CONTENT, Gravity.BOTTOM);
 		textView.setLayoutParams(textBoxLayoutParams);
 		textView.setFocusable(true);
@@ -73,7 +73,7 @@ class AndroidOnscreenKeyboard implements OnKeyListener, OnTouchListener {
 		textView.setImeOptions(textView.getImeOptions() | EditorInfo.IME_FLAG_NO_EXTRACT_UI);
 
 		final FrameLayout layout = new FrameLayout(context);
-		ViewGroup.LayoutParams layoutParams = new ViewGroup.LayoutParams(ViewGroup.LayoutParams.FILL_PARENT, 0);
+		ViewGroup.LayoutParams layoutParams = new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, 0);
 		layout.setLayoutParams(layoutParams);
 		layout.addView(textView);
 		layout.setOnTouchListener(this);


### PR DESCRIPTION
Since 2.2 is our minimum I cleaned up most of the deprecation of the
classes. I skipped only what wasn't possible right now or what I (and
eclipse) didn't notice. All using the recommend by Google. 
