### PR TITLE
Android (fragment): Added isFragment method + Fixed possible ClassNotFoundException

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplication.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplication.java
@@ -503,4 +503,9 @@ public class AndroidApplication extends Activity implements AndroidApplicationBa
 	public Array<LifecycleListener> getLifecycleListeners () {
 		return lifecycleListeners;
 	}
+
+	@Override
+	public boolean isFragment () {
+		return false;
+	}
 }

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplicationBase.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplicationBase.java
@@ -76,5 +76,11 @@ public interface AndroidApplicationBase extends Application {
 	 * @return the array of {@link LifecycleListener}'s
 	 */
 	Array<LifecycleListener> getLifecycleListeners();
+	
+	/**
+	 * Returns if this application is a fragment
+	 * @return true if the application is a fragment, otherwise false
+	 */
+	boolean isFragment();
 
 }

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidFragmentApplication.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidFragmentApplication.java
@@ -383,4 +383,9 @@ public class AndroidFragmentApplication extends Fragment implements AndroidAppli
 	public Array<LifecycleListener> getLifecycleListeners () {
 		return lifecycleListeners;
 	}
+
+	@Override
+	public boolean isFragment () {
+		return true;
+	}
 }

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphics.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphics.java
@@ -489,7 +489,7 @@ public final class AndroidGraphics implements Graphics, Renderer {
 		}
 
 		if (lresume) {
-			if (app instanceof AndroidFragmentApplication) {
+			if (app.isFragment()) {
 				((AndroidAudio)((AndroidApplicationBase)app).getAudio()).resume();
 			}
 			Array<LifecycleListener> listeners = ((AndroidApplicationBase)app).getLifecycleListeners();


### PR DESCRIPTION
This allows us to make check if the app is a fragment without having the
developer depend on the support jar. This prevents an ClassNotFoundException in AndroidGraphics that could occur if support jar is missing. My bad.
