### PR TITLE
GWT Reflection: Create Type information on Demand

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/preloader/Preloader.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/preloader/Preloader.java
@@ -123,7 +123,7 @@ public class Preloader {
 			@Override
 			public void onSuccess (String result) {
 				String[] lines = result.split("\n");
-				Array<Asset> assets = new Array<Asset>();
+				Array<Asset> assets = new Array<Asset>(lines.length);
 				for (String line : lines) {
 					String[] tokens = line.split(":");
 					if (tokens.length != 4) {

--- a/backends/gdx-backends-gwt/src/com/badlogic/gwtref/client/IReflectionCache.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gwtref/client/IReflectionCache.java
@@ -20,8 +20,6 @@ import java.util.Collection;
 
 public interface IReflectionCache {
 	// Class level methods
-	public Collection<Type> getKnownTypes ();
-
 	public Type forName (String name);
 
 	public Object newArray (Type componentType, int size);

--- a/backends/gdx-backends-gwt/src/com/badlogic/gwtref/client/ReflectionCache.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gwtref/client/ReflectionCache.java
@@ -82,10 +82,6 @@ public class ReflectionCache {
 		return instance.newArray(getType(componentType), size);
 	}
 
-	public static Collection<Type> getKnownTypes () {
-		return instance.getKnownTypes();
-	}
-
 	public static Object getFieldValue (Field field, Object obj) throws IllegalAccessException {
 		return instance.get(field, obj);
 	}


### PR DESCRIPTION
To reduce startup time and memory footprint it is better to create the Type information on demand and not to create all types on startup and put them into a big HashMap.

Example for the generated code of the boolean type:

  private static Type c0;
  private static Type c0() {
  if(c0!=null) return c0;
  c0 = new Type("boolean", 0, boolean.class, null, null);
  c0.isPrimitive = true;
  return c0;
  }

And in forName a switch statement is used:

```
  case 64711720:
      if(name.equals("boolean"))return c0();
  break;
```
