### PR TITLE
Added support for dynamic resources to SkinLoader

### DIFF
--- a/gdx/src/com/badlogic/gdx/assets/loaders/SkinLoader.java
+++ b/gdx/src/com/badlogic/gdx/assets/loaders/SkinLoader.java
@@ -26,10 +26,15 @@ import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.graphics.g2d.TextureAtlas;
 import com.badlogic.gdx.scenes.scene2d.ui.Skin;
 import com.badlogic.gdx.utils.Array;
+import com.badlogic.gdx.utils.ObjectMap;
+import com.badlogic.gdx.utils.ObjectMap.Entry;
 
 /** {@link AssetLoader} for {@link Skin} instances. All {@link Texture} and {@link BitmapFont} instances will be loaded as
  * dependencies. Passing a {@link SkinParameter} allows one to specify the exact name of the texture associated with the skin.
  * Otherwise the skin texture is looked up just as with a call to {@link Skin#Skin(com.badlogic.gdx.files.FileHandle)}.
+ * Also a {@link SkinParameter} allows one to specify a set of named resources that will be added to the skin before loading
+ * the json file, meaning that they can be referenced from inside the json file itself. This is extremely useful for dynamic
+ * resources such as a BitmapFont generated through a {@link FreeTypeFontGenerator}.
  * @author Nathan Sweet */
 public class SkinLoader extends AsynchronousAssetLoader<Skin, SkinLoader.SkinParameter> {
 	public SkinLoader (FileHandleResolver resolver) {
@@ -53,23 +58,41 @@ public class SkinLoader extends AsynchronousAssetLoader<Skin, SkinLoader.SkinPar
 	@Override
 	public Skin loadSync (AssetManager manager, String fileName, FileHandle file, SkinParameter parameter) {
 		String textureAtlasPath;
-		if (parameter == null)
+		ObjectMap<String, Object> resources;
+		if (parameter == null) {
 			textureAtlasPath = file.pathWithoutExtension() + ".atlas";
-		else
+			resources = null;
+		}
+		else {
 			textureAtlasPath = parameter.textureAtlasPath;
+			resources = parameter.resources;
+		}
 		TextureAtlas atlas = manager.get(textureAtlasPath, TextureAtlas.class);
-		return new Skin(file, atlas);
+		Skin skin = new Skin(atlas);
+		if (resources != null) {
+			for (Entry<String, Object> entry : resources.entries()) {
+				skin.add(entry.key, entry.value);
+			}
+		}
+		skin.load(file);
+		return skin;
 	}
 
 	static public class SkinParameter extends AssetLoaderParameters<Skin> {
 		public final String textureAtlasPath;
+		public final ObjectMap<String, Object> resources;
 
 		public SkinParameter () {
-			this.textureAtlasPath = null;
+			this(null, null);
 		}
 
 		public SkinParameter (String textureAtlasPath) {
+			this(textureAtlasPath, null);
+		}
+
+		public SkinParameter (String textureAtlasPath, ObjectMap<String, Object> resources) {
 			this.textureAtlasPath = textureAtlasPath;
+			this.resources = resources;
 		}
 	}
 }


### PR DESCRIPTION
Now SkinParameter allows one to specify a set of named resources that will be added to the skin before loading the json file, meaning that they can be referenced from inside the json file itself.
This is extremely useful for dynamic resources such as a BitmapFont generated through a FreeTypeFontGenerator.
