### PR TITLE
Workaround for Android bug 10515463 on pre-4.4 devices

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplication.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplication.java
@@ -107,6 +107,7 @@ public class AndroidApplication extends Activity implements AndroidApplicationBa
 			: config.resolutionStrategy);
 		input = AndroidInputFactory.newAndroidInput(this, this, graphics.view, config);
 		audio = new AndroidAudio(this, config);
+		this.getFilesDir(); // workaround for Android bug #10515463
 		files = new AndroidFiles(this.getAssets(), this.getFilesDir().getAbsolutePath());
 		net = new AndroidNet(this);
 		this.listener = listener;
@@ -241,6 +242,7 @@ public class AndroidApplication extends Activity implements AndroidApplicationBa
 			: config.resolutionStrategy);
 		input = AndroidInputFactory.newAndroidInput(this, this, graphics.view, config);
 		audio = new AndroidAudio(this, config);
+		this.getFilesDir(); // workaround for Android bug #10515463
 		files = new AndroidFiles(this.getAssets(), this.getFilesDir().getAbsolutePath());
 		net = new AndroidNet(this);
 		this.listener = listener;

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidDaydream.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidDaydream.java
@@ -103,6 +103,7 @@ public class AndroidDaydream extends DreamService implements Application {
 			: config.resolutionStrategy);
 		input = AndroidInputFactory.newAndroidInput(this, this, graphics.view, config);
 		audio = new AndroidAudio(this, config);
+		this.getFilesDir(); // workaround for Android bug #10515463
 		files = new AndroidFiles(this.getAssets(), this.getFilesDir().getAbsolutePath());
 		net = new AndroidNet(null);
 		this.listener = listener;
@@ -184,6 +185,7 @@ public class AndroidDaydream extends DreamService implements Application {
 			: config.resolutionStrategy);
 		input = AndroidInputFactory.newAndroidInput(this, this, graphics.view, config);
 		audio = new AndroidAudio(this, config);
+		this.getFilesDir(); // workaround for Android bug #10515463
 		files = new AndroidFiles(this.getAssets(), this.getFilesDir().getAbsolutePath());
 		net = new AndroidNet(null);
 		this.listener = listener;

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidLiveWallpaper.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidLiveWallpaper.java
@@ -91,13 +91,14 @@ public class AndroidLiveWallpaper implements Application {
 			: config.resolutionStrategy);
 
 		// factory in use, but note: AndroidInputFactory causes exceptions when obfuscated: java.lang.RuntimeException: Couldn't
-// construct AndroidInput, this should never happen, proguard deletes constructor used only by reflection
+		// construct AndroidInput, this should never happen, proguard deletes constructor used only by reflection
 		input = AndroidInputFactory.newAndroidInput(this, this.getService(), graphics.view, config);
 		// input = new AndroidInput(this, this.getService(), null, config);
 
 		audio = new AndroidAudio(this.getService(), config);
 
 		// added initialization of android local storage: /data/data/<app package>/files/
+		this.getService().getFilesDir(); // workaround for Android bug #10515463
 		files = new AndroidFiles(this.getService().getAssets(), this.getService().getFilesDir().getAbsolutePath());
 
 		this.listener = listener;


### PR DESCRIPTION
Just to add a more meaningful description to code change in Android Application subclasses. There is a confirmed bug in all pre-4.4 Android devices, which occurs rarely but could be very annoying to application developer. The reason for a bug is a racing condition in creating app private directory on first launch; Android Open Source project team member has suggested to try the Context.getFilesDir() method again after first one failed with a "null" return value.

There is no impact on runtime performance as figuring out the private directory location and creation of necessary files is done only once; subsequent calls get the internally cached location (path).

Refer to pull request #1313 for previous discussion of this topic.

Original discussion can be found here:
https://code.google.com/p/android/issues/detail?id=8886
