### PR TITLE
Allow SO_TIMEOUT to be set on client sockets

### DIFF
--- a/gdx/src/com/badlogic/gdx/net/NetJavaSocketImpl.java
+++ b/gdx/src/com/badlogic/gdx/net/NetJavaSocketImpl.java
@@ -68,6 +68,7 @@ public class NetJavaSocketImpl implements Socket {
 				socket.setSendBufferSize(hints.sendBufferSize);
 				socket.setReceiveBufferSize(hints.receiveBufferSize);
 				socket.setSoLinger(hints.linger, hints.lingerDuration);
+				socket.setSoTimeout(hints.socketTimeout);
 			} catch (Exception e) {
 				throw new GdxRuntimeException("Error setting socket hints.", e);
 			}

--- a/gdx/src/com/badlogic/gdx/net/SocketHints.java
+++ b/gdx/src/com/badlogic/gdx/net/SocketHints.java
@@ -65,4 +65,6 @@ public class SocketHints {
 	public boolean linger = false;
 	/** The linger duration in seconds (NOT milliseconds!). Only used if linger is true! */
 	public int lingerDuration = 0;
+	/** Enable/disable SO_TIMEOUT with the specified timeout, in milliseconds. With this option set to a non-zero timeout, a read() call on the InputStream associated with this Socket will block for only this amount of time */
+	public int socketTimeout = 0;
 }


### PR DESCRIPTION
This change allows the SO_TIMEOUT option on client sockets to be set.
