### PR TITLE
Fix casting android application to base interface

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphics.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphics.java
@@ -533,15 +533,14 @@ public final class AndroidGraphics implements Graphics, Renderer {
 		}
 
 		if (ldestroy) {
-			Array<LifecycleListener> listeners = ((AndroidApplication)app).lifecycleListeners;
+			Array<LifecycleListener> listeners = ((AndroidApplicationBase)app).getLifecycleListeners();
 			synchronized (listeners) {
 				for (LifecycleListener listener : listeners) {
 					listener.dispose();
 				}
 			}
-			app.getApplicationListener().dispose();
-			((AndroidApplication)app).audio.dispose();
-			((AndroidApplication)app).audio = null;
+			((AndroidApplicationBase)app).getApplicationListener().dispose();
+			((AndroidAudio)((AndroidApplicationBase)app).getAudio()).dispose();
 			Gdx.app.log("AndroidGraphics", "destroyed");
 		}
 


### PR DESCRIPTION
Casting to AndroidApplication instead of AndroidApplicationBase is causing crashes on Android, when using the new AndroidFragmentApplication class.
