### PR TITLE
Bug where key events were being tracked, but not deduped

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtInput.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtInput.java
@@ -533,8 +533,9 @@ public class GwtInput implements Input {
 					processor.keyTyped('\b');
 				}
 			} else {
-				this.pressedKeys.add(code);
-				if (processor != null) processor.keyDown(code);
+				if (this.pressedKeys.add(code) && processor != null) {
+					processor.keyDown(code);
+				}
 			}
 		}
 
@@ -548,7 +549,9 @@ public class GwtInput implements Input {
 			System.out.println("keyup");
 			int code = keyForCode(e.getKeyCode());
 			this.pressedKeys.remove(code);
-			if (processor != null) processor.keyUp(code);
+			if (processor != null) {
+				processor.keyUp(code);
+			}
 		}
 
 		if (e.getType().equals("touchstart")) {


### PR DESCRIPTION
Fixing an issue that manifests itself on GWT builds. Input events, specifically key up and key down events, are being tracked, but that tracking information is not used to filter duplicate key events.

This can cause unexpected behavior as the desktop backend does not trigger on duplicate events.
