### PR TITLE
Added missing buildscript snapshot repository required for GDX-Tools resolution

### DIFF
--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/build.gradle
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/build.gradle
@@ -7,6 +7,7 @@ buildscript {
             url 'https://github.com/steffenschaefer/gwt-gradle-plugin/raw/maven-repo/'
         }
         mavenCentral()
+        maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
     }
 
     dependencies {


### PR DESCRIPTION
Build script was failing due to not finding '**com.badlogicgames.gdx:gdx-tools:1.0-SNAPSHOT**'. This was because the buildscript-related section of **build.gradle** did not reference the snapshots repository @ https://oss.sonatype.org/content/repositories/snapshots/.

See https://github.com/libgdx/libgdx/issues/1396
