### PR TITLE
Added skipPngCrush to the robovm.xml generator

### DIFF
--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/ios/build.gradle
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/ios/build.gradle
@@ -58,6 +58,7 @@ task buildRoboVMXML << {
         includes {
           include '**'
         }
+        skipPngCrush true
       }
     }
   }


### PR DESCRIPTION
Without skipPngCrush enabled in robovm.xml, any .png assets will be made unusable by LibGDX when run on iOS.
