### PR TITLE
Resolve 'collision.com.badlogic.gdx.physics.bullet.collision' issue

### DIFF
--- a/extensions/gdx-bullet/pom.xml
+++ b/extensions/gdx-bullet/pom.xml
@@ -43,7 +43,7 @@
             </goals>
             <configuration>
               <sources>                
-                <source>jni/swig-src/</source>
+                <source>jni/swig-src/collision</source>
               </sources>
             </configuration>
           </execution>


### PR DESCRIPTION
Source is generated into the collision subdirectory, so jni/swig-src/collision must be added to the maven add-source plugin so that IDEs import the source from the correct root.

With eclipse m2e you'll need to 'Maven->Update Project...' to see the correction work.
