### PR TITLE
Gdx-Setup-UI: Android SDK minimum is now 8

### DIFF
--- a/extensions/gdx-setup-ui/src/aurelienribon/gdxsetupui/ProjectSetupConfiguration.java
+++ b/extensions/gdx-setup-ui/src/aurelienribon/gdxsetupui/ProjectSetupConfiguration.java
@@ -22,7 +22,7 @@ package aurelienribon.gdxsetupui;
 public class ProjectSetupConfiguration extends BaseProjectConfiguration {
 	public String mainClassName = "MyGdxGame";
 	public String packageName = "com.me.mygdxgame";
-	public String androidMinSdkVersion = "5";
+	public String androidMinSdkVersion = "8";
 	public String androidTargetSdkVersion = "19";
 	public String androidMaxSdkVersion = "";
 }


### PR DESCRIPTION
We dropped support for versions < 2.2 (8).
