### PR TITLE
SharedLibraryLoader: Fixed possible issue with upcoming Android ART introduction

### DIFF
--- a/gdx/src/com/badlogic/gdx/utils/SharedLibraryLoader.java
+++ b/gdx/src/com/badlogic/gdx/utils/SharedLibraryLoader.java
@@ -45,8 +45,8 @@ public class SharedLibraryLoader {
 	static public String abi = (System.getProperty("sun.arch.abi") != null ? System.getProperty("sun.arch.abi") : "");
 
 	static {
-		String vm = System.getProperty("java.vm.name");
-		if (vm != null && vm.contains("Dalvik")) {
+		String vm = System.getProperty("java.runtime.name");
+		if (vm != null && vm.contains("Android Runtime")) {
 			isAndroid = true;
 			isWindows = false;
 			isLinux = false;


### PR DESCRIPTION
We currently check the VM name which is Dalvik, but in the future this vm name might change to ART or something similar as Dalvik is going to eventually be replaced. In order to make sure that applications do not break if such a change occurs, switching now might be the best option. That way if such a change occurs, which is highly likely, developers' games won't become broken if they are using a nightly that has the fix included.

THIS IS BACKWARDS COMPATIBLE WITH DALVIK-BASED DEVICES.

Per Android specification, java.runtime.name should equal, 'Android Runtime' regardless of Google's proprietary presence in the operating system. Even then, please test on your devices. I did some tests on mine and they loaded correctly.
