### PR TITLE
Fixed an issue with fonts that use id values larger than 9999

### DIFF
--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/bmfont/BitmapFontWriter.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/bmfont/BitmapFontWriter.java
@@ -212,7 +212,7 @@ public class BitmapFontWriter {
 		// CHAR definitions
 		for (int i = 0; i < glyphs.size; i++) {
 			Glyph g = glyphs.get(i);
-			buf.append(xmlTab).append(xmlOpen).append("char id=").append(quote(String.format("%-5s", g.id), true)).append("x=")
+			buf.append(xmlTab).append(xmlOpen).append("char id=").append(quote(String.format("%-6s", g.id), true)).append("x=")
 				.append(quote(String.format("%-5s", g.srcX), true)).append("y=").append(quote(String.format("%-5s", g.srcY), true))
 				.append("width=").append(quote(String.format("%-5s", g.width), true)).append("height=")
 				.append(quote(String.format("%-5s", g.height), true)).append("xoffset=")


### PR DESCRIPTION
Changed char id number formatting to 6 numbers instead of 5, which was causing issues with japanese fonts with ids larger than 9999.

For example:

```
char id=32   x=2
char id=1235 x=2 
char id=12358x=2
```

The last id is read as "12358x" and not "12358"
