### PR TITLE
Fix gdx-bullet swigging on case-sensitive systems

### DIFF
--- a/extensions/gdx-bullet/jni/swig/module.xml
+++ b/extensions/gdx-bullet/jni/swig/module.xml
@@ -32,7 +32,7 @@
 			<arg value="${module.package}" />
 			<arg value="-I${basedir}/../src/bullet" />
 			<arg value="-I${basedir}/../src/custom" />
-			<arg value="-I${basedir}/../src/extras/serialize" />
+			<arg value="-I${basedir}/../src/extras/Serialize" />
 			<!-- Disable Bullet profiling -->
 			<arg value="-DBT_NO_PROFILE" />
 			<arg value="-outdir" />


### PR DESCRIPTION
Error part of ant build script output:

```
gen:
     [echo] Swigging
     [exec] /home/alex/libgdx/extensions/gdx-bullet/jni/swig/extras/./serialize/gdxBulletSerialize.i:40: Error: Unable to find 'BulletWorldImporter/btWorldImporter.h'
     [exec] /home/alex/libgdx/extensions/gdx-bullet/jni/swig/extras/./serialize/gdxBulletSerialize.i:41: Error: Unable to find 'BulletWorldImporter/btBulletWorldImporter.h'
     [exec] Result: 1
```

`src/extras/serialize/` doesn't exists, `src/extras/Serialize/` do.
