### PR TITLE
MipMap, filtering, texture format support for 3D model loaders

### DIFF
--- a/gdx/src/com/badlogic/gdx/assets/loaders/ModelLoader.java
+++ b/gdx/src/com/badlogic/gdx/assets/loaders/ModelLoader.java
@@ -32,12 +32,13 @@ import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.Disposable;
 import com.badlogic.gdx.utils.ObjectMap;
 
-public abstract class ModelLoader<P extends AssetLoaderParameters<Model>> extends AsynchronousAssetLoader<Model, P> {
+public abstract class ModelLoader<P extends ModelLoader.ModelParameters> extends AsynchronousAssetLoader<Model, P> {
 	public ModelLoader (FileHandleResolver resolver) {
 		super(resolver);
 	}
 
 	protected Array<ObjectMap.Entry<String, ModelData>> items = new Array<ObjectMap.Entry<String, ModelData>>();
+	protected ModelParameters defaultParameters = new ModelParameters();
 
 	/** Directly load the raw model data on the calling thread. */
 	public abstract ModelData loadModelData (final FileHandle fileHandle, P parameters);
@@ -81,10 +82,14 @@ public abstract class ModelLoader<P extends AssetLoaderParameters<Model>> extend
 			items.add(item);
 		}
 
+		TextureLoader.TextureParameter textureParameter = (parameters != null)
+				? parameters.textureParameter
+				: defaultParameters.textureParameter;
+
 		for (final ModelMaterial modelMaterial : data.materials) {
 			if (modelMaterial.textures != null) {
 				for (final ModelTexture modelTexture : modelMaterial.textures)
-					deps.add(new AssetDescriptor(modelTexture.fileName, Texture.class));
+					deps.add(new AssetDescriptor(modelTexture.fileName, Texture.class, textureParameter));
 			}
 		}
 		return deps;
@@ -118,5 +123,15 @@ public abstract class ModelLoader<P extends AssetLoaderParameters<Model>> extend
 		}
 		data = null;
 		return result;
+	}
+
+	static public class ModelParameters extends AssetLoaderParameters<Model> {
+		public TextureLoader.TextureParameter textureParameter;
+
+		public ModelParameters() {
+			textureParameter = new TextureLoader.TextureParameter();
+			textureParameter.minFilter = textureParameter.magFilter = Texture.TextureFilter.Linear;
+			textureParameter.wrapU = textureParameter.wrapV = Texture.TextureWrap.Repeat;
+		}
 	}
 }

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/Model.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/Model.java
@@ -255,7 +255,7 @@ public class Model implements Disposable {
 
 		ObjectMap<String, Texture> textures = new ObjectMap<String, Texture>();
 
-		// FIXME mipmapping totally ignored, filters totally ignored, uvScaling/uvTranslation totally ignored
+		// FIXME uvScaling/uvTranslation totally ignored
 		if (mtl.textures != null) {
 			for (ModelTexture tex : mtl.textures) {
 				Texture texture;
@@ -268,10 +268,10 @@ public class Model implements Disposable {
 				}
 
 				TextureDescriptor descriptor = new TextureDescriptor(texture);
-				descriptor.minFilter = Texture.TextureFilter.Linear;
-				descriptor.magFilter = Texture.TextureFilter.Linear;
-				descriptor.uWrap = Texture.TextureWrap.Repeat;
-				descriptor.vWrap = Texture.TextureWrap.Repeat;
+				descriptor.minFilter = texture.getMinFilter();
+				descriptor.magFilter = texture.getMagFilter();
+				descriptor.uWrap = texture.getUWrap();
+				descriptor.vWrap = texture.getVWrap();
 				switch (tex.usage) {
 				case ModelTexture.USAGE_DIFFUSE:
 					result.set(new TextureAttribute(TextureAttribute.Diffuse, descriptor));

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/loader/G3dModelLoader.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/loader/G3dModelLoader.java
@@ -16,14 +16,12 @@
 
 package com.badlogic.gdx.graphics.g3d.loader;
 
-import com.badlogic.gdx.assets.AssetLoaderParameters;
 import com.badlogic.gdx.assets.loaders.FileHandleResolver;
 import com.badlogic.gdx.assets.loaders.ModelLoader;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.VertexAttribute;
-import com.badlogic.gdx.graphics.g3d.Model;
 import com.badlogic.gdx.graphics.g3d.model.data.ModelAnimation;
 import com.badlogic.gdx.graphics.g3d.model.data.ModelData;
 import com.badlogic.gdx.graphics.g3d.model.data.ModelMaterial;
@@ -44,7 +42,7 @@ import com.badlogic.gdx.utils.BaseJsonReader;
 import com.badlogic.gdx.utils.GdxRuntimeException;
 import com.badlogic.gdx.utils.JsonValue;
 
-public class G3dModelLoader extends ModelLoader<AssetLoaderParameters<Model>> {
+public class G3dModelLoader extends ModelLoader<ModelLoader.ModelParameters> {
 	public static final short VERSION_HI = 0;
 	public static final short VERSION_LO = 1;
 	protected final BaseJsonReader reader;
@@ -59,7 +57,7 @@ public class G3dModelLoader extends ModelLoader<AssetLoaderParameters<Model>> {
 	}
 
 	@Override
-	public ModelData loadModelData (FileHandle fileHandle, AssetLoaderParameters<Model> parameters) {
+	public ModelData loadModelData (FileHandle fileHandle, ModelLoader.ModelParameters parameters) {
 		return parseModel(fileHandle);
 	}
 

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/loader/ObjLoader.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/loader/ObjLoader.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 
 import com.badlogic.gdx.Gdx;
-import com.badlogic.gdx.assets.AssetLoaderParameters;
 import com.badlogic.gdx.assets.AssetManager;
 import com.badlogic.gdx.assets.loaders.FileHandleResolver;
 import com.badlogic.gdx.assets.loaders.ModelLoader;
@@ -67,7 +66,7 @@ public class ObjLoader extends ModelLoader<ObjLoader.ObjLoaderParameters> {
 	 * absolutely sure what you are doing. Consult the documentation for more information. */
 	public static boolean logWarning = false;
 
-	public static class ObjLoaderParameters extends AssetLoaderParameters<Model> {
+	public static class ObjLoaderParameters extends ModelLoader.ModelParameters {
 		public boolean flipV;
 
 		public ObjLoaderParameters () {


### PR DESCRIPTION
Adding ModelLoader.ModelParameters to support TextureParameter, including MipMapping, Filtering and TextureFormat. Preserves default behavior.
