### PR TITLE
Various Quaternion changes

### DIFF
--- a/gdx/src/com/badlogic/gdx/math/Quaternion.java
+++ b/gdx/src/com/badlogic/gdx/math/Quaternion.java
@@ -18,11 +18,11 @@ package com.badlogic.gdx.math;
 
 import java.io.Serializable;
 
-/** A simple quaternion class. See <a href="http://en.wikipedia.org/wiki/Quaternion">http://en.wikipedia.org/wiki/Quaternion</a>
- * for more information.
- * 
+/** A simple quaternion class.
+ * @see <a href="http://en.wikipedia.org/wiki/Quaternion">http://en.wikipedia.org/wiki/Quaternion</a>
  * @author badlogicgames@gmail.com
- * @author vesuvio */
+ * @author vesuvio
+ * @author xoppa */
 public class Quaternion implements Serializable {
 	private static final long serialVersionUID = -7661875440774897168L;
 	private static final float NORMALIZATION_TOLERANCE = 0.00001f;
@@ -97,20 +97,25 @@ public class Quaternion implements Serializable {
 		return new Quaternion(this);
 	}
 
+	/** @return the euclidian length of the specified quaternion */
+	public final static float len (final float x, final float y, final float z, final float w) {
+		return (float)Math.sqrt(x * x + y * y + z * z + w * w);
+	}
+
 	/** @return the euclidian length of this quaternion */
 	public float len () {
 		return (float)Math.sqrt(x * x + y * y + z * z + w * w);
 	}
 
-	/** {@inheritDoc} */
+	@Override
 	public String toString () {
 		return "[" + x + "|" + y + "|" + z + "|" + w + "]";
 	}
 
 	/** Sets the quaternion to the given euler angles in degrees.
-	 * @param yaw the yaw in degrees
-	 * @param pitch the pitch in degress
-	 * @param roll the roll in degess
+	 * @param yaw the rotation around the z axis in degrees
+	 * @param pitch the rotation around the y axis in degrees
+	 * @param roll the rotation around the x axis degrees
 	 * @return this quaternion */
 	public Quaternion setEulerAngles (float yaw, float pitch, float roll) {
 		return setEulerAnglesRad(yaw * MathUtils.degreesToRadians, pitch * MathUtils.degreesToRadians, roll
@@ -118,30 +123,79 @@ public class Quaternion implements Serializable {
 	}
 
 	/** Sets the quaternion to the given euler angles in radians.
-	 * @param yaw the yaw in radians
-	 * @param pitch the pitch in radians
-	 * @param roll the roll in radians
+	 * @param yaw the rotation around the y axis in radians
+	 * @param pitch the rotation around the x axis in radians
+	 * @param roll the rotation around the z axis in radians
 	 * @return this quaternion */
 	public Quaternion setEulerAnglesRad (float yaw, float pitch, float roll) {
-		float num9 = roll * 0.5f;
-		float num6 = (float)Math.sin(num9);
-		float num5 = (float)Math.cos(num9);
-		float num8 = pitch * 0.5f;
-		float num4 = (float)Math.sin(num8);
-		float num3 = (float)Math.cos(num8);
-		float num7 = yaw * 0.5f;
-		float num2 = (float)Math.sin(num7);
-		float num = (float)Math.cos(num7);
-		float f1 = num * num4;
-		float f2 = num2 * num3;
-		float f3 = num * num3;
-		float f4 = num2 * num4;
+		final float hr = roll * 0.5f;
+		final float shr = (float)Math.sin(hr);
+		final float chr = (float)Math.cos(hr);
+		final float hp = pitch * 0.5f;
+		final float shp = (float)Math.sin(hp);
+		final float chp = (float)Math.cos(hp);
+		final float hy = yaw * 0.5f;
+		final float shy = (float)Math.sin(hy);
+		final float chy = (float)Math.cos(hy);
+		final float chy_shp = chy * shp;
+		final float shy_chp = shy * chp;
+		final float chy_chp = chy * chp;
+		final float shy_shp = shy * shp;
 
-		x = (f1 * num5) + (f2 * num6);
-		y = (f2 * num5) - (f1 * num6);
-		z = (f3 * num6) - (f4 * num5);
-		w = (f3 * num5) + (f4 * num6);
+		x = (chy_shp * chr) + (shy_chp * shr); // cos(yaw/2) * sin(pitch/2) * cos(roll/2) + sin(yaw/2) * cos(pitch/2) * sin(roll/2)
+		y = (shy_chp * chr) - (chy_shp * shr); // sin(yaw/2) * cos(pitch/2) * cos(roll/2) - cos(yaw/2) * sin(pitch/2) * sin(roll/2)
+		z = (chy_chp * shr) - (shy_shp * chr); // cos(yaw/2) * cos(pitch/2) * sin(roll/2) - sin(yaw/2) * sin(pitch/2) * cos(roll/2)
+		w = (chy_chp * chr) + (shy_shp * shr); // cos(yaw/2) * cos(pitch/2) * cos(roll/2) + sin(yaw/2) * sin(pitch/2) * sin(roll/2)
 		return this;
+	}
+
+	/** Get the pole of the gimbal lock, if any. 
+	 * @return positive (+1) for north pole, negative (-1) for south pole, zero (0) when no gimbal lock */ 
+	public int getGimbalPole() {
+		final float t = y*x+z*w;
+		return t > 0.499f ? 1 : (t < -0.499f ? -1 : 0);
+	}
+	
+	/** Get the roll euler angle in radians, which is the rotation around the z axis. Requires that this quaternion is normalized. 
+	 * @return the rotation around the z axis in radians (between -PI and +PI) */
+	public float getRollRad() {
+		final int pole = getGimbalPole();
+		return pole == 0 ? MathUtils.atan2(2f*(w*z + y*x), 1f - 2f * (x*x + z*z)) : (float)pole * 2f * MathUtils.atan2(y, w);
+	}
+	
+	/** Get the roll euler angle in degrees, which is the rotation around the z axis. Requires that this quaternion is normalized. 
+	 * @return the rotation around the z axis in degrees (between -180 and +180) */
+	public float getRoll() {
+		return getRollRad() * MathUtils.radiansToDegrees;
+	}
+	
+	/** Get the pitch euler angle in radians, which is the rotation around the x axis. Requires that this quaternion is normalized. 
+	 * @return the rotation around the x axis in radians (between -(PI/2) and +(PI/2)) */
+	public float getPitchRad() {
+		final int pole = getGimbalPole();
+		return pole == 0 ? (float)Math.asin(2f*(w*x-z*y)) : (float)pole * MathUtils.PI * 0.5f;
+	}
+
+	/** Get the pitch euler angle in degrees, which is the rotation around the x axis. Requires that this quaternion is normalized. 
+	 * @return the rotation around the x axis in degrees (between -90 and +90) */
+	public float getPitch() {
+		return getPitchRad() * MathUtils.radiansToDegrees;
+	}
+	
+	/** Get the yaw euler angle in radians, which is the rotation around the y axis. Requires that this quaternion is normalized. 
+	 * @return the rotation around the y axis in radians (between -PI and +PI) */
+	public float getYawRad() {
+		return getGimbalPole() == 0 ? MathUtils.atan2(2f*(y*w + x*z), 1f - 2f*(y*y+x*x)) : 0f;
+	}
+	
+	/** Get the yaw euler angle in degrees, which is the rotation around the y axis. Requires that this quaternion is normalized. 
+	 * @return the rotation around the y axis in degrees (between -180 and +180) */
+	public float getYaw() {
+		return getYawRad() * MathUtils.radiansToDegrees;
+	}
+
+	public final static float len2 (final float x, final float y, final float z, final float w) {
+		return x * x + y * y + z * z + w * w;
 	}
 
 	/** @return the length of this quaternion without square root */
@@ -188,35 +242,73 @@ public class Quaternion implements Serializable {
 		return v;
 	}
 
-	/** Multiplies this quaternion with another one
+	/** Multiplies this quaternion with another one in the form of this = this * other
 	 * 
-	 * @param q Quaternion to multiply with
+	 * @param other Quaternion to multiply with
 	 * @return This quaternion for chaining */
-	public Quaternion mul (Quaternion q) {
-		final float newX = w * q.x + x * q.w + y * q.z - z * q.y;
-		final float newY = w * q.y + y * q.w + z * q.x - x * q.z;
-		final float newZ = w * q.z + z * q.w + x * q.y - y * q.x;
-		final float newW = w * q.w - x * q.x - y * q.y - z * q.z;
-		x = newX;
-		y = newY;
-		z = newZ;
-		w = newW;
+	public Quaternion mul (final Quaternion other) {
+		final float newX = this.w * other.x + this.x * other.w + this.y * other.z - this.z * other.y;
+		final float newY = this.w * other.y + this.y * other.w + this.z * other.x - this.x * other.z;
+		final float newZ = this.w * other.z + this.z * other.w + this.x * other.y - this.y * other.x;
+		final float newW = this.w * other.w - this.x * other.x - this.y * other.y - this.z * other.z;
+		this.x = newX;
+		this.y = newY;
+		this.z = newZ;
+		this.w = newW;
 		return this;
 	}
 
-	/** Multiplies this quaternion with another one in the form of q * this
+	/** Multiplies this quaternion with another one in the form of this = this * other
 	 * 
-	 * @param q Quaternion to multiply with
+	 * @param x the x component of the other quaternion to multiply with
+	 * @param y the y component of the other quaternion to multiply with
+	 * @param z the z component of the other quaternion to multiply with
+	 * @param w the w component of the other quaternion to multiply with
 	 * @return This quaternion for chaining */
-	public Quaternion mulLeft (Quaternion q) {
-		final float newX = q.w * x + q.x * w + q.y * z - q.z * y;
-		final float newY = q.w * y + q.y * w + q.z * x - q.x * z;
-		final float newZ = q.w * z + q.z * w + q.x * y - q.y * x;
-		final float newW = q.w * w - q.x * x - q.y * y - q.z * z;
-		x = newX;
-		y = newY;
-		z = newZ;
-		w = newW;
+	public Quaternion mul (final float x, final float y, final float z, final float w) {
+		final float newX = this.w * x + this.x * w + this.y * z - this.z * y;
+		final float newY = this.w * y + this.y * w + this.z * x - this.x * z;
+		final float newZ = this.w * z + this.z * w + this.x * y - this.y * x;
+		final float newW = this.w * w - this.x * x - this.y * y - this.z * z;
+		this.x = newX;
+		this.y = newY;
+		this.z = newZ;
+		this.w = newW;
+		return this;
+	}
+
+	/** Multiplies this quaternion with another one in the form of this = other * this
+	 * 
+	 * @param other Quaternion to multiply with
+	 * @return This quaternion for chaining */
+	public Quaternion mulLeft (Quaternion other) {
+		final float newX = other.w * this.x + other.x * this.w + other.y * this.z - other.z * y;
+		final float newY = other.w * this.y + other.y * this.w + other.z * this.x - other.x * z;
+		final float newZ = other.w * this.z + other.z * this.w + other.x * this.y - other.y * x;
+		final float newW = other.w * this.w - other.x * this.x - other.y * this.y - other.z * z;
+		this.x = newX;
+		this.y = newY;
+		this.z = newZ;
+		this.w = newW;
+		return this;
+	}
+
+	/** Multiplies this quaternion with another one in the form of this = other * this
+	 * 
+	 * @param x the x component of the other quaternion to multiply with
+	 * @param y the y component of the other quaternion to multiply with
+	 * @param z the z component of the other quaternion to multiply with
+	 * @param w the w component of the other quaternion to multiply with
+	 * @return This quaternion for chaining */
+	public Quaternion mulLeft (final float x, final float y, final float z, final float w) {
+		final float newX = w * this.x + x * this.w + y * this.z - z * y;
+		final float newY = w * this.y + y * this.w + z * this.x - x * z;
+		final float newZ = w * this.z + z * this.w + x * this.y - y * x;
+		final float newW = w * this.w - x * this.x - y * this.y - z * z;
+		this.x = newX;
+		this.y = newY;
+		this.z = newZ;
+		this.w = newW;
 		return this;
 	}
 
@@ -266,7 +358,7 @@ public class Quaternion implements Serializable {
 	}
 
 	/** @return If this quaternion is an identity Quaternion */
-	public boolean isIdentity (float tolerance) {
+	public boolean isIdentity (final float tolerance) {
 		return MathUtils.isZero(x, tolerance) && MathUtils.isZero(y, tolerance) && MathUtils.isZero(z, tolerance)
 			&& MathUtils.isEqual(w, 1f, tolerance);
 	}
@@ -511,11 +603,36 @@ public class Quaternion implements Serializable {
 
 	}
 
-	/** Dot product between this and the other quaternion.
+	/** Get the dot product between the two quaternions (commutative).
+	 * @param x1 the x component of the first quaternion
+	 * @param y1 the y component of the first quaternion
+	 * @param z1 the z component of the first quaternion
+	 * @param w1 the w component of the first quaternion
+	 * @param x2 the x component of the second quaternion
+	 * @param y2 the y component of the second quaternion
+	 * @param z2 the z component of the second quaternion
+	 * @param w2 the w component of the second quaternion
+	 * @return the dot product between the first and second quaternion. */
+	public final static float dot (final float x1, final float y1, final float z1, final float w1, final float x2, final float y2,
+		final float z2, final float w2) {
+		return x1 * x2 + y1 * y2 + z1 * z2 + w1 * w2;
+	}
+
+	/** Get the dot product between this and the other quaternion (commutative).
 	 * @param other the other quaternion.
-	 * @return this quaternion for chaining. */
-	public float dot (Quaternion other) {
-		return x * other.x + y * other.y + z * other.z + w * other.w;
+	 * @return the dot product of this and the other quaternion. */
+	public float dot (final Quaternion other) {
+		return this.x * other.x + this.y * other.y + this.z * other.z + this.w * other.w;
+	}
+
+	/** Get the dot product between this and the other quaternion (commutative).
+	 * @param x the x component of the other quaternion
+	 * @param y the y component of the other quaternion
+	 * @param z the z component of the other quaternion
+	 * @param w the w component of the other quaternion
+	 * @return the dot product of this and the other quaternion. */
+	public float dot (final float x, final float y, final float z, final float w) {
+		return this.x * x + this.y * y + this.z * z + this.w * w;
 	}
 
 	/** Multiplies the components of this quaternion with the given scalar.
@@ -530,23 +647,30 @@ public class Quaternion implements Serializable {
 	}
 
 	/** Get the axis angle representation of the rotation in degrees. The supplied vector will receive the axis (x, y and z values)
-	 * of the rotation and the value returned is the angle in degrees around that axis. Note that this method will alter the supplied
-	 * vector, the existing value of the vector is ignored.
-	 *  
-	 * @param axis vector which will receive the axis 
-	 * @return the angle in degrees */
+	 * of the rotation and the value returned is the angle in degrees around that axis. Note that this method will alter the
+	 * supplied vector, the existing value of the vector is ignored. </p> This will normalize this quaternion if needed. The
+	 * received axis is a unit vector. However, if this is an identity quaternion (no rotation), then the length of the axis may be
+	 * zero.
+	 * 
+	 * @param axis vector which will receive the axis
+	 * @return the angle in degrees
+	 * @see <a href="http://en.wikipedia.org/wiki/Axis%E2%80%93angle_representation">wikipedia</a>
+	 * @see <a href="http://www.euclideanspace.com/maths/geometry/rotations/conversions/quaternionToAngle">calculation</a> */
 	public float getAxisAngle (Vector3 axis) {
 		return getAxisAngleRad(axis) * MathUtils.radiansToDegrees;
 	}
 
-	/** Get the axis angle representation of the rotation in radians. The supplied vector will receive the axis (x, y and z values)
-	 * of the rotation and the value returned is the angle in radians around that axis. Note that this method will alter the supplied
-	 * vector, the existing value of the vector is ignored.
+	/** Get the axis-angle representation of the rotation in radians. The supplied vector will receive the axis (x, y and z values)
+	 * of the rotation and the value returned is the angle in radians around that axis. Note that this method will alter the
+	 * supplied vector, the existing value of the vector is ignored. </p> This will normalize this quaternion if needed. The
+	 * received axis is a unit vector. However, if this is an identity quaternion (no rotation), then the length of the axis may be
+	 * zero.
 	 * 
 	 * @param axis vector which will receive the axis
-	 * @return the angle in radians */
+	 * @return the angle in radians
+	 * @see <a href="http://en.wikipedia.org/wiki/Axis%E2%80%93angle_representation">wikipedia</a>
+	 * @see <a href="http://www.euclideanspace.com/maths/geometry/rotations/conversions/quaternionToAngle">calculation</a> */
 	public float getAxisAngleRad (Vector3 axis) {
-		// source : http://www.euclideanspace.com/maths/geometry/rotations/conversions/quaternionToAngle/
 		if (this.w > 1) this.nor(); // if w>1 acos and sqrt will produce errors, this cant happen if quaternion is normalised
 		float angle = (float)(2.0 * Math.acos(this.w));
 		double s = Math.sqrt(1 - this.w * this.w); // assuming quaternion normalised then w is less than 1, so term always positive.
@@ -562,5 +686,87 @@ public class Quaternion implements Serializable {
 		}
 
 		return angle;
+	}
+
+	/** Get the angle in radians of the rotation this quaternion represents. Does not normalize the quaternion. Use
+	 * {@link #getAxisAngleRad(Vector3)} to get both the axis and the angle of this rotation. Use
+	 * {@link #getAngleAroundRad(Vector3)} to get the angle around a specific axis.
+	 * @return the angle in radians of the rotation */
+	public float getAngleRad () {
+		return (float)(2.0 * Math.acos((this.w > 1) ? (this.w / len()) : this.w));
+	}
+
+	/** Get the angle in degrees of the rotation this quaternion represents. Use {@link #getAxisAngle(Vector3)} to get both the axis
+	 * and the angle of this rotation. Use {@link #getAngleAround(Vector3)} to get the angle around a specific axis.
+	 * @return the angle in degrees of the rotation */
+	public float getAngle () {
+		return getAngleRad() * MathUtils.radiansToDegrees;
+	}
+
+	/** Get the swing rotation and twist rotation for the specified axis. The twist rotation represents the rotation around the
+	 * specified axis. The swing rotation represents the rotation of the specified axis itself, which is the rotation around an
+	 * axis perpendicular to the specified axis.
+	 * </p>
+	 * The swing and twist rotation can be used to reconstruct the original quaternion: this = swing * twist
+	 * 
+	 * @param axisX the X component of the normalized axis for which to get the swing and twist rotation
+	 * @param axisY the Y component of the normalized axis for which to get the swing and twist rotation
+	 * @param axisZ the Z component of the normalized axis for which to get the swing and twist rotation
+	 * @param swing will receive the swing rotation: the rotation around an axis perpendicular to the specified axis
+	 * @param twist will receive the twist rotation: the rotation around the specified axis
+	 * @see <a href="http://www.euclideanspace.com/maths/geometry/rotations/for/decomposition">calculation</a> */
+	public void getSwingTwist (final float axisX, final float axisY, final float axisZ, final Quaternion swing,
+		final Quaternion twist) {
+		final float d = Vector3.dot(this.x, this.y, this.z, axisX, axisY, axisZ);
+		twist.set(axisX * d, axisY * d, axisZ * d, this.w).nor();
+		swing.set(twist).conjugate().mulLeft(this);
+	}
+
+	/** Get the swing rotation and twist rotation for the specified axis. The twist rotation represents the rotation around the
+	 * specified axis. The swing rotation represents the rotation of the specified axis itself, which is the rotation around an
+	 * axis perpendicular to the specified axis.
+	 * </p>
+	 * The swing and twist rotation can be used to reconstruct the original quaternion: this = swing * twist
+	 * 
+	 * @param axis the normalized axis for which to get the swing and twist rotation
+	 * @param swing will receive the swing rotation: the rotation around an axis perpendicular to the specified axis
+	 * @param twist will receive the twist rotation: the rotation around the specified axis
+	 * @see <a href="http://www.euclideanspace.com/maths/geometry/rotations/for/decomposition">calculation</a> */
+	public void getSwingTwist (final Vector3 axis, final Quaternion swing, final Quaternion twist) {
+		getSwingTwist(axis.x, axis.y, axis.z, swing, twist);
+	}
+
+	/** Get the angle in radians of the rotation around the specified axis. The axis must be normalized.
+	 * @param axisX the x component of the normalized axis for which to get the angle
+	 * @param axisY the y component of the normalized axis for which to get the angle
+	 * @param axisZ the z component of the normalized axis for which to get the angle
+	 * @return the angle in radians of the rotation around the specified axis */
+	public float getAngleAroundRad (final float axisX, final float axisY, final float axisZ) {
+		final float d = Vector3.dot(this.x, this.y, this.z, axisX, axisY, axisZ);
+		final float l2 = Quaternion.len2(axisX * d, axisY * d, axisZ * d, this.w);
+		return l2 == 0f ? 0f : (float)(2.0 * Math.acos(this.w / Math.sqrt(l2)));
+	}
+
+	/** Get the angle in radians of the rotation around the specified axis. The axis must be normalized.
+	 * @param axis the normalized axis for which to get the angle
+	 * @return the angle in radians of the rotation around the specified axis */
+	public float getAngleAroundRad (final Vector3 axis) {
+		return getAngleAroundRad(axis.x, axis.y, axis.z);
+	}
+
+	/** Get the angle in degrees of the rotation around the specified axis. The axis must be normalized.
+	 * @param axisX the x component of the normalized axis for which to get the angle
+	 * @param axisY the y component of the normalized axis for which to get the angle
+	 * @param axisZ the z component of the normalized axis for which to get the angle
+	 * @return the angle in degrees of the rotation around the specified axis */
+	public float getAngleAround (final float axisX, final float axisY, final float axisZ) {
+		return getAngleAroundRad(axisX, axisY, axisZ) * MathUtils.radiansToDegrees;
+	}
+
+	/** Get the angle in degrees of the rotation around the specified axis. The axis must be normalized.
+	 * @param axis the normalized axis for which to get the angle
+	 * @return the angle in degrees of the rotation around the specified axis */
+	public float getAngleAround (final Vector3 axis) {
+		return getAngleAround(axis.x, axis.y, axis.z);
 	}
 }


### PR DESCRIPTION
Lately I saw quite a few people do something like: `angle = quaternion.getAxisAngle(Vector3.Y);`. This will modify Vector3.Y, which is probably undesired. Understandable mistake, given the lack of javadocs (see #1488). Since the goal of the user was probably to get the angle _around_ the axis, I took the extra effort to implement those methods as well. As well as fetching euler angles and added some static methods which might help to remove the temp usage. Also added some javadocs along the way.

Note that I did test the methods and they seem to function correctly (within the range mathematical expected). But especially the euler angles were a bit confusing (its all a matter of order). Therefor I guess it doesn't harm if someone can double check.
