### PR TITLE
Added function to return image rects

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g2d/PixmapPacker.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/PixmapPacker.java
@@ -114,6 +114,10 @@ public class PixmapPacker implements Disposable {
 		public Pixmap getPixmap () {
 			return image;
 		}
+		
+		public OrderedMap<String, Rectangle> getRects () {
+			return rects;
+		}
 	}
 
 	final int pageWidth;


### PR DESCRIPTION
returns the orderedmap of image regions in a Page.
This function would be helpful for dynamically created textureatlases from pixmap packer.
With this function available anyone can get the pixmap image from the packer saving game time 
and memory.

Explaining further:
I am a game developer using Libgdx.
I use Pixmap packer to pack images on the fly. However I further need a stream of images as pixmap for scaling and drawing which is already available in the Pixmap packer and can be accessed using "getPixmap" function from "Page". However I also need the exact positions of those images to carve it out. Hence used this function "getRects" for accessing the OrderedMap "rects"(I use a custom edited source of libgdx). It was a heavy advantage for my game(which is yet to be released).
So thought this addition might help others if added. A good functionality.
