### PR TITLE
Fix a possible typo for magFilter assignment in DirectionalShadowLight.

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g3d/environment/DirectionalShadowLight.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/environment/DirectionalShadowLight.java
@@ -48,7 +48,7 @@ public class DirectionalShadowLight extends DirectionalLight implements ShadowMa
 		halfHeight = shadowViewportHeight * 0.5f;
 		halfDepth = shadowNear + 0.5f * (shadowFar - shadowNear);
 		textureDesc = new TextureDescriptor();
-		textureDesc.minFilter = textureDesc.minFilter = Texture.TextureFilter.Nearest;
+		textureDesc.minFilter = textureDesc.magFilter = Texture.TextureFilter.Nearest;
 		textureDesc.uWrap = textureDesc.vWrap = Texture.TextureWrap.ClampToEdge;
 	}
 


### PR DESCRIPTION
Not sure if it was marked as deprecated because it's experimental and not yet finished/stable API, or if it literally is deprecated, so I figured I'd make this PR just in case it's the former.
