### PR TITLE
Mark deprecated methods with the @Deprecated annotation.

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g3d/loader/ObjLoader.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/loader/ObjLoader.java
@@ -95,7 +95,8 @@ public class ObjLoader extends ModelLoader<ObjLoader.ObjLoaderParameters> {
 	 *             Loads a Wavefront OBJ file from a given file handle.
 	 * 
 	 * @param file the FileHandle */
-	public Model loadObj (FileHandle file) {
+	@Deprecated
+ 	public Model loadObj (FileHandle file) {
 		return loadModel(file);
 	}
 
@@ -105,7 +106,8 @@ public class ObjLoader extends ModelLoader<ObjLoader.ObjLoaderParameters> {
 	 * 
 	 * @param file the FileHandle
 	 * @param flipV whether to flip the v texture coordinate (Blender, Wings3D, et al) */
-	public Model loadObj (FileHandle file, boolean flipV) {
+	@Deprecated
+ 	public Model loadObj (FileHandle file, boolean flipV) {
 		return loadModel(file, flipV);
 	}
 

--- a/gdx/src/com/badlogic/gdx/math/Vector3.java
+++ b/gdx/src/com/badlogic/gdx/math/Vector3.java
@@ -34,13 +34,16 @@ public class Vector3 implements Serializable, Vector<Vector3> {
 
 	/** @deprecated Static temporary vector. Use with care! Use only when sure other code will not also use this.
 	 * @see #tmp() **/
-	public final static Vector3 tmp = new Vector3();
+	@Deprecated
+ 	public final static Vector3 tmp = new Vector3();
 	/** @deprecated Static temporary vector. Use with care! Use only when sure other code will not also use this.
 	 * @see #tmp() **/
-	public final static Vector3 tmp2 = new Vector3();
+	@Deprecated
+ 	public final static Vector3 tmp2 = new Vector3();
 	/** @deprecated Static temporary vector. Use with care! Use only when sure other code will not also use this.
 	 * @see #tmp() **/
-	public final static Vector3 tmp3 = new Vector3();
+	@Deprecated
+ 	public final static Vector3 tmp3 = new Vector3();
 
 	public final static Vector3 X = new Vector3(1, 0, 0);
 	public final static Vector3 Y = new Vector3(0, 1, 0);
@@ -126,7 +129,8 @@ public class Vector3 implements Serializable, Vector<Vector3> {
 	 *             might call this as well.
 	 * 
 	 * @return a temporary copy of this vector */
-	public Vector3 tmp () {
+	@Deprecated
+ 	public Vector3 tmp () {
 		return tmp.set(this);
 	}
 
@@ -134,7 +138,8 @@ public class Vector3 implements Serializable, Vector<Vector3> {
 	 *             might call this as well.
 	 * 
 	 * @return a temporary copy of this vector */
-	public Vector3 tmp2 () {
+	@Deprecated
+ 	public Vector3 tmp2 () {
 		return tmp2.set(this);
 	}
 
@@ -142,7 +147,8 @@ public class Vector3 implements Serializable, Vector<Vector3> {
 	 *             might call this as well.
 	 * 
 	 * @return a temporary copy of this vector */
-	Vector3 tmp3 () {
+	@Deprecated
+ 	Vector3 tmp3 () {
 		return tmp3.set(this);
 	}
 

--- a/gdx/src/com/badlogic/gdx/math/collision/Ray.java
+++ b/gdx/src/com/badlogic/gdx/math/collision/Ray.java
@@ -47,6 +47,7 @@ public class Ray implements Serializable {
 	 *             startpoint + distance * direction.
 	 * @param distance The distance from the end point to the start point.
 	 * @return The end point */
+	@Deprecated
 	public Vector3 getEndPoint (float distance) {
 		return getEndPoint(new Vector3(), distance);
 	}

--- a/gdx/src/com/badlogic/gdx/utils/JsonValue.java
+++ b/gdx/src/com/badlogic/gdx/utils/JsonValue.java
@@ -146,6 +146,7 @@ public class JsonValue implements Iterable<JsonValue> {
 	}
 
 	/** @deprecated Use the size property instead. Returns this number of children in the array or object. */
+	@Deprecated
 	public int size () {
 		return size;
 	}


### PR DESCRIPTION
Mainly for consistency with all of the other things labeled with this annotation.
