### PR TITLE
Fix a possible typo in ScrollPane's getScrollWidth method.

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ScrollPane.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ScrollPane.java
@@ -803,7 +803,7 @@ public class ScrollPane extends WidgetGroup {
 
 	/** Returns the width of the scrolled viewport. */
 	public float getScrollWidth () {
-		return areaHeight;
+		return areaWidth;
 	}
 
 	/** Returns the height of the scrolled viewport. */


### PR DESCRIPTION
Seems a little odd for both getScrollHeight and getScrollWidth to return the same thing.
