### PR TITLE
Enforced minimum SDK version on Android

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplication.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplication.java
@@ -61,6 +61,7 @@ public class AndroidApplication extends Activity implements AndroidApplicationBa
 		GdxNativesLoader.load();
 	}
 
+	public static final int MINIMUM_SDK = 8;
 	protected AndroidGraphics graphics;
 	protected AndroidInput input;
 	protected AndroidAudio audio;
@@ -95,8 +96,8 @@ public class AndroidApplication extends Activity implements AndroidApplicationBa
 	 * @param config the {@link AndroidApplicationConfiguration}, defining various settings of the application (use accelerometer,
 	 *           etc.). */
 	public void initialize (ApplicationListener listener, AndroidApplicationConfiguration config) {
-		if (this.getVersion() < 8) {
-			throw new GdxRuntimeException("LibGDX requires Android 2.2 or later.");
+		if (this.getVersion() < MINIMUM_SDK) {
+			throw new GdxRuntimeException("LibGDX requires Android API Level " + MINIMUM_SDK + " or later.");
 		}
 		graphics = new AndroidGraphics(this, config, config.resolutionStrategy == null ? new FillResolutionStrategy()
 			: config.resolutionStrategy);
@@ -225,8 +226,8 @@ public class AndroidApplication extends Activity implements AndroidApplicationBa
 	 *           etc.).
 	 * @return the GLSurfaceView of the application */
 	public View initializeForView (ApplicationListener listener, AndroidApplicationConfiguration config) {
-		if (this.getVersion() < 8) {
-			throw new GdxRuntimeException("LibGDX requires Android 2.2 or later.");
+		if (this.getVersion() < MINIMUM_SDK) {
+			throw new GdxRuntimeException("LibGDX requires Android API Level " + MINIMUM_SDK + " or later.");
 		}
 		graphics = new AndroidGraphics(this, config, config.resolutionStrategy == null ? new FillResolutionStrategy()
 			: config.resolutionStrategy);

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidFragmentApplication.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidFragmentApplication.java
@@ -49,6 +49,7 @@ public class AndroidFragmentApplication extends Fragment implements AndroidAppli
 		GdxNativesLoader.load();
 	}
 
+	public static final int MINIMUM_SDK = 8;
 	protected AndroidGraphics graphics;
 	protected AndroidInput input;
 	protected AndroidAudio audio;
@@ -145,8 +146,8 @@ public class AndroidFragmentApplication extends Fragment implements AndroidAppli
 	 *           etc.).
 	 * @return the GLSurfaceView of the application */
 	public View initializeForView (ApplicationListener listener, AndroidApplicationConfiguration config) {
-		if (this.getVersion() < 8) {
-			throw new GdxRuntimeException("LibGDX requires Android 2.2 or later.");
+		if (this.getVersion() < MINIMUM_SDK) {
+			throw new GdxRuntimeException("LibGDX requires Android API Level " + MINIMUM_SDK + " or later.");
 		}
 		graphics = new AndroidGraphics(this, config, config.resolutionStrategy == null ? new FillResolutionStrategy()
 			: config.resolutionStrategy);

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidLiveWallpaper.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidLiveWallpaper.java
@@ -49,7 +49,8 @@ public class AndroidLiveWallpaper implements Application {
 	static {
 		GdxNativesLoader.load();
 	}
-
+	
+	public static final int MINIMUM_SDK = 8;
 	protected AndroidLiveWallpaperService service;
 
 	protected AndroidGraphicsLiveWallpaper graphics;
@@ -69,8 +70,8 @@ public class AndroidLiveWallpaper implements Application {
 	}
 
 	public void initialize (ApplicationListener listener, AndroidApplicationConfiguration config) {
-		if (this.getVersion() < 8) {
-			throw new GdxRuntimeException("LibGDX requires Android 2.2 or later.");
+		if (this.getVersion() < MINIMUM_SDK) {
+			throw new GdxRuntimeException("LibGDX requires Android API Level " + MINIMUM_SDK + " or later.");
 		}
 		graphics = new AndroidGraphicsLiveWallpaper(this, config, config.resolutionStrategy == null ? new FillResolutionStrategy()
 			: config.resolutionStrategy);


### PR DESCRIPTION
This prevents devs that don't update their AndroidManifest.xml from having their games explode with a random exception.
