### PR TITLE
Gradle: Enforced OpenGL ES 2.0 requirement on iOS

### DIFF
--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/ios/Info.plist.xml
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/ios/Info.plist.xml
@@ -36,6 +36,7 @@
     <key>UIRequiredDeviceCapabilities</key>
     <array>
         <string>armv7</string>
+        <string>opengles-2</string>
     </array>
     <key>UISupportedInterfaceOrientations</key>
     <array>


### PR DESCRIPTION
Apple developer guidelines recommend putting this in the Info.plist
This also prevents libGDX from running on devices without OpenGL ES 2.0 support
