### PR TITLE
Natives: Patched SharedLibraryLoader for BlackBerry support

### DIFF
--- a/gdx/src/com/badlogic/gdx/utils/SharedLibraryLoader.java
+++ b/gdx/src/com/badlogic/gdx/utils/SharedLibraryLoader.java
@@ -53,6 +53,12 @@ public class SharedLibraryLoader {
 			isMac = false;
 			is64Bit = false;
 		}
+		
+		//Blackberry devices should be treated as Android devices
+		if (System.getProperty("os.name").contains("qnx")) {
+			isAndroid = true;
+		}
+	
 		if (!isAndroid && !isWindows && !isLinux && !isMac) {
 			isIos = true;
 			is64Bit = false;


### PR DESCRIPTION
SharedLibraryLoader failed to load natives do to being unable to load natives for BlackBerry this patch allows the BlackBerry OS to be recongized and load the Android natives since BlackBerry contains an Android environment and newer versions of the OS actually run Android
