### PR TITLE
CheckBoxStyle with padding between image and label

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/CheckBox.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/CheckBox.java
@@ -29,7 +29,7 @@ public class CheckBox extends TextButton {
 	private Image image;
 	private CheckBoxStyle style;
 	/** Used for updating padding */
-	private Cell<Image> imageCell;
+	private Cell<Image> imageCell = null;
 
 	public CheckBox (String text, Skin skin) {
 		this(text, skin.get(CheckBoxStyle.class));
@@ -54,7 +54,8 @@ public class CheckBox extends TextButton {
 		if (!(style instanceof CheckBoxStyle)) throw new IllegalArgumentException("style must be a CheckBoxStyle.");
 		super.setStyle(style);
 		this.style = (CheckBoxStyle)style;
-		imageCell.padRight(this.style.padBetween);
+		if (imageCell != null)
+			imageCell.padRight(this.style.padBetween);
 	}
 
 	/** Returns the checkbox's style. Modifying the returned style may not have an effect until {@link #setStyle(ButtonStyle)} is


### PR DESCRIPTION
**Problem**
Whenever (read always) I wanted to pad the area between images and text in checkboxes I had to call checkbox.getLabelCell().padLeft(someValue); for all checkboxes. This was a bit cumbersome as I had to remember to call this method for all checkboxes.

**Possible solution**
I've created a solution which adds a new optional padding variable to the CheckBoxStyle. This variable determines the padding between the image and the label.

**Possible future enhancement**
Create a method setPadBetween(float) or padBetween(float) to override the style's padding for single checkboxes.

**Testing**
I've tested this implementation and I'm currently using it in my game :)
