### PR TITLE
Fix for Music (isPlaying when paused) on iOS

### DIFF
--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSMusic.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSMusic.java
@@ -72,7 +72,7 @@ public class IOSMusic implements Music {
 
 	@Override
 	public boolean isPlaying () {
-		return track.isPlaying();
+		return track.isPlaying() && !track.isPaused();
 	}
 
 	@Override


### PR DESCRIPTION
Music isPlaying() returns true on iOS when is paused.

To reproduce it, create a Music object and call play(), then pause() and finally check that the result of calling isPlaying() is true instead of false (default behaviour for Android and Desktop).

Please bear in mind that this is my first PR (not very familiar with Git yet) and, even if it's really small, I may have made a mistake, I apologise in advance if that's the case.
