### PR TITLE
Fix android fragment lifecycle

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidFragmentApplication.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidFragmentApplication.java
@@ -179,6 +179,28 @@ public class AndroidFragmentApplication extends Fragment implements AndroidAppli
 		return graphics.getView();
 	}
 
+    @Override
+    public void onResume () {
+        Gdx.app = this;
+        Gdx.input = this.getInput();
+        Gdx.audio = this.getAudio();
+        Gdx.files = this.getFiles();
+        Gdx.graphics = this.getGraphics();
+        Gdx.net = this.getNet();
+
+        ((AndroidInput)getInput()).registerSensorListeners();
+
+        if (graphics != null && graphics.view != null) {
+            if (graphics.view instanceof android.opengl.GLSurfaceView) ((android.opengl.GLSurfaceView)graphics.view).onResume();
+        }
+
+        if (!firstResume) {
+            graphics.resume();
+        } else
+            firstResume = false;
+        super.onResume();
+    }
+
 	@Override
 	public void onPause () {
 		boolean isContinuous = graphics.isContinuousRendering();
@@ -199,40 +221,17 @@ public class AndroidFragmentApplication extends Fragment implements AndroidAppli
 		if (graphics != null && graphics.view != null) {
 			if (graphics.view instanceof android.opengl.GLSurfaceView) ((android.opengl.GLSurfaceView)graphics.view).onPause();
 		}
-
 		super.onPause();
 	}
 
-	@Override
-	public void onResume () {
-		Gdx.app = this;
-		Gdx.input = this.getInput();
-		Gdx.audio = this.getAudio();
-		Gdx.files = this.getFiles();
-		Gdx.graphics = this.getGraphics();
-		Gdx.net = this.getNet();
+    @Override
+    public void onDestroyView() {
+        graphics.clearManagedCaches();
+        graphics.destroySync();
+        super.onDestroyView();
+    }
 
-		((AndroidInput)getInput()).registerSensorListeners();
-
-		if (graphics != null && graphics.view != null) {
-			if (graphics.view instanceof android.opengl.GLSurfaceView) ((android.opengl.GLSurfaceView)graphics.view).onResume();
-		}
-
-		if (!firstResume) {
-			graphics.resume();
-		} else
-			firstResume = false;
-		super.onResume();
-	}
-
-	@Override
-	public void onDestroyView () {
-		super.onDestroyView();
-		graphics.clearManagedCaches();
-		graphics.destroy();
-	}
-
-	@Override
+    @Override
 	public ApplicationListener getApplicationListener () {
 		return listener;
 	}

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphics.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphics.java
@@ -322,6 +322,10 @@ public final class AndroidGraphics implements Graphics, Renderer {
 		}
 	}
 
+    void destroySync() {
+        dispose();
+    }
+
 	@Override
 	public void onDrawFrame (javax.microedition.khronos.opengles.GL10 gl) {
 		long time = System.nanoTime();
@@ -404,14 +408,7 @@ public final class AndroidGraphics implements Graphics, Renderer {
 		}
 
 		if (ldestroy) {
-			Array<LifecycleListener> listeners = ((AndroidApplicationBase)app).getLifecycleListeners();
-			synchronized (listeners) {
-				for (LifecycleListener listener : listeners) {
-					listener.dispose();
-				}
-			}
-			((AndroidApplicationBase)app).getApplicationListener().dispose();
-			((AndroidAudio)((AndroidApplicationBase)app).getAudio()).dispose();
+			dispose();
 			Gdx.app.log("AndroidGraphics", "destroyed");
 		}
 
@@ -422,6 +419,18 @@ public final class AndroidGraphics implements Graphics, Renderer {
 		}
 		frames++;
 	}
+
+    private void dispose() {
+        Array<LifecycleListener> listeners = ((AndroidApplicationBase)app).getLifecycleListeners();
+        synchronized (listeners) {
+            for (LifecycleListener listener : listeners) {
+                listener.dispose();
+            }
+        }
+        ((AndroidApplicationBase)app).getApplicationListener().dispose();
+        ((AndroidAudio)((AndroidApplicationBase)app).getAudio()).dispose();
+        Gdx.app.log("AndroidGraphics", "destroyed");
+    }
 
 	/** {@inheritDoc} */
 	@Override


### PR DESCRIPTION
Fix for blocking call to `graphics.onDestroy()`. Currently still leads to a crash in some situations, but I could use some help trying to figure out the root cause. Please don't merge without testing. Continuation of https://github.com/libgdx/libgdx/pull/1439

On my Intel emulator this crashes now with the following logcat output;

```
F/libc    ( 3642): Fatal signal 11 (SIGSEGV) at 0x00000e4a (code=1), thread 3657 (Thread-114)
I/DEBUG   (  921): *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
I/DEBUG   (  921): Build fingerprint: 'generic_x86/google_sdk_x86/generic_x86:4.4.2/KK/1082983:eng/test-keys'
I/DEBUG   (  921): Revision: '0'
I/DEBUG   (  921): pid: 3642, tid: 3657, name: Thread-114  >>> io.blueapps.android <<<
I/DEBUG   (  921): signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 00000e4a
```

I'm not sure what this could be caused by. I will investigate further tomorrow.
