### PR TITLE
Simple 'remove comments from JSON' functionality in Skin & SkinLoader

### DIFF
--- a/gdx/src/com/badlogic/gdx/assets/loaders/SkinLoader.java
+++ b/gdx/src/com/badlogic/gdx/assets/loaders/SkinLoader.java
@@ -36,8 +36,22 @@ import com.badlogic.gdx.utils.ObjectMap.Entry;
  * generated through FreeTypeFontGenerator.
  * @author Nathan Sweet */
 public class SkinLoader extends AsynchronousAssetLoader<Skin, SkinLoader.SkinParameter> {
+	/** If true removes comments from the skin before loading them */
+	private boolean skinHasComments = false;
+	
 	public SkinLoader (FileHandleResolver resolver) {
 		super(resolver);
+	}
+	
+	/**
+	 * Creates a skin loader with the ability to remove skin comment
+	 * @param resolver 
+	 * @param skinHasComments set to true to remove skin comments from the JSON file
+	 * before parsing it
+	 */
+	public SkinLoader(FileHandleResolver resolver, boolean skinHasComments) {
+		super(resolver);
+		this.skinHasComments = skinHasComments;
 	}
 
 	@Override
@@ -71,7 +85,10 @@ public class SkinLoader extends AsynchronousAssetLoader<Skin, SkinLoader.SkinPar
 				skin.add(entry.key, entry.value);
 			}
 		}
+		
+		skin.removeCommentsWhenLoading(skinHasComments);
 		skin.load(file);
+		
 		return skin;
 	}
 


### PR DESCRIPTION
**Problem**
Under multiple times I've wanted to add comments to the JSON skin file. Why? 1) To add headlines; 2) Add simple description of UI elements, although these are not as necessary; 3) Comments for variables, such as what do the Float bar_above_below_height do, where is it used?

Currently we (me and my designer) are using google docs to document each variable, what it does etc. This is quite a lot of duplicate work and it's cumbersome to just look-up the variable, what it does, and its value. As these three attributes are stored in two different files.

An easier approach would be to document the variable inside the JSON file.

**Proposed solution**
I've changed Skin and SkinLoader to remove all comments in the JSON file before sending it to the parser, but only if the functionality is wanted. I.e. I've added another constructor to SkinLoader and a new method to Skin. These works just as before if the user doesn't make use of these methods.

**Possible enhancement**
Creating new constructors for Skin that takes a boolean (much like new SkinLoader constructor). More efficient wrapper for removing JSON comments.

**Thoughts**
I'm not sure on the naming of the variables and methods. I also see this as a first draft and suggestion. I've implemented things as simple and understandable as I could, thus they might not be the most efficient.
