### PR TITLE
Add TextureRegion UV range setter to MeshBuilder.

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g3d/utils/MeshBuilder.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/utils/MeshBuilder.java
@@ -290,6 +290,11 @@ public class MeshBuilder implements MeshPartBuilder {
 		vMax = v2;
 	}
 
+	@Override
+	public void setUVRange (TextureRegion region) {
+		setUVRange(region.getU(), region.getV(), region.getU2(), region.getV2());
+	}
+
 	/** Increases the size of the backing vertices array to accommodate the specified number of additional vertices. Useful before
 	 * adding many vertices to avoid multiple backing array resizes.
 	 * @param numVertices The number of vertices you are about to add */

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/utils/MeshPartBuilder.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/utils/MeshPartBuilder.java
@@ -41,6 +41,9 @@ public interface MeshPartBuilder {
 	/** Set range of texture coordinates used (default is 0,0,1,1). */
 	public void setUVRange (float u1, float v1, float u2, float v2);
 
+	/** Set range of texture coordinates from the specified TextureRegion. */
+	public void setUVRange (TextureRegion r);
+
 	/** Add one or more vertices, returns the index of the last vertex added. The length of values must a power of the vertex size. */
 	public short vertex (final float... values);
 


### PR DESCRIPTION
I often use `meshBuilder.setUVRange(region.getU(), region.getV(), region.getU2(), region.getV2());`
when building meshes, so why not add setUVRange(TextureRegion) to the builder.
