### PR TITLE
Fix unwanted visuals on touch up outside of tap area

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/ClickListener.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/ClickListener.java
@@ -87,10 +87,10 @@ public class ClickListener extends InputListener {
 					tapCount++;
 					lastTapTime = time;
 					clicked(event, x, y);
+					visualPressedTime = TimeUtils.nanoTime() + visualPressedDuration * 1000000000;
 				}
 			}
 			pressed = false;
-			visualPressedTime = TimeUtils.nanoTime() + visualPressedDuration * 1000000000;
 			pressedPointer = -1;
 			pressedButton = -1;
 			cancelled = false;


### PR DESCRIPTION
So, if one taps a button, drags pointer outside of tap area and releases it then unwanted visual feedback will be shown. See: https://www.dropbox.com/s/3r27s21fxnhmyvv/2014-03-31%2010.10.22.mp4
