### PR TITLE
Set key event timestamp

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidInput.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidInput.java
@@ -457,6 +457,7 @@ public class AndroidInput implements Input, OnKeyListener, OnTouchListener {
 				String chars = e.getCharacters();
 				for (int i = 0; i < chars.length(); i++) {
 					event = usedKeyEvents.obtain();
+					event.timeStamp = System.nanoTime();
 					event.keyCode = 0;
 					event.keyChar = chars.charAt(i);
 					event.type = KeyEvent.KEY_TYPED;
@@ -472,6 +473,7 @@ public class AndroidInput implements Input, OnKeyListener, OnTouchListener {
 			switch (e.getAction()) {
 			case android.view.KeyEvent.ACTION_DOWN:
 				event = usedKeyEvents.obtain();
+				event.timeStamp = System.nanoTime();
 				event.keyChar = 0;
 				event.keyCode = e.getKeyCode();
 				event.type = KeyEvent.KEY_DOWN;
@@ -486,7 +488,9 @@ public class AndroidInput implements Input, OnKeyListener, OnTouchListener {
 				keys.put(event.keyCode, null);
 				break;
 			case android.view.KeyEvent.ACTION_UP:
+				long timeStamp = System.nanoTime();
 				event = usedKeyEvents.obtain();
+				event.timeStamp = timeStamp;
 				event.keyChar = 0;
 				event.keyCode = e.getKeyCode();
 				event.type = KeyEvent.KEY_UP;
@@ -498,6 +502,7 @@ public class AndroidInput implements Input, OnKeyListener, OnTouchListener {
 				keyEvents.add(event);
 
 				event = usedKeyEvents.obtain();
+				event.timeStamp = timeStamp;
 				event.keyChar = character;
 				event.keyCode = 0;
 				event.type = KeyEvent.KEY_TYPED;

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/surfaceview/ResolutionStrategy.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/surfaceview/ResolutionStrategy.java
@@ -16,7 +16,7 @@
 
 package com.badlogic.gdx.backends.android.surfaceview;
 
-/** Will manipulate the GLSurfaceView. Gravity is always center. The width and height of the View will be determinded by the
+/** Will manipulate the GLSurfaceView. Gravity is always center. The width and height of the View will be determined by the
  * classes implementing {@link ResolutionStrategy}.
  * 
  * @author christoph widulle */


### PR DESCRIPTION
This is a fix for the issue mentioned here: https://github.com/libgdx/libgdx/issues/1576#issuecomment-38982627

Furthermore, the request to add a Input#clearEvents() method is quite recurrent and the answer is always a won't fix  (for good reasons though).
So do you think that the InputConsumer proposed at the link above might deserve its place in gdx ?
If so I'll make a PR soon.
