### PR TITLE
Fixed overflow

### DIFF
--- a/gdx/src/com/badlogic/gdx/math/WindowedMean.java
+++ b/gdx/src/com/badlogic/gdx/math/WindowedMean.java
@@ -54,7 +54,8 @@ public final class WindowedMean {
 	 * 
 	 * @param value The value to add */
 	public void addValue (float value) {
-		added_values++;
+		if (added_values < values.length)
+			added_values++;
 		values[last_value++] = value;
 		if (last_value > values.length - 1) last_value = 0;
 		dirty = true;


### PR DESCRIPTION
If you add more than 2^31 values to the windowed mean you get an overflow and the mean will be 0 for the next 2^31 values you add.
Actually this cannot be considered an issue for the windowed deltaTime between frames because you have to spend more than 1 year to get the overflow (assuming 60 FPS).
However, WindowedMean is a generic math util that you can use for your own stuff making it possible to trigger the overflow.
Test program:

``` java
public class WindowedMeanTest {
    public static void main(String args[]) {
        WindowedMean wm = new WindowedMean(5);
        long t = (1L << 31) - 10;
        long n = t + 20;
        for(long i = 0; i < n; i++) {
            wm.addValue(i%10);
            if (i > t || i < 10)
                System.out.println(i+": "+wm.getMean());
        }
    }
}
```
