### PR TITLE
*.jar files are not ignored by default

### DIFF
--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/gitignore
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/gitignore
@@ -1,7 +1,6 @@
 ## Java
 
 *.class
-*.jar
 *.war
 *.ear
 hs_err_pid*


### PR DESCRIPTION
This caused gradle-wrapper.jar to not be included in the project repo thus defying the whole purpose of using gradlew.
Also needed for libraries that still need to be added manually.
