### PR TITLE
Call LoadedCallback when asset is loaded in AssetManager

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,5 @@
 [1.0.0]
+- Now LoadedCallback in AssetLoaderParameters is always called after loading an asset from AssetManager, even if the asset is already loaded
 - Added Payload as a new parameter to Source.dragStop, see https://github.com/libgdx/libgdx/pull/1666
 - You can now load PolygonRegions via AssetLoader,  see https://github.com/libgdx/libgdx/pull/1602
 - implemented software keyboard support in RoboVM iOS backend

--- a/gdx/src/com/badlogic/gdx/assets/AssetManager.java
+++ b/gdx/src/com/badlogic/gdx/assets/AssetManager.java
@@ -435,6 +435,9 @@ public class AssetManager implements Disposable {
 			RefCountedContainer assetRef = assets.get(type).get(assetDesc.fileName);
 			assetRef.incRefCount();
 			incrementRefCountedDependencies(assetDesc.fileName);
+            if (assetDesc.params != null && assetDesc.params.loadedCallback != null) {
+                assetDesc.params.loadedCallback.finishedLoading(this, assetDesc.fileName, assetDesc.type);
+            }
 			loaded++;
 		} else {
 			// else add a new task for the asset.


### PR DESCRIPTION
Right now, if you try to load an asset already loaded by the AssetManager, passing along AssetParameters with a loadedCallback, loadedCallback is never called.

It seems reasonable that, since the asset is already loaded, loadedCallback is called right away. This PR modifies AssetManager to introduce this change.
