### PR TITLE
Made Payload available on dragstop without target

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/DragAndDrop.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/DragAndDrop.java
@@ -126,7 +126,7 @@ public class DragAndDrop {
 					target.actor.stageToLocalCoordinates(tmpVector.set(stageX, stageY));
 					target.drop(source, payload, tmpVector.x, tmpVector.y, pointer);
 				}
-				source.dragStop(event, x, y, pointer, payload, isValidTarget ? target : null);
+				source.dragStop(event, payload, x, y, pointer, isValidTarget ? target : null);
 				if (target != null) target.reset(source, payload);
 				payload = null;
 				target = null;
@@ -211,7 +211,7 @@ public class DragAndDrop {
 		abstract public Payload dragStart (InputEvent event, float x, float y, int pointer);
 
 		/** @param target null if not dropped on a valid target. */
-		public void dragStop (InputEvent event, float x, float y, int pointer, Payload payload, Target target) {
+		public void dragStop (InputEvent event, Payload payload, float x, float y, int pointer, Target target) {
 		}
 
 		public Actor getActor () {


### PR DESCRIPTION
There are some situations in which a drag starts with a payload and the payload is removed from the source (e. g. Inventory). When the dragging does NOT stop over a target, then only `dragStop` is called on the source, but the payload is not supplied anymore and that makes it more difficult to put the payload back to the source.

The additional payload parameter makes this situation much easier to handle.
