### PR TITLE
add get window method to IOSApplocation

### DIFF
--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSApplication.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSApplication.java
@@ -163,6 +163,14 @@ public class IOSApplication implements Application {
 		return graphics.viewController;
 	}
 
+	/**
+	 * Return the UI Window of IOSApplication
+	 * @return the window
+	 */
+	public UIWindow getUIWindow() {
+		return uiWindow;
+	}
+
 	/** Returns our real display dimension based on screen orientation.
 	 * 
 	 * @param viewController The view controller.


### PR DESCRIPTION
This is necessary for a particular method of showing interstitial ads, it solves an issue (by workaround) I and others are currently encountering using admob bindings in robovm.

I can also see it being useful in other situations.
