### PR TITLE
MathUtils: Fixed isEqual() documentation

### DIFF
--- a/gdx/src/com/badlogic/gdx/math/MathUtils.java
+++ b/gdx/src/com/badlogic/gdx/math/MathUtils.java
@@ -273,7 +273,7 @@ public final class MathUtils {
 	/** Returns true if a is nearly equal to b.
 	 * @param a the first value.
 	 * @param b the second value.
-	 * @param tolerance represent an upper bound below which the value is considered zero. */
+	 * @param tolerance represent an upper bound below which the two values are considered equal. */
 	static public boolean isEqual (float a, float b, float tolerance) {
 		return Math.abs(a - b) <= tolerance;
 	}


### PR DESCRIPTION
This was obviously a copy-paste issue relating to `isZero()`
