### PR TITLE
Added default styles

### DIFF
--- a/tests/gdx-tests-android/assets/data/uiskin.json
+++ b/tests/gdx-tests-android/assets/data/uiskin.json
@@ -35,8 +35,13 @@ com.badlogic.gdx.scenes.scene2d.ui.Window$WindowStyle: {
 	default: { titleFont: default-font, background: default-window, titleFontColor: white },
 	dialog: { titleFont: default-font, background: default-window, titleFontColor: white, stageBackground: dialogDim }
 },
+com.badlogic.gdx.scenes.scene2d.ui.ProgressBar$ProgressBarStyle: {
+	default-horizontal: { background: default-slider, knob: default-slider-knob },
+	default-vertical: { background: default-slider, knob: default-round-large }
+},
 com.badlogic.gdx.scenes.scene2d.ui.Slider$SliderStyle: {
-	default-horizontal: { background: default-slider, knob: default-slider-knob }
+	default-horizontal: { background: default-slider, knob: default-slider-knob },
+	default-vertical: { background: default-slider, knob: default-round-large }
 },
 com.badlogic.gdx.scenes.scene2d.ui.Label$LabelStyle: {
 	default: { font: default-font, fontColor: white }


### PR DESCRIPTION
Many people use the default skin for testing scene2d.ui, because it is the only one available AFAIK.

Calling any of the following will result in an exception, because the default skins which are set in the constructors do not exist in the uiskin.json:

`ProgressBar progressBar = new ProgressBar(0, 100, 1, true, skin);`
`ProgressBar progressBar = new ProgressBar(0, 100, 1, false, skin);`
`Slider slider = new Slider(0, 100, 1, true, skin);`

Thus I added some styles for those cases.
