### PR TITLE
Updated to gradle-robovm-plugin 0.0.7.

### DIFF
--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/build.gradle
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     dependencies {
         classpath 'de.richsource.gradle.plugins:gwt-gradle-plugin:0.3'
         classpath 'com.android.tools.build:gradle:0.9+'
-        classpath 'com.github.jtakakura:gradle-robovm-plugin:0.0.6'
+        classpath 'com.github.jtakakura:gradle-robovm-plugin:0.0.7'
     }
 }
 


### PR DESCRIPTION
gradle-robovm-plugin 0.0.7 supported to redirect the stdout and stderr of the ios-sim to files.
