### PR TITLE
Orientation issues in ipad1,2

### DIFF
--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSApplication.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSApplication.java
@@ -183,7 +183,7 @@ public class IOSApplication implements Application {
 		// determine orientation and resulting width + height
 		UIInterfaceOrientation orientation;
 		if (viewController != null) {
-			viewController.getInterfaceOrientation();
+			orientation = viewController.getInterfaceOrientation();
 		} else if (config.orientationLandscape == config.orientationPortrait) {
 			/*
 			 * if the app has orientation in any side then we can only check


### PR DESCRIPTION
Basic issue:
My game is in default landscape. However in ipad 1 and 2 it plays in portrait, but works correctly in ipad 3. Traced the issue back to here. So it would be nice if we check wether the user has any orientation preferences given in config file.

if landscape and portrait both valeus are same then we check status bar orientation
else we give in to user preferred orientation

PS: Orientiation values are in landscpae for iphone and ipadt in info.plist of my game.
