### PR TITLE
Patch for the Setup. Remove android dependency. Add version Options.

### DIFF
--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/DependencyBank.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/DependencyBank.java
@@ -99,11 +99,11 @@ public class DependencyBank {
 			new String[]{"com.badlogicgames.gdx:gdx-box2d:$gdxVersion:sources", "com.badlogicgames.gdx:gdx-box2d-gwt:$gdxVersion:sources"}
 		),	
 		BOX2DLIGHTS(
-			new String[]{"com.badlogicgames.box2dlights:box2dlights:1.2"},
+			new String[]{"com.badlogicgames.box2dlights:box2dlights:1.2-SNAPSHOT"},
 			new String[]{},
-			new String[]{"com.badlogicgames.box2dlights:box2dlights:1.2"},
+			new String[]{"com.badlogicgames.box2dlights:box2dlights:1.2-SNAPSHOT"},
 			new String[]{},
-			new String[]{"com.badlogicgames.box2dlights:box2dlights:1.2:sources"}
+			new String[]{"com.badlogicgames.box2dlights:box2dlights:1.2-SNAPSHOT:sources"}
 		);
 
 		private String[] coreDependencies;

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetup.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetup.java
@@ -33,6 +33,14 @@ public class GdxSetup {
 		return new File(sdkLocation, "tools").exists() && new File(sdkLocation, "platforms").exists();
 	}
 
+	public static boolean isEmptyDirectory (String destination) {
+		if (new File(destination).exists()) {
+			return new File(destination).list().length == 0;
+		} else {
+			return true;
+		}
+	}
+
 	public void build (ProjectBuilder builder, String outputDir, String appName, String packageName, String mainClass,
 		String sdkLocation, CharCallback callback) {
 		Project project = new Project();

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetupUI.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetupUI.java
@@ -121,6 +121,13 @@ public class GdxSetupUI extends JFrame {
 			return;
 		}
 
+		if (!GdxSetup.isEmptyDirectory(destination)) {
+			int value = JOptionPane.showConfirmDialog(this, "The destination is not empty, do you want to overwrite?", "Warning!", JOptionPane.YES_NO_OPTION);
+			if (value == 1) {
+				return;
+			}
+		}
+
 		String selectedVersion = (String)ui.form.versionButton.getSelectedItem();
 		if (selectedVersion.equals("Nightlies")) {
 			DependencyBank.libgdxVersion = DependencyBank.libgdxNightlyVersion;
@@ -405,7 +412,7 @@ public class GdxSetupUI extends JFrame {
 
 			nightlyWarning.setForeground(new Color(200, 20, 20));
 			nightlyWarning.setVisible(false);
-            projectsLabel.setForeground(new Color(200, 20, 20));
+			projectsLabel.setForeground(new Color(200, 20, 20));
 			extensionsLabel.setForeground(new Color(200, 20, 20));
 
 			subProjectsPanel.setOpaque(true);


### PR DESCRIPTION
This adds a few tweaks to the setup:
- Adds the ability to select version of libgdx 1.0.0+, as well as choose to be put onto the nightlies.
- Removes dependency on Android when you dont have the project selected, no local.properties file is generated, nor will the project check if the sdk location is valid, in fact it disables the field to provide some better feedback.
- Puts box2dlights onto the 2-SNAPSHOT until its released.
- Remove duplicate dependency of x86 natives in the android backend.
- Some visual tweaks like cursors in the text fields
