### PR TITLE
Less GC in RoboVM iOS backend

### DIFF
--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
@@ -20,7 +20,6 @@ import org.robovm.apple.coregraphics.CGPoint;
 import org.robovm.apple.coregraphics.CGRect;
 import org.robovm.apple.coregraphics.CGSize;
 import org.robovm.apple.foundation.NSObject;
-import org.robovm.apple.foundation.NSSet;
 import org.robovm.apple.glkit.GLKView;
 import org.robovm.apple.glkit.GLKViewController;
 import org.robovm.apple.glkit.GLKViewControllerDelegate;
@@ -35,11 +34,12 @@ import org.robovm.apple.uikit.UIDevice;
 import org.robovm.apple.uikit.UIEvent;
 import org.robovm.apple.uikit.UIInterfaceOrientation;
 import org.robovm.apple.uikit.UIScreen;
-import org.robovm.apple.uikit.UITouch;
 import org.robovm.apple.uikit.UIUserInterfaceIdiom;
 import org.robovm.objc.Selector;
 import org.robovm.objc.annotation.BindSelector;
+import org.robovm.objc.annotation.Method;
 import org.robovm.rt.bro.annotation.Callback;
+import org.robovm.rt.bro.annotation.Pointer;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Graphics;
@@ -142,27 +142,23 @@ public class IOSGraphics extends NSObject implements Graphics, GLKViewDelegate, 
 		context = new EAGLContext(EAGLRenderingAPI.OpenGLES2);
 
 		view = new GLKView(new CGRect(new CGPoint(0, 0), bounds), context) {
-			@Override
-			public void touchesBegan (NSSet<UITouch> touches, UIEvent event) {
-				super.touchesBegan(touches, event);
+			@Method(selector = "touchesBegan:withEvent:")
+			public void touchesBegan (@Pointer long touches, UIEvent event) {
 				IOSGraphics.this.input.touchDown(touches, event);
 			}
 
-			@Override
-			public void touchesCancelled (NSSet<UITouch> touches, UIEvent event) {
-				super.touchesCancelled(touches, event);
+			@Method(selector = "touchesCancelled:withEvent:")
+			public void touchesCancelled (@Pointer long touches, UIEvent event) {
 				IOSGraphics.this.input.touchUp(touches, event);
 			}
 
-			@Override
-			public void touchesEnded (NSSet<UITouch> touches, UIEvent event) {
-				super.touchesEnded(touches, event);
+			@Method(selector = "touchesEnded:withEvent:")
+			public void touchesEnded (@Pointer long touches, UIEvent event) {
 				IOSGraphics.this.input.touchUp(touches, event);
 			}
 
-			@Override
-			public void touchesMoved (NSSet<UITouch> touches, UIEvent event) {
-				super.touchesMoved(touches, event);
+			@Method(selector = "touchesMoved:withEvent:")
+			public void touchesMoved (@Pointer long touches, UIEvent event) {
 				IOSGraphics.this.input.touchMoved(touches, event);
 			}
 


### PR DESCRIPTION
The ObjC-Java bridge in RoboVM will create a Java peer the first time an ObjC instance crosses the ObjC<->Java boundary. This peer will be associated (using the `objc_setAssociatedObject()` in the Objective-C runtime) with the ObjC instance and the next time the same ObjC instance crosses the boundary the same peer will be used on the Java side. The Java peer will retain the ObjC instance until the Java peer is GCed.

For frequently created, short-lived objects (like `UIAcceleration` or `UITouch` instances) this can lead to performance problems. The Java peers quickly become unreachable but cannot be reclaimed until the next GC and the corresponding ObjC instances will not be deallocated until the Java peer is GCed.

This patch uses a single `UITouch` and a single `UIAcceleration` instead of creating new ones on each touch/acceleration event. These events are handled single-threaded so reusing the same instance should not be a problem. As far as I can see this significantly decreases the garbage generated and thus the frequency of GC pauses during touch and acceleration events.
