### PR TITLE
Fix bug in polygon intersections

### DIFF
--- a/gdx/src/com/badlogic/gdx/math/Intersector.java
+++ b/gdx/src/com/badlogic/gdx/math/Intersector.java
@@ -682,9 +682,9 @@ public final class Intersector {
 					if (ua >= 0 && ua <= 1) {
 						 return true;
 					}
-					x3 = x4;
-					y3 = y4;
 			  }
+			  x3 = x4;
+			  y3 = y4;
 		 }
 		 return false;
 	}
@@ -726,9 +726,9 @@ public final class Intersector {
 								return true;
 						  }
 					 }
-					 x3 = x4;
-					 y3 = y4;
 				}
+				x3 = x4;
+				y3 = y4;
 		  }
 		  return false;
 	 }


### PR DESCRIPTION
There was a bug in the latest fix for polygon intersections: advancing x3, y3 to x4, y4 should be done for _every_
 polygon edge, even if that edge was parallel to the segment or line being tested (d == 0). My apologies for not testing the original fix better.
