### PR TITLE
These AsynchronousAssetLoaders now release their assets when finished.

### DIFF
--- a/gdx/src/com/badlogic/gdx/assets/loaders/MusicLoader.java
+++ b/gdx/src/com/badlogic/gdx/assets/loaders/MusicLoader.java
@@ -41,6 +41,8 @@ public class MusicLoader extends AsynchronousAssetLoader<Music, MusicLoader.Musi
 
 	@Override
 	public Music loadSync (AssetManager manager, String fileName, FileHandle file, MusicParameter parameter) {
+		Music music = this.music;
+		this.music = null;
 		return music;
 	}
 

--- a/gdx/src/com/badlogic/gdx/assets/loaders/PixmapLoader.java
+++ b/gdx/src/com/badlogic/gdx/assets/loaders/PixmapLoader.java
@@ -40,6 +40,8 @@ public class PixmapLoader extends AsynchronousAssetLoader<Pixmap, PixmapLoader.P
 
 	@Override
 	public Pixmap loadSync (AssetManager manager, String fileName, FileHandle file, PixmapParameter parameter) {
+		Pixmap pixmap = this.pixmap;
+		this.pixmap = null;
 		return pixmap;
 	}
 

--- a/gdx/src/com/badlogic/gdx/assets/loaders/SoundLoader.java
+++ b/gdx/src/com/badlogic/gdx/assets/loaders/SoundLoader.java
@@ -41,6 +41,8 @@ public class SoundLoader extends AsynchronousAssetLoader<Sound, SoundLoader.Soun
 
 	@Override
 	public Sound loadSync (AssetManager manager, String fileName, FileHandle file, SoundParameter parameter) {
+		Sound sound = this.sound;
+		this.sound = null;
 		return sound;
 	}
 


### PR DESCRIPTION
MusicLoader, PixmapLoader, and SoundLoader instances are hanging into their last processed asset. This pull request releases these assets as they are picked up.
