### PR TITLE
fix bug where you cannot insert at the end of a ShortArray

### DIFF
--- a/gdx/src/com/badlogic/gdx/utils/ShortArray.java
+++ b/gdx/src/com/badlogic/gdx/utils/ShortArray.java
@@ -128,7 +128,7 @@ public class ShortArray {
 	}
 
 	public void insert (int index, short value) {
-		if (index >= size) throw new IndexOutOfBoundsException("index can't be >= size: " + index + " >= " + size);
+		if (index > size) throw new IndexOutOfBoundsException("index can't be > size: " + index + " > " + size);
 		short[] items = this.items;
 		if (size == items.length) items = resize(Math.max(8, (int)(size * 1.75f)));
 		if (ordered)


### PR DESCRIPTION
It seems ShortArray is the only array that doesn't let you insert at the end of the array (index = size). It seemed like a simple error, that's why I thought I was allowed to simply PR it
