### PR TITLE
fix issue 910: refresh controllers extension when window handle lost

### DIFF
--- a/extensions/gdx-controllers/gdx-controllers-desktop/src/com/badlogic/gdx/controllers/desktop/OisControllers.java
+++ b/extensions/gdx-controllers/gdx-controllers-desktop/src/com/badlogic/gdx/controllers/desktop/OisControllers.java
@@ -41,7 +41,7 @@ import javax.swing.SwingUtilities;
 public class OisControllers {
 	final DesktopControllerManager manager;
 	long hwnd = getWindowHandle();
-	Ois ois = new Ois(getWindowHandle());
+	Ois ois = new Ois(hwnd);
 	OisController[] controllers;
 
 	public OisControllers (final DesktopControllerManager manager) {


### PR DESCRIPTION
Fixes this bug: https://github.com/libgdx/libgdx/issues/910
The window handle gets lost on windows when full screen is toggled. This causes the controller extension to stop working. The below changes fix this issue by reloading the handle and controllers when the handle changes.
