### PR TITLE
Methods to enable averaging multiple transform matrices

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/math/Matrix4.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/math/Matrix4.java
@@ -907,6 +907,92 @@ public class Matrix4 implements Serializable {
 		return this;
 	}
 
+	/**
+	 * Averages the given transform with this one and stores the result in this matrix.
+	 * Translations and scales are lerped while rotations are slerped. 
+	 * @param other The other transform
+	 * @param w Weight of this transform; weight of the other transform is (1 - w)
+	 * @return This matrix for chaining */
+	public Matrix4 avg (Matrix4 other, float w) {
+
+		getScale(tmpVec);
+		getRotation(quat);
+		getTranslation(tmpUp);
+		
+		//Calculate scale components
+		setToScaling(tmpVec.scl(w).add(other.getScale(tmpForward).scl(1 - w)));
+
+		//Calculate rotation components
+		final Quaternion tmpq2 = new Quaternion();
+		rotate(quat.slerp(other.getRotation(tmpq2), 1 - w));
+
+		//Calculate translation components
+		setTranslation(tmpUp.scl(w).add(other.getTranslation(tmpForward).scl(1 - w)));
+		
+		return this;
+	}
+	
+	/**
+	 * Averages the given transforms and stores the result in this matrix.
+	 * Translations and scales are lerped while rotations are slerped. 
+	 * Does not destroy the data contained in t.
+	 * @param t List of transforms
+	 * @return This matrix for chaining */
+	public Matrix4 avg (Matrix4[] t) {
+		final float w = 1.0f/t.length;
+
+		//Calculate scale components
+		tmpVec.set(0,0,0);
+		for(int i=0;i<t.length;i++)
+			tmpVec.add(t[i].getScale(tmpUp).scl(w));
+		setToScaling(tmpVec);
+
+		//Calculate rotation components
+		final Quaternion tmpq2 = new Quaternion();
+		quat.set(t[0].getRotation(tmpq2).exp(w));
+		for(int i=1;i<t.length;i++)
+			quat.mul(t[i].getRotation(tmpq2).exp(w));
+		rotate(quat);
+
+		//Calculate translation components
+		setTranslation(0, 0, 0);
+		for(int i=0;i<t.length;i++)
+			trn(t[i].getTranslation(tmpVec).scl(w));
+
+		return this;
+	}
+
+	/**
+	 * Averages the given transforms with the given weights and stores the result in this matrix.
+	 * Translations and scales are lerped while rotations are slerped. 
+	 * Does not destroy the data contained in t or w;
+	 * Sum of w_i must be equal to 1, or unexpected results will occur.
+	 * @param t List of transforms
+	 * @param w List of weights
+	 * @return This matrix for chaining */
+	public Matrix4 avg (Matrix4[] t, float[] w) {
+
+		//Calculate scale components
+		tmpVec.set(0,0,0);
+		for(int i=0;i<t.length;i++)
+			tmpVec.add(t[i].getScale(tmpUp).scl(w[i]));
+		setToScaling(tmpVec);
+
+		//Calculate rotation components
+		final Quaternion tmpq2 = new Quaternion();
+		quat.set(t[0].getRotation(tmpq2).exp(w[0]));
+		for(int i=1;i<t.length;i++)
+			quat.mul(t[i].getRotation(tmpq2).exp(w[i]));
+		rotate(quat);
+
+		//Calculate translation components
+		setTranslation(0, 0, 0);
+		for(int i=0;i<t.length;i++)
+			trn(t[i].getTranslation(tmpVec).scl(w[i]));
+
+		return this;
+	}
+	
 	/** Sets this matrix to the given 3x3 matrix. The third column of this matrix is set to (0,0,1,0).
 	 * @param mat the matrix */
 	public Matrix4 set (Matrix3 mat) {

--- a/gdx/src/com/badlogic/gdx/math/Quaternion.java
+++ b/gdx/src/com/badlogic/gdx/math/Quaternion.java
@@ -592,6 +592,72 @@ public class Quaternion implements Serializable {
 		return this;
 	}
 
+	/**
+	 * Spherical linearly interpolates multiple quaternions and stores the result in this Quaternion.
+	 * Will not destroy the data previously inside the elements of q.
+	 * result = (q_1^w_1)*(q_2^w_2)* ... *(q_n^w_n) where w_i=1/n.
+	 * @param q List of quaternions
+	 * @return This quaternion for chaining */
+	public Quaternion slerp (Quaternion[] q) {
+		
+		//Calculate exponents and multiply everything from left to right
+		final float w = 1.0f/q.length;
+		set(q[0]).exp(w);
+		for(int i=1;i<q.length;i++)
+			mul(tmp1.set(q[i]).exp(w));
+		return this;
+	}
+	
+	/**
+	 * Spherical linearly interpolates multiple quaternions by the given weights and stores the result in this Quaternion.
+	 * Will not destroy the data previously inside the elements of q or w.
+	 * result = (q_1^w_1)*(q_2^w_2)* ... *(q_n^w_n) where the sum of w_i is 1.
+	 * Lists must be equal in length.
+	 * @param q List of quaternions
+	 * @param w List of weights
+	 * @return This quaternion for chaining */
+	public Quaternion slerp (Quaternion[] q, float[] w) {
+		
+		//Calculate exponents and multiply everything from left to right
+		set(q[0]).exp(w[0]);
+		for(int i=1;i<q.length;i++)
+			mul(tmp1.set(q[i]).exp(w[i]));
+		return this;
+	}
+	
+	/**
+	 * Calculates (this quaternion)^alpha where alpha is a real number and stores the result in this quaternion.
+	 * See http://en.wikipedia.org/wiki/Quaternion#Exponential.2C_logarithm.2C_and_power
+	 * @param alpha Exponent
+	 * @return This quaternion for chaining */
+	public Quaternion exp (float alpha) {
+
+		//Calculate |q|^alpha
+		float norm = len();
+		float normExp = (float)Math.pow(norm, alpha);
+
+		//Calculate theta
+		float theta = (float)Math.acos(w / norm);
+
+		//Calculate coefficient of basis elements
+		float coeff = 0;
+		if(Math.abs(theta) < 0.001) //If theta is small enough, use the limit of sin(alpha*theta) / sin(theta) instead of actual value
+			coeff = normExp*alpha / norm;
+		else
+			coeff = (float)(normExp*Math.sin(alpha*theta) / (norm*Math.sin(theta)));
+
+		//Write results
+		w = (float)(normExp*Math.cos(alpha*theta));
+		x *= coeff;
+		y *= coeff;
+		z *= coeff;
+
+		//Fix any possible discrepancies
+		nor();
+
+		return this;
+	}
+	
 	@Override
 	public int hashCode () {
 		final int prime = 31;


### PR DESCRIPTION
I wrote some methods to enable weighted averaging of multiple transform matrices in order to obtain a transform which is the "weighted midway" between the given transforms. To achieve this, translations are lerped and rotations are slerped. By definition, more than two Quaternions are slerped by:

```
(q_1^w_1)*(q_2^w_2)* ... *(q_n^w_n)
```

where `w_i` sum to 1. This is particularly useful when transform information from multiple observers must be combined into a single one. 
