### PR TITLE
Added option to SharedLibraryFinder interface to specify extraction sub-...

### DIFF
--- a/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/JniGenSharedLibraryLoader.java
+++ b/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/JniGenSharedLibraryLoader.java
@@ -107,7 +107,13 @@ public class JniGenSharedLibraryLoader {
 	}
 
 	private String extractLibrary (String sharedLibName) {
-		String srcCrc = crc(JniGenSharedLibraryLoader.class.getResourceAsStream("/" + sharedLibName));
+		String srcCrc = null;
+		if (libraryFinder != null) {
+			srcCrc = libraryFinder.getSharedLibraryExtractFolder(sharedLibName, nativesZip);
+		}
+		if (srcCrc == null) {
+			srcCrc = crc(JniGenSharedLibraryLoader.class.getResourceAsStream("/" + sharedLibName));
+		}
 		File nativesDir = new File(System.getProperty("java.io.tmpdir") + "/jnigen/" + srcCrc);
 		File nativeFile = new File(nativesDir, sharedLibName);
 

--- a/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/SharedLibraryFinder.java
+++ b/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/SharedLibraryFinder.java
@@ -32,4 +32,17 @@ public interface SharedLibraryFinder {
 	 *           matching. May be null if no zipfile is used.
 	 * @return The name of the shared file, or null if none available */
 	String getSharedLibraryNameAndroid (String sharedLibName, ZipFile nativesJar);
+
+	/**
+	 * By default, gdx-jnigen extracts each native library into a folder "${java.io.tmpdir}/jnigen/${crc}", where {crc}
+	 * is a CRC32 checksum of the library's binary content. This function can be used to override this part, so
+	 * libraries are extracted to "${java.io.tmpdir}/jnigen/${your-folder-name}".
+	 *
+	 * @param sharedLibName The name of the shared lib that is asked to be loaded. This is the full name, which matches
+	 *                      the return value of a previous getSharedLibraryName*() call.
+	 * @param nativesJar A ZipFile object, which gives the ability to walk through the containing files, and allows for pattern
+	 *           matching. May be null if no zipfile is used.
+	 * @return The name of the subdirectory to extract this library into, or null to use the default behaviour of libGDX.
+	 */
+	String getSharedLibraryExtractFolder(String sharedLibName, ZipFile nativesJar);
 }


### PR DESCRIPTION
...folder for native libraries.

By default JniGenSharedLibraryLoader extracts each native library to its own temp folder (named by the crc32 of its content). With this small change the application can opt to specify a custom folder name.

I'm working with a setup of two dynamic libraries which depend on each other (libB links to libA), and by extracting them both to the same folder I can avoid the library path issue when libB is loaded.
