### PR TITLE
Added posibility to override density on desktop

### DIFF
--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglApplicationConfiguration.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglApplicationConfiguration.java
@@ -47,6 +47,8 @@ public class LwjglApplicationConfiguration {
 	public int x = -1, y = -1;
 	/** fullscreen **/
 	public boolean fullscreen = false;
+	/** used to emulate screen densities **/
+	public int overrideDensity = -1;
 	/** whether to enable vsync, can be changed at runtime via {@link Graphics#setVSync(boolean)} **/
 	public boolean vSyncEnabled = true;
 	/** title of application **/

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGraphics.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGraphics.java
@@ -277,6 +277,8 @@ public class LwjglGraphics implements Graphics {
 
 	@Override
 	public float getDensity () {
+		if (config.overrideDensity != -1)
+			return config.overrideDensity / 160f;
 		return (Toolkit.getDefaultToolkit().getScreenResolution() / 160f);
 	}
 


### PR DESCRIPTION
As suggested in issue #1823.

Example of usage: http://i.imgur.com/Xj2n3tG.png

This is very handy to emulate screen sizes on desktop, without having to use the android emulator. E.g. set the resolution to 800x480 and set overrideDensity to 252 to emulate a 3.7 inch phone display with the same resolution.
