### PR TITLE
Box2d: Fixed issue #1381. Missing fixtureB in Contact when Body is removed.

### DIFF
--- a/extensions/gdx-box2d/gdx-box2d/src/com/badlogic/gdx/physics/box2d/World.java
+++ b/extensions/gdx-box2d/gdx-box2d/src/com/badlogic/gdx/physics/box2d/World.java
@@ -315,16 +315,16 @@ b2ContactFilter defaultFilter;
 	 * @warning This automatically deletes all associated shapes and joints.
 	 * @warning This function is locked during callbacks. */
 	public void destroyBody (Body body) {
+		Array<JointEdge> jointList = body.getJointList();
+		while (jointList.size > 0)
+			destroyJoint(body.getJointList().get(0).joint);
+		jniDestroyBody(addr, body.addr);
 		body.setUserData(null);
 		this.bodies.remove(body.addr);
 		Array<Fixture> fixtureList = body.getFixtureList();
 		while(fixtureList.size > 0) {
 			this.fixtures.remove(fixtureList.removeIndex(0).addr).setUserData(null);
 		}
-		Array<JointEdge> jointList = body.getJointList();
-		while (jointList.size > 0)
-			destroyJoint(body.getJointList().get(0).joint);
-		jniDestroyBody(addr, body.addr);
 		freeBodies.free(body);
 	}
 


### PR DESCRIPTION
Hi! I've got a simple solution to the bug #1381. :P
In the World class the destroyBody() method frees Java objects in the wrong order. All joints, fixtures and the body are removed before jniDestroyBody() method is called and usually this is a correct behaviour. But, in this case the ContactListener callbacks are invoked while destroying the body, so Java-side objects should be preserved until their native counterparts are destroyed.
