### PR TITLE
Restored Gdx.net on resume and removed outdated stuff.

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidLiveWallpaper.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidLiveWallpaper.java
@@ -53,7 +53,7 @@ public class AndroidLiveWallpaper implements AndroidApplicationBase {
 	static {
 		GdxNativesLoader.load();
 	}
-	
+
 	protected AndroidLiveWallpaperService service;
 
 	protected AndroidGraphicsLiveWallpaper graphics;
@@ -112,8 +112,8 @@ public class AndroidLiveWallpaper implements AndroidApplicationBase {
 		// near mEglHelper.swap() in GLSurfaceView while processing next onPause event.
 		// See related issue:
 		// http://code.google.com/p/libgdx/issues/detail?id=541
-		// the problem with graphics.pause occurs while using OpenGL 2.0 and original GLSurfaceView while rotating device in lwp
-// preview
+		// the problem with graphics.pause occurs while using OpenGL 2.0 and original GLSurfaceView while rotating device
+		// in lwp preview
 		// in my opinion it is a bug of android not libgdx, even example Cubic live wallpaper from
 		// Android SDK crashes on affected devices.......... and on some configurations of android emulator too.
 		//
@@ -121,8 +121,8 @@ public class AndroidLiveWallpaper implements AndroidApplicationBase {
 		// also I moved audio lifecycle methods from AndroidGraphicsLiveWallpaper into this class
 
 		// graphics.pause();
-		// if (AndroidLiveWallpaperService.DEBUG) Log.d(AndroidLiveWallpaperService.TAG,
-// " > AndroidLiveWallpaper - onPause() application paused!");
+		// if (AndroidLiveWallpaperService.DEBUG)
+		// Log.d(AndroidLiveWallpaperService.TAG, " > AndroidLiveWallpaper - onPause() application paused!");
 		audio.pause();
 
 		input.unregisterSensorListeners();
@@ -147,13 +147,10 @@ public class AndroidLiveWallpaper implements AndroidApplicationBase {
 		Gdx.audio = audio;
 		Gdx.files = files;
 		Gdx.graphics = graphics;
+		Gdx.net = net;
 
 		input.registerSensorListeners();
 
-		// FIXME restore conditional execution if lifecycle errors will occur when GLSurfaceView used.
-		// GLSurfaceView is guaranteed to work with this condition on, but GLSurfaceViewCupcake requires it off,
-		// so I disabled it.
-		// if (!firstResume) // mentioned condition
 		if (graphics != null) {
 			graphics.onResumeGLSurfaceView();
 		}
@@ -196,11 +193,6 @@ public class AndroidLiveWallpaper implements AndroidApplicationBase {
 
 	public AndroidLiveWallpaperService getService () {
 		return service;
-	}
-
-	@Deprecated
-	public ApplicationListener getListener () {
-		return listener;
 	}
 
 	@Override


### PR DESCRIPTION
- Fixed missing `Gdx.net = net` in onResume()
- Removed outdated comments (GLSurfaceViewCupcake doesn't exist anymore)
- Removed deprecated method `getListener` (I made it deprecated with application/graphics refactoring)
