### PR TITLE
Added user-defined color example.

### DIFF
--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/BitmapFontTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/BitmapFontTest.java
@@ -18,6 +18,7 @@ package com.badlogic.gdx.tests;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.Colors;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.graphics.g2d.BitmapFont.HAlignment;
@@ -40,6 +41,9 @@ public class BitmapFontTest extends GdxTest {
 		font = new BitmapFont(Gdx.files.internal("data/verdana39.fnt"), false);
 
 		multiPageFont = new BitmapFont(Gdx.files.internal("data/multipagefont.fnt"));
+
+		// Add user defined color
+		Colors.put("PERU", Color.valueOf("CD853F"));
 
 		renderer = new ShapeRenderer();
 		renderer.setProjectionMatrix(spriteBatch.getProjectionMatrix());
@@ -102,7 +106,7 @@ public class BitmapFontTest extends GdxTest {
 		textX += cache.setText("[black] ", textX, 150).width;
 		multiPageFont.setMarkupEnabled(true);
 		textX += cache.addText("[[[PINK]pink[]] ", textX, 150).width;
-		textX += cache.addText("[ORANGE][[orange] ", textX, 150).width;
+		textX += cache.addText("[PERU][[peru] ", textX, 150).width;
 		cache.setColor(Color.GREEN);
 		textX += cache.addText("green ", textX, 150).width;
 		textX += cache.addText("[#A52A2A]br[#A52A2ADF]ow[#A52A2ABF]n f[#A52A2A9F]ad[#A52A2A7F]in[#A52A2A5F]g o[#A52A2A3F]ut ",
@@ -125,5 +129,8 @@ public class BitmapFontTest extends GdxTest {
 		spriteBatch.dispose();
 		renderer.dispose();
 		font.dispose();
+
+		// Restore predefined colors
+		Colors.reset();
 	}
 }


### PR DESCRIPTION
Since I'm too lazy to write sample code directly to the [color markup wiki page](https://github.com/libgdx/libgdx/wiki/Color-Markup-Language) I just tell the user to see the `BitmapFontTest` source code, which is rather self-explanatory.
So I thought it was worth adding a user-defined color example.
