### PR TITLE
Added convenience methods for normal/bump maps

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g3d/attributes/TextureAttribute.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/attributes/TextureAttribute.java
@@ -50,6 +50,14 @@ public class TextureAttribute extends Attribute {
 		return new TextureAttribute(Specular, texture);
 	}
 
+	public static TextureAttribute createNormal (final Texture texture) {
+		return new TextureAttribute(Normal, texture);
+	}
+	
+	public static TextureAttribute createBump (final Texture texture) {
+		return new TextureAttribute(Bump, texture);
+	}
+
 	public final TextureDescriptor<Texture> textureDescription;
 
 	public TextureAttribute (final long type) {


### PR DESCRIPTION
Added the "missing" convenience methods to quickly create normal and bump maps.
They are not really helping that much, but it appears like a slight inconsistency to not have them.
