### PR TITLE
Only set modules to dev Modules when superDev task is executed, bring back configure on demand

### DIFF
--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/gradle.properties
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/gradle.properties
@@ -1,2 +1,3 @@
 org.gradle.daemon=true
 org.gradle.jvmargs=-Xms128m -Xmx256m
+org.gradle.configureondemand=true

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/html/build.gradle
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/html/build.gradle
@@ -54,9 +54,15 @@ draftWar {
    from "war"
 }
 
+task addSource << {
+	sourceSets.main.compileClasspath += files(project(':core').sourceSets.main.allJava.srcDirs)
+}
+
+tasks.compileGwt.dependsOn(addSource)
+tasks.draftCompileGwt.dependsOn(addSource)
+
 sourceCompatibility = 1.6
 sourceSets.main.java.srcDirs = [ "src/" ]
-sourceSets.main.compileClasspath += files(project(':core').sourceSets.main.allJava.srcDirs)
 
 
 eclipse.project {


### PR DESCRIPTION
- Stops the modules being set to devModules where it is not wanted
- Brings back configuration on demand as its now fixed in the HMTL project

We add the sources from the core project manually in the html project, but with Configure on Demand, the HTML project gets configured first.  This means that we add the sourceset for the core project before that source set is configured in the core project.  This adds the default java sourceset, which is src/main/java, which is not the convention we use.  

To fix this, I've added a task that compileGwt and draftCompileGwt depend on which adds the core source after the core project has been correctly configured. 
