### PR TITLE
Intersector.overlapConvexPolygon directionality

### DIFF
--- a/gdx/src/com/badlogic/gdx/math/Intersector.java
+++ b/gdx/src/com/badlogic/gdx/math/Intersector.java
@@ -816,7 +816,7 @@ public final class Intersector {
 		return closestX + closestY < c.radius * c.radius;
 	}
 
-	/** Check whether specified convex polygons overlap.
+	/** Check whether specified counter-clockwise wound convex polygons overlap.
 	 * 
 	 * @param p1 The first polygon.
 	 * @param p2 The second polygon.
@@ -825,8 +825,8 @@ public final class Intersector {
 		return overlapConvexPolygons(p1, p2, null);
 	}
 
-	/** Check whether specified convex polygons overlap. If they do, optionally obtain a Minimum Translation Vector indicating the
-	 * minimum magnitude vector required to push the polygons out of the collision.
+	/** Check whether specified counter-clockwise wound convex polygons overlap. If they do, optionally obtain a Minimum Translation Vector indicating the
+	 * minimum magnitude vector required to push the polygon p1 out of collision with polygon p2.
 	 * 
 	 * @param p1 The first polygon.
 	 * @param p2 The second polygon.
@@ -841,8 +841,8 @@ public final class Intersector {
 		return overlapConvexPolygons(verts1, 0, verts1.length, verts2, 0, verts2.length, mtv);
 	}
 
-	/** Check whether polygons defined by the given vertex arrays overlap. If they do, optionally obtain a Minimum Translation
-	 * Vector indicating the minimum magnitude vector required to push the polygons out of the collision.
+	/** Check whether polygons defined by the given counter-clockwise wound vertex arrays overlap. If they do, optionally obtain a Minimum Translation
+	 * Vector indicating the minimum magnitude vector required to push the polygon defined by verts1 out of the collision with the polygon defined by verts2.
 	 * 
 	 * @param verts1 Vertices of the first polygon.
 	 * @param verts2 Vertices of the second polygon.


### PR DESCRIPTION
Fixed the issue with Intersector.overlapConvexPolygon not honoring directionality with respect to moving p1 out of p2 as per issue described in Issue #1898.
