### PR TITLE
Add DS_Store to default gitignore

### DIFF
--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/gitignore
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/gitignore
@@ -58,3 +58,6 @@ nb-configuration.xml
 
 .gradle
 build/
+
+## OS Specific
+.DS_Store


### PR DESCRIPTION
Those files are automatically created in folders of OSX and don't belong to repository. Since a lot of people code in OSX this is quite convenient and doesn't hurt anything, they would probably add it anyway.
