### PR TITLE
Added setZero method to Vector interface.

### DIFF
--- a/gdx/src/com/badlogic/gdx/math/Vector.java
+++ b/gdx/src/com/badlogic/gdx/math/Vector.java
@@ -46,6 +46,10 @@ public interface Vector<T extends Vector<T>> {
 	 * @return This vector for chaining */
 	T set (T v);
 
+	/** Sets the components of this vector to 0
+	 * @return This vector for chaining */
+	T setZero ();
+
 	/** Subtracts the given vector from this vector.
 	 * @param v The vector
 	 * @return This vector for chaining */

--- a/gdx/src/com/badlogic/gdx/math/Vector2.java
+++ b/gdx/src/com/badlogic/gdx/math/Vector2.java
@@ -99,6 +99,12 @@ public class Vector2 implements Serializable, Vector<Vector2> {
 		return this;
 	}
 
+	@Override
+	public Vector2 setZero () {
+		x = y = 0f;
+		return this;
+	}
+
 	/** Substracts the other vector from this vector.
 	 * @param x The x-component of the other vector
 	 * @param y The y-component of the other vector

--- a/gdx/src/com/badlogic/gdx/math/Vector3.java
+++ b/gdx/src/com/badlogic/gdx/math/Vector3.java
@@ -108,6 +108,12 @@ public class Vector3 implements Serializable, Vector<Vector3> {
 	}
 
 	@Override
+	public Vector3 setZero () {
+		x = y = z = 0f;
+		return this;
+	}
+
+	@Override
 	public Vector3 cpy () {
 		return new Vector3(this);
 	}


### PR DESCRIPTION
Of course one could use `v.sub(v)` where v is declared as Vector, but `v.setZero()` is more readable IMO.
Also `setZero` falls in line with `isZero` which already exists.
