### PR TITLE
make particle effect loading less restrictive when using an atlas image

### DIFF
--- a/gdx/src/com/badlogic/gdx/assets/loaders/ParticleEffectLoader.java
+++ b/gdx/src/com/badlogic/gdx/assets/loaders/ParticleEffectLoader.java
@@ -36,7 +36,7 @@ public class ParticleEffectLoader extends SynchronousAssetLoader<ParticleEffect,
 	public ParticleEffect load (AssetManager am, String fileName, FileHandle file, ParticleEffectParameter param) {
 		ParticleEffect effect = new ParticleEffect();
 		if (param != null && param.atlasFile != null)
-			effect.load(file, am.get(param.atlasFile, TextureAtlas.class));
+			effect.load(file, am.get(param.atlasFile, TextureAtlas.class), param.atlasPrefix);
 		else if (param != null && param.imagesDir != null)
 			effect.load(file, param.imagesDir);
 		else
@@ -59,6 +59,8 @@ public class ParticleEffectLoader extends SynchronousAssetLoader<ParticleEffect,
 	public static class ParticleEffectParameter extends AssetLoaderParameters<ParticleEffect> {
 		/** Atlas file name. */
 		public String atlasFile;
+		/** Prefix to be added to the image names **/
+		public String atlasPrefix = "";
 		/** Image directory. */
 		public FileHandle imagesDir;
 	}

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/ParticleEffect.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/ParticleEffect.java
@@ -139,9 +139,9 @@ public class ParticleEffect implements Disposable {
 		loadEmitterImages(imagesDir);
 	}
 
-	public void load (FileHandle effectFile, TextureAtlas atlas) {
+	public void load (FileHandle effectFile, TextureAtlas atlas, String atlasPrefix) {
 		loadEmitters(effectFile);
-		loadEmitterImages(atlas);
+		loadEmitterImages(atlas, atlasPrefix);
 	}
 
 	public void loadEmitters (FileHandle effectFile) {
@@ -165,7 +165,7 @@ public class ParticleEffect implements Disposable {
 		}
 	}
 
-	public void loadEmitterImages (TextureAtlas atlas) {
+	public void loadEmitterImages (TextureAtlas atlas, String atlasPrefix) {
 		for (int i = 0, n = emitters.size; i < n; i++) {
 			ParticleEmitter emitter = emitters.get(i);
 			String imagePath = emitter.getImagePath();
@@ -173,6 +173,7 @@ public class ParticleEffect implements Disposable {
 			String imageName = new File(imagePath.replace('\\', '/')).getName();
 			int lastDotIndex = imageName.lastIndexOf('.');
 			if (lastDotIndex != -1) imageName = imageName.substring(0, lastDotIndex);
+			if (atlasPrefix.length() > 0) imageName = atlasPrefix + "/" + imageName;
 			Sprite sprite = atlas.createSprite(imageName);
 			if (sprite == null) throw new IllegalArgumentException("SpriteSheet missing image: " + imageName);
 			emitter.setSprite(sprite);


### PR DESCRIPTION
The particle loading system strips the Image Path, keeping only the filename without the extension. But when using an atlas, you might wanna use an image with a name such as "game/particle". But this is impossible, even if I manually change the particle file made by the particle editor and put "game/particle" as the image path, the loading system will strip it to "particle", and throw an exception of a missing atlas image.

This is quite annoying, as I do not wish to change my atlas hierarchy. This commit is a simple but dirty fix for this, allowing you to pass a prefix to be added to the image name. In the example above, you'd pass "game" as a prefix.

A real fix would be to add real atlas support directly in the particle editor, allowing you to load an atlas, and choose an image from it. I'd be glad to contribute this, but before spending any more time on it, I wanna know what you guys think
