### PR TITLE
TiledMap uses ObjectMap, override equals/hashcode for GridPoint.

### DIFF
--- a/gdx/src/com/badlogic/gdx/maps/tiled/TiledMapTileLayer.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/TiledMapTileLayer.java
@@ -17,6 +17,8 @@
 package com.badlogic.gdx.maps.tiled;
 
 import com.badlogic.gdx.maps.MapLayer;
+import com.badlogic.gdx.math.GridPoint2;
+import com.badlogic.gdx.utils.ObjectMap;
 
 /** @brief Layer for a TiledMap */
 public class TiledMapTileLayer extends MapLayer {
@@ -27,7 +29,8 @@ public class TiledMapTileLayer extends MapLayer {
 	private float tileWidth;
 	private float tileHeight;
 
-	private Cell[][] cells;
+	private GridPoint2 tempPoint = new GridPoint2();
+	private ObjectMap<GridPoint2, Cell> cells;
 
 	/** @return layer's width in tiles */
 	public int getWidth () {
@@ -61,16 +64,14 @@ public class TiledMapTileLayer extends MapLayer {
 		this.height = height;
 		this.tileWidth = tileWidth;
 		this.tileHeight = tileHeight;
-		this.cells = new Cell[width][height];
+		this.cells = new ObjectMap<GridPoint2, Cell>();
 	}
 
 	/** @param x X coordinate
 	 * @param y Y coordinate
 	 * @return {@link Cell} at (x, y) */
 	public Cell getCell (int x, int y) {
-		if (x < 0 || x >= width) return null;
-		if (y < 0 || y >= height) return null;
-		return cells[x][y];
+		return this.cells.get(tempPoint.set(x, y));
 	}
 
 	/** Sets the {@link Cell} at the given coordinates.
@@ -79,9 +80,7 @@ public class TiledMapTileLayer extends MapLayer {
 	 * @param y Y coordinate
 	 * @param cell the {@link Cell} to set at the given coordinates. */
 	public void setCell (int x, int y, Cell cell) {
-		if (x < 0 || x >= width) return;
-		if (y < 0 || y >= height) return;
-		cells[x][y] = cell;
+		this.cells.put(new GridPoint2(x, y), cell);
 	}
 
 	/** @brief represents a cell in a TiledLayer: TiledMapTile, flip and rotation properties. */

--- a/gdx/src/com/badlogic/gdx/math/GridPoint2.java
+++ b/gdx/src/com/badlogic/gdx/math/GridPoint2.java
@@ -16,6 +16,8 @@
 
 package com.badlogic.gdx.math;
 
+import com.badlogic.gdx.utils.NumberUtils;
+
 /** A point in a 2D grid, with integer x and y coordinates
  * 
  * @author badlogic */
@@ -65,5 +67,25 @@ public class GridPoint2 {
 		this.x = x;
 		this.y = y;
 		return this;
+	}
+
+	@Override
+	public int hashCode () {
+		final int prime = 37;
+		int result = 1;
+		result = prime * result + NumberUtils.floatToIntBits(x);
+		result = prime * result + NumberUtils.floatToIntBits(y);
+		return result;
+	}
+
+	@Override
+	public boolean equals (Object obj) {
+		if (this == obj) return true;
+		if (obj == null) return false;
+		if (getClass() != obj.getClass()) return false;
+		GridPoint2 other = (GridPoint2)obj;
+		if (NumberUtils.floatToIntBits(x) != NumberUtils.floatToIntBits(other.x)) return false;
+		if (NumberUtils.floatToIntBits(y) != NumberUtils.floatToIntBits(other.y)) return false;
+		return true;
 	}
 }

--- a/gdx/src/com/badlogic/gdx/math/GridPoint3.java
+++ b/gdx/src/com/badlogic/gdx/math/GridPoint3.java
@@ -16,6 +16,8 @@
 
 package com.badlogic.gdx.math;
 
+import com.badlogic.gdx.utils.NumberUtils;
+
 /** A point in a 3D grid, with integer x and y coordinates
  * 
  * @author badlogic */
@@ -72,5 +74,27 @@ public class GridPoint3 {
 		this.y = y;
 		this.z = z;
 		return this;
+	}
+
+	@Override
+	public int hashCode () {
+		final int prime = 37;
+		int result = 1;
+		result = prime * result + NumberUtils.floatToIntBits(x);
+		result = prime * result + NumberUtils.floatToIntBits(y);
+		result = prime * result + NumberUtils.floatToIntBits(z);
+		return result;
+	}
+
+	@Override
+	public boolean equals (Object obj) {
+		if (this == obj) return true;
+		if (obj == null) return false;
+		if (getClass() != obj.getClass()) return false;
+		GridPoint3 other = (GridPoint3)obj;
+		if (NumberUtils.floatToIntBits(x) != NumberUtils.floatToIntBits(other.x)) return false;
+		if (NumberUtils.floatToIntBits(y) != NumberUtils.floatToIntBits(other.y)) return false;
+		if (NumberUtils.floatToIntBits(z) != NumberUtils.floatToIntBits(other.z)) return false;
+		return true;
 	}
 }


### PR DESCRIPTION
I am writing this openstreetmap extension for Libgdx. However I ran into memory problems when using the TiledMap-API. When creating a new layer, the layer immediately allocates Cell[width][height]. For potentially large maps this is problematic (gives JVM out of memory exception). This solution uses ObjectMap instead of allocating the arrays. However, I also had to override equals/hashcode for GridPoint (which is used as the key).
