### PR TITLE
Avoid unnecessary memory allocation on ImmediateModeRenderer20 end() call

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/glutils/ImmediateModeRenderer20.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/ImmediateModeRenderer20.java
@@ -45,6 +45,7 @@ public class ImmediateModeRenderer20 implements ImmediateModeRenderer {
 	private final int texCoordOffset;
 	private final Matrix4 projModelView = new Matrix4();
 	private final float[] vertices;
+	private final String[] shaderUniformNames;
 
 	public ImmediateModeRenderer20 (boolean hasNormals, boolean hasColors, int numTexCoords) {
 		this(5000, hasNormals, hasColors, numTexCoords, createDefaultShader(hasNormals, hasColors, numTexCoords));
@@ -71,6 +72,11 @@ public class ImmediateModeRenderer20 implements ImmediateModeRenderer {
 			: 0;
 		texCoordOffset = mesh.getVertexAttribute(Usage.TextureCoordinates) != null ? mesh
 			.getVertexAttribute(Usage.TextureCoordinates).offset / 4 : 0;
+			
+		shaderUniformNames = new String[numTexCoords];
+		for (int i = 0; i < numTexCoords; i++) {
+			shaderUniformNames[i] = "u_sampler" + i;
+		}
 	}
 
 	private VertexAttribute[] buildVertexAttributes (boolean hasNormals, boolean hasColor, int numTexCoords) {
@@ -136,7 +142,7 @@ public class ImmediateModeRenderer20 implements ImmediateModeRenderer {
 		shader.begin();
 		shader.setUniformMatrix("u_projModelView", projModelView);
 		for (int i = 0; i < numTexCoords; i++)
-			shader.setUniformi("u_sampler" + i, i);
+			shader.setUniformi(shaderUniformNames[i], i);
 		mesh.setVertices(vertices, 0, vertexIdx);
 		mesh.render(shader, primitiveType);
 		shader.end();


### PR DESCRIPTION
Removes the implicit StringBuilder to generate the uniform name instantiated on every end() call replacing it with pre-generated values.

Because the end() method can be called once or more per frame, this could lead to memory allocation issues.
