### PR TITLE
Make findActor method in Group return typed actor

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/Group.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/Group.java
@@ -286,15 +286,15 @@ public class Group extends Actor implements Cullable {
 	}
 
 	/** Returns the first actor found with the specified name. Note this recursively compares the name of every actor in the group. */
-	public Actor findActor (String name) {
+	public <T extends Actor> T findActor (String name) {
 		Array<Actor> children = this.children;
 		for (int i = 0, n = children.size; i < n; i++)
-			if (name.equals(children.get(i).getName())) return children.get(i);
+			if (name.equals(children.get(i).getName())) return (T) children.get(i);
 		for (int i = 0, n = children.size; i < n; i++) {
 			Actor child = children.get(i);
 			if (child instanceof Group) {
 				Actor actor = ((Group)child).findActor(name);
-				if (actor != null) return actor;
+				if (actor != null) return (T) actor;
 			}
 		}
 		return null;


### PR DESCRIPTION
Since there are no names by default, if `findActor` returns something, it has known type to the user, because he is the one who assigns names. This tiny pull request reduces typecasting boilerplate.
