### PR TITLE
FrameBuffer with multisampling

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/glutils/FrameBuffer.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/FrameBuffer.java
@@ -40,21 +40,22 @@ import com.badlogic.gdx.utils.BufferUtils;
 import com.badlogic.gdx.utils.Disposable;
 import com.badlogic.gdx.utils.GdxRuntimeException;
 
-/**
- * <p>
- * Encapsulates OpenGL ES 2.0 frame buffer objects. This is a simple helper class which should cover most FBO uses. It will automatically create a texture for the color attachment and a renderbuffer for the depth buffer. You can get a hold of the texture by {@link FrameBuffer#getColorBufferTexture()}. This class will only work with OpenGL ES 2.0.
+/** <p>
+ * Encapsulates OpenGL ES 2.0 frame buffer objects. This is a simple helper class which should cover most FBO uses. It will
+ * automatically create a texture for the color attachment and a renderbuffer for the depth buffer. You can get a hold of the
+ * texture by {@link FrameBuffer#getColorBufferTexture()}. This class will only work with OpenGL ES 2.0.
  * </p>
  * 
  * <p>
- * FrameBuffers are managed. In case of an OpenGL context loss, which only happens on Android when a user switches to another application or receives an incoming call, the framebuffer will be automatically recreated.
+ * FrameBuffers are managed. In case of an OpenGL context loss, which only happens on Android when a user switches to another
+ * application or receives an incoming call, the framebuffer will be automatically recreated.
  * </p>
  * 
  * <p>
  * A FrameBuffer must be disposed if it is no longer needed
  * </p>
  * 
- * @author mzechner
- */
+ * @author mzechner */
 public class FrameBuffer implements Disposable {
 	/** the frame buffers **/
 	private final static Map<Application, Array<FrameBuffer>> buffers = new HashMap<Application, Array<FrameBuffer>>();
@@ -90,41 +91,36 @@ public class FrameBuffer implements Disposable {
 	protected boolean isMsaa = true;
 	protected int maxsamples = 1;
 
-	/**
-	 * Creates a new FrameBuffer having the given dimensions and potentially a depth buffer attached.
+	/** Creates a new FrameBuffer having the given dimensions and potentially a depth buffer attached.
 	 * 
-	 * @param format
-	 *            the format of the color buffer; according to the OpenGL ES 2.0 spec, only RGB565, RGBA4444 and RGB5_A1 are color-renderable
-	 * @param width
-	 *            the width of the framebuffer in pixels
-	 * @param height
-	 *            the height of the framebuffer in pixels
-	 * @param hasDepth
-	 *            whether to attach a depth buffer
-	 * @throws GdxRuntimeException
-	 *             in case the FrameBuffer could not be created
-	 */
-	public FrameBuffer(Pixmap.Format format, int width, int height, boolean hasDepth) {
+	 * @param format the format of the color buffer; according to the OpenGL ES 2.0 spec, only RGB565, RGBA4444 and RGB5_A1 are
+	 *           color-renderable
+	 * @param width the width of the framebuffer in pixels
+	 * @param height the height of the framebuffer in pixels
+	 * @param hasDepth whether to attach a depth buffer
+	 * @throws GdxRuntimeException in case the FrameBuffer could not be created */
+	public FrameBuffer (Pixmap.Format format, int width, int height, boolean hasDepth) {
 		this.width = width;
 		this.height = height;
 		this.format = format;
 		this.hasDepth = hasDepth;
-		
-		this.isMsaa = GLContext.getCapabilities().GL_EXT_framebuffer_multisample & GLContext.getCapabilities().GL_EXT_framebuffer_blit;
-		
+
+		this.isMsaa = GLContext.getCapabilities().GL_EXT_framebuffer_multisample
+			& GLContext.getCapabilities().GL_EXT_framebuffer_blit;
+
 		build();
 
 		addManagedFrameBuffer(Gdx.app, this);
 	}
 
 	/** Override this method in a derived class to set up the backing texture as you like. */
-	protected void setupTexture() {
+	protected void setupTexture () {
 		colorTexture = new Texture(width, height, format);
 		colorTexture.setFilter(TextureFilter.Linear, TextureFilter.Linear);
 		colorTexture.setWrap(TextureWrap.ClampToEdge, TextureWrap.ClampToEdge);
 	}
 
-	private void build() {
+	private void build () {
 		GL20 gl = Gdx.graphics.getGL20();
 
 		// iOS uses a different framebuffer handle! (not necessarily 0)
@@ -147,7 +143,8 @@ public class FrameBuffer implements Disposable {
 			gl.glGenRenderbuffers(1, colorBuffer);
 			colorBufferHandle = colorBuffer.get(0);
 			gl.glBindRenderbuffer(GL20.GL_RENDERBUFFER, colorBufferHandle);
-			EXTFramebufferMultisample.glRenderbufferStorageMultisampleEXT(GL20.GL_RENDERBUFFER, maxsamples, GL11.GL_RGBA8, width, height);
+			EXTFramebufferMultisample.glRenderbufferStorageMultisampleEXT(GL20.GL_RENDERBUFFER, maxsamples, GL11.GL_RGBA8, width,
+				height);
 		}
 
 		IntBuffer handle = BufferUtils.newIntBuffer(1);
@@ -166,9 +163,11 @@ public class FrameBuffer implements Disposable {
 			gl.glBindRenderbuffer(GL20.GL_RENDERBUFFER, depthbufferHandle);
 
 			if (isMsaa) {
-				EXTFramebufferMultisample.glRenderbufferStorageMultisampleEXT(GL20.GL_RENDERBUFFER, maxsamples, GL20.GL_DEPTH_COMPONENT16, width, height);
+				EXTFramebufferMultisample.glRenderbufferStorageMultisampleEXT(GL20.GL_RENDERBUFFER, maxsamples,
+					GL20.GL_DEPTH_COMPONENT16, width, height);
 			} else {
-				gl.glRenderbufferStorage(GL20.GL_RENDERBUFFER, GL20.GL_DEPTH_COMPONENT16, colorTexture.getWidth(), colorTexture.getHeight());
+				gl.glRenderbufferStorage(GL20.GL_RENDERBUFFER, GL20.GL_DEPTH_COMPONENT16, colorTexture.getWidth(),
+					colorTexture.getHeight());
 			}
 		}
 
@@ -185,7 +184,8 @@ public class FrameBuffer implements Disposable {
 		}
 
 		gl.glBindFramebuffer(GL20.GL_FRAMEBUFFER, framebufferHandle);
-		gl.glFramebufferTexture2D(GL20.GL_FRAMEBUFFER, GL20.GL_COLOR_ATTACHMENT0, GL20.GL_TEXTURE_2D, colorTexture.getTextureObjectHandle(), 0);
+		gl.glFramebufferTexture2D(GL20.GL_FRAMEBUFFER, GL20.GL_COLOR_ATTACHMENT0, GL20.GL_TEXTURE_2D,
+			colorTexture.getTextureObjectHandle(), 0);
 		if (hasDepth && !isMsaa) {
 			gl.glFramebufferRenderbuffer(GL20.GL_FRAMEBUFFER, GL20.GL_DEPTH_ATTACHMENT, GL20.GL_RENDERBUFFER, depthbufferHandle);
 		}
@@ -222,7 +222,7 @@ public class FrameBuffer implements Disposable {
 	}
 
 	/** Releases all resources associated with the FrameBuffer. */
-	public void dispose() {
+	public void dispose () {
 		GL20 gl = Gdx.graphics.getGL20();
 
 		IntBuffer handle = BufferUtils.newIntBuffer(1);
@@ -233,12 +233,12 @@ public class FrameBuffer implements Disposable {
 			handle.flip();
 			gl.glDeleteRenderbuffers(1, handle);
 		}
-		
-		if(isMsaa) {
+
+		if (isMsaa) {
 			handle.clear();
 			handle.put(multiFramebufferHandle);
 			handle.flip();
-			gl.glDeleteRenderbuffers(1,  handle);
+			gl.glDeleteRenderbuffers(1, handle);
 		}
 
 		handle.clear();
@@ -246,12 +246,11 @@ public class FrameBuffer implements Disposable {
 		handle.flip();
 		gl.glDeleteFramebuffers(1, handle);
 
-		if (buffers.get(Gdx.app) != null)
-			buffers.get(Gdx.app).removeValue(this, true);
+		if (buffers.get(Gdx.app) != null) buffers.get(Gdx.app).removeValue(this, true);
 	}
 
 	/** Makes the frame buffer current so everything gets drawn to it. */
-	public void bind() {
+	public void bind () {
 		if (isMsaa) {
 			Gdx.graphics.getGL20().glBindFramebuffer(GL20.GL_FRAMEBUFFER, multiFramebufferHandle);
 		} else {
@@ -260,100 +259,91 @@ public class FrameBuffer implements Disposable {
 	}
 
 	/** Unbinds the framebuffer, all drawing will be performed to the normal framebuffer from here on. */
-	public void unbind() {
+	public void unbind () {
 		GL20 gl = Gdx.graphics.getGL20();
 
 		if (isMsaa) {
 			gl.glBindFramebuffer(EXTFramebufferBlit.GL_READ_FRAMEBUFFER_EXT, multiFramebufferHandle);
 			gl.glBindFramebuffer(EXTFramebufferBlit.GL_DRAW_FRAMEBUFFER_EXT, framebufferHandle);
-			EXTFramebufferBlit.glBlitFramebufferEXT(0, 0, width, height, 0, 0, width, height, GL20.GL_COLOR_BUFFER_BIT, GL20.GL_NEAREST);
+			EXTFramebufferBlit.glBlitFramebufferEXT(0, 0, width, height, 0, 0, width, height, GL20.GL_COLOR_BUFFER_BIT,
+				GL20.GL_NEAREST);
 		}
 
 		gl.glBindFramebuffer(GL20.GL_FRAMEBUFFER, defaultFramebufferHandle);
 	}
 
 	/** Binds the frame buffer and sets the viewport accordingly, so everything gets drawn to it. */
-	public void begin() {
+	public void begin () {
 		bind();
 		setFrameBufferViewport();
 	}
 
 	/** Sets viewport to the dimensions of framebuffer. Called by {@link #begin()}. */
-	protected void setFrameBufferViewport() {
+	protected void setFrameBufferViewport () {
 		Gdx.graphics.getGL20().glViewport(0, 0, colorTexture.getWidth(), colorTexture.getHeight());
 	}
 
 	/** Unbinds the framebuffer, all drawing will be performed to the normal framebuffer from here on. */
-	public void end() {
+	public void end () {
 		unbind();
 		setDefaultFrameBufferViewport();
 	}
 
 	/** Sets viewport to the dimensions of default framebuffer (window). Called by {@link #end()}. */
-	protected void setDefaultFrameBufferViewport() {
+	protected void setDefaultFrameBufferViewport () {
 		Gdx.graphics.getGL20().glViewport(0, 0, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
 	}
 
-	/**
-	 * Unbinds the framebuffer and sets viewport sizes, all drawing will be performed to the normal framebuffer from here on.
+	/** Unbinds the framebuffer and sets viewport sizes, all drawing will be performed to the normal framebuffer from here on.
 	 * 
-	 * @param x
-	 *            the x-axis position of the viewport in pixels
-	 * @param y
-	 *            the y-asis position of the viewport in pixels
-	 * @param width
-	 *            the width of the viewport in pixels
-	 * @param height
-	 *            the height of the viewport in pixels
-	 */
-	public void end(int x, int y, int width, int height) {
+	 * @param x the x-axis position of the viewport in pixels
+	 * @param y the y-asis position of the viewport in pixels
+	 * @param width the width of the viewport in pixels
+	 * @param height the height of the viewport in pixels */
+	public void end (int x, int y, int width, int height) {
 		unbind();
 		Gdx.graphics.getGL20().glViewport(x, y, width, height);
 	}
 
 	/** @return the color buffer texture */
-	public Texture getColorBufferTexture() {
+	public Texture getColorBufferTexture () {
 		return colorTexture;
 	}
 
 	/** @return the height of the framebuffer in pixels */
-	public int getHeight() {
+	public int getHeight () {
 		return colorTexture.getHeight();
 	}
 
 	/** @return the width of the framebuffer in pixels */
-	public int getWidth() {
+	public int getWidth () {
 		return colorTexture.getWidth();
 	}
 
-	private static void addManagedFrameBuffer(Application app, FrameBuffer frameBuffer) {
+	private static void addManagedFrameBuffer (Application app, FrameBuffer frameBuffer) {
 		Array<FrameBuffer> managedResources = buffers.get(app);
-		if (managedResources == null)
-			managedResources = new Array<FrameBuffer>();
+		if (managedResources == null) managedResources = new Array<FrameBuffer>();
 		managedResources.add(frameBuffer);
 		buffers.put(app, managedResources);
 	}
 
-	/**
-	 * Invalidates all frame buffers. This can be used when the OpenGL context is lost to rebuild all managed frame buffers. This assumes that the texture attached to this buffer has already been rebuild! Use with care.
-	 */
-	public static void invalidateAllFrameBuffers(Application app) {
-		if (Gdx.graphics.getGL20() == null)
-			return;
+	/** Invalidates all frame buffers. This can be used when the OpenGL context is lost to rebuild all managed frame buffers. This
+	 * assumes that the texture attached to this buffer has already been rebuild! Use with care. */
+	public static void invalidateAllFrameBuffers (Application app) {
+		if (Gdx.graphics.getGL20() == null) return;
 
 		Array<FrameBuffer> bufferArray = buffers.get(app);
-		if (bufferArray == null)
-			return;
+		if (bufferArray == null) return;
 		for (int i = 0; i < bufferArray.size; i++) {
 			bufferArray.get(i).build();
 		}
 	}
 
-	public static void clearAllFrameBuffers(Application app) {
+	public static void clearAllFrameBuffers (Application app) {
 		buffers.remove(app);
 	}
 
-	public static StringBuilder getManagedStatus(final StringBuilder builder) {
+	public static StringBuilder getManagedStatus (final StringBuilder builder) {
 		builder.append("Managed buffers/app: { ");
 		for (Application app : buffers.keySet()) {
 			builder.append(buffers.get(app).size);
@@ -363,7 +353,7 @@ public class FrameBuffer implements Disposable {
 		return builder;
 	}
 
-	public static String getManagedStatus() {
+	public static String getManagedStatus () {
 		return getManagedStatus(new StringBuilder()).toString();
 	}
 }


### PR DESCRIPTION
Hello all,

After working with post-processing shaders, I found out that framebuffers don't use msaa (only the default one).
It was a very annoying discovery so I decided to modify the FrameBuffer class and add the ability to automatically use multisampling if graphic card is able to.

It's quite brute coded but everything should be there before refactoring !
I know it uses opengl extensions, so for compatibility this is not the best thing, but because it switches automatically to multisampling if and only if available, it shouldn't be a problem for non-capable graphic cards.
(perhaps frameBuffer multisampling should it be an option in FrameBuffer constructor or get the msaa variable of configuration ?)
What do you think ?
