### PR TITLE
Added a FreeTypeFontGeneratorLoader

### DIFF
--- a/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGeneratorLoader.java
+++ b/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGeneratorLoader.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  ******************************************************************************/
+
 package com.badlogic.gdx.graphics.g2d.freetype;
 
 import com.badlogic.gdx.assets.AssetDescriptor;
@@ -21,22 +22,25 @@ import com.badlogic.gdx.assets.AssetManager;
 import com.badlogic.gdx.assets.loaders.FileHandleResolver;
 import com.badlogic.gdx.assets.loaders.SynchronousAssetLoader;
 import com.badlogic.gdx.files.FileHandle;
-import com.badlogic.gdx.graphics.g2d.freetype.FreeTypeFontGenerator;
 import com.badlogic.gdx.utils.Array;
 
-/**
- * @author Daniel Holderbaum
- */
+/** Makes {@link FreeTypeFontGenerator} managable via {@link AssetManager}.
+ * <p>
+ * Do
+ * {@code assetManager.setLoader(FreeTypeFontGenerator.class, new FreeTypeFontGeneratorLoader(new InternalFileHandleResolver()))}
+ * to register it.
+ * </p>
+ * @author Daniel Holderbaum */
 public class FreeTypeFontGeneratorLoader extends
-		SynchronousAssetLoader<FreeTypeFontGenerator, FreeTypeFontGeneratorLoader.FreeTypeFontGeneratorParameters> {
+	SynchronousAssetLoader<FreeTypeFontGenerator, FreeTypeFontGeneratorLoader.FreeTypeFontGeneratorParameters> {
 
-	public FreeTypeFontGeneratorLoader(FileHandleResolver resolver) {
+	public FreeTypeFontGeneratorLoader (FileHandleResolver resolver) {
 		super(resolver);
 	}
 
 	@Override
-	public FreeTypeFontGenerator load(AssetManager assetManager, String fileName, FileHandle file,
-			FreeTypeFontGeneratorParameters parameter) {
+	public FreeTypeFontGenerator load (AssetManager assetManager, String fileName, FileHandle file,
+		FreeTypeFontGeneratorParameters parameter) {
 		FreeTypeFontGenerator generator = new FreeTypeFontGenerator(file);
 
 		return generator;
@@ -46,7 +50,7 @@ public class FreeTypeFontGeneratorLoader extends
 	}
 
 	@Override
-	public Array<AssetDescriptor> getDependencies(String fileName, FileHandle file, FreeTypeFontGeneratorParameters parameter) {
+	public Array<AssetDescriptor> getDependencies (String fileName, FileHandle file, FreeTypeFontGeneratorParameters parameter) {
 		return null;
 	}
 }


### PR DESCRIPTION
(New PR because I broke the old one...)

I added a loader to be able to manage `FreeTypeFontGenerator`s with an `AssetManager`. I think the generators might be used in a lot of places and being able to load and retrieve them via the `AssetManager` should be good choice.
