### PR TITLE
Rectangle: Equals and HashCode

### DIFF
--- a/gdx/src/com/badlogic/gdx/math/Rectangle.java
+++ b/gdx/src/com/badlogic/gdx/math/Rectangle.java
@@ -360,10 +360,6 @@ public class Rectangle implements Serializable {
 		return x + "," + y + "," + width + "," + height;
 	}
 
-	/* (non-Javadoc)
-	 * @see java.lang.Object#hashCode()
-	 */
-	@Override
 	public int hashCode () {
 		final int prime = 31;
 		int result = 1;
@@ -374,10 +370,6 @@ public class Rectangle implements Serializable {
 		return result;
 	}
 
-	/* (non-Javadoc)
-	 * @see java.lang.Object#equals(java.lang.Object)
-	 */
-	@Override
 	public boolean equals (Object obj) {
 		if (this == obj) return true;
 		if (obj == null) return false;


### PR DESCRIPTION
Hi,

I was working on my game for the Nar8 jam, and upon implementing a bounding volume hierarchy using rectangles, I noticed two critical functions were missing. First, the equals method was non-existent, making equivalence comparison between rectangles impossible. Secondly, the hashcode method was missing. Normally overriding hashcode is not required, but given that I have chosen to override equals, it is good coding practice to thereby override hashcode (See http://stackoverflow.com/questions/27581/overriding-equals-and-hashcode-in-java). I hope you find these additions useful to the API.

Cheers,
MadcowD
carlostnb@gmail dot com.
