### PR TITLE
TMXLoader : Add support for 'rotation' property

### DIFF
--- a/gdx/src/com/badlogic/gdx/maps/tiled/AtlasTmxMapLoader.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/AtlasTmxMapLoader.java
@@ -530,6 +530,10 @@ public class AtlasTmxMapLoader extends AsynchronousAssetLoader<TiledMap, AtlasTm
 				object = new RectangleMapObject(x, y - height, width, height);
 			}
 			object.setName(element.getAttribute("name", null));
+			String rotation = element.getAttribute("rotation", null);
+			if (rotation != null) {
+				object.getProperties().put("rotation", Float.parseFloat(rotation));
+			}
 			String type = element.getAttribute("type", null);
 			if (type != null) {
 				object.getProperties().put("type", type);

--- a/gdx/src/com/badlogic/gdx/maps/tiled/TmxMapLoader.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/TmxMapLoader.java
@@ -488,6 +488,10 @@ public class TmxMapLoader extends AsynchronousAssetLoader<TiledMap, TmxMapLoader
 				object = new RectangleMapObject(x, y - height, width, height);
 			}
 			object.setName(element.getAttribute("name", null));
+			String rotation = element.getAttribute("rotation", null);
+			if (rotation != null) {
+				object.getProperties().put("rotation", Float.parseFloat(rotation));
+			}
 			String type = element.getAttribute("type", null);
 			if (type != null) {
 				object.getProperties().put("type", type);


### PR DESCRIPTION
Very simple commit, just to load Tiled's 'rotation' property when it is defined (i.e. when used in Tiled editor) in the MapObject properties. When the rotation is not used, Tiled do not put this property, therefore nothing is loaded and you just get the current behavior.
