### PR TITLE
iOS; Allow to run without IOSAudio

### DIFF
--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSAudio.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSAudio.java
@@ -17,6 +17,7 @@
 package com.badlogic.gdx.backends.iosrobovm;
 
 import com.badlogic.gdx.Audio;
+import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.audio.AudioDevice;
 import com.badlogic.gdx.audio.AudioRecorder;
 import com.badlogic.gdx.audio.Music;
@@ -29,8 +30,12 @@ import com.badlogic.gdx.utils.GdxRuntimeException;
 public class IOSAudio implements Audio {
 
 	public IOSAudio (IOSApplicationConfiguration config) {
-		OALSimpleAudio.sharedInstance().setAllowIpod(config.allowIpod);
-		OALSimpleAudio.sharedInstance().setHonorSilentSwitch(true);
+		OALSimpleAudio audio = OALSimpleAudio.sharedInstance();
+		if (audio != null) {
+			audio.setAllowIpod(config.allowIpod);
+			audio.setHonorSilentSwitch(true);
+		} else
+			Gdx.app.error("IOSAudio", "No OALSimpleAudio instance available, audio will not be availabe");
 	}
 
 	@Override

--- a/tests/gdx-tests-iosrobovm/src/com/badlogic/gdx/tests/IOSRobovmTests.java
+++ b/tests/gdx-tests-iosrobovm/src/com/badlogic/gdx/tests/IOSRobovmTests.java
@@ -21,6 +21,7 @@ import org.robovm.apple.uikit.UIApplication;
 
 import com.badlogic.gdx.backends.iosrobovm.IOSApplication;
 import com.badlogic.gdx.backends.iosrobovm.IOSApplicationConfiguration;
+import com.badlogic.gdx.tests.g3d.Benchmark3DTest;
 
 public class IOSRobovmTests extends IOSApplication.Delegate {
 	
@@ -28,7 +29,7 @@ public class IOSRobovmTests extends IOSApplication.Delegate {
 	protected IOSApplication createApplication() {
 		IOSApplicationConfiguration config = new IOSApplicationConfiguration();
 		config.useAccelerometer = false;
-		return new IOSApplication(new InputTest(), config);
+		return new IOSApplication(new Benchmark3DTest(), config);
 	}
 
 	public static void main(String[] argv) {

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/Benchmark3DTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/Benchmark3DTest.java
@@ -17,6 +17,7 @@
 package com.badlogic.gdx.tests.g3d;
 
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Input.Buttons;
 import com.badlogic.gdx.Input.Keys;
 import com.badlogic.gdx.graphics.Camera;
 import com.badlogic.gdx.graphics.Color;
@@ -71,7 +72,7 @@ public class Benchmark3DTest extends BaseG3dHudTest {
 
 		randomizeLights();
 
-		cam.position.set(1, 1, 1);
+		cam.position.set(10, 10, 10);
 		cam.lookAt(0, 0, 0);
 		cam.update();
 		showAxes = true;
@@ -237,7 +238,7 @@ public class Benchmark3DTest extends BaseG3dHudTest {
 		instance.transform.rotate(Vector3.Z, MathUtils.random(-180, 180));
 		instances.add(instance);
 	}
-
+	
 	@Override
 	public boolean keyUp (int keycode) {
 		if (keycode == Keys.SPACE || keycode == Keys.MENU) {
@@ -245,7 +246,13 @@ public class Benchmark3DTest extends BaseG3dHudTest {
 		}
 		return super.keyUp(keycode);
 	}
-
+	
+	@Override
+	public boolean touchUp (int screenX, int screenY, int pointer, int button) {
+		onModelClicked(models[MathUtils.random(models.length-1)]);
+		return false;
+	}
+	
 	@Override
 	public void dispose () {
 		super.dispose();


### PR DESCRIPTION
I finally have OSX running. The only problem i encountered was that the audio device wasn't available (which makes sense), causing a NPE in IOSAudio. This change checks for this NPE, making it possible to run without an audio device.
