### PR TITLE
avoid raw Types when dealing with scene2d Cell

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Table.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Table.java
@@ -51,10 +51,10 @@ public class Table extends WidgetGroup {
 
 	private int columns, rows;
 
-	private final Array<Cell> cells = new Array<Cell>(4);
-	private final Cell<Actor> cellDefaults;
-	private final Array<Cell> columnDefaults = new Array<Cell>(2);
-	private Cell<Actor> rowDefaults;
+	private final Array<Cell> cells = new Array(4);
+	private final Cell cellDefaults;
+	private final Array<Cell> columnDefaults = new Array(2);
+	private Cell rowDefaults;
 
 	private boolean sizeInvalid = true;
 	private float[] columnMinWidth, rowMinHeight;
@@ -280,7 +280,7 @@ public class Table extends WidgetGroup {
 	}
 
 	/** Adds a cell without an actor. */
-	public Cell<Actor> add () {
+	public Cell add () {
 		return add((Actor) null);
 	}
 
@@ -367,7 +367,7 @@ public class Table extends WidgetGroup {
 
 	/** Gets the cell values that will be used as the defaults for all cells in the specified column. Columns are indexed starting
 	 * at 0. */
-	public <T extends Actor> Cell<T> columnDefaults (int column) {
+	public Cell columnDefaults (int column) {
 		Cell cell = columnDefaults.size > column ? columnDefaults.get(column) : null;
 		if (cell == null) {
 			cell = obtainCell();


### PR DESCRIPTION
The integration of scene2d ui into libgdx seemed to do something with generic types that broke the API for Kotlin (and other JVM languages that don't support raw types). In short, it made chaining impossible which meant lots of redundant casting in a new statement, which is a pain.

This PR fixes that.

I did some rudimentary testing with existing scene2d ui apps, seems to not have broken anything.
