### PR TITLE
Add VertexAttribute#type, #normalized, #hashCode(), .ColorPacked()

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/glutils/VertexArray.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/VertexArray.java
@@ -114,12 +114,8 @@ public class VertexArray implements VertexData {
 				shader.enableVertexAttribute(location);
 
 				byteBuffer.position(attribute.offset);
-				if (attribute.usage == Usage.ColorPacked)
-					shader.setVertexAttribute(location, attribute.numComponents, GL20.GL_UNSIGNED_BYTE, true, attributes.vertexSize,
-						byteBuffer);
-				else
-					shader.setVertexAttribute(location, attribute.numComponents, GL20.GL_FLOAT, false, attributes.vertexSize,
-						byteBuffer);
+				shader.setVertexAttribute(location, attribute.numComponents, attribute.type, attribute.normalized, attributes.vertexSize,
+					byteBuffer);
 			}
 		} else {
 			for (int i = 0; i < numAttributes; i++) {
@@ -129,12 +125,8 @@ public class VertexArray implements VertexData {
 				shader.enableVertexAttribute(location);
 
 				byteBuffer.position(attribute.offset);
-				if (attribute.usage == Usage.ColorPacked)
-					shader.setVertexAttribute(location, attribute.numComponents, GL20.GL_UNSIGNED_BYTE, true, attributes.vertexSize,
-						byteBuffer);
-				else
-					shader.setVertexAttribute(location, attribute.numComponents, GL20.GL_FLOAT, false, attributes.vertexSize,
-						byteBuffer);
+				shader.setVertexAttribute(location, attribute.numComponents, attribute.type, attribute.normalized, attributes.vertexSize,
+					byteBuffer);
 			}
 		}
 		isBound = true;

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/VertexBufferObject.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/VertexBufferObject.java
@@ -168,13 +168,10 @@ public class VertexBufferObject implements VertexData {
 				if (location < 0) continue;
 				shader.enableVertexAttribute(location);
 
-				if (attribute.usage == Usage.ColorPacked)
-					shader.setVertexAttribute(location, attribute.numComponents, GL20.GL_UNSIGNED_BYTE, true, attributes.vertexSize,
-						attribute.offset);
-				else
-					shader.setVertexAttribute(location, attribute.numComponents, GL20.GL_FLOAT, false, attributes.vertexSize,
+				shader.setVertexAttribute(location, attribute.numComponents, attribute.type, attribute.normalized, attributes.vertexSize,
 						attribute.offset);
 			}
+			
 		} else {
 			for (int i = 0; i < numAttributes; i++) {
 				final VertexAttribute attribute = attributes.get(i);
@@ -182,12 +179,8 @@ public class VertexBufferObject implements VertexData {
 				if (location < 0) continue;
 				shader.enableVertexAttribute(location);
 
-				if (attribute.usage == Usage.ColorPacked)
-					shader.setVertexAttribute(location, attribute.numComponents, GL20.GL_UNSIGNED_BYTE, true, attributes.vertexSize,
-						attribute.offset);
-				else
-					shader.setVertexAttribute(location, attribute.numComponents, GL20.GL_FLOAT, false, attributes.vertexSize,
-						attribute.offset);
+				shader.setVertexAttribute(location, attribute.numComponents, attribute.type, attribute.normalized, attributes.vertexSize,
+					attribute.offset);
 			}
 		}
 		isBound = true;

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/VertexBufferObjectSubData.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/VertexBufferObjectSubData.java
@@ -177,11 +177,7 @@ public class VertexBufferObjectSubData implements VertexData {
 				if (location < 0) continue;
 				shader.enableVertexAttribute(location);
 
-				if (attribute.usage == Usage.ColorPacked)
-					shader.setVertexAttribute(location, attribute.numComponents, GL20.GL_UNSIGNED_BYTE, true, attributes.vertexSize,
-						attribute.offset);
-				else
-					shader.setVertexAttribute(location, attribute.numComponents, GL20.GL_FLOAT, false, attributes.vertexSize,
+				shader.setVertexAttribute(location, attribute.numComponents, attribute.type, attribute.normalized, attributes.vertexSize,
 						attribute.offset);
 			}
 		} else {
@@ -191,11 +187,7 @@ public class VertexBufferObjectSubData implements VertexData {
 				if (location < 0) continue;
 				shader.enableVertexAttribute(location);
 
-				if (attribute.usage == Usage.ColorPacked)
-					shader.setVertexAttribute(location, attribute.numComponents, GL20.GL_UNSIGNED_BYTE, true, attributes.vertexSize,
-						attribute.offset);
-				else
-					shader.setVertexAttribute(location, attribute.numComponents, GL20.GL_FLOAT, false, attributes.vertexSize,
+				shader.setVertexAttribute(location, attribute.numComponents, attribute.type, attribute.normalized, attributes.vertexSize,
 						attribute.offset);
 			}
 		}


### PR DESCRIPTION
Small change removing the branch on `Usage.ColorPacked` when binding the vertex attribute. I've added two `public final` members to `VertexAttribute` named `type` and `normalized` to match the arguments of `glVertexAttribPointer`. The value of these members depend on the specified `usage`, keeping consistency with current behavior.

I noticed a small inconsistency:
`VertexAttribute.Color()` results in `ColorPacked`
`VertexAttribute.ColorUnpacked()` results in `Color`
Therefore I deprecated `VertexAttribute.Color()` and introduced `VertexAttribute.ColorPacked()`

Also added `VertexAttribute#hashCode()` to be consistent with `#equals()`
