### PR TITLE
Add new Drawable class ColorDrawable

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,6 @@
 [1.2.1]
 - API Addition: 3d particle system and accompanying editor, contributed by lordjone, see https://github.com/libgdx/libgdx/pull/2005
+- API Addition: class ColorDrawable added for plain color drawables
 
 [1.2.0]
 - API Addition: Some OpenGL profiling utilities have been added, see https://github.com/libgdx/libgdx/wiki/Profiling

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Skin.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Skin.java
@@ -28,6 +28,7 @@ import com.badlogic.gdx.graphics.g2d.TextureAtlas.AtlasRegion;
 import com.badlogic.gdx.graphics.g2d.TextureAtlas.AtlasSprite;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.scenes.scene2d.Actor;
+import com.badlogic.gdx.scenes.scene2d.utils.ColorDrawable;
 import com.badlogic.gdx.scenes.scene2d.utils.Drawable;
 import com.badlogic.gdx.scenes.scene2d.utils.NinePatchDrawable;
 import com.badlogic.gdx.scenes.scene2d.utils.SpriteDrawable;
@@ -262,6 +263,9 @@ public class Skin implements Disposable {
 		if (drawable != null) return drawable;
 
 		drawable = optional(name, TiledDrawable.class);
+		if (drawable != null) return drawable;
+		
+		drawable = optional(name, ColorDrawable.class);
 		if (drawable != null) return drawable;
 
 		// Use texture or texture region. If it has splits, use ninepatch. If it has rotation or whitespace stripping, use sprite.

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/ColorDrawable.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/ColorDrawable.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+* Copyright 2011 See AUTHORS file.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+******************************************************************************/
+
+package com.badlogic.gdx.scenes.scene2d.utils;
+
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.g2d.Batch;
+import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
+import com.badlogic.gdx.graphics.glutils.ShapeRenderer.ShapeType;
+import com.badlogic.gdx.utils.Disposable;
+
+/**
+ * Drawable that will draw in a single plain color.
+ * 
+ * @author Noel De Martin
+ */
+public class ColorDrawable extends BaseDrawable implements Disposable {
+
+	public Color color;
+	private ShapeRenderer renderer;
+
+	/**
+	 * Create a ColorDrawable, with a default white color.
+	 */
+	public ColorDrawable () {
+		this(Color.WHITE);
+	}
+
+	/**
+	 * Create a ColorDrawable with the given color.
+	 * 
+	 * @param color
+	 */
+	public ColorDrawable (Color color) {
+		if (color == null) {
+			throw new NullPointerException("null color passed in ColorDrawable constructor");
+		}
+		this.color = color;
+		this.renderer = new ShapeRenderer();
+	}
+
+	@Override
+	public void draw (Batch batch, float x, float y, float width, float height) {
+		batch.end();
+
+		renderer.setProjectionMatrix(batch.getProjectionMatrix());
+		renderer.setTransformMatrix(batch.getTransformMatrix());
+		renderer.begin(ShapeType.Filled);
+		renderer.setColor(color);
+		renderer.rect(x, y, width, height);
+		renderer.end();
+
+		batch.begin();
+		super.draw(batch, x, y, width, height);
+	}
+
+	@Override
+	public void dispose () {
+		renderer.dispose();
+	}
+
+}


### PR DESCRIPTION
Hello,

I started working on a project and I found it difficult to create a simple Drawable with a plain color (my case was for using a color in the background of a button, as seen in the image below).
![buttons](https://cloud.githubusercontent.com/assets/1517677/3372863/b8209642-fbae-11e3-9236-5450b334c0af.png)

For that purpose I created this class, ColorDrawable. Later on I discovered android has a class with the exact same name, so I guess that's a good point for the correctness of this class (conceptually at least, not sure if the implementation of the ShapeRenderer usage could improve).

I have tried to follow all the instructions for contributing, the only thing missing is the Contributor License Agreement. If this commit is ok and it will be merged, I will proceed to send that document.

An example usage of how I am using this new class is the following (in a skin json file):

```
com.badlogic.gdx.graphics.Color: {
    font-color: { r: 1, g: 1, b: 1, a: 1 },
    main-strong: { r: 1, g: 0, b: 0, a: 1 },
    main-soft: { r: 1, g: 1, b: 0, a: 1 }
},
com.badlogic.gdx.scenes.scene2d.utils.ColorDrawable: {
    main-strong-drawable: { color: main-strong }
    main-soft-drawable: { color: main-soft }
},
com.badlogic.gdx.graphics.g2d.BitmapFont: { default-font: { file: fonts/default.fnt } },
com.badlogic.gdx.scenes.scene2d.ui.TextButton$TextButtonStyle: {
    call-to-action: {
        font: default-font,
        fontColor: font-color,
        down: main-strong-drawable,
        up: main-soft-drawable
    }
}
```

Cheers
