### PR TITLE
Fix android:run task so it works when ANDROID_HOME isnt set

### DIFF
--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/android/build.gradle
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/android/build.gradle
@@ -45,7 +45,24 @@ task copyAndroidNatives() {
 }
 
 task run(type: Exec) {
-    def adb = "$System.env.ANDROID_HOME/platform-tools/adb"
+    def path
+    def localProperties = project.file("../local.properties")
+    if (localProperties.exists()) {
+        Properties properties = new Properties()
+        localProperties.withInputStream { instr ->
+            properties.load(instr)
+        }
+        def sdkDir = properties.getProperty('sdk.dir')
+        if (sdkDir) {
+            path = sdkDir
+        } else {
+            path = "$System.env.ANDROID_HOME"
+        }
+    } else {
+        path = "$System.env.ANDROID_HOME"
+    }
+
+    def adb = path + "/platform-tools/adb"
     commandLine "$adb", 'shell', 'am', 'start', '-n', '%PACKAGE%.android/%PACKAGE%.android.AndroidLauncher'
 }
 


### PR DESCRIPTION
If a user runs android:run without ANDROID_HOME being set, it fail.

This checks local.properties for sdk.dir, if not found, use ANDROID_HOME variable.
