### PR TITLE
Add a test to show what happens when a long http request is canceled

### DIFF
--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/net/NetAPITest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/net/NetAPITest.java
@@ -44,6 +44,7 @@ public class NetAPITest extends GdxTest implements HttpResponseListener {
 	Stage stage;
 	TextButton btnDownloadImage;
 	TextButton btnDownloadText;
+	TextButton btnDownloadLarge;
 	TextButton btnDownloadError;
 	TextButton btnPost;
 	TextButton btnCancel;
@@ -106,6 +107,8 @@ public class NetAPITest extends GdxTest implements HttpResponseListener {
 						url = "http://i.imgur.com/vxomF.jpg";
 					else if (clickedButton == btnDownloadText)
 						url = "http://www.apache.org/licenses/LICENSE-2.0.txt";
+					else if (clickedButton == btnDownloadLarge)
+						url = "http://libgdx.badlogicgames.com/releases/libgdx-1.2.0.zip";
 					else if (clickedButton == btnDownloadError)
 						url = "http://www.badlogicgames.com/doesnotexist";
 					else {
@@ -129,13 +132,14 @@ public class NetAPITest extends GdxTest implements HttpResponseListener {
 					super.clicked(event, x, y);
 					if (httpRequest != null) {
 						Gdx.net.cancelHttpRequest(httpRequest);
+						Gdx.app.log("NetAPITest", "Cancelling request " + httpRequest.getUrl());
 						statusLabel.setText("Cancelling request " + httpRequest.getUrl());
 					}
 				}
 			};
 
 			btnCancel = new TextButton("Cancel", skin);
-			btnCancel.setPosition(Gdx.graphics.getWidth() * 0.5f - btnCancel.getWidth() * 1.5f, 60f);
+			btnCancel.setPosition(Gdx.graphics.getWidth() * 0.35f - btnCancel.getWidth() * 1.5f, 60f);
 			btnCancel.addListener(cancelListener);
 			stage.addActor(btnCancel);
 
@@ -149,8 +153,13 @@ public class NetAPITest extends GdxTest implements HttpResponseListener {
 			btnDownloadText.addListener(clickListener);
 			stage.addActor(btnDownloadText);
 
+			btnDownloadLarge = new TextButton("GET Large", skin);
+			btnDownloadLarge.setPosition(btnDownloadText.getX() + btnDownloadText.getWidth() + 10, 60f);
+			btnDownloadLarge.addListener(clickListener);
+			stage.addActor(btnDownloadLarge);
+
 			btnDownloadError = new TextButton("GET Error", skin);
-			btnDownloadError.setPosition(btnDownloadText.getX() + btnDownloadText.getWidth() + 10, 60f);
+			btnDownloadError.setPosition(btnDownloadLarge.getX() + btnDownloadLarge.getWidth() + 10, 60f);
 			btnDownloadError.addListener(clickListener);
 			stage.addActor(btnDownloadError);
 
@@ -189,6 +198,20 @@ public class NetAPITest extends GdxTest implements HttpResponseListener {
 					texture = new Texture(pixmap);
 				}
 			});
+
+		} else if (clickedButton == btnDownloadLarge) {
+			Gdx.app.postRunnable(new Runnable() {
+				public void run () {
+					text = "Retrieving large file...";
+				}
+			});
+			final byte[] rawFileBytes = httpResponse.getResult();
+			Gdx.app.postRunnable(new Runnable() {
+				public void run () {
+					text = "Retrieved large file: " + rawFileBytes.length;
+				}
+			});
+
 		} else {
 			setText(httpResponse);
 		}
@@ -255,6 +278,7 @@ public class NetAPITest extends GdxTest implements HttpResponseListener {
 		Gdx.app.postRunnable(new Runnable() {
 			public void run () {
 				setButtonDisabled(false);
+				Gdx.app.log("NetAPITest", "HTTP request cancelled");
 				statusLabel.setText("HTTP request cancelled");
 			}
 		});


### PR DESCRIPTION
See https://github.com/libgdx/libgdx/pull/1287#issuecomment-47743225 for a description of the problem.

To see the problem, click the "GET Large" button, and then try canceling or clicking on another button to start another request before the first finishes.

The application will be blocked until the first download completes.
