### PR TITLE
quick fix for scene2d debug memory leak

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Table.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Table.java
@@ -1150,7 +1150,11 @@ public class Table extends WidgetGroup {
 		}
 
 		static void draw (Stage stage) {
-			if (app != Gdx.app) debugRenderer = new ImmediateModeRenderer20(128, false, true, 0);
+			// Handle cases where Android holds on to static objects
+			if (app != Gdx.app || debugRenderer == null) {
+				debugRenderer = new ImmediateModeRenderer20(128, false, true, 0);
+				app = Gdx.app;
+			}
 
 			debugRenderer.begin(stage.getBatch().getProjectionMatrix(), GL20.GL_LINES);
 			draw(stage.getActors());


### PR DESCRIPTION
fixes #2013

I just removed the app check. I'm not sure when one would want to debug multiple apps or how that would be possible, but maybe @NathanSweet knows something I don't.

Now it is just a lazy initialization.
