### PR TITLE
AndroidApplication, hideStatusBar

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplication.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplication.java
@@ -177,7 +177,7 @@ public class AndroidApplication extends Activity implements AndroidApplicationBa
 		}
 
 		createWakeLock(config.useWakelock);
-		hideStatusBar(this.hideStatusBar);
+		hideStatusBar();
 		useImmersiveMode(this.useImmersiveMode);
 		if (this.useImmersiveMode && getVersion() >= 19) {
 			try {
@@ -204,8 +204,8 @@ public class AndroidApplication extends Activity implements AndroidApplicationBa
 		}
 	}
 
-	protected void hideStatusBar (boolean hide) {
-		if (!hide || getVersion() < 11) return;
+	protected void hideStatusBar () {
+		if (!this.hideStatusBar || getVersion() < 11) return;
 
 		final View rootView = getWindow().getDecorView();
 
@@ -225,7 +225,7 @@ public class AndroidApplication extends Activity implements AndroidApplicationBa
 	public void onWindowFocusChanged (boolean hasFocus) {
 		super.onWindowFocusChanged(hasFocus);
 		useImmersiveMode(this.useImmersiveMode);
-		hideStatusBar(this.hideStatusBar);
+		hideStatusBar();
 		if (hasFocus) {
 			this.wasFocusChanged = 1;
 			if (this.isWaitingForAudio) {


### PR DESCRIPTION
Show status bar before hiding need only for Android 3.x.
Otherwise screen can lag (twitch) if hideStatusBar called while app is running on some devices (e.g. Nexus series).
