### PR TITLE
Added missing Decal.setRotation method.

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g3d/decals/Decal.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/decals/Decal.java
@@ -144,8 +144,8 @@ public class Decal {
 	}
 
 	/** Sets the rotation of this decal to the given angles on all axes.
-	 * @param yaw Angle in degrees to rotate around the X axis
-	 * @param pitch Angle in degrees to rotate around the Y axis
+	 * @param yaw Angle in degrees to rotate around the Y axis
+	 * @param pitch Angle in degrees to rotate around the X axis
 	 * @param roll Angle in degrees to rotate around the Z axis */
 	public void setRotation (float yaw, float pitch, float roll) {
 		rotation.setEulerAngles(yaw, pitch, roll);


### PR DESCRIPTION
http://stackoverflow.com/questions/24632095/how-to-rotate-decal-over-more-then-one-axis-at-moment

It looks like currently the only way to set a rotation on all axes at the same time is via a workaround like this:

```
decal.setRotationX(0);
decal.setRotationY(0);
decal.setRotationZ(0);
decal.rotateX(angleX);
decal.rotateY(angleY);
decal.rotateZ(angleZ);
```

Or the shorter but more ugly version:

```
decal.setRotationX(angleX);
decal.rotateY(angleY);
decal.rotateZ(angleZ);
```

That's why I added a `Decal.setRotation(...)` method which can set all angles at once.
