### PR TITLE
Added MultiAspectViewport to support many aspect ratios

### DIFF
--- a/gdx/src/com/badlogic/gdx/utils/viewport/MultiAspectViewport.java
+++ b/gdx/src/com/badlogic/gdx/utils/viewport/MultiAspectViewport.java
@@ -1,0 +1,121 @@
+package com.badlogic.gdx.utils.viewport;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.Camera;
+import com.badlogic.gdx.graphics.OrthographicCamera;
+import com.badlogic.gdx.graphics.PerspectiveCamera;
+import com.badlogic.gdx.math.MathUtils;
+import com.badlogic.gdx.math.Vector2;
+import com.badlogic.gdx.utils.Scaling;
+
+/**
+ * Sets up a new FitViewport everytime screen size is changed to account for multiple aspect ratios.
+ * Uses {@link Scaling#fit} to scale the virtual viewport.
+ * @author Glen Murdock
+ */
+public class MultiAspectViewport extends Viewport {
+
+	private Scaling scaling;
+
+	private float minWidth;
+	private float minHeight;
+	private float maxWidth;
+	private float maxHeight;
+
+	private float minAspect;
+	private float maxAspect;
+
+	/**
+	 * Creates a MutliAspectViewport using a new {@link OrthographicCamera}.
+	 */
+	public MultiAspectViewport() {
+		this(new OrthographicCamera());
+	}
+
+	/**
+	 * Creates a MultiAspectViewport.
+	 * @param camera {@link Camera} is for using {@link OrthographicCamera} or {@link PerspectiveCamera}.
+	 */
+	public MultiAspectViewport(Camera camera) {
+		this.scaling = Scaling.fit;
+		this.camera = camera;
+	}
+
+	/**
+	 * This class must be called before MultiAspectViewport can be used. Sets up the minimum and maximum size for virtual
+	 * viewport along with the minimum and maximum aspect supported by game or application.
+	 * @param minWidth Minimum width of the virtual viewport.
+	 * @param minHeight Minimum height of the virtual viewport.
+	 * @param maxWidth Maximum width of the virtual viewport.
+	 * @param maxHeight Maximum height of the virtual viewport.
+	 * @param minAspect Minimum aspect supported by minWidth, minHeight, maxWidth, maxHeight.
+	 * @param maxAspect Maximum aspect supported by minWidth, minHeight, maxWidth, maxHeight.
+	 */
+	public void setup(float minWidth, float minHeight, float maxWidth, float maxHeight,
+		float minAspect, float maxAspect) {
+		this.minWidth = minWidth;
+		this.minHeight = minHeight;
+		this.maxWidth = maxWidth;
+		this.maxHeight = maxHeight;
+		this.minAspect = minAspect;
+		this.maxAspect = maxAspect;
+		update(Gdx.graphics.getWidth(), Gdx.graphics.getHeight(), false);
+	}
+
+	@Override
+	public void update (int screenWidth, int screenHeight, boolean centerCamera) {
+		createVirtualSize(screenWidth, screenHeight); // Make changes to virtual size
+		Vector2 scaled = scaling.apply(worldWidth, worldHeight, screenWidth, screenHeight);
+		viewportWidth = Math.round(scaled.x);
+		viewportHeight = Math.round(scaled.y);
+		//center the viewport in the middle of the screen
+		viewportX = (screenWidth - viewportWidth) / 2;
+		viewportY = (screenHeight - viewportHeight) / 2;
+		super.update(screenWidth, screenHeight, centerCamera);
+	}
+
+	/**
+	 * Tests to see which screen size within a minimum and maximum size of width, height and aspect would be allowed
+	 * for current screen size.
+	 * @param width Width of application screen
+	 * @param height Height of application screen
+	 */
+	public void createVirtualSize(int width, int height) {
+		float aspect = (float) width / (float) height;
+
+		if(aspect > maxAspect) {
+			aspect = maxAspect;
+		} else if(aspect < minAspect) {
+			aspect = minAspect;
+		}
+
+		boolean foundVirtual = false;
+		for(float i = maxWidth; i >= minWidth; i--) {
+			float scaleForSize = i / (float) width;
+			float virtualViewportWidth = (float) width * scaleForSize;
+			float virtualViewportHeight = virtualViewportWidth / aspect;
+			virtualViewportWidth = (float) MathUtils.round(virtualViewportWidth);
+			virtualViewportHeight = (float) MathUtils.round(virtualViewportHeight);
+			if(insideBounds(virtualViewportWidth, virtualViewportHeight)) {
+				worldWidth = virtualViewportWidth;
+				worldHeight = virtualViewportHeight;
+				foundVirtual = true;
+				break;
+			}
+		}
+
+		if(!foundVirtual) {
+			worldWidth = minWidth;
+			worldHeight = minHeight;
+		}
+	}
+
+	private boolean insideBounds(float width, float height) {
+		if (width < minWidth || width > maxWidth)
+			return false;
+		if (height < minHeight || height > maxHeight)
+			return false;
+		return true;
+	}
+
+}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ViewportTestMultiAspectRatio.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ViewportTestMultiAspectRatio.java
@@ -1,0 +1,106 @@
+package com.badlogic.gdx.tests;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.Pixmap;
+import com.badlogic.gdx.graphics.Pixmap.Format;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.BitmapFont;
+import com.badlogic.gdx.graphics.g2d.Sprite;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.graphics.g2d.freetype.FreeTypeFontGenerator;
+import com.badlogic.gdx.graphics.g2d.freetype.FreeTypeFontGenerator.FreeTypeFontParameter;
+import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
+import com.badlogic.gdx.graphics.glutils.ShapeRenderer.ShapeType;
+import com.badlogic.gdx.tests.utils.GdxTest;
+import com.badlogic.gdx.utils.viewport.MultiAspectViewport;
+
+public class ViewportTestMultiAspectRatio extends GdxTest {
+	
+	MultiAspectViewport viewport;
+
+   float minWidth;
+   float minHeight;
+   float maxWidth;
+   float maxHeight;
+
+   SpriteBatch spriteBatch;
+   ShapeRenderer shaper;
+   BitmapFont font;
+   
+   Sprite minimumAreaSprite;
+   Sprite maximumAreaSprite;
+   Sprite floatingButtonSprite;
+
+	@Override
+	public void create () {
+		float minWidth = 1200;
+		float minHeight = 720;
+		float maxWidth = 1280;
+		float maxHeight = 900;
+		
+		viewport = new MultiAspectViewport();
+		viewport.setup(minWidth, minHeight, maxWidth, maxHeight, 4f / 3f, 16f / 9f);
+		spriteBatch = new SpriteBatch();
+		shaper = new ShapeRenderer();
+		font = new BitmapFont();
+		font.setColor(Color.BLACK);
+		font.scale(4f);
+
+		Pixmap pixmap = new Pixmap(64, 64, Format.RGBA8888);
+		pixmap.setColor(Color.WHITE);
+		pixmap.fillRectangle(0, 0, 64, 64);
+
+		minimumAreaSprite = new Sprite(new Texture(pixmap));
+		minimumAreaSprite.setPosition(-minWidth / 2, -minHeight / 2);
+		minimumAreaSprite.setSize(minWidth, minHeight);
+		minimumAreaSprite.setColor(0f, 1f, 0f, 1f);
+
+		maximumAreaSprite = new Sprite(new Texture(pixmap));
+		maximumAreaSprite.setPosition(-maxWidth / 2, -maxHeight / 2);
+		maximumAreaSprite.setSize(maxWidth, maxHeight);
+		maximumAreaSprite.setColor(1f, 1f, 0f, 1f);
+		
+		floatingButtonSprite = new Sprite(new Texture(pixmap));
+		floatingButtonSprite.setPosition(viewport.getWorldWidth() * 0.5f - 80, viewport.getWorldHeight() * 0.5f - 80);
+		floatingButtonSprite.setSize(64, 64);
+		floatingButtonSprite.setColor(1f, 1f, 1f, 1f);
+	}
+
+	@Override
+	public void render () {
+		Gdx.gl.glClearColor(1f, 0, 0, 1);
+		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+
+		spriteBatch.setProjectionMatrix(viewport.getCamera().combined);
+		shaper.setProjectionMatrix(viewport.getCamera().combined);
+		spriteBatch.begin();
+		shaper.begin(ShapeType.Line);
+		shaper.setColor(Color.BLACK);
+		maximumAreaSprite.draw(spriteBatch);
+		minimumAreaSprite.draw(spriteBatch);
+		floatingButtonSprite.draw(spriteBatch);
+		String tmp = String.format("%1$sx%2$s", Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+		font.draw(spriteBatch, tmp, -font.getBounds(tmp).width / 2, 0);  
+		shaper.rect(viewport.getWorldWidth() / -2 + 5, viewport.getWorldHeight() / -2 + 5,
+			viewport.getWorldWidth() - 10, viewport.getWorldHeight() - 10);
+
+		spriteBatch.end();
+		shaper.end();
+	}
+
+	@Override
+	public void resize (int width, int height) {
+		viewport.update(width, height, false);
+		floatingButtonSprite.setPosition(viewport.getWorldWidth() * 0.5f - 80, viewport.getWorldHeight() * 0.5f - 80);
+	}
+
+	@Override
+	public void dispose () {
+		spriteBatch.dispose();
+		shaper.dispose();
+		font.dispose();
+	}
+	
+}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
@@ -214,6 +214,7 @@ public class GdxTests {
 		ViewportTest1.class,
 		ViewportTest2.class,
 		ViewportTest3.class,
+		ViewportTestMultiAspectRatio.class,
 		YDownTest.class,
 		FreeTypeFontLoaderTest.class
 		// @on


### PR DESCRIPTION
Commit comment: Added MultiAspectViewport and created ViewportTestMultiAspectRatio for testing the class.

Summary: I needed a view port which could account for many aspect ratios, being 4:3 - 16:9. I liked the solution that was presented for Clash of the Olympians, but it did not work like they said. I now have a proper working version of what he was trying to create. This includes a test class to show how it works.

Basic idea: Creates a new FitViewport at largest possible size that preserves a certain range of view port aspect ratios and sizes. While it does not extend FitViewport, it does the same basic thing.

Here is a download to a working example (JAR): https://drive.google.com/file/d/0B5FgN8-ZK8hPWUNka0Y5eG5zTFk/edit?usp=sharing

Here is virus total for the JAR: https://www.virustotal.com/en/file/29c32c5403183bb5bfec4fd46b3e426d5a9cf9966cce124a58e5a89530697975/analysis/1405450317/

**Ikarus is presenting a false positive for the virus total.

As you can see, for any give screen width and height it will not show red as long as it is between 4:3 and 16:9.

Please let me know if you think this would be helpful to libgdx and its community.

Thanks!
