### PR TITLE
Adding custom timing possibility for MessageDispatcher

### DIFF
--- a/extensions/gdx-ai/src/com/badlogic/gdx/ai/RealTimeProvider.java
+++ b/extensions/gdx-ai/src/com/badlogic/gdx/ai/RealTimeProvider.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogic.gdx.ai;
+
+import com.badlogic.gdx.utils.TimeUtils;
+
+public class RealTimeProvider implements TimeProvider {
+	
+	private static final long START = TimeUtils.nanoTime();
+
+	/** Returns the current time in nanoseconds.
+	 * <p>
+	 * This implementation returns the value of the system timer minus a constant value determined when this class was loaded the
+	 * first time in order to ensure it takes increasing values (for 2 ^ 63 nanoseconds, i.e. 292 years) since the time stamp is
+	 * used to order the telegrams in the queue. */
+	@Override
+	public long getCurrentTime () {
+		return TimeUtils.nanoTime() - START;
+	}
+	
+}

--- a/extensions/gdx-ai/src/com/badlogic/gdx/ai/TimeProvider.java
+++ b/extensions/gdx-ai/src/com/badlogic/gdx/ai/TimeProvider.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogic.gdx.ai;
+
+public interface TimeProvider {
+	
+		/** Should return the current time in nano-seconds **/ 
+		public long getCurrentTime();
+		
+}

--- a/extensions/gdx-ai/src/com/badlogic/gdx/ai/msg/MessageDispatcher.java
+++ b/extensions/gdx-ai/src/com/badlogic/gdx/ai/msg/MessageDispatcher.java
@@ -18,8 +18,9 @@ package com.badlogic.gdx.ai.msg;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.ai.Agent;
+import com.badlogic.gdx.ai.RealTimeProvider;
+import com.badlogic.gdx.ai.TimeProvider;
 import com.badlogic.gdx.utils.Pool;
-import com.badlogic.gdx.utils.TimeUtils;
 
 /** The MessageDispatcher is a singleton in charge of the creation, dispatch, and management of telegrams.
  * 
@@ -31,8 +32,8 @@ public class MessageDispatcher {
 	private static final float NANOS_PER_SEC = 1000000000f;
 
 	private static final MessageDispatcher instance = new MessageDispatcher();
-
-	private static final long START = TimeUtils.nanoTime();
+	
+	private static TimeProvider timeProvider = new RealTimeProvider();
 
 	private PriorityQueue<Telegram> queue = new PriorityQueue<Telegram>();
 
@@ -57,13 +58,9 @@ public class MessageDispatcher {
 		return instance;
 	}
 
-	/** Returns the current time in nanoseconds.
-	 * <p>
-	 * This implementation returns the value of the system timer minus a constant value determined when this class was loaded the
-	 * first time in order to ensure it takes increasing values (for 2 ^ 63 nanoseconds, i.e. 292 years) since the time stamp is
-	 * used to order the telegrams in the queue. */
+	/** Returns current time acquired from the time provider. */
 	public static long getCurrentTime () {
-		return TimeUtils.nanoTime() - START;
+		return timeProvider.getCurrentTime();
 	}
 
 	/** Returns the time granularity. */
@@ -182,6 +179,11 @@ public class MessageDispatcher {
 		}
 
 		pool.free(telegram);
+	}
+	
+	/** Sets the custom time provider. */
+	public static void setTimeProvider(TimeProvider provider) {
+		timeProvider = provider;
 	}
 
 }


### PR DESCRIPTION
Previous implementation used real-timing and pausing was not possible. E.g. if I post delayed message that should be dispatched in 3 sec and then pause my game for 3 or more secs, this message will be dispatched on next #dispatchDelayedMessages() immediately however in game 0 time have passed (cause of pause).

Current implementation allows you to set the custom TimeProvider (e.g. your game level timing) that might  support such things like pause/resume or slow motion timing. By default the RealTimeProvider is used implementing previous getCurrentTime to support backward-compatibility.

The other solution is to use something like standard #update(float delta) to accumulate current time, but this will be breaking implementation, so I used current approach.
