### PR TITLE
MessageDispatcher: added support for multiple recipients.

### DIFF
--- a/extensions/gdx-ai/src/com/badlogic/gdx/ai/fsm/DefaultStateMachine.java
+++ b/extensions/gdx-ai/src/com/badlogic/gdx/ai/fsm/DefaultStateMachine.java
@@ -19,6 +19,9 @@ package com.badlogic.gdx.ai.fsm;
 import com.badlogic.gdx.ai.msg.Telegram;
 
 /** Default implementation of the {@link StateMachine} interface.
+ * 
+ * @param <E> is the type of the entity handled by this state machine
+ * 
  * @author davebaol */
 public class DefaultStateMachine<E> implements StateMachine<E> {
 
@@ -103,10 +106,10 @@ public class DefaultStateMachine<E> implements StateMachine<E> {
 		// Call the exit method of the existing state
 		currentState.exit(owner);
 
-		// change state to the new state
+		// Change state to the new state
 		currentState = newState;
 
-		// call the entry method of the new state
+		// Call the entry method of the new state
 		currentState.enter(owner);
 	}
 
@@ -117,11 +120,11 @@ public class DefaultStateMachine<E> implements StateMachine<E> {
 
 	/** Indicates whether the state machine is in the given state.
 	 * <p>
-	 * This implementation assumes states are singletons (typically a enum) so they are compared with the {@code ==} operator
+	 * This implementation assumes states are singletons (typically an enum) so they are compared with the {@code ==} operator
 	 * instead of the {@code equals} method.
 	 * 
 	 * @param state the state to be compared with the current state
-	 * @returns true if the current state's type is equal to the type of the class passed as a parameter. */
+	 * @returns true if the current state and the given state are the same object. */
 	@Override
 	public boolean isInState (State<E> state) {
 		return currentState == state;
@@ -136,13 +139,13 @@ public class DefaultStateMachine<E> implements StateMachine<E> {
 	public boolean handleMessage (Telegram telegram) {
 
 		// First see if the current state is valid and that it can handle the message
-		if (currentState != null && currentState.onMessage(telegram)) {
+		if (currentState != null && currentState.onMessage(owner, telegram)) {
 			return true;
 		}
 
 		// If not, and if a global state has been implemented, send
 		// the message to the global state
-		if (globalState != null && globalState.onMessage(telegram)) {
+		if (globalState != null && globalState.onMessage(owner, telegram)) {
 			return true;
 		}
 

--- a/extensions/gdx-ai/src/com/badlogic/gdx/ai/fsm/State.java
+++ b/extensions/gdx-ai/src/com/badlogic/gdx/ai/fsm/State.java
@@ -21,29 +21,31 @@ import com.badlogic.gdx.ai.msg.Telegram;
 /** The state of a state machine defines the logic of the entities that enter, exit and last this state. Additionally, a state may
  * be delegated by an entity to handle its messages.
  * 
- * E is the type of the entities handled by this state
+ * @param <E> is the type of the entity handled by this state machine
  * 
  * @author davebaol */
 public interface State<E> {
 
 	/** This method will execute when the state is entered.
 	 * 
-	 * @param entity */
+	 * @param entity the entity entering the state */
 	public void enter (E entity);
 
 	/** This is the state's normal update function
 	 * 
-	 * @param entity */
+	 * @param entity the entity lasting the state */
 	public void update (E entity);
 
 	/** This method will execute when the state is exited.
 	 * 
-	 * @param entity */
+	 * @param entity the entity exiting the state */
 	public void exit (E entity);
 
-	/** This method executes if the entity receives a message from the message dispatcher while it is in this state.
+	/** This method executes if the {@code entity} receives a {@code telegram} from the message dispatcher while it is in this
+	 * state.
 	 * 
-	 * @param telegram
+	 * @param entity the entity that received the message
+	 * @param telegram the message sent to the entity
 	 * @return true if the message has been successfully handled; false otherwise. */
-	public boolean onMessage (Telegram telegram);
+	public boolean onMessage (E entity, Telegram telegram);
 }

--- a/extensions/gdx-ai/src/com/badlogic/gdx/ai/fsm/StateMachine.java
+++ b/extensions/gdx-ai/src/com/badlogic/gdx/ai/fsm/StateMachine.java
@@ -21,6 +21,8 @@ import com.badlogic.gdx.ai.msg.Telegram;
 /** A state machine manages the state transitions of its entity. Additionally, the state machine may be delegated by the entity to
  * handle its messages.
  * 
+ * @param <E> is the type of the entity
+ * 
  * @author davebaol */
 public interface StateMachine<E> {
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ai/fsm/BobState.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ai/fsm/BobState.java
@@ -99,9 +99,8 @@ public enum BobState implements State<Bob> {
 		}
 
 		@Override
-		public boolean onMessage (Telegram telegram) {
+		public boolean onMessage (Bob bob, Telegram telegram) {
 			if (telegram.message == MessageType.STEW_READY) {
-				Bob bob = (Bob)(telegram.receiver);
 
 				System.out.println("Message handled by " + bob.getClass().getSimpleName() + " at time: "
 					+ MessageDispatcher.getCurrentTime());
@@ -111,7 +110,6 @@ public enum BobState implements State<Bob> {
 				bob.getStateMachine().changeState(EAT_STEW);
 
 				return true;
-
 			}
 
 			return false; // send message to global message handler
@@ -198,7 +196,7 @@ public enum BobState implements State<Bob> {
 	};
 
 	@Override
-	public boolean onMessage (Telegram telegram) {
+	public boolean onMessage (Bob bob, Telegram telegram) {
 		return false;
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ai/fsm/ElsaState.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ai/fsm/ElsaState.java
@@ -92,9 +92,8 @@ public enum ElsaState implements State<Elsa> {
 		}
 
 		@Override
-		public boolean onMessage (Telegram telegram) {
+		public boolean onMessage (Elsa elsa, Telegram telegram) {
 			if (telegram.message == MessageType.STEW_READY) {
-				Elsa elsa = (Elsa)(telegram.receiver);
 
 				System.out.println("Message received by " + elsa.getClass().getSimpleName() + " at time: "
 					+ MessageDispatcher.getCurrentTime());
@@ -130,10 +129,9 @@ public enum ElsaState implements State<Elsa> {
 		}
 
 		@Override
-		public boolean onMessage (Telegram telegram) {
+		public boolean onMessage (Elsa elsa, Telegram telegram) {
 
 			if (telegram.message == MessageType.HI_HONEY_I_M_HOME) {
-				Elsa elsa = (Elsa)(telegram.receiver);
 
 				System.out.println("Message handled by " + elsa.getClass().getSimpleName() + " at time: "
 					+ MessageDispatcher.getCurrentTime());
@@ -157,7 +155,7 @@ public enum ElsaState implements State<Elsa> {
 	}
 
 	@Override
-	public boolean onMessage (Telegram telegram) {
+	public boolean onMessage (Elsa elsa, Telegram telegram) {
 		return false;
 	}
 


### PR DESCRIPTION
I've added support for multiple recipients while keeping both backward compatibility and unchanged performance in case of single recipient.
- Agents can register themselves to message codes they are interested in. This means that MessageDispatcher has an `IntMap<Array<Agent>>` where the key is the message code and the value an array of agents.  
- If the telegram is for a specific agent he doesn't have to be registered and the telegram will be dispatched only to him (just like before)
- If the telegram has no explicit recipient, i.e. `telegram.receiver == null`, it will be dispatched to all the agents registered for that message code. 

Now I'm at a crossroads. Telegrams are created and pooled by MessageDispatcher, also a telegram might have an extraInfo object containing message-specific information. The exraInfo object might be pooled by the application, why not? In case it's pooled, how can we let the app know that the telegram has been dispatched to all the receivers and that it can be returned to the pool? 
- **Option 1**:
  - The Agent interface has a new method `notifySender(Telegram)` that will be called by the MessageDispatcher after dispatching the telegram to the recipients and before returning the telegram to the pool. This gives the sender the opportunity to free the `telegram.extraInfo` object in case is pooled.
  - Additionally the sender might explicitly request the notification through an optional boolean parameter passed to the `MessageDispatcher.dispatchMessage()` method that creates the telegram. Of course this means that the telegram will have a new boolean field.
- **Option 2**:
  After dispatching the telegram to the recipients and before returning the telegram to the pool, the  MessageDispatcher first checks if `telegram.extraInfo instanceof Pooled` then calls the free method of the Pooled interface.

Option 2 is more specific and backward compatible while option 1 is more general (can be used - and abused - for all kind of stuff) but breaks compatibility.
Also, with option 1 it is responsibility of the sender to perform the right action based on the message code and the extraInfo object, since the sender can send telegrams carrying different types of message.

I'd like to know your opinion and of course any "option 3" is welcome :)
