### PR TITLE
Fix FileHandle.list(FileFilter)

### DIFF
--- a/gdx/src/com/badlogic/gdx/files/FileHandle.java
+++ b/gdx/src/com/badlogic/gdx/files/FileHandle.java
@@ -412,8 +412,9 @@ public class FileHandle {
 		int count = 0;
 		for (int i = 0, n = relativePaths.length; i < n; i++) {
 			String path = relativePaths[i];
-			if (!filter.accept(file)) continue;
-			handles[count] = child(path);
+			FileHandle child = child(path);
+			if (!filter.accept(child.file())) continue;
+			handles[count] = child;
 			count++;
 		}
 		if (count < relativePaths.length) {


### PR DESCRIPTION
Before it used to always call the Filter's accept method on the parent. Now it will function properly.
I don't know if there is a better way to fix this, but this is a simple solution.
