### PR TITLE
Fix size-setting methods ignoring height

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Container.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Container.java
@@ -286,7 +286,7 @@ public class Container<T extends Actor> extends WidgetGroup {
 
 	/** Sets the minWidth and minHeight to the specified values. */
 	public Container<T> minSize (float width, float height) {
-		minSize(new Fixed(width));
+		minSize(new Fixed(width), new Fixed(height));
 		return this;
 	}
 
@@ -326,7 +326,7 @@ public class Container<T extends Actor> extends WidgetGroup {
 
 	/** Sets the prefWidth and prefHeight to the specified value. */
 	public Container<T> prefSize (float width, float height) {
-		prefSize(new Fixed(width));
+		prefSize(new Fixed(width), new Fixed(height));
 		return this;
 	}
 
@@ -378,7 +378,7 @@ public class Container<T extends Actor> extends WidgetGroup {
 
 	/** Sets the maxWidth and maxHeight to the specified values. */
 	public Container<T> maxSize (float width, float height) {
-		maxSize(new Fixed(width));
+		maxSize(new Fixed(width), new Fixed(height));
 		return this;
 	}
 


### PR DESCRIPTION
In ui.Container. I believe this wasn't intentional.
