### PR TITLE
setBackground(null) on Container has caused layout() to NPE

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Container.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Container.java
@@ -83,7 +83,7 @@ public class Container<T extends Actor> extends WidgetGroup {
 		this.background = background;
 		if (adjustPadding) {
 			if (background == null)
-				pad(null);
+				pad(Value.zero);
 			else
 				pad(background.getTopHeight(), background.getLeftWidth(), background.getBottomHeight(), background.getRightWidth());
 			invalidate();


### PR DESCRIPTION
Maybe we should add javadoc and/or null checks for padding setting.
