### PR TITLE
Added angle calculation methods to Vector2

### DIFF
--- a/gdx/src/com/badlogic/gdx/math/Vector2.java
+++ b/gdx/src/com/badlogic/gdx/math/Vector2.java
@@ -300,7 +300,7 @@ public class Vector2 implements Serializable, Vector<Vector2> {
 	/** @return the angle in radians of this vector (point) relative to the given vector. Angles are towards the positive y-axis.
 	 * 	   (typically counter-clockwise.)*/
 	 public float angleRad(Vector reference) {
-	 	return (float)Math.atan2(crs(reference), dot(reference)) * MathUtils.radiansToDegrees;
+	 	return (float)Math.atan2(crs(reference), dot(reference));
 	 }
 
 	/** Sets the angle of the vector in degrees relative to the x-axis, towards the positive y-axis (typically counter-clockwise).


### PR DESCRIPTION
Added two methods to the Vector2 class, allowing to calculate angle between two vectors, and not only between the x-axis.

I'm not using the standard acos solution, math explained here: http://geomalgorithms.com/vector_products.html

Since the dot product is the cosine of the angle between two vectors, and the 2d cross product (perp dot) is the sine of the same angle, plugging both on a `atan2(crs, dot)` call can give the angle on the full circle (-180~+180, instead of `acos(dot)` solution, which gives only 0~180) and also avoid the two sqrts involved in normalising the vectors.

Here's another explanation on the matter: http://johnblackburne.blogspot.com.br/2012/01/angle-between-two-vectors.html
