### PR TITLE
Reset scale and rotation values on simplified SpriteDrawable draw() call

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/SpriteDrawable.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/SpriteDrawable.java
@@ -39,11 +39,7 @@ public class SpriteDrawable extends BaseDrawable implements TransformDrawable {
 	}
 
 	public void draw (Batch batch, float x, float y, float width, float height) {
-		sprite.setBounds(x, y, width, height);
-		Color color = sprite.getColor();
-		sprite.setColor(Color.tmp.set(color).mul(batch.getColor()));
-		sprite.draw(batch);
-		sprite.setColor(color);
+		draw(batch, x, y, width / 2f, height / 2f, width, height, 1f, 1f, 0f);
 	}
 
 	public void draw (Batch batch, float x, float y, float originX, float originY, float width, float height, float scaleX,


### PR DESCRIPTION
This fixes an issue that happens when scaling or rotating a SpriteDrawable wrapper (like Image) with a value different from default value (1 for scaling 0 for rotation) and then scaling/rotating it back to default value. The scale and rotation values of the Sprite don't get updated back to the default values.

It happens because the simplified/short draw call(), that doesn't change the scale and rotation of the Sprite, is usually used when the scale of the SpriteDrawable wrapper is 1 and the rotation 0 (see the draw() implementation of the Image class for instance).

To reproduce the issue, create an Image() with a SpriteDrawable, set the scale to 0.5, draw it and then set it back to 1. It will still be drawn as if it was scaled 0.5.

And as a nice side effect we reuse some code :)
