### PR TITLE
handle display creation failure for LWJGL

### DIFF
--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglApplicationConfiguration.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglApplicationConfiguration.java
@@ -43,8 +43,6 @@ public class LwjglApplicationConfiguration {
 	public int samples = 0;
 	/** width & height of application window **/
 	public int width = 640, height = 480;
-	/** failsafe width & height to use if initial display creation failes, values <= 0 disable failsafe */
-	public int failsafeWidth = 0, failsafeHeight = 0;
 	/** x & y of application window, -1 for center **/
 	public int x = -1, y = -1;
 	/** fullscreen **/
@@ -75,6 +73,8 @@ public class LwjglApplicationConfiguration {
 	public boolean allowSoftwareMode = false;
 	/** Preferences directory on the desktop. Default is ".prefs/". */
 	public String preferencesDirectory = ".prefs/";
+	/** Callback used when trying to create a display, can handle failures, default value is null (disabled) */
+	public LwjglGraphics.SetDisplayModeCallback setDisplayModeCallback;
 
 	Array<String> iconPaths = new Array();
 	Array<FileType> iconFileTypes = new Array();	

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGraphics.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGraphics.java
@@ -129,16 +129,17 @@ public class LwjglGraphics implements Graphics {
 		} else {
 			boolean displayCreated = setDisplayMode(config.width, config.height, config.fullscreen);
 			if (!displayCreated) {
-				// open in windowed failsafe dimensions if first mode fails and failsafe enabled
-				if (config.failsafeWidth > 0 && config.failsafeHeight > 0) {
-					displayCreated = setDisplayMode(config.failsafeWidth, config.failsafeHeight, false);
+				if (config.setDisplayModeCallback != null) {
+					config = config.setDisplayModeCallback.onFailure(config);
+					if (config != null) {
+						displayCreated = setDisplayMode(config.width, config.height, config.fullscreen);
+					}
+				}
+				if (!displayCreated) {
+					throw new GdxRuntimeException("Couldn't set display mode " + config.width + "x" + config.height + ", fullscreen: "
+							+ config.fullscreen);
 				}
 			}
-			if (!displayCreated) {
-				throw new GdxRuntimeException("Couldn't set display mode " + config.width + "x" + config.height + ", fullscreen: "
-						+ config.fullscreen);
-			}
-
 			if (config.iconPaths.size > 0) {
 				ByteBuffer[] icons = new ByteBuffer[config.iconPaths.size];
 				for (int i = 0, n = config.iconPaths.size; i < n; i++) {
@@ -467,5 +468,15 @@ public class LwjglGraphics implements Graphics {
 	@Override
 	public GL30 getGL30 () {
 		return gl30;
+	}
+
+	/** A callback used by LwjglApplication when trying to create the display */
+	public interface SetDisplayModeCallback {
+		/** If the display creation fails, this method will be called.
+		 * Suggested usage is to modify the passed configuration to use
+		 * a common width and height, and set fullscreen to false.
+		 * @return the configuration to be used for a second attempt at creating a display.
+		 * A null value results in NOT attempting to create the display a second time */
+		public LwjglApplicationConfiguration onFailure(LwjglApplicationConfiguration initialConfig);
 	}
 }


### PR DESCRIPTION
I ran into a problem where I was populating a list of desktop resolutions in an options menu using the getDisplayModes method and some resolutions caused a crash on startup (despite supposedly being supported, probably a fullscreen issue).

Of course, LwjglGraphics throws a GdxRuntimeException when this happens, but there is no way to catch it in application code.

This PR allows a failsafe mode for creating a (windowed, non-fullscreen) display mode if the first one fails.  The default settings have it disabled, so it will not cause unexpected confusion from silent failures and recoveries.

like setTitle(), it is only applicable for desktop, but in this case specifically only LWJGL.  I don't really see the need for it on JGLFW.

This allows something like this in the create method:

``` java
if (Gdx.graphics.isUsingFailsafeDisplay()) {
            PopUpMenu.show("Using failsafe display settings! Please change resolution in Options menu!");
        }
```
