### PR TITLE
do not let users add null inputprocessors to multiplexer

### DIFF
--- a/gdx/src/com/badlogic/gdx/InputMultiplexer.java
+++ b/gdx/src/com/badlogic/gdx/InputMultiplexer.java
@@ -33,6 +33,7 @@ public class InputMultiplexer implements InputProcessor {
 	}
 
 	public void addProcessor (int index, InputProcessor processor) {
+		if (processor == null) throw new NullPointerException("processor cannot be null");
 		processors.insert(index, processor);
 	}
 
@@ -41,6 +42,7 @@ public class InputMultiplexer implements InputProcessor {
 	}
 
 	public void addProcessor (InputProcessor processor) {
+		if (processor == null) throw new NullPointerException("processor cannot be null");
 		processors.add(processor);
 	}
 


### PR DESCRIPTION
It's possible to accidentally add null processors, which will result in hard crashes with unhelpful errors messages
