### PR TITLE
ResolutionFileResolver supports DP and have different matching strategy

### DIFF
--- a/gdx/src/com/badlogic/gdx/assets/loaders/resolvers/ResolutionDPFileResolver.java
+++ b/gdx/src/com/badlogic/gdx/assets/loaders/resolvers/ResolutionDPFileResolver.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogic.gdx.assets.loaders.resolvers;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.assets.loaders.FileHandleResolver;
+
+public class ResolutionDPFileResolver extends ResolutionFileResolver {
+
+	public ResolutionDPFileResolver (FileHandleResolver baseResolver, Resolution[] descriptors) {
+		super(baseResolver, descriptors);
+	}
+
+	public ResolutionDPFileResolver (FileHandleResolver baseResolver, ResolutionChooser chooserStrategy, Resolution[] descriptors) {
+		super(baseResolver, chooserStrategy, descriptors);
+	}
+	
+	/** @return screen width in density pixels */
+	@Override
+	protected int getScreenWidth () {
+		return (int)Gdx.graphics.getPpiX();
+	}
+
+	/** @return screen height in density pixels */
+	@Override
+	protected int getScreenHeight () {
+		return (int)Gdx.graphics.getPpiY();
+	}
+
+}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/AssetManagerTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/AssetManagerTest.java
@@ -27,10 +27,9 @@ import com.badlogic.gdx.assets.AssetManager;
 import com.badlogic.gdx.assets.loaders.I18NBundleLoader;
 import com.badlogic.gdx.assets.loaders.TextureLoader;
 import com.badlogic.gdx.assets.loaders.resolvers.InternalFileHandleResolver;
-import com.badlogic.gdx.assets.loaders.resolvers.ResolutionFileResolver;
-import com.badlogic.gdx.assets.loaders.resolvers.ResolutionFileResolver.MatchStrategy;
-import com.badlogic.gdx.assets.loaders.resolvers.ResolutionFileResolver.Metric;
+import com.badlogic.gdx.assets.loaders.resolvers.ResolutionDPFileResolver;
 import com.badlogic.gdx.assets.loaders.resolvers.ResolutionFileResolver.Resolution;
+import com.badlogic.gdx.assets.loaders.resolvers.ResolutionFileResolver.ResolutionChooser;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
@@ -56,8 +55,8 @@ public class AssetManagerTest extends GdxTest implements AssetErrorListener {
 			new Resolution(480, 856, ".480854")};
 
 // ResolutionFileResolver resolver = new ResolutionFileResolver(new InternalFileHandleResolver(), resolutions);
-		ResolutionFileResolver resolver = new ResolutionFileResolver(new InternalFileHandleResolver(), MatchStrategy.bestMatch,
-			Metric.DP, resolutions);
+		ResolutionDPFileResolver resolver = new ResolutionDPFileResolver(new InternalFileHandleResolver(),
+			ResolutionChooser.bestMatch, resolutions);
 
 		manager = new AssetManager();
 		manager.setLoader(Texture.class, new TextureLoader(resolver));


### PR DESCRIPTION
Additions to [ResolutionFileResolver](https://github.com/libgdx/libgdx/blob/master/gdx/src/com/badlogic/gdx/assets/loaders/resolvers/ResolutionFileResolver.java) see issue #2161

now supports
- bestMatch: closest size to target screen
- higherMatch: smallest size larger than the target screen
- lowerMatch: largest size smaller than the target screen

Also added Density pixel resolution metric, match sizes based on screen density.
