### PR TITLE
Avoid ByteBuffer.asFloatBuffer() call, causing heap allocation, on every...

### DIFF
--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGL20.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGL20.java
@@ -719,6 +719,16 @@ class LwjglGL20 implements com.badlogic.gdx.graphics.GL20 {
 						+ " with type "
 						+ type
 						+ " with this method. Use ByteBuffer and one of GL_BYTE, GL_UNSIGNED_BYTE, GL_SHORT, GL_UNSIGNED_SHORT or GL_FLOAT for type. Blame LWJGL");
+		} else if (buffer instanceof FloatBuffer) {
+			if (type == GL_FLOAT)
+				GL20.glVertexAttribPointer(indx, size, normalized, stride, (FloatBuffer)buffer);
+			else
+				throw new GdxRuntimeException(
+						"Can't use "
+								+ buffer.getClass().getName()
+								+ " with type "
+								+ type
+								+ " with this method.");
 		} else
 			throw new GdxRuntimeException("Can't use " + buffer.getClass().getName()
 				+ " with this method. Use ByteBuffer instead. Blame LWJGL");

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/VertexArray.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/VertexArray.java
@@ -113,13 +113,15 @@ public class VertexArray implements VertexData {
 				if (location < 0) continue;
 				shader.enableVertexAttribute(location);
 
-				byteBuffer.position(attribute.offset);
-				if (attribute.usage == Usage.ColorPacked)
+				if (attribute.usage == Usage.ColorPacked) {
+					byteBuffer.position(attribute.offset);
 					shader.setVertexAttribute(location, attribute.numComponents, GL20.GL_UNSIGNED_BYTE, true, attributes.vertexSize,
 						byteBuffer);
-				else
+				} else {
+					buffer.position(attribute.offset / 4);
 					shader.setVertexAttribute(location, attribute.numComponents, GL20.GL_FLOAT, false, attributes.vertexSize,
-						byteBuffer);
+						buffer);
+				}
 			}
 		} else {
 			for (int i = 0; i < numAttributes; i++) {
@@ -128,13 +130,15 @@ public class VertexArray implements VertexData {
 				if (location < 0) continue;
 				shader.enableVertexAttribute(location);
 
-				byteBuffer.position(attribute.offset);
-				if (attribute.usage == Usage.ColorPacked)
+				if (attribute.usage == Usage.ColorPacked) {
+					byteBuffer.position(attribute.offset);
 					shader.setVertexAttribute(location, attribute.numComponents, GL20.GL_UNSIGNED_BYTE, true, attributes.vertexSize,
 						byteBuffer);
-				else
+				} else {
+					buffer.position(attribute.offset / 4);
 					shader.setVertexAttribute(location, attribute.numComponents, GL20.GL_FLOAT, false, attributes.vertexSize,
-						byteBuffer);
+						buffer);
+				}
 			}
 		}
 		isBound = true;


### PR DESCRIPTION
... vertex buffer bind.

I found this while trying to optimise Java heap operations in Halfway. Profiler listed Buffer.asFloatBuffer() in our top allocations. Seems like that's been a workaround for an older version of Lwjgl which didn't have a appropriate function implemented.
