### PR TITLE
Avoid ByteBuffer.asFloatBuffer() call, causing heap allocation, on verte...

### DIFF
--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGL20.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGL20.java
@@ -719,6 +719,16 @@ class LwjglGL20 implements com.badlogic.gdx.graphics.GL20 {
 						+ " with type "
 						+ type
 						+ " with this method. Use ByteBuffer and one of GL_BYTE, GL_UNSIGNED_BYTE, GL_SHORT, GL_UNSIGNED_SHORT or GL_FLOAT for type. Blame LWJGL");
+		} else if (buffer instanceof FloatBuffer) {
+			if (type == GL_FLOAT)
+				GL20.glVertexAttribPointer(indx, size, normalized, stride, (FloatBuffer)buffer);
+			else
+				throw new GdxRuntimeException(
+					"Can't use "
+						+ buffer.getClass().getName()
+						+ " with type "
+						+ type
+						+ " with this method.");
 		} else
 			throw new GdxRuntimeException("Can't use " + buffer.getClass().getName()
 				+ " with this method. Use ByteBuffer instead. Blame LWJGL");

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/VertexArray.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/VertexArray.java
@@ -113,9 +113,15 @@ public class VertexArray implements VertexData {
 				if (location < 0) continue;
 				shader.enableVertexAttribute(location);
 
-				byteBuffer.position(attribute.offset);
-				shader.setVertexAttribute(location, attribute.numComponents, attribute.type, attribute.normalized, attributes.vertexSize,
-					byteBuffer);
+				if (attribute.type == GL20.GL_FLOAT) {
+					buffer.position(attribute.offset / 4);
+					shader.setVertexAttribute(location, attribute.numComponents, attribute.type, attribute.normalized, attributes.vertexSize,
+							buffer);
+				} else {
+					byteBuffer.position(attribute.offset);
+					shader.setVertexAttribute(location, attribute.numComponents, attribute.type, attribute.normalized, attributes.vertexSize,
+						byteBuffer);
+				}
 			}
 		} else {
 			for (int i = 0; i < numAttributes; i++) {
@@ -124,9 +130,15 @@ public class VertexArray implements VertexData {
 				if (location < 0) continue;
 				shader.enableVertexAttribute(location);
 
-				byteBuffer.position(attribute.offset);
-				shader.setVertexAttribute(location, attribute.numComponents, attribute.type, attribute.normalized, attributes.vertexSize,
-					byteBuffer);
+				if (attribute.type == GL20.GL_FLOAT) {
+					buffer.position(attribute.offset / 4);
+					shader.setVertexAttribute(location, attribute.numComponents, attribute.type, attribute.normalized, attributes.vertexSize,
+							buffer);
+				} else {
+					byteBuffer.position(attribute.offset);
+					shader.setVertexAttribute(location, attribute.numComponents, attribute.type, attribute.normalized, attributes.vertexSize,
+						byteBuffer);
+				}
 			}
 		}
 		isBound = true;


### PR DESCRIPTION
...x array bind.

New PR for #2179, "rebased" (redone, actually) on current master.
