### PR TITLE
Add Mappings for Xbox 360 Controller on Windows and Mac

### DIFF
--- a/extensions/gdx-controllers/gdx-controllers/src/com/badlogic/gdx/controllers/mappings/Xbox360.java
+++ b/extensions/gdx-controllers/gdx-controllers/src/com/badlogic/gdx/controllers/mappings/Xbox360.java
@@ -27,14 +27,22 @@ public class Xbox360 {
 	private static final OperatingSystem os;
 
 	static {
-		String osName = System.getProperty("os.name").toLowerCase();
-		if (osName.contains("win")) {
-			os = OperatingSystem.WINDOWS;
-		} else if (osName.contains("mac")) {
-			os = OperatingSystem.OSX;
-		} else {
-			os = OperatingSystem.UNKNOWN;
+		String osName = System.getProperty("os.name");
+		os = getOperatingSystem(osName);
+	}
+
+	private static OperatingSystem getOperatingSystem (String name) {
+		if (name == null) {
+			return OperatingSystem.UNKNOWN;
 		}
+		name = name.toLowerCase();
+		if (name.contains("win")) {
+			return OperatingSystem.WINDOWS;
+		}
+		if (name.contains("mac")) {
+			return OperatingSystem.OSX;
+		}
+		return OperatingSystem.UNKNOWN;
 	}
 
 	/** On windows the triggers on the back work a little differently than one might expect.


### PR DESCRIPTION
This is a weird way of doing it, but this adds mappings for the Xbox 360 controller on windows and mac (using the tattiebogle.net driver).

Because some controls are mapped differently, some fields will stay undefined even if the operating system is supported. For example on Windows AXIS_LEFT_TRIGGER will stay undefined, but on Mac AXIS_BACK_TRIGGERS will stay undefined. This is because the back triggers are mapped to two different axes on Mac, but are combined into one single axis on Windows. For those fields, libgdx users will have to compare the field with the UNDEFINED constant.

What do you think?
