### PR TITLE
Initial state should be entered

### DIFF
--- a/extensions/gdx-ai/src/com/badlogic/gdx/ai/fsm/DefaultStateMachine.java
+++ b/extensions/gdx-ai/src/com/badlogic/gdx/ai/fsm/DefaultStateMachine.java
@@ -60,8 +60,7 @@ public class DefaultStateMachine<E> implements StateMachine<E> {
 	@Override
 	public void setInitialState (State<E> state) {
 		this.previousState = null;
-		this.currentState = state;
-		this.currentState.enter(owner);
+		changeState(state);
 	}
 
 	@Override

--- a/extensions/gdx-ai/src/com/badlogic/gdx/ai/fsm/StackStateMachine.java
+++ b/extensions/gdx-ai/src/com/badlogic/gdx/ai/fsm/StackStateMachine.java
@@ -55,7 +55,7 @@ public class StackStateMachine<E> extends DefaultStateMachine<E> {
 		}
 
 		this.stateStack.clear();
-		this.currentState = state;
+		changeState(state, false);
 	}
 
 	@Override


### PR DESCRIPTION
When I was implementing some enemy AI with the `StateMachine`, I stumbled over a "feature" that I did not expect at first.

I was assuming that whenever a `State` gets `update()`ed, it has been `enter()`ed before. However in case of the initial state this does not happen. I think it won't harm anyone to enter the initial state as well, and in my case it saved me from some NPEs :)

Maybe we should also add a call to `exit()` in case the current state is not `null` when `setInitialState()` is called. Usually this should not be called several times, but it is public and the API does not deny it. If I'd use the method myself, I'd expect it to `exit()` my current state as well.

@davebaol: What do you think?
