### PR TITLE
Add outline and shadow rendering to gdx-freetype

### DIFF
--- a/extensions/gdx-freetype/jni/com.badlogic.gdx.graphics.g2d.freetype.FreeType.cpp
+++ b/extensions/gdx-freetype/jni/com.badlogic.gdx.graphics.g2d.freetype.FreeType.cpp
@@ -1,13 +1,54 @@
 #include <com.badlogic.gdx.graphics.g2d.freetype.FreeType.h>
 
-//@line:32
+//@line:33
 
 	#include <ft2build.h>
 	#include FT_FREETYPE_H
-	 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getFaceFlags(JNIEnv* env, jclass clazz, jlong face) {
+	 JNIEXPORT void JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Library_doneFreeType(JNIEnv* env, jclass clazz, jlong library) {
 
 
-//@line:65
+//@line:61
+
+			FT_Done_FreeType((FT_Library)library);
+		
+
+}
+
+static inline jlong wrapped_Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Library_newMemoryFace
+(JNIEnv* env, jclass clazz, jlong library, jobject obj_data, jint dataSize, jint faceIndex, char* data) {
+
+//@line:84
+
+			FT_Face face = 0;
+			FT_Error error = FT_New_Memory_Face((FT_Library)library, (const FT_Byte*)data, dataSize, faceIndex, &face);
+			if(error) return 0;
+			else return (jlong)face;
+		
+}
+
+JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Library_newMemoryFace(JNIEnv* env, jclass clazz, jlong library, jobject obj_data, jint dataSize, jint faceIndex) {
+	char* data = (char*)(obj_data?env->GetDirectBufferAddress(obj_data):0);
+
+	jlong JNI_returnValue = wrapped_Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Library_newMemoryFace(env, clazz, library, obj_data, dataSize, faceIndex, data);
+
+
+	return JNI_returnValue;
+}
+
+JNIEXPORT void JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_doneFace(JNIEnv* env, jclass clazz, jlong face) {
+
+
+//@line:110
+
+			FT_Done_Face((FT_Face)face);
+		
+
+}
+
+JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getFaceFlags(JNIEnv* env, jclass clazz, jlong face) {
+
+
+//@line:118
 
 			return ((FT_Face)face)->face_flags;
 		
@@ -17,7 +58,7 @@
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getStyleFlags(JNIEnv* env, jclass clazz, jlong face) {
 
 
-//@line:73
+//@line:126
 
 			return ((FT_Face)face)->style_flags;
 		
@@ -27,7 +68,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getNumGlyphs(JNIEnv* env, jclass clazz, jlong face) {
 
 
-//@line:81
+//@line:134
 
 			return ((FT_Face)face)->num_glyphs;
 		
@@ -37,7 +78,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getAscender(JNIEnv* env, jclass clazz, jlong face) {
 
 
-//@line:89
+//@line:142
 
 			return ((FT_Face)face)->ascender;
 		
@@ -47,7 +88,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getDescender(JNIEnv* env, jclass clazz, jlong face) {
 
 
-//@line:97
+//@line:150
 
 			return ((FT_Face)face)->descender;
 		
@@ -57,7 +98,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getHeight(JNIEnv* env, jclass clazz, jlong face) {
 
 
-//@line:105
+//@line:158
 
 			return ((FT_Face)face)->height;
 		
@@ -67,7 +108,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getMaxAdvanceWidth(JNIEnv* env, jclass clazz, jlong face) {
 
 
-//@line:113
+//@line:166
 
 			return ((FT_Face)face)->max_advance_width;
 		
@@ -77,7 +118,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getMaxAdvanceHeight(JNIEnv* env, jclass clazz, jlong face) {
 
 
-//@line:121
+//@line:174
 
 			return ((FT_Face)face)->max_advance_height;
 		
@@ -87,7 +128,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getUnderlinePosition(JNIEnv* env, jclass clazz, jlong face) {
 
 
-//@line:129
+//@line:182
 
 			return ((FT_Face)face)->underline_position;
 		
@@ -97,9 +138,59 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getUnderlineThickness(JNIEnv* env, jclass clazz, jlong face) {
 
 
-//@line:137
+//@line:190
 
 			return ((FT_Face)face)->underline_thickness;
+		
+
+}
+
+JNIEXPORT jboolean JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_selectSize(JNIEnv* env, jclass clazz, jlong face, jint strike_index) {
+
+
+//@line:198
+
+			return !FT_Select_Size((FT_Face)face, strike_index);
+		
+
+}
+
+JNIEXPORT jboolean JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_setCharSize(JNIEnv* env, jclass clazz, jlong face, jint charWidth, jint charHeight, jint horzResolution, jint vertResolution) {
+
+
+//@line:206
+
+			return !FT_Set_Char_Size((FT_Face)face, charWidth, charHeight, horzResolution, vertResolution);
+		
+
+}
+
+JNIEXPORT jboolean JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_setPixelSizes(JNIEnv* env, jclass clazz, jlong face, jint pixelWidth, jint pixelHeight) {
+
+
+//@line:214
+
+			return !FT_Set_Pixel_Sizes((FT_Face)face, pixelWidth, pixelHeight);
+		
+
+}
+
+JNIEXPORT jboolean JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_loadGlyph(JNIEnv* env, jclass clazz, jlong face, jint glyphIndex, jint loadFlags) {
+
+
+//@line:222
+
+			return !FT_Load_Glyph((FT_Face)face, glyphIndex, loadFlags);
+		
+
+}
+
+JNIEXPORT jboolean JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_loadChar(JNIEnv* env, jclass clazz, jlong face, jint charCode, jint loadFlags) {
+
+
+//@line:230
+
+			return !FT_Load_Char((FT_Face)face, charCode, loadFlags);
 		
 
 }
@@ -107,7 +198,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getGlyph(JNIEnv* env, jclass clazz, jlong face) {
 
 
-//@line:145
+//@line:238
 
 			return (jlong)((FT_Face)face)->glyph;
 		
@@ -117,17 +208,50 @@ JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_000
 JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getSize(JNIEnv* env, jclass clazz, jlong face) {
 
 
-//@line:153
+//@line:246
 
 			return (jlong)((FT_Face)face)->size;
 		
 
 }
 
+JNIEXPORT jboolean JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_hasKerning(JNIEnv* env, jclass clazz, jlong face) {
+
+
+//@line:254
+
+	   	return FT_HAS_KERNING(((FT_Face)face));
+	   
+
+}
+
+JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getKerning(JNIEnv* env, jclass clazz, jlong face, jint leftGlyph, jint rightGlyph, jint kernMode) {
+
+
+//@line:262
+
+	   	FT_Vector kerning;
+	   	FT_Error error = FT_Get_Kerning((FT_Face)face, leftGlyph, rightGlyph, kernMode, &kerning);
+	   	if(error) return 0;
+	   	return kerning.x;
+	   
+
+}
+
+JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getCharIndex(JNIEnv* env, jclass clazz, jlong face, jint charCode) {
+
+
+//@line:273
+
+	   	return FT_Get_Char_Index((FT_Face)face, charCode);
+	   
+
+}
+
 JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Size_getMetrics(JNIEnv* env, jclass clazz, jlong address) {
 
 
-//@line:167
+//@line:288
 
 			return (jlong)&((FT_Size)address)->metrics;
 		
@@ -137,7 +261,7 @@ JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_000
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024SizeMetrics_getXppem(JNIEnv* env, jclass clazz, jlong metrics) {
 
 
-//@line:181
+//@line:302
 
 			return ((FT_Size_Metrics*)metrics)->x_ppem;
 		
@@ -147,7 +271,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024SizeMetrics_getYppem(JNIEnv* env, jclass clazz, jlong metrics) {
 
 
-//@line:189
+//@line:310
 
 			return ((FT_Size_Metrics*)metrics)->y_ppem;
 		
@@ -157,7 +281,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024SizeMetrics_getXscale(JNIEnv* env, jclass clazz, jlong metrics) {
 
 
-//@line:197
+//@line:318
 
 			return ((FT_Size_Metrics*)metrics)->x_scale;
 		
@@ -167,7 +291,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024SizeMetrics_getYscale(JNIEnv* env, jclass clazz, jlong metrics) {
 
 
-//@line:205
+//@line:326
 
 			return ((FT_Size_Metrics*)metrics)->x_scale;
 		
@@ -177,7 +301,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024SizeMetrics_getAscender(JNIEnv* env, jclass clazz, jlong metrics) {
 
 
-//@line:213
+//@line:334
 
 			return ((FT_Size_Metrics*)metrics)->ascender;
 		
@@ -187,7 +311,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024SizeMetrics_getDescender(JNIEnv* env, jclass clazz, jlong metrics) {
 
 
-//@line:221
+//@line:342
 
 			return ((FT_Size_Metrics*)metrics)->descender;
 		
@@ -197,7 +321,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024SizeMetrics_getHeight(JNIEnv* env, jclass clazz, jlong metrics) {
 
 
-//@line:229
+//@line:350
 
 			return ((FT_Size_Metrics*)metrics)->height;
 		
@@ -207,7 +331,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024SizeMetrics_getMaxAdvance(JNIEnv* env, jclass clazz, jlong metrics) {
 
 
-//@line:237
+//@line:358
 
 			return ((FT_Size_Metrics*)metrics)->max_advance;
 		
@@ -217,7 +341,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphSlot_getMetrics(JNIEnv* env, jclass clazz, jlong slot) {
 
 
-//@line:251
+//@line:372
 
 			return (jlong)&((FT_GlyphSlot)slot)->metrics;
 		
@@ -227,7 +351,7 @@ JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_000
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphSlot_getLinearHoriAdvance(JNIEnv* env, jclass clazz, jlong slot) {
 
 
-//@line:259
+//@line:380
 
 			return ((FT_GlyphSlot)slot)->linearHoriAdvance;
 		
@@ -237,7 +361,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphSlot_getLinearVertAdvance(JNIEnv* env, jclass clazz, jlong slot) {
 
 
-//@line:267
+//@line:388
 
 			return ((FT_GlyphSlot)slot)->linearVertAdvance;
 		
@@ -247,7 +371,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphSlot_getAdvanceX(JNIEnv* env, jclass clazz, jlong slot) {
 
 
-//@line:275
+//@line:396
 
 			return ((FT_GlyphSlot)slot)->advance.x;
 		
@@ -257,7 +381,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphSlot_getAdvanceY(JNIEnv* env, jclass clazz, jlong slot) {
 
 
-//@line:283
+//@line:404
 
 			return ((FT_GlyphSlot)slot)->advance.y;
 		
@@ -267,7 +391,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphSlot_getFormat(JNIEnv* env, jclass clazz, jlong slot) {
 
 
-//@line:291
+//@line:412
 
 			return ((FT_GlyphSlot)slot)->format;
 		
@@ -277,7 +401,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphSlot_getBitmap(JNIEnv* env, jclass clazz, jlong slot) {
 
 
-//@line:299
+//@line:420
 
 			FT_GlyphSlot glyph = ((FT_GlyphSlot)slot);
 			return (jlong)&(glyph->bitmap);
@@ -288,7 +412,7 @@ JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_000
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphSlot_getBitmapLeft(JNIEnv* env, jclass clazz, jlong slot) {
 
 
-//@line:308
+//@line:429
 
 			return ((FT_GlyphSlot)slot)->bitmap_left;
 		
@@ -298,9 +422,19 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphSlot_getBitmapTop(JNIEnv* env, jclass clazz, jlong slot) {
 
 
-//@line:316
+//@line:437
 
 			return ((FT_GlyphSlot)slot)->bitmap_top;
+		
+
+}
+
+JNIEXPORT jboolean JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphSlot_renderGlyph(JNIEnv* env, jclass clazz, jlong slot, jint renderMode) {
+
+
+//@line:445
+
+			return !FT_Render_Glyph((FT_GlyphSlot)slot, (FT_Render_Mode)renderMode);
 		
 
 }
@@ -308,7 +442,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Bitmap_getRows(JNIEnv* env, jclass clazz, jlong bitmap) {
 
 
-//@line:330
+//@line:459
 
 			return ((FT_Bitmap*)bitmap)->rows;
 		
@@ -318,7 +452,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Bitmap_getWidth(JNIEnv* env, jclass clazz, jlong bitmap) {
 
 
-//@line:338
+//@line:467
 
 			return ((FT_Bitmap*)bitmap)->width;
 		
@@ -328,7 +462,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Bitmap_getPitch(JNIEnv* env, jclass clazz, jlong bitmap) {
 
 
-//@line:346
+//@line:475
 
 			return ((FT_Bitmap*)bitmap)->pitch;
 		
@@ -338,7 +472,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jobject JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Bitmap_getBuffer(JNIEnv* env, jclass clazz, jlong bitmap) {
 
 
-//@line:376
+//@line:505
 
 			FT_Bitmap* bmp = (FT_Bitmap*)bitmap;
 			return env->NewDirectByteBuffer((void*)bmp->buffer, bmp->rows * abs(bmp->pitch));
@@ -349,7 +483,7 @@ JNIEXPORT jobject JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Bitmap_getNumGray(JNIEnv* env, jclass clazz, jlong bitmap) {
 
 
-//@line:385
+//@line:514
 
 			return ((FT_Bitmap*)bitmap)->num_grays;
 		
@@ -359,7 +493,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Bitmap_getPixelMode(JNIEnv* env, jclass clazz, jlong bitmap) {
 
 
-//@line:393
+//@line:522
 
 			return ((FT_Bitmap*)bitmap)->pixel_mode;
 		
@@ -369,7 +503,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphMetrics_getWidth(JNIEnv* env, jclass clazz, jlong metrics) {
 
 
-//@line:407
+//@line:536
 
 			return ((FT_Glyph_Metrics*)metrics)->width;
 		
@@ -379,7 +513,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphMetrics_getHeight(JNIEnv* env, jclass clazz, jlong metrics) {
 
 
-//@line:415
+//@line:544
 
 			return ((FT_Glyph_Metrics*)metrics)->height;
 		
@@ -389,7 +523,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphMetrics_getHoriBearingX(JNIEnv* env, jclass clazz, jlong metrics) {
 
 
-//@line:423
+//@line:552
 
 			return ((FT_Glyph_Metrics*)metrics)->horiBearingX;
 		
@@ -399,7 +533,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphMetrics_getHoriBearingY(JNIEnv* env, jclass clazz, jlong metrics) {
 
 
-//@line:431
+//@line:560
 
 			return ((FT_Glyph_Metrics*)metrics)->horiBearingY;
 		
@@ -409,7 +543,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphMetrics_getHoriAdvance(JNIEnv* env, jclass clazz, jlong metrics) {
 
 
-//@line:439
+//@line:568
 
 			return ((FT_Glyph_Metrics*)metrics)->horiAdvance;
 		
@@ -419,7 +553,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphMetrics_getVertBearingX(JNIEnv* env, jclass clazz, jlong metrics) {
 
 
-//@line:447
+//@line:576
 
 			return ((FT_Glyph_Metrics*)metrics)->vertBearingX;
 		
@@ -429,7 +563,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphMetrics_getVertBearingY(JNIEnv* env, jclass clazz, jlong metrics) {
 
 
-//@line:455
+//@line:584
 
 			return ((FT_Glyph_Metrics*)metrics)->vertBearingY;
 		 
@@ -439,7 +573,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphMetrics_getVertAdvance(JNIEnv* env, jclass clazz, jlong metrics) {
 
 
-//@line:463
+//@line:592
 
 			return ((FT_Glyph_Metrics*)metrics)->vertAdvance;
 		
@@ -449,147 +583,13 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_initFreeTypeJni(JNIEnv* env, jclass clazz) {
 
 
-//@line:547
+//@line:676
 
 		FT_Library library = 0;
 		FT_Error error = FT_Init_FreeType(&library);
 		if(error) return 0;
 		else return (jlong)library;
 	
-
-}
-
-JNIEXPORT void JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_doneFreeType(JNIEnv* env, jclass clazz, jlong library) {
-
-
-//@line:561
-
-		FT_Done_FreeType((FT_Library)library);
-	
-
-}
-
-static inline jlong wrapped_Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_newMemoryFace
-(JNIEnv* env, jclass clazz, jlong library, jobject obj_data, jint dataSize, jint faceIndex, char* data) {
-
-//@line:584
-
-		FT_Face face = 0;
-		FT_Error error = FT_New_Memory_Face((FT_Library)library, (const FT_Byte*)data, dataSize, faceIndex, &face);
-		if(error) return 0;
-		else return (jlong)face; 
-	
-}
-
-JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_newMemoryFace(JNIEnv* env, jclass clazz, jlong library, jobject obj_data, jint dataSize, jint faceIndex) {
-	char* data = (char*)(obj_data?env->GetDirectBufferAddress(obj_data):0);
-
-	jlong JNI_returnValue = wrapped_Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_newMemoryFace(env, clazz, library, obj_data, dataSize, faceIndex, data);
-
-
-	return JNI_returnValue;
-}
-
-JNIEXPORT void JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_doneFace(JNIEnv* env, jclass clazz, jlong face) {
-
-
-//@line:600
-
-		FT_Done_Face((FT_Face)face);
-	
-
-}
-
-JNIEXPORT jboolean JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_selectSize(JNIEnv* env, jclass clazz, jlong face, jint strike_index) {
-
-
-//@line:608
-
-		return !FT_Select_Size((FT_Face)face, strike_index);
-	
-
-}
-
-JNIEXPORT jboolean JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_setCharSize(JNIEnv* env, jclass clazz, jlong face, jint charWidth, jint charHeight, jint horzResolution, jint vertResolution) {
-
-
-//@line:616
-
-		return !FT_Set_Char_Size((FT_Face)face, charWidth, charHeight, horzResolution, vertResolution);
-	
-
-}
-
-JNIEXPORT jboolean JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_setPixelSizes(JNIEnv* env, jclass clazz, jlong face, jint pixelWidth, jint pixelHeight) {
-
-
-//@line:624
-
-		return !FT_Set_Pixel_Sizes((FT_Face)face, pixelWidth, pixelHeight);
-	
-
-}
-
-JNIEXPORT jboolean JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_loadGlyph(JNIEnv* env, jclass clazz, jlong face, jint glyphIndex, jint loadFlags) {
-
-
-//@line:632
-
-		return !FT_Load_Glyph((FT_Face)face, glyphIndex, loadFlags);
-	
-
-}
-
-JNIEXPORT jboolean JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_loadChar(JNIEnv* env, jclass clazz, jlong face, jint charCode, jint loadFlags) {
-
-
-//@line:640
-
-		return !FT_Load_Char((FT_Face)face, charCode, loadFlags);
-	
-
-}
-
-JNIEXPORT jboolean JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_renderGlyph(JNIEnv* env, jclass clazz, jlong slot, jint renderMode) {
-
-
-//@line:648
-
-		return !FT_Render_Glyph((FT_GlyphSlot)slot, (FT_Render_Mode)renderMode);
-	
-
-}
-
-JNIEXPORT jboolean JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_hasKerning(JNIEnv* env, jclass clazz, jlong face) {
-
-
-//@line:656
-
-   	return FT_HAS_KERNING(((FT_Face)face));
-   
-
-}
-
-JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_getKerning(JNIEnv* env, jclass clazz, jlong face, jint leftGlyph, jint rightGlyph, jint kernMode) {
-
-
-//@line:664
-
-   	FT_Vector kerning;
-   	FT_Error error = FT_Get_Kerning((FT_Face)face, leftGlyph, rightGlyph, kernMode, &kerning);
-   	if(error) return 0;
-   	return kerning.x;
-   
-
-}
-
-JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_getCharIndex(JNIEnv* env, jclass clazz, jlong face, jint charCode) {
-
-
-//@line:675
-
-   	return FT_Get_Char_Index((FT_Face)face, charCode);
-   
 
 }
 

--- a/extensions/gdx-freetype/jni/com.badlogic.gdx.graphics.g2d.freetype.FreeType.cpp
+++ b/extensions/gdx-freetype/jni/com.badlogic.gdx.graphics.g2d.freetype.FreeType.cpp
@@ -1,13 +1,14 @@
 #include <com.badlogic.gdx.graphics.g2d.freetype.FreeType.h>
 
-//@line:33
+//@line:35
 
 	#include <ft2build.h>
 	#include FT_FREETYPE_H
+	#include FT_STROKER_H
 	 JNIEXPORT void JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Library_doneFreeType(JNIEnv* env, jclass clazz, jlong library) {
 
 
-//@line:61
+//@line:64
 
 			FT_Done_FreeType((FT_Library)library);
 		
@@ -17,7 +18,7 @@
 static inline jlong wrapped_Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Library_newMemoryFace
 (JNIEnv* env, jclass clazz, jlong library, jobject obj_data, jint dataSize, jint faceIndex, char* data) {
 
-//@line:84
+//@line:87
 
 			FT_Face face = 0;
 			FT_Error error = FT_New_Memory_Face((FT_Library)library, (const FT_Byte*)data, dataSize, faceIndex, &face);
@@ -35,10 +36,23 @@ JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_000
 	return JNI_returnValue;
 }
 
+JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Library_strokerNew(JNIEnv* env, jclass clazz, jlong library) {
+
+
+//@line:100
+
+         FT_Stroker stroker;
+         FT_Error error = FT_Stroker_New((FT_Library)library, &stroker);
+			if(error) return 0;
+			else return (jlong)stroker;
+		
+
+}
+
 JNIEXPORT void JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_doneFace(JNIEnv* env, jclass clazz, jlong face) {
 
 
-//@line:110
+//@line:126
 
 			FT_Done_Face((FT_Face)face);
 		
@@ -48,7 +62,7 @@ JNIEXPORT void JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getFaceFlags(JNIEnv* env, jclass clazz, jlong face) {
 
 
-//@line:118
+//@line:134
 
 			return ((FT_Face)face)->face_flags;
 		
@@ -58,7 +72,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getStyleFlags(JNIEnv* env, jclass clazz, jlong face) {
 
 
-//@line:126
+//@line:142
 
 			return ((FT_Face)face)->style_flags;
 		
@@ -68,7 +82,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getNumGlyphs(JNIEnv* env, jclass clazz, jlong face) {
 
 
-//@line:134
+//@line:150
 
 			return ((FT_Face)face)->num_glyphs;
 		
@@ -78,7 +92,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getAscender(JNIEnv* env, jclass clazz, jlong face) {
 
 
-//@line:142
+//@line:158
 
 			return ((FT_Face)face)->ascender;
 		
@@ -88,7 +102,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getDescender(JNIEnv* env, jclass clazz, jlong face) {
 
 
-//@line:150
+//@line:166
 
 			return ((FT_Face)face)->descender;
 		
@@ -98,7 +112,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getHeight(JNIEnv* env, jclass clazz, jlong face) {
 
 
-//@line:158
+//@line:174
 
 			return ((FT_Face)face)->height;
 		
@@ -108,7 +122,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getMaxAdvanceWidth(JNIEnv* env, jclass clazz, jlong face) {
 
 
-//@line:166
+//@line:182
 
 			return ((FT_Face)face)->max_advance_width;
 		
@@ -118,7 +132,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getMaxAdvanceHeight(JNIEnv* env, jclass clazz, jlong face) {
 
 
-//@line:174
+//@line:190
 
 			return ((FT_Face)face)->max_advance_height;
 		
@@ -128,7 +142,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getUnderlinePosition(JNIEnv* env, jclass clazz, jlong face) {
 
 
-//@line:182
+//@line:198
 
 			return ((FT_Face)face)->underline_position;
 		
@@ -138,7 +152,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getUnderlineThickness(JNIEnv* env, jclass clazz, jlong face) {
 
 
-//@line:190
+//@line:206
 
 			return ((FT_Face)face)->underline_thickness;
 		
@@ -148,7 +162,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jboolean JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_selectSize(JNIEnv* env, jclass clazz, jlong face, jint strike_index) {
 
 
-//@line:198
+//@line:214
 
 			return !FT_Select_Size((FT_Face)face, strike_index);
 		
@@ -158,7 +172,7 @@ JNIEXPORT jboolean JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_
 JNIEXPORT jboolean JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_setCharSize(JNIEnv* env, jclass clazz, jlong face, jint charWidth, jint charHeight, jint horzResolution, jint vertResolution) {
 
 
-//@line:206
+//@line:222
 
 			return !FT_Set_Char_Size((FT_Face)face, charWidth, charHeight, horzResolution, vertResolution);
 		
@@ -168,7 +182,7 @@ JNIEXPORT jboolean JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_
 JNIEXPORT jboolean JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_setPixelSizes(JNIEnv* env, jclass clazz, jlong face, jint pixelWidth, jint pixelHeight) {
 
 
-//@line:214
+//@line:230
 
 			return !FT_Set_Pixel_Sizes((FT_Face)face, pixelWidth, pixelHeight);
 		
@@ -178,7 +192,7 @@ JNIEXPORT jboolean JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_
 JNIEXPORT jboolean JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_loadGlyph(JNIEnv* env, jclass clazz, jlong face, jint glyphIndex, jint loadFlags) {
 
 
-//@line:222
+//@line:238
 
 			return !FT_Load_Glyph((FT_Face)face, glyphIndex, loadFlags);
 		
@@ -188,7 +202,7 @@ JNIEXPORT jboolean JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_
 JNIEXPORT jboolean JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_loadChar(JNIEnv* env, jclass clazz, jlong face, jint charCode, jint loadFlags) {
 
 
-//@line:230
+//@line:246
 
 			return !FT_Load_Char((FT_Face)face, charCode, loadFlags);
 		
@@ -198,7 +212,7 @@ JNIEXPORT jboolean JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_
 JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getGlyph(JNIEnv* env, jclass clazz, jlong face) {
 
 
-//@line:238
+//@line:254
 
 			return (jlong)((FT_Face)face)->glyph;
 		
@@ -208,7 +222,7 @@ JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_000
 JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getSize(JNIEnv* env, jclass clazz, jlong face) {
 
 
-//@line:246
+//@line:262
 
 			return (jlong)((FT_Face)face)->size;
 		
@@ -218,7 +232,7 @@ JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_000
 JNIEXPORT jboolean JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_hasKerning(JNIEnv* env, jclass clazz, jlong face) {
 
 
-//@line:254
+//@line:270
 
 	   	return FT_HAS_KERNING(((FT_Face)face));
 	   
@@ -228,7 +242,7 @@ JNIEXPORT jboolean JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getKerning(JNIEnv* env, jclass clazz, jlong face, jint leftGlyph, jint rightGlyph, jint kernMode) {
 
 
-//@line:262
+//@line:278
 
 	   	FT_Vector kerning;
 	   	FT_Error error = FT_Get_Kerning((FT_Face)face, leftGlyph, rightGlyph, kernMode, &kerning);
@@ -241,7 +255,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getCharIndex(JNIEnv* env, jclass clazz, jlong face, jint charCode) {
 
 
-//@line:273
+//@line:289
 
 	   	return FT_Get_Char_Index((FT_Face)face, charCode);
 	   
@@ -251,7 +265,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Size_getMetrics(JNIEnv* env, jclass clazz, jlong address) {
 
 
-//@line:288
+//@line:304
 
 			return (jlong)&((FT_Size)address)->metrics;
 		
@@ -261,7 +275,7 @@ JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_000
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024SizeMetrics_getXppem(JNIEnv* env, jclass clazz, jlong metrics) {
 
 
-//@line:302
+//@line:318
 
 			return ((FT_Size_Metrics*)metrics)->x_ppem;
 		
@@ -271,7 +285,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024SizeMetrics_getYppem(JNIEnv* env, jclass clazz, jlong metrics) {
 
 
-//@line:310
+//@line:326
 
 			return ((FT_Size_Metrics*)metrics)->y_ppem;
 		
@@ -281,7 +295,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024SizeMetrics_getXscale(JNIEnv* env, jclass clazz, jlong metrics) {
 
 
-//@line:318
+//@line:334
 
 			return ((FT_Size_Metrics*)metrics)->x_scale;
 		
@@ -291,7 +305,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024SizeMetrics_getYscale(JNIEnv* env, jclass clazz, jlong metrics) {
 
 
-//@line:326
+//@line:342
 
 			return ((FT_Size_Metrics*)metrics)->x_scale;
 		
@@ -301,7 +315,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024SizeMetrics_getAscender(JNIEnv* env, jclass clazz, jlong metrics) {
 
 
-//@line:334
+//@line:350
 
 			return ((FT_Size_Metrics*)metrics)->ascender;
 		
@@ -311,7 +325,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024SizeMetrics_getDescender(JNIEnv* env, jclass clazz, jlong metrics) {
 
 
-//@line:342
+//@line:358
 
 			return ((FT_Size_Metrics*)metrics)->descender;
 		
@@ -321,7 +335,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024SizeMetrics_getHeight(JNIEnv* env, jclass clazz, jlong metrics) {
 
 
-//@line:350
+//@line:366
 
 			return ((FT_Size_Metrics*)metrics)->height;
 		
@@ -331,7 +345,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024SizeMetrics_getMaxAdvance(JNIEnv* env, jclass clazz, jlong metrics) {
 
 
-//@line:358
+//@line:374
 
 			return ((FT_Size_Metrics*)metrics)->max_advance;
 		
@@ -341,7 +355,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphSlot_getMetrics(JNIEnv* env, jclass clazz, jlong slot) {
 
 
-//@line:372
+//@line:388
 
 			return (jlong)&((FT_GlyphSlot)slot)->metrics;
 		
@@ -351,7 +365,7 @@ JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_000
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphSlot_getLinearHoriAdvance(JNIEnv* env, jclass clazz, jlong slot) {
 
 
-//@line:380
+//@line:396
 
 			return ((FT_GlyphSlot)slot)->linearHoriAdvance;
 		
@@ -361,7 +375,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphSlot_getLinearVertAdvance(JNIEnv* env, jclass clazz, jlong slot) {
 
 
-//@line:388
+//@line:404
 
 			return ((FT_GlyphSlot)slot)->linearVertAdvance;
 		
@@ -371,7 +385,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphSlot_getAdvanceX(JNIEnv* env, jclass clazz, jlong slot) {
 
 
-//@line:396
+//@line:412
 
 			return ((FT_GlyphSlot)slot)->advance.x;
 		
@@ -381,7 +395,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphSlot_getAdvanceY(JNIEnv* env, jclass clazz, jlong slot) {
 
 
-//@line:404
+//@line:420
 
 			return ((FT_GlyphSlot)slot)->advance.y;
 		
@@ -391,7 +405,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphSlot_getFormat(JNIEnv* env, jclass clazz, jlong slot) {
 
 
-//@line:412
+//@line:428
 
 			return ((FT_GlyphSlot)slot)->format;
 		
@@ -401,7 +415,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphSlot_getBitmap(JNIEnv* env, jclass clazz, jlong slot) {
 
 
-//@line:420
+//@line:436
 
 			FT_GlyphSlot glyph = ((FT_GlyphSlot)slot);
 			return (jlong)&(glyph->bitmap);
@@ -412,7 +426,7 @@ JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_000
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphSlot_getBitmapLeft(JNIEnv* env, jclass clazz, jlong slot) {
 
 
-//@line:429
+//@line:445
 
 			return ((FT_GlyphSlot)slot)->bitmap_left;
 		
@@ -422,7 +436,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphSlot_getBitmapTop(JNIEnv* env, jclass clazz, jlong slot) {
 
 
-//@line:437
+//@line:453
 
 			return ((FT_GlyphSlot)slot)->bitmap_top;
 		
@@ -432,9 +446,90 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jboolean JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphSlot_renderGlyph(JNIEnv* env, jclass clazz, jlong slot, jint renderMode) {
 
 
-//@line:445
+//@line:461
 
 			return !FT_Render_Glyph((FT_GlyphSlot)slot, (FT_Render_Mode)renderMode);
+		
+
+}
+
+JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphSlot_getGlyph(JNIEnv* env, jclass clazz, jlong glyphSlot) {
+
+
+//@line:471
+
+			FT_Glyph glyph;
+			FT_Error error = FT_Get_Glyph((FT_GlyphSlot)glyphSlot, &glyph);
+			if(error) return 0;
+			else return (jlong)glyph;
+		
+
+}
+
+JNIEXPORT void JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Glyph_done(JNIEnv* env, jclass clazz, jlong glyph) {
+
+
+//@line:491
+
+			FT_Done_Glyph((FT_Glyph)glyph);
+		
+
+}
+
+JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Glyph_strokeBorder(JNIEnv* env, jclass clazz, jlong glyph, jlong stroker, jboolean inside) {
+
+
+//@line:499
+
+			FT_Glyph border_glyph = (FT_Glyph)glyph;
+			FT_Glyph_StrokeBorder(&border_glyph, (FT_Stroker)stroker, inside, 1);
+			return (jlong)border_glyph;
+		
+
+}
+
+JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Glyph_toBitmap(JNIEnv* env, jclass clazz, jlong glyph, jint renderMode) {
+
+
+//@line:512
+
+			FT_Glyph bitmap = (FT_Glyph)glyph;
+			FT_Error error = FT_Glyph_To_Bitmap(&bitmap, (FT_Render_Mode)renderMode, NULL, 1);
+			if(error) return 0;
+			return (jlong)bitmap;
+		
+
+}
+
+JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Glyph_getBitmap(JNIEnv* env, jclass clazz, jlong glyph) {
+
+
+//@line:526
+
+			FT_BitmapGlyph glyph_bitmap = ((FT_BitmapGlyph)glyph);
+			return (jlong)&(glyph_bitmap->bitmap);
+		
+
+}
+
+JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Glyph_getLeft(JNIEnv* env, jclass clazz, jlong glyph) {
+
+
+//@line:538
+
+			FT_BitmapGlyph glyph_bitmap = ((FT_BitmapGlyph)glyph);
+			return glyph_bitmap->left;
+		
+
+}
+
+JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Glyph_getTop(JNIEnv* env, jclass clazz, jlong glyph) {
+
+
+//@line:550
+
+			FT_BitmapGlyph glyph_bitmap = ((FT_BitmapGlyph)glyph);
+			return glyph_bitmap->top;
 		
 
 }
@@ -442,7 +537,7 @@ JNIEXPORT jboolean JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Bitmap_getRows(JNIEnv* env, jclass clazz, jlong bitmap) {
 
 
-//@line:459
+//@line:566
 
 			return ((FT_Bitmap*)bitmap)->rows;
 		
@@ -452,7 +547,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Bitmap_getWidth(JNIEnv* env, jclass clazz, jlong bitmap) {
 
 
-//@line:467
+//@line:574
 
 			return ((FT_Bitmap*)bitmap)->width;
 		
@@ -462,7 +557,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Bitmap_getPitch(JNIEnv* env, jclass clazz, jlong bitmap) {
 
 
-//@line:475
+//@line:582
 
 			return ((FT_Bitmap*)bitmap)->pitch;
 		
@@ -472,7 +567,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jobject JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Bitmap_getBuffer(JNIEnv* env, jclass clazz, jlong bitmap) {
 
 
-//@line:505
+//@line:630
 
 			FT_Bitmap* bmp = (FT_Bitmap*)bitmap;
 			return env->NewDirectByteBuffer((void*)bmp->buffer, bmp->rows * abs(bmp->pitch));
@@ -483,7 +578,7 @@ JNIEXPORT jobject JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Bitmap_getNumGray(JNIEnv* env, jclass clazz, jlong bitmap) {
 
 
-//@line:514
+//@line:639
 
 			return ((FT_Bitmap*)bitmap)->num_grays;
 		
@@ -493,7 +588,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Bitmap_getPixelMode(JNIEnv* env, jclass clazz, jlong bitmap) {
 
 
-//@line:522
+//@line:647
 
 			return ((FT_Bitmap*)bitmap)->pixel_mode;
 		
@@ -503,7 +598,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphMetrics_getWidth(JNIEnv* env, jclass clazz, jlong metrics) {
 
 
-//@line:536
+//@line:661
 
 			return ((FT_Glyph_Metrics*)metrics)->width;
 		
@@ -513,7 +608,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphMetrics_getHeight(JNIEnv* env, jclass clazz, jlong metrics) {
 
 
-//@line:544
+//@line:669
 
 			return ((FT_Glyph_Metrics*)metrics)->height;
 		
@@ -523,7 +618,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphMetrics_getHoriBearingX(JNIEnv* env, jclass clazz, jlong metrics) {
 
 
-//@line:552
+//@line:677
 
 			return ((FT_Glyph_Metrics*)metrics)->horiBearingX;
 		
@@ -533,7 +628,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphMetrics_getHoriBearingY(JNIEnv* env, jclass clazz, jlong metrics) {
 
 
-//@line:560
+//@line:685
 
 			return ((FT_Glyph_Metrics*)metrics)->horiBearingY;
 		
@@ -543,7 +638,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphMetrics_getHoriAdvance(JNIEnv* env, jclass clazz, jlong metrics) {
 
 
-//@line:568
+//@line:693
 
 			return ((FT_Glyph_Metrics*)metrics)->horiAdvance;
 		
@@ -553,7 +648,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphMetrics_getVertBearingX(JNIEnv* env, jclass clazz, jlong metrics) {
 
 
-//@line:576
+//@line:701
 
 			return ((FT_Glyph_Metrics*)metrics)->vertBearingX;
 		
@@ -563,7 +658,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphMetrics_getVertBearingY(JNIEnv* env, jclass clazz, jlong metrics) {
 
 
-//@line:584
+//@line:709
 
 			return ((FT_Glyph_Metrics*)metrics)->vertBearingY;
 		 
@@ -573,9 +668,29 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphMetrics_getVertAdvance(JNIEnv* env, jclass clazz, jlong metrics) {
 
 
-//@line:592
+//@line:717
 
 			return ((FT_Glyph_Metrics*)metrics)->vertAdvance;
+		
+
+}
+
+JNIEXPORT void JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Stroker_set(JNIEnv* env, jclass clazz, jlong stroker, jint radius, jint lineCap, jint lineJoin, jint miterLimit) {
+
+
+//@line:731
+
+			FT_Stroker_Set((FT_Stroker)stroker, radius, (FT_Stroker_LineCap)lineCap, (FT_Stroker_LineJoin)lineJoin, miterLimit);
+		
+
+}
+
+JNIEXPORT void JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Stroker_done(JNIEnv* env, jclass clazz, jlong stroker) {
+
+
+//@line:740
+
+			FT_Stroker_Done((FT_Stroker)stroker);
 		
 
 }
@@ -583,7 +698,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_initFreeTypeJni(JNIEnv* env, jclass clazz) {
 
 
-//@line:676
+//@line:834
 
 		FT_Library library = 0;
 		FT_Error error = FT_Init_FreeType(&library);

--- a/extensions/gdx-freetype/jni/com.badlogic.gdx.graphics.g2d.freetype.FreeType.h
+++ b/extensions/gdx-freetype/jni/com.badlogic.gdx.graphics.g2d.freetype.FreeType.h
@@ -15,268 +15,6 @@ extern "C" {
 JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_initFreeTypeJni
   (JNIEnv *, jclass);
 
-/*
- * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType
- * Method:    doneFreeType
- * Signature: (J)V
- */
-JNIEXPORT void JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_doneFreeType
-  (JNIEnv *, jclass, jlong);
-
-/*
- * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType
- * Method:    newMemoryFace
- * Signature: (JLjava/nio/ByteBuffer;II)J
- */
-JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_newMemoryFace
-  (JNIEnv *, jclass, jlong, jobject, jint, jint);
-
-/*
- * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType
- * Method:    doneFace
- * Signature: (J)V
- */
-JNIEXPORT void JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_doneFace
-  (JNIEnv *, jclass, jlong);
-
-/*
- * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType
- * Method:    selectSize
- * Signature: (JI)Z
- */
-JNIEXPORT jboolean JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_selectSize
-  (JNIEnv *, jclass, jlong, jint);
-
-/*
- * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType
- * Method:    setCharSize
- * Signature: (JIIII)Z
- */
-JNIEXPORT jboolean JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_setCharSize
-  (JNIEnv *, jclass, jlong, jint, jint, jint, jint);
-
-/*
- * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType
- * Method:    setPixelSizes
- * Signature: (JII)Z
- */
-JNIEXPORT jboolean JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_setPixelSizes
-  (JNIEnv *, jclass, jlong, jint, jint);
-
-/*
- * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType
- * Method:    loadGlyph
- * Signature: (JII)Z
- */
-JNIEXPORT jboolean JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_loadGlyph
-  (JNIEnv *, jclass, jlong, jint, jint);
-
-/*
- * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType
- * Method:    loadChar
- * Signature: (JII)Z
- */
-JNIEXPORT jboolean JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_loadChar
-  (JNIEnv *, jclass, jlong, jint, jint);
-
-/*
- * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType
- * Method:    renderGlyph
- * Signature: (JI)Z
- */
-JNIEXPORT jboolean JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_renderGlyph
-  (JNIEnv *, jclass, jlong, jint);
-
-/*
- * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType
- * Method:    hasKerning
- * Signature: (J)Z
- */
-JNIEXPORT jboolean JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_hasKerning
-  (JNIEnv *, jclass, jlong);
-
-/*
- * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType
- * Method:    getKerning
- * Signature: (JIII)I
- */
-JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_getKerning
-  (JNIEnv *, jclass, jlong, jint, jint, jint);
-
-/*
- * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType
- * Method:    getCharIndex
- * Signature: (JI)I
- */
-JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_getCharIndex
-  (JNIEnv *, jclass, jlong, jint);
-
-#ifdef __cplusplus
-}
-#endif
-#endif
-/* Header for class com_badlogic_gdx_graphics_g2d_freetype_FreeType_Bitmap */
-
-#ifndef _Included_com_badlogic_gdx_graphics_g2d_freetype_FreeType_Bitmap
-#define _Included_com_badlogic_gdx_graphics_g2d_freetype_FreeType_Bitmap
-#ifdef __cplusplus
-extern "C" {
-#endif
-/*
- * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_Bitmap
- * Method:    getRows
- * Signature: (J)I
- */
-JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Bitmap_getRows
-  (JNIEnv *, jclass, jlong);
-
-/*
- * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_Bitmap
- * Method:    getWidth
- * Signature: (J)I
- */
-JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Bitmap_getWidth
-  (JNIEnv *, jclass, jlong);
-
-/*
- * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_Bitmap
- * Method:    getPitch
- * Signature: (J)I
- */
-JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Bitmap_getPitch
-  (JNIEnv *, jclass, jlong);
-
-/*
- * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_Bitmap
- * Method:    getBuffer
- * Signature: (J)Ljava/nio/ByteBuffer;
- */
-JNIEXPORT jobject JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Bitmap_getBuffer
-  (JNIEnv *, jclass, jlong);
-
-/*
- * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_Bitmap
- * Method:    getNumGray
- * Signature: (J)I
- */
-JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Bitmap_getNumGray
-  (JNIEnv *, jclass, jlong);
-
-/*
- * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_Bitmap
- * Method:    getPixelMode
- * Signature: (J)I
- */
-JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Bitmap_getPixelMode
-  (JNIEnv *, jclass, jlong);
-
-#ifdef __cplusplus
-}
-#endif
-#endif
-/* Header for class com_badlogic_gdx_graphics_g2d_freetype_FreeType_Face */
-
-#ifndef _Included_com_badlogic_gdx_graphics_g2d_freetype_FreeType_Face
-#define _Included_com_badlogic_gdx_graphics_g2d_freetype_FreeType_Face
-#ifdef __cplusplus
-extern "C" {
-#endif
-/*
- * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_Face
- * Method:    getFaceFlags
- * Signature: (J)I
- */
-JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getFaceFlags
-  (JNIEnv *, jclass, jlong);
-
-/*
- * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_Face
- * Method:    getStyleFlags
- * Signature: (J)I
- */
-JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getStyleFlags
-  (JNIEnv *, jclass, jlong);
-
-/*
- * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_Face
- * Method:    getNumGlyphs
- * Signature: (J)I
- */
-JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getNumGlyphs
-  (JNIEnv *, jclass, jlong);
-
-/*
- * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_Face
- * Method:    getAscender
- * Signature: (J)I
- */
-JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getAscender
-  (JNIEnv *, jclass, jlong);
-
-/*
- * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_Face
- * Method:    getDescender
- * Signature: (J)I
- */
-JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getDescender
-  (JNIEnv *, jclass, jlong);
-
-/*
- * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_Face
- * Method:    getHeight
- * Signature: (J)I
- */
-JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getHeight
-  (JNIEnv *, jclass, jlong);
-
-/*
- * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_Face
- * Method:    getMaxAdvanceWidth
- * Signature: (J)I
- */
-JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getMaxAdvanceWidth
-  (JNIEnv *, jclass, jlong);
-
-/*
- * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_Face
- * Method:    getMaxAdvanceHeight
- * Signature: (J)I
- */
-JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getMaxAdvanceHeight
-  (JNIEnv *, jclass, jlong);
-
-/*
- * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_Face
- * Method:    getUnderlinePosition
- * Signature: (J)I
- */
-JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getUnderlinePosition
-  (JNIEnv *, jclass, jlong);
-
-/*
- * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_Face
- * Method:    getUnderlineThickness
- * Signature: (J)I
- */
-JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getUnderlineThickness
-  (JNIEnv *, jclass, jlong);
-
-/*
- * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_Face
- * Method:    getGlyph
- * Signature: (J)J
- */
-JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getGlyph
-  (JNIEnv *, jclass, jlong);
-
-/*
- * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_Face
- * Method:    getSize
- * Signature: (J)J
- */
-JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getSize
-  (JNIEnv *, jclass, jlong);
-
 #ifdef __cplusplus
 }
 #endif
@@ -350,6 +88,65 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
  * Signature: (J)I
  */
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphMetrics_getVertAdvance
+  (JNIEnv *, jclass, jlong);
+
+#ifdef __cplusplus
+}
+#endif
+#endif
+/* Header for class com_badlogic_gdx_graphics_g2d_freetype_FreeType_Bitmap */
+
+#ifndef _Included_com_badlogic_gdx_graphics_g2d_freetype_FreeType_Bitmap
+#define _Included_com_badlogic_gdx_graphics_g2d_freetype_FreeType_Bitmap
+#ifdef __cplusplus
+extern "C" {
+#endif
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_Bitmap
+ * Method:    getRows
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Bitmap_getRows
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_Bitmap
+ * Method:    getWidth
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Bitmap_getWidth
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_Bitmap
+ * Method:    getPitch
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Bitmap_getPitch
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_Bitmap
+ * Method:    getBuffer
+ * Signature: (J)Ljava/nio/ByteBuffer;
+ */
+JNIEXPORT jobject JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Bitmap_getBuffer
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_Bitmap
+ * Method:    getNumGray
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Bitmap_getNumGray
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_Bitmap
+ * Method:    getPixelMode
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Bitmap_getPixelMode
   (JNIEnv *, jclass, jlong);
 
 #ifdef __cplusplus
@@ -435,46 +232,13 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphSlot_getBitmapTop
   (JNIEnv *, jclass, jlong);
 
-#ifdef __cplusplus
-}
-#endif
-#endif
-/* Header for class com_badlogic_gdx_graphics_g2d_freetype_FreeType_Library */
-
-#ifndef _Included_com_badlogic_gdx_graphics_g2d_freetype_FreeType_Library
-#define _Included_com_badlogic_gdx_graphics_g2d_freetype_FreeType_Library
-#ifdef __cplusplus
-extern "C" {
-#endif
-#ifdef __cplusplus
-}
-#endif
-#endif
-/* Header for class com_badlogic_gdx_graphics_g2d_freetype_FreeType_Pointer */
-
-#ifndef _Included_com_badlogic_gdx_graphics_g2d_freetype_FreeType_Pointer
-#define _Included_com_badlogic_gdx_graphics_g2d_freetype_FreeType_Pointer
-#ifdef __cplusplus
-extern "C" {
-#endif
-#ifdef __cplusplus
-}
-#endif
-#endif
-/* Header for class com_badlogic_gdx_graphics_g2d_freetype_FreeType_Size */
-
-#ifndef _Included_com_badlogic_gdx_graphics_g2d_freetype_FreeType_Size
-#define _Included_com_badlogic_gdx_graphics_g2d_freetype_FreeType_Size
-#ifdef __cplusplus
-extern "C" {
-#endif
 /*
- * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_Size
- * Method:    getMetrics
- * Signature: (J)J
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_GlyphSlot
+ * Method:    renderGlyph
+ * Signature: (JI)Z
  */
-JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Size_getMetrics
-  (JNIEnv *, jclass, jlong);
+JNIEXPORT jboolean JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphSlot_renderGlyph
+  (JNIEnv *, jclass, jlong, jint);
 
 #ifdef __cplusplus
 }
@@ -551,6 +315,242 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024SizeMetrics_getMaxAdvance
   (JNIEnv *, jclass, jlong);
 
+#ifdef __cplusplus
+}
+#endif
+#endif
+/* Header for class com_badlogic_gdx_graphics_g2d_freetype_FreeType_Size */
+
+#ifndef _Included_com_badlogic_gdx_graphics_g2d_freetype_FreeType_Size
+#define _Included_com_badlogic_gdx_graphics_g2d_freetype_FreeType_Size
+#ifdef __cplusplus
+extern "C" {
+#endif
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_Size
+ * Method:    getMetrics
+ * Signature: (J)J
+ */
+JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Size_getMetrics
+  (JNIEnv *, jclass, jlong);
+
+#ifdef __cplusplus
+}
+#endif
+#endif
+/* Header for class com_badlogic_gdx_graphics_g2d_freetype_FreeType_Face */
+
+#ifndef _Included_com_badlogic_gdx_graphics_g2d_freetype_FreeType_Face
+#define _Included_com_badlogic_gdx_graphics_g2d_freetype_FreeType_Face
+#ifdef __cplusplus
+extern "C" {
+#endif
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_Face
+ * Method:    doneFace
+ * Signature: (J)V
+ */
+JNIEXPORT void JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_doneFace
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_Face
+ * Method:    getFaceFlags
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getFaceFlags
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_Face
+ * Method:    getStyleFlags
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getStyleFlags
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_Face
+ * Method:    getNumGlyphs
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getNumGlyphs
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_Face
+ * Method:    getAscender
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getAscender
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_Face
+ * Method:    getDescender
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getDescender
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_Face
+ * Method:    getHeight
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getHeight
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_Face
+ * Method:    getMaxAdvanceWidth
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getMaxAdvanceWidth
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_Face
+ * Method:    getMaxAdvanceHeight
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getMaxAdvanceHeight
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_Face
+ * Method:    getUnderlinePosition
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getUnderlinePosition
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_Face
+ * Method:    getUnderlineThickness
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getUnderlineThickness
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_Face
+ * Method:    selectSize
+ * Signature: (JI)Z
+ */
+JNIEXPORT jboolean JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_selectSize
+  (JNIEnv *, jclass, jlong, jint);
+
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_Face
+ * Method:    setCharSize
+ * Signature: (JIIII)Z
+ */
+JNIEXPORT jboolean JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_setCharSize
+  (JNIEnv *, jclass, jlong, jint, jint, jint, jint);
+
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_Face
+ * Method:    setPixelSizes
+ * Signature: (JII)Z
+ */
+JNIEXPORT jboolean JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_setPixelSizes
+  (JNIEnv *, jclass, jlong, jint, jint);
+
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_Face
+ * Method:    loadGlyph
+ * Signature: (JII)Z
+ */
+JNIEXPORT jboolean JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_loadGlyph
+  (JNIEnv *, jclass, jlong, jint, jint);
+
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_Face
+ * Method:    loadChar
+ * Signature: (JII)Z
+ */
+JNIEXPORT jboolean JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_loadChar
+  (JNIEnv *, jclass, jlong, jint, jint);
+
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_Face
+ * Method:    getGlyph
+ * Signature: (J)J
+ */
+JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getGlyph
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_Face
+ * Method:    getSize
+ * Signature: (J)J
+ */
+JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getSize
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_Face
+ * Method:    hasKerning
+ * Signature: (J)Z
+ */
+JNIEXPORT jboolean JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_hasKerning
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_Face
+ * Method:    getKerning
+ * Signature: (JIII)I
+ */
+JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getKerning
+  (JNIEnv *, jclass, jlong, jint, jint, jint);
+
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_Face
+ * Method:    getCharIndex
+ * Signature: (JI)I
+ */
+JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getCharIndex
+  (JNIEnv *, jclass, jlong, jint);
+
+#ifdef __cplusplus
+}
+#endif
+#endif
+/* Header for class com_badlogic_gdx_graphics_g2d_freetype_FreeType_Library */
+
+#ifndef _Included_com_badlogic_gdx_graphics_g2d_freetype_FreeType_Library
+#define _Included_com_badlogic_gdx_graphics_g2d_freetype_FreeType_Library
+#ifdef __cplusplus
+extern "C" {
+#endif
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_Library
+ * Method:    doneFreeType
+ * Signature: (J)V
+ */
+JNIEXPORT void JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Library_doneFreeType
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_Library
+ * Method:    newMemoryFace
+ * Signature: (JLjava/nio/ByteBuffer;II)J
+ */
+JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Library_newMemoryFace
+  (JNIEnv *, jclass, jlong, jobject, jint, jint);
+
+#ifdef __cplusplus
+}
+#endif
+#endif
+/* Header for class com_badlogic_gdx_graphics_g2d_freetype_FreeType_Pointer */
+
+#ifndef _Included_com_badlogic_gdx_graphics_g2d_freetype_FreeType_Pointer
+#define _Included_com_badlogic_gdx_graphics_g2d_freetype_FreeType_Pointer
+#ifdef __cplusplus
+extern "C" {
+#endif
 #ifdef __cplusplus
 }
 #endif

--- a/extensions/gdx-freetype/jni/com.badlogic.gdx.graphics.g2d.freetype.FreeType.h
+++ b/extensions/gdx-freetype/jni/com.badlogic.gdx.graphics.g2d.freetype.FreeType.h
@@ -19,81 +19,6 @@ JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_ini
 }
 #endif
 #endif
-/* Header for class com_badlogic_gdx_graphics_g2d_freetype_FreeType_GlyphMetrics */
-
-#ifndef _Included_com_badlogic_gdx_graphics_g2d_freetype_FreeType_GlyphMetrics
-#define _Included_com_badlogic_gdx_graphics_g2d_freetype_FreeType_GlyphMetrics
-#ifdef __cplusplus
-extern "C" {
-#endif
-/*
- * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_GlyphMetrics
- * Method:    getWidth
- * Signature: (J)I
- */
-JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphMetrics_getWidth
-  (JNIEnv *, jclass, jlong);
-
-/*
- * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_GlyphMetrics
- * Method:    getHeight
- * Signature: (J)I
- */
-JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphMetrics_getHeight
-  (JNIEnv *, jclass, jlong);
-
-/*
- * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_GlyphMetrics
- * Method:    getHoriBearingX
- * Signature: (J)I
- */
-JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphMetrics_getHoriBearingX
-  (JNIEnv *, jclass, jlong);
-
-/*
- * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_GlyphMetrics
- * Method:    getHoriBearingY
- * Signature: (J)I
- */
-JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphMetrics_getHoriBearingY
-  (JNIEnv *, jclass, jlong);
-
-/*
- * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_GlyphMetrics
- * Method:    getHoriAdvance
- * Signature: (J)I
- */
-JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphMetrics_getHoriAdvance
-  (JNIEnv *, jclass, jlong);
-
-/*
- * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_GlyphMetrics
- * Method:    getVertBearingX
- * Signature: (J)I
- */
-JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphMetrics_getVertBearingX
-  (JNIEnv *, jclass, jlong);
-
-/*
- * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_GlyphMetrics
- * Method:    getVertBearingY
- * Signature: (J)I
- */
-JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphMetrics_getVertBearingY
-  (JNIEnv *, jclass, jlong);
-
-/*
- * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_GlyphMetrics
- * Method:    getVertAdvance
- * Signature: (J)I
- */
-JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphMetrics_getVertAdvance
-  (JNIEnv *, jclass, jlong);
-
-#ifdef __cplusplus
-}
-#endif
-#endif
 /* Header for class com_badlogic_gdx_graphics_g2d_freetype_FreeType_Bitmap */
 
 #ifndef _Included_com_badlogic_gdx_graphics_g2d_freetype_FreeType_Bitmap
@@ -147,191 +72,6 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
  * Signature: (J)I
  */
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Bitmap_getPixelMode
-  (JNIEnv *, jclass, jlong);
-
-#ifdef __cplusplus
-}
-#endif
-#endif
-/* Header for class com_badlogic_gdx_graphics_g2d_freetype_FreeType_GlyphSlot */
-
-#ifndef _Included_com_badlogic_gdx_graphics_g2d_freetype_FreeType_GlyphSlot
-#define _Included_com_badlogic_gdx_graphics_g2d_freetype_FreeType_GlyphSlot
-#ifdef __cplusplus
-extern "C" {
-#endif
-/*
- * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_GlyphSlot
- * Method:    getMetrics
- * Signature: (J)J
- */
-JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphSlot_getMetrics
-  (JNIEnv *, jclass, jlong);
-
-/*
- * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_GlyphSlot
- * Method:    getLinearHoriAdvance
- * Signature: (J)I
- */
-JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphSlot_getLinearHoriAdvance
-  (JNIEnv *, jclass, jlong);
-
-/*
- * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_GlyphSlot
- * Method:    getLinearVertAdvance
- * Signature: (J)I
- */
-JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphSlot_getLinearVertAdvance
-  (JNIEnv *, jclass, jlong);
-
-/*
- * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_GlyphSlot
- * Method:    getAdvanceX
- * Signature: (J)I
- */
-JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphSlot_getAdvanceX
-  (JNIEnv *, jclass, jlong);
-
-/*
- * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_GlyphSlot
- * Method:    getAdvanceY
- * Signature: (J)I
- */
-JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphSlot_getAdvanceY
-  (JNIEnv *, jclass, jlong);
-
-/*
- * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_GlyphSlot
- * Method:    getFormat
- * Signature: (J)I
- */
-JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphSlot_getFormat
-  (JNIEnv *, jclass, jlong);
-
-/*
- * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_GlyphSlot
- * Method:    getBitmap
- * Signature: (J)J
- */
-JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphSlot_getBitmap
-  (JNIEnv *, jclass, jlong);
-
-/*
- * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_GlyphSlot
- * Method:    getBitmapLeft
- * Signature: (J)I
- */
-JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphSlot_getBitmapLeft
-  (JNIEnv *, jclass, jlong);
-
-/*
- * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_GlyphSlot
- * Method:    getBitmapTop
- * Signature: (J)I
- */
-JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphSlot_getBitmapTop
-  (JNIEnv *, jclass, jlong);
-
-/*
- * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_GlyphSlot
- * Method:    renderGlyph
- * Signature: (JI)Z
- */
-JNIEXPORT jboolean JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphSlot_renderGlyph
-  (JNIEnv *, jclass, jlong, jint);
-
-#ifdef __cplusplus
-}
-#endif
-#endif
-/* Header for class com_badlogic_gdx_graphics_g2d_freetype_FreeType_SizeMetrics */
-
-#ifndef _Included_com_badlogic_gdx_graphics_g2d_freetype_FreeType_SizeMetrics
-#define _Included_com_badlogic_gdx_graphics_g2d_freetype_FreeType_SizeMetrics
-#ifdef __cplusplus
-extern "C" {
-#endif
-/*
- * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_SizeMetrics
- * Method:    getXppem
- * Signature: (J)I
- */
-JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024SizeMetrics_getXppem
-  (JNIEnv *, jclass, jlong);
-
-/*
- * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_SizeMetrics
- * Method:    getYppem
- * Signature: (J)I
- */
-JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024SizeMetrics_getYppem
-  (JNIEnv *, jclass, jlong);
-
-/*
- * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_SizeMetrics
- * Method:    getXscale
- * Signature: (J)I
- */
-JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024SizeMetrics_getXscale
-  (JNIEnv *, jclass, jlong);
-
-/*
- * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_SizeMetrics
- * Method:    getYscale
- * Signature: (J)I
- */
-JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024SizeMetrics_getYscale
-  (JNIEnv *, jclass, jlong);
-
-/*
- * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_SizeMetrics
- * Method:    getAscender
- * Signature: (J)I
- */
-JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024SizeMetrics_getAscender
-  (JNIEnv *, jclass, jlong);
-
-/*
- * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_SizeMetrics
- * Method:    getDescender
- * Signature: (J)I
- */
-JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024SizeMetrics_getDescender
-  (JNIEnv *, jclass, jlong);
-
-/*
- * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_SizeMetrics
- * Method:    getHeight
- * Signature: (J)I
- */
-JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024SizeMetrics_getHeight
-  (JNIEnv *, jclass, jlong);
-
-/*
- * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_SizeMetrics
- * Method:    getMaxAdvance
- * Signature: (J)I
- */
-JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024SizeMetrics_getMaxAdvance
-  (JNIEnv *, jclass, jlong);
-
-#ifdef __cplusplus
-}
-#endif
-#endif
-/* Header for class com_badlogic_gdx_graphics_g2d_freetype_FreeType_Size */
-
-#ifndef _Included_com_badlogic_gdx_graphics_g2d_freetype_FreeType_Size
-#define _Included_com_badlogic_gdx_graphics_g2d_freetype_FreeType_Size
-#ifdef __cplusplus
-extern "C" {
-#endif
-/*
- * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_Size
- * Method:    getMetrics
- * Signature: (J)J
- */
-JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Size_getMetrics
   (JNIEnv *, jclass, jlong);
 
 #ifdef __cplusplus
@@ -517,6 +257,239 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 }
 #endif
 #endif
+/* Header for class com_badlogic_gdx_graphics_g2d_freetype_FreeType_Glyph */
+
+#ifndef _Included_com_badlogic_gdx_graphics_g2d_freetype_FreeType_Glyph
+#define _Included_com_badlogic_gdx_graphics_g2d_freetype_FreeType_Glyph
+#ifdef __cplusplus
+extern "C" {
+#endif
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_Glyph
+ * Method:    done
+ * Signature: (J)V
+ */
+JNIEXPORT void JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Glyph_done
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_Glyph
+ * Method:    strokeBorder
+ * Signature: (JJZ)J
+ */
+JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Glyph_strokeBorder
+  (JNIEnv *, jclass, jlong, jlong, jboolean);
+
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_Glyph
+ * Method:    toBitmap
+ * Signature: (JI)J
+ */
+JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Glyph_toBitmap
+  (JNIEnv *, jclass, jlong, jint);
+
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_Glyph
+ * Method:    getBitmap
+ * Signature: (J)J
+ */
+JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Glyph_getBitmap
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_Glyph
+ * Method:    getLeft
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Glyph_getLeft
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_Glyph
+ * Method:    getTop
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Glyph_getTop
+  (JNIEnv *, jclass, jlong);
+
+#ifdef __cplusplus
+}
+#endif
+#endif
+/* Header for class com_badlogic_gdx_graphics_g2d_freetype_FreeType_GlyphMetrics */
+
+#ifndef _Included_com_badlogic_gdx_graphics_g2d_freetype_FreeType_GlyphMetrics
+#define _Included_com_badlogic_gdx_graphics_g2d_freetype_FreeType_GlyphMetrics
+#ifdef __cplusplus
+extern "C" {
+#endif
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_GlyphMetrics
+ * Method:    getWidth
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphMetrics_getWidth
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_GlyphMetrics
+ * Method:    getHeight
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphMetrics_getHeight
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_GlyphMetrics
+ * Method:    getHoriBearingX
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphMetrics_getHoriBearingX
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_GlyphMetrics
+ * Method:    getHoriBearingY
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphMetrics_getHoriBearingY
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_GlyphMetrics
+ * Method:    getHoriAdvance
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphMetrics_getHoriAdvance
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_GlyphMetrics
+ * Method:    getVertBearingX
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphMetrics_getVertBearingX
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_GlyphMetrics
+ * Method:    getVertBearingY
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphMetrics_getVertBearingY
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_GlyphMetrics
+ * Method:    getVertAdvance
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphMetrics_getVertAdvance
+  (JNIEnv *, jclass, jlong);
+
+#ifdef __cplusplus
+}
+#endif
+#endif
+/* Header for class com_badlogic_gdx_graphics_g2d_freetype_FreeType_GlyphSlot */
+
+#ifndef _Included_com_badlogic_gdx_graphics_g2d_freetype_FreeType_GlyphSlot
+#define _Included_com_badlogic_gdx_graphics_g2d_freetype_FreeType_GlyphSlot
+#ifdef __cplusplus
+extern "C" {
+#endif
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_GlyphSlot
+ * Method:    getMetrics
+ * Signature: (J)J
+ */
+JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphSlot_getMetrics
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_GlyphSlot
+ * Method:    getLinearHoriAdvance
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphSlot_getLinearHoriAdvance
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_GlyphSlot
+ * Method:    getLinearVertAdvance
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphSlot_getLinearVertAdvance
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_GlyphSlot
+ * Method:    getAdvanceX
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphSlot_getAdvanceX
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_GlyphSlot
+ * Method:    getAdvanceY
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphSlot_getAdvanceY
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_GlyphSlot
+ * Method:    getFormat
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphSlot_getFormat
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_GlyphSlot
+ * Method:    getBitmap
+ * Signature: (J)J
+ */
+JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphSlot_getBitmap
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_GlyphSlot
+ * Method:    getBitmapLeft
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphSlot_getBitmapLeft
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_GlyphSlot
+ * Method:    getBitmapTop
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphSlot_getBitmapTop
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_GlyphSlot
+ * Method:    renderGlyph
+ * Signature: (JI)Z
+ */
+JNIEXPORT jboolean JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphSlot_renderGlyph
+  (JNIEnv *, jclass, jlong, jint);
+
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_GlyphSlot
+ * Method:    getGlyph
+ * Signature: (J)J
+ */
+JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphSlot_getGlyph
+  (JNIEnv *, jclass, jlong);
+
+#ifdef __cplusplus
+}
+#endif
+#endif
 /* Header for class com_badlogic_gdx_graphics_g2d_freetype_FreeType_Library */
 
 #ifndef _Included_com_badlogic_gdx_graphics_g2d_freetype_FreeType_Library
@@ -540,6 +513,14 @@ JNIEXPORT void JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Library_newMemoryFace
   (JNIEnv *, jclass, jlong, jobject, jint, jint);
 
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_Library
+ * Method:    strokerNew
+ * Signature: (J)J
+ */
+JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Library_strokerNew
+  (JNIEnv *, jclass, jlong);
+
 #ifdef __cplusplus
 }
 #endif
@@ -551,6 +532,127 @@ JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_000
 #ifdef __cplusplus
 extern "C" {
 #endif
+#ifdef __cplusplus
+}
+#endif
+#endif
+/* Header for class com_badlogic_gdx_graphics_g2d_freetype_FreeType_Size */
+
+#ifndef _Included_com_badlogic_gdx_graphics_g2d_freetype_FreeType_Size
+#define _Included_com_badlogic_gdx_graphics_g2d_freetype_FreeType_Size
+#ifdef __cplusplus
+extern "C" {
+#endif
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_Size
+ * Method:    getMetrics
+ * Signature: (J)J
+ */
+JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Size_getMetrics
+  (JNIEnv *, jclass, jlong);
+
+#ifdef __cplusplus
+}
+#endif
+#endif
+/* Header for class com_badlogic_gdx_graphics_g2d_freetype_FreeType_SizeMetrics */
+
+#ifndef _Included_com_badlogic_gdx_graphics_g2d_freetype_FreeType_SizeMetrics
+#define _Included_com_badlogic_gdx_graphics_g2d_freetype_FreeType_SizeMetrics
+#ifdef __cplusplus
+extern "C" {
+#endif
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_SizeMetrics
+ * Method:    getXppem
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024SizeMetrics_getXppem
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_SizeMetrics
+ * Method:    getYppem
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024SizeMetrics_getYppem
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_SizeMetrics
+ * Method:    getXscale
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024SizeMetrics_getXscale
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_SizeMetrics
+ * Method:    getYscale
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024SizeMetrics_getYscale
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_SizeMetrics
+ * Method:    getAscender
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024SizeMetrics_getAscender
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_SizeMetrics
+ * Method:    getDescender
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024SizeMetrics_getDescender
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_SizeMetrics
+ * Method:    getHeight
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024SizeMetrics_getHeight
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_SizeMetrics
+ * Method:    getMaxAdvance
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024SizeMetrics_getMaxAdvance
+  (JNIEnv *, jclass, jlong);
+
+#ifdef __cplusplus
+}
+#endif
+#endif
+/* Header for class com_badlogic_gdx_graphics_g2d_freetype_FreeType_Stroker */
+
+#ifndef _Included_com_badlogic_gdx_graphics_g2d_freetype_FreeType_Stroker
+#define _Included_com_badlogic_gdx_graphics_g2d_freetype_FreeType_Stroker
+#ifdef __cplusplus
+extern "C" {
+#endif
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_Stroker
+ * Method:    set
+ * Signature: (JIIII)V
+ */
+JNIEXPORT void JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Stroker_set
+  (JNIEnv *, jclass, jlong, jint, jint, jint, jint);
+
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType_Stroker
+ * Method:    done
+ * Signature: (J)V
+ */
+JNIEXPORT void JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Stroker_done
+  (JNIEnv *, jclass, jlong);
+
 #ifdef __cplusplus
 }
 #endif

--- a/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeType.java
+++ b/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeType.java
@@ -28,6 +28,7 @@ import com.badlogic.gdx.utils.BufferUtils;
 import com.badlogic.gdx.utils.Disposable;
 import com.badlogic.gdx.utils.GdxRuntimeException;
 import com.badlogic.gdx.utils.LongMap;
+import com.badlogic.gdx.utils.SharedLibraryLoader;
 
 public class FreeType {
 	// @off

--- a/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeType.java
+++ b/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeType.java
@@ -824,7 +824,7 @@ public class FreeType {
 	public static int FT_STROKER_LINEJOIN_MITER_FIXED    = 3;
 
    public static Library initFreeType() {
-   	//new SharedLibraryLoader().load("gdx-freetype");
+   	new SharedLibraryLoader().load("gdx-freetype");
    	long address = initFreeTypeJni();
    	if(address == 0) throw new GdxRuntimeException("Couldn't initialize FreeType library");
    	else return new Library(address);

--- a/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGenerator.java
+++ b/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGenerator.java
@@ -391,7 +391,7 @@ public class FreeTypeFontGenerator implements Disposable {
 			Bitmap mainBitmap = mainGlyph.getBitmap();
 			Pixmap mainPixmap = mainBitmap.getPixmap(Format.RGBA8888, parameter.color);
 
-			if (parameter.borderWidth > 0 || parameter.shadowOffset > 0) {
+			if (parameter.borderWidth > 0 || parameter.shadowOffsetX != 0 || parameter.shadowOffsetY != 0) {
 				com.badlogic.gdx.graphics.g2d.freetype.FreeType.Glyph borderGlyph = mainGlyph;
 				Bitmap borderBitmap = mainBitmap;
 
@@ -412,18 +412,18 @@ public class FreeTypeFontGenerator implements Disposable {
 					mainPixmap = borderPixmap;
 					mainGlyph = borderGlyph;
 				}
-				if (parameter.shadowOffset > 0) {
+				if (parameter.shadowOffsetX != 0 || parameter.shadowOffsetY != 0) {
 					//render the shadow
 					Pixmap shadowPixmapSrc = borderBitmap.getPixmap(Format.RGBA8888, parameter.shadowColor);
 					//create a new bigger Pixmap with shadowOffset applied, and draw shadow glyph
-					Pixmap shadowPixmap = new Pixmap(shadowPixmapSrc.getWidth() + parameter.shadowOffset,
-						shadowPixmapSrc.getHeight() + parameter.shadowOffset, Format.RGBA8888);
+					Pixmap shadowPixmap = new Pixmap(shadowPixmapSrc.getWidth() + Math.abs(parameter.shadowOffsetX),
+						shadowPixmapSrc.getHeight() + Math.abs(parameter.shadowOffsetY), Format.RGBA8888);
 					Blending blending = Pixmap.getBlending();
 					Pixmap.setBlending(Blending.None);
-					shadowPixmap.drawPixmap(shadowPixmapSrc, parameter.shadowOffset, parameter.shadowOffset);
+					shadowPixmap.drawPixmap(shadowPixmapSrc, Math.max(parameter.shadowOffsetX, 0), Math.max(parameter.shadowOffsetY, 0));
 					Pixmap.setBlending(blending);
 					//draw main glyph (with border) on top of shadow
-					shadowPixmap.drawPixmap(mainPixmap, 0, 0);
+					shadowPixmap.drawPixmap(mainPixmap, Math.max(-parameter.shadowOffsetX, 0), Math.max(-parameter.shadowOffsetY, 0));
 					mainPixmap.dispose();
 					mainPixmap = shadowPixmap;
 				}
@@ -560,8 +560,10 @@ public class FreeTypeFontGenerator implements Disposable {
 		public Color borderColor = Color.BLACK;
 		/** true for straight (mitered), false for rounded borders */
 		public boolean borderStraight = false;
-		/** Offset of text shadow in pixels, 0 to disable */
-		public int shadowOffset = 0;
+		/** Offset of text shadow on X axis in pixels, 0 to disable */
+		public int shadowOffsetX = 0;
+		/** Offset of text shadow on Y axis in pixels, 0 to disable */
+		public int shadowOffsetY = 0;
 		/** Shadow color; only used if shadowOffset > 0 */
 		public Color shadowColor = new Color(0, 0, 0, 0.75f);
 		/** The characters the font should contain */


### PR DESCRIPTION
The current rendering styles of gdx-freetype are somewhat limited, requiring you to revert to external tools if you want any more fancy effects, such as outlines or shadows. Without shadow, text is really hard to read in any normal game.

To address this issue, this request adds a couple of new font parameters (documented in code):
- color: Foreground color; required as multi-colored fonts cannot be colored on rendering by GL. Defaults to white like before
- borderWidth / borderColor: Outline, defaults to off. Note: large border widths may lead to overlap, but this should be way beyond the "looks good" zone
- borderStraight: Line ending style for outline (curved or straight)
- shadowOffset / shadowColor: Shadow, defaults to off

Example rendering:
![gdx-freetype](https://cloud.githubusercontent.com/assets/5091018/3770809/022612fa-18ef-11e4-8f64-09bfb8e29044.png)

While implementing, I found that the current freetype JNI interface was a little weird, so I did some refactoring (first commit).

Only tested on Win64.