### PR TITLE
Animation PlayMode.LOOP_RANDOM fixed

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g2d/Animation.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/Animation.java
@@ -146,7 +146,7 @@ public class Animation {
 			if (frameNumber >= keyFrames.length) frameNumber = keyFrames.length - 2 - (frameNumber - keyFrames.length);
 			break;
 		case LOOP_RANDOM:
-			int lastFrameNumber = (int) ((stateTime - (stateTime - lastStateTime)) / frameDuration);
+			int lastFrameNumber = (int) ((lastStateTime) / frameDuration);
 			if (lastFrameNumber != frameNumber) {
 				frameNumber = MathUtils.random(keyFrames.length - 1);
 			} else {


### PR DESCRIPTION
I noticed that in case `PlayMode.LOOP_RANDOM` is used in `Animation`, the `frameDuration` does not apply, but the texture region is changed in every frame.

This PR should fix that and keep the same texture region for as long as a frame duration. I used a small hack by using the last deltaTime to check which frameNumber there would have been in the past. I think that should be okay though.

It might happen though that because of the randomness the same texture region can be picked multiple times in a row which might not be what's expected. I'd expect it to choose a random region, but not the same one again. Because that would also contradict frameDuration somehow and makes the animation look... laggy.

But since I wasn't sure about that, I've kept it the way it was for now. Should that be changed as well?
