### PR TITLE
Repaced "Done" key for "Return" in IOS Keyboard (updated)

### DIFF
--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSInput.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSInput.java
@@ -319,8 +319,8 @@ public class IOSInput implements Input {
 
 		@Override
 		public boolean shouldReturn(UITextField textField) {
-			app.input.inputProcessor.keyTyped((char)13);
 			app.input.inputProcessor.keyDown(Keys.ENTER);
+			app.input.inputProcessor.keyTyped((char)13);
 			return false;
 		}
 	};


### PR DESCRIPTION
Done key is unhelpfull.. it just closes the keyboard (easily done by code) and doesn't triggers anything, its a big useless button on the user keyboard. I want to experiment with the "return" key (default) and see if it can be mapped and usefull instead.
