### PR TITLE
fix useImmersiveMode

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplication.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplication.java
@@ -235,25 +235,15 @@ public class AndroidApplication extends Activity implements AndroidApplicationBa
 		}
 	}
 
-	@TargetApi(19)
-	@Override
-	public void useImmersiveMode (boolean use) {
-		if (!use || getVersion() < 19) return;
-
-		View view = getWindow().getDecorView();
-		try {
-			Method m = View.class.getMethod("setSystemUiVisibility", int.class);
-			int code = View.SYSTEM_UI_FLAG_LAYOUT_STABLE;
-			code ^= View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION;
-			code ^= View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN;
-			code ^= View.SYSTEM_UI_FLAG_FULLSCREEN;
-			code ^= View.SYSTEM_UI_FLAG_HIDE_NAVIGATION;
-			code ^= View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY;
-			m.invoke(view, code);
-		} catch (Exception e) {
-			log("AndroidApplication", "Can't set immersive mode", e);
-		}
-	}
+    	@TargetApi(Build.VERSION_CODES.KITKAT)
+    	@Override
+    	public void useImmersiveMode (boolean use) {
+        	if (!use || getVersion() < Build.VERSION_CODES.KITKAT) return;
+        	View view = getWindow().getDecorView(); // findViewById is preferable
+		view.setSystemUiVisibility(View.SYSTEM_UI_FLAG_FULLSCREEN |
+                	View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY |
+                	View.SYSTEM_UI_FLAG_HIDE_NAVIGATION);
+    	}
 
 	@Override
 	protected void onPause () {


### PR DESCRIPTION
The previous implementation was not properly fullscreening on my kitkat devices (the kitkat immersive mode is distinct in that first entering it shows a blue overlay which tells you how to leave it, by swiping down from the menu bar area).  The previous method xor'd the UI flags, which does not make sense; they should be inclusive or'd and sent into the setSystemUiVisibility method; testing with this method yields the correct fullscreen kitkat "immersive" mode, with a swipe down from the top to redisplay the navigation controls, and menu bar, etc.

I'm also unsure why reflection was being used; calling the method normally on the view object is completely sufficient; using this approach removes the need for a try catch block (the view should not be null anyway, or you have major problems regardless).

The KITKAT version codes were also used, instead of hardcoding 19.
