### PR TITLE
LwjglAWTCanvas: Allow Texture disposal during stop().

### DIFF
--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglAWTCanvas.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglAWTCanvas.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -63,6 +63,7 @@ public class LwjglAWTCanvas implements Application {
 	int lastWidth;
 	int lastHeight;
 	int logLevel = LOG_INFO;
+	final String logTag = "LwjglAWTCanvas";
 	private Cursor cursor;
 
 	public LwjglAWTCanvas (ApplicationListener listener) {
@@ -78,6 +79,7 @@ public class LwjglAWTCanvas implements Application {
 				sharedDrawable) {
 				private final Dimension minSize = new Dimension(0, 0);
 
+				@Override
 				public Dimension getMinimumSize () {
 					return minSize;
 				}
@@ -103,17 +105,20 @@ public class LwjglAWTCanvas implements Application {
 		}
 
 		graphics = new LwjglGraphics(canvas) {
+			@Override
 			public void setTitle (String title) {
 				super.setTitle(title);
 				LwjglAWTCanvas.this.setTitle(title);
 			}
 
+			@Override
 			public boolean setDisplayMode (int width, int height, boolean fullscreen) {
 				if (!super.setDisplayMode(width, height, fullscreen)) return false;
 				if (!fullscreen) LwjglAWTCanvas.this.setDisplayMode(width, height);
 				return true;
 			}
 
+			@Override
 			public boolean setDisplayMode (DisplayMode displayMode) {
 				if (!super.setDisplayMode(displayMode)) return false;
 				LwjglAWTCanvas.this.setDisplayMode(displayMode.width, displayMode.height);
@@ -220,7 +225,7 @@ public class LwjglAWTCanvas implements Application {
 
 	void render () {
 		if (!running) return;
-		
+
 		setGlobals();
 		canvas.setCursor(cursor);
 		graphics.updateTime();
@@ -275,6 +280,14 @@ public class LwjglAWTCanvas implements Application {
 		running = false;
 		setGlobals();
 		Array<LifecycleListener> listeners = lifecycleListeners;
+
+		// To allow destroying of OpenGL textures during disposal.
+		if (canvas.isDisplayable()) {
+			makeCurrent();
+		} else {
+			error(logTag, "OpenGL context destroyed before application listener has had a chance to dispose of textures.");
+		}
+
 		synchronized (listeners) {
 			for (LifecycleListener listener : listeners) {
 				listener.pause();
@@ -285,9 +298,9 @@ public class LwjglAWTCanvas implements Application {
 		listener.dispose();
 
 		Gdx.app = null;
-		
+
 		Gdx.graphics = null;
-		
+
 		if (audio != null) {
 			audio.dispose();
 			Gdx.audio = null;
@@ -296,7 +309,7 @@ public class LwjglAWTCanvas implements Application {
 		if (files != null) Gdx.files = null;
 
 		if (net != null) Gdx.net = null;
-		
+
 		stopped();
 	}
 
@@ -350,6 +363,7 @@ public class LwjglAWTCanvas implements Application {
 		}
 	}
 
+	@Override
 	public void log (String tag, String message) {
 		if (logLevel >= LOG_INFO) {
 			System.out.println(tag + ": " + message);

--- a/tests/gdx-tests-lwjgl/src/com/badlogic/gdx/tests/lwjgl/SwingLwjglTest.java
+++ b/tests/gdx-tests-lwjgl/src/com/badlogic/gdx/tests/lwjgl/SwingLwjglTest.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -36,14 +36,16 @@ import com.badlogic.gdx.tests.UITest;
  * @author mzechner */
 public class SwingLwjglTest extends JFrame {
 	LwjglAWTCanvas canvas1;
+	LwjglAWTCanvas canvas2;
+	LwjglAWTCanvas canvas3;
 
 	public SwingLwjglTest () {
-		setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+		setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
 
 		Container container = getContentPane();
 		canvas1 = new LwjglAWTCanvas(new MusicTest());
-		LwjglAWTCanvas canvas2 = new LwjglAWTCanvas(new UITest(), canvas1);
-		LwjglAWTCanvas canvas3 = new LwjglAWTCanvas(new WindowCreator(), canvas1);
+		canvas2 = new LwjglAWTCanvas(new UITest(), canvas1);
+		canvas3 = new LwjglAWTCanvas(new WindowCreator(), canvas1);
 
 		canvas1.getCanvas().setSize(200, 480);
 		canvas2.getCanvas().setSize(200, 480);
@@ -66,6 +68,12 @@ public class SwingLwjglTest extends JFrame {
 		public void create () {
 			batch = new SpriteBatch();
 			font = new BitmapFont();
+		}
+
+		@Override
+		public void dispose () {
+			font.dispose();
+			batch.dispose();
 		}
 
 		@Override
@@ -97,5 +105,14 @@ public class SwingLwjglTest extends JFrame {
 				new SwingLwjglTest();
 			}
 		});
+	}
+
+	@Override
+	public void dispose() {
+		canvas3.stop();
+		canvas2.stop();
+		canvas1.stop();
+
+		super.dispose();
 	}
 }


### PR DESCRIPTION
- Update SwingLwjglTest to test proper cleanup of LwjglAWTCanvas. 
- Make LwjglAWTCanvas OpenGL context current during stop() to allow disposal of Texture resources.
