### PR TITLE
DebugDrawer improved.

### DIFF
--- a/extensions/gdx-bullet/src/com/badlogic/gdx/physics/bullet/DebugDrawer.java
+++ b/extensions/gdx-bullet/src/com/badlogic/gdx/physics/bullet/DebugDrawer.java
@@ -149,7 +149,7 @@ public class DebugDrawer extends btIDebugDraw implements Disposable {
 
 	/** Switches the {@link SpriteBatch}. The given sprite batch won't be disposed when {@link #dispose()} is called. */
 	public void setSpriteBatch (SpriteBatch spriteBatch) {
-		if (ownsSpriteBatch) {
+		if (ownsSpriteBatch && this.spriteBatch != null) {
 			this.spriteBatch.dispose();
 		}
 		this.spriteBatch = spriteBatch;
@@ -162,7 +162,7 @@ public class DebugDrawer extends btIDebugDraw implements Disposable {
 
 	/** Switches the {@link BitmapFont}. The given font won't be disposed when {@link #dispose()} is called. */
 	public void setFont (BitmapFont font) {
-		if (ownsFont) {
+		if (ownsFont && this.font != null) {
 			this.font.dispose();
 		}
 		this.font = font;


### PR DESCRIPTION
I have added a few more implementations to the `DebugDrawer`:
- `reportErrorWarning`
- `drawContactPoint`
- `drawTriangle`
- `draw3dText`

The `draw3dText` implementation is probably the most interesting part as it's in need of the current `glViewport` parameters, which is why I added `begin(Viewport)`. Another alternative (@Xoppa's idea) would be to keep track of the current `glViewport` paramters in a static way, for example via `Gdx.graphics.getGlViewport()`. A more slow (but maybe for debugging purposes appropriate?) way would be to just read it like this:

```
private static final Rectangle viewportRect = new Rectangle();

public static Rectangle getGlViewport() {
    FloatBuffer buffer = BufferUtils.newFloatBuffer(16);

    Gdx.graphics.getGL20().glGetFloatv(GL20.GL_VIEWPORT, buffer);
    viewportRect.x = buffer.get(0);
    viewportRect.y = buffer.get(1);
    viewportRect.width = buffer.get(2);
    viewportRect.height = buffer.get(3);

    return viewportRect;
}
```

In both cases we could get rid of the `Viewport` completely here.

The way this PR draws 3D text is by projecting the destination position to the screen and then drawing it in 2D, centered on the position. This has the advantage of pixel perfection. However there are also some drawbacks:
- Impossible to make use of the depth buffer
- The text has always the same size, however far away it is

I've tried to implement it following kalle_h's advice and draw it via the spritebatch with manipulated matrices to "real" 3D, however I could not make it work completely. Something must be wrong with the object matrix's rotation:

```
public void draw3dText(Vector3 location, String textString) {
    shapeRenderer.end();

    Matrix4 lookAtMatrix = new Matrix4().setToLookAt(location, camera.position, Vector3.Y);
    Quaternion lookAtQuaternion = new Quaternion();
    lookAtMatrix.getRotation(lookAtQuaternion, true);

    Matrix4 objectMatrix = new Matrix4();
    objectMatrix.set(location, lookAtQuaternion);

    spriteBatch.setProjectionMatrix(camera.combined);
    spriteBatch.setTransformMatrix(objectMatrix);
    spriteBatch.begin();

    Gdx.graphics.getGL20().glEnable(GL20.GL_DEPTH_TEST);

    TextBounds bounds = font.getBounds(textString);
    font.draw(spriteBatch, textString, -bounds.width / 2, bounds.height / 2);

    spriteBatch.end();
    shapeRenderer.begin(ShapeType.Line);
}
```

If we could get this to work, there's no need for the `glViewport` parameters at all.
