### PR TITLE
correct return value for IntFloatMap and IntIntMap getAndIncrement with 0 key

### DIFF
--- a/gdx/src/com/badlogic/gdx/utils/IntFloatMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/IntFloatMap.java
@@ -319,13 +319,15 @@ public class IntFloatMap implements Iterable<IntFloatMap.Entry> {
 	public float getAndIncrement (int key, float defaultValue, float increment) {
 		if (key == 0) {
 			if (hasZeroValue) {
+				float value = zeroValue;
 				zeroValue += increment;
+				return value;
 			} else {
 				hasZeroValue = true;
 				zeroValue = defaultValue + increment;
 				++size;
+				return defaultValue;
 			}
-			return zeroValue;
 		}
 		int index = key & mask;
 		if (key != keyTable[index]) {

--- a/gdx/src/com/badlogic/gdx/utils/IntIntMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/IntIntMap.java
@@ -317,13 +317,15 @@ public class IntIntMap implements Iterable<IntIntMap.Entry> {
 	public int getAndIncrement (int key, int defaultValue, int increment) {
 		if (key == 0) {
 			if (hasZeroValue) {
+				int value = zeroValue;
 				zeroValue += increment;
+				return value;
 			} else {
 				hasZeroValue = true;
 				zeroValue = defaultValue + increment;
 				++size;
+				return defaultValue;
 			}
-			return zeroValue;
 		}
 		int index = key & mask;
 		if (key != keyTable[index]) {


### PR DESCRIPTION
When calling IntFloatMap or IntIntMap getAndIncrement(..) with '0' key the returned value was not the value before increment but the value after.
