### PR TITLE
ResolutionFileResolver documented.

### DIFF
--- a/gdx/src/com/badlogic/gdx/assets/loaders/resolvers/ResolutionFileResolver.java
+++ b/gdx/src/com/badlogic/gdx/assets/loaders/resolvers/ResolutionFileResolver.java
@@ -20,32 +20,72 @@ import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.assets.loaders.FileHandleResolver;
 import com.badlogic.gdx.files.FileHandle;
 
+/** This {@link FileHandleResolver} uses a given list of {@link Resolution}s to determine the best match based on the current
+ * Screen size. An example of how this resolver works:
+ * 
+ * <p>
+ * Let's assume that we have only a single {@link Resolution} added to this resolver. This resolution has the following
+ * properties:
+ * </p>
+ * 
+ * <ul>
+ * <li>{@code portraitWidth = 1920}</li>
+ * <li>{@code portraitHeight = 1080}</li>
+ * <li>{@code folder = "1920x1080"}</li>
+ * </ul>
+ * 
+ * <p>
+ * One would now supply a file to be found to the resolver. For this example, we assume it is "{@code textures/walls/brick.png}".
+ * Since there is only a single {@link Resolution}, this will be the best match for any screen size. The resolver will now try to
+ * find the file in the following ways:
+ * </p>
+ * 
+ * <ul>
+ * <li>{@code "textures/walls/1920x1080/brick.png"}</li>
+ * <li>{@code "textures/walls/brick.png"}</li>
+ * </ul>
+ * 
+ * <p>
+ * The files are ultimately resolved via the given {{@link #baseResolver}. In case the first version cannot be resolved, the
+ * fallback will try to search for the file without the resolution folder.
+ * </p> */
 public class ResolutionFileResolver implements FileHandleResolver {
+
 	public static class Resolution {
 		public final int portraitWidth;
 		public final int portraitHeight;
-		public final String suffix;
 
-		public Resolution (int portraitWidth, int portraitHeight, String suffix) {
+		/** The name of the folder, where the assets which fit this resolution, are located. */
+		public final String folder;
+
+		/** Constructs a {@code Resolution}.
+		 * @param portraitWidth This resolution's width.
+		 * @param portraitHeight This resolution's height.
+		 * @param folder The name of the folder, where the assets which fit this resolution, are located. */
+		public Resolution (int portraitWidth, int portraitHeight, String folder) {
 			this.portraitWidth = portraitWidth;
 			this.portraitHeight = portraitHeight;
-			this.suffix = suffix;
+			this.folder = folder;
 		}
 	}
 
 	protected final FileHandleResolver baseResolver;
 	protected final Resolution[] descriptors;
 
+	/** Creates a {@code ResolutionFileResolver} based on a given {@link FileHandleResolver} and a list of {@link Resolution}s.
+	 * @param baseResolver The {@link FileHandleResolver} that will ultimately used to resolve the file.
+	 * @param descriptors A list of {@link Resolution}s. At least one has to be supplied. */
 	public ResolutionFileResolver (FileHandleResolver baseResolver, Resolution... descriptors) {
+		if (descriptors.length == 0) throw new IllegalArgumentException("At least one Resolution needs to be supplied.");
 		this.baseResolver = baseResolver;
 		this.descriptors = descriptors;
 	}
 
 	@Override
 	public FileHandle resolve (String fileName) {
-		Resolution bestDesc = choose(descriptors);
+		Resolution bestResolution = choose(descriptors);
 		FileHandle originalHandle = new FileHandle(fileName);
-		FileHandle handle = baseResolver.resolve(resolve(originalHandle, bestDesc.suffix));
+		FileHandle handle = baseResolver.resolve(resolve(originalHandle, bestResolution.folder));
 		if (!handle.exists()) handle = baseResolver.resolve(fileName);
 		return handle;
 	}
@@ -55,12 +95,11 @@ public class ResolutionFileResolver implements FileHandleResolver {
 		FileHandle parent = originalHandle.parent();
 		if (parent != null && !parent.name().equals("")) {
 			parentString = parent + "/";
-		}		
+		}
 		return parentString + suffix + "/" + originalHandle.name();
 	}
 
 	static public Resolution choose (Resolution... descriptors) {
-		if (descriptors == null) throw new IllegalArgumentException("descriptors cannot be null.");
 		int w = Gdx.graphics.getWidth(), h = Gdx.graphics.getHeight();
 
 		// Prefer the shortest side.


### PR DESCRIPTION
Whenever someone wants to use the `ResolutionFileResolver`, there's a lot of confusion. The implementation has changed over time and there is 0 documentation as to how it works in the JavaDoc. That is why I have added some docs to the class.

I have also fixed an invalid argument check (`if (descriptors == null)` became `if (descriptors.length == 0)`) and moved it to the correct place.

Furthermore, this is actually an API breaking change, because I have renamed a public field from `suffix` to `folder`, because it is not used as a suffix anymore. I think in the past it was used to search for `textures/brick.png.<suffix>`, nowadays this behaviour has changed to `textures/<folder>/brick.png`.
