### PR TITLE
Made StateMachine an Agent.

### DIFF
--- a/extensions/gdx-ai/src/com/badlogic/gdx/ai/fsm/StateMachine.java
+++ b/extensions/gdx-ai/src/com/badlogic/gdx/ai/fsm/StateMachine.java
@@ -16,7 +16,7 @@
 
 package com.badlogic.gdx.ai.fsm;
 
-import com.badlogic.gdx.ai.Agent;
+import com.badlogic.gdx.ai.msg.Telegraph;
 import com.badlogic.gdx.ai.msg.Telegram;
 
 /** A state machine manages the state transitions of its entity. Additionally, the state machine may be delegated by the entity to
@@ -25,7 +25,7 @@ import com.badlogic.gdx.ai.msg.Telegram;
  * @param <E> is the type of the entity
  * 
  * @author davebaol */
-public interface StateMachine<E> extends Agent {
+public interface StateMachine<E> extends Telegraph {
 
 	/** Updates the state machine.
 	 * <p>

--- a/extensions/gdx-ai/src/com/badlogic/gdx/ai/msg/MessageDispatcher.java
+++ b/extensions/gdx-ai/src/com/badlogic/gdx/ai/msg/MessageDispatcher.java
@@ -17,7 +17,6 @@
 package com.badlogic.gdx.ai.msg;
 
 import com.badlogic.gdx.Gdx;
-import com.badlogic.gdx.ai.Agent;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.IntMap;
 import com.badlogic.gdx.utils.Pool;
@@ -40,7 +39,7 @@ public class MessageDispatcher {
 
 	private final Pool<Telegram> pool;
 
-	private IntMap<Array<Agent>> msgListeners = new IntMap<Array<Agent>>();
+	private IntMap<Array<Telegraph>> msgListeners = new IntMap<Array<Telegraph>>();
 
 	private long timeGranularity;
 
@@ -99,11 +98,11 @@ public class MessageDispatcher {
 	 * registered listeners.
 	 * @param msg the message code
 	 * @param listener the listener to add */
-	public void addListener (int msg, Agent listener) {
-		Array<Agent> listeners = msgListeners.get(msg);
+	public void addListener (int msg, Telegraph listener) {
+		Array<Telegraph> listeners = msgListeners.get(msg);
 		if (listeners == null) {
 			// Associate an empty unordered array with the message code
-			listeners = new Array<Agent>(false, 16);
+			listeners = new Array<Telegraph>(false, 16);
 			msgListeners.put(msg, listeners);
 		}
 		listeners.add(listener);
@@ -112,8 +111,8 @@ public class MessageDispatcher {
 	/** Unregister the specified listener for the specified message code.
 	 * @param msg the message code
 	 * @param listener the listener to remove */
-	public void removeListener (int msg, Agent listener) {
-		Array<Agent> listeners = msgListeners.get(msg);
+	public void removeListener (int msg, Telegraph listener) {
+		Array<Telegraph> listeners = msgListeners.get(msg);
 		if (listeners != null) {
 			listeners.removeValue(listener, true);
 		}
@@ -144,9 +143,9 @@ public class MessageDispatcher {
 		clearListeners();
 	}
 
-	/** Shortcut method for {@link #dispatchMessage(float, Agent, Agent, int, Object) dispatchMessage(delay, sender,
+	/** Shortcut method for {@link #dispatchMessage(float, Telegraph, Telegraph, int, Object) dispatchMessage(delay, sender,
 	 * receiver, msg, extraInfo)} where {@code extraInfo} is {@code null}. */
-	public void dispatchMessage (float delay, Agent sender, Agent receiver, int msg) {
+	public void dispatchMessage (float delay, Telegraph sender, Telegraph receiver, int msg) {
 		dispatchMessage(delay, sender, receiver, msg, null);
 	}
 
@@ -158,7 +157,7 @@ public class MessageDispatcher {
 	 *           the specified message code
 	 * @param msg the message code
 	 * @param extraInfo an optional object */
-	public void dispatchMessage (float delay, Agent sender, Agent receiver, int msg, Object extraInfo) {
+	public void dispatchMessage (float delay, Telegraph sender, Telegraph receiver, int msg, Object extraInfo) {
 
 		// Get a telegram from the pool
 		Telegram telegram = pool.obtain();
@@ -240,7 +239,7 @@ public class MessageDispatcher {
 		} else {
 			// Dispatch the telegram to all the registered receivers
 			int handledCount = 0;
-			Array<Agent> listeners = msgListeners.get(telegram.message);
+			Array<Telegraph> listeners = msgListeners.get(telegram.message);
 			if (listeners != null) {
 				for (int i = 0; i < listeners.size; i++) {
 					if (listeners.get(i).handleMessage(telegram)) {

--- a/extensions/gdx-ai/src/com/badlogic/gdx/ai/msg/Telegram.java
+++ b/extensions/gdx-ai/src/com/badlogic/gdx/ai/msg/Telegram.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.ai.msg;
 
-import com.badlogic.gdx.ai.Agent;
 import com.badlogic.gdx.utils.Pool.Poolable;
 
 /** A Telegram is the container of a message. The {@link MessageDispatcher} manages telegram life-cycle.
@@ -24,10 +23,10 @@ import com.badlogic.gdx.utils.Pool.Poolable;
 public class Telegram implements Comparable<Telegram>, Poolable {
 
 	/** The agent that sent this telegram */
-	public Agent sender;
+	public Telegraph sender;
 
 	/** The agent that is to receive this telegram */
-	public Agent receiver;
+	public Telegraph receiver;
 
 	/** The message type. */
 	public int message;

--- a/extensions/gdx-ai/src/com/badlogic/gdx/ai/msg/Telegraph.java
+++ b/extensions/gdx-ai/src/com/badlogic/gdx/ai/msg/Telegraph.java
@@ -14,12 +14,11 @@
  * limitations under the License.
  ******************************************************************************/
 
-package com.badlogic.gdx.ai;
+package com.badlogic.gdx.ai.msg;
 
-import com.badlogic.gdx.ai.msg.Telegram;
 
 /** @author davebaol */
-public interface Agent {
+public interface Telegraph {
 
 	public boolean handleMessage (Telegram msg);
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ai/fsm/Bob.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ai/fsm/Bob.java
@@ -16,13 +16,13 @@
 
 package com.badlogic.gdx.tests.ai.fsm;
 
-import com.badlogic.gdx.ai.Agent;
 import com.badlogic.gdx.ai.fsm.DefaultStateMachine;
 import com.badlogic.gdx.ai.fsm.StateMachine;
+import com.badlogic.gdx.ai.msg.Telegraph;
 import com.badlogic.gdx.ai.msg.Telegram;
 
 /** @author davebaol */
-public class Bob implements Agent {
+public class Bob implements Telegraph {
 	// the amount of gold a miner must have before he feels comfortable
 	final public static int COMFORT_LEVEL = 5;
 	// the amount of nuggets a miner can carry

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ai/fsm/Elsa.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ai/fsm/Elsa.java
@@ -16,13 +16,13 @@
 
 package com.badlogic.gdx.tests.ai.fsm;
 
-import com.badlogic.gdx.ai.Agent;
 import com.badlogic.gdx.ai.fsm.DefaultStateMachine;
 import com.badlogic.gdx.ai.fsm.StateMachine;
+import com.badlogic.gdx.ai.msg.Telegraph;
 import com.badlogic.gdx.ai.msg.Telegram;
 
 /** @author davebaol */
-public class Elsa implements Agent {
+public class Elsa implements Telegraph {
 
 	// an instance of the state machine class
 	private StateMachine<Elsa> stateMachine;


### PR DESCRIPTION
I don't see why the `Agent` actually needs an `update` method. It seems a bit misplaced, because the `MessageDispatcher` needs to be updated, not the `Agent`s. By removing that it is possible to make `StateMachine` directly an `Agent` as well, so one can send telegrams directly to the state machine and does not necessarily need another agent to delegate to it.(see `Bob` and `Elsa`).
