### PR TITLE
FSM changeState possible with null.

### DIFF
--- a/extensions/gdx-ai/src/com/badlogic/gdx/ai/fsm/DefaultStateMachine.java
+++ b/extensions/gdx-ai/src/com/badlogic/gdx/ai/fsm/DefaultStateMachine.java
@@ -109,7 +109,7 @@ public class DefaultStateMachine<E> implements StateMachine<E> {
 		currentState = newState;
 
 		// Call the entry method of the new state
-		currentState.enter(owner);
+		if (currentState != null) currentState.enter(owner);
 	}
 
 	@Override


### PR DESCRIPTION
I have added a `null` check to `DefaultStateMachine.changeState(...)`. It is the only place where this check is not performed yet. That way it is possible to exit the "last" state via a state change to `null`.

In my case I have an enemy class that switches from `CombatState` to `DieState`. After the dying animation is completed, I switch to `DeadState`. Now the enemy is lying on the ground. I want it to "rot" and disappear after a few seconds. So I got a counter that starts in `DeadState.enter()`. In `DeadState.exit()` I call `enemy.dispose()` to completely remove it from the game. There isn't really a `State` I could switch to at this point. That's why I want to perform a `changeState(null)` which results in an `exit()`.
