### PR TITLE
Change IOSSound default panning to center

### DIFF
--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSSound.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSSound.java
@@ -38,12 +38,12 @@ public class IOSSound implements Sound {
 
 	@Override
 	public long play () {
-		return play(1, 1, 1, false);
+		return play(1, 1, 0, false);
 	}
 
 	@Override
 	public long play (float volume) {
-		return play(volume, 1, 1, false);
+		return play(volume, 1, 0, false);
 	}
 
 	@Override
@@ -58,12 +58,12 @@ public class IOSSound implements Sound {
 
 	@Override
 	public long loop () {
-		return play(1, 1, 1, true);
+		return play(1, 1, 0, true);
 	}
 
 	@Override
 	public long loop (float volume) {
-		return play(volume, 1, 1, true);
+		return play(volume, 1, 0, true);
 	}
 
 	@Override


### PR DESCRIPTION
Sets default panning 0 (center) not 1 (full right) in IOSSound.
