### PR TITLE
Expose useHardwareIfAvailable to resolve #2136

### DIFF
--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/objectal/OALSimpleAudio.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/objectal/OALSimpleAudio.java
@@ -60,4 +60,10 @@ public final class OALSimpleAudio extends NSObject {
 
 	@Property
 	public native void setHonorSilentSwitch (boolean honorSilentSwitch);
+	
+	@Property
+	public native boolean isUseHardwareIfAvailable ();
+
+	@Property
+	public native void setUseHardwareIfAvailable (boolean useHardwareIfAvailable);
 }


### PR DESCRIPTION
**Note:** This is not tested, I haven't the hardware to do so. 

Required control when using allowIpod setting.

From the documentation:

``` java
/** Determines what to do if no other application is playing audio and allowIpod = YES
* (NOT SUPPORTED ON THE SIMULATOR). <br>
*
* If NO, the application will ALWAYS use software decoding. The advantage to this is that
* the user can background your application and then start audio playing from another
* application. If useHardwareIfAvailable = YES, the user won't be able to do this. <br>
*
* If this is set to YES, the application will use hardware decoding if no other application
* is currently playing audio. However, no other application will be able to start playing
* audio if it wasn't playing already. <br>
*
* Note: This switch has no effect if allowIpod = NO. <br>
*
* iOS Only. <br>
*
* @see allowIpod
*
* Default value: YES
*/
@property(nonatomic,readwrite,assign) bool useHardwareIfAvailable;
```
