### PR TITLE
Added frame identification support.

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphics.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphics.java
@@ -69,6 +69,7 @@ public class AndroidGraphics implements Graphics, Renderer {
 	protected long lastFrameTime = System.nanoTime();
 	protected float deltaTime = 0;
 	protected long frameStart = System.nanoTime();
+	protected long frameId = -1;
 	protected int frames = 0;
 	protected int fps;
 	protected WindowedMean mean = new WindowedMean(5);
@@ -411,6 +412,7 @@ public class AndroidGraphics implements Graphics, Renderer {
 				}
 			}
 			app.getInput().processEvents();
+			frameId++;
 			app.getApplicationListener().render();
 		}
 
@@ -442,6 +444,11 @@ public class AndroidGraphics implements Graphics, Renderer {
 			frameStart = time;
 		}
 		frames++;
+	}
+
+	@Override
+	public long getFrameId () {
+		return frameId;
 	}
 
 	/** {@inheritDoc} */

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphicsLiveWallpaper.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphicsLiveWallpaper.java
@@ -217,6 +217,7 @@ public final class AndroidGraphicsLiveWallpaper extends AndroidGraphics {
 			 */
 
 			app.getInput().processEvents();
+			frameId++;
 			app.getApplicationListener().render();
 		}
 

--- a/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/HeadlessApplication.java
+++ b/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/HeadlessApplication.java
@@ -120,6 +120,7 @@ public class HeadlessApplication implements Application {
 					t = n + renderInterval;
 				
 				executeRunnables();
+				graphics.incrementFrameId();
 				listener.render();
 				graphics.updateTime();
 	

--- a/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/mock/graphics/MockGraphics.java
+++ b/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/mock/graphics/MockGraphics.java
@@ -24,6 +24,7 @@ import com.badlogic.gdx.graphics.GL30;
  * server and client as simple as possible.
  */
 public class MockGraphics implements Graphics {
+	long frameId = -1;
 	float deltaTime = 0;
 	long frameStart = 0;
 	int frames = 0;
@@ -53,6 +54,11 @@ public class MockGraphics implements Graphics {
 	@Override
 	public int getHeight() {
 		return 0;
+	}
+
+	@Override
+	public long getFrameId() {
+		return frameId;
 	}
 
 	@Override
@@ -176,6 +182,10 @@ public class MockGraphics implements Graphics {
 			frameStart = time;
 		}
 		frames++;
+	}
+
+	public void incrementFrameId () {
+		frameId++;
 	}
 
 }

--- a/backends/gdx-backend-jglfw/src/com/badlogic/gdx/backends/jglfw/JglfwGraphics.java
+++ b/backends/gdx-backend-jglfw/src/com/badlogic/gdx/backends/jglfw/JglfwGraphics.java
@@ -53,6 +53,7 @@ public class JglfwGraphics implements Graphics {
 	private volatile boolean isContinuous = true, renderRequested;
 	volatile boolean foreground, minimized;
 
+	private long frameId = -1;
 	private float deltaTime;
 	private long frameStart, lastTime = -1;
 	private int frames, fps;
@@ -155,6 +156,7 @@ public class JglfwGraphics implements Graphics {
 			frameStart = time;
 		}
 		frames++;
+		frameId++;
 	}
 
 	void sizeChanged (int width, int height) {
@@ -190,6 +192,10 @@ public class JglfwGraphics implements Graphics {
 
 	public int getHeight () {
 		return height;
+	}
+
+	public long getFrameId () {
+		return frameId;
 	}
 
 	public float getDeltaTime () {

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglAWTCanvas.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglAWTCanvas.java
@@ -256,6 +256,7 @@ public class LwjglAWTCanvas implements Application {
 
 		input.processEvents();
 		if (running) {
+			graphics.frameId++;
 			listener.render();
 			if (audio != null) {
 				audio.update();

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglApplication.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglApplication.java
@@ -203,6 +203,7 @@ public class LwjglApplication implements Application {
 			int frameRate = isActive ? graphics.config.foregroundFPS : graphics.config.backgroundFPS;
 			if (shouldRender) {
 				graphics.updateTime();
+				graphics.frameId++;
 				listener.render();
 				Display.update(false);
 			} else {

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglCanvas.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglCanvas.java
@@ -222,6 +222,7 @@ public class LwjglCanvas implements Application {
 
 					input.update();
 					input.processEvents();
+					graphics.frameId++;
 					listener.render();
 					if (audio != null) audio.update();
 					Display.update();

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGraphics.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGraphics.java
@@ -41,6 +41,7 @@ public class LwjglGraphics implements Graphics {
 
 	GL20 gl20;
 	GL30 gl30;
+	long frameId = -1;
 	float deltaTime = 0;
 	long frameStart = 0;
 	int frames = 0;
@@ -92,6 +93,10 @@ public class LwjglGraphics implements Graphics {
 
 	public boolean isGL20Available () {
 		return gl20 != null;
+	}
+
+	public long getFrameId () {
+		return frameId;
 	}
 
 	public float getDeltaTime () {

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplication.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplication.java
@@ -215,7 +215,8 @@ public abstract class GwtApplication implements EntryPoint, Application {
 		for (int i = 0; i < runnablesHelper.size; i++) {
 			runnablesHelper.get(i).run();
 		}
-		runnablesHelper.clear();					
+		runnablesHelper.clear();
+		graphics.frameId++;
 		listener.render();
 		input.reset();
 	}

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtGraphics.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtGraphics.java
@@ -34,6 +34,7 @@ public class GwtGraphics implements Graphics {
 	String extensions;
 	float fps = 0;
 	long lastTimeStamp = System.currentTimeMillis();
+	long frameId = -1;
 	float deltaTime = 0;
 	float time = 0;
 	int frames;
@@ -78,6 +79,11 @@ public class GwtGraphics implements Graphics {
 	@Override
 	public int getHeight () {
 		return canvas.getHeight();
+	}
+
+	@Override
+	public long getFrameId () {
+		return frameId;
 	}
 
 	@Override

--- a/gdx/src/com/badlogic/gdx/Graphics.java
+++ b/gdx/src/com/badlogic/gdx/Graphics.java
@@ -116,6 +116,13 @@ public interface Graphics {
 	/** @return the height in pixels of the display surface */
 	public int getHeight ();
 
+	/** Returns the id of the current frame. The general contract of this method is that the id is incremented only when the
+	 * application is in the running state right before calling the {@link ApplicationListener#render()} method. Also, the id of
+	 * the first frame is 0; the id of subsequent frames is guaranteed to take increasing values for 2<sup>63</sup>-1 rendering
+	 * cycles.
+	 * @return the id of the current frame */
+	public long getFrameId ();
+
 	/** @return the time span between the current frame and the last frame in seconds. Might be smoothed over n frames. */
 	public float getDeltaTime ();
 


### PR DESCRIPTION
Frame identification is a very cheap and common technique to avoid repeating calculations during the same frame.
Of course if you're writing an app you can quickly implement this technique inside the render() method of your ApplicationListener.
However, if you're writing a gdx extension or any high abstraction level framework the above solution is not acceptable. In these cases, a cleaner solution is possible only if the gdx core provides frame identification support directly.

In fact, I've tried to exploit Gdx.graphics.getRawDeltaTime() hoping that it always takes different values for subsequent frames, see https://github.com/libgdx/libgdx/pull/2202#discussion_r15785050. Unfortunately, it turned out that the delta time has the same value of the previous frame more than once per minute. In short, it's a ugly hack, and performs poorly too.

So I added the getFrameId method to the Graphics interface and implemented this feature for all the back-ends but the robovm one, because unfortunately I can't compile and test.

Finally I'm sorry for the wall of pink in this PR. I've literally spent countless hours so far trying to get rid of it. Unfortunately it happens too rarely to see if you have found the ultimate solution. I won't give up though :) 
