### PR TITLE
Proper mouse support for Android backend

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidInput.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidInput.java
@@ -70,11 +70,15 @@ public class AndroidInput implements Input, OnKeyListener, OnTouchListener {
 		static final int TOUCH_DOWN = 0;
 		static final int TOUCH_UP = 1;
 		static final int TOUCH_DRAGGED = 2;
+		static final int TOUCH_SCROLLED = 3;
+		static final int TOUCH_MOVED = 4;
 
 		long timeStamp;
 		int type;
 		int x;
 		int y;
+		int scrollAmount;
+		int button;
 		int pointer;
 	}
 
@@ -100,6 +104,7 @@ public class AndroidInput implements Input, OnKeyListener, OnTouchListener {
 	int[] deltaX = new int[NUM_TOUCHES];
 	int[] deltaY = new int[NUM_TOUCHES];
 	boolean[] touched = new boolean[NUM_TOUCHES];
+	int[] button = new int[NUM_TOUCHES];
 	int[] realId = new int[NUM_TOUCHES];
 	final boolean hasMultitouch;
 	private int keyCount = 0;
@@ -325,7 +330,7 @@ public class AndroidInput implements Input, OnKeyListener, OnTouchListener {
 	}
 
 	@Override
-	public boolean isTouched() {
+	public boolean isTouched () {
 		synchronized (this) {
 			if (hasMultitouch) {
 				for (int pointer = 0; pointer < NUM_TOUCHES; pointer++) {
@@ -382,14 +387,20 @@ public class AndroidInput implements Input, OnKeyListener, OnTouchListener {
 					currentEventTimeStamp = e.timeStamp;
 					switch (e.type) {
 					case TouchEvent.TOUCH_DOWN:
-						processor.touchDown(e.x, e.y, e.pointer, Buttons.LEFT);
+						processor.touchDown(e.x, e.y, e.pointer, e.button);
 						justTouched = true;
 						break;
 					case TouchEvent.TOUCH_UP:
-						processor.touchUp(e.x, e.y, e.pointer, Buttons.LEFT);
+						processor.touchUp(e.x, e.y, e.pointer, e.button);
 						break;
 					case TouchEvent.TOUCH_DRAGGED:
 						processor.touchDragged(e.x, e.y, e.pointer);
+						break;
+					case TouchEvent.TOUCH_MOVED:
+						processor.mouseMoved(e.x, e.y);
+						break;
+					case TouchEvent.TOUCH_SCROLLED:
+						processor.scrolled(e.scrollAmount);
 					}
 					usedTouchEvents.free(e);
 				}
@@ -618,10 +629,16 @@ public class AndroidInput implements Input, OnKeyListener, OnTouchListener {
 
 	@Override
 	public boolean isButtonPressed (int button) {
-		if (button == Buttons.LEFT)
-			return isTouched();
-		else
-			return false;
+		synchronized (this) {
+			if (hasMultitouch) {
+				for (int pointer = 0; pointer < NUM_TOUCHES; pointer++) {
+					if (touched[pointer] && (this.button[pointer] == button)) {
+						return true;
+					}
+				}
+			}
+			return (touched[0] && (this.button[0] == button));
+		}
 	}
 
 	final float[] R = new float[9];
@@ -743,6 +760,7 @@ public class AndroidInput implements Input, OnKeyListener, OnTouchListener {
 		deltaX = resize(deltaX);
 		deltaY = resize(deltaY);
 		touched = resize(touched);
+		button = resize(button);
 
 		return len;
 	}

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidInputThreePlus.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidInputThreePlus.java
@@ -29,6 +29,7 @@ import com.badlogic.gdx.Application;
  * @author mzechner */
 public class AndroidInputThreePlus extends AndroidInput implements OnGenericMotionListener {
 	ArrayList<OnGenericMotionListener> genericMotionListeners = new ArrayList();
+	private final AndroidMouseHandler mouseHandler;
 
 	public AndroidInputThreePlus (Application activity, Context context, Object view, AndroidApplicationConfiguration config) {
 		super(activity, context, view, config);
@@ -38,10 +39,12 @@ public class AndroidInputThreePlus extends AndroidInput implements OnGenericMoti
 			View v = (View)view;
 			v.setOnGenericMotionListener(this);
 		}
+		mouseHandler = new AndroidMouseHandler();
 	}
 
 	@Override
 	public boolean onGenericMotion (View view, MotionEvent event) {
+		if (mouseHandler.onGenericMotion(event, this)) return true;
 		for (int i = 0, n = genericMotionListeners.size(); i < n; i++)
 			if (genericMotionListeners.get(i).onGenericMotion(view, event)) return true;
 		return false;

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidMouseHandler.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidMouseHandler.java
@@ -1,0 +1,91 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogic.gdx.backends.android;
+
+import android.content.Context;
+import android.view.InputDevice;
+import android.view.MotionEvent;
+import android.view.View;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Input.Buttons;
+import com.badlogic.gdx.backends.android.AndroidInput.TouchEvent;
+
+/** Mouse handler for devices running Android >= 3.1.
+ * 
+ * @author Richard Martin */
+public class AndroidMouseHandler {
+	private int deltaX = 0;
+	private int deltaY = 0;
+
+	public boolean onGenericMotion (MotionEvent event, AndroidInput input) {
+		if ((event.getSource() & InputDevice.SOURCE_CLASS_POINTER) == 0) return false;
+
+		final int action = event.getAction() & MotionEvent.ACTION_MASK;
+
+		int x = 0, y = 0;
+		int scrollAmount = 0;
+
+		long timeStamp = System.nanoTime();
+		synchronized (input) {
+			switch (action) {
+			case MotionEvent.ACTION_HOVER_MOVE:
+				x = (int)event.getX();
+				y = (int)event.getY();
+				if ((x != deltaX) || (y != deltaY)) { // Avoid garbage events
+					postTouchEvent(input, TouchEvent.TOUCH_MOVED, x, y, 0, timeStamp);
+					deltaX = x;
+					deltaY = y;
+				}
+				break;
+
+			case MotionEvent.ACTION_SCROLL:
+				scrollAmount = (int)-Math.signum(event.getAxisValue(MotionEvent.AXIS_VSCROLL));
+				postTouchEvent(input, TouchEvent.TOUCH_SCROLLED, 0, 0, scrollAmount, timeStamp);
+
+			}
+		}
+		Gdx.app.getGraphics().requestRendering();
+		return true;
+	}
+
+	private void logAction (int action) {
+		String actionStr = "";
+		if (action == MotionEvent.ACTION_HOVER_ENTER)
+			actionStr = "HOVER_ENTER";
+		else if (action == MotionEvent.ACTION_HOVER_MOVE)
+			actionStr = "HOVER_MOVE";
+		else if (action == MotionEvent.ACTION_HOVER_EXIT)
+			actionStr = "HOVER_EXIT";
+		else if (action == MotionEvent.ACTION_SCROLL)
+			actionStr = "SCROLL";
+		else
+			actionStr = "UNKNOWN (" + action + ")";
+		Gdx.app.log("AndroidMouseHandler", "action " + actionStr);
+	}
+
+	private void postTouchEvent (AndroidInput input, int type, int x, int y, int scrollAmount, long timeStamp) {
+		TouchEvent event = input.usedTouchEvents.obtain();
+		event.timeStamp = timeStamp;
+		event.x = x;
+		event.y = y;
+		event.type = type;
+		event.scrollAmount = scrollAmount;
+		input.touchEvents.add(event);
+	}
+
+}

--- a/gdx/src/com/badlogic/gdx/Input.java
+++ b/gdx/src/com/badlogic/gdx/Input.java
@@ -622,7 +622,7 @@ public interface Input {
 	public boolean isTouched (int pointer);
 
 	/** Whether a given button is pressed or not. Button constants can be found in {@link Buttons}. On Android only the Button#LEFT
-	 * constant is meaningful.
+	 * constant is meaningful before version 4.0.
 	 * @param button the button to check.
 	 * @return whether the button is down or not. */
 	public boolean isButtonPressed (int button);
@@ -751,8 +751,8 @@ public interface Input {
 		Landscape, Portrait
 	}
 
-	/** Only viable on the desktop. Will confine the mouse cursor location to the window and hide the mouse cursor. X and y coordinates
-	 * are still reported as if the mouse was not catched.
+	/** Only viable on the desktop. Will confine the mouse cursor location to the window and hide the mouse cursor. X and y
+	 * coordinates are still reported as if the mouse was not catched.
 	 * @param catched whether to catch or not to catch the mouse cursor */
 	public void setCursorCatched (boolean catched);
 

--- a/gdx/src/com/badlogic/gdx/InputProcessor.java
+++ b/gdx/src/com/badlogic/gdx/InputProcessor.java
@@ -43,8 +43,7 @@ public interface InputProcessor {
 	 * @return whether the input was processed */
 	public boolean keyTyped (char character);
 
-	/** Called when the screen was touched or a mouse button was pressed. The button parameter will be {@link Buttons#LEFT} on
-	 * Android and iOS.
+	/** Called when the screen was touched or a mouse button was pressed. The button parameter will be {@link Buttons#LEFT} on iOS.
 	 * @param screenX The x coordinate, origin is in the upper left corner
 	 * @param screenY The y coordinate, origin is in the upper left corner
 	 * @param pointer the pointer for the event.
@@ -52,8 +51,7 @@ public interface InputProcessor {
 	 * @return whether the input was processed */
 	public boolean touchDown (int screenX, int screenY, int pointer, int button);
 
-	/** Called when a finger was lifted or a mouse button was released. The button parameter will be {@link Buttons#LEFT} on Android
-	 * and iOS.
+	/** Called when a finger was lifted or a mouse button was released. The button parameter will be {@link Buttons#LEFT} on iOS.
 	 * @param pointer the pointer for the event.
 	 * @param button the button
 	 * @return whether the input was processed */
@@ -64,11 +62,11 @@ public interface InputProcessor {
 	 * @return whether the input was processed */
 	public boolean touchDragged (int screenX, int screenY, int pointer);
 
-	/** Called when the mouse was moved without any buttons being pressed. Will not be called on either Android or iOS.
+	/** Called when the mouse was moved without any buttons being pressed. Will not be called on iOS.
 	 * @return whether the input was processed */
 	public boolean mouseMoved (int screenX, int screenY);
 
-	/** Called when the mouse wheel was scrolled. Will not be called on either Android or iOS.
+	/** Called when the mouse wheel was scrolled. Will not be called on iOS.
 	 * @param amount the scroll amount, -1 or 1 depending on the direction the wheel was scrolled.
 	 * @return whether the input was processed. */
 	public boolean scrolled (int amount);


### PR DESCRIPTION
This PR adds the handling of mouse cursor movement and scroll wheel on Android 3.1+. It also correctly report the mid and right mouse buttons on 4.0+

I've tested this with a USB mouse and the touchpad on my ASUS Transformer tablet. (Had to manually configure the tablet not to report mid/right buttons as menu and back.) I've also tested it on my old Archos 43 to make sure I didn't break anything all the way back to Android 2.2.
