### PR TITLE
set empty Gdx.* fields and made get[Component]() methods work in headless backend

### DIFF
--- a/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/HeadlessApplication.java
+++ b/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/HeadlessApplication.java
@@ -75,6 +75,7 @@ public class HeadlessApplication implements Application {
 		Gdx.net = net;
 		Gdx.audio = audio;
 		Gdx.graphics = graphics;
+		Gdx.input = input;
 		
 		renderInterval = config.renderInterval > 0 ? (long)(config.renderInterval * 1000000000f) : (config.renderInterval < 0 ? -1 : 0);
 		
@@ -158,20 +159,17 @@ public class HeadlessApplication implements Application {
 
 	@Override
 	public Graphics getGraphics() {
-		// no graphics
-		return null;
+		return graphics;
 	}
 
 	@Override
 	public Audio getAudio() {
-		// no audio
-		return null;
+		return audio;
 	}
 
 	@Override
 	public Input getInput() {
-		// no input
-		return null;
+		return input;
 	}
 
 	@Override


### PR DESCRIPTION
`HeadlessApplication#get[Input/Graphics/Audio]()` returned null even though `HeadlessApplication` had corresponding mock implementations.  
Correct me if I'm wrong, but I guess this was because the getters were forgotten when those mock implementations were added.

I don't think they returned null intentionally because the `Gdx.[audio/graphics]` fields were set (`Gdx.input` wasn't though, so it seems it was forgotten as well).
