### PR TITLE
Added intensity back into the PointLight.

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/DefaultShader.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/DefaultShader.java
@@ -474,6 +474,7 @@ public class DefaultShader extends BaseShader {
 	protected int pointLightsLoc;
 	protected int pointLightsColorOffset;
 	protected int pointLightsPositionOffset;
+	protected int pointLightsIntensityOffset;
 	protected int pointLightsSize;
 
 	protected final boolean lighting;
@@ -581,6 +582,7 @@ public class DefaultShader extends BaseShader {
 		pointLightsLoc = loc(u_pointLights0color);
 		pointLightsColorOffset = loc(u_pointLights0color) - pointLightsLoc;
 		pointLightsPositionOffset = loc(u_pointLights0position) - pointLightsLoc;
+		pointLightsIntensityOffset = loc(u_pointLights0intensity) - pointLightsLoc;
 		pointLightsSize = loc(u_pointLights1color) - pointLightsLoc;
 		if (pointLightsSize < 0) pointLightsSize = 0;
 	}
@@ -785,6 +787,7 @@ public class DefaultShader extends BaseShader {
 				program.setUniformf(idx + pointLightsColorOffset, pointLights[i].color.r * pointLights[i].intensity,
 					pointLights[i].color.g * pointLights[i].intensity, pointLights[i].color.b * pointLights[i].intensity);
 				program.setUniformf(idx + pointLightsPositionOffset, pointLights[i].position);
+				program.setUniformf(idx + pointLightsIntensityOffset, pointLights[i].intensity);
 				if (pointLightsSize <= 0) break;
 			}
 		}


### PR DESCRIPTION
It would be better to get the intensity back into the light itself, and get the rgb color computed in the shader instead of having it precomputed.

The reason for this is that the intensity information can be used later on in the shader itself, instead of deriving it from the rgb color. Furthermore it's very easy to check if the intensity is 0 not to run the shader illumination calculation part since there are apparently always 5 lights.
