### PR TITLE
fixed PolygonRegionLoader GWT compatibility and error report

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g2d/PolygonRegionLoader.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/PolygonRegionLoader.java
@@ -87,7 +87,7 @@ public class PolygonRegionLoader extends SynchronousAssetLoader<PolygonRegion, P
 				}
 			reader.close();
 		} catch (IOException e) {
-			Gdx.app.error(PolygonRegionLoader.class.getSimpleName(), "could not read " + fileName, e);
+			throw new GdxRuntimeException("Error reading " + fileName, e);
 		}
 
 		if (image == null && params.textureExtensions != null) for (String extension : params.textureExtensions) {


### PR DESCRIPTION
removed call to `Class#getSimpleName()` for GWT compatibility  
throws `GdxRuntimeException` instead of logging to `Gdx.app.error(..)`
