### PR TITLE
Skin.getTiledDrawable(String) create it when not found.

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Skin.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Skin.java
@@ -195,14 +195,9 @@ public class Skin implements Disposable {
 		if (tiled != null) return tiled;
 
 		Drawable drawable = optional(name, Drawable.class);
-		if (drawable != null) {
-			if (!(drawable instanceof TiledDrawable)) {
-				throw new GdxRuntimeException("Drawable found but is not a TiledDrawable: " + name + ", "
-					+ drawable.getClass().getName());
-			}
-			return (TiledDrawable)drawable;
-		}
+		if (drawable instanceof TiledDrawable) return (TiledDrawable)drawable;
 
+		// if not a TiledDrawable try to create it
 		tiled = new TiledDrawable(getRegion(name));
 		add(name, tiled, TiledDrawable.class);
 		return tiled;


### PR DESCRIPTION
When needing a TiledDrawable object it will in last resort extract the corresponding region from the textures atlas and wrap it in a TiledDrawable object. Else user would receive an exception saying none is defined, even if there is a region with corresponding name.
