### PR TITLE
added OutputType.jsonQuoteLong

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -20,6 +20,7 @@
 - API Change: Removed Actor#setCenterPosition, added setPosition(x,y,align).
 - API Change: JsonReader, forward slash added to characters an unquoted strings cannot start with.
 - API Change: Stage#cancelTouchFocus(EventListener,Actor) changed to cancelTouchFocusExcept.
+- API Change: Json/JsonWriter.setQuoteLongValues() quotes Long, BigDecimal and BigInteger types to prevent truncation in languages like JavaScript and PHP.
 
 [1.3.1]
 - API change: Viewport refactoring. https://github.com/libgdx/libgdx/pull/2220

--- a/gdx/src/com/badlogic/gdx/utils/Json.java
+++ b/gdx/src/com/badlogic/gdx/utils/Json.java
@@ -50,6 +50,7 @@ public class Json {
 	private String typeName = "class";
 	private boolean usePrototypes = true;
 	private OutputType outputType;
+	private boolean quoteLongValues = false;
 	private final ObjectMap<Class, ObjectMap<String, FieldMetadata>> typeToFields = new ObjectMap();
 	private final ObjectMap<String, Class> tagToClass = new ObjectMap();
 	private final ObjectMap<Class, String> classToTag = new ObjectMap();
@@ -72,6 +73,11 @@ public class Json {
 
 	public void setOutputType (OutputType outputType) {
 		this.outputType = outputType;
+	}
+
+	/** When true, quotes Long, BigDecimal and BigInteger types to prevent truncation in languages like JavaScript and PHP. */
+	public void setQuoteLongValues (boolean quoteLongValues) {
+		this.quoteLongValues = quoteLongValues;
 	}
 
 	public void addClassTag (String tag, Class type) {
@@ -220,6 +226,7 @@ public class Json {
 		if (!(writer instanceof JsonWriter)) writer = new JsonWriter(writer);
 		this.writer = (JsonWriter)writer;
 		this.writer.setOutputType(outputType);
+		this.writer.setQuoteLongValues(quoteLongValues);
 	}
 
 	public JsonWriter getWriter () {

--- a/gdx/src/com/badlogic/gdx/utils/JsonWriter.java
+++ b/gdx/src/com/badlogic/gdx/utils/JsonWriter.java
@@ -30,6 +30,7 @@ public class JsonWriter extends Writer {
 	private JsonObject current;
 	private boolean named;
 	private OutputType outputType = OutputType.json;
+	private boolean quoteLongValues = false;
 
 	public JsonWriter (Writer writer) {
 		this.writer = writer;
@@ -41,6 +42,11 @@ public class JsonWriter extends Writer {
 
 	public void setOutputType (OutputType outputType) {
 		this.outputType = outputType;
+	}
+
+	/** When true, quotes Long, BigDecimal and BigInteger types to prevent truncation in languages like JavaScript and PHP. */
+	public void setQuoteLongValues (boolean quoteLongValues) {
+		this.quoteLongValues = quoteLongValues;
 	}
 
 	public JsonWriter name (String name) throws IOException {
@@ -88,6 +94,14 @@ public class JsonWriter extends Writer {
 	}
 
 	public JsonWriter value (Object value) throws IOException {
+		// quote long values; convert integer Doubles to Long
+		if (quoteLongValues && (value instanceof Long || value instanceof BigDecimal || value instanceof BigInteger)) {
+			value = String.valueOf(value);
+		} else if (value instanceof Number) {
+			Number number = (Number)value;
+			long longValue = number.longValue();
+			if (number.doubleValue() == longValue) value = longValue;
+		}
 		if (current != null) {
 			if (current.array) {
 				if (!current.needsComma)
@@ -153,8 +167,6 @@ public class JsonWriter extends Writer {
 	static public enum OutputType {
 		/** Normal JSON, with all its quotes. */
 		json,
-		/** Like JSON, but quotes Long, BigDecimal and BigInteger types to prevent truncation in languages like JavaScript and PHP. */
-		jsonQuoteLong,
 		/** Like JSON, but names are only quoted if necessary. */
 		javascript,
 		/** Like JSON, but names and values are only quoted if they don't contain <code>\r\n\t</code> or <code>space</code> and don't
@@ -167,14 +179,6 @@ public class JsonWriter extends Writer {
 		static private Pattern minimalValuePattern = Pattern.compile("[^/{}\\[\\],\":\\r\\n\\t ][^}\\],\\r\\n\\t ]*");
 
 		public String quoteValue (Object value) {
-			if (this == OutputType.jsonQuoteLong
-				&& (value instanceof Long || value instanceof BigDecimal || value instanceof BigInteger)) {
-				return '"' + String.valueOf(value) + '"';
-			} else if (value instanceof Number) {
-				Number number = (Number)value;
-				long longValue = number.longValue();
-				if (number.doubleValue() == longValue) value = longValue;
-			}
 			if (value == null || value instanceof Number || value instanceof Boolean) return String.valueOf(value);
 			String string = String.valueOf(value).replace("\\", "\\\\").replace("\r", "\\r").replace("\n", "\\n")
 				.replace("\t", "\\t");


### PR DESCRIPTION
Added new enum JsonWriter.OutputtType.jsonQuoteLong which quotes Long, BigDecimal and BigInteger types to prevent truncation in languages like JavaScript and PHP.
