### PR TITLE
Add Usage.ColorUnpacked, deprecate Usage.Color.

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/VertexAttributes.java
+++ b/gdx/src/com/badlogic/gdx/graphics/VertexAttributes.java
@@ -32,7 +32,10 @@ public final class VertexAttributes implements Iterable<VertexAttribute> {
 	 * @author mzechner */
 	public static final class Usage {
 		public static final int Position = 1;
+		/** @deprecated use {@link #ColorUnpacked} instead. */
+		@Deprecated
 		public static final int Color = 2;
+		public static final int ColorUnpacked = 2;
 		public static final int ColorPacked = 4;
 		public static final int Normal = 8;
 		public static final int TextureCoordinates = 16;


### PR DESCRIPTION
Related to #2015. 
`Usage.Color` is commonly used when e.g. using ModelBuilder to specify the vertex attributes to be build. Quite a few of those users probably use `Usage.Color` because they don't know (and don't have to know) that it is unpacked. This (non breaking) change tries to make these users aware of this.
