### PR TITLE
IOSMusic.play() shouldn't restart if called while playing

### DIFF
--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSMusic.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSMusic.java
@@ -50,7 +50,7 @@ public class IOSMusic implements Music {
 	public void play () {
 		if (track.isPaused()) {
 			track.setPaused(false);
-		} else {
+		} else if (!track.isPlaying()) {
 			track.play();
 		}
 	}


### PR DESCRIPTION
Currently if Music.play is called in iOS the music gets restarted. However on all other backends calling play on a already playing music instance does nothing. This simple pull request copes with that.
