### PR TITLE
default cancelTouchFocusChild() to protected

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ScrollPane.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ScrollPane.java
@@ -185,7 +185,7 @@ public class ScrollPane extends WidgetGroup {
 				amountX -= deltaX;
 				amountY += deltaY;
 				clamp();
-				cancelTouchFocusedChild(event);
+				cancelTouchFocusedChildPan(event,amountX,amountY);
 			}
 
 			public void fling (InputEvent event, float x, float y, int button) {
@@ -230,7 +230,11 @@ public class ScrollPane extends WidgetGroup {
 		fadeDelay = fadeDelaySeconds;
 	}
 
-	void cancelTouchFocusedChild (InputEvent event) {
+	protected void cancelTouchFocusedChildPan (InputEvent event,float amountX,float amountY) {
+		cancelTouchFocusedChild(event);
+	}
+	
+	protected void cancelTouchFocusedChild (InputEvent event) {
 		if (!cancelTouchFocus) return;
 		Stage stage = getStage();
 		if (stage != null) stage.cancelTouchFocus(flickScrollListener, this);


### PR DESCRIPTION
To be able to extend Scrollpane and have control about those methods,
see http://www.badlogicgames.com/forum/viewtopic.php?f=11&t=16416
Not sure what has to be changed on the gwt backend
