### PR TITLE
Rotated texture width/height messup

### DIFF
--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/texturepacker/TextureUnpacker.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/texturepacker/TextureUnpacker.java
@@ -134,12 +134,12 @@ public class TextureUnpacker {
 
 		// get the needed part of the page and rotate if needed
 		if (region.rotate) {
-			BufferedImage srcImage = page.getSubimage(region.left, region.top, region.width, region.height);
+			BufferedImage srcImage = page.getSubimage(region.left, region.top, region.height, region.width);
 			splitImage = new BufferedImage(region.height, region.width, page.getType());
 
 			AffineTransform transform = new AffineTransform();
 			transform.rotate(Math.toRadians(90.0));
-			transform.translate(0, -region.height);
+			transform.translate(0, -region.width);
 			AffineTransformOp op = new AffineTransformOp(transform, AffineTransformOp.TYPE_BILINEAR);
 			op.filter(srcImage, splitImage);
 		} else {


### PR DESCRIPTION
@NathanSweet 
For rotated images (when rotate is set to true) the unpacking is working wrong, when image is 90 rotated, height is width, and width is height...
as well as transform.translate was offsetting image to the right. 
This changes fix the problem (tested)
