### PR TITLE
Don't force batch flush when drawing group children

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/Group.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/Group.java
@@ -83,7 +83,6 @@ public class Group extends Actor implements Cullable {
 					if (cx <= cullRight && cy <= cullTop && cx + child.width >= cullLeft && cy + child.height >= cullBottom)
 						child.draw(batch, parentAlpha);
 				}
-				batch.flush();
 			} else {
 				// No transform for this group, offset each child.
 				float offsetX = x, offsetY = y;
@@ -112,7 +111,6 @@ public class Group extends Actor implements Cullable {
 					if (!child.isVisible()) continue;
 					child.draw(batch, parentAlpha);
 				}
-				batch.flush();
 			} else {
 				// No transform for this group, offset each child.
 				float offsetX = x, offsetY = y;

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Container.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Container.java
@@ -49,6 +49,7 @@ public class Container<T extends Actor> extends WidgetGroup {
 					getWidth() - padLeft - padRight.get(this), getHeight() - padBottom - padTop.get(this));
 				if (draw) {
 					drawChildren(batch, parentAlpha);
+					batch.flush();
 					clipEnd();
 				}
 			} else

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ScrollPane.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ScrollPane.java
@@ -556,6 +556,7 @@ public class ScrollPane extends WidgetGroup {
 		// Enable scissors for widget area and draw the widget.
 		if (ScissorStack.pushScissors(scissorBounds)) {
 			drawChildren(batch, parentAlpha);
+			batch.flush();
 			ScissorStack.popScissors();
 		}
 

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Table.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Table.java
@@ -112,6 +112,7 @@ public class Table extends WidgetGroup {
 				}
 				if (clipBegin(x, y, width, height)) {
 					drawChildren(batch, parentAlpha);
+					batch.flush();
 					clipEnd();
 				}
 			} else


### PR DESCRIPTION
It's possible to define a custom `Batch` whose transform matrix may be changed without flushing. For subsequent draws, the vertices are simply adjusted in software. I expect the performance gain from longer batches to easily offset this transformation overhead (especially for 2D).

For my [prototype](http://pastebin.com/hDuggVwu) I had to do a nasty hack, because `Group` insists on flushing the batch when `transform` is set. Could we remove the `flush()` from `Group.drawChildren()`?
