### PR TITLE
Added a Box2D class to load the natives.

### DIFF
--- a/extensions/gdx-box2d/gdx-box2d-gwt/src/com/badlogic/gdx/physics/box2d/gwt/emu/com/badlogic/gdx/physics/box2d/Box2D.java
+++ b/extensions/gdx-box2d/gdx-box2d-gwt/src/com/badlogic/gdx/physics/box2d/gwt/emu/com/badlogic/gdx/physics/box2d/Box2D.java
@@ -18,7 +18,10 @@ package com.badlogic.gdx.physics.box2d;
 
 /** A stub that does nothing at all, since there is no initialization necessary in case of GWT.
  * @author Daniel Holderbaum */
-public abstract class Box2D {
+public final class Box2D {
+
+	private Box2D () {
+	}
 
 	/** Does nothing on GWT. */
 	public static void init () {

--- a/extensions/gdx-box2d/gdx-box2d/src/com/badlogic/gdx/physics/box2d/Box2D.java
+++ b/extensions/gdx-box2d/gdx-box2d/src/com/badlogic/gdx/physics/box2d/Box2D.java
@@ -20,7 +20,10 @@ import com.badlogic.gdx.utils.SharedLibraryLoader;
 
 /** This class's only purpose is to initialize Box2D by calling its {@link #init()} method.
  * @author Daniel Holderbaum */
-public abstract class Box2D {
+public final class Box2D {
+
+	private Box2D () {
+	}
 
 	/** Loads the Box2D native library and initializes the gdx-box2d extension. Must be called before any of the box2d
 	 * classes/methods can be used. Currently with the exception of the {@link World} class, which will also cause the Box2D


### PR DESCRIPTION
To offer a more "obvious" solution to problems like https://github.com/libgdx/libgdx/issues/2393. Will add a short note about it to the wikipage if it gets merged.

I did not remove the static block in the World class to keep it backwards compatible. It won't be loaded twice since SharedLibraryLoader checks that itself.
