### PR TITLE
changed access modifier of fields to default (no modifier) to avoid eclipse warnings: "access to enclosing field is emulated by a synthetic accessor method"

### DIFF
--- a/extensions/gdx-pay/gdx-pay-android-ouya/src/com/badlogic/gdx/pay/android/ouya/PurchaseManagerAndroidOUYA.java
+++ b/extensions/gdx-pay/gdx-pay-android-ouya/src/com/badlogic/gdx/pay/android/ouya/PurchaseManagerAndroidOUYA.java
@@ -81,7 +81,7 @@ public class PurchaseManagerAndroidOUYA implements PurchaseManager {
 	private static final int LOGTYPEERROR = 1;
 
 	/** Our Android activity. */
-	private Activity activity;
+	Activity activity;
 
 	/** The registered observer. */
 	PurchaseObserver observer;
@@ -89,23 +89,23 @@ public class PurchaseManagerAndroidOUYA implements PurchaseManager {
 	PurchaseManagerConfig config;
 
 	/** the ouya helper */
-	private OuyaFacade ouyaFacade;
+	OuyaFacade ouyaFacade;
 
 	/** The OUYA cryptographic key for the application */
-	public PublicKey ouyaPublicKey;
-	private String applicationKeyPath;
-	public List<Purchasable> productIDList; 	// --- This is the set of OUYA product IDs which our app knows about
-	private final Map<String, Product> ouyaOutstandingPurchaseRequests = new HashMap<String, Product>();
+	PublicKey ouyaPublicKey;
+	String applicationKeyPath;
+	List<Purchasable> productIDList; 	// --- This is the set of OUYA product IDs which our app knows about
+	final Map<String, Product> ouyaOutstandingPurchaseRequests = new HashMap<String, Product>();
 	ReceiptListener myOUYAreceiptListener = new ReceiptListener();
-	private List<Receipt> mReceiptList; 		// the list of purchased items, sorted
-	private ArrayList<Product> productList = new ArrayList<Product>();
-	private Purchasable purchasable; 			// for a concrete purchase
+	List<Receipt> mReceiptList; 		// the list of purchased items, sorted
+	ArrayList<Product> productList = new ArrayList<Product>();
+	Purchasable purchasable; 			// for a concrete purchase
 	Product OUYApurchaseProduct;
 //	com.badlogic.gdx.pay.PurchaseListener appPurchaseListener; // this is the listener from the app that will be informed after a purchase
 
 	// ------- for Toasts (debugging) -----
-	public String toastText;
-	public int duration;
+	String toastText;
+	int duration;
 
 	// --------------------------------------------------
 
@@ -189,7 +189,7 @@ public class PurchaseManagerAndroidOUYA implements PurchaseManager {
 	final static int requestOUYApurchase = 2;
 	final static int requestPurchaseRestore = 3;
 
-	private final class HandlerExtension extends Handler {
+	final class HandlerExtension extends Handler {
 
 		@Override
 		public void handleMessage (Message msg) {
@@ -613,7 +613,7 @@ public class PurchaseManagerAndroidOUYA implements PurchaseManager {
 		return "OUYA";
 	}
 
-	private void showMessage (final int type, final String message) {
+	void showMessage (final int type, final String message) {
 		if (LOGDEBUG) {
 			if (type == LOGTYPELOG) Log.d(TAG, message);
 			if (type == LOGTYPEERROR) Log.e(TAG, message);
@@ -625,7 +625,7 @@ public class PurchaseManagerAndroidOUYA implements PurchaseManager {
 	}
 
 	// ---- saves the toast text and displays it
-	public void showToast (String toastText) {
+	void showToast (String toastText) {
 		this.duration = Toast.LENGTH_SHORT;
 		this.toastText = toastText;
 		handler.sendEmptyMessage(showToast);


### PR DESCRIPTION
changed access modifier of fields to default (no modifier) to avoid eclipse warnings: "access to enclosing field is emulated by a synthetic accessor method"

there are still 3 warnings....maybe someone more experienced could take a look or give some hints if this is critical and how we can avoid it.....

1.
String name = android.os.Build.MODEL.toLowerCase();
Implicitly using the default locale is a common source of bugs: Use toLowerCase(Locale) instead

2.
protected final class HandlerExtension extends Handler {
This Handler class should be static or leaks might occur (com.badlogic.gdx.pay.android.ouya.PurchaseManagerAndroidOUYA.HandlerExtension)

3.
SecureRandom sr = SecureRandom.getInstance("SHA1PRNG");
Potentially insecure random numbers on Android 4.3 and older. Read https://android-developers.blogspot.com/2013/08/some-securerandom-thoughts.html for more info.

bye
phil
