### PR TITLE
Removed gdx-pay-android-openiab.jar dependency

### DIFF
--- a/tests/gdx-tests-android/project.properties
+++ b/tests/gdx-tests-android/project.properties
@@ -11,6 +11,5 @@
 split.density=false
 # Project target.
 target=android-19
-android.library.reference.1=../../extensions/gdx-pay/gdx-pay-android
-android.library.reference.3=../../extensions/gdx-pay/gdx-pay-android-ouya
-android.library.reference.2=..\\..\\extensions\\gdx-pay\\gdx-pay-android-openiab
+android.library.reference.1=..\\..\\extensions\\gdx-pay\\gdx-pay-android
+android.library.reference.2=..\\..\\extensions\\gdx-pay\\gdx-pay-android-ouya


### PR DESCRIPTION
Currently one cannot run the android tests anymore, since there's a build path problem:

"The container 'Android Dependencies' references non existing library '...\libgdx\extensions\gdx-pay\gdx-pay-android-openiab\bin\gdx-pay-android-openiab.jar'.

The android tests project currently depends on the gdx-pay-android-openiab project anyway, so I think it's no problem to remove that "extra" dependency. I could still run the `PayTest`.
