### PR TITLE
Fixed formatting and crash in ShaderTest

### DIFF
--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/ShaderTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/ShaderTest.java
@@ -61,11 +61,23 @@ public class ShaderTest extends GdxTest {
 	}
 
 	public static class TestShader extends BaseShader {
-		public final static String vertexShader = "attribute vec3 a_position;\n" + "uniform mat4 u_projTrans;\n"
-			+ "uniform mat4 u_worldTrans;\n" + "uniform float u_test;\n" + "varying float v_test;\n" + "void main() {\n"
-			+ "	v_test = u_test;\n" + "	gl_Position = u_projTrans * u_worldTrans * vec4(a_position, 1.0);\n" + "}\n";
-		public final static String fragmentShader = "varying float v_test;\n" + "void main() {\n"
-			+ "	gl_FragColor.rgb = vec3(v_test);\n" + "}\n";
+		// @off
+		public final static String vertexShader =
+			  "attribute vec3 a_position;\n"
+			+ "uniform mat4 u_projTrans;\n"
+			+ "uniform mat4 u_worldTrans;\n"
+			+ "uniform mediump float u_test;\n"
+			+ "varying mediump float v_test;\n"
+			+ "void main() {\n"
+			+ "	v_test = u_test;\n"
+			+ "	gl_Position = u_projTrans * u_worldTrans * vec4(a_position, 1.0);\n"
+			+ "}\n";
+		public final static String fragmentShader =
+			  "varying mediump float v_test;\n"
+			+ "void main() {\n"
+			+ "	gl_FragColor.rgb = vec3(v_test);\n"
+			+ "}\n";
+		// @on
 
 		protected final int u_projTrans = register(new Uniform("u_projTrans"));
 		protected final int u_worldTrans = register(new Uniform("u_worldTrans"));


### PR DESCRIPTION
Shader in ShaderTest was not compiling. Log:

```
10-06 00:12:03.129: E/AndroidRuntime(16514): FATAL EXCEPTION: GLThread 739
10-06 00:12:03.129: E/AndroidRuntime(16514): com.badlogic.gdx.utils.GdxRuntimeException: Couldn't compile shader Compile failed.
10-06 00:12:03.129: E/AndroidRuntime(16514): ERROR: 0:1: 'float' : No precision defined for this type
10-06 00:12:03.129: E/AndroidRuntime(16514): ERROR: 1 compilation errors. No code generated.
10-06 00:12:03.129: E/AndroidRuntime(16514):    at com.badlogic.gdx.tests.g3d.ShaderTest$TestShader.<init>(ShaderTest.java:79)
10-06 00:12:03.129: E/AndroidRuntime(16514):    at com.badlogic.gdx.tests.g3d.ShaderTest$1.createShader(ShaderTest.java:135)
10-06 00:12:03.129: E/AndroidRuntime(16514):    at com.badlogic.gdx.graphics.g3d.utils.BaseShaderProvider.getShader(BaseShaderProvider.java:34)
10-06 00:12:03.129: E/AndroidRuntime(16514):    at com.badlogic.gdx.graphics.g3d.ModelBatch.render(ModelBatch.java:246)
10-06 00:12:03.129: E/AndroidRuntime(16514):    at com.badlogic.gdx.tests.g3d.ShaderTest.render(ShaderTest.java:169)
10-06 00:12:03.129: E/AndroidRuntime(16514):    at com.badlogic.gdx.backends.android.AndroidGraphics.onDrawFrame(AndroidGraphics.java:416)
10-06 00:12:03.129: E/AndroidRuntime(16514):    at android.opengl.GLSurfaceView$GLThread.guardedRun(GLSurfaceView.java:1516)
10-06 00:12:03.129: E/AndroidRuntime(16514):    at android.opengl.GLSurfaceView$GLThread.run(GLSurfaceView.java:1240)

```
