### PR TITLE
Fix for Dialogs steal keyboard focus and don't give it back

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Dialog.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Dialog.java
@@ -107,7 +107,9 @@ public class Dialog extends Window {
 				if (isModal && stage != null && stage.getRoot().getChildren().size > 0
 					&& stage.getRoot().getChildren().peek() == Dialog.this) { // Dialog is top most actor.
 					Actor newFocusedActor = event.getRelatedActor();
-					if (newFocusedActor != null && !newFocusedActor.isDescendantOf(Dialog.this)) event.cancel();
+					if (newFocusedActor != null && !newFocusedActor.isDescendantOf(Dialog.this) &&
+						!(newFocusedActor.equals(previousKeyboardFocus) || newFocusedActor.equals(previousScrollFocus)) )
+						event.cancel();
 				}
 			}
 		};


### PR DESCRIPTION
Also check for previousKeyboardFocus and previousScrollFocus before cancelling a focus change
