### PR TITLE
Fix getCenter(out)

### DIFF
--- a/gdx/src/com/badlogic/gdx/math/collision/BoundingBox.java
+++ b/gdx/src/com/badlogic/gdx/math/collision/BoundingBox.java
@@ -49,7 +49,7 @@ public class BoundingBox implements Serializable {
 	/** @param out The {@link Vector3} to receive the center of the bounding box.
 	 * @return The vector specified with the out argument. */
 	public Vector3 getCenter (Vector3 out) {
-		return cnt;
+		return out.set(cnt);
 	}
 
 	public float getCenterX () {


### PR DESCRIPTION
Fix public Vector3 getCenter (Vector3 out) to actually update the out parameter
