### PR TITLE
Fixed Android 4.4+ external storage behavior

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplication.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplication.java
@@ -135,7 +135,7 @@ public class AndroidApplication extends Activity implements AndroidApplicationBa
 		input = AndroidInputFactory.newAndroidInput(this, this, graphics.view, config);
 		audio = new AndroidAudio(this, config);
 		this.getFilesDir(); // workaround for Android bug #10515463
-		files = new AndroidFiles(this.getAssets(), this.getFilesDir().getAbsolutePath());
+		files = new AndroidFiles(this.getAssets(), this.getFilesDir().getAbsolutePath(), this);
 		net = new AndroidNet(this);
 		this.listener = listener;
 		this.handler = new Handler();

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidDaydream.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidDaydream.java
@@ -124,7 +124,7 @@ public class AndroidDaydream extends DreamService implements AndroidApplicationB
 		input = AndroidInputFactory.newAndroidInput(this, this, graphics.view, config);
 		audio = new AndroidAudio(this, config);
 		this.getFilesDir(); // workaround for Android bug #10515463
-		files = new AndroidFiles(this.getAssets(), this.getFilesDir().getAbsolutePath());
+		files = new AndroidFiles(this.getAssets(), this.getFilesDir().getAbsolutePath(), this.getApplicationContext());
 		net = new AndroidNet(this);
 		this.listener = listener;
 		this.handler = new Handler();

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidFileHandle.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidFileHandle.java
@@ -24,6 +24,7 @@ import java.io.InputStream;
 
 import android.content.res.AssetFileDescriptor;
 import android.content.res.AssetManager;
+import android.os.Environment;
 
 import com.badlogic.gdx.Files.FileType;
 import com.badlogic.gdx.Gdx;
@@ -35,15 +36,18 @@ import com.badlogic.gdx.utils.GdxRuntimeException;
 public class AndroidFileHandle extends FileHandle {
 	// The asset manager, or null if this is not an internal file.
 	final AssetManager assets;
-
+   final AndroidFiles files;
+   
 	AndroidFileHandle (AssetManager assets, String fileName, FileType type) {
 		super(fileName.replace('\\', '/'), type);
 		this.assets = assets;
+		this.files = (AndroidFiles)Gdx.files;
 	}
 
 	AndroidFileHandle (AssetManager assets, File file, FileType type) {
 		super(file, type);
 		this.assets = assets;
+		this.files = (AndroidFiles)Gdx.files;
 	}
 
 	public FileHandle child (String name) {
@@ -226,6 +230,17 @@ public class AndroidFileHandle extends FileHandle {
 
 	public File file () {
 		if (type == FileType.Local) return new File(Gdx.files.getLocalStoragePath(), file.getPath());
+		if (type == FileType.External) {
+			if (!this.files.legacyWriting) {
+				File tempFile = new File(Environment.getExternalStorageDirectory(), this.file.getPath());
+				if (tempFile.exists()) {
+					return tempFile;
+				} else {
+					tempFile = new File(this.files.sdcard, this.file.getPath());
+					return tempFile;
+				}
+			}
+		}
 		return super.file();
 	}
 

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidFileHandle.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidFileHandle.java
@@ -232,8 +232,11 @@ public class AndroidFileHandle extends FileHandle {
 		if (type == FileType.Local) return new File(Gdx.files.getLocalStoragePath(), file.getPath());
 		if (type == FileType.External) {
 			File tempFile = new File(Environment.getExternalStorageDirectory(), this.file.getPath());
-			File tempFile2 = new File(this.files.sdcard, this.file.getPath());
+			File tempFile2 = new File(this.files.getModernSdcardPath(), this.file.getPath());
 			
+			if (this.files.getModernSdcardPath() == null) {
+				throw new GdxRuntimeException("External storage has not been mounted.");
+			}
 			if (tempFile.exists()) {
 				if (tempFile2.exists()) {
 					// They both exist. Oh shoot. Use new apis

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidFileHandle.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidFileHandle.java
@@ -231,14 +231,17 @@ public class AndroidFileHandle extends FileHandle {
 	public File file () {
 		if (type == FileType.Local) return new File(Gdx.files.getLocalStoragePath(), file.getPath());
 		if (type == FileType.External) {
-			if (!this.files.legacyWriting) {
-				File tempFile = new File(Environment.getExternalStorageDirectory(), this.file.getPath());
-				if (tempFile.exists()) {
-					return tempFile;
-				} else {
-					tempFile = new File(this.files.sdcard, this.file.getPath());
-					return tempFile;
+			File tempFile = new File(Environment.getExternalStorageDirectory(), this.file.getPath());
+			File tempFile2 = new File(this.files.sdcard, this.file.getPath());
+			
+			if (tempFile.exists()) {
+				if (tempFile2.exists()) {
+					// They both exist. Oh shoot. Use new apis
+					return tempFile2;
 				}
+				return tempFile;
+			} else {
+				return tempFile2;
 			}
 		}
 		return super.file();

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidFiles.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidFiles.java
@@ -33,6 +33,7 @@ public class AndroidFiles implements Files {
 	protected String sdcard = Environment.getExternalStorageDirectory().getAbsolutePath() + "/";
 	protected final String localpath;
 
+	protected final String sdcardRoot = Environment.getExternalStorageDirectory().getAbsolutePath() + "/";
 	protected boolean legacyWriting = true;
 	protected final AssetManager assets;
 
@@ -49,39 +50,12 @@ public class AndroidFiles implements Files {
 	}
 
 	private void setupExternalStorage (Context context) {
-		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-			// Android 4.4 'KitKat' and above have new external storage guidelines 
-			// Some devices don't respect this, so we have a nice little patch to detect that.
-			
-			File testFile = new File(this.sdcard, ".gdxexternaltest");
-			
-			if (testFile.exists()) {
-				testFile.delete();
-			}
-			
-			try {
-				this.legacyWriting = testFile.createNewFile();
-			} catch (IOException e) {
-				// Legacy writing is not available.
-				this.legacyWriting = false;
-			}
-			
-			if (!this.legacyWriting) {
-				// Gets an application-specific directory that is writable on the external storage.
-				File externalDir = context.getExternalFilesDir(null);
-				if (!externalDir.exists()) {
-					externalDir.mkdirs();
-				}
-				
-				this.sdcard = externalDir.getAbsolutePath() + "/";
-				
-				try {
-					testFile.delete();
-				} catch (Exception e) {
-					// Ignored
-				}
-			}
+		// Gets an application-specific directory that is writable on the external storage.
+		File externalDir = context.getExternalFilesDir(null);
+		if (!externalDir.exists()) {
+			externalDir.mkdirs();
 		}
+		this.sdcard = externalDir.getAbsolutePath() + "/";
 	}
 
 	@Override
@@ -116,7 +90,7 @@ public class AndroidFiles implements Files {
 
 	@Override
 	public String getExternalStoragePath () {
-		return sdcard;
+		return this.sdcardRoot;
 	}
 
 	@Override

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidFiles.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidFiles.java
@@ -30,28 +30,35 @@ import com.badlogic.gdx.files.FileHandle;
 /** @author mzechner
  * @author Nathan Sweet */
 public class AndroidFiles implements Files {
-	protected String sdcard = Environment.getExternalStorageDirectory().getAbsolutePath() + "/";
+	protected String sdcard = null;
 	protected final String localpath;
-
-	protected final String sdcardRoot = Environment.getExternalStorageDirectory().getAbsolutePath() + "/";
+	
 	protected boolean legacyWriting = true;
 	protected final AssetManager assets;
+	protected Context context;
 
 	public AndroidFiles (AssetManager assets, Context context) {
 		this.assets = assets;
-		setupExternalStorage(context);
+		this.context = context;
+		setupExternalStorage(this.context);
 		localpath = sdcard;
 	}
 
 	public AndroidFiles (AssetManager assets, String localpath, Context context) {
 		this.assets = assets;
+		this.context = context;
 		this.localpath = localpath.endsWith("/") ? localpath : localpath + "/";
-		setupExternalStorage(context);
+		setupExternalStorage(this.context);
 	}
 
 	private void setupExternalStorage (Context context) {
 		// Gets an application-specific directory that is writable on the external storage.
 		File externalDir = context.getExternalFilesDir(null);
+		
+		if (externalDir == null) {
+			this.sdcard = null;
+		}
+		
 		if (!externalDir.exists()) {
 			externalDir.mkdirs();
 		}
@@ -90,7 +97,7 @@ public class AndroidFiles implements Files {
 
 	@Override
 	public String getExternalStoragePath () {
-		return this.sdcardRoot;
+		return this.sdcard;
 	}
 
 	@Override
@@ -106,5 +113,12 @@ public class AndroidFiles implements Files {
 	@Override
 	public boolean isLocalStorageAvailable () {
 		return true;
+	}
+	
+	protected String getModernSdcardPath() {
+		if (this.sdcard == null && this.isExternalStorageAvailable()) {
+			this.setupExternalStorage(this.context);
+		}
+		return this.sdcard;
 	}
 }

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidFiles.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidFiles.java
@@ -53,7 +53,7 @@ public class AndroidFiles implements Files {
 			// Android 4.4 'KitKat' and above have new external storage guidelines 
 			// Some devices don't respect this, so we have a nice little patch to detect that.
 			
-			File testFile = new File(this.sdcard, ".gdxexternaltest.");
+			File testFile = new File(this.sdcard, ".gdxexternaltest");
 			
 			if (testFile.exists()) {
 				testFile.delete();
@@ -74,6 +74,12 @@ public class AndroidFiles implements Files {
 				}
 				
 				this.sdcard = externalDir.getAbsolutePath() + "/";
+				
+				try {
+					testFile.delete();
+				} catch (Exception e) {
+					// Ignored
+				}
 			}
 		}
 	}

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidFragmentApplication.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidFragmentApplication.java
@@ -157,7 +157,7 @@ public class AndroidFragmentApplication extends Fragment implements AndroidAppli
 			: config.resolutionStrategy);
 		input = AndroidInputFactory.newAndroidInput(this, getActivity(), graphics.view, config);
 		audio = new AndroidAudio(getActivity(), config);
-		files = new AndroidFiles(getResources().getAssets(), getActivity().getFilesDir().getAbsolutePath());
+		files = new AndroidFiles(getResources().getAssets(), getActivity().getFilesDir().getAbsolutePath(), this.getContext());
 		net = new AndroidNet(this);
 		this.listener = listener;
 		this.handler = new Handler();

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidLiveWallpaper.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidLiveWallpaper.java
@@ -88,7 +88,7 @@ public class AndroidLiveWallpaper implements AndroidApplicationBase {
 
 		// added initialization of android local storage: /data/data/<app package>/files/
 		this.getService().getFilesDir(); // workaround for Android bug #10515463
-		files = new AndroidFiles(this.getService().getAssets(), this.getService().getFilesDir().getAbsolutePath());
+		files = new AndroidFiles(this.getService().getAssets(), this.getService().getFilesDir().getAbsolutePath(), this.getService());
 		net = new AndroidNet(this);
 		this.listener = listener;
 

--- a/gdx/src/com/badlogic/gdx/Files.java
+++ b/gdx/src/com/badlogic/gdx/Files.java
@@ -69,7 +69,7 @@ public interface Files {
 	/** Convenience method that returns a {@link FileType#Local} file handle. */
 	public FileHandle local (String path);
 
-	/** Returns the external storage path directory. This is the SD card on Android and the home directory of the current user on
+	/** Returns the external storage path directory. This is an app-specific directory on the SD card on Android and the home directory of the current user on
 	 * the desktop. */
 	public String getExternalStoragePath ();
 


### PR DESCRIPTION
Closes #2426 

What this PR does:
- Switches reading and writing by default to the new external storage APIs which creates an application-specific directory on the sd card.
- Falls back to legacy root of sdcard if file exists there.
- Hides these changes from the developer, it is all done under-the-hood.

Tested with FilesTest in gdx-tests
- Nexus 7 (2013) running Android L Developer Preview [tested with legacy + forced new behavior]
- Blu Advance 4.5 4G running Android 4.2.2 [tested with legacy + forced new behavior]

This PR does compile, I check that. :)