### PR TITLE
fixing BoundingBox mul

### DIFF
--- a/gdx/src/com/badlogic/gdx/math/collision/BoundingBox.java
+++ b/gdx/src/com/badlogic/gdx/math/collision/BoundingBox.java
@@ -300,6 +300,7 @@ public class BoundingBox implements Serializable {
 	 * @return This bounding box for chaining. */
 	public BoundingBox mul (Matrix4 transform) {
 		final float x0 = min.x, y0 = min.y, z0 = min.z, x1 = max.x, y1 = max.y, z1 = max.z;
+		inf();
 		ext(tmpVector.set(x0, y0, z0).mul(transform));
 		ext(tmpVector.set(x0, y0, z1).mul(transform));
 		ext(tmpVector.set(x0, y1, z0).mul(transform));


### PR DESCRIPTION
multiplication on bounding box must be set to inf() before using ext().
because a transformation like a translation is not an extension of the bounding box, so ext() is not valid in this case.
boundingbox must be reset with inf() first.

fix now seems to work :)
