### PR TITLE
Enforce continuous rendering while pausing Android backends

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplication.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplication.java
@@ -257,10 +257,10 @@ public class AndroidApplication extends Activity implements AndroidApplicationBa
 	@Override
 	protected void onPause () {
 		boolean isContinuous = graphics.isContinuousRendering();
-		boolean isContinuousEnforced = AndroidGraphics.enforceContinuousRenderingOnPause;
+		boolean isContinuousEnforced = AndroidGraphics.enforceContinuousRendering;
 
 		// from here we don't want non continuous rendering
-		AndroidGraphics.enforceContinuousRenderingOnPause = true;
+		AndroidGraphics.enforceContinuousRendering = true;
 		graphics.setContinuousRendering(true);
 		// calls to setContinuousRendering(false) from other thread (ex: GLThread)
 		// will be ignored at this point...
@@ -273,7 +273,7 @@ public class AndroidApplication extends Activity implements AndroidApplicationBa
 			graphics.destroy();
 		}
 
-		AndroidGraphics.enforceContinuousRenderingOnPause = isContinuousEnforced;
+		AndroidGraphics.enforceContinuousRendering = isContinuousEnforced;
 		graphics.setContinuousRendering(isContinuous);
 
 		graphics.onPauseGLSurfaceView();

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidFragmentApplication.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidFragmentApplication.java
@@ -202,10 +202,10 @@ public class AndroidFragmentApplication extends Fragment implements AndroidAppli
 	@Override
 	public void onPause () {
 		boolean isContinuous = graphics.isContinuousRendering();
-		boolean isContinuousEnforced = AndroidGraphics.enforceContinuousRenderingOnPause;
+		boolean isContinuousEnforced = AndroidGraphics.enforceContinuousRendering;
 
 		// from here we don't want non continuous rendering
-		AndroidGraphics.enforceContinuousRenderingOnPause = true;
+		AndroidGraphics.enforceContinuousRendering = true;
 		graphics.setContinuousRendering(true);
 		// calls to setContinuousRendering(false) from other thread (ex: GLThread)
 		// will be ignored at this point...
@@ -220,7 +220,7 @@ public class AndroidFragmentApplication extends Fragment implements AndroidAppli
 			graphics.destroy();
 		}
 
-		AndroidGraphics.enforceContinuousRenderingOnPause = isContinuousEnforced;
+		AndroidGraphics.enforceContinuousRendering = isContinuousEnforced;
 		graphics.setContinuousRendering(isContinuous);
 
 		graphics.onPauseGLSurfaceView();

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphics.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphics.java
@@ -62,7 +62,7 @@ public class AndroidGraphics implements Graphics, Renderer {
 	 * be called in the GLThread while {@link #pause()} is sleeping in the Android UI Thread which will cause the
 	 * {@link AndroidGraphics#pause} variable never be set to false. As a result, the {@link AndroidGraphics#pause()} method will
 	 * kill the current process to avoid ANR */
-	static volatile boolean enforceContinuousRenderingOnPause = false;
+	static volatile boolean enforceContinuousRendering = false;
 
 	final View view;
 	int width;
@@ -583,7 +583,7 @@ public class AndroidGraphics implements Graphics, Renderer {
 	public void setContinuousRendering (boolean isContinuous) {
 		if (view != null) {
 			// ignore setContinuousRendering(false) while pausing
-			this.isContinuous = enforceContinuousRenderingOnPause || isContinuous;
+			this.isContinuous = enforceContinuousRendering || isContinuous;
 			int renderMode = this.isContinuous ? GLSurfaceView.RENDERMODE_CONTINUOUSLY : GLSurfaceView.RENDERMODE_WHEN_DIRTY;
 			if (view instanceof GLSurfaceViewAPI18) ((GLSurfaceViewAPI18)view).setRenderMode(renderMode);
 			if (view instanceof GLSurfaceView) ((GLSurfaceView)view).setRenderMode(renderMode);


### PR DESCRIPTION
Backends takes care to setContinuousRendering(true) before calling AndroidGraphics#pause() in their #onPause() method. The problem is that the #onPause() method of the backends are called from the Android UI Thread so a call to AndroidGraphics#onDrawFrame(GL10) may occur (on the GLThread) between those calls :
-  graphics.setContinuousRendering(true)
-  graphics.pause();

AndroidGraphics#onDrawFrame(GL10) may call the ApplicationListener#render() method in the meantime that could set continuous rendering to false as discussed in #2461 

Thus very unlikely, it might appen if the GLThread has the lock on the AndroidGraphics#synch var in the onDrawFrame(GL10) while the UI Thread wait for it in the pause() method... Then the pause() method will set the AndroidGraphics#pause var to true which will never get back to false (it get false in onDrawFrame(GL10) which will never be called as we switch to non continuous rendering...)

hope i'm clear ;-)
