### PR TITLE
Make iPhone 6+ behave more sensibly.

### DIFF
--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
@@ -246,6 +246,7 @@ public class IOSGraphics extends NSObject implements Graphics, GLKViewDelegate, 
 
 		app.debug(tag, "Calculating density, UIScreen.mainScreen.scale: " + scale);
 		if (scale == 2) density = 2f;
+		if (scale == 3) density = 3f;
 
 		int ppi;
 		if (UIDevice.getCurrentDevice().getUserInterfaceIdiom() == UIUserInterfaceIdiom.Pad) {


### PR DESCRIPTION
The iPhone 6+ behaves badly without this.  It returns a density of 1 which makes apps think its a very very large screen (vs a regular screen with very small pixels). Note that this also affects ppiX & ppiY (et al), but in an appropriate way.

This is not a perfect fix for density on iOS, but it's a decent bandaid for now.
