### PR TITLE
Fix IOSGraphics density by simply setting density == scale for all cases

### DIFF
--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
@@ -241,12 +241,8 @@ public class IOSGraphics extends NSObject implements Graphics, GLKViewDelegate, 
 		bufferFormat = new BufferFormat(r, g, b, a, depth, stencil, samples, false);
 		this.gl20 = gl20;
 
-		// determine display density and PPI (PPI values via Wikipedia!)
-		density = 1f;
-
 		app.debug(tag, "Calculating density, UIScreen.mainScreen.scale: " + scale);
-		if (scale == 2) density = 2f;
-		if (scale == 3) density = 3f;
+    density = scale;
 
 		int ppi;
 		if (UIDevice.getCurrentDevice().getUserInterfaceIdiom() == UIUserInterfaceIdiom.Pad) {


### PR DESCRIPTION
This change will remove complexity around calculating density, and uses the non-integer scale values that are calculated elsewhere using UIScreen.nativeScale

iPhone 6 in zoomed mode and iPhone 6+ in zoomed or regular mode never have an integer scale in practice, at least not nativeScale which is what is relevant for OpenGl.
