### PR TITLE
Add isOnscreenKeyboardVisisble to Input. Fix closing keyboard in iOS

### DIFF
--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSApplicationConfiguration.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSApplicationConfiguration.java
@@ -89,4 +89,7 @@ public class IOSApplicationConfiguration {
 
 	/** whether or not to allow background music from iPod **/
 	public boolean allowIpod = false;
+	
+	/** whether or not the onScreenKeyboard should be closed on return key **/
+	public boolean keyboardCloseOnReturn = true;
 }


### PR DESCRIPTION
- Creates getter for UITextField on iOS for customization of the keyboard
- Adds method `setKeyboardCloseOnReturnKey (boolean shouldClose)` to IOSInput
- Adds boolean entry `keyboardCloseOnReturn` in `IOSApplicationConfiguration`
- Throws keyDown and keyTyped event for the shouldClose event

Related PR #2211 
