### PR TITLE
Add support for converting popular Android ARGB8888 format

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/Color.java
+++ b/gdx/src/com/badlogic/gdx/graphics/Color.java
@@ -392,6 +392,10 @@ public class Color {
 		return ((int)(color.r * 255) << 24) | ((int)(color.g * 255) << 16) | ((int)(color.b * 255) << 8) | (int)(color.a * 255);
 	}
 
+	public static int argb8888 (Color color) {
+		return ((int)(color.a * 255) << 24) | ((int)(color.r * 255) << 16) | ((int)(color.g * 255) << 8) | (int)(color.b * 255);
+	}
+
 	/** Sets the Color components using the specified integer value in the format RGB565. This is inverse to the rgb565(r, g, b)
 	 * method.
 	 * 
@@ -436,6 +440,18 @@ public class Color {
 		color.g = ((value & 0x00ff0000) >>> 16) / 255f;
 		color.b = ((value & 0x0000ff00) >>> 8) / 255f;
 		color.a = ((value & 0x000000ff)) / 255f;
+	}
+
+	/** Sets the Color components using the specified integer value in the format ARGB8888. This is the inverse to the argb8888(a, r,
+     * g, b) method
+	 *
+	 * @param color The Color to be modified.
+	 * @param value An integer color value in ARGB8888 format. */
+	public static void argb8888ToColor(Color color, int value) {
+		color.a = ((value & 0xff000000) >>> 24) / 255f;
+		color.r = ((value & 0x00ff0000) >>> 16) / 255f;
+		color.g = ((value & 0x0000ff00) >>> 8) / 255f;
+		color.b = ((value & 0x000000ff)) / 255f;
 	}
 
 	/** Returns a temporary copy of this color. This is not thread safe, do not save a reference to this instance.


### PR DESCRIPTION
As requested, replaces PR #2410 with a clean change history.

In a recent code review, I found two versions of this function in my code, so I thought it might be a useful addition. My code originally was Android-only before porting to libGDX, so perhaps others will be in this same situation and will find it convenient.
