### PR TITLE
Added renderObjects() to TiledMapRenderer

### DIFF
--- a/gdx/src/com/badlogic/gdx/maps/tiled/TiledMapRenderer.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/TiledMapRenderer.java
@@ -16,14 +16,12 @@
 
 package com.badlogic.gdx.maps.tiled;
 
-import static com.badlogic.gdx.graphics.g2d.SpriteBatch.*;
-
-import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
+import com.badlogic.gdx.maps.MapLayer;
 import com.badlogic.gdx.maps.MapObject;
 import com.badlogic.gdx.maps.MapRenderer;
-import com.badlogic.gdx.math.Polygon;
 
 public interface TiledMapRenderer extends MapRenderer {
+	public void renderObjects (MapLayer layer);
 	public void renderObject (MapObject object);
 
 	public void renderTileLayer (TiledMapTileLayer layer);

--- a/gdx/src/com/badlogic/gdx/maps/tiled/renderers/BatchTiledMapRenderer.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/renderers/BatchTiledMapRenderer.java
@@ -108,9 +108,7 @@ public abstract class BatchTiledMapRenderer implements TiledMapRenderer, Disposa
 				if (layer instanceof TiledMapTileLayer) {
 					renderTileLayer((TiledMapTileLayer)layer);
 				} else {
-					for (MapObject object : layer.getObjects()) {
-						renderObject(object);
-					}
+					renderObjects(layer);
 				}
 			}
 		}
@@ -126,13 +124,23 @@ public abstract class BatchTiledMapRenderer implements TiledMapRenderer, Disposa
 				if (layer instanceof TiledMapTileLayer) {
 					renderTileLayer((TiledMapTileLayer)layer);
 				} else {
-					for (MapObject object : layer.getObjects()) {
-						renderObject(object);
-					}
+					renderObjects(layer);
 				}
 			}
 		}
 		endRender();
+	}
+
+	@Override
+	public void renderObjects(MapLayer layer) {
+		for (MapObject object : layer.getObjects()) {
+			renderObject(object);
+		}
+	}
+
+	@Override
+	public void renderObject(MapObject object) {
+
 	}
 
 	/** Called before the rendering of all layers starts. */

--- a/gdx/src/com/badlogic/gdx/maps/tiled/renderers/HexagonalTiledMapRenderer.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/renderers/HexagonalTiledMapRenderer.java
@@ -21,7 +21,6 @@ import static com.badlogic.gdx.graphics.g2d.Batch.*;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.g2d.Batch;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
-import com.badlogic.gdx.maps.MapObject;
 import com.badlogic.gdx.maps.tiled.TiledMap;
 import com.badlogic.gdx.maps.tiled.TiledMapTile;
 import com.badlogic.gdx.maps.tiled.TiledMapTileLayer;
@@ -159,11 +158,5 @@ public class HexagonalTiledMapRenderer extends BatchTiledMapRenderer {
 				}
 			}
 		}
-
-	}
-
-	@Override
-	public void renderObject (MapObject object) {
-
 	}
 }

--- a/gdx/src/com/badlogic/gdx/maps/tiled/renderers/IsometricStaggeredTiledMapRenderer.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/renderers/IsometricStaggeredTiledMapRenderer.java
@@ -20,9 +20,7 @@ import static com.badlogic.gdx.graphics.g2d.SpriteBatch.*;
 
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.g2d.Batch;
-import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
-import com.badlogic.gdx.maps.MapObject;
 import com.badlogic.gdx.maps.tiled.TiledMap;
 import com.badlogic.gdx.maps.tiled.TiledMapTile;
 import com.badlogic.gdx.maps.tiled.TiledMapTileLayer;
@@ -44,11 +42,6 @@ public class IsometricStaggeredTiledMapRenderer extends BatchTiledMapRenderer {
 
 	public IsometricStaggeredTiledMapRenderer (TiledMap map, float unitScale, Batch batch) {
 		super(map, unitScale, batch);
-	}
-
-	@Override
-	public void renderObject (MapObject object) {
-
 	}
 
 	@Override

--- a/gdx/src/com/badlogic/gdx/maps/tiled/renderers/IsometricTiledMapRenderer.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/renderers/IsometricTiledMapRenderer.java
@@ -21,12 +21,10 @@ import static com.badlogic.gdx.graphics.g2d.Batch.*;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.g2d.Batch;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
-import com.badlogic.gdx.maps.MapObject;
 import com.badlogic.gdx.maps.tiled.TiledMap;
 import com.badlogic.gdx.maps.tiled.TiledMapTile;
 import com.badlogic.gdx.maps.tiled.TiledMapTileLayer;
 import com.badlogic.gdx.maps.tiled.TiledMapTileLayer.Cell;
-import com.badlogic.gdx.maps.tiled.renderers.BatchTiledMapRenderer;
 import com.badlogic.gdx.math.Matrix4;
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.math.Vector3;
@@ -74,11 +72,6 @@ public class IsometricTiledMapRenderer extends BatchTiledMapRenderer {
 		// ... and the inverse matrix
 		invIsotransform = new Matrix4(isoTransform);
 		invIsotransform.inv();
-	}
-
-	@Override
-	public void renderObject (MapObject object) {
-
 	}
 
 	private Vector3 translateScreenToIso (Vector2 vec) {

--- a/gdx/src/com/badlogic/gdx/maps/tiled/renderers/OrthoCachedTiledMapRenderer.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/renderers/OrthoCachedTiledMapRenderer.java
@@ -142,9 +142,7 @@ public class OrthoCachedTiledMapRenderer implements TiledMapRenderer, Disposable
 			MapLayer layer = mapLayers.get(i);
 			if (layer.isVisible()) {
 				spriteCache.draw(i);
-				for (MapObject object : layer.getObjects()) {
-					renderObject(object);
-				}
+				renderObjects(layer);
 			}
 		}
 		spriteCache.end();
@@ -184,13 +182,18 @@ public class OrthoCachedTiledMapRenderer implements TiledMapRenderer, Disposable
 			MapLayer layer = mapLayers.get(i);
 			if (layer.isVisible()) {
 				spriteCache.draw(i);
-				for (MapObject object : layer.getObjects()) {
-					renderObject(object);
-				}
+				renderObjects(layer);
 			}
 		}
 		spriteCache.end();
 		if (blending) Gdx.gl.glDisable(GL20.GL_BLEND);
+	}
+
+	@Override
+	public void renderObjects (MapLayer layer) {
+		for (MapObject object : layer.getObjects()) {
+			renderObject(object);
+		}
 	}
 
 	@Override

--- a/gdx/src/com/badlogic/gdx/maps/tiled/renderers/OrthogonalTiledMapRenderer.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/renderers/OrthogonalTiledMapRenderer.java
@@ -40,7 +40,6 @@ import static com.badlogic.gdx.graphics.g2d.Batch.Y4;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.g2d.Batch;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
-import com.badlogic.gdx.maps.MapObject;
 import com.badlogic.gdx.maps.tiled.TiledMap;
 import com.badlogic.gdx.maps.tiled.TiledMapTile;
 import com.badlogic.gdx.maps.tiled.TiledMapTileLayer;
@@ -62,11 +61,6 @@ public class OrthogonalTiledMapRenderer extends BatchTiledMapRenderer {
 
 	public OrthogonalTiledMapRenderer (TiledMap map, float unitScale, Batch batch) {
 		super(map, unitScale, batch);
-	}
-
-	@Override
-	public void renderObject (MapObject object) {
-
 	}
 
 	@Override


### PR DESCRIPTION
This is a very simple change. Instead of just calling `renderObject(object)` on the `TiledMapRenderer` on a loop for every layer, I created `renderObjects(layer)`, that contains the loop and calls `renderObject(object)`. This allows you to do any pre and post preparations before rendering the objects (like setting and restoring some values on the `spriteBatch`, my use case, but I'm sure I'll use it for more than that)

I also removed the extended `renderObject` on every subclass and added it only to the abstract base classes
