### PR TITLE
rearrange Screen methods to represent the android lifecycle better

### DIFF
--- a/gdx/src/com/badlogic/gdx/Screen.java
+++ b/gdx/src/com/badlogic/gdx/Screen.java
@@ -24,6 +24,10 @@ package com.badlogic.gdx;
  * </p>
  * @see Game */
 public interface Screen {
+	
+	/** Called when this screen becomes the current screen for a {@link Game}. */
+	public void show ();
+	
 	/** Called when the screen should render itself.
 	 * @param delta The time in seconds since the last render. */
 	public void render (float delta);
@@ -31,17 +35,14 @@ public interface Screen {
 	/** @see ApplicationListener#resize(int, int) */
 	public void resize (int width, int height);
 
-	/** Called when this screen becomes the current screen for a {@link Game}. */
-	public void show ();
-
-	/** Called when this screen is no longer the current screen for a {@link Game}. */
-	public void hide ();
-
 	/** @see ApplicationListener#pause() */
 	public void pause ();
 
 	/** @see ApplicationListener#resume() */
 	public void resume ();
+
+	/** Called when this screen is no longer the current screen for a {@link Game}. */
+	public void hide ();
 
 	/** Called when this screen should release all resources. */
 	public void dispose ();


### PR DESCRIPTION
Whenever I make a screen I end up rearranging these, as eclipse imports them in the same order as defined in the interface.

Not sure if this is helpful at all, but I find it better now :)
