### PR TITLE
Allow libgdx to function under 3.2 core profile on desktop.

### DIFF
--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGraphics.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGraphics.java
@@ -434,8 +434,23 @@ public class LwjglGraphics implements Graphics {
 	}
 
 	@Override
-	public boolean supportsExtension (String extension) {
-		if (extensions == null) extensions = gl20.glGetString(GL20.GL_EXTENSIONS);
+	public boolean supportsExtension(String extension) {
+		if (extensions == null) {
+			if(gl30 != null) {
+				//old style glGetString(GL_EXTENSIONS) is not valid in 3.2 core:
+				StringBuilder extensionsBuilder = new StringBuilder();
+
+				int numExtensions = GL11.glGetInteger(GL30.GL_NUM_EXTENSIONS);
+				for (int i = 0; i < numExtensions; ++i) {
+					extensionsBuilder.append(gl30.glGetStringi(GL20.GL_EXTENSIONS, i));
+					extensionsBuilder.append(" ");
+				}
+				extensions = extensionsBuilder.toString();
+			} else {
+				extensions = gl20.glGetString(GL20.GL_EXTENSIONS);
+			}
+		}
+
 		return extensions.contains(extension);
 	}
 

--- a/gdx/src/com/badlogic/gdx/graphics/GL20.java
+++ b/gdx/src/com/badlogic/gdx/graphics/GL20.java
@@ -626,6 +626,11 @@ public interface GL20 {
 
 	public void glVertexAttrib4fv (int indx, FloatBuffer values);
 
+	/**
+	 * In OpenGl core profiles (3.1+), passing a pointer to client memory is not valid.
+	 * In 3.0 and later, use the other version of this function instead, pass a zero-based
+	 * offset which references the buffer currently bound to GL_ARRAY_BUFFER.
+	 */
 	public void glVertexAttribPointer (int indx, int size, int type, boolean normalized, int stride, Buffer ptr);
 
 	public void glVertexAttribPointer (int indx, int size, int type, boolean normalized, int stride, int ptr);

--- a/gdx/src/com/badlogic/gdx/graphics/GL30.java
+++ b/gdx/src/com/badlogic/gdx/graphics/GL30.java
@@ -19,6 +19,8 @@
 
 package com.badlogic.gdx.graphics;
 
+import java.nio.Buffer;
+
 /** OpenGL ES 3.0 */
 public interface GL30 extends GL20 {
 	public final int GL_READ_BUFFER = 0x0C02;
@@ -1395,4 +1397,12 @@ public interface GL30 extends GL20 {
 // java.nio.IntBuffer params
 // );
 
+	@Override
+	@Deprecated
+	/**
+	 * In OpenGl core profiles (3.1+), passing a pointer to client memory is not valid.
+	 * Use the other version of this function instead, pass a zero-based offset which references
+	 * the buffer currently bound to GL_ARRAY_BUFFER.
+	 */
+	void glVertexAttribPointer(int indx, int size, int type, boolean normalized, int stride, Buffer ptr);
 }

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/PolygonSpriteBatch.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/PolygonSpriteBatch.java
@@ -114,7 +114,11 @@ public class PolygonSpriteBatch implements Batch {
 		// 32767 is max index, so 32767 / 3 - (32767 / 3 % 3) = 10920.
 		if (size > 10920) throw new IllegalArgumentException("Can't have more than 10920 triangles per batch: " + size);
 
-		mesh = new Mesh(VertexDataType.VertexArray, false, size, size * 3, new VertexAttribute(Usage.Position, 2,
+		Mesh.VertexDataType vertexDataType = Mesh.VertexDataType.VertexArray;
+		if (Gdx.gl30 != null) {
+			vertexDataType = VertexDataType.VertexBufferObjectWithVAO;
+		}
+		mesh = new Mesh(vertexDataType, false, size, size * 3, new VertexAttribute(Usage.Position, 2,
 			ShaderProgram.POSITION_ATTRIBUTE), new VertexAttribute(Usage.ColorPacked, 4, ShaderProgram.COLOR_ATTRIBUTE),
 			new VertexAttribute(Usage.TextureCoordinates, 2, ShaderProgram.TEXCOORD_ATTRIBUTE + "0"));
 

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/SpriteBatch.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/SpriteBatch.java
@@ -92,7 +92,11 @@ public class SpriteBatch implements Batch {
 		// 32767 is max index, so 32767 / 6 - (32767 / 6 % 3) = 5460.
 		if (size > 5460) throw new IllegalArgumentException("Can't have more than 5460 sprites per batch: " + size);
 
-		mesh = new Mesh(VertexDataType.VertexArray, false, size * 4, size * 6, new VertexAttribute(Usage.Position, 2,
+		Mesh.VertexDataType vertexDataType = Mesh.VertexDataType.VertexArray;
+		if (Gdx.gl30 != null) {
+			vertexDataType = Mesh.VertexDataType.VertexBufferObjectWithVAO;
+		}
+		mesh = new Mesh(vertexDataType, false, size * 4, size * 6, new VertexAttribute(Usage.Position, 2,
 			ShaderProgram.POSITION_ATTRIBUTE), new VertexAttribute(Usage.ColorPacked, 4, ShaderProgram.COLOR_ATTRIBUTE),
 			new VertexAttribute(Usage.TextureCoordinates, 2, ShaderProgram.TEXCOORD_ATTRIBUTE + "0"));
 

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/decals/DecalBatch.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/decals/DecalBatch.java
@@ -16,6 +16,7 @@
 
 package com.badlogic.gdx.graphics.g3d.decals;
 
+import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Mesh;
 import com.badlogic.gdx.graphics.VertexAttribute;
@@ -86,10 +87,15 @@ public class DecalBatch implements Disposable {
 	 * @param size Maximum size of decal objects to hold in memory */
 	public void initialize (int size) {
 		vertices = new float[size * Decal.SIZE];
-		mesh = new Mesh(Mesh.VertexDataType.VertexArray, false, size * 4, size * 6, new VertexAttribute(
-			VertexAttributes.Usage.Position, 3, ShaderProgram.POSITION_ATTRIBUTE), new VertexAttribute(
-			VertexAttributes.Usage.ColorPacked, 4, ShaderProgram.COLOR_ATTRIBUTE), new VertexAttribute(
-			VertexAttributes.Usage.TextureCoordinates, 2, ShaderProgram.TEXCOORD_ATTRIBUTE + "0"));
+
+		Mesh.VertexDataType vertexDataType = Mesh.VertexDataType.VertexArray;
+		if(Gdx.gl30 != null) {
+			vertexDataType = Mesh.VertexDataType.VertexBufferObjectWithVAO;
+		}
+		mesh = new Mesh(vertexDataType, false, size * 4, size * 6, new VertexAttribute(
+				VertexAttributes.Usage.Position, 3, ShaderProgram.POSITION_ATTRIBUTE), new VertexAttribute(
+				VertexAttributes.Usage.ColorPacked, 4, ShaderProgram.COLOR_ATTRIBUTE), new VertexAttribute(
+				VertexAttributes.Usage.TextureCoordinates, 2, ShaderProgram.TEXCOORD_ATTRIBUTE + "0"));
 
 		short[] indices = new short[size * 6];
 		int v = 0;

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/VertexArray.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/VertexArray.java
@@ -19,11 +19,9 @@ package com.badlogic.gdx.graphics.glutils;
 import java.nio.ByteBuffer;
 import java.nio.FloatBuffer;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.VertexAttribute;
 import com.badlogic.gdx.graphics.VertexAttributes;
-import com.badlogic.gdx.graphics.VertexAttributes.Usage;
 import com.badlogic.gdx.utils.BufferUtils;
 
 /** <p>
@@ -32,7 +30,7 @@ import com.badlogic.gdx.utils.BufferUtils;
  * </p>
  * 
  * <p>
- * This class does not support shaders and for that matter OpenGL ES 2.0. For this {@link VertexBufferObject}s are needed.
+ * This class is not compatible with OpenGL 3+ core profiles. For this {@link VertexBufferObject}s are needed.
  * </p>
  * 
  * @author mzechner, Dave Clayton <contact@redskyforge.com> */
@@ -103,7 +101,6 @@ public class VertexArray implements VertexData {
 
 	@Override
 	public void bind (final ShaderProgram shader, final int[] locations) {
-		final GL20 gl = Gdx.gl20;
 		final int numAttributes = attributes.size();
 		byteBuffer.limit(buffer.limit() * 4);
 		if (locations == null) {
@@ -154,7 +151,6 @@ public class VertexArray implements VertexData {
 
 	@Override
 	public void unbind (ShaderProgram shader, int[] locations) {
-		final GL20 gl = Gdx.gl20;
 		final int numAttributes = attributes.size();
 		if (locations == null) {
 			for (int i = 0; i < numAttributes; i++) {

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/VertexBufferObjectWithVAO.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/VertexBufferObjectWithVAO.java
@@ -1,0 +1,251 @@
+package com.badlogic.gdx.graphics.glutils;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.GL30;
+import com.badlogic.gdx.graphics.VertexAttribute;
+import com.badlogic.gdx.graphics.VertexAttributes;
+import com.badlogic.gdx.utils.BufferUtils;
+
+import java.nio.ByteBuffer;
+import java.nio.FloatBuffer;
+import java.nio.IntBuffer;
+
+/**
+ * <p>
+ * A {@link VertexData} implementation that uses vertex buffer objects and vertex array objects.
+ * (This is required for OpenGL 3.0+ core profiles. In particular, the default VAO has been
+ * deprecated, as has the use of client memory for passing vertex attributes.) Use of VAOs should
+ * give a slight performance benefit since you don't have to bind the attributes on every draw
+ * anymore.
+ * </p>
+ *
+ * <p>
+ * If the OpenGL ES context was lost you can call {@link #invalidate()} to recreate a new OpenGL vertex buffer object.
+ * </p>
+ *
+ * <p>
+ * VertexBufferObjectWithVAO objects must be disposed via the {@link #dispose()} method when no longer needed
+ * </p>
+ *
+ * Code adapted from {@link VertexBufferObject}.
+ * @author mzechner, Dave Clayton <contact@redskyforge.com>, Nate Austin <nate.austin gmail>
+ */
+public class VertexBufferObjectWithVAO implements VertexData {
+	final static IntBuffer tmpHandle = BufferUtils.newIntBuffer(1);
+
+	final VertexAttributes attributes;
+	final FloatBuffer buffer;
+	final ByteBuffer byteBuffer;
+	int bufferHandle;
+	final boolean isStatic;
+	final int usage;
+	boolean isDirty = false;
+	boolean isBound = false;
+	boolean vaoDirty = true;
+	int vaoHandle = -1;
+
+
+	/**
+	 * Constructs a new interleaved VertexBufferObjectWithVAO.
+	 *
+	 * @param isStatic    whether the vertex data is static.
+	 * @param numVertices the maximum number of vertices
+	 * @param attributes  the {@link com.badlogic.gdx.graphics.VertexAttribute}s.
+	 */
+	public VertexBufferObjectWithVAO(boolean isStatic, int numVertices, VertexAttribute... attributes) {
+		this(isStatic, numVertices, new VertexAttributes(attributes));
+	}
+
+	/**
+	 * Constructs a new interleaved VertexBufferObjectWithVAO.
+	 *
+	 * @param isStatic    whether the vertex data is static.
+	 * @param numVertices the maximum number of vertices
+	 * @param attributes  the {@link VertexAttributes}.
+	 */
+	public VertexBufferObjectWithVAO(boolean isStatic, int numVertices, VertexAttributes attributes) {
+		this.isStatic = isStatic;
+		this.attributes = attributes;
+
+		byteBuffer = BufferUtils.newUnsafeByteBuffer(this.attributes.vertexSize * numVertices);
+		buffer = byteBuffer.asFloatBuffer();
+		buffer.flip();
+		byteBuffer.flip();
+		bufferHandle = createBufferObject();
+		usage = isStatic ? GL20.GL_STATIC_DRAW : GL20.GL_DYNAMIC_DRAW;
+	}
+
+	private int createBufferObject() {
+		Gdx.gl20.glGenBuffers(1, tmpHandle);
+		return tmpHandle.get(0);
+	}
+
+	@Override
+	public VertexAttributes getAttributes() {
+		return attributes;
+	}
+
+	@Override
+	public int getNumVertices() {
+		return buffer.limit() * 4 / attributes.vertexSize;
+	}
+
+	@Override
+	public int getNumMaxVertices() {
+		return byteBuffer.capacity() / attributes.vertexSize;
+	}
+
+	@Override
+	public FloatBuffer getBuffer() {
+		isDirty = true;
+		return buffer;
+	}
+
+	private void bufferChanged() {
+		if (isBound) {
+			Gdx.gl20.glBufferData(GL20.GL_ARRAY_BUFFER, byteBuffer.limit(), byteBuffer, usage);
+			isDirty = false;
+		}
+	}
+
+	@Override
+	public void setVertices(float[] vertices, int offset, int count) {
+		isDirty = true;
+		BufferUtils.copy(vertices, byteBuffer, count, offset);
+		buffer.position(0);
+		buffer.limit(count);
+		bufferChanged();
+	}
+
+	@Override
+	public void updateVertices(int targetOffset, float[] vertices, int sourceOffset, int count) {
+		isDirty = true;
+		final int pos = byteBuffer.position();
+		byteBuffer.position(targetOffset * 4);
+		BufferUtils.copy(vertices, sourceOffset, count, byteBuffer);
+		byteBuffer.position(pos);
+		buffer.position(0);
+		bufferChanged();
+	}
+
+	/**
+	 * Binds this VertexBufferObject for rendering via glDrawArrays or glDrawElements
+	 *
+	 * @param shader the shader
+	 */
+	@Override
+	public void bind(ShaderProgram shader) {
+		bind(shader, null);
+	}
+
+	@Override
+	public void bind(ShaderProgram shader, int[] locations) {
+		GL30 gl = Gdx.gl30;
+		if (vaoDirty || !gl.glIsVertexArray(vaoHandle)) {
+			tmpHandle.clear();
+			gl.glGenVertexArrays(1, tmpHandle);
+			vaoHandle = tmpHandle.get(0);
+			gl.glBindVertexArray(vaoHandle);
+
+			//initialize the VAO with our vertex attributes and buffer:
+			bindAttributes(shader, locations);
+			vaoDirty = false;
+
+		} else {
+			//else simply bind the VAO.
+			gl.glBindVertexArray(vaoHandle);
+		}
+		//if our data has changed upload it:
+		bindData(gl);
+
+		isBound = true;
+	}
+
+	private void bindAttributes(ShaderProgram shader, int[] locations) {
+		final GL20 gl = Gdx.gl20;
+		gl.glBindBuffer(GL20.GL_ARRAY_BUFFER, bufferHandle);
+		final int numAttributes = attributes.size();
+		if (locations == null) {
+			for (int i = 0; i < numAttributes; i++) {
+				final VertexAttribute attribute = attributes.get(i);
+				final int location = shader.getAttributeLocation(attribute.alias);
+				if (location < 0) continue;
+				shader.enableVertexAttribute(location);
+
+				shader.setVertexAttribute(location, attribute.numComponents, attribute.type, attribute.normalized, attributes.vertexSize,
+						attribute.offset);
+			}
+
+		} else {
+			for (int i = 0; i < numAttributes; i++) {
+				final VertexAttribute attribute = attributes.get(i);
+				final int location = locations[i];
+				if (location < 0) continue;
+				shader.enableVertexAttribute(location);
+
+				shader.setVertexAttribute(location, attribute.numComponents, attribute.type, attribute.normalized, attributes.vertexSize,
+						attribute.offset);
+			}
+		}
+	}
+
+	private void bindData(GL20 gl) {
+		if (isDirty) {
+			gl.glBindBuffer(GL20.GL_ARRAY_BUFFER, bufferHandle);
+			byteBuffer.limit(buffer.limit() * 4);
+			gl.glBufferData(GL20.GL_ARRAY_BUFFER, byteBuffer.limit(), byteBuffer, usage);
+			isDirty = false;
+		}
+	}
+
+	/**
+	 * Unbinds this VertexBufferObject.
+	 *
+	 * @param shader the shader
+	 */
+	@Override
+	public void unbind(final ShaderProgram shader) {
+		unbind(shader, null);
+	}
+
+	@Override
+	public void unbind(final ShaderProgram shader, final int[] locations) {
+		GL30 gl = Gdx.gl30;
+		gl.glBindVertexArray(0);
+		isBound = false;
+	}
+
+	//TODO: should invalidate be added to the VertexData interface?
+	/**
+	 * Invalidates the VertexBufferObject so a new OpenGL buffer handle is created. Use this in case of a context loss.
+	 */
+	public void invalidate() {
+		bufferHandle = createBufferObject();
+		isDirty = true;
+		vaoDirty = true;
+	}
+
+	/**
+	 * Disposes of all resources this VertexBufferObject uses.
+	 */
+	@Override
+	public void dispose() {
+		GL30 gl = Gdx.gl30;
+		tmpHandle.clear();
+		tmpHandle.put(bufferHandle);
+		tmpHandle.flip();
+
+		gl.glBindBuffer(GL20.GL_ARRAY_BUFFER, 0);
+		gl.glDeleteBuffers(1, tmpHandle);
+		bufferHandle = 0;
+		BufferUtils.disposeUnsafeByteBuffer(byteBuffer);
+
+		if (gl.glIsVertexArray(vaoHandle)) {
+			tmpHandle.clear();
+			tmpHandle.put(vaoHandle);
+			tmpHandle.flip();
+			gl.glDeleteVertexArrays(1, tmpHandle);
+		}
+	}
+}


### PR DESCRIPTION
In core profiles glGetString(GL_EXTENSIONS) is deprecated, so a new mechanism is used to test for extensions.

In core profiles VAOs are mandatory, and VertexAttribPointer cannot use
client memory, so I introduced a parallel VertexData implementation,
VertexBufferObjectWithVAO, that is used when gl3 is available.

I have tested on my windows desktop. This fixes the behavior of SpriteBatch and works with my plain Meshes and Shaders. Everything appears to be working now in the core profile.

I have not tested on mac or mobile.