### PR TITLE
correct color scaling in vertex shader

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g2d/SpriteBatch.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/SpriteBatch.java
@@ -132,7 +132,7 @@ public class SpriteBatch implements Batch {
 			+ "void main()\n" //
 			+ "{\n" //
 			+ "   v_color = " + ShaderProgram.COLOR_ATTRIBUTE + ";\n" //
-			+ "   v_color.a = v_color.a * (256.0/255.0);\n" //
+			+ "   v_color.a = v_color.a * (255.0/254.0);\n" //
 			+ "   v_texCoords = " + ShaderProgram.TEXCOORD_ATTRIBUTE + "0;\n" //
 			+ "   gl_Position =  u_projTrans * " + ShaderProgram.POSITION_ATTRIBUTE + ";\n" //
 			+ "}\n";

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/SpriteCache.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/SpriteCache.java
@@ -983,7 +983,7 @@ public class SpriteCache implements Disposable {
 			+ "void main()\n" //
 			+ "{\n" //
 			+ "   v_color = " + ShaderProgram.COLOR_ATTRIBUTE + ";\n" //
-			+ "   v_color.a = v_color.a * (256.0/255.0);\n" //
+			+ "   v_color.a = v_color.a * (255.0/254.0);\n" //
 			+ "   v_texCoords = " + ShaderProgram.TEXCOORD_ATTRIBUTE + "0;\n" //
 			+ "   gl_Position =  u_projectionViewMatrix * " + ShaderProgram.POSITION_ATTRIBUTE + ";\n" //
 			+ "}\n";


### PR DESCRIPTION
Nitpicking, but fix for #1815 didn't get the ratio exactly right.

```
float truncated = 0xFE / 255.0f;
System.out.println(truncated * (256.0f / 255.0f)); // 0.9999847
System.out.println(truncated * (255.0f / 254.0f)); // 1.0
```
