### PR TITLE
Fixed accuracy of the OpenAL music getPosition() and setPosition() on lwjgl backend

### DIFF
--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/audio/Mp3.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/audio/Mp3.java
@@ -41,9 +41,10 @@ public class Mp3 {
 			if (audio.noDevice) return;
 			bitstream = new Bitstream(file.read());
 			decoder = new MP3Decoder();
+			bufferOverhead = 4096;
 			try {
 				Header header = bitstream.readFrame();
-				if (header == null) throw new GdxRuntimeException("empty ogg");
+				if (header == null) throw new GdxRuntimeException("Empty MP3");
 				int channels = header.mode() == Header.SINGLE_CHANNEL ? 1 : 2;
 				outputBuffer = new OutputBuffer(channels, false);
 				decoder.setOutputBuffer(outputBuffer);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/MusicTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/MusicTest.java
@@ -35,6 +35,7 @@ public class MusicTest extends GdxTest {
 
 	Music music;
 	float songDuration = 183;
+	float currentPosition;
 
 	TextureRegion buttons;
 	SpriteBatch batch;
@@ -80,13 +81,15 @@ public class MusicTest extends GdxTest {
 
 	@Override
 	public void render () {
+		currentPosition = music.getPosition();
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		batch.begin();
 		batch.draw(buttons, 0, 0);
+		font.draw(batch, String.format("%02d:%02d", (int)currentPosition / 60, (int)currentPosition % 60), 365, 35);
 		batch.end();
 
 		sliderUpdating = true;
-		//slider.setValue((music.getPosition() / songDuration) * 100f);
+		slider.setValue((currentPosition / songDuration) * 100f);
 		sliderUpdating = false;
 		stage.act();
 		stage.draw();


### PR DESCRIPTION
This should hopefully fix #2545 and #2546.

I've reworked `setPosition()` to be more accurate and fixed a bug where it actually added the buffer's length to the elapsed time.

I've also found out that calculation for `secondsPerBuffer` was off for MP3 as the decoder apparently requires a 4096 bytes buffer overhead. This caused the reported time from `getPosition()` to become more and more off as the playback went on, and the issue also plagued `setPosition()` who relied on the same numbers for it's positioning. I've taken this overhead into account and the reported position is now spot on.
