### PR TITLE
Fixed "ClassCastException"

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidAudio.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidAudio.java
@@ -120,8 +120,8 @@ public final class AndroidAudio implements Audio {
 	/** {@inheritDoc} */
 	@Override
 	public Sound newSound (FileHandle file) {
-		AndroidFileHandle aHandle = (AndroidFileHandle)file;
-		if (aHandle.type() == FileType.Internal) {
+		if (file.type() == FileType.Internal) {
+			AndroidFileHandle aHandle = (AndroidFileHandle)file;
 			try {
 				AssetFileDescriptor descriptor = aHandle.assets.openFd(aHandle.path());
 				AndroidSound sound = new AndroidSound(soundPool, manager, soundPool.load(descriptor, 1));
@@ -133,7 +133,7 @@ public final class AndroidAudio implements Audio {
 			}
 		} else {
 			try {
-				return new AndroidSound(soundPool, manager, soundPool.load(aHandle.file().getPath(), 1));
+				return new AndroidSound(soundPool, manager, soundPool.load(file.file().getPath(), 1));
 			} catch (Exception ex) {
 				throw new GdxRuntimeException("Error loading audio file: " + file, ex);
 			}


### PR DESCRIPTION
Hello!

Recently I faced to the problem with loading Android audio from custom external FileHandle's using AssetManager. It is custom, because I would like to load audio from external zip archive.

com.badlogic.gdx.utils.GdxRuntimeException: java.lang.ClassCastException: (custom class) cannot be cast to com.badlogic.gdx.backends.android.AndroidFileHandle

If user will create customized `FileHandleResolver`, so `resolve` method will return user `FileHandle`, the android application would crash at `AndroidAudio:144`.

To fix this the class cast should be called after checking if the file is internal.