### PR TITLE
Make sure SelectBox does not use the old scrollToCenter API

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/SelectBox.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/SelectBox.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -404,7 +404,7 @@ public class SelectBox<T> extends Widget implements Disableable {
 			setSize(Math.max(getPrefWidth(), selectBox.getWidth()), height);
 
 			validate();
-			scrollToCenter(0, list.getHeight() - selectBox.getSelectedIndex() * itemHeight - itemHeight / 2, 0, 0);
+			scrollTo(0, list.getHeight() - selectBox.getSelectedIndex() * itemHeight - itemHeight / 2, 0, 0, true, true);
 			updateVisualScroll();
 
 			previousScrollFocus = null;


### PR DESCRIPTION
With 830b1c1, `ScrollPane#scrollToCenter` has been removed, but `SelectBox` still called it in `#show` - this PR fixes it and calls `scrollTo` with `centerHorizontal` and `centerVertical` set to true.
