### PR TITLE
added missing methods to GWT WeldJoint

### DIFF
--- a/extensions/gdx-box2d/gdx-box2d-gwt/src/com/badlogic/gdx/physics/box2d/gwt/emu/com/badlogic/gdx/physics/box2d/joints/WeldJoint.java
+++ b/extensions/gdx-box2d/gdx-box2d-gwt/src/com/badlogic/gdx/physics/box2d/gwt/emu/com/badlogic/gdx/physics/box2d/joints/WeldJoint.java
@@ -47,6 +47,23 @@ public class WeldJoint extends Joint {
 	}
 
 	public float getReferenceAngle () {
-		return 0;
+		return joint.getReferenceAngle();
 	}
+	
+	public float getFrequency () {
+		return joint.getFrequency();
+	}
+	
+	public void setFrequency (float frequencyHz) {
+		joint.setFrequency(frequencyHz);
+	}
+	
+	public float getDampingRatio () {
+		return joint.getDampingRatio();
+	}
+	
+	public void setDampingRatio (float dampingRatio) {
+		joint.setDampingRatio(dampingRatio);
+	}
+	
 }


### PR DESCRIPTION
also fixed getReferenceAngle()
