### PR TITLE
Ignore the gradle-app.setting file.

### DIFF
--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/gitignore
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/gitignore
@@ -57,6 +57,7 @@ nb-configuration.xml
 ## Gradle
 
 .gradle
+gradle-app.setting
 build/
 
 ## OS Specific


### PR DESCRIPTION
I believe this file can be ignored, considering that it's only useful on the machine on which it was created (unless the other users have the same exact path), and it can easily be recreated by running the '--gui' option.

It really has no reason to be there.
