### PR TITLE
Fix potential null pointer in Android fragment's immersive mode implementation

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,7 @@
 - API Change: BatchTiledMapRenderer *SpriteBatch fields and methods renamed to *Batch
 - API Change: ScrollPane#scrollToCenter -> ScrollPane#scrollTo; see optional boolean arguments centerHorizontal and centerVertical (scrollToCenter centered vertically only).
 - API Change: Changed Input#getTextInput to accept both text and hint, removed Input#getPlaceholderTextInput.
+- Bug Fix: Fixed potential NPE with immersive mode in the Android fragment backend. 
 
 [1.4.1]
 - Update to the Gradle Integration plugin nightly build if you are on Eclipse 4.4.x!

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidFragmentApplication.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidFragmentApplication.java
@@ -106,10 +106,10 @@ public class AndroidFragmentApplication extends Fragment implements AndroidAppli
 	@Override
 	public void useImmersiveMode (boolean use) {
 		if (!use || getVersion() < Build.VERSION_CODES.KITKAT) return;
-
-		View view = getApplicationWindow().getDecorView();
-
+		
 		try {
+			View view = this.graphics.getView();
+
 			Method m = View.class.getMethod("setSystemUiVisibility", int.class);
 			int code = View.SYSTEM_UI_FLAG_LAYOUT_STABLE
 						| View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
@@ -119,7 +119,7 @@ public class AndroidFragmentApplication extends Fragment implements AndroidAppli
 						| View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY;
 			m.invoke(view, code);
 		} catch (Exception e) {
-			log("AndroidApplication", "Can't set immersive mode", e);
+			log("AndroidApplication", "Failed to setup immersive mode, a throwable has occurred.", e);
 		}
 	}
 

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidVisibilityListener.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidVisibilityListener.java
@@ -37,7 +37,7 @@ public class AndroidVisibilityListener {
 				}
 			});
 		} catch (Throwable t) {
-			application.log("AndroidApplication", "Can't create OnSystemUiVisibilityChangeListener", t);
+			application.log("AndroidApplication", "Can't create OnSystemUiVisibilityChangeListener, unable to use immersive mode.", t);
 		}
 	}
 }

--- a/tests/gdx-tests-android/src/com/badlogic/gdx/tests/android/FragmentTestStarter.java
+++ b/tests/gdx-tests-android/src/com/badlogic/gdx/tests/android/FragmentTestStarter.java
@@ -132,7 +132,9 @@ public class FragmentTestStarter extends FragmentActivity implements AndroidFrag
 
 		@Override
 		public View onCreateView (LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-			return initializeForView(test, new AndroidApplicationConfiguration());
+			AndroidApplicationConfiguration config = new AndroidApplicationConfiguration();
+			config.useImmersiveMode = true;
+			return initializeForView(test, config);
 		}
 		
 	}


### PR DESCRIPTION
- When immersive mode was implemented in fragments, it worked by getting
  the parent activity's application window's decor view.
- Sometimes getActivity() can return null.
- This patch prevents the application from crashing if the view is null,
  but also uses AndroidGraphics' view for immersive mode.
- Android fragment starter now uses immersive mode by default like
  Android test starter.
- Better exception logging
  This patch resolves #2602

This has been tested on a Nexus 7 2013 running Android 5.0 build LRX21P
