### PR TITLE
Register 3D ParticleEffectLoader by default.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,5 @@
 [1.4.2]
+- API Addition: 3D ParticleEffects now have their ParticleEffectLoader registered by default.
 - API Addition: Added ability to save PixmapPackers to atlas files. See PixmapPackerIO.
 - API Addition: Added HttpRequestHeader and HttpResponseHeader with constants for HTTP headers.
 - API Addition: HttpRequest is now poolable.

--- a/gdx/src/com/badlogic/gdx/assets/AssetManager.java
+++ b/gdx/src/com/badlogic/gdx/assets/AssetManager.java
@@ -93,6 +93,8 @@ public class AssetManager implements Disposable {
 		setLoader(Texture.class, new TextureLoader(resolver));
 		setLoader(Skin.class, new SkinLoader(resolver));
 		setLoader(ParticleEffect.class, new ParticleEffectLoader(resolver));
+		setLoader(com.badlogic.gdx.graphics.g3d.particles.ParticleEffect.class,
+			new com.badlogic.gdx.graphics.g3d.particles.ParticleEffectLoader(resolver));
 		setLoader(PolygonRegion.class, new PolygonRegionLoader(resolver));
 		setLoader(I18NBundle.class, new I18NBundleLoader(resolver));
 		setLoader(Model.class, ".g3dj", new G3dModelLoader(new JsonReader(), resolver));
@@ -127,13 +129,13 @@ public class AssetManager implements Disposable {
 		if (asset == null) throw new GdxRuntimeException("Asset not loaded: " + fileName);
 		return asset;
 	}
-	
+
 	/** @param type the asset type
 	 * @return all the assets matching the specified type */
 	public synchronized <T> Array<T> getAll (Class<T> type, Array<T> out) {
 		ObjectMap<String, RefCountedContainer> assetsByType = assets.get(type);
-		if (assetsByType != null){
-			for(ObjectMap.Entry<String, RefCountedContainer> asset : assetsByType.entries()){
+		if (assetsByType != null) {
+			for (ObjectMap.Entry<String, RefCountedContainer> asset : assetsByType.entries()) {
 				out.add(asset.value.getObject(type));
 			}
 		}
@@ -423,9 +425,9 @@ public class AssetManager implements Disposable {
 			RefCountedContainer assetRef = assets.get(type).get(assetDesc.fileName);
 			assetRef.incRefCount();
 			incrementRefCountedDependencies(assetDesc.fileName);
-            if (assetDesc.params != null && assetDesc.params.loadedCallback != null) {
-                assetDesc.params.loadedCallback.finishedLoading(this, assetDesc.fileName, assetDesc.type);
-            }
+			if (assetDesc.params != null && assetDesc.params.loadedCallback != null) {
+				assetDesc.params.loadedCallback.finishedLoading(this, assetDesc.fileName, assetDesc.type);
+			}
 			loaded++;
 		} else {
 			// else add a new task for the asset.
@@ -572,6 +574,7 @@ public class AssetManager implements Disposable {
 	}
 
 	/** Disposes all assets in the manager and stops all asynchronous loading. */
+	@Override
 	public synchronized void dispose () {
 		log.debug("Disposing.");
 		clear();


### PR DESCRIPTION
The 3D `ParticleEffectLoader` is part of the core and should be registered by default inside the `AssetManager`, just like the 2D version of it.