### PR TITLE
TextField - Repeatable ctrl+v

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextField.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextField.java
@@ -186,7 +186,7 @@ public class TextField extends Widget implements Disableable {
 						// paste
 						if (keycode == Keys.V) {
 							paste();
-							return true;
+							repeat = true;
 						}
 						// copy
 						if (keycode == Keys.C || keycode == Keys.INSERT) {


### PR DESCRIPTION
The actual TextField does not permit to paste repeatedly by keeping pressed the keys, now it does.
