### PR TITLE
Refactor BitmapFontCache color markdown

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFontCache.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFontCache.java
@@ -17,37 +17,24 @@
 package com.badlogic.gdx.graphics.g2d;
 
 import com.badlogic.gdx.graphics.Color;
-import com.badlogic.gdx.graphics.Colors;
 import com.badlogic.gdx.graphics.g2d.BitmapFont.BitmapFontData;
 import com.badlogic.gdx.graphics.g2d.BitmapFont.Glyph;
 import com.badlogic.gdx.graphics.g2d.BitmapFont.HAlignment;
 import com.badlogic.gdx.graphics.g2d.BitmapFont.TextBounds;
-import com.badlogic.gdx.utils.Array;
-import com.badlogic.gdx.utils.GdxRuntimeException;
 import com.badlogic.gdx.utils.IntArray;
 import com.badlogic.gdx.utils.NumberUtils;
-import com.badlogic.gdx.utils.Pool;
-import com.badlogic.gdx.utils.Pool.Poolable;
-import com.badlogic.gdx.utils.StringBuilder;
 
 /** Caches glyph geometry for a BitmapFont, providing a fast way to render static text. This saves needing to compute the location
  * of each glyph each frame.
  * @author Nathan Sweet
  * @author Matthias Mann
- * @author davebaol */
+ * @author davebaol
+ * @author Alexander Dorokhov */
 public class BitmapFontCache {
 
 	private final BitmapFont font;
 
 	private float[][] vertexData;
-
-	private static final Pool<ColorChunk> colorChunkPool = new Pool<ColorChunk>(32) {
-		protected ColorChunk newObject () {
-			return new ColorChunk();
-		}
-	};
-
-	private Array<ColorChunk> colorChunks;
 
 	private int[] idx;
 	/** Used internally to ensure a correct capacity for multi-page font vertex data. */
@@ -56,8 +43,6 @@ public class BitmapFontCache {
 	private float x, y;
 	private float color = Color.WHITE.toFloatBits();
 	private final Color tempColor = new Color(1, 1, 1, 1);
-	private final Color hexColor = new Color();
-	private final StringBuilder colorBuffer = new StringBuilder();
 	private final TextBounds textBounds = new TextBounds();
 	private boolean integer = true;
 	private int glyphCount = 0;
@@ -68,8 +53,10 @@ public class BitmapFontCache {
 
 	private boolean textChanged;
 	private float oldTint = 0;
-	private final Color currentChunkColor = new Color();
-	private int currentChunkEndIndex = 0;
+
+	private TextMarkup markup = new TextMarkup();
+
+	private int charsCount;
 
 	public BitmapFontCache (BitmapFont font) {
 		this(font, font.usesIntegerPositions());
@@ -84,7 +71,6 @@ public class BitmapFontCache {
 		if (regionsLength == 0) throw new IllegalArgumentException("The specified font must contain at least one texture page.");
 
 		this.vertexData = new float[regionsLength][];
-		this.colorChunks = new Array<ColorChunk>();
 
 		this.idx = new int[regionsLength];
 		int vertexDataLength = vertexData.length;
@@ -136,53 +122,13 @@ public class BitmapFontCache {
 		return color;
 	}
 
-	private int updateCurrentChunk (int lastChunkIndex, Color tint) {
-		lastChunkIndex++;
-		if (colorChunks.size <= lastChunkIndex) {
-			if (colorChunks.size <= 0) currentChunkColor.set(tint);
-			currentChunkEndIndex = Integer.MAX_VALUE;
-		} else {
-			ColorChunk cc = colorChunks.get(lastChunkIndex);
-			if (currentChunkEndIndex == cc.endIndex)
-				lastChunkIndex = updateCurrentChunk(lastChunkIndex, tint);
-			else {
-				setColor(currentChunkColor, cc.color).mul(tint);
-				currentChunkEndIndex = cc.endIndex;
-			}
-		}
-		return lastChunkIndex;
-	}
-
 	/** Tints all text currently in the cache. Does not affect subsequently added text. */
 	public void tint (Color tint) {
-		float floatTint = tint.toFloatBits();
+		final float floatTint = tint.toFloatBits();
 		if (textChanged || oldTint != floatTint) {
 			textChanged = false;
 			oldTint = floatTint;
-			if (font.markupEnabled) {
-				int lastChunkIndex = updateCurrentChunk(-1, tint);
-				float color = currentChunkColor.toFloatBits();
-				int ci = 0; // character index
-				for (int j = 0, length = vertexData.length; j < length; j++) {
-					float[] vertices = vertexData[j];
-					for (int i = 2, n = idx[j]; i < n; i += 5) {
-						if ((i % 20) == 2) {
-							if (++ci > currentChunkEndIndex) {
-								lastChunkIndex = updateCurrentChunk(lastChunkIndex, tint);
-								color = currentChunkColor.toFloatBits();
-							}
-						}
-						vertices[i] = color;
-					}
-				}
-			} else {
-				for (int j = 0, length = vertexData.length; j < length; j++) {
-					float[] vertices = vertexData[j];
-					for (int i = 2, n = idx[j]; i < n; i += 5) {
-						vertices[i] = floatTint;
-					}
-				}
-			}
+			markup.tint(this, tint);
 		}
 	}
 
@@ -219,8 +165,12 @@ public class BitmapFontCache {
 	/** Sets the color of the specified characters. This may only be called after {@link #setText(CharSequence, float, float)} and
 	 * is reset every time setText is called. */
 	public void setColors (Color tint, int start, int end) {
-		final float color = tint.toFloatBits();
+		setColors(tint.toFloatBits(), start, end);
+	}
 
+	/** Sets the color of the specified characters. This may only be called after {@link #setText(CharSequence, float, float)} and
+	 * is reset every time setText is called. */
+	public void setColors (float color, int start, int end) {
 		if (vertexData.length == 1) { // only one page...
 			float[] vertices = vertexData[0];
 			for (int i = start * 20 + 2, n = end * 20; i < n; i += 5)
@@ -254,17 +204,20 @@ public class BitmapFontCache {
 	/** Sets the color of subsequently added text. Does not affect text currently in the cache. */
 	public void setColor (Color tint) {
 		color = tint.toFloatBits();
+		markup.setDefaultChunk(tint, charsCount);
 	}
 
 	/** Sets the color of subsequently added text. Does not affect text currently in the cache. */
 	public void setColor (float r, float g, float b, float a) {
 		int intBits = (int)(255 * a) << 24 | (int)(255 * b) << 16 | (int)(255 * g) << 8 | (int)(255 * r);
 		color = NumberUtils.intToFloatColor(intBits);
+		markup.setDefaultChunk(intBits, charsCount);
 	}
 
 	/** Sets the color of subsequently added text. Does not affect text currently in the cache. */
 	public void setColor (float color) {
 		this.color = color;
+		markup.setDefaultChunk(color, charsCount);
 	}
 
 	public Color getColor () {
@@ -351,17 +304,12 @@ public class BitmapFontCache {
 		x = 0;
 		y = 0;
 		glyphCount = 0;
+		charsCount = 0;
+		markup.clear();
 		for (int i = 0, n = idx.length; i < n; i++) {
 			if (glyphIndices != null) glyphIndices[i].clear();
 			idx[i] = 0;
 		}
-
-		// Remove all the color chunks from the list and releases them to the internal pool
-		for (int i = 0; i < colorChunks.size; i++) {
-			colorChunkPool.free(colorChunks.get(i));
-			colorChunks.set(i, null);
-		}
-		colorChunks.size = 0;
 	}
 
 	/** Counts the actual glyphs excluding characters used to markup the text. */
@@ -432,96 +380,19 @@ public class BitmapFontCache {
 		}
 	}
 
-	private int parseAndSetColor (CharSequence str, int start, int end) {
-		if (start < end) {
-			if (str.charAt(start) == '#') {
-				// Parse hex color RRGGBBAA where AA is optional and defaults to 0xFF if less than 6 chars are used
-				int colorInt = 0;
-				for (int i = start + 1; i < end; i++) {
-					char ch = str.charAt(i);
-					if (ch == ']') {
-						if (i < start + 2 || i > start + 9)
-							throw new GdxRuntimeException("Hex color cannot have " + (i - start - 1) + " digits.");
-						if (i <= start + 7) { // RRGGBB
-							Color.rgb888ToColor(hexColor, colorInt);
-							hexColor.a = 1f;
-						} else { // RRGGBBAA
-							Color.rgba8888ToColor(hexColor, colorInt);
-						}
-						this.color = hexColor.toFloatBits();
-						addColorChunk(this.color, false);
-						return i - start;
-					}
-					if (ch >= '0' && ch <= '9')
-						colorInt = colorInt * 16 + (ch - '0');
-					else if (ch >= 'a' && ch <= 'f')
-						colorInt = colorInt * 16 + (ch - ('a' - 10));
-					else if (ch >= 'A' && ch <= 'F')
-						colorInt = colorInt * 16 + (ch - ('A' - 10));
-					else
-						throw new GdxRuntimeException("Unexpected character in hex color: " + ch);
-				}
-			} else {
-				// Parse named color
-				colorBuffer.setLength(0);
-				for (int i = start; i < end; i++) {
-					char ch = str.charAt(i);
-					if (ch == ']') {
-						if (colorBuffer.length() == 0) { // end tag []
-							int popIndex = Math.max(0, colorChunks.peek().popIndex);
-							this.color = colorChunks.get(popIndex).color;
-							addColorChunk(this.color, true);
-						} else {
-							String colorString = colorBuffer.toString();
-							Color newColor = Colors.get(colorString);
-							if (newColor == null) throw new GdxRuntimeException("Unknown color: " + colorString);
-							this.color = newColor.toFloatBits();
-							addColorChunk(this.color, false);
-						}
-						return i - start;
-					} else {
-						colorBuffer.append(ch);
-					}
-				}
-			}
-		}
-		throw new GdxRuntimeException("Unclosed color tag.");
-	}
-
-	private void addColorChunk (float color, boolean isPop) {
-		int popIndex = -1;
-		if (colorChunks.size > 0) {
-			ColorChunk last = colorChunks.peek();
-			last.endIndex = (glyphIndices != null ? glyphCount : this.idx[0] / 20);
-			if (isPop)
-				popIndex = colorChunks.get(Math.max(0, last.popIndex)).popIndex;
-			else
-				popIndex = colorChunks.size - 1;
-		}
-		colorChunks.add(obtainColorChunk(color, popIndex));
-	}
-
-	private ColorChunk obtainColorChunk (float color, int popIndex) {
-		// Get a color chunk from the pool
-		ColorChunk colorChunk = colorChunkPool.obtain();
-		colorChunk.color = color;
-		colorChunk.popIndex = popIndex;
-		return colorChunk;
-	}
-
 	private float addToCache (CharSequence str, float x, float y, int start, int end) {
 		float startX = x;
 		BitmapFont font = this.font;
 		Glyph lastGlyph = null;
 		BitmapFontData data = font.data;
 		textChanged = start < end;
-		if (font.markupEnabled && colorChunks.size == 0) colorChunks.add(obtainColorChunk(this.color, -1));
 		if (data.scaleX == 1 && data.scaleY == 1) {
 			while (start < end) {
 				char ch = str.charAt(start++);
 				if (ch == '[' && font.markupEnabled) {
 					if (!(start < end && str.charAt(start) == '[')) { // non escaped '['
-						start += parseAndSetColor(str, start, end) + 1;
+						start += TextMarkup.parseColorTag(markup, str, charsCount, start, end) + 1;
+						color = markup.getLastColor().toFloatBits();
 						continue;
 					}
 					start++;
@@ -537,7 +408,8 @@ public class BitmapFontCache {
 				char ch = str.charAt(start++);
 				if (ch == '[' && font.markupEnabled) {
 					if (!(start < end && str.charAt(start) == '[')) { // non escaped '['
-						start += parseAndSetColor(str, start, end) + 1;
+						start += TextMarkup.parseColorTag(markup, str, charsCount, start, end) + 1;
+						color = markup.getLastColor().toFloatBits();
 						continue;
 					}
 					start++;
@@ -556,7 +428,8 @@ public class BitmapFontCache {
 				char ch = str.charAt(start++);
 				if (ch == '[' && font.markupEnabled) {
 					if (!(start < end && str.charAt(start) == '[')) { // non escaped '['
-						start += parseAndSetColor(str, start, end) + 1;
+						start += TextMarkup.parseColorTag(markup, str, charsCount, start, end) + 1;
+						color = markup.getLastColor().toFloatBits();
 						continue;
 					}
 					start++;
@@ -576,7 +449,8 @@ public class BitmapFontCache {
 				char ch = str.charAt(start++);
 				if (ch == '[' && font.markupEnabled) {
 					if (!(start < end && str.charAt(start) == '[')) { // non escaped '['
-						start += parseAndSetColor(str, start, end) + 1;
+						start += TextMarkup.parseColorTag(markup, str, charsCount, start, end) + 1;
+						color = markup.getLastColor().toFloatBits();
 						continue;
 					}
 					start++;
@@ -646,6 +520,8 @@ public class BitmapFontCache {
 		vertices[idx++] = color;
 		vertices[idx++] = u2;
 		vertices[idx] = v;
+
+		charsCount++;
 	}
 
 	/** Clears any cached glyphs and adds glyphs for the specified text.
@@ -865,26 +741,8 @@ public class BitmapFontCache {
 		return vertexData[page];
 	}
 
-	private static class ColorChunk implements Poolable {
-		float color;
-		int endIndex;
-		int popIndex; // needed to emulate the color stack
-
-		ColorChunk () {
-			this.endIndex = Integer.MAX_VALUE;
-		}
-
-		ColorChunk (float color, int popIndex) {
-			this.color = color;
-			this.endIndex = Integer.MAX_VALUE;
-			this.popIndex = popIndex;
-		}
-
-		@Override
-		public void reset () {
-			this.color = 0f;
-			this.endIndex = Integer.MAX_VALUE;
-			this.popIndex = 0;
-		}
+	/** Count of characters currently being in cache */
+	public int getCharsCount () {
+		return charsCount;
 	}
 }

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/TextMarkup.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/TextMarkup.java
@@ -1,0 +1,187 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogic.gdx.graphics.g2d;
+
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.Colors;
+import com.badlogic.gdx.utils.Array;
+import com.badlogic.gdx.utils.GdxRuntimeException;
+import com.badlogic.gdx.utils.NumberUtils;
+import com.badlogic.gdx.utils.Pool;
+import com.badlogic.gdx.utils.StringBuilder;
+
+/** @see com.badlogic.gdx.graphics.g2d.BitmapFontCache
+ *
+ * @author davebaol
+ * @author Alexander Dorokhov */
+class TextMarkup {
+	private static final Pool<ColorChunk> colorChunkPool = new Pool<ColorChunk>(32) {
+		protected ColorChunk newObject () {
+			return new ColorChunk();
+		}
+	};
+
+	private static final Color tempColor = new Color();
+	private static final com.badlogic.gdx.utils.StringBuilder tempColorBuffer = new StringBuilder();
+
+	public static int parseColorTag (TextMarkup markup, CharSequence str, int nomarkupStart, int start, int end) {
+		if (start < end) {
+			final Color hexColor = tempColor;
+			if (str.charAt(start) == '#') {
+				// Parse hex color RRGGBBAA where AA is optional and defaults to 0xFF if less than 6 chars are used
+				int colorInt = 0;
+				for (int i = start + 1; i < end; i++) {
+					char ch = str.charAt(i);
+					if (ch == ']') {
+						if (i < start + 2 || i > start + 9)
+							throw new GdxRuntimeException("Hex color cannot have " + (i - start - 1) + " digits.");
+						if (i <= start + 7) { // RRGGBB
+							Color.rgb888ToColor(hexColor, colorInt);
+							hexColor.a = 1f;
+						} else { // RRGGBBAA
+							Color.rgba8888ToColor(hexColor, colorInt);
+						}
+						markup.beginChunk(hexColor, nomarkupStart);
+						return i - start;
+					}
+					if (ch >= '0' && ch <= '9')
+						colorInt = colorInt * 16 + (ch - '0');
+					else if (ch >= 'a' && ch <= 'f')
+						colorInt = colorInt * 16 + (ch - ('a' - 10));
+					else if (ch >= 'A' && ch <= 'F')
+						colorInt = colorInt * 16 + (ch - ('A' - 10));
+					else
+						throw new GdxRuntimeException("Unexpected character in hex color: " + ch);
+				}
+			} else {
+				// Parse named color
+				tempColorBuffer.setLength(0);
+				for (int i = start; i < end; i++) {
+					char ch = str.charAt(i);
+					if (ch == ']') {
+						if (tempColorBuffer.length() == 0) { // end tag []
+							markup.endChunk(nomarkupStart);
+						} else {
+							String colorString = tempColorBuffer.toString();
+							Color newColor = Colors.get(colorString);
+							if (newColor == null) throw new GdxRuntimeException("Unknown color: " + colorString);
+							markup.beginChunk(newColor, nomarkupStart);
+						}
+						return i - start;
+					} else {
+						tempColorBuffer.append(ch);
+					}
+				}
+			}
+		}
+		throw new GdxRuntimeException("Unclosed color tag.");
+	}
+
+	private Array<ColorChunk> colorChunks = new Array<ColorChunk>();
+	private Array<Color> currentColorStack = new Array<Color>();
+	private Color lastColor = Color.WHITE;
+	private Color defaultColor = Color.WHITE;
+
+	public void beginChunk (Color color, int start) {
+		ColorChunk newChunk = colorChunkPool.obtain();
+		newChunk.color.set(color);
+		newChunk.start = start;
+		colorChunks.add(newChunk);
+		currentColorStack.add(lastColor);
+		lastColor = newChunk.color;
+	}
+
+	public void endChunk (int start) {
+		if (currentColorStack.size > 0) {
+			lastColor = currentColorStack.pop();
+			ColorChunk newChunk = colorChunkPool.obtain();
+			newChunk.color.set(lastColor);
+			newChunk.start = start;
+			colorChunks.add(newChunk);
+		}
+	}
+
+	public void tint (BitmapFontCache cache, Color tint) {
+		int current = 0;
+		float floatColor = tempColor.set(defaultColor).mul(tint).toFloatBits();
+		for (ColorChunk chunk : colorChunks) {
+			int next = chunk.start;
+			if (current < next) {
+				cache.setColors(floatColor, current, next);
+				current = next;
+			}
+			floatColor = tempColor.set(chunk.color).mul(tint).toFloatBits();
+		}
+		int charsCount = cache.getCharsCount();
+		if (current < charsCount) {
+			cache.setColors(floatColor, current, charsCount);
+		}
+	}
+
+	/** Removes all the color chunks from the list and releases them to the internal pool */
+	public void clear () {
+		final int size = colorChunks.size;
+		for (int i = 0; i < size; i++) {
+			colorChunkPool.free(colorChunks.get(i));
+			colorChunks.set(i, null);
+		}
+		colorChunks.size = 0;
+		currentColorStack.clear();
+		setDefaultChunk(defaultColor, 0);
+	}
+
+	public Color getLastColor () {
+		return lastColor;
+	}
+
+	private void setDefaultColor (Color defaultColor) {
+		if (currentColorStack.size == 0) {
+			this.defaultColor = defaultColor;
+			this.lastColor = defaultColor;
+		}
+	}
+
+	public void setDefaultChunk (float color, int start) {
+		int abgr = NumberUtils.floatToIntColor(color);
+		setDefaultChunk(abgr, start);
+	}
+
+	public void setDefaultChunk (int abgr, int start) {
+		ColorChunk newChunk = colorChunkPool.obtain();
+		Color color = newChunk.color;
+		color.r = (abgr & 0xff) / 255f;
+		color.g = ((abgr >>> 8) & 0xff) / 255f;
+		color.b = ((abgr >>> 16) & 0xff) / 255f;
+		color.a = ((abgr >>> 24) & 0xff) / 255f;
+		newChunk.start = start;
+		colorChunks.add(newChunk);
+		setDefaultColor(newChunk.color);
+	}
+
+	public void setDefaultChunk (Color color, int start) {
+		ColorChunk newChunk = colorChunkPool.obtain();
+		newChunk.color.set(color);
+		newChunk.start = start;
+		colorChunks.add(newChunk);
+		setDefaultColor(newChunk.color);
+	}
+
+	public static class ColorChunk {
+		public int start;
+		public final Color color = new Color();
+	}
+}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/BitmapFontTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/BitmapFontTest.java
@@ -139,6 +139,11 @@ public class BitmapFontTest extends GdxTest {
 
 		cache.draw(spriteBatch);
 
+		// tinting
+		cache.tint(new Color(1f, 1f, 1f, 0.3f));
+		cache.translate(0f, 40f);
+		cache.draw(spriteBatch);
+
 		spriteBatch.end();
 		// System.out.println(spriteBatch.renderCalls);
 


### PR DESCRIPTION
Extract:
- TextMarkdown class - can be used to change different parts of text without using color tags inside text
- ColorTagMarkdownParser - parses color markup of a text and fills TextMarkdown object

Fix #2433 BitmapFontCache setting colors goes wrong
