### PR TITLE
Wrong stage-to-local transform when the root is not identity

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/Actor.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/Actor.java
@@ -712,8 +712,7 @@ public class Actor {
 
 	/** Transforms the specified point in the stage's coordinates to the actor's local coordinate system. */
 	public Vector2 stageToLocalCoordinates (Vector2 stageCoords) {
-		if (parent == null) return stageCoords;
-		parent.stageToLocalCoordinates(stageCoords);
+		if (parent != null) parent.stageToLocalCoordinates(stageCoords);
 		parentToLocalCoordinates(stageCoords);
 		return stageCoords;
 	}


### PR DESCRIPTION
1. Make a `Scene` with an `InputListener`
2. Change the scene's root position

=> touch positions are not adjusted to the root's local coordinate system.

This is because `Actor.stageToLocalCoordinates()` does nothing for root, whose parent is null.

For comparison `Stage.hit()` does the root transformation correctly.
