### PR TITLE
Enforce touchable attribute for Stage root

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/Stage.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/Stage.java
@@ -271,9 +271,12 @@ public class Stage extends InputAdapter implements Disposable {
 		event.setButton(button);
 
 		Actor target = hit(tempCoords.x, tempCoords.y, true);
-		if (target == null) target = root;
+		if (target == null) {
+			if (root.getTouchable() == Touchable.enabled) root.fire(event);
+		} else {
+			target.fire(event);
+		}
 
-		target.fire(event);
 		boolean handled = event.isHandled();
 		Pools.free(event);
 		return handled;


### PR DESCRIPTION
I looks like touch events can't be disabled for the entire Stage.
