### PR TITLE
Added Pools.set(...)

### DIFF
--- a/gdx/src/com/badlogic/gdx/utils/Pools.java
+++ b/gdx/src/com/badlogic/gdx/utils/Pools.java
@@ -16,15 +16,15 @@
 
 package com.badlogic.gdx.utils;
 
-/** Stores a map of {@link ReflectionPool}s by type for convenient static access.
+/** Stores a map of {@link Pool}s (usually {@link ReflectionPool}s) by type for convenient static access.
  * @author Nathan Sweet */
 public class Pools {
-	static private final ObjectMap<Class, ReflectionPool> typePools = new ObjectMap();
+	static private final ObjectMap<Class, Pool> typePools = new ObjectMap();
 
-	/** Returns a new or existing pool for the specified type, stored in a a Class to {@link ReflectionPool} map. Note the max size
-	 * is ignored if this is not the first time this pool has been requested. */
+	/** Returns a new or existing pool for the specified type, stored in a Class to {@link Pool} map. Note the max size is ignored
+	 * if this is not the first time this pool has been requested. */
 	static public <T> Pool<T> get (Class<T> type, int max) {
-		ReflectionPool pool = typePools.get(type);
+		Pool pool = typePools.get(type);
 		if (pool == null) {
 			pool = new ReflectionPool(type, 4, max);
 			typePools.put(type, pool);
@@ -32,21 +32,26 @@ public class Pools {
 		return pool;
 	}
 
-	/** Returns a new or existing pool for the specified type, stored in a a Class to {@link ReflectionPool} map. The max size of
-	 * the pool used is 100. */
+	/** Returns a new or existing pool for the specified type, stored in a Class to {@link Pool} map. The max size of the pool used
+	 * is 100. */
 	static public <T> Pool<T> get (Class<T> type) {
 		return get(type, 100);
 	}
 
+	/** Sets an existing pool for the specified type, stored in a Class to {@link Pool} map. */
+	static public <T> void set (Class<T> type, Pool<T> pool) {
+		typePools.put(type, pool);
+	}
+
 	/** Obtains an object from the {@link #get(Class) pool}. */
 	static public <T> T obtain (Class<T> type) {
-		return (T)get(type).obtain();
+		return get(type).obtain();
 	}
 
 	/** Frees an object from the {@link #get(Class) pool}. */
 	static public void free (Object object) {
-		if (object == null) throw new IllegalArgumentException("object cannot be null.");
-		ReflectionPool pool = typePools.get(object.getClass());
+		if (object == null) throw new IllegalArgumentException("Object cannot be null.");
+		Pool pool = typePools.get(object.getClass());
 		if (pool == null) return; // Ignore freeing an object that was never retained.
 		pool.free(object);
 	}
@@ -60,8 +65,8 @@ public class Pools {
 	/** Frees the specified objects from the {@link #get(Class) pool}. Null objects within the array are silently ignored.
 	 * @param samePool If true, objects don't need to be from the same pool but the pool must be looked up for each object. */
 	static public void freeAll (Array objects, boolean samePool) {
-		if (objects == null) throw new IllegalArgumentException("objects cannot be null.");
-		ReflectionPool pool = null;
+		if (objects == null) throw new IllegalArgumentException("Objects cannot be null.");
+		Pool pool = null;
 		for (int i = 0, n = objects.size; i < n; i++) {
 			Object object = objects.get(i);
 			if (object == null) continue;


### PR DESCRIPTION
I've added a small method to `Pools` to be able to set a pool for a class directly instead of having a `ReflectionPool` created automatically. Sometimes a ReflectionPool just isn't possible, for example in case there is no default constructor.

I was also required to change the internal `Map<Class, ReflectionPool>` to a `Map<Class, Pool>` for that reason, which shouldn't be bad though.
