### PR TITLE
Protected Screen in Game

### DIFF
--- a/gdx/src/com/badlogic/gdx/Game.java
+++ b/gdx/src/com/badlogic/gdx/Game.java
@@ -24,7 +24,7 @@ package com.badlogic.gdx;
  * screen is set.
  * </p> */
 public abstract class Game implements ApplicationListener {
-	private Screen screen;
+	protected Screen screen;
 
 	@Override
 	public void dispose () {


### PR DESCRIPTION
Sometimes it would be nice to be able to switch a screen without `Game` automatically calling `hide()` and `show()`. That's only possible by extending Game currently and overriding the method. However, this option is also not available, because the field is `private` and the extending class isn't able to set it.