### PR TITLE
Changed the Skin tinted drawable factory methods Skin#newDrawable to static

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@
 - 3D ParticleEffectLoader registered by default
 - Added HttpRequestBuilder, see https://github.com/libgdx/libgdx/pull/2698
 - Added LwjglApplicationConfiguration.useHDPI for Mac OS X with retina displays. Allows you to get "real" pixel coordinates for mouse and display coordinates.
+- Changed Skin#newDrawable(Drawable, Color) and 4-float versions to static
 
 [1.5.2]
 - Fixed issue #2433 with color markup and alpha animation. 

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Skin.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Skin.java
@@ -324,12 +324,12 @@ public class Skin implements Disposable {
 	}
 
 	/** Returns a tinted copy of a drawable found in the skin via {@link #getDrawable(String)}. */
-	public Drawable newDrawable (Drawable drawable, float r, float g, float b, float a) {
+	static public Drawable newDrawable (Drawable drawable, float r, float g, float b, float a) {
 		return newDrawable(drawable, new Color(r, g, b, a));
 	}
 
 	/** Returns a tinted copy of a drawable found in the skin via {@link #getDrawable(String)}. */
-	public Drawable newDrawable (Drawable drawable, Color tint) {
+	static public Drawable newDrawable (Drawable drawable, Color tint) {
 		Drawable newDrawable;
 		if (drawable instanceof TextureRegionDrawable) {
 			TextureRegion region = ((TextureRegionDrawable)drawable).getRegion();


### PR DESCRIPTION
I had a need for a tinted drawable without need for a skin instance, and realized the instance wasn't actually used in the method anyway. Maybe there's a reason to keep it an instance method, but as it is there didn't seem to be any problems. I know this will probably cause warnings on current projects that access the methods via instance.

I think there are more methods that could become static, looking at the class more now, like public Drawable newDrawable(Drawable). I could throw that in with this PR if you guys like the idea. Or if this whole idea sucks for reasons currently unknown to me, I'm cool with that too. 