### PR TITLE
Fix MoveToAction with alignment

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/MoveToAction.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/MoveToAction.java
@@ -26,8 +26,8 @@ public class MoveToAction extends TemporalAction {
 	private int alignment = Align.bottomLeft;
 
 	protected void begin () {
-		startX = target.getX();
-		startY = target.getY();
+		startX = target.getX(alignment);
+		startY = target.getY(alignment);
 	}
 
 	protected void update (float percent) {


### PR DESCRIPTION
The alignment must be used to get the starting position of the actor