### PR TITLE
Dialog constructor didn't call setSkin() on Table superclass

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Dialog.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Dialog.java
@@ -55,6 +55,7 @@ public class Dialog extends Window {
 
 	public Dialog (String title, Skin skin) {
 		super(title, skin.get(WindowStyle.class));
+		setSkin(skin);
 		this.skin = skin;
 		initialize();
 	}


### PR DESCRIPTION
One of the Dialog constructors didn't call `setSkin()` on the Table superclass, resulting in the Table's `skin` property being `null`.

See https://github.com/libgdx/libgdx/issues/2727