### PR TITLE
Adding ability to set line height for BitmapFontData

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFont.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFont.java
@@ -1015,6 +1015,12 @@ public class BitmapFont implements Disposable {
 				StreamUtils.closeQuietly(reader);
 			}
 		}
+		
+		/** Sets the line height, which is the distance from one line of text to the next. */
+		public void setLineHeight (float height) {
+			lineHeight = height * scaleY;
+			down = flipped ? lineHeight : -lineHeight;
+		}
 
 		public void setGlyph (int ch, Glyph glyph) {
 			Glyph[] page = glyphs[ch / PAGE_SIZE];


### PR DESCRIPTION
While using BitmapFont I've faced issue that sometimes fonts have too big line height, which makes drawn multiline text a bit ugly. #setLineHeight method gives an easy way to change it, e.g. make smaller, to have a more pretty text drawing result. This could be helpful when generating several fonts from one font file using gdx-freetype extension.

Sorry for any inconveniences I've not a git expert, this is the corrected PR for the same [old PR](https://github.com/libgdx/libgdx/pull/2695)