### PR TITLE
Fixed up struct accessors after accessors were renamed in RoboVM's cocoatouch bindings

### DIFF
--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSApplication.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSApplication.java
@@ -33,6 +33,7 @@ import org.robovm.apple.uikit.UIScreen;
 import org.robovm.apple.uikit.UIUserInterfaceIdiom;
 import org.robovm.apple.uikit.UIViewController;
 import org.robovm.apple.uikit.UIWindow;
+import org.robovm.rt.bro.Bro;
 
 import com.badlogic.gdx.Application;
 import com.badlogic.gdx.ApplicationListener;
@@ -119,6 +120,8 @@ public class IOSApplication implements Application {
 		Gdx.app.debug("IOSApplication", "iOS version: " + UIDevice.getCurrentDevice().getSystemVersion());
 		// fix the scale factor if we have a retina device (NOTE: iOS screen sizes are in "points" not pixels by default!)
 
+		Gdx.app.debug("IOSApplication", "Running in " + (Bro.IS_64BIT ? "64-bit" : "32-bit") + " mode");
+
 		float scale = (float)(getIosVersion() >= 8 ? UIScreen.getMainScreen().getNativeScale() : UIScreen.getMainScreen()
 			.getScale());
 		if (scale >= 2.0f) {
@@ -192,7 +195,7 @@ public class IOSApplication implements Application {
 	 * @return Or real display dimension. */
 	CGSize getBounds (UIViewController viewController) {
 		// or screen size (always portrait)
-		CGSize bounds = UIScreen.getMainScreen().getApplicationFrame().size();
+		CGSize bounds = UIScreen.getMainScreen().getApplicationFrame().getSize();
 
 		// determine orientation and resulting width + height
 		UIInterfaceOrientation orientation;
@@ -213,17 +216,17 @@ public class IOSApplication implements Application {
 		switch (orientation) {
 		case LandscapeLeft:
 		case LandscapeRight:
-			height = (int)bounds.width();
-			width = (int)bounds.height();
+			height = (int)bounds.getWidth();
+			width = (int)bounds.getHeight();
 			if (width < height) {
-				width = (int)bounds.width();
-				height = (int)bounds.height();
+				width = (int)bounds.getWidth();
+				height = (int)bounds.getHeight();
 			}
 			break;
 		default:
 			// assume portrait
-			width = (int)bounds.width();
-			height = (int)bounds.height();
+			width = (int)bounds.getWidth();
+			height = (int)bounds.getHeight();
 		}
 
 		Gdx.app.debug("IOSApplication", "Unscaled View: " + orientation.toString() + " " + width + "x" + height);

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
@@ -84,8 +84,8 @@ public class IOSGraphics extends NSObject implements Graphics, GLKViewDelegate, 
 			// FIXME screen orientation needs to be stored for
 			// Input#getNativeOrientation
 			CGSize bounds = app.getBounds(this);
-			graphics.width = (int)bounds.width();
-			graphics.height = (int)bounds.height();
+			graphics.width = (int)bounds.getWidth();
+			graphics.height = (int)bounds.getHeight();
 			graphics.makeCurrent();
 			app.listener.resize(graphics.width, graphics.height);
 		}
@@ -167,9 +167,9 @@ public class IOSGraphics extends NSObject implements Graphics, GLKViewDelegate, 
 		GL20 gl20) {
 		this.config = config;
 		// setup view and OpenGL
-		width = (int)bounds.width();
-		height = (int)bounds.height();
-		app.debug(tag, bounds.width() + "x" + bounds.height() + ", " + scale);
+		width = (int)bounds.getWidth();
+		height = (int)bounds.getHeight();
+		app.debug(tag, bounds.getWidth() + "x" + bounds.getHeight() + ", " + scale);
 		this.gl20 = gl20;
 
 		context = new EAGLContext(EAGLRenderingAPI.OpenGLES2);

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSInput.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSInput.java
@@ -380,12 +380,12 @@ public class IOSInput implements Input {
 	private final UITextFieldDelegate textDelegate = new UITextFieldDelegateAdapter() {
 		@Override
 		public boolean shouldChangeCharacters (UITextField textField, NSRange range, String string) {
-			for (int i = 0; i < range.length(); i++) {
+			for (int i = 0; i < range.getLength(); i++) {
 				app.input.inputProcessor.keyTyped((char)8);
 			}
 
 			if (string.isEmpty()) {
-				if (range.length() > 0) Gdx.graphics.requestRendering();
+				if (range.getLength() > 0) Gdx.graphics.requestRendering();
 				return false;
 			}
 
@@ -668,8 +668,8 @@ public class IOSInput implements Input {
 			synchronized (touchEvents) {
 				UITouchPhase phase = touch.getPhase();
 				TouchEvent event = touchEventPool.obtain();
-				event.x = (int)(loc.x() * app.displayScaleFactor);
-				event.y = (int)(loc.y() * app.displayScaleFactor);
+				event.x = (int)(loc.getX() * app.displayScaleFactor);
+				event.y = (int)(loc.getY() * app.displayScaleFactor);
 				event.phase = phase;
 				event.timestamp = (long)(touch.getTimestamp() * 1000000000);
 				touchEvents.add(event);


### PR DESCRIPTION
Fixed up struct accessors after accessors were renamed in RoboVM's cocoatouch bindings. Also added logging of whether the app is running in 32-bit or 64-bit mode. (fixes #2734).