### PR TITLE
Add the ability to set alpha component to BitmapFontCache keeping RGB

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFontCache.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFontCache.java
@@ -132,6 +132,27 @@ public class BitmapFontCache {
 		}
 	}
 
+	/** Sets the alpha component of all text currently in the cache. Does not affect subsequently added text. */
+	public void setAlphas (float alpha) {
+		int alphaBits = ((int)(254 * alpha)) << 24;
+		float prev = 0, newColor = 0;
+		for (int j = 0, length = vertexData.length; j < length; j++) {
+			float[] vertices = vertexData[j];
+			for (int i = 2, n = idx[j]; i < n; i += 5) {
+				float c = vertices[i];
+				if (c == prev && i != 2) {
+					vertices[i] = newColor;
+				} else {
+					prev = c;
+					int rgba = NumberUtils.floatToIntColor(c);
+					rgba = (rgba & 0x00FFFFFF) | alphaBits;
+					newColor = NumberUtils.intToFloatColor(rgba);
+					vertices[i] = newColor;
+				}
+			}
+		}
+	}
+
 	/** Sets the color of all text currently in the cache. Does not affect subsequently added text. */
 	public void setColors (float color) {
 		for (int j = 0, length = vertexData.length; j < length; j++) {


### PR DESCRIPTION
This is usefull when using different colors in the BitmapFontCache ; is you want to fade he text, you need to change alpha and not RGB. The other functions don't do that.

I did not change the draw method of BitmapFontCache to use this instead of setColors because this would make a (small) API change. Just tell me if you would prefer the draw method to only update the alpha part (base don alphaModulation parameter) and I will add the commit.