### PR TITLE
Fix Issue 2475 by packing the JFrame before setting visible.

### DIFF
--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetupUI.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetupUI.java
@@ -97,6 +97,7 @@ public class GdxSetupUI extends JFrame {
 		setSize(620, 720);
 		setLocationRelativeTo(null);
 		setUndecorated(true);
+		pack();
 		setDefaultCloseOperation(EXIT_ON_CLOSE);
 
 		addMouseListener(new MouseAdapter() {


### PR DESCRIPTION
On Linux systems, GDXSetup comes up as a blank window. Packing the JFrame before setting it visible resolves the issue. There are other issues (e.g., some labels don't correctly paint before initial mouse hover), and questions (e.g., why the explicit setSize()?), but those should probably be addressed in one or more other PRs.