### PR TITLE
Make cullingArea in Group protected

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/Group.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/Group.java
@@ -41,7 +41,7 @@ public class Group extends Actor implements Cullable {
 	private final Matrix4 computedTransform = new Matrix4();
 	private final Matrix4 oldTransform = new Matrix4();
 	boolean transform = true;
-	private Rectangle cullingArea;
+	protected Rectangle cullingArea;
 
 	public void act (float delta) {
 		super.act(delta);


### PR DESCRIPTION
This is useful for classes overriding methods like drawChildren, since cullingArea does not even have a getter (only setter).