### PR TITLE
Add out/, classes/, gen-external-apklibs/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,10 +6,13 @@
 bin/
 target/
 obj/
+out/
+classes/
 .gwt/
 gwt-unitCache/
 war/
 gen/
+gen-external-apklibs/
 armeabi/
 armeabi-v7a/
 linux32/


### PR DESCRIPTION
“out/”, “classes/” and "gen-external-apklibs/" are generated in Intellij IDEA ,maven and android-maven-plugin environment.