### PR TITLE
Add off-center projection to Matrix4

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/math/Matrix4.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/math/Matrix4.java
@@ -578,6 +578,44 @@ public class Matrix4 implements Serializable {
 		return this;
 	}
 
+	/** Sets the matrix to a projection matrix with a near/far plane, and left, bottom, right and top specifying the points on the
+	 * near plane that are mapped to the lower left and upper right corners of the viewport. This allows to create projection
+	 * matrix with off-center vanishing point.
+	 * 
+	 * @param left
+	 * @param right
+	 * @param bottom
+	 * @param top
+	 * @param near The near plane
+	 * @param far The far plane
+	 * @return This matrix for the purpose of chaining methods together. */
+	public Matrix4 setToProjection (float left, float right, float bottom, float top, float near, float far) {
+		float x = 2.0f * near / (right - left);
+		float y = 2.0f * near / (top - bottom);
+		float a = (right + left) / (right - left);
+		float b = (top + bottom) / (top - bottom);
+		float l_a1 = (far + near) / (near - far);
+		float l_a2 = (2 * far * near) / (near - far);
+		val[M00] = x;
+		val[M10] = 0;
+		val[M20] = 0;
+		val[M30] = 0;
+		val[M01] = 0;
+		val[M11] = y;
+		val[M21] = 0;
+		val[M31] = 0;
+		val[M02] = a;
+		val[M12] = b;
+		val[M22] = l_a1;
+		val[M32] = -1;
+		val[M03] = 0;
+		val[M13] = 0;
+		val[M23] = l_a2;
+		val[M33] = 0;
+
+		return this;
+	}
+
 	/** Sets this matrix to an orthographic projection matrix with the origin at (x,y) extending by width and height. The near plane
 	 * is set to 0, the far plane is set to 1.
 	 * 

--- a/gdx/src/com/badlogic/gdx/math/Matrix4.java
+++ b/gdx/src/com/badlogic/gdx/math/Matrix4.java
@@ -71,8 +71,7 @@ public class Matrix4 implements Serializable {
 	public static final int M33 = 15;
 
 	/** @Deprecated Do not use this member, instead use a temporary Matrix4 instance, or create a temporary float array. */
-	@Deprecated
-	public static final float tmp[] = new float[16]; // FIXME Change to private access
+	@Deprecated public static final float tmp[] = new float[16]; // FIXME Change to private access
 	public final float val[] = new float[16];
 
 	/** Constructs an identity matrix */
@@ -502,6 +501,44 @@ public class Matrix4 implements Serializable {
 		return this;
 	}
 
+	/** Sets the matrix to a projection matrix with a near/far plane, and left, bottom, right and top specifying the points on the
+	 * near plane that are mapped to the lower left and upper right corners of the viewport. This allows to create projection
+	 * matrix with off-center vanishing point.
+	 * 
+	 * @param left
+	 * @param right
+	 * @param bottom
+	 * @param top
+	 * @param near The near plane
+	 * @param far The far plane
+	 * @return This matrix for the purpose of chaining methods together. */
+	public Matrix4 setToProjection (float left, float right, float bottom, float top, float near, float far) {
+		float x = 2.0f * near / (right - left);
+		float y = 2.0f * near / (top - bottom);
+		float a = (right + left) / (right - left);
+		float b = (top + bottom) / (top - bottom);
+		float l_a1 = (far + near) / (near - far);
+		float l_a2 = (2 * far * near) / (near - far);
+		val[M00] = x;
+		val[M10] = 0;
+		val[M20] = 0;
+		val[M30] = 0;
+		val[M01] = 0;
+		val[M11] = y;
+		val[M21] = 0;
+		val[M31] = 0;
+		val[M02] = a;
+		val[M12] = b;
+		val[M22] = l_a1;
+		val[M32] = -1;
+		val[M03] = 0;
+		val[M13] = 0;
+		val[M23] = l_a2;
+		val[M33] = 0;
+
+		return this;
+	}
+
 	/** Sets this matrix to an orthographic projection matrix with the origin at (x,y) extending by width and height. The near plane
 	 * is set to 0, the far plane is set to 1.
 	 * 
@@ -852,71 +889,68 @@ public class Matrix4 implements Serializable {
 		return this;
 	}
 
-	/**
-	 * Averages the given transform with this one and stores the result in this matrix.
-	 * Translations and scales are lerped while rotations are slerped. 
+	/** Averages the given transform with this one and stores the result in this matrix. Translations and scales are lerped while
+	 * rotations are slerped.
 	 * @param other The other transform
 	 * @param w Weight of this transform; weight of the other transform is (1 - w)
 	 * @return This matrix for chaining */
 	public Matrix4 avg (Matrix4 other, float w) {
 
-		//Get this and other matrix's scale component
+		// Get this and other matrix's scale component
 		getScale(tmpVec);
 		other.getScale(tmpForward);
-		
-		//Get this and other matrix's rotation component
+
+		// Get this and other matrix's rotation component
 		getRotation(quat);
 		other.getRotation(quat2);
-		
-		//Get this and other matrix's translation component
+
+		// Get this and other matrix's translation component
 		getTranslation(tmpUp);
 		other.getTranslation(right);
-		
-		//Calculate scale components
+
+		// Calculate scale components
 		setToScaling(tmpVec.scl(w).add(tmpForward.scl(1 - w)));
 
-		//Calculate rotation components
+		// Calculate rotation components
 		rotate(quat.slerp(quat2, 1 - w));
 
-		//Calculate translation components
+		// Calculate translation components
 		setTranslation(tmpUp.scl(w).add(right.scl(1 - w)));
-		
+
 		return this;
 	}
-	
-	/**
-	 * Averages the given transforms and stores the result in this matrix.
-	 * Translations and scales are lerped while rotations are slerped. 
-	 * Does not destroy the data contained in t.
+
+	/** Averages the given transforms and stores the result in this matrix. Translations and scales are lerped while rotations are
+	 * slerped. Does not destroy the data contained in t.
 	 * @param t List of transforms
 	 * @return This matrix for chaining */
 	public Matrix4 avg (Matrix4[] t) {
-		final float w = 1.0f/t.length;
+		final float w = 1.0f / t.length;
 
-		//Initialize scale components
+		// Initialize scale components
 		tmpVec.set(t[0].getScale(tmpUp).scl(w));
-		
-		//Initialize rotation components
+
+		// Initialize rotation components
 		quat.set(t[0].getRotation(quat2).exp(w));
-		
-		//Initialize translation components
+
+		// Initialize translation components
 		tmpForward.set(t[0].getTranslation(tmpUp).scl(w));
-		
-		//Continue calculating
-		for(int i=1;i<t.length;i++){
-			
-			//Calculate scale components
+
+		// Continue calculating
+		for (int i = 1; i < t.length; i++) {
+
+			// Calculate scale components
 			tmpVec.add(t[i].getScale(tmpUp).scl(w));
-			
-			//Calculate rotation components
+
+			// Calculate rotation components
 			quat.mul(t[i].getRotation(quat2).exp(w));
-			
-			//Calculate translation components
+
+			// Calculate translation components
 			tmpForward.add(t[i].getTranslation(tmpUp).scl(w));
 		}
 		quat.nor();
-		
-		//Set calculated components to this matrix
+
+		// Set calculated components to this matrix
 		setToScaling(tmpVec);
 		rotate(quat);
 		setTranslation(tmpForward);
@@ -924,47 +958,45 @@ public class Matrix4 implements Serializable {
 		return this;
 	}
 
-	/**
-	 * Averages the given transforms with the given weights and stores the result in this matrix.
-	 * Translations and scales are lerped while rotations are slerped. 
-	 * Does not destroy the data contained in t or w;
-	 * Sum of w_i must be equal to 1, or unexpected results will occur.
+	/** Averages the given transforms with the given weights and stores the result in this matrix. Translations and scales are
+	 * lerped while rotations are slerped. Does not destroy the data contained in t or w; Sum of w_i must be equal to 1, or
+	 * unexpected results will occur.
 	 * @param t List of transforms
 	 * @param w List of weights
 	 * @return This matrix for chaining */
 	public Matrix4 avg (Matrix4[] t, float[] w) {
 
-		//Initialize scale components
+		// Initialize scale components
 		tmpVec.set(t[0].getScale(tmpUp).scl(w[0]));
-		
-		//Initialize rotation components
+
+		// Initialize rotation components
 		quat.set(t[0].getRotation(quat2).exp(w[0]));
-		
-		//Initialize translation components
+
+		// Initialize translation components
 		tmpForward.set(t[0].getTranslation(tmpUp).scl(w[0]));
-		
-		//Continue calculating
-		for(int i=1;i<t.length;i++){
-			
-			//Calculate scale components
+
+		// Continue calculating
+		for (int i = 1; i < t.length; i++) {
+
+			// Calculate scale components
 			tmpVec.add(t[i].getScale(tmpUp).scl(w[i]));
-			
-			//Calculate rotation components
+
+			// Calculate rotation components
 			quat.mul(t[i].getRotation(quat2).exp(w[i]));
-			
-			//Calculate translation components
+
+			// Calculate translation components
 			tmpForward.add(t[i].getTranslation(tmpUp).scl(w[i]));
 		}
 		quat.nor();
-		
-		//Set calculated components to this matrix
+
+		// Set calculated components to this matrix
 		setToScaling(tmpVec);
 		rotate(quat);
 		setTranslation(tmpForward);
 
 		return this;
 	}
-	
+
 	/** Sets this matrix to the given 3x3 matrix. The third column of this matrix is set to (0,0,1,0).
 	 * @param mat the matrix */
 	public Matrix4 set (Matrix3 mat) {


### PR DESCRIPTION
Just add the equivalent of glFrustrum to create off-center projection matrix (usefull when you want to use a 3D element in a 2D UI without changing the viewport => you create an off centered 3D view).

There are also a few formatter changes. I checked and I use the libGdx formatter. Seems like previous commit were not formatted right or I missed something.