### PR TITLE
Add exception in Mesh.java

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/Mesh.java
+++ b/gdx/src/com/badlogic/gdx/graphics/Mesh.java
@@ -548,6 +548,8 @@ public class Mesh implements Disposable {
 	 * @param count number of vertices or indices to use
 	 * @param autoBind overrides the autoBind member of this Mesh */
 	public void render (ShaderProgram shader, int primitiveType, int offset, int count, boolean autoBind) {
+               if (shader == null) throw new IllegalArgumentException("shader cannot be null.");
+
 		if (count == 0) return;
 
 		if (autoBind) bind(shader);


### PR DESCRIPTION
If ShaderProgram is null, it reports only NullPointer exception. Because the previous version does not require transfer ShaderProgram, NullPointer exception will mislead new hands.