### PR TITLE
Height and width properties on the map objects

### DIFF
--- a/gdx/src/com/badlogic/gdx/maps/tiled/BaseTmxMapLoader.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/BaseTmxMapLoader.java
@@ -227,6 +227,8 @@ public abstract class BaseTmxMapLoader<P extends AssetLoaderParameters<TiledMap>
 			}
 			object.getProperties().put("x", x * scaleX);
 			object.getProperties().put("y", (y - height) * scaleY);
+			object.getProperties().put("width", width);
+			object.getProperties().put("height", height);
 			object.setVisible(element.getIntAttribute("visible", 1) == 1);
 			Element properties = element.getChildByName("properties");
 			if (properties != null) {


### PR DESCRIPTION
Adds access to the height and width of a TMX Map object.
I believe these were previously unavailable.