### PR TITLE
Fix limit function in Vector3

### DIFF
--- a/gdx/src/com/badlogic/gdx/math/Vector3.java
+++ b/gdx/src/com/badlogic/gdx/math/Vector3.java
@@ -569,18 +569,14 @@ public class Vector3 implements Serializable, Vector<Vector3> {
 
 	@Override
 	public Vector3 limit (float limit) {
-		float len2 = len2();
-		if (len2 > limit * limit) {
-			scl(limit / (float) Math.sqrt(len2));
-		}
-		return this;
+		return limit2(limit * limit);
 	}
 
 	@Override
 	public Vector3 limit2 (float limit2) {
 		float len2 = len2();
 		if (len2 > limit2) {
-			scl(limit2 / len2);
+			scl((float) Math.sqrt(limit2 / len2));
 		}
 		return this;
 	}

--- a/gdx/src/com/badlogic/gdx/math/Vector3.java
+++ b/gdx/src/com/badlogic/gdx/math/Vector3.java
@@ -569,7 +569,11 @@ public class Vector3 implements Serializable, Vector<Vector3> {
 
 	@Override
 	public Vector3 limit (float limit) {
-		return limit2(limit * limit);
+		float len2 = len2();
+		if (len2 > limit * limit) {
+			scl(limit / (float) Math.sqrt(len2));
+		}
+		return this;
 	}
 
 	@Override


### PR DESCRIPTION
If I understand the function right, the purpose of this function is to limit the len of the vector to the given limit, which is not what it does right now.

For the time being, the code is:
```java
return limit2(limit * limit);
```
which is not right since scaling factor should be:
```java
vector * limit / len
```
which is not the same as:
```java
vector * (limit * limit) / (len * len) // equivalent of current code
```
This PR fix this (if I'm rightly understanding the expected behavior, of course)