### PR TITLE
Overlap2d runtime extension for libgdx-setup

### DIFF
--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/BuildScriptHelper.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/BuildScriptHelper.java
@@ -49,7 +49,7 @@ public class BuildScriptHelper {
 		write(wr, "box2DLightsVersion = '" + DependencyBank.box2DLightsVersion + "'");
 		write(wr, "ashleyVersion = '" + DependencyBank.ashleyVersion + "'");
 		write(wr, "aiVersion = '" + DependencyBank.aiVersion + "'");
-		write(wr, "overlap2dVersion = '" + DependencyBank.ashleyVersion + "'");
+		write(wr, "overlap2dVersion = '" + DependencyBank.overlap2dVersion + "'");
 		write(wr, "}");
 		space(wr);
 		write(wr, "repositories {");

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/BuildScriptHelper.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/BuildScriptHelper.java
@@ -49,6 +49,7 @@ public class BuildScriptHelper {
 		write(wr, "box2DLightsVersion = '" + DependencyBank.box2DLightsVersion + "'");
 		write(wr, "ashleyVersion = '" + DependencyBank.ashleyVersion + "'");
 		write(wr, "aiVersion = '" + DependencyBank.aiVersion + "'");
+		write(wr, "overlap2dVersion = '" + DependencyBank.ashleyVersion + "'");
 		write(wr, "}");
 		space(wr);
 		write(wr, "repositories {");

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/DependencyBank.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/DependencyBank.java
@@ -30,6 +30,7 @@ public class DependencyBank {
 	static String box2DLightsVersion = "1.3";
 	static String ashleyVersion = "1.3.1";
 	static String aiVersion = "1.5.0";
+	static String overlap2dVersion = "0.0.8";
 
 	HashMap<ProjectDependency, Dependency> gdxDependencies = new HashMap<ProjectDependency, Dependency>();
 	LinkedHashMap<ProjectDependency, String[]> gwtInheritances = new LinkedHashMap<ProjectDependency, String[]>();
@@ -50,6 +51,7 @@ public class DependencyBank {
 		gwtInheritances.put(ProjectDependency.BOX2DLIGHTS, new String[]{"Box2DLights"});
 		gwtInheritances.put(ProjectDependency.ASHLEY, new String[]{"com.badlogic.ashley_gwt"});
 		gwtInheritances.put(ProjectDependency.AI, new String[]{"com.badlogic.gdx.ai"});
+		gwtInheritances.put(ProjectDependency.OVERLAP2D, new String[]{"com.underwaterapps.overlap2druntime"});
 	}
 
 	public Dependency getDependency(ProjectDependency gdx) {
@@ -148,6 +150,15 @@ public class DependencyBank {
 			new String[]{"com.badlogicgames.gdx:gdx-ai:$aiVersion:sources"},
 			
 			"Artificial Intelligence framework"
+		),
+		OVERLAP2D(
+				new String[]{"com.underwaterapps.overlap2druntime:overlap2d-runtime-libgdx:$overlap2dVersion"},
+				new String[]{},
+				new String[]{"com.underwaterapps.overlap2druntime:overlap2d-runtime-libgdx:$overlap2dVersion"},
+				new String[]{},
+				new String[]{"com.underwaterapps.overlap2druntime:overlap2d-runtime-libgdx:$overlap2dVersion:sources"},
+
+				"Lightweight Entity framework"
 		);
 
 		private String[] coreDependencies;

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/DependencyBank.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/DependencyBank.java
@@ -158,7 +158,7 @@ public class DependencyBank {
 				new String[]{},
 				new String[]{"com.underwaterapps.overlap2druntime:overlap2d-runtime-libgdx:$overlap2dVersion:sources"},
 
-				"Lightweight Entity framework"
+				"Overlap2D level and ui editor runtime"
 		);
 
 		private String[] coreDependencies;

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/DependencyBank.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/DependencyBank.java
@@ -152,13 +152,13 @@ public class DependencyBank {
 			"Artificial Intelligence framework"
 		),
 		OVERLAP2D(
-				new String[]{"com.underwaterapps.overlap2druntime:overlap2d-runtime-libgdx:$overlap2dVersion"},
-				new String[]{},
-				new String[]{"com.underwaterapps.overlap2druntime:overlap2d-runtime-libgdx:$overlap2dVersion"},
-				new String[]{},
-				new String[]{"com.underwaterapps.overlap2druntime:overlap2d-runtime-libgdx:$overlap2dVersion:sources"},
+			new String[]{"com.underwaterapps.overlap2druntime:overlap2d-runtime-libgdx:$overlap2dVersion"},
+			new String[]{},
+			new String[]{"com.underwaterapps.overlap2druntime:overlap2d-runtime-libgdx:$overlap2dVersion"},
+			new String[]{},
+			new String[]{"com.underwaterapps.overlap2druntime:overlap2d-runtime-libgdx:$overlap2dVersion:sources"},
 
-				"Overlap2D level and ui editor runtime"
+			"Overlap2D level and ui editor runtime"
 		);
 
 		private String[] coreDependencies;

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetupUI.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetupUI.java
@@ -568,7 +568,7 @@ public class GdxSetupUI extends JFrame {
 								}
 							}
 						});
-						if (depCounter % 5 == 0) {
+						if (depCounter % 6 == 0) {
 							depCounter++;
 							break;
 						}
@@ -576,7 +576,7 @@ public class GdxSetupUI extends JFrame {
 					}
 				}
 				
-				for (int left = depCounter - 5; left > 1; left--) {
+				for (int left = depCounter - 6; left > 1; left--) {
 					extensionPanel.add(Box.createHorizontalBox());
 				}
 


### PR DESCRIPTION
Added Overlap2d runtime extension to the list of extensions:
sources here: https://github.com/UnderwaterApps/overlap2d-runtime-libgdx

Note for commit #6de8ecb :
Box2dlights on second row somehow was messing up paddings, I changed depCounter drop to 6 in order to move box2d lights to the first row, this is a quick solution, other advantage is box2dlights and box2d are now on the same row, which is more logical, and because there is so many extensions now, this way all looks more compact and overall better (hope it's ok?)