### PR TITLE
Fix automipmap for KTX files

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/glutils/KTXTextureData.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/KTXTextureData.java
@@ -121,6 +121,10 @@ public class KTXTextureData implements TextureData, CubemapData {
 		numberOfArrayElements = compressedData.getInt();
 		numberOfFaces = compressedData.getInt();
 		numberOfMipmapLevels = compressedData.getInt();
+		if (numberOfMipmapLevels == 0) {
+			numberOfMipmapLevels = 1;
+			useMipMaps = true;
+		}
 		int bytesOfKeyValueData = compressedData.getInt();
 		imagePos = compressedData.position() + bytesOfKeyValueData;
 		if (!compressedData.isDirect()) {
@@ -271,7 +275,7 @@ public class KTXTextureData implements TextureData, CubemapData {
 			}
 		}
 		if (previousUnpackAlignment != 4) Gdx.gl.glPixelStorei(GL20.GL_UNPACK_ALIGNMENT, previousUnpackAlignment);
-		if (useMipMaps && numberOfMipmapLevels == 1) Gdx.gl.glGenerateMipmap(target);
+		if (useMipMaps()) Gdx.gl.glGenerateMipmap(target);
 
 		// dispose data once transfered to GPU
 		disposePreparedData();


### PR DESCRIPTION
In KTX files, you can set a flag for mipmap generation at load time (see https://www.khronos.org/opengles/sdk/tools/KTX/file_format_spec/#2.11). You get this type of file when using the --automipmap from the toktx tools for example.

This was incorrectly processed by the current implementation, resulting with empty texture (since numberOfMipmapLevels  = 0 means "please generate mipmaps at load time", and not "there are no mip levels"). This few lines fix this.