### PR TITLE
Third party extensions to be read from XML file (gdx-setup)

### DIFF
--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/Dependency.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/Dependency.java
@@ -37,4 +37,17 @@ public class Dependency {
         return name;
     }
 
+    @Override
+    public boolean equals(Object obj) {
+        if(((Dependency)obj).getName().equals(getName())) {
+            return true;
+        }
+
+        return false;
+    }
+
+	 @Override
+	 public int hashCode () {
+		  return name.hashCode();
+	 }
 }

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/ExternalExtension.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/ExternalExtension.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogic.gdx.setup;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Created by azakhary on 2/9/2015.
+ */
+public class ExternalExtension {
+
+	 private String name;
+	 private String description;
+	 private String version;
+
+	 private Map<String, List<String>> dependencies;
+
+	 public ExternalExtension (String name, String description, String version) {
+		  this.name = name;
+		  this.description = description;
+		  this.version = version;
+	 }
+
+	 public void setDependencies (Map<String, List<String>> dependencies) {
+		  this.dependencies = dependencies;
+	 }
+
+	 public Dependency generateDependency () {
+
+		  Dependency dep = new Dependency(name, getPlatformDependencies("core"), getPlatformDependencies("desktop"),
+			  getPlatformDependencies("android"), getPlatformDependencies("ios"), getPlatformDependencies("html"));
+
+		  return dep;
+	 }
+
+	 private String[] getPlatformDependencies (String platformName) {
+		  if (dependencies.get(platformName) == null) {
+				return null;
+		  } else if (dependencies.get(platformName) != null && dependencies.get(platformName).size() == 0) {
+				return new String[] {};
+		  } else {
+				String[] arr = new String[dependencies.get(platformName).size()];
+				for (int i = 0; i < dependencies.get(platformName).size(); i++) {
+					 arr[i] = dependencies.get(platformName).get(i) + ":" + version;
+				}
+				return arr;
+		  }
+	 }
+
+	 public String getName () {
+		  return name;
+	 }
+}

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/ExternalExtensionsDialog.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/ExternalExtensionsDialog.java
@@ -1,0 +1,277 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogic.gdx.setup;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+import javax.swing.*;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.awt.GridBagConstraints.*;
+
+/**
+ * Created by azakhary on 2/9/2015.
+ */
+public class ExternalExtensionsDialog extends JDialog {
+
+	 private JPanel contentPane;
+	 private JButton buttonOK;
+	 private JButton buttonCancel;
+	 private JPanel topPanel;
+	 private JPanel content;
+	 private JPanel bottomPanel;
+	 private JPanel buttonPanel;
+	 private JScrollPane scrollPane;
+
+	 private JLabel warningNotice;
+
+	 private HashMap<String, ExtensionRowCheckbox> checkBoxesMap = new HashMap<String, ExtensionRowCheckbox>();
+
+	 private List<Dependency> mainDependenciesSnapshot = new ArrayList<Dependency>();
+	 private List<Dependency> mainDependencies;
+
+	 public ExternalExtensionsDialog (List<Dependency> mainDependencies) {
+		  this.mainDependencies = mainDependencies;
+
+		  contentPane = new JPanel(new GridBagLayout());
+		  setContentPane(contentPane);
+		  setModal(true);
+		  getRootPane().setDefaultButton(buttonOK);
+
+		  uiLayout();
+		  uiStyle();
+
+		  buttonOK.addActionListener(new ActionListener() {
+				public void actionPerformed (ActionEvent e) {
+					 onOK();
+				}
+		  });
+		  buttonCancel.addActionListener(new ActionListener() {
+				@Override public void actionPerformed (ActionEvent e) {
+					 onCancel();
+				}
+		  });
+
+		  setTitle("Third party external extensions");
+		  setSize(400, 240);
+		  setLocationRelativeTo(null);
+	 }
+
+	 public void showDialog () {
+		  takeSnapshot();
+		  setVisible(true);
+	 }
+
+	 private void uiLayout () {
+
+		  topPanel = new JPanel(new GridBagLayout());
+		  topPanel.setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5));
+
+		  content = new JPanel(new GridBagLayout());
+		  content.setBorder(BorderFactory.createEmptyBorder(20, 20, 5, 5));
+
+		  scrollPane = new JScrollPane(content);
+
+		  bottomPanel = new JPanel(new GridBagLayout());
+
+		  buttonPanel = new JPanel(new GridBagLayout());
+		  buttonPanel.setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5));
+		  buttonOK = new JButton("Save");
+		  buttonCancel = new JButton("Cancel");
+		  buttonPanel.add(buttonOK, new GridBagConstraints(0, 0, 1, 1, 0, 0, CENTER, HORIZONTAL, new Insets(0, 0, 0, 0), 0, 0));
+		  buttonPanel.add(buttonCancel, new GridBagConstraints(1, 0, 1, 1, 0, 0, CENTER, HORIZONTAL, new Insets(0, 0, 0, 0), 0, 0));
+		  bottomPanel.add(buttonPanel, new GridBagConstraints(3, 0, 1, 1, 1, 1, SOUTHEAST, NONE, new Insets(0, 0, 0, 0), 0, 0));
+
+		  contentPane.add(topPanel, new GridBagConstraints(0, 0, 1, 1, 1, 1, NORTH, BOTH, new Insets(0, 0, 0, 0), 0, 0));
+		  contentPane.add(scrollPane, new GridBagConstraints(0, 1, 1, 1, 1, 1, NORTH, BOTH, new Insets(0, 0, 0, 0), 0, 0));
+		  contentPane.add(bottomPanel, new GridBagConstraints(0, 2, 4, 1, 1, 1, SOUTH, HORIZONTAL, new Insets(0, 0, 0, 0), 0, 0));
+
+		  warningNotice = new JLabel("List of third party extensions, not maintained by libGDX team");
+		  warningNotice.setHorizontalAlignment(JLabel.CENTER);
+		  topPanel.add(warningNotice, new GridBagConstraints(0, 0, 1, 1, 1, 0, NORTH, HORIZONTAL, new Insets(0, 0, 0, 0), 0, 0));
+
+		  JSeparator separator = new JSeparator();
+		  separator.setForeground(new Color(85, 85, 85));
+		  separator.setBackground(new Color(85, 85, 85));
+
+		  topPanel.add(separator, new GridBagConstraints(0, 1, 4, 1, 1, 1, NORTH, HORIZONTAL, new Insets(10, 0, 0, 0), 0, 0));
+
+		  try {
+				initData();
+		  } catch (Exception e) {
+				e.printStackTrace();
+		  }
+
+	 }
+
+	 private void initData () throws ParserConfigurationException, IOException, SAXException {
+		  DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+		  DocumentBuilder builder = dbFactory.newDocumentBuilder();
+		  Document doc = builder
+			  .parse(ExternalExtensionsDialog.class.getResourceAsStream("/com/badlogic/gdx/setup/data/extensions.xml"));
+
+		  doc.getDocumentElement().normalize();
+
+		  NodeList nList = doc.getElementsByTagName("extension");
+
+		  for (int i = 0; i < nList.getLength(); i++) {
+				Node nNode = nList.item(i);
+				if (nNode.getNodeType() == Node.ELEMENT_NODE) {
+
+					 Element eElement = (Element)nNode;
+					 String name = eElement.getElementsByTagName("name").item(0).getTextContent();
+					 String description = eElement.getElementsByTagName("description").item(0).getTextContent();
+					 String version = eElement.getElementsByTagName("version").item(0).getTextContent();
+
+					 String rowText = name + " - " + description + " (v" + version + ")";
+
+					 final HashMap<String, List<String>> dependencies = new HashMap<String, List<String>>();
+
+					 addToDependencyMapFromXML(dependencies, eElement, "core");
+					 addToDependencyMapFromXML(dependencies, eElement, "desktop");
+					 addToDependencyMapFromXML(dependencies, eElement, "android");
+					 addToDependencyMapFromXML(dependencies, eElement, "ios");
+					 addToDependencyMapFromXML(dependencies, eElement, "html");
+
+					 ExtensionRowCheckbox checkBox = new ExtensionRowCheckbox(rowText);
+					 checkBoxesMap.put(name, checkBox);
+
+					 content.add(checkBox, new GridBagConstraints(0, i, 1, 1, 1, 1, NORTH, HORIZONTAL, new Insets(0, 0, 0, 0), 0, 0));
+
+					 final ExternalExtension extension = new ExternalExtension(name, description, version);
+					 extension.setDependencies(dependencies);
+
+					 checkBox.addItemListener(new ItemListener() {
+						  @Override public void itemStateChanged (ItemEvent e) {
+								ExtensionRowCheckbox box = (ExtensionRowCheckbox)e.getSource();
+								Dependency dep = extension.generateDependency();
+								if (box.isSelected()) {
+									 if(!mainDependencies.contains(dep)) {
+										  mainDependencies.add(dep);
+									 }
+								} else {
+									 mainDependencies.remove(dep);
+								}
+						  }
+					 });
+				}
+		  }
+	 }
+
+	 private void uiStyle () {
+		  contentPane.setBackground(new Color(36, 36, 36));
+
+		  topPanel.setBackground(new Color(36, 36, 36));
+		  topPanel.setForeground(new Color(255, 255, 255));
+		  content.setBackground(new Color(36, 36, 36));
+		  content.setForeground(new Color(255, 255, 255));
+		  bottomPanel.setBackground(new Color(36, 36, 36));
+		  bottomPanel.setForeground(new Color(255, 255, 255));
+		  buttonPanel.setBackground(new Color(36, 36, 36));
+		  buttonPanel.setForeground(new Color(255, 255, 255));
+
+		  scrollPane.setBorder(BorderFactory.createEmptyBorder());
+
+		  warningNotice.setForeground(new Color(200, 20, 20));
+	 }
+
+	 void onOK () {
+		  setVisible(false);
+	 }
+
+	 void onCancel () {
+		  setVisible(false);
+		  restore();
+	 }
+
+	 private void takeSnapshot () {
+		  mainDependenciesSnapshot.clear();
+		  for (int i = 0; i < mainDependencies.size(); i++) {
+				mainDependenciesSnapshot.add(mainDependencies.get(i));
+		  }
+	 }
+
+	 private void restore () {
+		  mainDependencies.clear();
+		  for (ExtensionRowCheckbox checkBox : checkBoxesMap.values()) {
+				checkBox.setSelected(false);
+		  }
+		  for (int i = 0; i < mainDependenciesSnapshot.size(); i++) {
+				mainDependencies.add(mainDependenciesSnapshot.get(i));
+				String extensionName = mainDependenciesSnapshot.get(i).getName();
+				if(checkBoxesMap.containsKey(extensionName)) {
+					 checkBoxesMap.get(extensionName).setSelected(true);
+				}
+		  }
+	 }
+
+	 private void addToDependencyMapFromXML (Map<String, List<String>> dependencies, Element eElement, String platform) {
+		  if (eElement.getElementsByTagName(platform).item(0) != null) {
+				Element project = (Element)eElement.getElementsByTagName(platform).item(0);
+
+				ArrayList<String> deps = new ArrayList<String>();
+
+				if (project.getTextContent().trim().equals("")) {
+					 // No dependencies required
+				} else if (project.getTextContent().trim().equals("null")) {
+					 // Not supported
+					 deps = null;
+				} else {
+					 NodeList nList = project.getElementsByTagName("dependency");
+
+					 for (int i = 0; i < nList.getLength(); i++) {
+						  Node nNode = nList.item(i);
+						  if (nNode.getNodeType() == Node.ELEMENT_NODE) {
+								Element dependencyNode = (Element)nNode;
+								deps.add(dependencyNode.getTextContent());
+						  }
+
+					 }
+				}
+
+				dependencies.put(platform, deps);
+		  }
+	 }
+
+	 class ExtensionRowCheckbox extends JCheckBox {
+
+		  ExtensionRowCheckbox (String selectName) {
+				super(selectName);
+				setOpaque(false);
+				setBackground(new Color(0, 0, 0));
+				setForeground(new Color(255, 255, 255));
+				setFocusPainted(false);
+		  }
+
+	 }
+}

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetupUI.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetupUI.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  ******************************************************************************/
+
 package com.badlogic.gdx.setup;
 
 import static java.awt.GridBagConstraints.*;
@@ -86,6 +87,7 @@ public class GdxSetupUI extends JFrame {
 	ProjectBuilder builder;
 	List<ProjectType> modules = new ArrayList<ProjectType>();
 	List<Dependency> dependencies = new ArrayList<Dependency>();
+	ArrayList<ExternalExtension> externalExtensions = new ArrayList<ExternalExtension>();
 
 	UI ui = new UI();
 	static Point point = new Point();
@@ -400,7 +402,7 @@ public class GdxSetupUI extends JFrame {
 		private void uiEvents () {
 			advancedButton.addActionListener(new ActionListener() {
 				public void actionPerformed (ActionEvent e) {
-					settings.showDialog();;
+					settings.showDialog();
 				}
 			});
 			generateButton.addActionListener(new ActionListener() {
@@ -412,6 +414,7 @@ public class GdxSetupUI extends JFrame {
 	}
 
 	class Form extends JPanel {
+		ExternalExtensionsDialog externalExtensionsDialog = new ExternalExtensionsDialog(dependencies);
 		JLabel nameLabel = new JLabel("Name:");
 		JTextField nameText = new JTextField("my-gdx-game");
 		JLabel packageLabel = new JLabel("Package:");
@@ -431,6 +434,7 @@ public class GdxSetupUI extends JFrame {
 		JLabel projectsLabel = new JLabel("Sub Projects");
 		JLabel extensionsLabel = new JLabel("Extensions");
 		List<JPanel> extensionsPanels = new ArrayList<JPanel>();
+		SetupButton showMoreExtensionsButton = new SetupButton("Show Third Party Extensions");
 
 		{
 			uiLayout();
@@ -589,6 +593,7 @@ public class GdxSetupUI extends JFrame {
 				add(extensionsPanel, new GridBagConstraints(0, rowCounter, 3, 1, 0, 0, CENTER, HORIZONTAL, new Insets(5, 0, 0, 0), 0, 0));
 				rowCounter++;
 			}
+			add(showMoreExtensionsButton, new GridBagConstraints(0, 12, 0, 1, 0, 0, CENTER, WEST, new Insets(20, 0, 30, 0), 0, 0));
 		}
 
 		File getDirectory () {
@@ -633,6 +638,11 @@ public class GdxSetupUI extends JFrame {
 						sdkLocationText.setText(path.getAbsolutePath());
 					}
 				}
+			});
+			showMoreExtensionsButton.addActionListener(new ActionListener() {
+				 public void actionPerformed (ActionEvent e) {
+					  externalExtensionsDialog.showDialog();
+				 }
 			});
 		}
 	}

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/data/extensions.xml
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/data/extensions.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+    <extension>
+       <name>Overlap2D</name>
+       <description>level and ui editor runtime</description>
+       <package>com.underwaterapps.overlap2druntime</package>
+       <version>0.0.8</version>
+       <projects>
+           <core>
+               <dependency>com.underwaterapps.overlap2druntime:overlap2d-runtime-libgdx</dependency>
+           </core>
+           <desktop></desktop>
+           <android></android>
+           <ios></ios>
+           <html>null</html>
+       </projects>
+    </extension>
+</extensions>


### PR DESCRIPTION
As discussed yesterday per #2822 setup app required some sort of way to separate third party extensions from main extensions in a different dialog. The other part was for list of third party extensions to be read from an XML file that can be later modified with pull requests. Lastly it was needed to make sure it is clear for user that third party extensions are not maintained by libgdx team.

This is a bit of a big change, so I it probably requires to take a look on it in depth, to test it, and make sure all is correct and the way it should be before this can be considered to be merged. I do not expect it to be merged right away of course.

Would love comments! Maybe some text changes?

Notes / potential issues:
1) The list is currently does not use scroll pane, because at this moment there is just one extension and I was not sure how will it look in future when others add their own. (this can be fixed in later prs)
2) Each extension can contain only one dependency per platform. I am not sure what actual real life examples for others might be though, and what we want to allow?
3) Do you guys require heavy commenting? the rest of code was not commented.
4) Swing is a nightmare to make look good. So I made it look just "okay"