### PR TITLE
Added missing GL30.GL_LOGIC_OP for glBlendEquation

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/GL30.java
+++ b/gdx/src/com/badlogic/gdx/graphics/GL30.java
@@ -50,6 +50,7 @@ public interface GL30 extends GL20 {
 	public final int GL_TEXTURE_MAX_LEVEL = 0x813D;
 	public final int GL_MIN = 0x8007;
 	public final int GL_MAX = 0x8008;
+	public final int GL_LOGIC_OP = 0x0BF1;
 	public final int GL_DEPTH_COMPONENT24 = 0x81A6;
 	public final int GL_MAX_TEXTURE_LOD_BIAS = 0x84FD;
 	public final int GL_TEXTURE_COMPARE_MODE = 0x884C;


### PR DESCRIPTION
Just found that I wasn't able to use the GL_LOGIC_OP as it is missing, however GL_MIN and GL_MAX are defined. If this constant was not omitted specially we could add it's definition to GL30 also.