### PR TITLE
Made Cell#defaults() public 

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Cell.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Cell.java
@@ -889,7 +889,7 @@ public class Cell<T extends Actor> implements Poolable {
 	}
 
 	/** Set all constraints to cell default values. */
-	void defaults () {
+	public void defaults () {
 		minWidth = Value.minWidth;
 		minHeight = Value.minHeight;
 		prefWidth = Value.prefWidth;


### PR DESCRIPTION
So that when Table#defaults() is changed, it can be reverted without having to call Table#reset().

Table.defaults().defaults() is obviously not the best code, but Cell is pooleable so reset() is already taken.