### PR TITLE
added alpha and premultiplied alpha config values to GWT backend

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplicationConfiguration.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplicationConfiguration.java
@@ -42,6 +42,11 @@ public class GwtApplicationConfiguration {
 	public boolean preferFlash = true;
 	/** preserve the back buffer, needed if you fetch a screenshot via canvas#toDataUrl, may have performance impact **/
 	public boolean preserveDrawingBuffer = false;
+	/** whether to include an alpha channel in the color buffer to combine the color buffer with the rest of the webpage
+	 * effectively allows transparent backgrounds in GWT, at a performance cost. **/
+	public boolean alpha = false;
+	/** wether to use premultipliedalpha, may have performance impact  **/
+	public boolean premultipliedAlpha = false;
 
 	public GwtApplicationConfiguration (int width, int height) {
 		this.width = width;

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtGraphics.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtGraphics.java
@@ -53,8 +53,8 @@ public class GwtGraphics implements Graphics {
 		WebGLContextAttributes attributes = WebGLContextAttributes.create();
 		attributes.setAntialias(config.antialiasing);
 		attributes.setStencil(config.stencil);
-		attributes.setAlpha(false);
-		attributes.setPremultipliedAlpha(false);
+		attributes.setAlpha(config.alpha);
+		attributes.setPremultipliedAlpha(config.premultipliedAlpha);
 		attributes.setPreserveDrawingBuffer(config.preserveDrawingBuffer);
 
 		context = WebGLRenderingContext.getContext(canvas, attributes);


### PR DESCRIPTION
Extremely minor, but I need the first for a small project and i've noted a few others asked about it over time too.

The first allows for showing the page behind the canvas, the second is just a different way of transparency. They still default to false, as they affect performance, but with this we have the option if we need them. 

I understand HTML5 isn't exactly the chief target of LibGDX, but I for one would like to do some fancy background things in the HTML5 side of my game :)