### PR TITLE
set mouse cursor using a Cursor object

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphics.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphics.java
@@ -38,9 +38,11 @@ import com.badlogic.gdx.backends.android.surfaceview.GLSurfaceViewAPI18;
 import com.badlogic.gdx.backends.android.surfaceview.GdxEglConfigChooser;
 import com.badlogic.gdx.backends.android.surfaceview.ResolutionStrategy;
 import com.badlogic.gdx.graphics.Cubemap;
+import com.badlogic.gdx.graphics.Cursor;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.GL30;
 import com.badlogic.gdx.graphics.Mesh;
+import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.glutils.FrameBuffer;
 import com.badlogic.gdx.graphics.glutils.ShaderProgram;
@@ -618,5 +620,14 @@ public class AndroidGraphics implements Graphics, Renderer {
 	@Override
 	public GL30 getGL30 () {
 		return gl30;
+	}
+	
+	@Override
+	public Cursor newCursor (Pixmap pixmap, int xHotspot, int yHotspot) {
+		return null;
+	}
+
+	@Override
+	public void setCursor (Cursor cursor) {
 	}
 }

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidInput.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidInput.java
@@ -47,7 +47,6 @@ import com.badlogic.gdx.Input;
 import com.badlogic.gdx.Input.TextInputListener;
 import com.badlogic.gdx.InputProcessor;
 import com.badlogic.gdx.backends.android.AndroidLiveWallpaperService.AndroidWallpaperEngine;
-import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.utils.IntSet;
 import com.badlogic.gdx.utils.Pool;
 
@@ -819,10 +818,6 @@ public class AndroidInput implements Input, OnKeyListener, OnTouchListener {
 
 	@Override
 	public void setCursorPosition (int x, int y) {
-	}
-
-	@Override
-	public void setCursorImage (Pixmap pixmap, int xHotspot, int yHotspot) {
 	}
 
 	@Override

--- a/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/mock/graphics/MockGraphics.java
+++ b/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/mock/graphics/MockGraphics.java
@@ -17,8 +17,10 @@
 package com.badlogic.gdx.backends.headless.mock.graphics;
 
 import com.badlogic.gdx.Graphics;
+import com.badlogic.gdx.graphics.Cursor;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.GL30;
+import com.badlogic.gdx.graphics.Pixmap;
 
 /** The headless backend does its best to mock elements. This is intended to make code-sharing between
  * server and client as simple as possible.
@@ -186,6 +188,15 @@ public class MockGraphics implements Graphics {
 
 	public void incrementFrameId () {
 		frameId++;
+	}
+	
+	@Override
+	public Cursor newCursor (Pixmap pixmap, int xHotspot, int yHotspot) {
+		return null;
+	}
+
+	@Override
+	public void setCursor (Cursor cursor) {
 	}
 
 }

--- a/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/mock/input/MockInput.java
+++ b/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/mock/input/MockInput.java
@@ -20,7 +20,6 @@ import com.badlogic.gdx.Input;
 import com.badlogic.gdx.Input.TextInputListener;
 import com.badlogic.gdx.InputAdapter;
 import com.badlogic.gdx.InputProcessor;
-import com.badlogic.gdx.graphics.Pixmap;
 
 /** The headless backend does its best to mock elements. This is intended to make code-sharing between
  * server and client as simple as possible.
@@ -219,11 +218,6 @@ public class MockInput implements Input {
 
 	@Override
 	public void setCursorPosition(int x, int y) {
-
-	}
-
-	@Override
-	public void setCursorImage(Pixmap pixmap, int xHotspot, int yHotspot) {
 
 	}
 }

--- a/backends/gdx-backend-jglfw/src/com/badlogic/gdx/backends/jglfw/JglfwGraphics.java
+++ b/backends/gdx-backend-jglfw/src/com/badlogic/gdx/backends/jglfw/JglfwGraphics.java
@@ -22,8 +22,10 @@ import com.badlogic.gdx.ApplicationListener;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Graphics;
 import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.Cursor;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.GL30;
+import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.GdxRuntimeException;
 import com.badlogic.jglfw.GlfwVideoMode;
@@ -402,5 +404,14 @@ public class JglfwGraphics implements Graphics {
 	@Override
 	public GL30 getGL30 () {
 		return null;
+	}
+	
+	@Override
+	public Cursor newCursor (Pixmap pixmap, int xHotspot, int yHotspot) {
+		return null;
+	}
+
+	@Override
+	public void setCursor (Cursor cursor) {
 	}
 }

--- a/backends/gdx-backend-jglfw/src/com/badlogic/gdx/backends/jglfw/JglfwInput.java
+++ b/backends/gdx-backend-jglfw/src/com/badlogic/gdx/backends/jglfw/JglfwInput.java
@@ -38,7 +38,6 @@ import com.badlogic.gdx.Input;
 import com.badlogic.gdx.InputProcessor;
 import com.badlogic.gdx.InputProcessorQueue;
 import com.badlogic.gdx.Input.Buttons;
-import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.utils.IntSet;
 import com.badlogic.jglfw.GlfwCallbackAdapter;
 
@@ -292,10 +291,6 @@ public class JglfwInput implements Input {
 
 	public void setCursorPosition (int x, int y) {
 		glfwSetCursorPos(app.graphics.window, x, y);
-	}
-
-	@Override
-	public void setCursorImage (Pixmap pixmap, int xHotspot, int yHotspot) {
 	}
 
 	public void getTextInput (final TextInputListener listener, final String title, final String text, final String hint) {

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglAWTInput.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglAWTInput.java
@@ -57,8 +57,6 @@ import javax.swing.event.DocumentListener;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.InputProcessor;
-import com.badlogic.gdx.Input.TextInputListener;
-import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.utils.IntSet;
 import com.badlogic.gdx.utils.Pool;
 
@@ -807,10 +805,6 @@ public class LwjglAWTInput implements Input, MouseMotionListener, MouseListener,
 			robot.mouseMove(canvas.getLocationOnScreen().x + x, canvas.getLocationOnScreen().y + y);
 		}
 	}
-
-  @Override
-  public void setCursorImage(Pixmap pixmap, int xHotspot, int yHotspot) {
-  }
 
   @Override
 	public void setCatchMenuKey (boolean catchMenu) {

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglCursor.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglCursor.java
@@ -1,0 +1,98 @@
+
+package com.badlogic.gdx.backends.lwjgl;
+
+import java.nio.ByteOrder;
+import java.nio.IntBuffer;
+
+import org.lwjgl.LWJGLException;
+import org.lwjgl.input.Mouse;
+
+import com.badlogic.gdx.graphics.Cursor;
+import com.badlogic.gdx.graphics.Pixmap;
+import com.badlogic.gdx.utils.GdxRuntimeException;
+
+public class LwjglCursor implements Cursor {
+	/** Revert to the default system cursor */
+	public static void resetCursor () {
+		try {
+			Mouse.setNativeCursor(null);
+		} catch (LWJGLException e) {
+			throw new GdxRuntimeException("Could not set cursor image.", e);
+		}
+	}
+
+	private org.lwjgl.input.Cursor lwjglCursor = null;
+
+	public LwjglCursor (Pixmap pixmap, int xHotspot, int yHotspot) {
+
+		try {
+			if (pixmap == null) {
+				lwjglCursor = null;
+				return;
+			}
+
+			if (pixmap.getFormat() != Pixmap.Format.RGBA8888) {
+				throw new GdxRuntimeException("Cursor image pixmap is not in RGBA8888 format.");
+			}
+
+			if ((pixmap.getWidth() & (pixmap.getWidth() - 1)) != 0) {
+				throw new GdxRuntimeException("Cursor image pixmap width of " + pixmap.getWidth()
+					+ " is not a power-of-two greater than zero.");
+			}
+
+			if ((pixmap.getHeight() & (pixmap.getHeight() - 1)) != 0) {
+				throw new GdxRuntimeException("Cursor image pixmap height of " + pixmap.getHeight()
+					+ " is not a power-of-two greater than zero.");
+			}
+
+			if (xHotspot < 0 || xHotspot >= pixmap.getWidth()) {
+				throw new GdxRuntimeException("xHotspot coordinate of " + xHotspot + " is not within image width bounds: [0, "
+					+ pixmap.getWidth() + ").");
+			}
+
+			if (yHotspot < 0 || yHotspot >= pixmap.getHeight()) {
+				throw new GdxRuntimeException("yHotspot coordinate of " + yHotspot + " is not within image height bounds: [0, "
+					+ pixmap.getHeight() + ").");
+			}
+
+			// Convert from RGBA8888 to ARGB8888 and flip vertically
+			IntBuffer pixelBuffer = pixmap.getPixels().asIntBuffer();
+			int[] pixelsRGBA = new int[pixelBuffer.capacity()];
+			pixelBuffer.get(pixelsRGBA);
+			int[] pixelsARGBflipped = new int[pixelBuffer.capacity()];
+			int pixel;
+			if (pixelBuffer.order() == ByteOrder.BIG_ENDIAN) {
+				for (int y = 0; y < pixmap.getHeight(); ++y) {
+					for (int x = 0; x < pixmap.getWidth(); ++x) {
+						pixel = pixelsRGBA[x + (y * pixmap.getWidth())];
+						pixelsARGBflipped[x + ((pixmap.getHeight() - 1 - y) * pixmap.getWidth())] = ((pixel >> 8) & 0x00FFFFFF)
+							| ((pixel << 24) & 0xFF000000);
+					}
+				}
+			} else {
+				for (int y = 0; y < pixmap.getHeight(); ++y) {
+					for (int x = 0; x < pixmap.getWidth(); ++x) {
+						pixel = pixelsRGBA[x + (y * pixmap.getWidth())];
+						pixelsARGBflipped[x + ((pixmap.getHeight() - 1 - y) * pixmap.getWidth())] = ((pixel & 0xFF) << 16)
+							| ((pixel & 0xFF0000) >> 16) | (pixel & 0xFF00FF00);
+					}
+				}
+			}
+
+			lwjglCursor = new org.lwjgl.input.Cursor(pixmap.getWidth(), pixmap.getHeight(), xHotspot, pixmap.getHeight() - yHotspot
+				- 4, 1, IntBuffer.wrap(pixelsARGBflipped), null);
+		} catch (LWJGLException e) {
+			throw new GdxRuntimeException("Could not create cursor image.", e);
+		}
+	}
+
+	@Override
+	public void setSystemCursor () {
+		try {
+			Mouse.setNativeCursor(lwjglCursor);
+		} catch (LWJGLException e) {
+			throw new GdxRuntimeException("Could not set cursor image.", e);
+		}
+	}
+
+}

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGraphics.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGraphics.java
@@ -28,6 +28,7 @@ import org.lwjgl.opengl.PixelFormat;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Graphics;
+import com.badlogic.gdx.graphics.Cursor;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.GL30;
 import com.badlogic.gdx.graphics.Pixmap;
@@ -518,5 +519,19 @@ public class LwjglGraphics implements Graphics {
 		 * @return the configuration to be used for a second attempt at creating a display. A null value results in NOT attempting
 		 *         to create the display a second time */
 		public LwjglApplicationConfiguration onFailure (LwjglApplicationConfiguration initialConfig);
+	}
+	
+	@Override
+	public com.badlogic.gdx.graphics.Cursor newCursor (Pixmap pixmap, int xHotspot, int yHotspot) {
+		return new LwjglCursor(pixmap, xHotspot, yHotspot);
+	}
+
+	@Override
+	public void setCursor (com.badlogic.gdx.graphics.Cursor cursor) {
+		if (cursor == null) {
+			LwjglCursor.resetCursor();
+		} else {
+			cursor.setSystemCursor();
+		}
 	}
 }

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglInput.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglInput.java
@@ -1019,69 +1019,6 @@ final public class LwjglInput implements Input {
 	}
 
 	@Override
-	public void setCursorImage (Pixmap pixmap, int xHotspot, int yHotspot) {
-		try {
-			if (pixmap == null) {
-				Mouse.setNativeCursor(null);
-				return;
-			}
-
-			if (pixmap.getFormat() != Pixmap.Format.RGBA8888) {
-				throw new GdxRuntimeException("Cursor image pixmap is not in RGBA8888 format.");
-			}
-
-			if ((pixmap.getWidth() & (pixmap.getWidth() - 1)) != 0) {
-				throw new GdxRuntimeException("Cursor image pixmap width of " + pixmap.getWidth()
-					+ " is not a power-of-two greater than zero.");
-			}
-
-			if ((pixmap.getHeight() & (pixmap.getHeight() - 1)) != 0) {
-				throw new GdxRuntimeException("Cursor image pixmap height of " + pixmap.getHeight()
-					+ " is not a power-of-two greater than zero.");
-			}
-
-			if (xHotspot < 0 || xHotspot >= pixmap.getWidth()) {
-				throw new GdxRuntimeException("xHotspot coordinate of " + xHotspot + " is not within image width bounds: [0, "
-					+ pixmap.getWidth() + ").");
-			}
-
-			if (yHotspot < 0 || yHotspot >= pixmap.getHeight()) {
-				throw new GdxRuntimeException("yHotspot coordinate of " + yHotspot + " is not within image height bounds: [0, "
-					+ pixmap.getHeight() + ").");
-			}
-
-			// Convert from RGBA8888 to ARGB8888 and flip vertically
-			IntBuffer pixelBuffer = pixmap.getPixels().asIntBuffer();
-			int[] pixelsRGBA = new int[pixelBuffer.capacity()];
-			pixelBuffer.get(pixelsRGBA);
-			int[] pixelsARGBflipped = new int[pixelBuffer.capacity()];
-			int pixel;
-			if (pixelBuffer.order() == ByteOrder.BIG_ENDIAN) {
-				for (int y = 0; y < pixmap.getHeight(); ++y) {
-					for (int x = 0; x < pixmap.getWidth(); ++x) {
-						pixel = pixelsRGBA[x + (y * pixmap.getWidth())];
-						pixelsARGBflipped[x + ((pixmap.getHeight() - 1 - y) * pixmap.getWidth())] = ((pixel >> 8) & 0x00FFFFFF)
-							| ((pixel << 24) & 0xFF000000);
-					}
-				}
-			} else {
-				for (int y = 0; y < pixmap.getHeight(); ++y) {
-					for (int x = 0; x < pixmap.getWidth(); ++x) {
-						pixel = pixelsRGBA[x + (y * pixmap.getWidth())];
-						pixelsARGBflipped[x + ((pixmap.getHeight() - 1 - y) * pixmap.getWidth())] = ((pixel & 0xFF) << 16)
-							| ((pixel & 0xFF0000) >> 16) | (pixel & 0xFF00FF00);
-					}
-				}
-			}
-
-			Mouse.setNativeCursor(new Cursor(pixmap.getWidth(), pixmap.getHeight(), xHotspot, pixmap.getHeight() - yHotspot - 4, 1,
-				IntBuffer.wrap(pixelsARGBflipped), null));
-		} catch (LWJGLException e) {
-			throw new GdxRuntimeException("Could not set cursor image.", e);
-		}
-	}
-
-	@Override
 	public void setCatchMenuKey (boolean catchMenu) {
 	}
 

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
@@ -43,8 +43,10 @@ import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Graphics;
 import com.badlogic.gdx.LifecycleListener;
 import com.badlogic.gdx.backends.iosrobovm.custom.HWMachine;
+import com.badlogic.gdx.graphics.Cursor;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.GL30;
+import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.utils.Array;
 
 public class IOSGraphics extends NSObject implements Graphics, GLKViewDelegate, GLKViewControllerDelegate {
@@ -490,5 +492,14 @@ public class IOSGraphics extends NSObject implements Graphics, GLKViewDelegate, 
 	@Override
 	public long getFrameId () {
 		return frameId;
+	}
+	
+	@Override
+	public Cursor newCursor (Pixmap pixmap, int xHotspot, int yHotspot) {
+		return null;
+	}
+
+	@Override
+	public void setCursor (Cursor cursor) {
 	}
 }

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSInput.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSInput.java
@@ -53,7 +53,6 @@ import com.badlogic.gdx.backends.iosrobovm.custom.UIAcceleration;
 import com.badlogic.gdx.backends.iosrobovm.custom.UIAccelerometer;
 import com.badlogic.gdx.backends.iosrobovm.custom.UIAccelerometerDelegate;
 import com.badlogic.gdx.backends.iosrobovm.custom.UIAccelerometerDelegateAdapter;
-import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.GdxRuntimeException;
@@ -584,10 +583,6 @@ public class IOSInput implements Input {
 
 	@Override
 	public void setCursorPosition (int x, int y) {
-	}
-
-	@Override
-	public void setCursorImage (Pixmap pixmap, int xHotspot, int yHotspot) {
 	}
 
 	public void touchDown (long touches, UIEvent event) {

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtGraphics.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtGraphics.java
@@ -18,8 +18,10 @@ package com.badlogic.gdx.backends.gwt;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Graphics;
+import com.badlogic.gdx.graphics.Cursor;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.GL30;
+import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.utils.GdxRuntimeException;
 import com.google.gwt.canvas.client.Canvas;
 import com.google.gwt.dom.client.CanvasElement;
@@ -275,5 +277,14 @@ public class GwtGraphics implements Graphics {
 	@Override
 	public GL30 getGL30 () {
 		return null;
+	}
+	
+	@Override
+	public Cursor newCursor (Pixmap pixmap, int xHotspot, int yHotspot) {
+		return null;
+	}
+
+	@Override
+	public void setCursor (Cursor cursor) {
 	}
 }

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtInput.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtInput.java
@@ -22,7 +22,6 @@ import com.badlogic.gdx.InputProcessor;
 import com.badlogic.gdx.Input.Buttons;
 import com.badlogic.gdx.backends.gwt.widgets.TextInputDialogBox;
 import com.badlogic.gdx.backends.gwt.widgets.TextInputDialogBox.TextInputDialogListener;
-import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.utils.IntMap;
 import com.badlogic.gdx.utils.IntSet;
 import com.badlogic.gdx.utils.TimeUtils;
@@ -373,10 +372,6 @@ public class GwtInput implements Input {
 	@Override
 	public void setCursorPosition (int x, int y) {
 		// FIXME??
-	}
-
-	@Override
-	public void setCursorImage (Pixmap pixmap, int xHotspot, int yHotspot) {
 	}
 
 	// kindly borrowed from our dear playn friends...

--- a/gdx/src/com/badlogic/gdx/Graphics.java
+++ b/gdx/src/com/badlogic/gdx/Graphics.java
@@ -16,9 +16,11 @@
 
 package com.badlogic.gdx;
 
+import com.badlogic.gdx.graphics.Cursor;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.GL30;
 import com.badlogic.gdx.graphics.Mesh;
+import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.g2d.Batch;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.graphics.glutils.FrameBuffer;
@@ -221,4 +223,23 @@ public interface Graphics {
 
 	/** Whether the app is fullscreen or not */
 	public boolean isFullscreen ();
+
+	/** Create a new cursor represented by the {@link com.badlogic.gdx.graphics.Pixmap}. The Pixmap must be in RGBA8888 format,
+	 * width & height must be powers-of-two greater than zero (not necessarily equal), and alpha transparency must be single-bit
+	 * (i.e., 0x00 or 0xFF only). This function returns a Cursor object that can be set as the system cursor by calling
+	 * {@link #setCursor(Cursor)} .
+	 * 
+	 * @param pixmap the mouse cursor image as a {@link com.badlogic.gdx.graphics.Pixmap}
+	 * @param xHotspot the x location of the hotspot pixel within the cursor image (origin top-left corner)
+	 * @param yHotspot the y location of the hotspot pixel within the cursor image (origin top-left corner)
+	 * @return a cursor object that can be used by calling {@link #setCursor(Cursor)} or null if not supported */
+	public Cursor newCursor (Pixmap pixmap, int xHotspot, int yHotspot);
+
+	/** Only viable on the desktop. Will set the mouse cursor image to the image represented by the
+	 * {@link com.badlogic.gdx.graphics.Cursor}. To revert to the default operating system cursor, pass in a null cursor. It is
+	 * recommended to call this function in the main render thread, and maximum one time per frame.
+	 * 
+	 * @param cursor the mouse cursor as a {@link com.badlogic.gdx.graphics.Cursor}, or null to revert to the default operating
+	 *           system cursor */
+	public void setCursor (Cursor cursor);
 }

--- a/gdx/src/com/badlogic/gdx/Input.java
+++ b/gdx/src/com/badlogic/gdx/Input.java
@@ -756,15 +756,4 @@ public interface Input {
 	 * @param x the x-position
 	 * @param y the y-position */
 	public void setCursorPosition (int x, int y);
-
-	/** Only viable on the desktop. Will set the mouse cursor image to the image represented by the
-	 * {@link com.badlogic.gdx.graphics.Pixmap}. The Pixmap must be in RGBA8888 format, width & height must be powers-of-two
-	 * greater than zero (not necessarily equal), and alpha transparency must be single-bit (i.e., 0x00 or 0xFF only). To revert to
-	 * the default operating system cursor, pass in a null Pixmap; xHotspot & yHotspot are ignored in this case.
-	 * 
-	 * @param pixmap the mouse cursor image as a {@link com.badlogic.gdx.graphics.Pixmap}, or null to revert to the default
-	 *           operating system cursor
-	 * @param xHotspot the x location of the hotspot pixel within the cursor image (origin top-left corner)
-	 * @param yHotspot the y location of the hotspot pixel within the cursor image (origin top-left corner) */
-	public void setCursorImage (Pixmap pixmap, int xHotspot, int yHotspot);
 }

--- a/gdx/src/com/badlogic/gdx/graphics/Cursor.java
+++ b/gdx/src/com/badlogic/gdx/graphics/Cursor.java
@@ -1,0 +1,22 @@
+
+package com.badlogic.gdx.graphics;
+
+import com.badlogic.gdx.Graphics;
+
+/** <p>
+ * A class representing a native cursor.
+ * </p>
+ * 
+ * <p>
+ * Cursor instances are created via a call to {@link Graphics#newCursor(Pixmap, int, int)}.
+ * </p>
+ * 
+ * <p>
+ * Cursor are set using {@link Graphics#setCursor(Cursor)}.
+ * </p> **/
+public interface Cursor {
+	/**
+	 * set the desktop mouse cursor to this cursor. 
+	 */
+	public void setSystemCursor ();
+}

--- a/gdx/src/com/badlogic/gdx/input/RemoteInput.java
+++ b/gdx/src/com/badlogic/gdx/input/RemoteInput.java
@@ -26,7 +26,6 @@ import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.Input.TextInputListener;
 import com.badlogic.gdx.InputProcessor;
-import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.utils.GdxRuntimeException;
 import com.badlogic.gdx.utils.IntSet;
 
@@ -503,10 +502,6 @@ public class RemoteInput implements Runnable, Input {
 
 	@Override
 	public void setCursorPosition (int x, int y) {
-	}
-
-	@Override
-	public void setCursorImage (Pixmap pixmap, int xHotspot, int yHotspot) {
 	}
 
 	@Override

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/CursorTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/CursorTest.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogic.gdx.tests;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.Cursor;
+import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.OrthographicCamera;
+import com.badlogic.gdx.graphics.Pixmap;
+import com.badlogic.gdx.graphics.Pixmap.Format;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.math.Vector3;
+import com.badlogic.gdx.tests.utils.GdxTest;
+
+/** Simple test case for mouse cursor change
+ * Switch between two cursors every frame, a third cursor is used when a mouse button is pressed
+ * @author haedri */
+public class CursorTest extends GdxTest {
+	Cursor cursor1;
+	Cursor cursor2;
+	Cursor cursor3;
+	boolean cursorActive = false;
+
+	public void create () {
+
+		Pixmap pixmap1 = new Pixmap(Gdx.files.internal("data/bobargb8888-32x32.png"));
+		cursor1 = Gdx.graphics.newCursor(pixmap1, 16, 16);
+		
+		Pixmap pixmap2 = new Pixmap(32, 32, Format.RGBA8888);
+		pixmap2.setColor(Color.RED);
+		pixmap2.fillCircle(16, 16, 8);
+		cursor2 = Gdx.graphics.newCursor(pixmap2, 16, 16);
+		
+		Pixmap pixmap3 = new Pixmap(32, 32, Format.RGBA8888);
+		pixmap3.setColor(Color.BLUE);
+		pixmap3.fillCircle(16, 16, 8);
+		cursor3 = Gdx.graphics.newCursor(pixmap3, 16, 16);
+
+	}
+
+	public void render () {
+		// set the clear color and clear the screen.
+		Gdx.gl.glClearColor(1, 1, 1, 1);
+		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+
+		if (Gdx.input.isTouched()) {
+			Gdx.graphics.setCursor(cursor1);
+		} else {
+			cursorActive = !cursorActive;
+			if (cursorActive) {
+				Gdx.graphics.setCursor(cursor2);
+			} else {
+				Gdx.graphics.setCursor(cursor3);
+			}
+		}
+	}
+}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtTestWrapper.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtTestWrapper.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -297,7 +297,7 @@ public class GwtTestWrapper extends GdxTest {
 		public boolean isKeyPressed (int key) {
 			return input.isKeyPressed(key);
 		}
-		
+
 		@Override
 		public boolean isKeyJustPressed (int key) {
 			return input.isKeyJustPressed(key);
@@ -408,10 +408,6 @@ public class GwtTestWrapper extends GdxTest {
 		@Override
 		public void setCursorPosition (int x, int y) {
 			setCursorPosition(x, y);
-		}
-
-		@Override
-		public void setCursorImage (Pixmap pixmap, int xHotspot, int yHotspot) {
 		}
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
@@ -109,6 +109,7 @@ public class GdxTests {
 		CpuSpriteBatchTest.class,
 		ContainerTest.class,
 		CullTest.class,
+		CursorTest.class,
 		DelaunayTriangulatorTest.class,
 		DeltaTimeTest.class,
 		DirtyRenderingTest.class,


### PR DESCRIPTION
This pull request is to solve issue #2839

Basically problem is that currently calling Gdx.input.setCursorImage will create a new (lwjgl) Cursor object everytime, even if pixmaps are identical + it will make some calculations to process the Pixmap.
This is ok if only a few setCursorImage call are made, but if the application requires to cycle a lot through a few cursors then it will eventually crash on Windows (invisible cursor) and also use unecessary memory + cpu.

This pull request adds a new Cursor object that can be created by calling Gdx.input.newCursor, and set anytime using Gdx.input.setCursor, when using this method no other object are created when calling Gdx.input.setCursor. It kinda provides a way for the user to use a cache for cursor creation.

This is my very first pull request (first time using commit, push and pull request actually) and my first contribution to Libgdx. So if I made anything wrong don't hesitate to tell me, I will do my best to correct this.

There are two things I am not sure about:
1- I kept the old Gdx.input.setCursorImage for compatibility reasons, it will call newCursor/setCursor, maybe it should be noted deprecated or something...
2- The Gdx.input.setCursor method is not necessary as the Cursor object has a setCursor() function, I was thinking of removing it, but lept it to match current setCursorImage method and to provide an easy way to revert to default cursor (other way is to call newCursor with a null pixmap and use this cursor next). It's 50/50, so if you want me to remove it I can easily understand.
