### PR TITLE
Fixed a NPE in HttpResponse.getResultAsString()

### DIFF
--- a/gdx/src/com/badlogic/gdx/net/NetJavaImpl.java
+++ b/gdx/src/com/badlogic/gdx/net/NetJavaImpl.java
@@ -71,6 +71,12 @@ public class NetJavaImpl {
 		@Override
 		public String getResultAsString () {
 			InputStream input = getInputStream();
+
+			// If the response does not contain any content, input will be null.
+			if (input == null) {
+				return "";
+			}
+
 			try {
 				return StreamUtils.copyStreamToString(input, connection.getContentLength());
 			} catch (IOException e) {


### PR DESCRIPTION
In case a HttpResponse does not contain any content, using `HttpResponse.getResultAsString()` will result in a NullPointerException:

    java.lang.NullPointerException
        at java.io.Reader.<init>(Reader.java:78)
        at java.io.InputStreamReader.<init>(InputStreamReader.java:72)
        at com.badlogic.gdx.utils.StreamUtils.copyStreamToString(StreamUtils.java:74)
        at com.badlogic.gdx.net.NetJavaImpl$HttpClientResponse.getResultAsString(NetJavaImpl.java:75)

This PR adds a nullcheck to `HttpResponse.getResultAsString()` and returns `""` instead.