### PR TITLE
Expose clearListeners method on ControllerManager

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 [1.5.5]
 - API Change: 3D Animation, NodeAnimation keyframes are separated into translation, rotation and scaling
 - Added capability to enable color markup from inside skin json file.
+- API Change: Exposed method ControllerManager#clearListeners on Controllers class
 
 [1.5.4]
 - Added support for image layers in Tiled maps (TiledMapImageLayer)

--- a/extensions/gdx-controllers/gdx-controllers/src/com/badlogic/gdx/controllers/Controllers.java
+++ b/extensions/gdx-controllers/gdx-controllers/src/com/badlogic/gdx/controllers/Controllers.java
@@ -58,6 +58,12 @@ public class Controllers {
 		initialize();
 		getManager().removeListener(listener);
 	}
+	
+	/** Removes every global {@link ControllerListener} previously added. */
+	static public void clearListeners () {
+		initialize();
+		getManager().clearListeners();
+	}
 
 	static private ControllerManager getManager () {
 		return managers.get(Gdx.app);


### PR DESCRIPTION
Currently, the only way of removing a previously added `ControllerListener` is by **holding a reference** to that instance. More often than not that is either impractical or, having it accessible, implies a violation of the architecture or forces to bend classes' responsibilities.

I have noticed that the `ControllerManager` interface defines a `clearListeners` method, which is the only one not accessible through a static method on the `Controllers` class. Was there a reason why this one was left behind?

Having this publicly accessible would be pretty handy.