### PR TITLE
Added TexturePacker silent mode

### DIFF
--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/texturepacker/GridPacker.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/texturepacker/GridPacker.java
@@ -33,7 +33,7 @@ public class GridPacker implements Packer {
 	}
 
 	public Array<Page> pack (Array<Rect> inputRects) {
-		System.out.print("Packing");
+		if (!settings.silent) System.out.print("Packing");
 
 		int cellWidth = 0, cellHeight = 0;
 		for (int i = 0, nn = inputRects.size; i < nn; i++) {

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/texturepacker/ImageProcessor.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/texturepacker/ImageProcessor.java
@@ -94,7 +94,7 @@ public class ImageProcessor {
 		Rect rect = processImage(image, name);
 
 		if (rect == null) {
-			System.out.println("Ignoring blank input image: " + name);
+			if(!settings.silent) System.out.println("Ignoring blank input image: " + name);
 			return null;
 		}
 
@@ -102,7 +102,7 @@ public class ImageProcessor {
 			String crc = hash(rect.getImage(this));
 			Rect existing = crcs.get(crc);
 			if (existing != null) {
-				System.out.println(rect.name + " (alias of " + existing.name + ")");
+				if (!settings.silent) System.out.println(rect.name + " (alias of " + existing.name + ")");
 				existing.aliases.add(new Alias(rect));
 				return null;
 			}

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/texturepacker/MaxRectsPacker.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/texturepacker/MaxRectsPacker.java
@@ -112,7 +112,7 @@ public class MaxRectsPacker implements Packer {
 		minWidth = Math.max(minWidth, settings.minWidth);
 		minHeight = Math.max(minHeight, settings.minHeight);
 
-		System.out.print("Packing");
+		if (!settings.silent) System.out.print("Packing");
 
 		// Find the minimal page size that fits all rects.
 		Page bestResult = null;
@@ -123,12 +123,14 @@ public class MaxRectsPacker implements Packer {
 			int size = sizeSearch.reset(), i = 0;
 			while (size != -1) {
 				Page result = packAtSize(true, size - edgePaddingX, size - edgePaddingY, inputRects);
-				if (++i % 70 == 0) System.out.println();
-				System.out.print(".");
+				if (!settings.silent) {
+					if (++i % 70 == 0) System.out.println();
+					System.out.print(".");
+				}
 				bestResult = getBest(bestResult, result);
 				size = sizeSearch.next(result == null);
 			}
-			System.out.println();
+			if (!settings.silent) System.out.println();
 			// Rects don't fit on one page. Fill a whole page and return.
 			if (bestResult == null) bestResult = packAtSize(false, maxSize - edgePaddingX, maxSize - edgePaddingY, inputRects);
 			sort.sort(bestResult.outputRects, rectComparator);
@@ -144,8 +146,10 @@ public class MaxRectsPacker implements Packer {
 				Page bestWidthResult = null;
 				while (width != -1) {
 					Page result = packAtSize(true, width - edgePaddingX, height - edgePaddingY, inputRects);
-					if (++i % 70 == 0) System.out.println();
-					System.out.print(".");
+					if (!settings.silent) {
+						if (++i % 70 == 0) System.out.println();
+						System.out.print(".");
+					}
 					bestWidthResult = getBest(bestWidthResult, result);
 					width = widthSearch.next(result == null);
 					if (settings.square) height = width;
@@ -156,7 +160,7 @@ public class MaxRectsPacker implements Packer {
 				if (height == -1) break;
 				width = widthSearch.reset();
 			}
-			System.out.println();
+			if (!settings.silent) System.out.println();
 			// Rects don't fit on one page. Fill a whole page and return.
 			if (bestResult == null)
 				bestResult = packAtSize(false, settings.maxWidth - edgePaddingX, settings.maxHeight - edgePaddingY, inputRects);

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/texturepacker/TexturePacker.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/texturepacker/TexturePacker.java
@@ -156,7 +156,7 @@ public class TexturePacker {
 			BufferedImage canvas = new BufferedImage(width, height, getBufferedImageType(settings.format));
 			Graphics2D g = (Graphics2D)canvas.getGraphics();
 
-			System.out.println("Writing " + canvas.getWidth() + "x" + canvas.getHeight() + ": " + outputFile);
+			if (!settings.silent) System.out.println("Writing " + canvas.getWidth() + "x" + canvas.getHeight() + ": " + outputFile);
 
 			for (Rect rect : page.outputRects) {
 				BufferedImage image = rect.getImage(imageProcessor);
@@ -529,6 +529,7 @@ public class TexturePacker {
 		public boolean ignoreBlankImages = true;
 		public boolean fast;
 		public boolean debug;
+		public boolean silent;
 		public boolean combineSubdirectories;
 		public boolean flattenPaths;
 		public boolean premultiplyAlpha;
@@ -568,6 +569,7 @@ public class TexturePacker {
 			wrapX = settings.wrapX;
 			wrapY = settings.wrapY;
 			debug = settings.debug;
+			silent = settings.silent;
 			combineSubdirectories = settings.combineSubdirectories;
 			flattenPaths = settings.flattenPaths;
 			premultiplyAlpha = settings.premultiplyAlpha;

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/texturepacker/TexturePackerFileProcessor.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/texturepacker/TexturePackerFileProcessor.java
@@ -211,7 +211,7 @@ public class TexturePackerFileProcessor extends FileProcessor {
 		});
 
 		// Pack.
-		System.out.println(inputDir.inputFile.getName());
+		if (!settings.silent) System.out.println(inputDir.inputFile.getName());
 		TexturePacker packer = new TexturePacker(root, settings);
 		for (Entry file : files)
 			packer.addImage(file.inputFile);


### PR DESCRIPTION
Added setting to run texture packer in silent mode that doesn't output information about packing progress. This may be useful for tools that uses texture packer from code and doesn't want to output progress information.