### PR TITLE
Fixed SplitPane handle drawing

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/SplitPane.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/SplitPane.java
@@ -251,7 +251,7 @@ public class SplitPane extends WidgetGroup {
 				ScissorStack.popScissors();
 			}
 		}
-		batch.setColor(color.r, color.g, color.b, color.a);
+		batch.setColor(color.r, color.g, color.b, parentAlpha * color.a);
 		handle.draw(batch, handleBounds.x, handleBounds.y, handleBounds.width, handleBounds.height);
 		resetTransform(batch);
 	}


### PR DESCRIPTION
SplitPane handle does not use parentAlpha while drawing.

When used in window with fade out animation handle stays with alpha == 1, like here:
![2015-02-20_2228](https://cloud.githubusercontent.com/assets/4594081/6309744/7b213cf0-b950-11e4-847d-92df9b0a5aef.png)

This PR fixes that.