### PR TITLE
Include dependencies count when reporting asset manager progress.

### DIFF
--- a/gdx/src/com/badlogic/gdx/assets/AssetLoadingTask.java
+++ b/gdx/src/com/badlogic/gdx/assets/AssetLoadingTask.java
@@ -39,6 +39,7 @@ class AssetLoadingTask implements AsyncTask<Void> {
 	final long startTime;
 
 	volatile boolean asyncDone = false;
+	volatile boolean dependenciesInjected = false;
 	volatile boolean dependenciesLoaded = false;
 	volatile Array<AssetDescriptor> dependencies;
 	volatile AsyncResult<Void> depsFuture = null;
@@ -64,6 +65,7 @@ class AssetLoadingTask implements AsyncTask<Void> {
 			dependencies = asyncLoader.getDependencies(assetDesc.fileName, resolve(loader, assetDesc), assetDesc.params);
 			if (dependencies != null) {
 				manager.injectDependencies(assetDesc.fileName, dependencies);
+				dependenciesInjected = true;
 			} else {
 				// if we have no dependencies, we load the async part of the task immediately.
 				asyncLoader.loadAsync(manager, assetDesc.fileName, resolve(loader, assetDesc), assetDesc.params);
@@ -101,6 +103,7 @@ class AssetLoadingTask implements AsyncTask<Void> {
 				return;
 			}
 			manager.injectDependencies(assetDesc.fileName, dependencies);
+			dependenciesInjected = true;
 		} else {
 			asset = syncLoader.load(manager, assetDesc.fileName, resolve(loader, assetDesc), assetDesc.params);
 		}

--- a/gdx/src/com/badlogic/gdx/assets/AssetManager.java
+++ b/gdx/src/com/badlogic/gdx/assets/AssetManager.java
@@ -421,6 +421,7 @@ public class AssetManager implements Disposable {
 		else {
 			log.info("Loading dependency: " + dependendAssetDesc);
 			addTask(dependendAssetDesc);
+            toLoad++;
 		}
 	}
 
@@ -478,7 +479,7 @@ public class AssetManager implements Disposable {
 			addAsset(task.assetDesc.fileName, task.assetDesc.type, task.getAsset());
 
 			// increase the number of loaded assets and pop the task from the stack
-			if (tasks.size() == 1) loaded++;
+			if(tasks.size() >= 1) loaded++;
 			tasks.pop();
 
 			// remove the asset if it was canceled.

--- a/gdx/src/com/badlogic/gdx/assets/AssetManager.java
+++ b/gdx/src/com/badlogic/gdx/assets/AssetManager.java
@@ -421,7 +421,6 @@ public class AssetManager implements Disposable {
 		else {
 			log.info("Loading dependency: " + dependendAssetDesc);
 			addTask(dependendAssetDesc);
-			toLoad++;
 		}
 	}
 
@@ -479,7 +478,7 @@ public class AssetManager implements Disposable {
 			addAsset(task.assetDesc.fileName, task.assetDesc.type, task.getAsset());
 
 			// increase the number of loaded assets and pop the task from the stack
-			if (tasks.size() >= 1) loaded++;
+			if (tasks.size() == 1) loaded++;
 			tasks.pop();
 
 			// remove the asset if it was canceled.
@@ -576,7 +575,20 @@ public class AssetManager implements Disposable {
 	/** @return the progress in percent of completion. */
 	public synchronized float getProgress () {
 		if (toLoad == 0) return 1;
-		return Math.min(1, loaded / (float)toLoad);
+
+		int tasksLength = tasks.size();
+		float completedProgress = loaded / (float) toLoad;
+		float progressForCurrentAsset = 0;
+
+		if(tasksLength > 1) {
+			progressForCurrentAsset = 0.9f / (tasksLength * toLoad);
+		} else if(tasksLength == 1) {
+			AssetLoadingTask task = tasks.peek();
+			if(task.dependenciesLoaded || task.dependenciesInjected) {
+				progressForCurrentAsset = 0.9f / toLoad;
+			}
+		}
+		return Math.min(1, completedProgress + progressForCurrentAsset);
 	}
 
 	/** Sets an {@link AssetErrorListener} to be invoked in case loading an asset failed.

--- a/gdx/src/com/badlogic/gdx/assets/AssetManager.java
+++ b/gdx/src/com/badlogic/gdx/assets/AssetManager.java
@@ -421,7 +421,7 @@ public class AssetManager implements Disposable {
 		else {
 			log.info("Loading dependency: " + dependendAssetDesc);
 			addTask(dependendAssetDesc);
-            toLoad++;
+			toLoad++;
 		}
 	}
 
@@ -479,7 +479,7 @@ public class AssetManager implements Disposable {
 			addAsset(task.assetDesc.fileName, task.assetDesc.type, task.getAsset());
 
 			// increase the number of loaded assets and pop the task from the stack
-			if(tasks.size() >= 1) loaded++;
+			if (tasks.size() >= 1) loaded++;
 			tasks.pop();
 
 			// remove the asset if it was canceled.

--- a/gdx/src/com/badlogic/gdx/assets/AssetManager.java
+++ b/gdx/src/com/badlogic/gdx/assets/AssetManager.java
@@ -584,7 +584,7 @@ public class AssetManager implements Disposable {
 			progressForCurrentAsset = 0.9f / (tasksLength * toLoad);
 		} else if(tasksLength == 1) {
 			AssetLoadingTask task = tasks.peek();
-			if(task.dependenciesLoaded || task.dependenciesInjected) {
+			if(task.dependenciesInjected) {
 				progressForCurrentAsset = 0.9f / toLoad;
 			}
 		}


### PR DESCRIPTION
This makes it so that when an asset has dependencies, the getProgress() call reflects the actual process for loading the assets. 

I'm not sure if it was created this way intentionally, but in my mind this gives a more accurate indication of the load progress than how it currently is. This can however make the percent completion go backwards at times (which I guess could be why it is the way that it currently is...). If this is an issue for including this change, I'll look into fixing it.