### PR TITLE
Added contains to Shape2D.

### DIFF
--- a/gdx/src/com/badlogic/gdx/math/Polygon.java
+++ b/gdx/src/com/badlogic/gdx/math/Polygon.java
@@ -194,6 +194,7 @@ public class Polygon implements Shape2D {
 	}
 
 	/** Returns whether an x, y pair is contained within the polygon. */
+	@Override
 	public boolean contains (float x, float y) {
 		final float[] vertices = getTransformedVertices();
 		final int numFloats = vertices.length;
@@ -207,6 +208,11 @@ public class Polygon implements Shape2D {
 			if (((y1 <= y && y < y2) || (y2 <= y && y < y1)) && x < ((x2 - x1) / (y2 - y1) * (y - y1) + x1)) intersects++;
 		}
 		return (intersects & 1) == 1;
+	}
+
+	@Override
+	public boolean contains (Vector2 point) {
+		return contains(point.x, point.y);
 	}
 
 	/** Returns the x-coordinate of the polygon's position within the world. */

--- a/gdx/src/com/badlogic/gdx/math/Polyline.java
+++ b/gdx/src/com/badlogic/gdx/math/Polyline.java
@@ -16,7 +16,7 @@
 
 package com.badlogic.gdx.math;
 
-public class Polyline {
+public class Polyline implements Shape2D {
 	private final float[] localVertices;
 	private float[] worldVertices;
 	private float x, y;
@@ -196,5 +196,15 @@ public class Polyline {
 		this.x += x;
 		this.y += y;
 		dirty = true;
+	}
+
+	@Override
+	public boolean contains (Vector2 point) {
+		return false;
+	}
+
+	@Override
+	public boolean contains (float x, float y) {
+		return false;
 	}
 }

--- a/gdx/src/com/badlogic/gdx/math/Polyline.java
+++ b/gdx/src/com/badlogic/gdx/math/Polyline.java
@@ -16,7 +16,7 @@
 
 package com.badlogic.gdx.math;
 
-public class Polyline implements Shape2D {
+public class Polyline {
 	private final float[] localVertices;
 	private float[] worldVertices;
 	private float x, y;

--- a/gdx/src/com/badlogic/gdx/math/Shape2D.java
+++ b/gdx/src/com/badlogic/gdx/math/Shape2D.java
@@ -1,4 +1,27 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
 package com.badlogic.gdx.math;
 
 public interface Shape2D {
+
+	/** Returns whether the given point is contained within the shape. */
+	boolean contains (Vector2 point);
+
+	/** Returns whether a point with the given coordinates is contained within the shape. */
+	boolean contains (float x, float y);
+
 }


### PR DESCRIPTION
This is the PR for https://github.com/libgdx/libgdx/issues/2880.

Polyline is no Shape2D anymore and `Shape2D` now has two methods `contains(float x, float y)` and `contains(Vector2 point)`.