### PR TITLE
Add option to skip ParticleEmitter's blendfunc clean-up to reduce Batch flushes

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g2d/ParticleEffect.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/ParticleEffect.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Writer;
+import java.util.HashMap;
 
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.Texture;
@@ -186,12 +187,18 @@ public class ParticleEffect implements Disposable {
 
 	public void loadEmitterImages (FileHandle imagesDir) {
 		ownsTexture = true;
+		HashMap<String, Sprite> loadedSprites = new HashMap<String, Sprite>(emitters.size);
 		for (int i = 0, n = emitters.size; i < n; i++) {
 			ParticleEmitter emitter = emitters.get(i);
 			String imagePath = emitter.getImagePath();
 			if (imagePath == null) continue;
 			String imageName = new File(imagePath.replace('\\', '/')).getName();
-			emitter.setSprite(new Sprite(loadTexture(imagesDir.child(imageName))));
+			Sprite sprite = loadedSprites.get(imageName);
+			if (sprite == null) {
+				sprite = new Sprite(loadTexture(imagesDir.child(imageName)));
+				loadedSprites.put(imageName, sprite);
+			}
+			emitter.setSprite(sprite);
 		}
 	}
 
@@ -218,30 +225,56 @@ public class ParticleEffect implements Disposable {
 			bounds.ext(emitter.getBoundingBox());
 		return bounds;
 	}
-	
-    public void scaleEffect(float scaleFactor) {
-        for (ParticleEmitter particleEmitter : emitters) {
-            particleEmitter.getScale().setHigh(particleEmitter.getScale().getHighMin() * scaleFactor, particleEmitter.getScale().getHighMax() * scaleFactor);
-            particleEmitter.getScale().setLow(particleEmitter.getScale().getLowMin() * scaleFactor, particleEmitter.getScale().getLowMax() * scaleFactor);
-            
-            particleEmitter.getVelocity().setHigh(particleEmitter.getVelocity().getHighMin() * scaleFactor, particleEmitter.getVelocity().getHighMax() * scaleFactor);
-            particleEmitter.getVelocity().setLow(particleEmitter.getVelocity().getLowMin() * scaleFactor, particleEmitter.getVelocity().getLowMax() * scaleFactor);
-            
-            particleEmitter.getGravity().setHigh(particleEmitter.getGravity().getHighMin() * scaleFactor, particleEmitter.getGravity().getHighMax() * scaleFactor);
-            particleEmitter.getGravity().setLow(particleEmitter.getGravity().getLowMin() * scaleFactor, particleEmitter.getGravity().getLowMax() * scaleFactor);
-            
-            particleEmitter.getWind().setHigh(particleEmitter.getWind().getHighMin() * scaleFactor, particleEmitter.getWind().getHighMax() * scaleFactor);
-            particleEmitter.getWind().setLow(particleEmitter.getWind().getLowMin() * scaleFactor, particleEmitter.getWind().getLowMax() * scaleFactor);
-            
-            particleEmitter.getSpawnWidth().setHigh(particleEmitter.getSpawnWidth().getHighMin() * scaleFactor, particleEmitter.getSpawnWidth().getHighMax() * scaleFactor);
-            particleEmitter.getSpawnWidth().setLow(particleEmitter.getSpawnWidth().getLowMin() * scaleFactor, particleEmitter.getSpawnWidth().getLowMax() * scaleFactor);
-            
-            particleEmitter.getSpawnHeight().setHigh(particleEmitter.getSpawnHeight().getHighMin() * scaleFactor, particleEmitter.getSpawnHeight().getHighMax() * scaleFactor);
-            particleEmitter.getSpawnHeight().setLow(particleEmitter.getSpawnHeight().getLowMin() * scaleFactor, particleEmitter.getSpawnHeight().getLowMax() * scaleFactor);
-            
-            particleEmitter.getXOffsetValue().setLow(particleEmitter.getXOffsetValue().getLowMin() * scaleFactor, particleEmitter.getXOffsetValue().getLowMax() * scaleFactor);
-            
-            particleEmitter.getYOffsetValue().setLow(particleEmitter.getYOffsetValue().getLowMin() * scaleFactor, particleEmitter.getYOffsetValue().getLowMax() * scaleFactor);
-        }
-    }
+
+	public void scaleEffect (float scaleFactor) {
+		for (ParticleEmitter particleEmitter : emitters) {
+			particleEmitter.getScale().setHigh(particleEmitter.getScale().getHighMin() * scaleFactor,
+				particleEmitter.getScale().getHighMax() * scaleFactor);
+			particleEmitter.getScale().setLow(particleEmitter.getScale().getLowMin() * scaleFactor,
+				particleEmitter.getScale().getLowMax() * scaleFactor);
+
+			particleEmitter.getVelocity().setHigh(particleEmitter.getVelocity().getHighMin() * scaleFactor,
+				particleEmitter.getVelocity().getHighMax() * scaleFactor);
+			particleEmitter.getVelocity().setLow(particleEmitter.getVelocity().getLowMin() * scaleFactor,
+				particleEmitter.getVelocity().getLowMax() * scaleFactor);
+
+			particleEmitter.getGravity().setHigh(particleEmitter.getGravity().getHighMin() * scaleFactor,
+				particleEmitter.getGravity().getHighMax() * scaleFactor);
+			particleEmitter.getGravity().setLow(particleEmitter.getGravity().getLowMin() * scaleFactor,
+				particleEmitter.getGravity().getLowMax() * scaleFactor);
+
+			particleEmitter.getWind().setHigh(particleEmitter.getWind().getHighMin() * scaleFactor,
+				particleEmitter.getWind().getHighMax() * scaleFactor);
+			particleEmitter.getWind().setLow(particleEmitter.getWind().getLowMin() * scaleFactor,
+				particleEmitter.getWind().getLowMax() * scaleFactor);
+
+			particleEmitter.getSpawnWidth().setHigh(particleEmitter.getSpawnWidth().getHighMin() * scaleFactor,
+				particleEmitter.getSpawnWidth().getHighMax() * scaleFactor);
+			particleEmitter.getSpawnWidth().setLow(particleEmitter.getSpawnWidth().getLowMin() * scaleFactor,
+				particleEmitter.getSpawnWidth().getLowMax() * scaleFactor);
+
+			particleEmitter.getSpawnHeight().setHigh(particleEmitter.getSpawnHeight().getHighMin() * scaleFactor,
+				particleEmitter.getSpawnHeight().getHighMax() * scaleFactor);
+			particleEmitter.getSpawnHeight().setLow(particleEmitter.getSpawnHeight().getLowMin() * scaleFactor,
+				particleEmitter.getSpawnHeight().getLowMax() * scaleFactor);
+
+			particleEmitter.getXOffsetValue().setLow(particleEmitter.getXOffsetValue().getLowMin() * scaleFactor,
+				particleEmitter.getXOffsetValue().getLowMax() * scaleFactor);
+
+			particleEmitter.getYOffsetValue().setLow(particleEmitter.getYOffsetValue().getLowMin() * scaleFactor,
+				particleEmitter.getYOffsetValue().getLowMax() * scaleFactor);
+		}
+	}
+
+	/** Sets the {@link com.badlogic.gdx.graphics.g2d.ParticleEmitter#setCleansUpBlendFunction(boolean) cleansUpBlendFunction}
+	 * parameter on all {@link com.badlogic.gdx.graphics.g2d.ParticleEmitter ParticleEmitters} currently in this ParticleEffect.
+	 * <p>
+	 * IMPORTANT: If set to false and if the next object to use this Batch expects alpha blending, you are responsible for setting
+	 * the Batch's blend function to (GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA) before that next object is drawn.
+	 * @param cleanUpBlendFunction */
+	public void setEmittersCleanUpBlendFunction (boolean cleanUpBlendFunction) {
+		for (int i = 0, n = emitters.size; i < n; i++) {
+			emitters.get(i).setCleansUpBlendFunction(cleanUpBlendFunction);
+		}
+	}
 }

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/ParticleEmitter.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/ParticleEmitter.java
@@ -26,7 +26,6 @@ import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.math.Rectangle;
 import com.badlogic.gdx.math.collision.BoundingBox;
 
-
 public class ParticleEmitter {
 	static private final int UPDATE_SCALE = 1 << 0;
 	static private final int UPDATE_ANGLE = 1 << 1;
@@ -235,12 +234,10 @@ public class ParticleEmitter {
 	public void draw (Batch batch) {
 		if (premultipliedAlpha) {
 			batch.setBlendFunction(GL20.GL_ONE, GL20.GL_ONE_MINUS_SRC_ALPHA);
+		} else if (additive) {
+			batch.setBlendFunction(GL20.GL_SRC_ALPHA, GL20.GL_ONE);
 		} else {
-			if (additive) {
-				batch.setBlendFunction(GL20.GL_SRC_ALPHA, GL20.GL_ONE);
-			} else {
-				batch.setBlendFunction(GL20.GL_SRC_ALPHA, GL20.GL_ONE_MINUS_SRC_ALPHA);
-			}
+			batch.setBlendFunction(GL20.GL_SRC_ALPHA, GL20.GL_ONE_MINUS_SRC_ALPHA);
 		}
 		Particle[] particles = this.particles;
 		boolean[] active = this.active;
@@ -249,7 +246,7 @@ public class ParticleEmitter {
 			if (active[i]) particles[i].draw(batch);
 		}
 
-		if (cleansUpBlendFunction && (additive || premultipliedAlpha)) 
+		if (cleansUpBlendFunction && (additive || premultipliedAlpha))
 			batch.setBlendFunction(GL20.GL_SRC_ALPHA, GL20.GL_ONE_MINUS_SRC_ALPHA);
 
 	}
@@ -267,12 +264,10 @@ public class ParticleEmitter {
 
 		if (premultipliedAlpha) {
 			batch.setBlendFunction(GL20.GL_ONE, GL20.GL_ONE_MINUS_SRC_ALPHA);
+		} else if (additive) {
+			batch.setBlendFunction(GL20.GL_SRC_ALPHA, GL20.GL_ONE);
 		} else {
-			if (additive) {
-				batch.setBlendFunction(GL20.GL_SRC_ALPHA, GL20.GL_ONE);
-			} else {
-				batch.setBlendFunction(GL20.GL_SRC_ALPHA, GL20.GL_ONE_MINUS_SRC_ALPHA);
-			}
+			batch.setBlendFunction(GL20.GL_SRC_ALPHA, GL20.GL_ONE_MINUS_SRC_ALPHA);
 		}
 
 		Particle[] particles = this.particles;
@@ -291,7 +286,7 @@ public class ParticleEmitter {
 		}
 		this.activeCount = activeCount;
 
-		if (cleansUpBlendFunction && (additive || premultipliedAlpha)) 
+		if (cleansUpBlendFunction && (additive || premultipliedAlpha))
 			batch.setBlendFunction(GL20.GL_SRC_ALPHA, GL20.GL_ONE_MINUS_SRC_ALPHA);
 
 		if (delayTimer < delay) {
@@ -739,27 +734,21 @@ public class ParticleEmitter {
 	public void setAdditive (boolean additive) {
 		this.additive = additive;
 	}
-	
-	/**
-	 * @return Whether this ParticleEmitter automatically returns the {@link com.badlogic.gdx.graphics.g2d.Batch Batch}'s 
-	 * blend function to the alpha-blending default (GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA) when done drawing. 
-	 */
+
+	/** @return Whether this ParticleEmitter automatically returns the {@link com.badlogic.gdx.graphics.g2d.Batch Batch}'s blend
+	 *         function to the alpha-blending default (GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA) when done drawing. */
 	public boolean cleansUpBlendFunction () {
 		return cleansUpBlendFunction;
 	}
 
-	/**
-	 * Set whether to automatically return the {@link com.badlogic.gdx.graphics.g2d.Batch Batch}'s 
-	 * blend function to the alpha-blending default (GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA) when 
-	 * done drawing. Is true by default. If set to false, the Batch's blend function is left as it
-	 * was for drawing this ParticleEmitter, which prevents the Batch from being flushed repeatedly 
-	 * if consecutive ParticleEmitters with the same additive or pre-multiplied alpha state are drawn 
-	 * in a row. 
-	 * <p> IMPORTANT: If set to false and if the next object to use this Batch expects alpha blending,
-	 * you are responsible for setting the Batch's blend function to (GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA) 
-	 * before that next object is drawn.
-	 * @param cleansUpBlendFunction
-	 */
+	/** Set whether to automatically return the {@link com.badlogic.gdx.graphics.g2d.Batch Batch}'s blend function to the
+	 * alpha-blending default (GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA) when done drawing. Is true by default. If set to false, the
+	 * Batch's blend function is left as it was for drawing this ParticleEmitter, which prevents the Batch from being flushed
+	 * repeatedly if consecutive ParticleEmitters with the same additive or pre-multiplied alpha state are drawn in a row.
+	 * <p>
+	 * IMPORTANT: If set to false and if the next object to use this Batch expects alpha blending, you are responsible for setting
+	 * the Batch's blend function to (GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA) before that next object is drawn.
+	 * @param cleansUpBlendFunction */
 	public void setCleansUpBlendFunction (boolean cleansUpBlendFunction) {
 		this.cleansUpBlendFunction = cleansUpBlendFunction;
 	}
@@ -916,7 +905,7 @@ public class ParticleEmitter {
 		output.write("behind: " + behind + "\n");
 		output.write("premultipliedAlpha: " + premultipliedAlpha + "\n");
 		output.write("- Image Path -\n");
-		output.write(imagePath + "\n");		
+		output.write(imagePath + "\n");
 	}
 
 	public void load (BufferedReader reader) throws IOException {
@@ -967,20 +956,20 @@ public class ParticleEmitter {
 			aligned = readBoolean(reader, "aligned");
 			additive = readBoolean(reader, "additive");
 			behind = readBoolean(reader, "behind");
-			
+
 			// Backwards compatibility
 			String line = reader.readLine();
 			if (line.startsWith("premultipliedAlpha")) {
 				premultipliedAlpha = readBoolean(line);
 				reader.readLine();
 			}
-			setImagePath(reader.readLine());		
+			setImagePath(reader.readLine());
 		} catch (RuntimeException ex) {
 			if (name == null) throw ex;
 			throw new RuntimeException("Error parsing emitter: " + name, ex);
 		}
 	}
-	
+
 	static String readString (String line) throws IOException {
 		return line.substring(line.indexOf(":") + 1).trim();
 	}

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/ParticleEmitter.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/ParticleEmitter.java
@@ -84,6 +84,7 @@ public class ParticleEmitter {
 	private boolean behind;
 	private boolean additive = true;
 	private boolean premultipliedAlpha = false;
+	boolean cleansUpBlendFunction = true;
 
 	public ParticleEmitter () {
 		initialize();
@@ -124,6 +125,7 @@ public class ParticleEmitter {
 		behind = emitter.behind;
 		additive = emitter.additive;
 		premultipliedAlpha = emitter.premultipliedAlpha;
+		cleansUpBlendFunction = emitter.cleansUpBlendFunction;
 	}
 
 	private void initialize () {
@@ -236,6 +238,8 @@ public class ParticleEmitter {
 		} else {
 			if (additive) {
 				batch.setBlendFunction(GL20.GL_SRC_ALPHA, GL20.GL_ONE);
+			} else {
+				batch.setBlendFunction(GL20.GL_SRC_ALPHA, GL20.GL_ONE_MINUS_SRC_ALPHA);
 			}
 		}
 		Particle[] particles = this.particles;
@@ -245,7 +249,8 @@ public class ParticleEmitter {
 			if (active[i]) particles[i].draw(batch);
 		}
 
-		if (additive || premultipliedAlpha) batch.setBlendFunction(GL20.GL_SRC_ALPHA, GL20.GL_ONE_MINUS_SRC_ALPHA);
+		if (cleansUpBlendFunction && (additive || premultipliedAlpha)) 
+			batch.setBlendFunction(GL20.GL_SRC_ALPHA, GL20.GL_ONE_MINUS_SRC_ALPHA);
 
 	}
 
@@ -265,6 +270,8 @@ public class ParticleEmitter {
 		} else {
 			if (additive) {
 				batch.setBlendFunction(GL20.GL_SRC_ALPHA, GL20.GL_ONE);
+			} else {
+				batch.setBlendFunction(GL20.GL_SRC_ALPHA, GL20.GL_ONE_MINUS_SRC_ALPHA);
 			}
 		}
 
@@ -284,7 +291,8 @@ public class ParticleEmitter {
 		}
 		this.activeCount = activeCount;
 
-		if (additive || premultipliedAlpha) batch.setBlendFunction(GL20.GL_SRC_ALPHA, GL20.GL_ONE_MINUS_SRC_ALPHA);
+		if (cleansUpBlendFunction && (additive || premultipliedAlpha)) 
+			batch.setBlendFunction(GL20.GL_SRC_ALPHA, GL20.GL_ONE_MINUS_SRC_ALPHA);
 
 		if (delayTimer < delay) {
 			delayTimer += deltaMillis;
@@ -731,8 +739,30 @@ public class ParticleEmitter {
 	public void setAdditive (boolean additive) {
 		this.additive = additive;
 	}
+	
+	/**
+	 * @return Whether this ParticleEmitter automatically returns the {@link com.badlogic.gdx.graphics.g2d.Batch Batch}'s 
+	 * blend function to the alpha-blending default (GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA) when done drawing. 
+	 */
+	public boolean cleansUpBlendFunction () {
+		return cleansUpBlendFunction;
+	}
 
-
+	/**
+	 * Set whether to automatically return the {@link com.badlogic.gdx.graphics.g2d.Batch Batch}'s 
+	 * blend function to the alpha-blending default (GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA) when 
+	 * done drawing. Is true by default. If set to false, the Batch's blend function is left as it
+	 * was for drawing this ParticleEmitter, which prevents the Batch from being flushed repeatedly 
+	 * if consecutive ParticleEmitters with the same additive or pre-multiplied alpha state are drawn 
+	 * in a row. 
+	 * <p> IMPORTANT: If set to false and if the next object to use this Batch expects alpha blending,
+	 * you are responsible for setting the Batch's blend function to (GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA) 
+	 * before that next object is drawn.
+	 * @param cleansUpBlendFunction
+	 */
+	public void setCleansUpBlendFunction (boolean cleansUpBlendFunction) {
+		this.cleansUpBlendFunction = cleansUpBlendFunction;
+	}
 
 	public boolean isBehind () {
 		return behind;

--- a/tests/gdx-tests-android/assets/data/singleTextureAllAdditive.p
+++ b/tests/gdx-tests-android/assets/data/singleTextureAllAdditive.p
@@ -1,0 +1,458 @@
+blue stars
+- Delay -
+active: false
+- Duration - 
+lowMin: 1.0
+lowMax: 1.0
+- Count - 
+min: 0
+max: 1000
+- Emission - 
+lowMin: 0.0
+lowMax: 0.0
+highMin: 10.0
+highMax: 10.0
+relative: false
+scalingCount: 1
+scaling0: 1.0
+timelineCount: 1
+timeline0: 0.0
+- Life - 
+lowMin: 0.0
+lowMax: 0.0
+highMin: 1000.0
+highMax: 1500.0
+relative: false
+scalingCount: 1
+scaling0: 1.0
+timelineCount: 1
+timeline0: 0.0
+- Life Offset - 
+active: false
+- X Offset - 
+active: false
+- Y Offset - 
+active: false
+- Spawn Shape - 
+shape: point
+- Spawn Width - 
+lowMin: 0.0
+lowMax: 0.0
+highMin: 0.0
+highMax: 0.0
+relative: false
+scalingCount: 1
+scaling0: 1.0
+timelineCount: 1
+timeline0: 0.0
+- Spawn Height - 
+lowMin: 0.0
+lowMax: 0.0
+highMin: 0.0
+highMax: 0.0
+relative: false
+scalingCount: 1
+scaling0: 1.0
+timelineCount: 1
+timeline0: 0.0
+- Scale - 
+lowMin: 0.0
+lowMax: 0.0
+highMin: 64.0
+highMax: 64.0
+relative: false
+scalingCount: 6
+scaling0: 0.0
+scaling1: 1.0
+scaling2: 0.33333334
+scaling3: 1.0
+scaling4: 0.4509804
+scaling5: 1.0
+timelineCount: 6
+timeline0: 0.0
+timeline1: 0.12328767
+timeline2: 0.28767124
+timeline3: 0.4041096
+timeline4: 0.5753425
+timeline5: 0.70547944
+- Velocity - 
+active: true
+lowMin: 0.0
+lowMax: 0.0
+highMin: 0.0
+highMax: 50.0
+relative: false
+scalingCount: 1
+scaling0: 1.0
+timelineCount: 1
+timeline0: 0.0
+- Angle - 
+active: true
+lowMin: 1.0
+lowMax: 360.0
+highMin: -180.0
+highMax: 180.0
+relative: true
+scalingCount: 2
+scaling0: 0.0
+scaling1: 1.0
+timelineCount: 2
+timeline0: 0.0
+timeline1: 0.51369864
+- Rotation - 
+active: true
+lowMin: 1.0
+lowMax: 360.0
+highMin: -360.0
+highMax: 360.0
+relative: true
+scalingCount: 2
+scaling0: 0.0
+scaling1: 1.0
+timelineCount: 2
+timeline0: 0.0
+timeline1: 1.0
+- Wind - 
+active: false
+- Gravity - 
+active: false
+- Tint - 
+colorsCount: 3
+colors0: 0.0
+colors1: 0.36862746
+colors2: 1.0
+timelineCount: 1
+timeline0: 0.0
+- Transparency - 
+lowMin: 0.0
+lowMax: 0.0
+highMin: 1.0
+highMax: 1.0
+relative: false
+scalingCount: 4
+scaling0: 1.0
+scaling1: 1.0
+scaling2: 0.0
+scaling3: 0.0
+timelineCount: 4
+timeline0: 0.0
+timeline1: 0.34246576
+timeline2: 0.74657536
+timeline3: 1.0
+- Options - 
+attached: false
+continuous: true
+aligned: false
+additive: true
+behind: false
+premultipliedAlpha: false
+- Image Path -
+particle-star.png
+
+
+red stars
+- Delay -
+active: false
+- Duration - 
+lowMin: 1.0
+lowMax: 1.0
+- Count - 
+min: 0
+max: 1000
+- Emission - 
+lowMin: 0.0
+lowMax: 0.0
+highMin: 6.0
+highMax: 6.0
+relative: false
+scalingCount: 1
+scaling0: 1.0
+timelineCount: 1
+timeline0: 0.0
+- Life - 
+lowMin: 0.0
+lowMax: 0.0
+highMin: 1000.0
+highMax: 1500.0
+relative: false
+scalingCount: 1
+scaling0: 1.0
+timelineCount: 1
+timeline0: 0.0
+- Life Offset - 
+active: false
+- X Offset - 
+active: false
+- Y Offset - 
+active: false
+- Spawn Shape - 
+shape: point
+- Spawn Width - 
+lowMin: 0.0
+lowMax: 0.0
+highMin: 0.0
+highMax: 0.0
+relative: false
+scalingCount: 1
+scaling0: 1.0
+timelineCount: 1
+timeline0: 0.0
+- Spawn Height - 
+lowMin: 0.0
+lowMax: 0.0
+highMin: 0.0
+highMax: 0.0
+relative: false
+scalingCount: 1
+scaling0: 1.0
+timelineCount: 1
+timeline0: 0.0
+- Scale - 
+lowMin: 0.0
+lowMax: 0.0
+highMin: 128.0
+highMax: 128.0
+relative: false
+scalingCount: 6
+scaling0: 0.0
+scaling1: 1.0
+scaling2: 0.78431374
+scaling3: 1.0
+scaling4: 0.88235295
+scaling5: 1.0
+timelineCount: 6
+timeline0: 0.0
+timeline1: 0.12328767
+timeline2: 0.29452056
+timeline3: 0.4041096
+timeline4: 0.58219177
+timeline5: 0.70547944
+- Velocity - 
+active: true
+lowMin: 0.0
+lowMax: 0.0
+highMin: 100.0
+highMax: 120.0
+relative: false
+scalingCount: 1
+scaling0: 1.0
+timelineCount: 1
+timeline0: 0.0
+- Angle - 
+active: true
+lowMin: 1.0
+lowMax: 360.0
+highMin: -180.0
+highMax: 180.0
+relative: true
+scalingCount: 2
+scaling0: 0.0
+scaling1: 1.0
+timelineCount: 2
+timeline0: 0.0
+timeline1: 0.51369864
+- Rotation - 
+active: true
+lowMin: 1.0
+lowMax: 360.0
+highMin: -360.0
+highMax: 360.0
+relative: true
+scalingCount: 2
+scaling0: 0.0
+scaling1: 1.0
+timelineCount: 2
+timeline0: 0.0
+timeline1: 1.0
+- Wind - 
+active: false
+- Gravity - 
+active: false
+- Tint - 
+colorsCount: 3
+colors0: 1.0
+colors1: 0.0
+colors2: 0.0
+timelineCount: 1
+timeline0: 0.0
+- Transparency - 
+lowMin: 0.0
+lowMax: 0.0
+highMin: 1.0
+highMax: 1.0
+relative: false
+scalingCount: 4
+scaling0: 1.0
+scaling1: 1.0
+scaling2: 0.0
+scaling3: 0.0
+timelineCount: 4
+timeline0: 0.0
+timeline1: 0.34246576
+timeline2: 0.74657536
+timeline3: 1.0
+- Options - 
+attached: false
+continuous: true
+aligned: false
+additive: true
+behind: false
+premultipliedAlpha: false
+- Image Path -
+particle-star.png
+
+
+yellow stars
+- Delay -
+active: false
+- Duration - 
+lowMin: 1.0
+lowMax: 1.0
+- Count - 
+min: 0
+max: 1000
+- Emission - 
+lowMin: 0.0
+lowMax: 0.0
+highMin: 20.0
+highMax: 20.0
+relative: false
+scalingCount: 1
+scaling0: 1.0
+timelineCount: 1
+timeline0: 0.0
+- Life - 
+lowMin: 0.0
+lowMax: 0.0
+highMin: 1000.0
+highMax: 1500.0
+relative: false
+scalingCount: 1
+scaling0: 1.0
+timelineCount: 1
+timeline0: 0.0
+- Life Offset - 
+active: false
+- X Offset - 
+active: false
+- Y Offset - 
+active: false
+- Spawn Shape - 
+shape: point
+- Spawn Width - 
+lowMin: 0.0
+lowMax: 0.0
+highMin: 0.0
+highMax: 0.0
+relative: false
+scalingCount: 1
+scaling0: 1.0
+timelineCount: 1
+timeline0: 0.0
+- Spawn Height - 
+lowMin: 0.0
+lowMax: 0.0
+highMin: 0.0
+highMax: 0.0
+relative: false
+scalingCount: 1
+scaling0: 1.0
+timelineCount: 1
+timeline0: 0.0
+- Scale - 
+lowMin: 0.0
+lowMax: 0.0
+highMin: 32.0
+highMax: 32.0
+relative: false
+scalingCount: 6
+scaling0: 0.0
+scaling1: 1.0
+scaling2: 0.33333334
+scaling3: 1.0
+scaling4: 0.4509804
+scaling5: 1.0
+timelineCount: 6
+timeline0: 0.0
+timeline1: 0.12328767
+timeline2: 0.28767124
+timeline3: 0.4041096
+timeline4: 0.5753425
+timeline5: 0.70547944
+- Velocity - 
+active: true
+lowMin: 0.0
+lowMax: 0.0
+highMin: 0.0
+highMax: 120.0
+relative: false
+scalingCount: 1
+scaling0: 1.0
+timelineCount: 1
+timeline0: 0.0
+- Angle - 
+active: true
+lowMin: 1.0
+lowMax: 360.0
+highMin: -180.0
+highMax: 180.0
+relative: true
+scalingCount: 2
+scaling0: 0.0
+scaling1: 1.0
+timelineCount: 2
+timeline0: 0.0
+timeline1: 0.51369864
+- Rotation - 
+active: true
+lowMin: 1.0
+lowMax: 360.0
+highMin: -360.0
+highMax: 360.0
+relative: true
+scalingCount: 2
+scaling0: 0.0
+scaling1: 1.0
+timelineCount: 2
+timeline0: 0.0
+timeline1: 1.0
+- Wind - 
+active: false
+- Gravity - 
+active: false
+- Tint - 
+colorsCount: 6
+colors0: 1.0
+colors1: 0.94509804
+colors2: 0.36078432
+colors3: 1.0
+colors4: 0.9137255
+colors5: 0.0
+timelineCount: 2
+timeline0: 0.0
+timeline1: 1.0
+- Transparency - 
+lowMin: 0.0
+lowMax: 0.0
+highMin: 1.0
+highMax: 1.0
+relative: false
+scalingCount: 4
+scaling0: 1.0
+scaling1: 1.0
+scaling2: 0.0
+scaling3: 0.0
+timelineCount: 4
+timeline0: 0.0
+timeline1: 0.34246576
+timeline2: 0.74657536
+timeline3: 1.0
+- Options - 
+attached: false
+continuous: true
+aligned: false
+additive: true
+behind: false
+premultipliedAlpha: false
+- Image Path -
+particle-star.png

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ParticleEmittersTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ParticleEmittersTest.java
@@ -1,0 +1,170 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogic.gdx.tests;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Input;
+import com.badlogic.gdx.InputAdapter;
+import com.badlogic.gdx.InputMultiplexer;
+import com.badlogic.gdx.InputProcessor;
+import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.g2d.ParticleEffect;
+import com.badlogic.gdx.graphics.g2d.ParticleEffectPool;
+import com.badlogic.gdx.graphics.g2d.ParticleEffectPool.PooledEffect;
+import com.badlogic.gdx.graphics.g2d.ParticleEmitter;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.scenes.scene2d.Actor;
+import com.badlogic.gdx.scenes.scene2d.Stage;
+import com.badlogic.gdx.scenes.scene2d.ui.Button;
+import com.badlogic.gdx.scenes.scene2d.ui.CheckBox;
+import com.badlogic.gdx.scenes.scene2d.ui.CheckBox.CheckBoxStyle;
+import com.badlogic.gdx.scenes.scene2d.ui.Label;
+import com.badlogic.gdx.scenes.scene2d.ui.Label.LabelStyle;
+import com.badlogic.gdx.scenes.scene2d.ui.Skin;
+import com.badlogic.gdx.scenes.scene2d.ui.Table;
+import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
+import com.badlogic.gdx.scenes.scene2d.ui.TextButton.TextButtonStyle;
+import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
+import com.badlogic.gdx.tests.utils.GdxTest;
+import com.badlogic.gdx.utils.Array;
+import com.badlogic.gdx.utils.viewport.ExtendViewport;
+
+public class ParticleEmittersTest extends GdxTest {
+	private SpriteBatch spriteBatch;
+	ParticleEffect effect;
+	ParticleEffectPool effectPool;
+	Array<PooledEffect> effects = new Array();
+	PooledEffect latestEffect;
+	float fpsCounter;
+	Stage ui;
+	CheckBox skipCleanup;
+	Button clearEmitters;
+	Label logLabel;
+
+	@Override
+	public void create () {
+		spriteBatch = new SpriteBatch();
+
+		effect = new ParticleEffect();
+		effect.load(Gdx.files.internal("data/singleTextureAllAdditive.p"), Gdx.files.internal("data"));
+		effect.setPosition(Gdx.graphics.getWidth() / 2, Gdx.graphics.getHeight() / 2);
+		effectPool = new ParticleEffectPool(effect, 20, 20);
+
+		setupUI();
+
+		InputProcessor inputProcessor = new InputAdapter() {
+
+			public boolean touchDragged (int x, int y, int pointer) {
+				if (latestEffect != null) latestEffect.setPosition(x, Gdx.graphics.getHeight() - y);
+				return false;
+			}
+
+			public boolean touchDown (int x, int y, int pointer, int newParam) {
+				latestEffect = effectPool.obtain();
+				latestEffect.setEmittersCleanUpBlendFunction(!skipCleanup.isChecked());
+				latestEffect.setPosition(x, Gdx.graphics.getHeight() - y);
+				effects.add(latestEffect);
+
+				return false;
+			}
+
+		};
+
+		InputMultiplexer multiplexer = new InputMultiplexer();
+		multiplexer.addProcessor(ui);
+		multiplexer.addProcessor(inputProcessor);
+
+		Gdx.input.setInputProcessor(multiplexer);
+	}
+
+	@Override
+	public void dispose () {
+		spriteBatch.dispose();
+		effect.dispose();
+	}
+
+	@Override
+	public void resize (int width, int height) {
+		ui.getViewport().update(width, height);
+	}
+
+	public void render () {
+		ui.act();
+		spriteBatch.getProjectionMatrix().setToOrtho2D(0, 0, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+		float delta = Gdx.graphics.getDeltaTime();
+		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		spriteBatch.begin();
+		for (ParticleEffect e : effects)
+			e.draw(spriteBatch, delta);
+		spriteBatch.end();
+		fpsCounter += delta;
+		if (fpsCounter > 3) {
+			fpsCounter = 0;
+			String log = effects.size + " particle effects, FPS: " + Gdx.graphics.getFramesPerSecond() + ", Render calls: "
+				+ spriteBatch.renderCalls;
+			Gdx.app.log("libgdx", log);
+			logLabel.setText(log);
+		}
+		ui.draw();
+	}
+
+	public boolean needsGL20 () {
+		return false;
+	}
+
+	private void setupUI () {
+		ui = new Stage(new ExtendViewport(640, 480));
+		Skin skin = new Skin(Gdx.files.internal("data/uiskin.json"));
+		skipCleanup = new CheckBox("Skip blend function clean-up", skin.get(CheckBoxStyle.class));
+		skipCleanup.setTransform(false);
+		skipCleanup.addListener(listener);
+		logLabel = new Label("", skin.get(LabelStyle.class));
+		clearEmitters = new TextButton("Clear screen", skin);
+		clearEmitters.setTransform(false);
+		clearEmitters.addListener(listener);
+		Table table = new Table();
+		table.setTransform(false);
+		table.setFillParent(true);
+		table.defaults().padTop(5).left();
+		table.top().left().padLeft(5);
+		table.add(skipCleanup).row();
+		table.add(clearEmitters).row();
+		table.add(logLabel);
+		ui.addActor(table);
+	}
+
+	void updateSkipCleanupState () {
+		for (ParticleEffect eff : effects) {
+			for (ParticleEmitter e : eff.getEmitters())
+				e.setCleansUpBlendFunction(!skipCleanup.isChecked());
+		}
+	}
+
+	ChangeListener listener = new ChangeListener() {
+
+		@Override
+		public void changed (ChangeEvent event, Actor actor) {
+			if (actor == skipCleanup) {
+				updateSkipCleanupState();
+			} else if (actor == clearEmitters) {
+				for (PooledEffect e : effects)
+					e.free();
+				effects.clear();
+			}
+		}
+	};
+}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
@@ -157,6 +157,7 @@ public class GdxTests {
 		ParallaxTest.class,
 		ParticleControllerTest.class,
 		ParticleEmitterTest.class,
+		ParticleEmittersTest.class,
 		PixelsPerInchTest.class,
 		PixmapBlendingTest.class,
 		PixmapPackerTest.class,


### PR DESCRIPTION
In my game I have a layer with many small ParticleEffects, all using the same Texture from a TextureAtlas, and all using pre-multiplied alpha. When this layer is drawn, it results in many unnecessary flushes of the SpriteBatch. Even if a single ParticleEffect is drawn, it results in a draw call for every ParticleEmitter it contains.

This pull request adds an option to ParticleEmitter that allows it to skip the step of returning the SpriteBatch's blend function to the default, which causes a flush whenever a ParticleEmitter is additive or has pre-multiplied alpha. The option defaults to the current behavior, so it will not affect current projects. The Javadoc clearly warns that the programmer must manually set the blend function back to the default if necessary.

I also added a convenience method to ParticleEffect, for applying this setting to all its owned emitters, since this is the typical use case.

I also noticed that ParticleEffect (when not using a TextureAtlas) was loading multiple copies of a Texture, even if all its emitters share the same image name. Aside from wasting memory, this prevents the above optimization from working. So I modified `ParticleEffect.loadEmitterImages(...)` to avoid this problem.

I assure you that `ParticleEffect.scaleEffect(...)` has not changed. That is only the effect of the libgdx formatter.

Note the render calls numbers in the following two pictures. It is 2 (rather than 1) in the second image only because of the SpriteBatch's capacity. 
![capture](https://cloud.githubusercontent.com/assets/1843131/6429493/7f6fcf70-bfa3-11e4-925b-0b8f3d7a5599.PNG) ![capture2](https://cloud.githubusercontent.com/assets/1843131/6429494/8780cde0-bfa3-11e4-9545-d82212c5eee9.PNG)

