### PR TITLE
Remove of static temporaries in math classes

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/math/Matrix4.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/math/Matrix4.java
@@ -128,7 +128,7 @@ public class Matrix4 implements Serializable {
 	 * @param values The matrix, in float form, that is to be copied. Remember that this matrix is in <a
 	 *           href="http://en.wikipedia.org/wiki/Row-major_order">column major</a> order.
 	 * @return This matrix for the purpose of chaining methods together. */
-	public Matrix4 set (float... values) {
+	public Matrix4 set (float[] values) {
 		val[M00] = values[M00];
 		val[M10] = values[M10];
 		val[M20] = values[M20];
@@ -145,6 +145,32 @@ public class Matrix4 implements Serializable {
 		val[M13] = values[M13];
 		val[M23] = values[M23];
 		val[M33] = values[M33];
+		return this;
+	}
+
+	/** Sets the matrix to the given matrix as an array of floats.
+	 * 
+	 * @param mat00 to mat33 The matrix, in float form, that is to be copied. Remember that this matrix is in <a
+	 *           href="http://en.wikipedia.org/wiki/Row-major_order">column major</a> order.
+	 * @return This matrix for the purpose of chaining methods together. */
+	public Matrix4 set (float mat00, float mat10, float mat20, float mat30, float mat01, float mat11, float mat21, float mat31,
+		float mat02, float mat12, float mat22, float mat32, float mat03, float mat13, float mat23, float mat33) {
+		val[M00] = mat00;
+		val[M10] = mat10;
+		val[M20] = mat20;
+		val[M30] = mat30;
+		val[M01] = mat01;
+		val[M11] = mat11;
+		val[M21] = mat21;
+		val[M31] = mat31;
+		val[M02] = mat02;
+		val[M12] = mat12;
+		val[M22] = mat22;
+		val[M32] = mat32;
+		val[M03] = mat03;
+		val[M13] = mat13;
+		val[M23] = mat23;
+		val[M33] = mat33;
 		return this;
 	}
 
@@ -956,7 +982,7 @@ public class Matrix4 implements Serializable {
 		uy = rz * fx - rx * fz;
 		uz = rx * fy - ry * fx;
 
-		set(rx, ux, -fx, 0, ry, uy, -fy, 0, rz, uz, -fz, position.x, position.y, position.z, 1);
+		set(rx, ux, -fx, 0, ry, uy, -fy, 0, rz, uz, -fz, 0, position.x, position.y, position.z, 1);
 
 		return this;
 	}
@@ -1293,6 +1319,29 @@ public class Matrix4 implements Serializable {
 		System.arraycopy(tmp, 0, mata, 0, 16);
 	}
 
+	static void matrix4_mul (float[] mata, float matb00, float matb10, float matb20, float matb30, float matb01, float matb11,
+		float matb21, float matb31, float matb02, float matb12, float matb22, float matb32, float matb03, float matb13,
+		float matb23, float matb33) {
+		float tmp[] = new float[16];
+		tmp[M00] = mata[M00] * matb00 + mata[M01] * matb10 + mata[M02] * matb20 + mata[M03] * matb30;
+		tmp[M01] = mata[M00] * matb01 + mata[M01] * matb11 + mata[M02] * matb21 + mata[M03] * matb31;
+		tmp[M02] = mata[M00] * matb02 + mata[M01] * matb12 + mata[M02] * matb22 + mata[M03] * matb32;
+		tmp[M03] = mata[M00] * matb03 + mata[M01] * matb13 + mata[M02] * matb23 + mata[M03] * matb33;
+		tmp[M10] = mata[M10] * matb00 + mata[M11] * matb10 + mata[M12] * matb20 + mata[M13] * matb30;
+		tmp[M11] = mata[M10] * matb01 + mata[M11] * matb11 + mata[M12] * matb21 + mata[M13] * matb31;
+		tmp[M12] = mata[M10] * matb02 + mata[M11] * matb12 + mata[M12] * matb22 + mata[M13] * matb32;
+		tmp[M13] = mata[M10] * matb03 + mata[M11] * matb13 + mata[M12] * matb23 + mata[M13] * matb33;
+		tmp[M20] = mata[M20] * matb00 + mata[M21] * matb10 + mata[M22] * matb20 + mata[M23] * matb30;
+		tmp[M21] = mata[M20] * matb01 + mata[M21] * matb11 + mata[M22] * matb21 + mata[M23] * matb31;
+		tmp[M22] = mata[M20] * matb02 + mata[M21] * matb12 + mata[M22] * matb22 + mata[M23] * matb32;
+		tmp[M23] = mata[M20] * matb03 + mata[M21] * matb13 + mata[M22] * matb23 + mata[M23] * matb33;
+		tmp[M30] = mata[M30] * matb00 + mata[M31] * matb10 + mata[M32] * matb20 + mata[M33] * matb30;
+		tmp[M31] = mata[M30] * matb01 + mata[M31] * matb11 + mata[M32] * matb21 + mata[M33] * matb31;
+		tmp[M32] = mata[M30] * matb02 + mata[M31] * matb12 + mata[M32] * matb22 + mata[M33] * matb32;
+		tmp[M33] = mata[M30] * matb03 + mata[M31] * matb13 + mata[M32] * matb23 + mata[M33] * matb33;
+		System.arraycopy(tmp, 0, mata, 0, 16);
+	}
+
 	static float matrix4_det (float[] val) {
 		return val[M30] * val[M21] * val[M12] * val[M03] - val[M20] * val[M31] * val[M12] * val[M03] - val[M30] * val[M11]
 				* val[M22] * val[M03] + val[M10] * val[M31] * val[M22] * val[M03] + val[M20] * val[M11] * val[M32] * val[M03] - val[M10]
@@ -1397,6 +1446,18 @@ public class Matrix4 implements Serializable {
 	 * @param matb the second matrix. */
 	public static void mul (float[] mata, float[] matb) {
 		matrix4_mul(mata, matb);
+	}
+
+	/** Multiplies the matrix mata with matrix matb, given as array of floats, storing the result in mata. The arrays are assumed to
+	 * hold 4x4 column major matrices as you can get from {@link Matrix4#val}. This is the same as {@link Matrix4#mul(Matrix4)}.
+	 * 
+	 * @param mata the first matrix.
+	 * @param matb00 to matb33 the second matrix. */
+	public static void mul (float[] mata, float matb00, float matb10, float matb20, float matb30, float matb01, float matb11,
+		float matb21, float matb31, float matb02, float matb12, float matb22, float matb32, float matb03, float matb13,
+		float matb23, float matb33) {
+		matrix4_mul(mata, matb00, matb10, matb20, matb30, matb01, matb11, matb21, matb31, matb02, matb12, matb22, matb32, matb03,
+			matb13, matb23, matb33);
 	}
 
 	/** Multiplies the vector with the given matrix. The matrix array is assumed to hold a 4x4 column major matrix as you can get
@@ -1514,7 +1575,7 @@ public class Matrix4 implements Serializable {
 	 * @param z Translation in the z-axis.
 	 * @return This matrix for the purpose of chaining methods together. */
 	public Matrix4 translate (float x, float y, float z) {
-		mulLocal(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, x, y, z, 1);
+		mul(val, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, x, y, z, 1);
 		return this;
 	}
 
@@ -1585,7 +1646,7 @@ public class Matrix4 implements Serializable {
 		final float zz = rotation.z * rotation.z;
 		final float zw = rotation.z * rotation.w;
 
-		mulLocal(1 - 2 * (yy + zz), 2 * (xy + zw), 2 * (xz - yw), 0, 2 * (xy - zw), 1 - 2 * (xx + zz), 2 * (yz + xw), 0,
+		mul(val, 1 - 2 * (yy + zz), 2 * (xy + zw), 2 * (xz - yw), 0, 2 * (xy - zw), 1 - 2 * (xx + zz), 2 * (yz + xw), 0,
 			2 * (xz + yw), 2 * (yz - xw), 1 - 2 * (xx + yy), 0, 0, 0, 0, 1);
 		
 		return this;
@@ -1606,7 +1667,7 @@ public class Matrix4 implements Serializable {
 	 * @param scaleZ The scale in the z-axis.
 	 * @return This matrix for the purpose of chaining methods together. */
 	public Matrix4 scale (float scaleX, float scaleY, float scaleZ) {
-		mulLocal(scaleX, 0, 0, 0, 0, scaleY, 0, 0, 0, 0, scaleZ, 0, 0, 0, 0, 1);
+		mul(val, scaleX, 0, 0, 0, 0, scaleY, 0, 0, 0, 0, scaleZ, 0, 0, 0, 0, 1);
 		return this;
 	}
 
@@ -1625,17 +1686,5 @@ public class Matrix4 implements Serializable {
 		dst[9] = val[M03];
 		dst[10] = val[M13];
 		dst[11] = val[M23];
-	}
-
-	/** Multiplies this matrix with matrix matb, storing the result in this matrix.
-	 * 
-	 * This is a private helper function to pass the second matrix as list of float parameters, which is then forwarded to
-	 * {@link Matrix4#mul(float[], float[])} as float[] array.
-	 * 
-	 * Note: The order of parameters needs to match the ordinals of the MXX constants. Use with care!
-	 * 
-	 * @param matb The second matrix. */
-	private void mulLocal (float... matb) {
-		mul(val, matb);
 	}
 }

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/math/Matrix4.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/math/Matrix4.java
@@ -125,7 +125,7 @@ public class Matrix4 implements Serializable {
 	 * @param values The matrix, in float form, that is to be copied. Remember that this matrix is in <a
 	 *           href="http://en.wikipedia.org/wiki/Row-major_order">column major</a> order.
 	 * @return This matrix for the purpose of chaining methods together. */
-	public Matrix4 set (float[] values) {
+	public Matrix4 set (float... values) {
 		val[M00] = values[M00];
 		val[M10] = values[M10];
 		val[M20] = values[M20];
@@ -333,39 +333,40 @@ public class Matrix4 implements Serializable {
 	 * @param matrix The other matrix to multiply by.
 	 * @return This matrix for the purpose of chaining operations together. */
 	public Matrix4 mul (Matrix4 matrix) {
-		tmp[M00] = val[M00] * matrix.val[M00] + val[M01] * matrix.val[M10] + val[M02] * matrix.val[M20] + val[M03]
+		float tmpM00 = val[M00] * matrix.val[M00] + val[M01] * matrix.val[M10] + val[M02] * matrix.val[M20] + val[M03]
 			* matrix.val[M30];
-		tmp[M01] = val[M00] * matrix.val[M01] + val[M01] * matrix.val[M11] + val[M02] * matrix.val[M21] + val[M03]
+		float tmpM01 = val[M00] * matrix.val[M01] + val[M01] * matrix.val[M11] + val[M02] * matrix.val[M21] + val[M03]
 			* matrix.val[M31];
-		tmp[M02] = val[M00] * matrix.val[M02] + val[M01] * matrix.val[M12] + val[M02] * matrix.val[M22] + val[M03]
+		float tmpM02 = val[M00] * matrix.val[M02] + val[M01] * matrix.val[M12] + val[M02] * matrix.val[M22] + val[M03]
 			* matrix.val[M32];
-		tmp[M03] = val[M00] * matrix.val[M03] + val[M01] * matrix.val[M13] + val[M02] * matrix.val[M23] + val[M03]
+		float tmpM03 = val[M00] * matrix.val[M03] + val[M01] * matrix.val[M13] + val[M02] * matrix.val[M23] + val[M03]
 			* matrix.val[M33];
-		tmp[M10] = val[M10] * matrix.val[M00] + val[M11] * matrix.val[M10] + val[M12] * matrix.val[M20] + val[M13]
+		float tmpM10 = val[M10] * matrix.val[M00] + val[M11] * matrix.val[M10] + val[M12] * matrix.val[M20] + val[M13]
 			* matrix.val[M30];
-		tmp[M11] = val[M10] * matrix.val[M01] + val[M11] * matrix.val[M11] + val[M12] * matrix.val[M21] + val[M13]
+		float tmpM11 = val[M10] * matrix.val[M01] + val[M11] * matrix.val[M11] + val[M12] * matrix.val[M21] + val[M13]
 			* matrix.val[M31];
-		tmp[M12] = val[M10] * matrix.val[M02] + val[M11] * matrix.val[M12] + val[M12] * matrix.val[M22] + val[M13]
+		float tmpM12 = val[M10] * matrix.val[M02] + val[M11] * matrix.val[M12] + val[M12] * matrix.val[M22] + val[M13]
 			* matrix.val[M32];
-		tmp[M13] = val[M10] * matrix.val[M03] + val[M11] * matrix.val[M13] + val[M12] * matrix.val[M23] + val[M13]
+		float tmpM13 = val[M10] * matrix.val[M03] + val[M11] * matrix.val[M13] + val[M12] * matrix.val[M23] + val[M13]
 			* matrix.val[M33];
-		tmp[M20] = val[M20] * matrix.val[M00] + val[M21] * matrix.val[M10] + val[M22] * matrix.val[M20] + val[M23]
+		float tmpM20 = val[M20] * matrix.val[M00] + val[M21] * matrix.val[M10] + val[M22] * matrix.val[M20] + val[M23]
 			* matrix.val[M30];
-		tmp[M21] = val[M20] * matrix.val[M01] + val[M21] * matrix.val[M11] + val[M22] * matrix.val[M21] + val[M23]
+		float tmpM21 = val[M20] * matrix.val[M01] + val[M21] * matrix.val[M11] + val[M22] * matrix.val[M21] + val[M23]
 			* matrix.val[M31];
-		tmp[M22] = val[M20] * matrix.val[M02] + val[M21] * matrix.val[M12] + val[M22] * matrix.val[M22] + val[M23]
+		float tmpM22 = val[M20] * matrix.val[M02] + val[M21] * matrix.val[M12] + val[M22] * matrix.val[M22] + val[M23]
 			* matrix.val[M32];
-		tmp[M23] = val[M20] * matrix.val[M03] + val[M21] * matrix.val[M13] + val[M22] * matrix.val[M23] + val[M23]
+		float tmpM23 = val[M20] * matrix.val[M03] + val[M21] * matrix.val[M13] + val[M22] * matrix.val[M23] + val[M23]
 			* matrix.val[M33];
-		tmp[M30] = val[M30] * matrix.val[M00] + val[M31] * matrix.val[M10] + val[M32] * matrix.val[M20] + val[M33]
+		float tmpM30 = val[M30] * matrix.val[M00] + val[M31] * matrix.val[M10] + val[M32] * matrix.val[M20] + val[M33]
 			* matrix.val[M30];
-		tmp[M31] = val[M30] * matrix.val[M01] + val[M31] * matrix.val[M11] + val[M32] * matrix.val[M21] + val[M33]
+		float tmpM31 = val[M30] * matrix.val[M01] + val[M31] * matrix.val[M11] + val[M32] * matrix.val[M21] + val[M33]
 			* matrix.val[M31];
-		tmp[M32] = val[M30] * matrix.val[M02] + val[M31] * matrix.val[M12] + val[M32] * matrix.val[M22] + val[M33]
+		float tmpM32 = val[M30] * matrix.val[M02] + val[M31] * matrix.val[M12] + val[M32] * matrix.val[M22] + val[M33]
 			* matrix.val[M32];
-		tmp[M33] = val[M30] * matrix.val[M03] + val[M31] * matrix.val[M13] + val[M32] * matrix.val[M23] + val[M33]
+		float tmpM33 = val[M30] * matrix.val[M03] + val[M31] * matrix.val[M13] + val[M32] * matrix.val[M23] + val[M33]
 			* matrix.val[M33];
-		return this.set(tmp);
+		return this.set(tmpM00, tmpM10, tmpM20, tmpM30, tmpM01, tmpM11, tmpM21, tmpM31, tmpM02, tmpM12, tmpM22, tmpM23, tmpM03,
+			tmpM13, tmpM23, tmpM33);
 	}
 
 	/** Premultiplies this matrix with the given matrix, storing the result in this matrix. For example:
@@ -377,62 +378,48 @@ public class Matrix4 implements Serializable {
 	 * @param matrix The other matrix to multiply by.
 	 * @return This matrix for the purpose of chaining operations together. */
 	public Matrix4 mulLeft (Matrix4 matrix) {
-		tmp[M00] = matrix.val[M00] * val[M00] + matrix.val[M01] * val[M10] + matrix.val[M02] * val[M20] + matrix.val[M03]
+		float tmpM00 = matrix.val[M00] * val[M00] + matrix.val[M01] * val[M10] + matrix.val[M02] * val[M20] + matrix.val[M03]
 			* val[M30];
-		tmp[M01] = matrix.val[M00] * val[M01] + matrix.val[M01] * val[M11] + matrix.val[M02] * val[M21] + matrix.val[M03]
+		float tmpM01 = matrix.val[M00] * val[M01] + matrix.val[M01] * val[M11] + matrix.val[M02] * val[M21] + matrix.val[M03]
 			* val[M31];
-		tmp[M02] = matrix.val[M00] * val[M02] + matrix.val[M01] * val[M12] + matrix.val[M02] * val[M22] + matrix.val[M03]
+		float tmpM02 = matrix.val[M00] * val[M02] + matrix.val[M01] * val[M12] + matrix.val[M02] * val[M22] + matrix.val[M03]
 			* val[M32];
-		tmp[M03] = matrix.val[M00] * val[M03] + matrix.val[M01] * val[M13] + matrix.val[M02] * val[M23] + matrix.val[M03]
+		float tmpM03 = matrix.val[M00] * val[M03] + matrix.val[M01] * val[M13] + matrix.val[M02] * val[M23] + matrix.val[M03]
 			* val[M33];
-		tmp[M10] = matrix.val[M10] * val[M00] + matrix.val[M11] * val[M10] + matrix.val[M12] * val[M20] + matrix.val[M13]
+		float tmpM10 = matrix.val[M10] * val[M00] + matrix.val[M11] * val[M10] + matrix.val[M12] * val[M20] + matrix.val[M13]
 			* val[M30];
-		tmp[M11] = matrix.val[M10] * val[M01] + matrix.val[M11] * val[M11] + matrix.val[M12] * val[M21] + matrix.val[M13]
+		float tmpM11 = matrix.val[M10] * val[M01] + matrix.val[M11] * val[M11] + matrix.val[M12] * val[M21] + matrix.val[M13]
 			* val[M31];
-		tmp[M12] = matrix.val[M10] * val[M02] + matrix.val[M11] * val[M12] + matrix.val[M12] * val[M22] + matrix.val[M13]
+		float tmpM12 = matrix.val[M10] * val[M02] + matrix.val[M11] * val[M12] + matrix.val[M12] * val[M22] + matrix.val[M13]
 			* val[M32];
-		tmp[M13] = matrix.val[M10] * val[M03] + matrix.val[M11] * val[M13] + matrix.val[M12] * val[M23] + matrix.val[M13]
+		float tmpM13 = matrix.val[M10] * val[M03] + matrix.val[M11] * val[M13] + matrix.val[M12] * val[M23] + matrix.val[M13]
 			* val[M33];
-		tmp[M20] = matrix.val[M20] * val[M00] + matrix.val[M21] * val[M10] + matrix.val[M22] * val[M20] + matrix.val[M23]
+		float tmpM20 = matrix.val[M20] * val[M00] + matrix.val[M21] * val[M10] + matrix.val[M22] * val[M20] + matrix.val[M23]
 			* val[M30];
-		tmp[M21] = matrix.val[M20] * val[M01] + matrix.val[M21] * val[M11] + matrix.val[M22] * val[M21] + matrix.val[M23]
+		float tmpM21 = matrix.val[M20] * val[M01] + matrix.val[M21] * val[M11] + matrix.val[M22] * val[M21] + matrix.val[M23]
 			* val[M31];
-		tmp[M22] = matrix.val[M20] * val[M02] + matrix.val[M21] * val[M12] + matrix.val[M22] * val[M22] + matrix.val[M23]
+		float tmpM22 = matrix.val[M20] * val[M02] + matrix.val[M21] * val[M12] + matrix.val[M22] * val[M22] + matrix.val[M23]
 			* val[M32];
-		tmp[M23] = matrix.val[M20] * val[M03] + matrix.val[M21] * val[M13] + matrix.val[M22] * val[M23] + matrix.val[M23]
+		float tmpM23 = matrix.val[M20] * val[M03] + matrix.val[M21] * val[M13] + matrix.val[M22] * val[M23] + matrix.val[M23]
 			* val[M33];
-		tmp[M30] = matrix.val[M30] * val[M00] + matrix.val[M31] * val[M10] + matrix.val[M32] * val[M20] + matrix.val[M33]
+		float tmpM30 = matrix.val[M30] * val[M00] + matrix.val[M31] * val[M10] + matrix.val[M32] * val[M20] + matrix.val[M33]
 			* val[M30];
-		tmp[M31] = matrix.val[M30] * val[M01] + matrix.val[M31] * val[M11] + matrix.val[M32] * val[M21] + matrix.val[M33]
+		float tmpM31 = matrix.val[M30] * val[M01] + matrix.val[M31] * val[M11] + matrix.val[M32] * val[M21] + matrix.val[M33]
 			* val[M31];
-		tmp[M32] = matrix.val[M30] * val[M02] + matrix.val[M31] * val[M12] + matrix.val[M32] * val[M22] + matrix.val[M33]
+		float tmpM32 = matrix.val[M30] * val[M02] + matrix.val[M31] * val[M12] + matrix.val[M32] * val[M22] + matrix.val[M33]
 			* val[M32];
-		tmp[M33] = matrix.val[M30] * val[M03] + matrix.val[M31] * val[M13] + matrix.val[M32] * val[M23] + matrix.val[M33]
+		float tmpM33 = matrix.val[M30] * val[M03] + matrix.val[M31] * val[M13] + matrix.val[M32] * val[M23] + matrix.val[M33]
 			* val[M33];
-		return this.set(tmp);
+		return this.set(tmpM00, tmpM10, tmpM20, tmpM30, tmpM01, tmpM11, tmpM21, tmpM31, tmpM02, tmpM12, tmpM22, tmpM23, tmpM03,
+			tmpM13, tmpM23, tmpM33);
 	}
 
 	/** Transposes the matrix.
 	 * 
 	 * @return This matrix for the purpose of chaining methods together. */
 	public Matrix4 tra () {
-		tmp[M00] = val[M00];
-		tmp[M01] = val[M10];
-		tmp[M02] = val[M20];
-		tmp[M03] = val[M30];
-		tmp[M10] = val[M01];
-		tmp[M11] = val[M11];
-		tmp[M12] = val[M21];
-		tmp[M13] = val[M31];
-		tmp[M20] = val[M02];
-		tmp[M21] = val[M12];
-		tmp[M22] = val[M22];
-		tmp[M23] = val[M32];
-		tmp[M30] = val[M03];
-		tmp[M31] = val[M13];
-		tmp[M32] = val[M23];
-		tmp[M33] = val[M33];
-		return set(tmp);
+		return set(val[M00], val[M10], val[M20], val[M30], val[M01], val[M11], val[M21], val[M31], val[M02], val[M12], val[M22],
+			val[M32], val[M03], val[M13], val[M23], val[M33]);
 	}
 
 	/** Sets the matrix to an identity matrix.
@@ -474,54 +461,54 @@ public class Matrix4 implements Serializable {
 			* val[M33] - val[M10] * val[M01] * val[M22] * val[M33] + val[M00] * val[M11] * val[M22] * val[M33];
 		if (l_det == 0f) throw new RuntimeException("non-invertible matrix");
 		float inv_det = 1.0f / l_det;
-		tmp[M00] = val[M12] * val[M23] * val[M31] - val[M13] * val[M22] * val[M31] + val[M13] * val[M21] * val[M32] - val[M11]
+		float tmpM00 = val[M12] * val[M23] * val[M31] - val[M13] * val[M22] * val[M31] + val[M13] * val[M21] * val[M32] - val[M11]
 			* val[M23] * val[M32] - val[M12] * val[M21] * val[M33] + val[M11] * val[M22] * val[M33];
-		tmp[M01] = val[M03] * val[M22] * val[M31] - val[M02] * val[M23] * val[M31] - val[M03] * val[M21] * val[M32] + val[M01]
+		float tmpM01 = val[M03] * val[M22] * val[M31] - val[M02] * val[M23] * val[M31] - val[M03] * val[M21] * val[M32] + val[M01]
 			* val[M23] * val[M32] + val[M02] * val[M21] * val[M33] - val[M01] * val[M22] * val[M33];
-		tmp[M02] = val[M02] * val[M13] * val[M31] - val[M03] * val[M12] * val[M31] + val[M03] * val[M11] * val[M32] - val[M01]
+		float tmpM02 = val[M02] * val[M13] * val[M31] - val[M03] * val[M12] * val[M31] + val[M03] * val[M11] * val[M32] - val[M01]
 			* val[M13] * val[M32] - val[M02] * val[M11] * val[M33] + val[M01] * val[M12] * val[M33];
-		tmp[M03] = val[M03] * val[M12] * val[M21] - val[M02] * val[M13] * val[M21] - val[M03] * val[M11] * val[M22] + val[M01]
+		float tmpM03 = val[M03] * val[M12] * val[M21] - val[M02] * val[M13] * val[M21] - val[M03] * val[M11] * val[M22] + val[M01]
 			* val[M13] * val[M22] + val[M02] * val[M11] * val[M23] - val[M01] * val[M12] * val[M23];
-		tmp[M10] = val[M13] * val[M22] * val[M30] - val[M12] * val[M23] * val[M30] - val[M13] * val[M20] * val[M32] + val[M10]
+		float tmpM10 = val[M13] * val[M22] * val[M30] - val[M12] * val[M23] * val[M30] - val[M13] * val[M20] * val[M32] + val[M10]
 			* val[M23] * val[M32] + val[M12] * val[M20] * val[M33] - val[M10] * val[M22] * val[M33];
-		tmp[M11] = val[M02] * val[M23] * val[M30] - val[M03] * val[M22] * val[M30] + val[M03] * val[M20] * val[M32] - val[M00]
+		float tmpM11 = val[M02] * val[M23] * val[M30] - val[M03] * val[M22] * val[M30] + val[M03] * val[M20] * val[M32] - val[M00]
 			* val[M23] * val[M32] - val[M02] * val[M20] * val[M33] + val[M00] * val[M22] * val[M33];
-		tmp[M12] = val[M03] * val[M12] * val[M30] - val[M02] * val[M13] * val[M30] - val[M03] * val[M10] * val[M32] + val[M00]
+		float tmpM12 = val[M03] * val[M12] * val[M30] - val[M02] * val[M13] * val[M30] - val[M03] * val[M10] * val[M32] + val[M00]
 			* val[M13] * val[M32] + val[M02] * val[M10] * val[M33] - val[M00] * val[M12] * val[M33];
-		tmp[M13] = val[M02] * val[M13] * val[M20] - val[M03] * val[M12] * val[M20] + val[M03] * val[M10] * val[M22] - val[M00]
+		float tmpM13 = val[M02] * val[M13] * val[M20] - val[M03] * val[M12] * val[M20] + val[M03] * val[M10] * val[M22] - val[M00]
 			* val[M13] * val[M22] - val[M02] * val[M10] * val[M23] + val[M00] * val[M12] * val[M23];
-		tmp[M20] = val[M11] * val[M23] * val[M30] - val[M13] * val[M21] * val[M30] + val[M13] * val[M20] * val[M31] - val[M10]
+		float tmpM20 = val[M11] * val[M23] * val[M30] - val[M13] * val[M21] * val[M30] + val[M13] * val[M20] * val[M31] - val[M10]
 			* val[M23] * val[M31] - val[M11] * val[M20] * val[M33] + val[M10] * val[M21] * val[M33];
-		tmp[M21] = val[M03] * val[M21] * val[M30] - val[M01] * val[M23] * val[M30] - val[M03] * val[M20] * val[M31] + val[M00]
+		float tmpM21 = val[M03] * val[M21] * val[M30] - val[M01] * val[M23] * val[M30] - val[M03] * val[M20] * val[M31] + val[M00]
 			* val[M23] * val[M31] + val[M01] * val[M20] * val[M33] - val[M00] * val[M21] * val[M33];
-		tmp[M22] = val[M01] * val[M13] * val[M30] - val[M03] * val[M11] * val[M30] + val[M03] * val[M10] * val[M31] - val[M00]
+		float tmpM22 = val[M01] * val[M13] * val[M30] - val[M03] * val[M11] * val[M30] + val[M03] * val[M10] * val[M31] - val[M00]
 			* val[M13] * val[M31] - val[M01] * val[M10] * val[M33] + val[M00] * val[M11] * val[M33];
-		tmp[M23] = val[M03] * val[M11] * val[M20] - val[M01] * val[M13] * val[M20] - val[M03] * val[M10] * val[M21] + val[M00]
+		float tmpM23 = val[M03] * val[M11] * val[M20] - val[M01] * val[M13] * val[M20] - val[M03] * val[M10] * val[M21] + val[M00]
 			* val[M13] * val[M21] + val[M01] * val[M10] * val[M23] - val[M00] * val[M11] * val[M23];
-		tmp[M30] = val[M12] * val[M21] * val[M30] - val[M11] * val[M22] * val[M30] - val[M12] * val[M20] * val[M31] + val[M10]
+		float tmpM30 = val[M12] * val[M21] * val[M30] - val[M11] * val[M22] * val[M30] - val[M12] * val[M20] * val[M31] + val[M10]
 			* val[M22] * val[M31] + val[M11] * val[M20] * val[M32] - val[M10] * val[M21] * val[M32];
-		tmp[M31] = val[M01] * val[M22] * val[M30] - val[M02] * val[M21] * val[M30] + val[M02] * val[M20] * val[M31] - val[M00]
+		float tmpM31 = val[M01] * val[M22] * val[M30] - val[M02] * val[M21] * val[M30] + val[M02] * val[M20] * val[M31] - val[M00]
 			* val[M22] * val[M31] - val[M01] * val[M20] * val[M32] + val[M00] * val[M21] * val[M32];
-		tmp[M32] = val[M02] * val[M11] * val[M30] - val[M01] * val[M12] * val[M30] - val[M02] * val[M10] * val[M31] + val[M00]
+		float tmpM32 = val[M02] * val[M11] * val[M30] - val[M01] * val[M12] * val[M30] - val[M02] * val[M10] * val[M31] + val[M00]
 			* val[M12] * val[M31] + val[M01] * val[M10] * val[M32] - val[M00] * val[M11] * val[M32];
-		tmp[M33] = val[M01] * val[M12] * val[M20] - val[M02] * val[M11] * val[M20] + val[M02] * val[M10] * val[M21] - val[M00]
+		float tmpM33 = val[M01] * val[M12] * val[M20] - val[M02] * val[M11] * val[M20] + val[M02] * val[M10] * val[M21] - val[M00]
 			* val[M12] * val[M21] - val[M01] * val[M10] * val[M22] + val[M00] * val[M11] * val[M22];
-		val[M00] = tmp[M00] * inv_det;
-		val[M01] = tmp[M01] * inv_det;
-		val[M02] = tmp[M02] * inv_det;
-		val[M03] = tmp[M03] * inv_det;
-		val[M10] = tmp[M10] * inv_det;
-		val[M11] = tmp[M11] * inv_det;
-		val[M12] = tmp[M12] * inv_det;
-		val[M13] = tmp[M13] * inv_det;
-		val[M20] = tmp[M20] * inv_det;
-		val[M21] = tmp[M21] * inv_det;
-		val[M22] = tmp[M22] * inv_det;
-		val[M23] = tmp[M23] * inv_det;
-		val[M30] = tmp[M30] * inv_det;
-		val[M31] = tmp[M31] * inv_det;
-		val[M32] = tmp[M32] * inv_det;
-		val[M33] = tmp[M33] * inv_det;
+		val[M00] = tmpM00 * inv_det;
+		val[M01] = tmpM01 * inv_det;
+		val[M02] = tmpM02 * inv_det;
+		val[M03] = tmpM03 * inv_det;
+		val[M10] = tmpM10 * inv_det;
+		val[M11] = tmpM11 * inv_det;
+		val[M12] = tmpM12 * inv_det;
+		val[M13] = tmpM13 * inv_det;
+		val[M20] = tmpM20 * inv_det;
+		val[M21] = tmpM21 * inv_det;
+		val[M22] = tmpM22 * inv_det;
+		val[M23] = tmpM23 * inv_det;
+		val[M30] = tmpM30 * inv_det;
+		val[M31] = tmpM31 * inv_det;
+		val[M32] = tmpM32 * inv_det;
+		val[M33] = tmpM33 * inv_det;
 		return this;
 	}
 
@@ -1468,24 +1455,7 @@ public class Matrix4 implements Serializable {
 	 * @param z Translation in the z-axis.
 	 * @return This matrix for the purpose of chaining methods together. */
 	public Matrix4 translate (float x, float y, float z) {
-		tmp[M00] = 1;
-		tmp[M01] = 0;
-		tmp[M02] = 0;
-		tmp[M03] = x;
-		tmp[M10] = 0;
-		tmp[M11] = 1;
-		tmp[M12] = 0;
-		tmp[M13] = y;
-		tmp[M20] = 0;
-		tmp[M21] = 0;
-		tmp[M22] = 1;
-		tmp[M23] = z;
-		tmp[M30] = 0;
-		tmp[M31] = 0;
-		tmp[M32] = 0;
-		tmp[M33] = 1;
-
-		mul(val, tmp);
+		mulLocal(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, x, y, z, 1);
 		return this;
 	}
 
@@ -1545,8 +1515,20 @@ public class Matrix4 implements Serializable {
 	 * @param rotation
 	 * @return This matrix for the purpose of chaining methods together. */
 	public Matrix4 rotate (Quaternion rotation) {
-		rotation.toMatrix(tmp);
-		mul(val, tmp);
+		// NOTE: this is an "unrolled" version of Quaternion.toMatrix(tmp) to avoid use of a tmp matrix
+		final float xx = rotation.x * rotation.x;
+		final float xy = rotation.x * rotation.y;
+		final float xz = rotation.x * rotation.z;
+		final float xw = rotation.x * rotation.w;
+		final float yy = rotation.y * rotation.y;
+		final float yz = rotation.y * rotation.z;
+		final float yw = rotation.y * rotation.w;
+		final float zz = rotation.z * rotation.z;
+		final float zw = rotation.z * rotation.w;
+
+		mulLocal(1 - 2 * (yy + zz), 2 * (xy + zw), 2 * (xz - yw), 0, 2 * (xy - zw), 1 - 2 * (xx + zz), 2 * (yz + xw), 0,
+			2 * (xz + yw), 2 * (yz - xw), 1 - 2 * (xx + yy), 0, 0, 0, 0, 1);
+		
 		return this;
 	}
 
@@ -1565,24 +1547,7 @@ public class Matrix4 implements Serializable {
 	 * @param scaleZ The scale in the z-axis.
 	 * @return This matrix for the purpose of chaining methods together. */
 	public Matrix4 scale (float scaleX, float scaleY, float scaleZ) {
-		tmp[M00] = scaleX;
-		tmp[M01] = 0;
-		tmp[M02] = 0;
-		tmp[M03] = 0;
-		tmp[M10] = 0;
-		tmp[M11] = scaleY;
-		tmp[M12] = 0;
-		tmp[M13] = 0;
-		tmp[M20] = 0;
-		tmp[M21] = 0;
-		tmp[M22] = scaleZ;
-		tmp[M23] = 0;
-		tmp[M30] = 0;
-		tmp[M31] = 0;
-		tmp[M32] = 0;
-		tmp[M33] = 1;
-
-		mul(val, tmp);
+		mulLocal(scaleX, 0, 0, 0, 0, scaleY, 0, 0, 0, 0, scaleZ, 0, 0, 0, 0, 1);
 		return this;
 	}
 
@@ -1601,5 +1566,17 @@ public class Matrix4 implements Serializable {
 		dst[9] = val[M03];
 		dst[10] = val[M13];
 		dst[11] = val[M23];
+	}
+
+	/** Multiplies this matrix with matrix matb, storing the result in this matrix.
+	 * 
+	 * This is a private helper function to pass the second matrix as list of float parameters, which is then forwarded to
+	 * {@link Matrix4#mul(float[], float[])} as float[] array.
+	 * 
+	 * Note: The order of parameters needs to match the ordinals of the MXX constants. Use with care!
+	 * 
+	 * @param matb The second matrix. */
+	private void mulLocal (float... matb) {
+		mul(val, matb);
 	}
 }

--- a/gdx/src/com/badlogic/gdx/math/Matrix3.java
+++ b/gdx/src/com/badlogic/gdx/math/Matrix3.java
@@ -509,24 +509,56 @@ public class Matrix3 implements Serializable {
 	}
 
 	/** Multiplies matrix a with matrix b in the following manner:
+	 *
+	 * <pre>
+	 * mul(A, B) => A := AB
+	 * </pre>
+	 * @param mata The float array representing the first matrix. Must have at least 9 elements.
+	 * @param matb The float array representing the second matrix. Must have at least 9 elements. */
+	private static void mul (float[] mata, float[] matb) {
+		float v00 = mata[M00] * matb[M00] + mata[M01] * matb[M10] + mata[M02] * matb[M20];
+		float v01 = mata[M00] * matb[M01] + mata[M01] * matb[M11] + mata[M02] * matb[M21];
+		float v02 = mata[M00] * matb[M02] + mata[M01] * matb[M12] + mata[M02] * matb[M22];
+
+		float v10 = mata[M10] * matb[M00] + mata[M11] * matb[M10] + mata[M12] * matb[M20];
+		float v11 = mata[M10] * matb[M01] + mata[M11] * matb[M11] + mata[M12] * matb[M21];
+		float v12 = mata[M10] * matb[M02] + mata[M11] * matb[M12] + mata[M12] * matb[M22];
+
+		float v20 = mata[M20] * matb[M00] + mata[M21] * matb[M10] + mata[M22] * matb[M20];
+		float v21 = mata[M20] * matb[M01] + mata[M21] * matb[M11] + mata[M22] * matb[M21];
+		float v22 = mata[M20] * matb[M02] + mata[M21] * matb[M12] + mata[M22] * matb[M22];
+
+		mata[M00] = v00;
+		mata[M10] = v10;
+		mata[M20] = v20;
+		mata[M01] = v01;
+		mata[M11] = v11;
+		mata[M21] = v21;
+		mata[M02] = v02;
+		mata[M12] = v12;
+		mata[M22] = v22;
+	}
+
+	/** Multiplies matrix a with matrix b in the following manner:
 	 * 
 	 * <pre>
 	 * mul(A, B) => A := AB
 	 * </pre>
 	 * @param mata The float array representing the first matrix. Must have at least 9 elements.
-	 * @param matb List of floats representing the second matrix. At least 9 arguments must be passed. */
-	private static void mul (float[] mata, float... matb) {
-		float v00 = mata[M00] * matb[0] + mata[M01] * matb[1] + mata[M02] * matb[2];
-		float v01 = mata[M00] * matb[3] + mata[M01] * matb[4] + mata[M02] * matb[5];
-		float v02 = mata[M00] * matb[6] + mata[M01] * matb[7] + mata[M02] * matb[8];
+	 * @param matb00 to matb22 List of floats representing the second matrix. */
+	private static void mul (float[] mata, float matb00, float matb10, float matb20, float matb01, float matb11, float matb21,
+		float matb02, float matb12, float matb22) {
+		float v00 = mata[M00] * matb00 + mata[M01] * matb10 + mata[M02] * matb20;
+		float v01 = mata[M00] * matb01 + mata[M01] * matb11 + mata[M02] * matb21;
+		float v02 = mata[M00] * matb02 + mata[M01] * matb12 + mata[M02] * matb22;
 
-		float v10 = mata[M10] * matb[0] + mata[M11] * matb[1] + mata[M12] * matb[2];
-		float v11 = mata[M10] * matb[3] + mata[M11] * matb[4] + mata[M12] * matb[5];
-		float v12 = mata[M10] * matb[6] + mata[M11] * matb[7] + mata[M12] * matb[8];
+		float v10 = mata[M10] * matb00 + mata[M11] * matb10 + mata[M12] * matb20;
+		float v11 = mata[M10] * matb01 + mata[M11] * matb11 + mata[M12] * matb21;
+		float v12 = mata[M10] * matb02 + mata[M11] * matb12 + mata[M12] * matb22;
 
-		float v20 = mata[M20] * matb[0] + mata[M21] * matb[1] + mata[M22] * matb[2];
-		float v21 = mata[M20] * matb[3] + mata[M21] * matb[4] + mata[M22] * matb[5];
-		float v22 = mata[M20] * matb[6] + mata[M21] * matb[7] + mata[M22] * matb[8];
+		float v20 = mata[M20] * matb00 + mata[M21] * matb10 + mata[M22] * matb20;
+		float v21 = mata[M20] * matb01 + mata[M21] * matb11 + mata[M22] * matb21;
+		float v22 = mata[M20] * matb02 + mata[M21] * matb12 + mata[M22] * matb22;
 
 		mata[M00] = v00;
 		mata[M10] = v10;

--- a/gdx/src/com/badlogic/gdx/math/Matrix3.java
+++ b/gdx/src/com/badlogic/gdx/math/Matrix3.java
@@ -36,7 +36,6 @@ public class Matrix3 implements Serializable {
 	public static final int M21 = 5;
 	public static final int M22 = 8;
 	public float[] val = new float[9];
-	private float[] tmp = new float[9];
 
 	public Matrix3 () {
 		idt();
@@ -275,25 +274,25 @@ public class Matrix3 implements Serializable {
 
 		float inv_det = 1.0f / det;
 
-		tmp[M00] = val[M11] * val[M22] - val[M21] * val[M12];
-		tmp[M10] = val[M20] * val[M12] - val[M10] * val[M22];
-		tmp[M20] = val[M10] * val[M21] - val[M20] * val[M11];
-		tmp[M01] = val[M21] * val[M02] - val[M01] * val[M22];
-		tmp[M11] = val[M00] * val[M22] - val[M20] * val[M02];
-		tmp[M21] = val[M20] * val[M01] - val[M00] * val[M21];
-		tmp[M02] = val[M01] * val[M12] - val[M11] * val[M02];
-		tmp[M12] = val[M10] * val[M02] - val[M00] * val[M12];
-		tmp[M22] = val[M00] * val[M11] - val[M10] * val[M01];
+		float tmpM00 = val[M11] * val[M22] - val[M21] * val[M12];
+		float tmpM10 = val[M20] * val[M12] - val[M10] * val[M22];
+		float tmpM20 = val[M10] * val[M21] - val[M20] * val[M11];
+		float tmpM01 = val[M21] * val[M02] - val[M01] * val[M22];
+		float tmpM11 = val[M00] * val[M22] - val[M20] * val[M02];
+		float tmpM21 = val[M20] * val[M01] - val[M00] * val[M21];
+		float tmpM02 = val[M01] * val[M12] - val[M11] * val[M02];
+		float tmpM12 = val[M10] * val[M02] - val[M00] * val[M12];
+		float tmpM22 = val[M00] * val[M11] - val[M10] * val[M01];
 
-		val[M00] = inv_det * tmp[M00];
-		val[M10] = inv_det * tmp[M10];
-		val[M20] = inv_det * tmp[M20];
-		val[M01] = inv_det * tmp[M01];
-		val[M11] = inv_det * tmp[M11];
-		val[M21] = inv_det * tmp[M21];
-		val[M02] = inv_det * tmp[M02];
-		val[M12] = inv_det * tmp[M12];
-		val[M22] = inv_det * tmp[M22];
+		val[M00] = inv_det * tmpM00;
+		val[M10] = inv_det * tmpM10;
+		val[M20] = inv_det * tmpM20;
+		val[M01] = inv_det * tmpM01;
+		val[M11] = inv_det * tmpM11;
+		val[M21] = inv_det * tmpM21;
+		val[M02] = inv_det * tmpM02;
+		val[M12] = inv_det * tmpM12;
+		val[M22] = inv_det * tmpM22;
 
 		return this;
 	}
@@ -384,18 +383,7 @@ public class Matrix3 implements Serializable {
 	 * @param y The y-component of the translation vector.
 	 * @return This matrix for the purpose of chaining. */
 	public Matrix3 translate (float x, float y) {
-		tmp[M00] = 1;
-		tmp[M10] = 0;
-		tmp[M20] = 0;
-
-		tmp[M01] = 0;
-		tmp[M11] = 1;
-		tmp[M21] = 0;
-
-		tmp[M02] = x;
-		tmp[M12] = y;
-		tmp[M22] = 1;
-		mul(val, tmp);
+		mul(val, 1, 0, 0, 0, 1, 0, x, y, 1);
 		return this;
 	}
 
@@ -404,18 +392,7 @@ public class Matrix3 implements Serializable {
 	 * @param translation The translation vector.
 	 * @return This matrix for the purpose of chaining. */
 	public Matrix3 translate (Vector2 translation) {
-		tmp[M00] = 1;
-		tmp[M10] = 0;
-		tmp[M20] = 0;
-
-		tmp[M01] = 0;
-		tmp[M11] = 1;
-		tmp[M21] = 0;
-
-		tmp[M02] = translation.x;
-		tmp[M12] = translation.y;
-		tmp[M22] = 1;
-		mul(val, tmp);
+		mul(val, 1, 0, 0, 0, 1, 0, translation.x, translation.y, 1);
 		return this;
 	}
 
@@ -436,18 +413,7 @@ public class Matrix3 implements Serializable {
 		float cos = (float)Math.cos(radians);
 		float sin = (float)Math.sin(radians);
 
-		tmp[M00] = cos;
-		tmp[M10] = sin;
-		tmp[M20] = 0;
-
-		tmp[M01] = -sin;
-		tmp[M11] = cos;
-		tmp[M21] = 0;
-
-		tmp[M02] = 0;
-		tmp[M12] = 0;
-		tmp[M22] = 1;
-		mul(val, tmp);
+		mul(val, cos, sin, 0, -sin, cos, 0, 0, 0, 1);
 		return this;
 	}
 
@@ -457,16 +423,7 @@ public class Matrix3 implements Serializable {
 	 * @param scaleY The scale in the y-axis.
 	 * @return This matrix for the purpose of chaining. */
 	public Matrix3 scale (float scaleX, float scaleY) {
-		tmp[M00] = scaleX;
-		tmp[M10] = 0;
-		tmp[M20] = 0;
-		tmp[M01] = 0;
-		tmp[M11] = scaleY;
-		tmp[M21] = 0;
-		tmp[M02] = 0;
-		tmp[M12] = 0;
-		tmp[M22] = 1;
-		mul(val, tmp);
+		mul(val, scaleX, 0, 0, 0, scaleY, 0, 0, 0, 1);
 		return this;
 	}
 
@@ -475,16 +432,7 @@ public class Matrix3 implements Serializable {
 	 * @param scale The vector to scale the matrix by.
 	 * @return This matrix for the purpose of chaining. */
 	public Matrix3 scale (Vector2 scale) {
-		tmp[M00] = scale.x;
-		tmp[M10] = 0;
-		tmp[M20] = 0;
-		tmp[M01] = 0;
-		tmp[M11] = scale.y;
-		tmp[M21] = 0;
-		tmp[M02] = 0;
-		tmp[M12] = 0;
-		tmp[M22] = 1;
-		mul(val, tmp);
+		mul(val, scale.x, 0, 0, 0, scale.y, 0, 0, 0, 1);
 		return this;
 	}
 
@@ -566,19 +514,19 @@ public class Matrix3 implements Serializable {
 	 * mul(A, B) => A := AB
 	 * </pre>
 	 * @param mata The float array representing the first matrix. Must have at least 9 elements.
-	 * @param matb The float array representing the second matrix. Must have at least 9 elements. */
-	private static void mul (float[] mata, float[] matb) {
-		float v00 = mata[M00] * matb[M00] + mata[M01] * matb[M10] + mata[M02] * matb[M20];
-		float v01 = mata[M00] * matb[M01] + mata[M01] * matb[M11] + mata[M02] * matb[M21];
-		float v02 = mata[M00] * matb[M02] + mata[M01] * matb[M12] + mata[M02] * matb[M22];
+	 * @param matb List of floats representing the second matrix. At least 9 arguments must be passed. */
+	private static void mul (float[] mata, float... matb) {
+		float v00 = mata[M00] * matb[0] + mata[M01] * matb[1] + mata[M02] * matb[2];
+		float v01 = mata[M00] * matb[3] + mata[M01] * matb[4] + mata[M02] * matb[5];
+		float v02 = mata[M00] * matb[6] + mata[M01] * matb[7] + mata[M02] * matb[8];
 
-		float v10 = mata[M10] * matb[M00] + mata[M11] * matb[M10] + mata[M12] * matb[M20];
-		float v11 = mata[M10] * matb[M01] + mata[M11] * matb[M11] + mata[M12] * matb[M21];
-		float v12 = mata[M10] * matb[M02] + mata[M11] * matb[M12] + mata[M12] * matb[M22];
+		float v10 = mata[M10] * matb[0] + mata[M11] * matb[1] + mata[M12] * matb[2];
+		float v11 = mata[M10] * matb[3] + mata[M11] * matb[4] + mata[M12] * matb[5];
+		float v12 = mata[M10] * matb[6] + mata[M11] * matb[7] + mata[M12] * matb[8];
 
-		float v20 = mata[M20] * matb[M00] + mata[M21] * matb[M10] + mata[M22] * matb[M20];
-		float v21 = mata[M20] * matb[M01] + mata[M21] * matb[M11] + mata[M22] * matb[M21];
-		float v22 = mata[M20] * matb[M02] + mata[M21] * matb[M12] + mata[M22] * matb[M22];
+		float v20 = mata[M20] * matb[0] + mata[M21] * matb[1] + mata[M22] * matb[2];
+		float v21 = mata[M20] * matb[3] + mata[M21] * matb[4] + mata[M22] * matb[5];
+		float v22 = mata[M20] * matb[6] + mata[M21] * matb[7] + mata[M22] * matb[8];
 
 		mata[M00] = v00;
 		mata[M10] = v10;

--- a/gdx/src/com/badlogic/gdx/math/Matrix4.java
+++ b/gdx/src/com/badlogic/gdx/math/Matrix4.java
@@ -127,8 +127,34 @@ public class Matrix4 implements Serializable {
 	 * @param values The matrix, in float form, that is to be copied. Remember that this matrix is in <a
 	 *           href="http://en.wikipedia.org/wiki/Row-major_order">column major</a> order.
 	 * @return This matrix for the purpose of chaining methods together. */
-	public Matrix4 set (float... values) {
+	public Matrix4 set (float[] values) {
 		System.arraycopy(values, 0, val, 0, val.length);
+		return this;
+	}
+
+	/** Sets the matrix to the given matrix as an array of floats.
+	 * 
+	 * @param mat00 to mat33 The matrix, in float form, that is to be copied. Remember that this matrix is in <a
+	 *           href="http://en.wikipedia.org/wiki/Row-major_order">column major</a> order.
+	 * @return This matrix for the purpose of chaining methods together. */
+	public Matrix4 set (float mat00, float mat10, float mat20, float mat30, float mat01, float mat11, float mat21, float mat31,
+		float mat02, float mat12, float mat22, float mat32, float mat03, float mat13, float mat23, float mat33) {
+		val[M00] = mat00;
+		val[M10] = mat10;
+		val[M20] = mat20;
+		val[M30] = mat30;
+		val[M01] = mat01;
+		val[M11] = mat11;
+		val[M21] = mat21;
+		val[M31] = mat31;
+		val[M02] = mat02;
+		val[M12] = mat12;
+		val[M22] = mat22;
+		val[M32] = mat32;
+		val[M03] = mat03;
+		val[M13] = mat13;
+		val[M23] = mat23;
+		val[M33] = mat33;
 		return this;
 	}
 
@@ -350,7 +376,7 @@ public class Matrix4 implements Serializable {
 		float tmpM23 = val[M23];
 		float tmpM33 = val[M33];
 		set(matrix);
-		mulLocal(tmpM00, tmpM10, tmpM20, tmpM30, tmpM01, tmpM11, tmpM21, tmpM31, tmpM02, tmpM12, tmpM22, tmpM32, tmpM03, tmpM13,
+		mul(val, tmpM00, tmpM10, tmpM20, tmpM30, tmpM01, tmpM11, tmpM21, tmpM31, tmpM02, tmpM12, tmpM22, tmpM32, tmpM03, tmpM13,
 			tmpM23, tmpM33);
 		return this;
 	}
@@ -894,7 +920,7 @@ public class Matrix4 implements Serializable {
 		uy = rz * fx - rx * fz;
 		uz = rx * fy - ry * fx;
 
-		set(rx, ux, -fx, 0, ry, uy, -fy, 0, rz, uz, -fz, position.x, position.y, position.z, 1);
+		set(rx, ux, -fx, 0, ry, uy, -fy, 0, rz, uz, -fz, 0, position.x, position.y, position.z, 1);
 
 		return this;
 	}
@@ -1356,6 +1382,23 @@ public class Matrix4 implements Serializable {
 		matrix4_mul(mata, matb);
 	*/
 
+	/** Multiplies the matrix mata with matrix matb, passed as array of float parameters, storing the result in mata. The arrays
+	 *  are assumed to hold 4x4 column major matrices as you can get from {@link Matrix4#val}. This is the same as
+	 *  {@link Matrix4#mul(Matrix4)}.
+	 * 
+	 * @param mata the first matrix.
+	 * @param matb00 to matb33 the second matrix. */
+	public static native void mul (float[] mata, float matb00, float matb10, float matb20, float matb30, float matb01,
+		float matb11, float matb21, float matb31, float matb02, float matb12, float matb22, float matb32, float matb03,
+		float matb13, float matb23, float matb33) /*-{ }-*/; /*
+		float matb[16];
+		matb[M00] = matb00; matb[M01] = matb01; matb[M02] = matb02; matb[M03] = matb03;
+		matb[M10] = matb10; matb[M11] = matb11; matb[M12] = matb12; matb[M13] = matb13;
+		matb[M20] = matb20; matb[M21] = matb21; matb[M22] = matb22; matb[M23] = matb23;
+		matb[M30] = matb30; matb[M31] = matb31; matb[M32] = matb32; matb[M33] = matb33;
+		matrix4_mul(mata, matb);
+	*/
+
 	/** Multiplies the vector with the given matrix. The matrix array is assumed to hold a 4x4 column major matrix as you can get
 	 * from {@link Matrix4#val}. The vector array is assumed to hold a 3-component vector, with x being the first element, y being
 	 * the second and z being the last component. The result is stored in the vector array. This is the same as
@@ -1475,7 +1518,7 @@ public class Matrix4 implements Serializable {
 	 * @param z Translation in the z-axis.
 	 * @return This matrix for the purpose of chaining methods together. */
 	public Matrix4 translate (float x, float y, float z) {
-		mulLocal(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, x, y, z, 1);
+		mul(val, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, x, y, z, 1);
 		return this;
 	}
 
@@ -1546,7 +1589,7 @@ public class Matrix4 implements Serializable {
 		final float zz = rotation.z * rotation.z;
 		final float zw = rotation.z * rotation.w;
 
-		mulLocal(1 - 2 * (yy + zz), 2 * (xy + zw), 2 * (xz - yw), 0, 2 * (xy - zw), 1 - 2 * (xx + zz), 2 * (yz + xw), 0,
+		mul(val, 1 - 2 * (yy + zz), 2 * (xy + zw), 2 * (xz - yw), 0, 2 * (xy - zw), 1 - 2 * (xx + zz), 2 * (yz + xw), 0,
 			2 * (xz + yw), 2 * (yz - xw), 1 - 2 * (xx + yy), 0, 0, 0, 0, 1);
 		
 		return this;
@@ -1567,7 +1610,7 @@ public class Matrix4 implements Serializable {
 	 * @param scaleZ The scale in the z-axis.
 	 * @return This matrix for the purpose of chaining methods together. */
 	public Matrix4 scale (float scaleX, float scaleY, float scaleZ) {
-		mulLocal(scaleX, 0, 0, 0, 0, scaleY, 0, 0, 0, 0, scaleZ, 0, 0, 0, 0, 1);
+		mul(val, scaleX, 0, 0, 0, 0, scaleY, 0, 0, 0, 0, scaleZ, 0, 0, 0, 0, 1);
 		return this;
 	}
 
@@ -1586,17 +1629,5 @@ public class Matrix4 implements Serializable {
 		dst[9] = val[M03];
 		dst[10] = val[M13];
 		dst[11] = val[M23];
-	}
-
-	/** Multiplies this matrix with matrix matb, storing the result in this matrix.
-	 * 
-	 * This is a private helper function to pass the second matrix as list of float parameters, which is then forwarded to
-	 * {@link Matrix4#mul(float[], float[])} as float[] array.
-	 * 
-	 * Note: The order of parameters needs to match the ordinals of the MXX constants. Use with care!
-	 * 
-	 * @param matb The second matrix. */
-	private void mulLocal (float... matb) {
-		mul(val, matb);
 	}
 }

--- a/gdx/src/com/badlogic/gdx/math/Matrix4.java
+++ b/gdx/src/com/badlogic/gdx/math/Matrix4.java
@@ -124,7 +124,7 @@ public class Matrix4 implements Serializable {
 	 * @param values The matrix, in float form, that is to be copied. Remember that this matrix is in <a
 	 *           href="http://en.wikipedia.org/wiki/Row-major_order">column major</a> order.
 	 * @return This matrix for the purpose of chaining methods together. */
-	public Matrix4 set (float[] values) {
+	public Matrix4 set (float... values) {
 		System.arraycopy(values, 0, val, 0, val.length);
 		return this;
 	}
@@ -339,23 +339,8 @@ public class Matrix4 implements Serializable {
 	 * 
 	 * @return This matrix for the purpose of chaining methods together. */
 	public Matrix4 tra () {
-		tmp[M00] = val[M00];
-		tmp[M01] = val[M10];
-		tmp[M02] = val[M20];
-		tmp[M03] = val[M30];
-		tmp[M10] = val[M01];
-		tmp[M11] = val[M11];
-		tmp[M12] = val[M21];
-		tmp[M13] = val[M31];
-		tmp[M20] = val[M02];
-		tmp[M21] = val[M12];
-		tmp[M22] = val[M22];
-		tmp[M23] = val[M32];
-		tmp[M30] = val[M03];
-		tmp[M31] = val[M13];
-		tmp[M32] = val[M23];
-		tmp[M33] = val[M33];
-		return set(tmp);
+		return set(val[M00], val[M10], val[M20], val[M30], val[M01], val[M11], val[M21], val[M31], val[M02], val[M12], val[M22],
+			val[M32], val[M03], val[M13], val[M23], val[M33]);
 	}
 
 	/** Sets the matrix to an identity matrix.
@@ -397,54 +382,54 @@ public class Matrix4 implements Serializable {
 			* val[M33] - val[M10] * val[M01] * val[M22] * val[M33] + val[M00] * val[M11] * val[M22] * val[M33];
 		if (l_det == 0f) throw new RuntimeException("non-invertible matrix");
 		float inv_det = 1.0f / l_det;
-		tmp[M00] = val[M12] * val[M23] * val[M31] - val[M13] * val[M22] * val[M31] + val[M13] * val[M21] * val[M32] - val[M11]
+		float tmpM00 = val[M12] * val[M23] * val[M31] - val[M13] * val[M22] * val[M31] + val[M13] * val[M21] * val[M32] - val[M11]
 			* val[M23] * val[M32] - val[M12] * val[M21] * val[M33] + val[M11] * val[M22] * val[M33];
-		tmp[M01] = val[M03] * val[M22] * val[M31] - val[M02] * val[M23] * val[M31] - val[M03] * val[M21] * val[M32] + val[M01]
+		float tmpM01 = val[M03] * val[M22] * val[M31] - val[M02] * val[M23] * val[M31] - val[M03] * val[M21] * val[M32] + val[M01]
 			* val[M23] * val[M32] + val[M02] * val[M21] * val[M33] - val[M01] * val[M22] * val[M33];
-		tmp[M02] = val[M02] * val[M13] * val[M31] - val[M03] * val[M12] * val[M31] + val[M03] * val[M11] * val[M32] - val[M01]
+		float tmpM02 = val[M02] * val[M13] * val[M31] - val[M03] * val[M12] * val[M31] + val[M03] * val[M11] * val[M32] - val[M01]
 			* val[M13] * val[M32] - val[M02] * val[M11] * val[M33] + val[M01] * val[M12] * val[M33];
-		tmp[M03] = val[M03] * val[M12] * val[M21] - val[M02] * val[M13] * val[M21] - val[M03] * val[M11] * val[M22] + val[M01]
+		float tmpM03 = val[M03] * val[M12] * val[M21] - val[M02] * val[M13] * val[M21] - val[M03] * val[M11] * val[M22] + val[M01]
 			* val[M13] * val[M22] + val[M02] * val[M11] * val[M23] - val[M01] * val[M12] * val[M23];
-		tmp[M10] = val[M13] * val[M22] * val[M30] - val[M12] * val[M23] * val[M30] - val[M13] * val[M20] * val[M32] + val[M10]
+		float tmpM10 = val[M13] * val[M22] * val[M30] - val[M12] * val[M23] * val[M30] - val[M13] * val[M20] * val[M32] + val[M10]
 			* val[M23] * val[M32] + val[M12] * val[M20] * val[M33] - val[M10] * val[M22] * val[M33];
-		tmp[M11] = val[M02] * val[M23] * val[M30] - val[M03] * val[M22] * val[M30] + val[M03] * val[M20] * val[M32] - val[M00]
+		float tmpM11 = val[M02] * val[M23] * val[M30] - val[M03] * val[M22] * val[M30] + val[M03] * val[M20] * val[M32] - val[M00]
 			* val[M23] * val[M32] - val[M02] * val[M20] * val[M33] + val[M00] * val[M22] * val[M33];
-		tmp[M12] = val[M03] * val[M12] * val[M30] - val[M02] * val[M13] * val[M30] - val[M03] * val[M10] * val[M32] + val[M00]
+		float tmpM12 = val[M03] * val[M12] * val[M30] - val[M02] * val[M13] * val[M30] - val[M03] * val[M10] * val[M32] + val[M00]
 			* val[M13] * val[M32] + val[M02] * val[M10] * val[M33] - val[M00] * val[M12] * val[M33];
-		tmp[M13] = val[M02] * val[M13] * val[M20] - val[M03] * val[M12] * val[M20] + val[M03] * val[M10] * val[M22] - val[M00]
+		float tmpM13 = val[M02] * val[M13] * val[M20] - val[M03] * val[M12] * val[M20] + val[M03] * val[M10] * val[M22] - val[M00]
 			* val[M13] * val[M22] - val[M02] * val[M10] * val[M23] + val[M00] * val[M12] * val[M23];
-		tmp[M20] = val[M11] * val[M23] * val[M30] - val[M13] * val[M21] * val[M30] + val[M13] * val[M20] * val[M31] - val[M10]
+		float tmpM20 = val[M11] * val[M23] * val[M30] - val[M13] * val[M21] * val[M30] + val[M13] * val[M20] * val[M31] - val[M10]
 			* val[M23] * val[M31] - val[M11] * val[M20] * val[M33] + val[M10] * val[M21] * val[M33];
-		tmp[M21] = val[M03] * val[M21] * val[M30] - val[M01] * val[M23] * val[M30] - val[M03] * val[M20] * val[M31] + val[M00]
+		float tmpM21 = val[M03] * val[M21] * val[M30] - val[M01] * val[M23] * val[M30] - val[M03] * val[M20] * val[M31] + val[M00]
 			* val[M23] * val[M31] + val[M01] * val[M20] * val[M33] - val[M00] * val[M21] * val[M33];
-		tmp[M22] = val[M01] * val[M13] * val[M30] - val[M03] * val[M11] * val[M30] + val[M03] * val[M10] * val[M31] - val[M00]
+		float tmpM22 = val[M01] * val[M13] * val[M30] - val[M03] * val[M11] * val[M30] + val[M03] * val[M10] * val[M31] - val[M00]
 			* val[M13] * val[M31] - val[M01] * val[M10] * val[M33] + val[M00] * val[M11] * val[M33];
-		tmp[M23] = val[M03] * val[M11] * val[M20] - val[M01] * val[M13] * val[M20] - val[M03] * val[M10] * val[M21] + val[M00]
+		float tmpM23 = val[M03] * val[M11] * val[M20] - val[M01] * val[M13] * val[M20] - val[M03] * val[M10] * val[M21] + val[M00]
 			* val[M13] * val[M21] + val[M01] * val[M10] * val[M23] - val[M00] * val[M11] * val[M23];
-		tmp[M30] = val[M12] * val[M21] * val[M30] - val[M11] * val[M22] * val[M30] - val[M12] * val[M20] * val[M31] + val[M10]
+		float tmpM30 = val[M12] * val[M21] * val[M30] - val[M11] * val[M22] * val[M30] - val[M12] * val[M20] * val[M31] + val[M10]
 			* val[M22] * val[M31] + val[M11] * val[M20] * val[M32] - val[M10] * val[M21] * val[M32];
-		tmp[M31] = val[M01] * val[M22] * val[M30] - val[M02] * val[M21] * val[M30] + val[M02] * val[M20] * val[M31] - val[M00]
+		float tmpM31 = val[M01] * val[M22] * val[M30] - val[M02] * val[M21] * val[M30] + val[M02] * val[M20] * val[M31] - val[M00]
 			* val[M22] * val[M31] - val[M01] * val[M20] * val[M32] + val[M00] * val[M21] * val[M32];
-		tmp[M32] = val[M02] * val[M11] * val[M30] - val[M01] * val[M12] * val[M30] - val[M02] * val[M10] * val[M31] + val[M00]
+		float tmpM32 = val[M02] * val[M11] * val[M30] - val[M01] * val[M12] * val[M30] - val[M02] * val[M10] * val[M31] + val[M00]
 			* val[M12] * val[M31] + val[M01] * val[M10] * val[M32] - val[M00] * val[M11] * val[M32];
-		tmp[M33] = val[M01] * val[M12] * val[M20] - val[M02] * val[M11] * val[M20] + val[M02] * val[M10] * val[M21] - val[M00]
+		float tmpM33 = val[M01] * val[M12] * val[M20] - val[M02] * val[M11] * val[M20] + val[M02] * val[M10] * val[M21] - val[M00]
 			* val[M12] * val[M21] - val[M01] * val[M10] * val[M22] + val[M00] * val[M11] * val[M22];
-		val[M00] = tmp[M00] * inv_det;
-		val[M01] = tmp[M01] * inv_det;
-		val[M02] = tmp[M02] * inv_det;
-		val[M03] = tmp[M03] * inv_det;
-		val[M10] = tmp[M10] * inv_det;
-		val[M11] = tmp[M11] * inv_det;
-		val[M12] = tmp[M12] * inv_det;
-		val[M13] = tmp[M13] * inv_det;
-		val[M20] = tmp[M20] * inv_det;
-		val[M21] = tmp[M21] * inv_det;
-		val[M22] = tmp[M22] * inv_det;
-		val[M23] = tmp[M23] * inv_det;
-		val[M30] = tmp[M30] * inv_det;
-		val[M31] = tmp[M31] * inv_det;
-		val[M32] = tmp[M32] * inv_det;
-		val[M33] = tmp[M33] * inv_det;
+		val[M00] = tmpM00 * inv_det;
+		val[M01] = tmpM01 * inv_det;
+		val[M02] = tmpM02 * inv_det;
+		val[M03] = tmpM03 * inv_det;
+		val[M10] = tmpM10 * inv_det;
+		val[M11] = tmpM11 * inv_det;
+		val[M12] = tmpM12 * inv_det;
+		val[M13] = tmpM13 * inv_det;
+		val[M20] = tmpM20 * inv_det;
+		val[M21] = tmpM21 * inv_det;
+		val[M22] = tmpM22 * inv_det;
+		val[M23] = tmpM23 * inv_det;
+		val[M30] = tmpM30 * inv_det;
+		val[M31] = tmpM31 * inv_det;
+		val[M32] = tmpM32 * inv_det;
+		val[M33] = tmpM33 * inv_det;
 		return this;
 	}
 
@@ -1414,24 +1399,7 @@ public class Matrix4 implements Serializable {
 	 * @param z Translation in the z-axis.
 	 * @return This matrix for the purpose of chaining methods together. */
 	public Matrix4 translate (float x, float y, float z) {
-		tmp[M00] = 1;
-		tmp[M01] = 0;
-		tmp[M02] = 0;
-		tmp[M03] = x;
-		tmp[M10] = 0;
-		tmp[M11] = 1;
-		tmp[M12] = 0;
-		tmp[M13] = y;
-		tmp[M20] = 0;
-		tmp[M21] = 0;
-		tmp[M22] = 1;
-		tmp[M23] = z;
-		tmp[M30] = 0;
-		tmp[M31] = 0;
-		tmp[M32] = 0;
-		tmp[M33] = 1;
-
-		mul(val, tmp);
+		mulLocal(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, x, y, z, 1);
 		return this;
 	}
 
@@ -1491,8 +1459,20 @@ public class Matrix4 implements Serializable {
 	 * @param rotation
 	 * @return This matrix for the purpose of chaining methods together. */
 	public Matrix4 rotate (Quaternion rotation) {
-		rotation.toMatrix(tmp);
-		mul(val, tmp);
+		// NOTE: this is an "unrolled" version of Quaternion.toMatrix(tmp) to avoid use of a tmp matrix
+		final float xx = rotation.x * rotation.x;
+		final float xy = rotation.x * rotation.y;
+		final float xz = rotation.x * rotation.z;
+		final float xw = rotation.x * rotation.w;
+		final float yy = rotation.y * rotation.y;
+		final float yz = rotation.y * rotation.z;
+		final float yw = rotation.y * rotation.w;
+		final float zz = rotation.z * rotation.z;
+		final float zw = rotation.z * rotation.w;
+
+		mulLocal(1 - 2 * (yy + zz), 2 * (xy + zw), 2 * (xz - yw), 0, 2 * (xy - zw), 1 - 2 * (xx + zz), 2 * (yz + xw), 0,
+			2 * (xz + yw), 2 * (yz - xw), 1 - 2 * (xx + yy), 0, 0, 0, 0, 1);
+		
 		return this;
 	}
 
@@ -1511,24 +1491,7 @@ public class Matrix4 implements Serializable {
 	 * @param scaleZ The scale in the z-axis.
 	 * @return This matrix for the purpose of chaining methods together. */
 	public Matrix4 scale (float scaleX, float scaleY, float scaleZ) {
-		tmp[M00] = scaleX;
-		tmp[M01] = 0;
-		tmp[M02] = 0;
-		tmp[M03] = 0;
-		tmp[M10] = 0;
-		tmp[M11] = scaleY;
-		tmp[M12] = 0;
-		tmp[M13] = 0;
-		tmp[M20] = 0;
-		tmp[M21] = 0;
-		tmp[M22] = scaleZ;
-		tmp[M23] = 0;
-		tmp[M30] = 0;
-		tmp[M31] = 0;
-		tmp[M32] = 0;
-		tmp[M33] = 1;
-
-		mul(val, tmp);
+		mulLocal(scaleX, 0, 0, 0, 0, scaleY, 0, 0, 0, 0, scaleZ, 0, 0, 0, 0, 1);
 		return this;
 	}
 
@@ -1547,5 +1510,17 @@ public class Matrix4 implements Serializable {
 		dst[9] = val[M03];
 		dst[10] = val[M13];
 		dst[11] = val[M23];
+	}
+
+	/** Multiplies this matrix with matrix matb, storing the result in this matrix.
+	 * 
+	 * This is a private helper function to pass the second matrix as list of float parameters, which is then forwarded to
+	 * {@link Matrix4#mul(float[], float[])} as float[] array.
+	 * 
+	 * Note: The order of parameters needs to match the ordinals of the MXX constants. Use with care!
+	 * 
+	 * @param matb The second matrix. */
+	private void mulLocal (float... matb) {
+		mul(val, matb);
 	}
 }

--- a/gdx/src/com/badlogic/gdx/math/Matrix4.java
+++ b/gdx/src/com/badlogic/gdx/math/Matrix4.java
@@ -74,6 +74,9 @@ public class Matrix4 implements Serializable {
 	@Deprecated public static final float tmp[] = new float[16]; // FIXME Change to private access
 	public final float val[] = new float[16];
 
+	private static final Quaternion quat = new Quaternion();
+	private static final Quaternion quat2 = new Quaternion();
+
 	/** Constructs an identity matrix */
 	public Matrix4 () {
 		val[M00] = 1f;
@@ -330,9 +333,26 @@ public class Matrix4 implements Serializable {
 	 * @param matrix The other matrix to multiply by.
 	 * @return This matrix for the purpose of chaining operations together. */
 	public Matrix4 mulLeft (Matrix4 matrix) {
-		tmpMat.set(matrix);
-		mul(tmpMat.val, this.val);
-		return set(tmpMat);
+		float tmpM00 = val[M00];
+		float tmpM10 = val[M10];
+		float tmpM20 = val[M20];
+		float tmpM30 = val[M30];
+		float tmpM01 = val[M01];
+		float tmpM11 = val[M11];
+		float tmpM21 = val[M21];
+		float tmpM31 = val[M31];
+		float tmpM02 = val[M02];
+		float tmpM12 = val[M12];
+		float tmpM22 = val[M22];
+		float tmpM32 = val[M32];
+		float tmpM03 = val[M03];
+		float tmpM13 = val[M13];
+		float tmpM23 = val[M23];
+		float tmpM33 = val[M33];
+		set(matrix);
+		mulLocal(tmpM00, tmpM10, tmpM20, tmpM30, tmpM01, tmpM11, tmpM21, tmpM31, tmpM02, tmpM12, tmpM22, tmpM32, tmpM03, tmpM13,
+			tmpM23, tmpM33);
+		return this;
 	}
 
 	/** Transposes the matrix.
@@ -684,9 +704,6 @@ public class Matrix4 implements Serializable {
 		return this;
 	}
 
-	static Quaternion quat = new Quaternion();
-	static Quaternion quat2 = new Quaternion();
-
 	/** Sets the matrix to a rotation matrix around the given axis.
 	 * 
 	 * @param axis The axis
@@ -799,10 +816,6 @@ public class Matrix4 implements Serializable {
 		return this;
 	}
 
-	static final Vector3 l_vez = new Vector3();
-	static final Vector3 l_vex = new Vector3();
-	static final Vector3 l_vey = new Vector3();
-
 	/** Sets the matrix to a look at matrix with a direction and an up vector. Multiply with a translation matrix to get a camera
 	 * model view matrix.
 	 * 
@@ -810,26 +823,37 @@ public class Matrix4 implements Serializable {
 	 * @param up The up vector
 	 * @return This matrix for the purpose of chaining methods together. */
 	public Matrix4 setToLookAt (Vector3 direction, Vector3 up) {
-		l_vez.set(direction).nor();
-		l_vex.set(direction).nor();
-		l_vex.crs(up).nor();
-		l_vey.set(l_vex).crs(l_vez).nor();
+		float invlen = 1.0f / direction.len();
+		float zx = direction.x * invlen;
+		float zy = direction.y * invlen;
+		float zz = direction.z * invlen;
+	
+		invlen = 1.0f / up.len();
+		float ux = up.x * invlen;
+		float uy = up.y * invlen;
+		float uz = up.z * invlen;
+		
+		float xx = zy * uz - zz * uy;
+		float xy = zz * ux - zx * uz;
+		float xz = zx * uy - zy * ux;
+
+		float yx = xy * zz - xz * zy;
+		float yy = xz * zx - xx * zz;
+		float yz = xx * zy - xy * zx;
+		
 		idt();
-		val[M00] = l_vex.x;
-		val[M01] = l_vex.y;
-		val[M02] = l_vex.z;
-		val[M10] = l_vey.x;
-		val[M11] = l_vey.y;
-		val[M12] = l_vey.z;
-		val[M20] = -l_vez.x;
-		val[M21] = -l_vez.y;
-		val[M22] = -l_vez.z;
+		val[M00] = xx;
+		val[M01] = xy;
+		val[M02] = xz;
+		val[M10] = yx;
+		val[M11] = yy;
+		val[M12] = yz;
+		val[M20] = -zx;
+		val[M21] = -zy;
+		val[M22] = -zz;
 
 		return this;
 	}
-
-	static final Vector3 tmpVec = new Vector3();
-	static final Matrix4 tmpMat = new Matrix4();
 
 	/** Sets this matrix to a look at matrix with the given position, target and up vector.
 	 * 
@@ -838,23 +862,40 @@ public class Matrix4 implements Serializable {
 	 * @param up the up vector
 	 * @return This matrix */
 	public Matrix4 setToLookAt (Vector3 position, Vector3 target, Vector3 up) {
-		tmpVec.set(target).sub(position);
-		setToLookAt(tmpVec, up);
-		this.mul(tmpMat.setToTranslation(-position.x, -position.y, -position.z));
+		float px = position.x;
+		float py = position.y;
+		float pz = position.z;
+
+		position.set(target).sub(px, py, pz);
+		setToLookAt(position, up);
+		translate(-px, -py, -pz);
+
+		position.set(px, py, pz);
 
 		return this;
 	}
 
-	static final Vector3 right = new Vector3();
-	static final Vector3 tmpForward = new Vector3();
-	static final Vector3 tmpUp = new Vector3();
-
 	public Matrix4 setToWorld (Vector3 position, Vector3 forward, Vector3 up) {
-		tmpForward.set(forward).nor();
-		right.set(tmpForward).crs(up).nor();
-		tmpUp.set(right).crs(tmpForward).nor();
+		float invlen = forward.len();
+		float fx = forward.x * invlen;
+		float fy = forward.y * invlen;
+		float fz = forward.z * invlen;
 
-		this.set(right, tmpUp, tmpForward.scl(-1), position);
+		invlen = 1.0f / up.len();
+		float ux = up.x * invlen;
+		float uy = up.y * invlen;
+		float uz = up.z * invlen;
+
+		float rx = fy * uz - fz * uy;
+		float ry = fz * ux - fx * uz;
+		float rz = fx * uy - fy * ux;
+
+		ux = ry * fz - rz * fy;
+		uy = rz * fx - rx * fz;
+		uz = rx * fy - ry * fx;
+
+		set(rx, ux, -fx, 0, ry, uy, -fy, 0, rz, uz, -fz, position.x, position.y, position.z, 1);
+
 		return this;
 	}
 
@@ -880,18 +921,28 @@ public class Matrix4 implements Serializable {
 	 * @param w Weight of this transform; weight of the other transform is (1 - w)
 	 * @return This matrix for chaining */
 	public Matrix4 avg (Matrix4 other, float w) {
-		getScale(tmpVec);
-		other.getScale(tmpForward);
+		float sx = getScaleX();
+		float sy = getScaleY();
+		float sz = getScaleZ();
+
+		float sx2 = other.getScaleX();
+		float sy2 = other.getScaleY();
+		float sz2 = other.getScaleZ();
 
 		getRotation(quat);
 		other.getRotation(quat2);
 
-		getTranslation(tmpUp);
-		other.getTranslation(right);
+		float tx = val[M03];
+		float ty = val[M13];
+		float tz = val[M23];
 
-		setToScaling(tmpVec.scl(w).add(tmpForward.scl(1 - w)));
+		float tx2 = other.val[M03];
+		float ty2 = other.val[M13];
+		float tz2 = other.val[M23];
+
+		setToScaling(sx * w + sx2 * (1 - w), sy * w + sy2 * (1 - w), sz * w + sz2 * (1 - w));
 		rotate(quat.slerp(quat2, 1 - w));
-		setTranslation(tmpUp.scl(w).add(right.scl(1 - w)));
+		setTranslation(tx * w + tx2 * (1 - w), ty * w + ty2 * (1 - w), tz * w + tz2 * (1 - w));
 
 		return this;
 	}
@@ -903,20 +954,33 @@ public class Matrix4 implements Serializable {
 	public Matrix4 avg (Matrix4[] t) {
 		final float w = 1.0f / t.length;
 
-		tmpVec.set(t[0].getScale(tmpUp).scl(w));
+		float sx = t[0].getScaleX() * w;
+		float sy = t[0].getScaleY() * w;
+		float sz = t[0].getScaleZ() * w;
+
 		quat.set(t[0].getRotation(quat2).exp(w));
-		tmpForward.set(t[0].getTranslation(tmpUp).scl(w));
+
+		float tx = t[0].val[M03] * w;
+		float ty = t[0].val[M13] * w;
+		float tz = t[0].val[M23] * w;
 
 		for (int i = 1; i < t.length; i++) {
-			tmpVec.add(t[i].getScale(tmpUp).scl(w));
+			sx += t[i].getScaleX() * w;
+			sy += t[i].getScaleY() * w;
+			sz += t[i].getScaleZ() * w;
+
 			quat.mul(t[i].getRotation(quat2).exp(w));
-			tmpForward.add(t[i].getTranslation(tmpUp).scl(w));
+
+			tx += t[i].val[M03] * w;
+			ty += t[i].val[M13] * w;
+			tz += t[i].val[M23] * w;
 		}
+
 		quat.nor();
 
-		setToScaling(tmpVec);
+		setToScaling(sx, sy, sz);
 		rotate(quat);
-		setTranslation(tmpForward);
+		setTranslation(tx, ty, tz);
 
 		return this;
 	}
@@ -928,20 +992,32 @@ public class Matrix4 implements Serializable {
 	 * @param w List of weights
 	 * @return This matrix for chaining */
 	public Matrix4 avg (Matrix4[] t, float[] w) {
-		tmpVec.set(t[0].getScale(tmpUp).scl(w[0]));
+		float sx = t[0].getScaleX() * w[0];
+		float sy = t[0].getScaleY() * w[0];
+		float sz = t[0].getScaleZ() * w[0];
+
 		quat.set(t[0].getRotation(quat2).exp(w[0]));
-		tmpForward.set(t[0].getTranslation(tmpUp).scl(w[0]));
+
+		float tx = t[0].val[M03] * w[0];
+		float ty = t[0].val[M13] * w[0];
+		float tz = t[0].val[M23] * w[0];
 
 		for (int i = 1; i < t.length; i++) {
-			tmpVec.add(t[i].getScale(tmpUp).scl(w[i]));
+			sx += t[i].getScaleX() * w[i];
+			sy += t[i].getScaleY() * w[i];
+			sz += t[i].getScaleZ() * w[i];
+
 			quat.mul(t[i].getRotation(quat2).exp(w[i]));
-			tmpForward.add(t[i].getTranslation(tmpUp).scl(w[i]));
+
+			tx += t[i].val[M03] * w[i];
+			ty += t[i].val[M13] * w[i];
+			tz += t[i].val[M23] * w[i];
 		}
 		quat.nor();
 
-		setToScaling(tmpVec);
+		setToScaling(sx, sy, sz);
 		rotate(quat);
-		setTranslation(tmpForward);
+		setTranslation(tx, ty, tz);
 
 		return this;
 	}

--- a/gdx/src/com/badlogic/gdx/math/Quaternion.java
+++ b/gdx/src/com/badlogic/gdx/math/Quaternion.java
@@ -27,8 +27,6 @@ import com.badlogic.gdx.utils.NumberUtils;
  * @author xoppa */
 public class Quaternion implements Serializable {
 	private static final long serialVersionUID = -7661875440774897168L;
-	private static Quaternion tmp1 = new Quaternion(0, 0, 0, 0);
-	private static Quaternion tmp2 = new Quaternion(0, 0, 0, 0);
 
 	public float x;
 	public float y;
@@ -233,13 +231,20 @@ public class Quaternion implements Serializable {
 	 * 
 	 * @param v Vector to transform */
 	public Vector3 transform (Vector3 v) {
-		tmp2.set(this);
-		tmp2.conjugate();
-		tmp2.mulLeft(tmp1.set(v.x, v.y, v.z, 0)).mulLeft(this);
+		float qx = this.x;
+		float qy = this.y;
+		float qz = this.z;
+		float qw = this.w;
 
-		v.x = tmp2.x;
-		v.y = tmp2.y;
-		v.z = tmp2.z;
+		conjugate();
+		mulLeft(v.x, v.y, v.z, 0).mulLeft(qx, qy, qz, qw);
+
+		v.x = x;
+		v.y = y;
+		v.z = z;
+
+		set(qx, qy, qz, qw);
+
 		return v;
 	}
 
@@ -616,12 +621,23 @@ public class Quaternion implements Serializable {
 	 * @param q List of quaternions
 	 * @return This quaternion for chaining */
 	public Quaternion slerp (Quaternion[] q) {
-		
-		//Calculate exponents and multiply everything from left to right
-		final float w = 1.0f/q.length;
+
+		// Calculate exponents and multiply everything from left to right
+		final float w = 1.0f / q.length;
+		float tx, ty, tz, tw, qx, qy, qz, qw;
 		set(q[0]).exp(w);
-		for(int i=1;i<q.length;i++)
-			mul(tmp1.set(q[i]).exp(w));
+		for (int i = 1; i < q.length; i++) {
+			tx = x;
+			ty = y;
+			tz = z;
+			tw = w;
+			set(q[i]).exp(tw);
+			qx = x;
+			qy = y;
+			qz = z;
+			qw = w;
+			set(tx, ty, tz, tw).mul(qx, qy, qz, qw);
+		}
 		nor();
 		return this;
 	}
@@ -635,11 +651,22 @@ public class Quaternion implements Serializable {
 	 * @param w List of weights
 	 * @return This quaternion for chaining */
 	public Quaternion slerp (Quaternion[] q, float[] w) {
-		
-		//Calculate exponents and multiply everything from left to right
+
+		// Calculate exponents and multiply everything from left to right
 		set(q[0]).exp(w[0]);
-		for(int i=1;i<q.length;i++)
-			mul(tmp1.set(q[i]).exp(w[i]));
+		float tx, ty, tz, tw, qx, qy, qz, qw;
+		for (int i = 1; i < q.length; i++) {
+			tx = x;
+			ty = y;
+			tz = z;
+			tw = this.w;
+			set(q[i]).exp(w[i]);
+			qx = x;
+			qy = y;
+			qz = z;
+			qw = this.w;
+			set(tx, ty, tz, tw).mul(qx, qy, qz, qw);
+		}
 		nor();
 		return this;
 	}


### PR DESCRIPTION
With this PR I want to revive an issue previously discussed in e.g. #846. It's one step towards thread safety in the math classes.

There are still some static temporaries left: Vector3.tmpMat and Matrix4.quat/quat2. The long-lived deprecated Matrix4.tmp could now be removed.

I've run a couple of tests to verify my changes, but as far as I've seen not all modified functions are covered by them. Also, I've only run the tests on desktop systems. That said, a code review and **some tests on Android/iOS** would be wise. ;) Also, feel free to try the changes with your project if you are heavily using Matrix4/Quaternion.