### PR TITLE
Fix TimSort runLength

### DIFF
--- a/gdx/src/com/badlogic/gdx/utils/TimSort.java
+++ b/gdx/src/com/badlogic/gdx/utils/TimSort.java
@@ -366,21 +366,25 @@ class TimSort<T> {
 
 	/** Examines the stack of runs waiting to be merged and merges adjacent runs until the stack invariants are reestablished:
 	 * 
-	 * 1. runLen[i - 3] > runLen[i - 2] + runLen[i - 1] 2. runLen[i - 2] > runLen[i - 1]
+	 * 1. runLen[n - 2] > runLen[n - 1] + runLen[n] 2. runLen[n - 1] > runLen[n]
+	 * 
+	 * where n is the index of the last run in runLen.
+	 * 
+	 * This method has been formally verified to be correct after checking the last 4 runs.
+	 * Checking for 3 runs results in an exception for large arrays.
+	 * (Source: http://envisage-project.eu/proving-android-java-and-python-sorting-algorithm-is-broken-and-how-to-fix-it/)
 	 * 
 	 * This method is called each time a new run is pushed onto the stack, so the invariants are guaranteed to hold for i <
 	 * stackSize upon entry to the method. */
 	private void mergeCollapse () {
 		while (stackSize > 1) {
 			int n = stackSize - 2;
-			if (n > 0 && runLen[n - 1] <= runLen[n] + runLen[n + 1]) {
+			if ((n >= 1 && runLen[n - 1] <= runLen[n] + runLen[n + 1]) || (n >= 2 && runLen[n - 2] <= runLen[n] + runLen[n - 1])) {
 				if (runLen[n - 1] < runLen[n + 1]) n--;
-				mergeAt(n);
-			} else if (runLen[n] <= runLen[n + 1]) {
-				mergeAt(n);
-			} else {
+			} else if (runLen[n] > runLen[n + 1]) {
 				break; // Invariant is established
 			}
+			mergeAt(n);
 		}
 	}
 


### PR DESCRIPTION
This pull request adds an additional check to search the invariant for the last 4 runs in the
runLength array to shore up an invariant that was not true for sufficiently large array sizes.

Refer to #2877 to get the gist of the reasoning behind the change. The source used to derive the implementation uses an Apache 2 licence for the test suite (see https://github.com/abstools/java-timsort-bug/blob/master/LICENSE), so, from what I can see, the proposed fix is also licensed in the same manner by the same party (due to the different places this invariant would need to be fixed to be universal, such as AOSP).