### PR TITLE
Lwjgl30 override EXTFramebufferObject usage

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@
 - API Change: Exposed method ControllerManager#clearListeners on Controllers class
 - API Change: Net#openURI now returns a boolean to indicate whether the uri was actually opened.
 - API Change: DefaultShader now always combines material and environment attributes
+- API Change: Added Texture constructor which takes an existing GL texture handle.
 
 [1.5.4]
 - Added support for image layers in Tiled maps (TiledMapImageLayer)

--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@
 - API Change: Net#openURI now returns a boolean to indicate whether the uri was actually opened.
 - API Change: DefaultShader now always combines material and environment attributes
 - API Change: Added Texture constructor which takes an existing GL texture handle.
+- API Change: Added ShapeRenderer constructor to pass a custom shader program to ImmediateModeRenderer20.
 
 [1.5.4]
 - Added support for image layers in Tiled maps (TiledMapImageLayer)

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGL30.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGL30.java
@@ -192,13 +192,104 @@ class LwjglGL30 extends LwjglGL20 implements com.badlogic.gdx.graphics.GL30 {
 	}
 
 	@Override
-	public void glBlitFramebuffer (int srcX0, int srcY0, int srcX1, int srcY1, int dstX0, int dstY0, int dstX1, int dstY1, int mask, int filter) {
+	public void glBlitFramebuffer (int srcX0, int srcY0, int srcX1, int srcY1, int dstX0, int dstY0, int dstX1, int dstY1,
+		int mask, int filter) {
 		GL30.glBlitFramebuffer(srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
+	}
+
+	@Override
+	public void glBindFramebuffer (int target, int framebuffer) {
+		GL30.glBindFramebuffer(target, framebuffer);
+	}
+
+	@Override
+	public void glBindRenderbuffer (int target, int renderbuffer) {
+		GL30.glBindRenderbuffer(target, renderbuffer);
+	}
+
+	@Override
+	public int glCheckFramebufferStatus (int target) {
+		return GL30.glCheckFramebufferStatus(target);
+	}
+
+	@Override
+	public void glDeleteFramebuffers (int n, IntBuffer framebuffers) {
+		GL30.glDeleteFramebuffers(framebuffers);
+	}
+
+	@Override
+	public void glDeleteFramebuffer (int framebuffer) {
+		GL30.glDeleteFramebuffers(framebuffer);
+	}
+
+	@Override
+	public void glDeleteRenderbuffers (int n, IntBuffer renderbuffers) {
+		GL30.glDeleteRenderbuffers(renderbuffers);
+	}
+
+	@Override
+	public void glDeleteRenderbuffer (int renderbuffer) {
+		GL30.glDeleteRenderbuffers(renderbuffer);
+	}
+
+	@Override
+	public void glGenerateMipmap (int target) {
+		GL30.glGenerateMipmap(target);
+	}
+
+	@Override
+	public void glGenFramebuffers (int n, IntBuffer framebuffers) {
+		GL30.glGenFramebuffers(framebuffers);
+	}
+
+	@Override
+	public int glGenFramebuffer () {
+		return GL30.glGenFramebuffers();
+	}
+
+	@Override
+	public void glGenRenderbuffers (int n, IntBuffer renderbuffers) {
+		GL30.glGenRenderbuffers(renderbuffers);
+	}
+
+	@Override
+	public int glGenRenderbuffer () {
+		return GL30.glGenRenderbuffers();
+	}
+
+	@Override
+	public void glGetRenderbufferParameteriv (int target, int pname, IntBuffer params) {
+		GL30.glGetRenderbufferParameter(target, pname, params);
+	}
+
+	@Override
+	public boolean glIsFramebuffer (int framebuffer) {
+		return GL30.glIsFramebuffer(framebuffer);
+	}
+
+	@Override
+	public boolean glIsRenderbuffer (int renderbuffer) {
+		return GL30.glIsRenderbuffer(renderbuffer);
+	}
+
+	@Override
+	public void glRenderbufferStorage (int target, int internalformat, int width, int height) {
+		GL30.glRenderbufferStorage(target, internalformat, width, height);
 	}
 
 	@Override
 	public void glRenderbufferStorageMultisample (int target, int samples, int internalformat, int width, int height) {
 		GL30.glRenderbufferStorageMultisample(target, samples, internalformat, width, height);
+	}
+
+	@Override
+	public void glFramebufferTexture2D (int target, int attachment, int textarget, int texture, int level) {
+		GL30.glFramebufferTexture2D(target, attachment, textarget, texture, level);
+	}
+
+	@Override
+	public void glFramebufferRenderbuffer (int target, int attachment, int renderbuffertarget, int renderbuffer) {
+		GL30.glFramebufferRenderbuffer(target, attachment, renderbuffertarget, renderbuffer);
 	}
 
 	@Override

--- a/gdx/src/com/badlogic/gdx/graphics/Texture.java
+++ b/gdx/src/com/badlogic/gdx/graphics/Texture.java
@@ -124,6 +124,14 @@ public class Texture extends GLTexture {
 		load(data);
 		if (data.isManaged()) addManagedTexture(Gdx.app, this);
 	}
+
+	public Texture (TextureData data, int glHandle) {
+		super(GL20.GL_TEXTURE_2D, glHandle);
+		load(data);
+		if (data.isManaged()) {
+			addManagedTexture(Gdx.app, this);
+		}
+	}
 	
 	public void load (TextureData data) {
 		if (this.data != null && data.isManaged() != this.data.isManaged())

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/ShapeRenderer.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/ShapeRenderer.java
@@ -108,7 +108,15 @@ public class ShapeRenderer implements Disposable {
 	}
 
 	public ShapeRenderer (int maxVertices) {
-		renderer = new ImmediateModeRenderer20(maxVertices, false, true, 0);
+		this(maxVertices, null);
+	}
+
+	public ShapeRenderer (int maxVertices, ShaderProgram defaultShader) {
+		if (defaultShader == null) {
+			renderer = new ImmediateModeRenderer20(maxVertices, false, true, 0);
+		} else {
+			renderer = new ImmediateModeRenderer20(maxVertices, false, true, 0, defaultShader);
+		}
 		projectionMatrix.setToOrtho2D(0, 0, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
 		matrixDirty = true;
 	}


### PR DESCRIPTION
I'm doing some experiments with multi-target rendering (G-Buffers), for now using the gl32core branch by @nelsonsilva. I'm doing a separate PR because the changes are independent of this pending work.

- Overrides all uses of EXTFramebufferObject with the GL3 core functions.
- The second, small change is a new Texture() constructor which takes an existing GL handle. I'm using this to easily pass G-Buffer textures to Batch.draw() for debugging.