### PR TITLE
ShapeRenderer: allow use of custom shader

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@
 - API Change: Exposed method ControllerManager#clearListeners on Controllers class
 - API Change: Net#openURI now returns a boolean to indicate whether the uri was actually opened.
 - API Change: DefaultShader now always combines material and environment attributes
+- API Change: Added ShapeRenderer constructor to pass a custom shader program to ImmediateModeRenderer20.
 
 [1.5.4]
 - Added support for image layers in Tiled maps (TiledMapImageLayer)

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/ShapeRenderer.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/ShapeRenderer.java
@@ -108,7 +108,15 @@ public class ShapeRenderer implements Disposable {
 	}
 
 	public ShapeRenderer (int maxVertices) {
-		renderer = new ImmediateModeRenderer20(maxVertices, false, true, 0);
+		this(maxVertices, null);
+	}
+
+	public ShapeRenderer (int maxVertices, ShaderProgram defaultShader) {
+		if (defaultShader == null) {
+			renderer = new ImmediateModeRenderer20(maxVertices, false, true, 0);
+		} else {
+			renderer = new ImmediateModeRenderer20(maxVertices, false, true, 0, defaultShader);
+		}
 		projectionMatrix.setToOrtho2D(0, 0, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
 		matrixDirty = true;
 	}


### PR DESCRIPTION
Already implemented by ImmediateModeRenderer20, just not exposed through the ShapeRenderer API.