### PR TITLE
Fix conditional packing  for issue #2883

### DIFF
--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/texturepacker/TexturePacker.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/texturepacker/TexturePacker.java
@@ -625,24 +625,44 @@ public class TexturePacker {
 
 	/** @return true if the output file does not yet exist or its last modification date is before the last modification date of the
 	 *         input file */
-	static public boolean isModified (String input, String output, String packFileName) {
+	static public boolean isModified (String input, String output, String packFileName, Settings settings) {
 		String packFullFileName = output;
-		if (!packFullFileName.endsWith("/")) packFullFileName += "/";
+
+        if (!packFullFileName.endsWith("/")) {
+            packFullFileName += "/";
+        }
+
+        // Check against the only file we know for sure will exist and will be changed if any asset changes:
+        // the atlas file
 		packFullFileName += packFileName;
+        packFullFileName += settings.atlasExtension;
 		File outputFile = new File(packFullFileName);
-		if (!outputFile.exists()) return true;
+
+		if (!outputFile.exists()) {
+            return true;
+        }
 
 		File inputFile = new File(input);
-		if (!inputFile.exists()) throw new IllegalArgumentException("Input file does not exist: " + inputFile.getAbsolutePath());
+		if (!inputFile.exists()) {
+            throw new IllegalArgumentException("Input file does not exist: " + inputFile.getAbsolutePath());
+        }
+
 		return inputFile.lastModified() > outputFile.lastModified();
 	}
 
 	static public void processIfModified (String input, String output, String packFileName) {
-		if (isModified(input, output, packFileName)) process(input, output, packFileName);
+        // Default settings (Needed to access the default atlas extension string)
+        Settings settings = new Settings();
+
+		if (isModified(input, output, packFileName, settings)) {
+            process(input, output, packFileName);
+        }
 	}
 
 	static public void processIfModified (Settings settings, String input, String output, String packFileName) {
-		if (isModified(input, output, packFileName)) process(settings, input, output, packFileName);
+		if (isModified(input, output, packFileName, settings)) {
+            process(settings, input, output, packFileName);
+        }
 	}
 
 	static public interface Packer {

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/texturepacker/TexturePacker.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/texturepacker/TexturePacker.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -628,41 +628,41 @@ public class TexturePacker {
 	static public boolean isModified (String input, String output, String packFileName, Settings settings) {
 		String packFullFileName = output;
 
-        if (!packFullFileName.endsWith("/")) {
-            packFullFileName += "/";
-        }
+		if (!packFullFileName.endsWith("/")) {
+			packFullFileName += "/";
+		}
 
-        // Check against the only file we know for sure will exist and will be changed if any asset changes:
-        // the atlas file
+		// Check against the only file we know for sure will exist and will be changed if any asset changes:
+		// the atlas file
 		packFullFileName += packFileName;
-        packFullFileName += settings.atlasExtension;
+		packFullFileName += settings.atlasExtension;
 		File outputFile = new File(packFullFileName);
 
 		if (!outputFile.exists()) {
-            return true;
-        }
+			return true;
+		}
 
 		File inputFile = new File(input);
 		if (!inputFile.exists()) {
-            throw new IllegalArgumentException("Input file does not exist: " + inputFile.getAbsolutePath());
-        }
+			throw new IllegalArgumentException("Input file does not exist: " + inputFile.getAbsolutePath());
+		}
 
 		return inputFile.lastModified() > outputFile.lastModified();
 	}
 
 	static public void processIfModified (String input, String output, String packFileName) {
-        // Default settings (Needed to access the default atlas extension string)
-        Settings settings = new Settings();
+		// Default settings (Needed to access the default atlas extension string)
+		Settings settings = new Settings();
 
 		if (isModified(input, output, packFileName, settings)) {
-            process(input, output, packFileName);
-        }
+			process(input, output, packFileName);
+		}
 	}
 
 	static public void processIfModified (Settings settings, String input, String output, String packFileName) {
 		if (isModified(input, output, packFileName, settings)) {
-            process(settings, input, output, packFileName);
-        }
+			 process(settings, input, output, packFileName);
+		}
 	}
 
 	static public interface Packer {

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/texturepacker/TexturePacker.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/texturepacker/TexturePacker.java
@@ -655,7 +655,7 @@ public class TexturePacker {
 		Settings settings = new Settings();
 
 		if (isModified(input, output, packFileName, settings)) {
-			process(input, output, packFileName);
+			process(settings, input, output, packFileName);
 		}
 	}
 


### PR DESCRIPTION
Augmented the **TexturePacker.isModified** method with the inclusion of a **TexturePacker.Settings** instance reference, which allows to retrieve the currently configured extension string for the atlas files.

Changed both overloads of the method **TexturePacker.processIfModified** to reflect that change (defaulting to the standard settings if none are passed by the user).

With this change the input string (raw assets folder to pack) will be checked against the generated atlas file that the packer produces. If a change is detected between the **last modified date** of the raw assets folder and the current (if existing) atlas file, the packing process should be triggered.