### PR TITLE
more functionalities (restart, setFrame, ..)

### DIFF
--- a/gdx/src/com/badlogic/gdx/maps/tiled/tiles/AnimatedTiledMapTile.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/tiles/AnimatedTiledMapTile.java
@@ -28,7 +28,7 @@ import com.badlogic.gdx.utils.TimeUtils;
 /** @brief Represents a changing {@link TiledMapTile}. */
 public class AnimatedTiledMapTile implements TiledMapTile {
 
-	private long lastTiledMapRenderTime = 0;
+	private static long lastTiledMapRenderTime = 0;
 	private long timeOffset = 0;
 	private int id;
 

--- a/gdx/src/com/badlogic/gdx/maps/tiled/tiles/AnimatedTiledMapTile.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/tiles/AnimatedTiledMapTile.java
@@ -83,6 +83,11 @@ public class AnimatedTiledMapTile implements TiledMapTile {
 	public TextureRegion getTextureRegion () {
 		return getCurrentFrame().getTextureRegion();
 	}
+	
+	public TextureRegion getTextureRegionFromIndex (int i) {
+		if(i <= frameTiles.length) return frameTiles[i];
+		else throw new GdxRuntimeException("Index out of Bounds: " + i + "/ " + frameTiles.length);
+	}
 
 	@Override
 	public void setTextureRegion(TextureRegion textureRegion) {

--- a/gdx/src/com/badlogic/gdx/maps/tiled/tiles/AnimatedTiledMapTile.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/tiles/AnimatedTiledMapTile.java
@@ -74,7 +74,34 @@ public class AnimatedTiledMapTile implements TiledMapTile {
 
 		throw new GdxRuntimeException("Could not determine current animation frame in AnimatedTiledMapTile.  This should never happen.");
 	}
+	
+		public void restartAnimation(){
+		int currentTime = (int)(lastTiledMapRenderTime % loopDuration);
+		lastTiledMapRenderTime -= currentTime;
+	}
 
+	public void setFrameIndex(int f){
+		
+		if(f > animationIntervals.length){
+			throw new GdxRuntimeException("Index out of Bounds: " + f + "/ " + frameTiles.length)
+			return;	
+		}
+
+		else if(f<0){
+			throw new GdxRuntimeException("Index out of Bounds: " + f + "/ " + frameTiles.length + ". Cannot set to a frame index which is less than 0");
+			return;	
+		} 
+		
+		restartAnimation();
+		if(f > 0){
+			int timestep = 0;
+			for (int i = 0 ; i < f ; i++) {
+				timestep += animationIntervals[i-1]
+			}
+			lastTiledMapRenderTime -= timestep;
+		}
+	}
+	
 	public TiledMapTile getCurrentFrame() {
 		return frameTiles[getCurrentFrameIndex()];
 	}
@@ -84,7 +111,7 @@ public class AnimatedTiledMapTile implements TiledMapTile {
 		return getCurrentFrame().getTextureRegion();
 	}
 	
-	public TextureRegion getTextureRegionFromIndex (int i) {
+	public TextureRegion getTextureRegionAtIndex (int i) {
 		if(i <= frameTiles.length) return frameTiles[i];
 		else throw new GdxRuntimeException("Index out of Bounds: " + i + "/ " + frameTiles.length);
 	}

--- a/gdx/src/com/badlogic/gdx/maps/tiled/tiles/AnimatedTiledMapTile.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/tiles/AnimatedTiledMapTile.java
@@ -29,7 +29,7 @@ import com.badlogic.gdx.utils.TimeUtils;
 public class AnimatedTiledMapTile implements TiledMapTile {
 
 	private long lastTiledMapRenderTime = 0;
-
+	private long timeOffset = 0;
 	private int id;
 
 	private BlendMode blendMode = BlendMode.ALPHA;
@@ -75,9 +75,9 @@ public class AnimatedTiledMapTile implements TiledMapTile {
 		throw new GdxRuntimeException("Could not determine current animation frame in AnimatedTiledMapTile.  This should never happen.");
 	}
 	
-	public void restartAnimation(){
-		int currentTime = (int)(lastTiledMapRenderTime % loopDuration);
-		lastTiledMapRenderTime -= currentTime;
+		public void restartAnimation(){
+		currentTime = lastTiledMapRenderTime % loopDuration;
+		timeOffset -= currentTime;
 	}
 
 	public void setFrame(int f){
@@ -94,13 +94,12 @@ public class AnimatedTiledMapTile implements TiledMapTile {
 		
 		restartAnimation();
 		if(f > 0){
-			int timestep = 0;
 			for (int i = 0 ; i < f ; i++) {
-				timestep += animationIntervals[i-1]
+				timeOffset += animationIntervals[i-1]
 			}
-			lastTiledMapRenderTime -= timestep;
 		}
 	}
+	
 	
 	public TiledMapTile getCurrentFrame() {
 		return frameTiles[getCurrentFrameIndex()];
@@ -164,7 +163,7 @@ public class AnimatedTiledMapTile implements TiledMapTile {
 	/** Function is called by BatchTiledMapRenderer render(), lastTiledMapRenderTime is used to keep all of the tiles in lock-step
 	 * animation and avoids having to call TimeUtils.millis() in getTextureRegion() */
 	public static void updateAnimationBaseTime () {
-		lastTiledMapRenderTime = TimeUtils.millis() - initialTimeOffset;
+		lastTiledMapRenderTime = TimeUtils.millis() - initialTimeOffset + timeOffset;
 	}
 
 	/** Creates an animated tile with the given animation interval and frame tiles.

--- a/gdx/src/com/badlogic/gdx/maps/tiled/tiles/AnimatedTiledMapTile.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/tiles/AnimatedTiledMapTile.java
@@ -80,7 +80,7 @@ public class AnimatedTiledMapTile implements TiledMapTile {
 		lastTiledMapRenderTime -= currentTime;
 	}
 
-	public void setFrameIndex(int f){
+	public void setFrame(int f){
 		
 		if(f > animationIntervals.length){
 			throw new GdxRuntimeException("Index out of Bounds: " + f + "/ " + frameTiles.length)

--- a/gdx/src/com/badlogic/gdx/maps/tiled/tiles/AnimatedTiledMapTile.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/tiles/AnimatedTiledMapTile.java
@@ -28,7 +28,7 @@ import com.badlogic.gdx.utils.TimeUtils;
 /** @brief Represents a changing {@link TiledMapTile}. */
 public class AnimatedTiledMapTile implements TiledMapTile {
 
-	private static long lastTiledMapRenderTime = 0;
+	private long lastTiledMapRenderTime = 0;
 
 	private int id;
 
@@ -75,7 +75,7 @@ public class AnimatedTiledMapTile implements TiledMapTile {
 		throw new GdxRuntimeException("Could not determine current animation frame in AnimatedTiledMapTile.  This should never happen.");
 	}
 	
-		public void restartAnimation(){
+	public void restartAnimation(){
 		int currentTime = (int)(lastTiledMapRenderTime % loopDuration);
 		lastTiledMapRenderTime -= currentTime;
 	}
@@ -112,7 +112,7 @@ public class AnimatedTiledMapTile implements TiledMapTile {
 	}
 	
 	public TextureRegion getTextureRegionAtIndex (int i) {
-		if(i <= frameTiles.length) return frameTiles[i];
+		if(i <= frameTiles.length && i > 0) return frameTiles[i];
 		else throw new GdxRuntimeException("Index out of Bounds: " + i + "/ " + frameTiles.length);
 	}
 

--- a/gdx/src/com/badlogic/gdx/maps/tiled/tiles/AnimatedTiledMapTile.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/tiles/AnimatedTiledMapTile.java
@@ -75,7 +75,7 @@ public class AnimatedTiledMapTile implements TiledMapTile {
 		throw new GdxRuntimeException("Could not determine current animation frame in AnimatedTiledMapTile.  This should never happen.");
 	}
 	
-		public void restartAnimation(){
+	public void restartAnimation(){
 		currentTime = lastTiledMapRenderTime % loopDuration;
 		timeOffset -= currentTime;
 	}


### PR DESCRIPTION
- added getTextureRegionAtIndex(int i)
- added restartAnimation()
- added setFrame(int f)

To keep the lightweight method for rendering/updating the AnimatedMapTiles, I use a timeOffset to move inside the different animation frames. I would highly appreciate any kind of criticism on this, through I don't think this is the best method, but can't find a different, better one. 