### PR TITLE
Added FilehandleResolver for classpaths

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,7 @@
 - Added ShapeRenderer constructor to pass a custom shader program to ImmediateModeRenderer20.
 - API Change: Group#toString now returns actor hierarchy. Group#print is gone.
 - Added SpotLight class, see https://github.com/libgdx/libgdx/pull/2907
+- Added support for resolving file handles using classpaths (ClasspathFileHandleResolver)
 
 [1.5.4]
 - Added support for image layers in Tiled maps (TiledMapImageLayer)

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -172,3 +172,4 @@ CodePoKE https://github.com/codepoke
 Konijnendijk https://github.com/Konijnendijk
 nooone https://github.com/nooone
 kotcrab https://github.com/kotcrab
+ClaudiuBele https://github.com/ClaudiuBele

--- a/gdx/src/com/badlogic/gdx/assets/loaders/resolvers/ClasspathFileHandleResolver
+++ b/gdx/src/com/badlogic/gdx/assets/loaders/resolvers/ClasspathFileHandleResolver
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright 2015 See AUTHORS file.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogic.gdx.assets.loaders.resolvers;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.assets.loaders.FileHandleResolver;
+import com.badlogic.gdx.files.FileHandle;
+
+public class ClasspathFileHandleResolver implements FileHandleResolver {
+	@Override
+	public FileHandle resolve (String fileName) {
+		return Gdx.files.classpath(fileName);
+	}
+}


### PR DESCRIPTION
Case: The resolver will be useful for libraries that use Libgdx as a backend and have default assets packed in the library in case a desired asset can't be found to draw/play/etc. 

The InternalFileHandleResolver does not suffice, as it prioritizes looking in the internal storage first. From the documentation: "If a file can't be found on the internal storage, the file module falls back to searching the file on the classpath". In my case ClasspathFileHandleResolver will be used because we do not want to potentially use assets with the same name that the user has placed in the assets folder. 

Example: Have a "Missing texture" texture drawn when developer using my library want to draw a texture from a filehandle that does not exist. The "Missing texture" could in this case be located at MissingTexture.png in the classpath. If the developer using the library already has a MissingTexture.png file in internal storage, that one would be used instead if we resolve the file using InternalFileHandleResolver. We don't want the developer using my library have to know by heart file names that have to be avoided.