### PR TITLE
Added HttpRequestBuilder to gdx.gwt.xml

### DIFF
--- a/gdx/src/com/badlogic/gdx.gwt.xml
+++ b/gdx/src/com/badlogic/gdx.gwt.xml
@@ -335,6 +335,7 @@
 		<include name="net/ServerSocketHints.java"/>
 		<include name="net/Socket.java"/>
 		<include name="net/SocketHints.java"/>
+		<include name="net/HttpRequestBuilder.java"/>
 	
 	<!-- physics/box2d -->
 	<!-- Box2d is fully emulated in GWT backend -->


### PR DESCRIPTION
> [ERROR] Line 19: No source code is available for type com.badlogic.gdx.net.HttpRequestBuilder; did you forget to inherit a required module?

That's what I get when I try to run my game via GWT. This should fix that problem.