### PR TITLE
gdx-setup: GWT inheritance support for 3rd party extensions

### DIFF
--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/Dependency.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/Dependency.java
@@ -10,10 +10,12 @@ import java.util.List;
 public class Dependency {
 
 	private HashMap<ProjectType, String[]> subDependencyMap = new HashMap<ProjectType, String[]>();
+	private String[] gwtInherits;
 	private String name;
 
-	public Dependency (String name, String[]... subDependencies) {
+	public Dependency (String name, String[] gwtInherits, String[]... subDependencies) {
 		this.name = name;
+		this.gwtInherits = gwtInherits;
 		for (ProjectType type : ProjectType.values()) {
 			subDependencyMap.put(type, subDependencies[type.ordinal()]);
 		}
@@ -32,6 +34,10 @@ public class Dependency {
 		return incompat;
 	}
 
+	public String[] getGwtInherits () {
+		return gwtInherits;
+	}
+	
 	public String getName () {
 		return name;
 	}

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/DependencyBank.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/DependencyBank.java
@@ -2,7 +2,6 @@ package com.badlogic.gdx.setup;
 
 
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 
 public class DependencyBank {
 
@@ -32,11 +31,11 @@ public class DependencyBank {
 	static String aiVersion = "1.5.0";
 
 	HashMap<ProjectDependency, Dependency> gdxDependencies = new HashMap<ProjectDependency, Dependency>();
-	LinkedHashMap<ProjectDependency, String[]> gwtInheritances = new LinkedHashMap<ProjectDependency, String[]>();
 
 	public DependencyBank() {
 		for (ProjectDependency projectDep : ProjectDependency.values()) {
 			Dependency dependency = new Dependency(projectDep.name(),
+					projectDep.getGwtInehrits(),
 					projectDep.getDependencies(ProjectType.CORE),
 					projectDep.getDependencies(ProjectType.DESKTOP),
 					projectDep.getDependencies(ProjectType.ANDROID),
@@ -44,18 +43,11 @@ public class DependencyBank {
 					projectDep.getDependencies(ProjectType.HTML));
 			gdxDependencies.put(projectDep, dependency);
 		}
-		gwtInheritances.put(ProjectDependency.GDX, new String[]{"com.badlogic.gdx.backends.gdx_backends_gwt"});
-		gwtInheritances.put(ProjectDependency.CONTROLLERS, new String[]{"com.badlogic.gdx.controllers.controllers-gwt"});
-		gwtInheritances.put(ProjectDependency.BOX2D, new String[]{"com.badlogic.gdx.physics.box2d.box2d-gwt"});
-		gwtInheritances.put(ProjectDependency.BOX2DLIGHTS, new String[]{"Box2DLights"});
-		gwtInheritances.put(ProjectDependency.ASHLEY, new String[]{"com.badlogic.ashley_gwt"});
-		gwtInheritances.put(ProjectDependency.AI, new String[]{"com.badlogic.gdx.ai"});
 	}
 
 	public Dependency getDependency(ProjectDependency gdx) {
 		return gdxDependencies.get(gdx);
 	}
-
 
 	/**
 	 * This enum will hold all dependencies available for libgdx, allowing the setup to pick the ones needed by default,
@@ -74,6 +66,7 @@ public class DependencyBank {
 			new String[]{"com.badlogicgames.gdx:gdx-backend-android:$gdxVersion", "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-armeabi", "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-armeabi-v7a", "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-x86"},
 			new String[]{"org.robovm:robovm-rt:${roboVMVersion}", "org.robovm:robovm-cocoatouch:${roboVMVersion}", "com.badlogicgames.gdx:gdx-backend-robovm:$gdxVersion", "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-ios"},
 			new String[]{"com.badlogicgames.gdx:gdx-backend-gwt:$gdxVersion", "com.badlogicgames.gdx:gdx:$gdxVersion:sources", "com.badlogicgames.gdx:gdx-backend-gwt:$gdxVersion:sources"},
+			new String[]{"com.badlogic.gdx.backends.gdx_backends_gwt"},
 			
 			"Core Library for LibGDX"
 		),
@@ -82,6 +75,7 @@ public class DependencyBank {
 			new String[]{"com.badlogicgames.gdx:gdx-bullet-platform:$gdxVersion:natives-desktop"},
 			new String[]{"com.badlogicgames.gdx:gdx-bullet:$gdxVersion", "com.badlogicgames.gdx:gdx-bullet-platform:$gdxVersion:natives-armeabi", "com.badlogicgames.gdx:gdx-bullet-platform:$gdxVersion:natives-armeabi-v7a", "com.badlogicgames.gdx:gdx-bullet-platform:$gdxVersion:natives-x86"},
 			new String[]{"com.badlogicgames.gdx:gdx-bullet-platform:$gdxVersion:natives-ios"},
+			null,
 			null,
 			
 			"3D Collision Detection and Rigid Body Dynamics"
@@ -92,12 +86,14 @@ public class DependencyBank {
 			new String[]{"com.badlogicgames.gdx:gdx-freetype:$gdxVersion", "com.badlogicgames.gdx:gdx-freetype-platform:$gdxVersion:natives-armeabi", "com.badlogicgames.gdx:gdx-freetype-platform:$gdxVersion:natives-armeabi-v7a", "com.badlogicgames.gdx:gdx-freetype-platform:$gdxVersion:natives-x86"},
 			new String[]{"com.badlogicgames.gdx:gdx-freetype-platform:$gdxVersion:natives-ios"},
 			null,
+			null,
 			
 			"Generate BitmapFonts from .ttf font files"
 		),
 		TOOLS(
 			new String[]{},
 			new String[]{"com.badlogicgames.gdx:gdx-tools:$gdxVersion"},
+			new String[]{},
 			new String[]{},
 			new String[]{},
 			new String[]{},
@@ -108,9 +104,10 @@ public class DependencyBank {
 			new String[]{"com.badlogicgames.gdx:gdx-controllers:$gdxVersion"},
 			new String[]{"com.badlogicgames.gdx:gdx-controllers-desktop:$gdxVersion", "com.badlogicgames.gdx:gdx-controllers-platform:$gdxVersion:natives-desktop"},
 			new String[]{"com.badlogicgames.gdx:gdx-controllers:$gdxVersion", "com.badlogicgames.gdx:gdx-controllers-android:$gdxVersion"},
-			new String[] {}, // works on iOS but never reports any controllers :)
+			new String[]{}, // works on iOS but never reports any controllers :)
 			new String[]{"com.badlogicgames.gdx:gdx-controllers:$gdxVersion:sources", "com.badlogicgames.gdx:gdx-controllers-gwt:$gdxVersion", "com.badlogicgames.gdx:gdx-controllers-gwt:$gdxVersion:sources"},
-			
+			new String[]{"com.badlogic.gdx.controllers.controllers-gwt"},
+
 			"Controller/Gamepad API"
 		),
 		BOX2D(
@@ -119,6 +116,7 @@ public class DependencyBank {
 			new String[]{"com.badlogicgames.gdx:gdx-box2d:$gdxVersion", "com.badlogicgames.gdx:gdx-box2d-platform:$gdxVersion:natives-armeabi", "com.badlogicgames.gdx:gdx-box2d-platform:$gdxVersion:natives-armeabi-v7a", "com.badlogicgames.gdx:gdx-box2d-platform:$gdxVersion:natives-x86"},
 			new String[]{"com.badlogicgames.gdx:gdx-box2d-platform:$gdxVersion:natives-ios"},
 			new String[]{"com.badlogicgames.gdx:gdx-box2d:$gdxVersion:sources", "com.badlogicgames.gdx:gdx-box2d-gwt:$gdxVersion:sources"},
+			new String[]{"com.badlogic.gdx.physics.box2d.box2d-gwt"},
 			
 			"2D Physics Library"
 		),	
@@ -128,6 +126,7 @@ public class DependencyBank {
 			new String[]{"com.badlogicgames.box2dlights:box2dlights:$box2DLightsVersion"},
 			new String[]{},
 			new String[]{"com.badlogicgames.box2dlights:box2dlights:$box2DLightsVersion:sources"},
+			new String[]{"Box2DLights"},
 			
 			"2D Lighting framework that utilises Box2D"
 		),
@@ -137,6 +136,7 @@ public class DependencyBank {
 			new String[]{"com.badlogicgames.ashley:ashley:$ashleyVersion"},
 			new String[]{},
 			new String[]{"com.badlogicgames.ashley:ashley:$ashleyVersion:sources"},
+			new String[]{"com.badlogic.ashley_gwt"},
 			
 			"Lightweight Entity framework"
 		),
@@ -146,6 +146,7 @@ public class DependencyBank {
 			new String[]{"com.badlogicgames.gdx:gdx-ai:$aiVersion"},
 			new String[]{},
 			new String[]{"com.badlogicgames.gdx:gdx-ai:$aiVersion:sources"},
+			new String[]{"com.badlogic.gdx.ai"},
 			
 			"Artificial Intelligence framework"
 		);
@@ -155,14 +156,16 @@ public class DependencyBank {
 		private String[] androidDependencies;
 		private String[] iosDependencies;
 		private String[] gwtDependencies;
+		private String[] gwtInherits;
 		private String description;
 
-		ProjectDependency(String[] coreDeps, String[] desktopDeps, String[] androidDeps, String[] iosDeps, String[] gwtDeps, String description) {
+		ProjectDependency(String[] coreDeps, String[] desktopDeps, String[] androidDeps, String[] iosDeps, String[] gwtDeps, String[] gwtInhertis, String description) {
 			this.coreDependencies = coreDeps;
 			this.desktopDependencies = desktopDeps;
 			this.androidDependencies = androidDeps;
 			this.iosDependencies = iosDeps;
 			this.gwtDependencies = gwtDeps;
+			this.gwtInherits = gwtInhertis;
 			this.description = description;
 		}
 
@@ -180,6 +183,10 @@ public class DependencyBank {
 					return gwtDependencies;
 			}
 			return null;
+		}
+		
+		public String[] getGwtInehrits() {
+			return gwtInherits;
 		}
 		
 		public String getDescription() {

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/ExternalExtension.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/ExternalExtension.java
@@ -22,23 +22,25 @@ import java.util.Map;
 public class ExternalExtension {
 
 	private String name;
+	private String[] gwtInherits;
 	private String description;
 	private String version;
 
 	private Map<String, List<String>> dependencies;
 
-	public ExternalExtension (String name, String description, String version) {
+	public ExternalExtension (String name, String[] gwtInherits, String description, String version) {
 		this.name = name;
+		this.gwtInherits = gwtInherits;
 		this.description = description;
 		this.version = version;
 	}
-
+	
 	public void setDependencies (Map<String, List<String>> dependencies) {
 		this.dependencies = dependencies;
 	}
 
 	public Dependency generateDependency () {
-		Dependency dep = new Dependency(name, getPlatformDependencies("core"), getPlatformDependencies("desktop"),
+		Dependency dep = new Dependency(name, gwtInherits, getPlatformDependencies("core"), getPlatformDependencies("desktop"),
 			getPlatformDependencies("android"), getPlatformDependencies("ios"), getPlatformDependencies("html"));
 
 		return dep;

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetup.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetup.java
@@ -332,7 +332,7 @@ public class GdxSetup {
 		values.put("%API_LEVEL%", DependencyBank.androidAPILevel);
 		values.put("%GWT_VERSION%", DependencyBank.gwtVersion);
 		if (builder.modules.contains(ProjectType.HTML)) {
-			values.put("%GWT_INHERITS%", parseGwtInherits(builder.bank.gwtInheritances, builder));
+			values.put("%GWT_INHERITS%", parseGwtInherits(builder));
 		}
 
 		copyAndReplace(outputDir, project, values);
@@ -499,15 +499,17 @@ public class GdxSetup {
 		return params;
 	}
 
-	private String parseGwtInherits (HashMap<ProjectDependency, String[]> gwtInheritances, ProjectBuilder builder) {
+	private String parseGwtInherits (ProjectBuilder builder) {
 		String parsed = "";
-		for (ProjectDependency dep : gwtInheritances.keySet()) {
-			if (containsDependency(builder.dependencies, dep)) {
-				for (String inherit : gwtInheritances.get(dep)) {
+		
+		for (Dependency dep : builder.dependencies) {
+			if (dep.getGwtInherits() != null) {
+				for (String inherit : dep.getGwtInherits()) {
 					parsed += "\t<inherits name='" + inherit + "' />\n";
 				}
 			}
 		}
+		
 		return parsed;
 	}
 

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetupUI.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetupUI.java
@@ -29,7 +29,6 @@ import java.awt.Desktop;
 import java.awt.Dimension;
 import java.awt.EventQueue;
 import java.awt.FileDialog;
-import java.awt.FlowLayout;
 import java.awt.Graphics;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
@@ -88,7 +87,6 @@ public class GdxSetupUI extends JFrame {
 	ProjectBuilder builder;
 	List<ProjectType> modules = new ArrayList<ProjectType>();
 	List<Dependency> dependencies = new ArrayList<Dependency>();
-	List<ExternalExtension> externalExtensions = new ArrayList<ExternalExtension>();
 
 	UI ui = new UI();
 	static Point point = new Point();

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/SettingsDialog.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/SettingsDialog.java
@@ -42,7 +42,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.swing.BorderFactory;
-import javax.swing.JCheckBox;
 import javax.swing.JDialog;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/data/extensions.xml
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/data/extensions.xml
@@ -1,20 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <extensions>
-    <extension>
-       <name>Overlap2D</name>
-       <description>Level and UI Editor Runtime</description>
-       <package>com.underwaterapps.overlap2druntime</package>
-       <version>0.0.8</version>
-       <compatibility>1.5.3</compatibility>
-       <website>http://overlap2d.com/</website>
-       <projects>
-           <core>
-               <dependency>com.underwaterapps.overlap2druntime:overlap2d-runtime-libgdx</dependency>
-           </core>
-           <desktop></desktop>
-           <android></android>
-           <ios></ios>
-           <html>null</html>
-       </projects>
-    </extension>
+	<extension>
+		<name>Overlap2D</name>
+		<description>Level and UI Editor Runtime</description>
+		<package>com.underwaterapps.overlap2druntime</package>
+		<version>0.0.8</version>
+		<compatibility>1.5.3</compatibility>
+		<website>http://overlap2d.com/</website>
+		<gwtInherits></gwtInherits>
+		<projects>
+			<core>
+				<dependency>com.underwaterapps.overlap2druntime:overlap2d-runtime-libgdx</dependency>
+			</core>
+			<desktop></desktop>
+			<android></android>
+			<ios></ios>
+			<html>null</html>
+		</projects>
+	</extension>
+	<extension>
+		<name>VisUI</name>
+		<description>Flat design skin for scene2d.ui and UI toolkit</description>
+		<package>com.kotcrab.vis.ui</package>
+		<version>0.6.1</version>
+		<compatibility>1.5.4</compatibility>
+		<website>https://github.com/kotcrab/VisEditor/wiki/VisUI</website>
+		<gwtInherits>
+		    <inherit>com.kotcrab.vis.vis-ui</inherit>
+		</gwtInherits>
+		<projects>
+			<core>
+				<dependency>com.kotcrab.vis:vis-ui</dependency>
+			</core>
+			<desktop></desktop>
+			<android></android>
+			<ios></ios>
+			<html>
+				<dependency>com.kotcrab.vis:vis-ui:sources</dependency>
+			</html>
+		</projects>
+	</extension>
 </extensions>


### PR DESCRIPTION
Now `gwtInherit` field can be defined in `extensions.xml`. If defined, `inherits name='...'` will be added to `GwtDefinition.gwt.xml` and `GdxDefinitionSuperdev.gwt`

Dependency class now has `gwtInherits` field, so I was able to remove `gwtInheritances` map from `DepedencyBank`. For official extensions gwt inherits now is defined in `ProjectDependency` enum.

Also fixes bug in 3rd party extension dialog. `MouseListener` was used for listening for table changes, where `TableModelListener` should be used. When using `MouseListener` some events may be not reported, like here: [GIF](https://cloud.githubusercontent.com/assets/4594081/6644029/3de7c6b2-c9b1-11e4-926e-167bb160cd4b.gif) (should print random int when check box was changed)
Because that listener is used for updating dependency list, user could check extension and it wouldn't be included.