### PR TITLE
Fix TextField not respecting onlyFontChars

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextField.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextField.java
@@ -881,7 +881,7 @@ public class TextField extends Widget implements Disableable {
 			} else {
 				boolean delete = character == DELETE;
 				boolean backspace = character == BACKSPACE;
-				boolean add = style.font.containsCharacter(character)
+				boolean add = (!onlyFontChars || style.font.containsCharacter(character))
 					|| (writeEnters && (character == ENTER_ANDROID || character == ENTER_DESKTOP));
 				boolean remove = backspace || delete;
 				if (add || remove) {


### PR DESCRIPTION
`onlyFontChars` behaviour was not consistent. It did allow those chars to be pasted, but not written.

For reference, I was using this for emulating iOS text field behaviour when writing letters like ě. Those are written by pressing `e` and `ˇ`. Natively, those chars are combined when rendering (Unicode standard). However, libGDX does not support such combining, so I have to listen for input (setTextFieldListener -> keyTyped) and then combine the chars manually. Problem is, that `ˇ` is not written in the TextField text, because my font does not contain it, so I can not combine it easily.