### PR TITLE
[gdx-jnigen] ARM compatibility

### DIFF
--- a/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/AntScriptGenerator.java
+++ b/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/AntScriptGenerator.java
@@ -71,11 +71,11 @@ public class AntScriptGenerator {
 
 		// copy jni headers
 		copyJniHeaders(config.jniDir.path());
-		
+
 		// copy memcpy_wrap.c, needed if your build platform uses the latest glibc, e.g. Ubuntu 12.10
-		if(config.jniDir.child("memcpy_wrap.c").exists() == false) {
-			new FileDescriptor("com/badlogic/gdx/jnigen/resources/scripts/memcpy_wrap.c", FileType.Classpath).copyTo(
-				config.jniDir.child("memcpy_wrap.c"));
+		if (config.jniDir.child("memcpy_wrap.c").exists() == false) {
+			new FileDescriptor("com/badlogic/gdx/jnigen/resources/scripts/memcpy_wrap.c", FileType.Classpath).copyTo(config.jniDir
+				.child("memcpy_wrap.c"));
 		}
 
 		ArrayList<String> buildFiles = new ArrayList<String>();
@@ -100,9 +100,14 @@ public class AntScriptGenerator {
 			if (!target.excludeFromMasterBuildFile) {
 				if (target.os != TargetOs.MacOsX && target.os != TargetOs.IOS) {
 					buildFiles.add(buildFileName);
-				} 
-				sharedLibFiles.add(getSharedLibFilename(target.os, target.is64Bit, config.sharedLibName));
-				if(target.os != TargetOs.Android && target.os != TargetOs.IOS) {
+				}
+
+				String sharedLibFilename = target.libName;
+				if (sharedLibFilename == null)
+					sharedLibFilename = getSharedLibFilename(target.os, target.is64Bit, config.sharedLibName);
+				
+				sharedLibFiles.add(sharedLibFilename);
+				if (target.os != TargetOs.Android && target.os != TargetOs.IOS) {
 					libsDirs.add("../" + libsDir.path().replace('\\', '/'));
 				}
 			}
@@ -122,10 +127,10 @@ public class AntScriptGenerator {
 		for (int i = 0; i < libsDirs.size(); i++) {
 			pack.append("\t\t\t<fileset dir=\"" + libsDirs.get(i) + "\" includes=\"" + sharedLibFiles.get(i) + "\"/>\n");
 		}
-		
-		if(config.sharedLibs != null) {
-			for(String sharedLib: config.sharedLibs) {
-				pack.append("\t\t\t<fileset dir=\"" + sharedLib+ "\"/>\n");
+
+		if (config.sharedLibs != null) {
+			for (String sharedLib : config.sharedLibs) {
+				pack.append("\t\t\t<fileset dir=\"" + sharedLib + "\"/>\n");
 			}
 		}
 
@@ -181,7 +186,9 @@ public class AntScriptGenerator {
 	}
 
 	private String getLibsDirectory (BuildConfig config, BuildTarget target) {
-		return config.libsDir.child(target.os.toString().toLowerCase() + (target.is64Bit ? "64" : "32")).path().replace('\\', '/');
+		String targetName = target.osFileName;
+		if (targetName == null) targetName = target.os.toString().toLowerCase() + (target.is64Bit ? "64" : "32");
+		return config.libsDir.child(targetName).path().replace('\\', '/');
 	}
 
 	private String generateBuildTargetTemplate (BuildConfig config, BuildTarget target) {
@@ -197,18 +204,18 @@ public class AntScriptGenerator {
 
 		// read template file from resources
 		String template = null;
-		if(target.os == TargetOs.IOS) {
-			template = new FileDescriptor("com/badlogic/gdx/jnigen/resources/scripts/build-ios.xml.template",
-			FileType.Classpath).readString();
+		if (target.os == TargetOs.IOS) {
+			template = new FileDescriptor("com/badlogic/gdx/jnigen/resources/scripts/build-ios.xml.template", FileType.Classpath)
+				.readString();
 		} else {
-			template = new FileDescriptor("com/badlogic/gdx/jnigen/resources/scripts/build-target.xml.template",
-				FileType.Classpath).readString();
+			template = new FileDescriptor("com/badlogic/gdx/jnigen/resources/scripts/build-target.xml.template", FileType.Classpath)
+				.readString();
 		}
 
 		// generate shared lib filename and jni platform headers directory name
-		String libName = getSharedLibFilename(target.os, target.is64Bit, config.sharedLibName);
+		String libName = target.libName;
+		if (libName == null) libName = getSharedLibFilename(target.os, target.is64Bit, config.sharedLibName);
 		String jniPlatform = getJniPlatform(target.os);
-
 
 		// generate include and exclude fileset Ant description for C/C++
 		// append memcpy_wrap.c to list of files to be build
@@ -236,10 +243,12 @@ public class AntScriptGenerator {
 			headerDirs.append("\t\t\t<arg value=\"-I" + headerDir + "\"/>\n");
 		}
 
+		String targetFolder = target.osFileName;
+		if (targetFolder == null) targetFolder = target.os.toString().toLowerCase() + (target.is64Bit ? "64" : "32");
+
 		// replace template vars with proper values
 		template = template.replace("%projectName%", config.sharedLibName + "-" + target.os + "-" + (target.is64Bit ? "64" : "32"));
-		template = template.replace("%buildDir%",
-			config.buildDir.child(target.os.toString().toLowerCase() + (target.is64Bit ? "64" : "32")).path().replace('\\', '/'));
+		template = template.replace("%buildDir%", config.buildDir.child(targetFolder).path().replace('\\', '/'));
 		template = template.replace("%libsDir%", "../" + getLibsDirectory(config, target));
 		template = template.replace("%libName%", libName);
 		template = template.replace("%jniPlatform%", jniPlatform);

--- a/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/BuildTarget.java
+++ b/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/BuildTarget.java
@@ -56,6 +56,11 @@ public class BuildTarget {
 	public String postCompileTask;
 	/** the libraries to be linked to the output, specify via e.g. -ldinput -ldxguid etc. **/
 	public String libraries;
+	/** The name used for folders for this specific target. Defaults to "${target}(64)" **/
+	public String osFileName;
+	/** The name used for the library file. This is a full file name, including file extension. Default is platform specific.
+	 *  E.g. "lib{sharedLibName}64.so" **/
+	public String libName; 
 
 	/** Creates a new build target. See members of this class for a description of the parameters. */
 	public BuildTarget (BuildTarget.TargetOs targetType, boolean is64Bit, String[] cIncludes, String[] cExcludes,

--- a/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/JniGenSharedLibraryLoader.java
+++ b/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/JniGenSharedLibraryLoader.java
@@ -163,6 +163,8 @@ public class JniGenSharedLibraryLoader {
 		boolean isMac = System.getProperty("os.name").contains("Mac");
 		boolean isAndroid = false;
 		boolean is64Bit = System.getProperty("os.arch").equals("amd64") || System.getProperty("os.arch").equals("x86_64");
+		boolean isArm = System.getProperty("os.arch").equals("arm");
+
 		String vm = System.getProperty("java.vm.name");
 		if (vm != null && vm.contains("Dalvik")) {
 			isAndroid = true;
@@ -183,16 +185,23 @@ public class JniGenSharedLibraryLoader {
 		}
 		if (isLinux) {
 			if (libraryFinder != null)
-				loaded = loadLibrary(libraryFinder.getSharedLibraryNameLinux(sharedLibName, is64Bit, nativesZip));
-			else if (!is64Bit)
-				loaded = loadLibrary("lib" + sharedLibName + ".so");
-			else
-				loaded = loadLibrary("lib" + sharedLibName + "64.so");
+				loaded = loadLibrary(libraryFinder.getSharedLibraryNameLinux(sharedLibName, is64Bit, isArm, nativesZip));
+			else if (!is64Bit) {
+				if (isArm)
+					loaded = loadLibrary("lib" + sharedLibName + "Arm.so");
+				else
+					loaded = loadLibrary("lib" + sharedLibName + ".so");
+			} else {
+				if (isArm)
+					loaded = loadLibrary("lib" + sharedLibName + "Arm64.so");
+				else
+					loaded = loadLibrary("lib" + sharedLibName + "64.so");
+			}
 		}
 		if (isMac) {
 			if (libraryFinder != null)
 				loaded = loadLibrary(libraryFinder.getSharedLibraryNameMac(sharedLibName, is64Bit, nativesZip));
-			else if(!is64Bit)
+			else if (!is64Bit)
 				loaded = loadLibrary("lib" + sharedLibName + ".dylib");
 			else
 				loaded = loadLibrary("lib" + sharedLibName + "64.dylib");

--- a/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/SharedLibraryFinder.java
+++ b/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/SharedLibraryFinder.java
@@ -1,3 +1,18 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
 
 package com.badlogic.gdx.jnigen;
 
@@ -15,13 +30,14 @@ public interface SharedLibraryFinder {
 
 	/** @param sharedLibName The name of the shared lib that is asked to be loaded.
 	 * @param is64Bit Whether the platform is 64 bit
+	 * @param isArm Whether the platform has the ARM architecture
 	 * @param nativesJar A ZipFile object, which gives the ability to walk through the containing files, and allows for pattern
 	 *           matching. May be null if no zipfile is used.
 	 * @return The name of the shared file, or null if none available */
 	String getSharedLibraryNameLinux (String sharedLibName, boolean is64Bit, boolean isArm, ZipFile nativesJar);
 
 	/** @param sharedLibName The name of the shared lib that is asked to be loaded.
-	 * @param is64Bit 
+	 * @param is64Bit
 	 * @param nativesJar A ZipFile object, which gives the ability to walk through the containing files, and allows for pattern
 	 *           matching. May be null if no zipfile is used.
 	 * @return The name of the shared file, or null if none available */

--- a/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/SharedLibraryFinder.java
+++ b/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/SharedLibraryFinder.java
@@ -18,7 +18,7 @@ public interface SharedLibraryFinder {
 	 * @param nativesJar A ZipFile object, which gives the ability to walk through the containing files, and allows for pattern
 	 *           matching. May be null if no zipfile is used.
 	 * @return The name of the shared file, or null if none available */
-	String getSharedLibraryNameLinux (String sharedLibName, boolean is64Bit, ZipFile nativesJar);
+	String getSharedLibraryNameLinux (String sharedLibName, boolean is64Bit, boolean isArm, ZipFile nativesJar);
 
 	/** @param sharedLibName The name of the shared lib that is asked to be loaded.
 	 * @param is64Bit 


### PR DESCRIPTION
I've been working on a project which uses gdx-jnigen for generating and loading native libraries. The project runs on any linux, and is most beneficial on a Raspberry Pi, which has the ARM architecture. 
Currently it is not possible to build a version for 32bit, 64bit and arm architectures at the same time. Therefore, I added some options to the buildscript generator, which gives more freedom, also for future additions.
I also added the ability to detect an ARM platform, and load the appropriate native library.

This will be usefull in all sorts of projects, and will also be helpfull if one would decide to port libgdx to another ARM platform (Iike the Rpi) later.