### PR TITLE
Added support for not flipping Y values in a TMX map.

### DIFF
--- a/gdx/src/com/badlogic/gdx/maps/tiled/AtlasTmxMapLoader.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/AtlasTmxMapLoader.java
@@ -139,8 +139,10 @@ public class AtlasTmxMapLoader extends BaseTmxMapLoader<AtlasTmxMapLoader.AtlasT
 		try {
 			if (parameter != null) {
 				convertObjectToTileSpace = parameter.convertObjectToTileSpace;
+				flipY = parameter.flipY;
 			} else {
 				convertObjectToTileSpace = false;
+				flipY = true;
 			}
 
 			FileHandle tmxFile = resolve(fileName);
@@ -203,8 +205,10 @@ public class AtlasTmxMapLoader extends BaseTmxMapLoader<AtlasTmxMapLoader.AtlasT
 
 		if (parameter != null) {
 			convertObjectToTileSpace = parameter.convertObjectToTileSpace;
+			flipY = parameter.flipY;
 		} else {
 			convertObjectToTileSpace = false;
+			flipY = true;
 		}
 
 		try {
@@ -369,7 +373,7 @@ public class AtlasTmxMapLoader extends BaseTmxMapLoader<AtlasTmxMapLoader.AtlasT
 					int tileid = firstgid + region.index;
 					tile.setId(tileid);
 					tile.setOffsetX(offsetX);
-					tile.setOffsetY(-offsetY);
+					tile.setOffsetY(flipY ? -offsetY : offsetY);
 					tileset.putTile(tileid, tile);
 				}
 			}
@@ -388,7 +392,7 @@ public class AtlasTmxMapLoader extends BaseTmxMapLoader<AtlasTmxMapLoader.AtlasT
 						tile = new StaticTiledMapTile(region);
 						tile.setId(tileid);
 						tile.setOffsetX(offsetX);
-						tile.setOffsetY(-offsetY);
+						tile.setOffsetY(flipY ? -offsetY : offsetY);
 						tileset.putTile(tileid, tile);
 					}
 				}

--- a/gdx/src/com/badlogic/gdx/maps/tiled/BaseTmxMapLoader.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/BaseTmxMapLoader.java
@@ -42,6 +42,8 @@ public abstract class BaseTmxMapLoader<P extends AssetLoaderParameters<TiledMap>
 		public TextureFilter textureMagFilter = TextureFilter.Nearest;
 		/** Whether to convert the objects' pixel position and size to the equivalent in tile space. **/
 		public boolean convertObjectToTileSpace = false;
+		/** Whether to flip all Y coordinates so that Y positive is down. */
+		public boolean flipY = true;
 	}
 
 	protected static final int FLAG_FLIP_HORIZONTALLY = 0x80000000;
@@ -52,6 +54,7 @@ public abstract class BaseTmxMapLoader<P extends AssetLoaderParameters<TiledMap>
 	protected XmlReader xml = new XmlReader();
 	protected Element root;
 	protected boolean convertObjectToTileSpace;
+	protected boolean flipY = true;
 
 	protected int mapTileWidth;
 	protected int mapTileHeight;
@@ -87,7 +90,7 @@ public abstract class BaseTmxMapLoader<P extends AssetLoaderParameters<TiledMap>
 					if (tile != null) {
 						Cell cell = createTileLayerCell(flipHorizontally, flipVertically, flipDiagonally);
 						cell.setTile(tile);
-						layer.setCell(x, height - 1 - y, cell);
+						layer.setCell(x, flipY ? height - 1 - y : y, cell);
 					}
 				}
 			}
@@ -121,7 +124,10 @@ public abstract class BaseTmxMapLoader<P extends AssetLoaderParameters<TiledMap>
 	protected void loadImageLayer (TiledMap map, Element element, FileHandle tmxFile, ImageResolver imageResolver) {
 		if (element.getName().equals("imagelayer")) {
 			int x = Integer.parseInt(element.getAttribute("x", "0"));
-			int y = mapHeightInPixels - Integer.parseInt(element.getAttribute("y", "0"));
+			int y = Integer.parseInt(element.getAttribute("y", "0"));
+
+			if (flipY) y = mapHeightInPixels - y;
+
 			TextureRegion texture = null;
 
 			Element image = element.getChildByName("image");
@@ -164,7 +170,7 @@ public abstract class BaseTmxMapLoader<P extends AssetLoaderParameters<TiledMap>
 			float scaleY = convertObjectToTileSpace ? 1.0f / mapTileHeight : 1.0f;
 
 			float x = element.getFloatAttribute("x", 0) * scaleX;
-			float y = (mapHeightInPixels - element.getFloatAttribute("y", 0)) * scaleY;
+			float y = (flipY ? (mapHeightInPixels - element.getFloatAttribute("y", 0)) : element.getFloatAttribute("y", 0)) * scaleY;
 
 			float width = element.getFloatAttribute("width", 0) * scaleX;
 			float height = element.getFloatAttribute("height", 0) * scaleY;
@@ -177,7 +183,7 @@ public abstract class BaseTmxMapLoader<P extends AssetLoaderParameters<TiledMap>
 					for (int i = 0; i < points.length; i++) {
 						String[] point = points[i].split(",");
 						vertices[i * 2] = Float.parseFloat(point[0]) * scaleX;
-						vertices[i * 2 + 1] = -Float.parseFloat(point[1]) * scaleY;
+						vertices[i * 2 + 1] = Float.parseFloat(point[1]) * scaleY * (flipY ? -1 : 1);
 					}
 					Polygon polygon = new Polygon(vertices);
 					polygon.setPosition(x, y);
@@ -188,13 +194,13 @@ public abstract class BaseTmxMapLoader<P extends AssetLoaderParameters<TiledMap>
 					for (int i = 0; i < points.length; i++) {
 						String[] point = points[i].split(",");
 						vertices[i * 2] = Float.parseFloat(point[0]) * scaleX;
-						vertices[i * 2 + 1] = -Float.parseFloat(point[1]) * scaleY;
+						vertices[i * 2 + 1] = Float.parseFloat(point[1]) * scaleY * (flipY ? -1 : 1);
 					}
 					Polyline polyline = new Polyline(vertices);
 					polyline.setPosition(x, y);
 					object = new PolylineMapObject(polyline);
 				} else if ((child = element.getChildByName("ellipse")) != null) {
-					object = new EllipseMapObject(x, y - height, width, height);
+					object = new EllipseMapObject(x, flipY ? y - height : y, width, height);
 				}
 			}
 			if (object == null) {
@@ -210,13 +216,13 @@ public abstract class BaseTmxMapLoader<P extends AssetLoaderParameters<TiledMap>
 					TextureMapObject textureMapObject = new TextureMapObject(textureRegion);
 					textureMapObject.getProperties().put("gid", id);
 					textureMapObject.setX(x);
-					textureMapObject.setY(y - height);
+					textureMapObject.setY(flipY ? y - height : y);
 					textureMapObject.setScaleX(scaleX);
 					textureMapObject.setScaleY(scaleY);
 					textureMapObject.setRotation(element.getFloatAttribute("rotation", 0));
 					object = textureMapObject;
 				} else {
-					object = new RectangleMapObject(x, y - height, width, height);
+					object = new RectangleMapObject(x, flipY ? y - height : y, width, height);
 				}
 			}
 			object.setName(element.getAttribute("name", null));
@@ -233,7 +239,7 @@ public abstract class BaseTmxMapLoader<P extends AssetLoaderParameters<TiledMap>
 				object.getProperties().put("id", id);
 			}
 			object.getProperties().put("x", x * scaleX);
-			object.getProperties().put("y", (y - height) * scaleY);
+			object.getProperties().put("y", (flipY ? y - height : y) * scaleY);
 			object.getProperties().put("width", width);
 			object.getProperties().put("height", height);
 			object.setVisible(element.getIntAttribute("visible", 1) == 1);

--- a/gdx/src/com/badlogic/gdx/maps/tiled/TmxMapLoader.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/TmxMapLoader.java
@@ -73,6 +73,7 @@ public class TmxMapLoader extends BaseTmxMapLoader<TmxMapLoader.Parameters> {
 	public TiledMap load (String fileName, TmxMapLoader.Parameters parameters) {
 		try {
 			this.convertObjectToTileSpace = parameters.convertObjectToTileSpace;
+			this.flipY = parameters.flipY;
 			FileHandle tmxFile = resolve(fileName);
 			root = xml.parse(tmxFile);
 			ObjectMap<String, Texture> textures = new ObjectMap<String, Texture>();
@@ -100,8 +101,10 @@ public class TmxMapLoader extends BaseTmxMapLoader<TmxMapLoader.Parameters> {
 
 		if (parameter != null) {
 			convertObjectToTileSpace = parameter.convertObjectToTileSpace;
+			flipY = parameter.flipY;
 		} else {
 			convertObjectToTileSpace = false;
+			flipY = true;
 		}
 		try {
 			map = loadTilemap(root, tmxFile, new AssetManagerImageResolver(manager));
@@ -379,7 +382,7 @@ public class TmxMapLoader extends BaseTmxMapLoader<TmxMapLoader.Parameters> {
 						TiledMapTile tile = new StaticTiledMapTile(tileRegion);
 						tile.setId(id);
 						tile.setOffsetX(offsetX);
-						tile.setOffsetY(-offsetY);
+						tile.setOffsetY(flipY ? -offsetY : offsetY);
 						tileset.putTile(id++, tile);
 					}
 				}
@@ -397,7 +400,7 @@ public class TmxMapLoader extends BaseTmxMapLoader<TmxMapLoader.Parameters> {
 					TiledMapTile tile = new StaticTiledMapTile(texture);
 					tile.setId(firstgid + tileElement.getIntAttribute("id"));
 					tile.setOffsetX(offsetX);
-					tile.setOffsetY(-offsetY);
+					tile.setOffsetY(flipY ? -offsetY : offsetY);
 					tileset.putTile(tile.getId(), tile);
 				}
 			}


### PR DESCRIPTION
As referenced in issue #2929 .

We ourselves have run into this usecase as well, as we use Tiled for creating meta information for maps.