### PR TITLE
fix #2974 GeometryUtils#polygonArea(float[], int, int)

### DIFF
--- a/gdx/src/com/badlogic/gdx/math/GeometryUtils.java
+++ b/gdx/src/com/badlogic/gdx/math/GeometryUtils.java
@@ -183,7 +183,11 @@ public final class GeometryUtils {
 			int x1 = i;
 			int y1 = i + 1;
 			int x2 = (i + 2) % n;
+			if(x2 < offset)
+				x2 += offset;
 			int y2 = (i + 3) % n;
+			if(y2 < offset)
+				y2 += offset;
 			area += polygon[x1] * polygon[y2];
 			area -= polygon[x2] * polygon[y1];
 		}


### PR DESCRIPTION
This is the fix for #2974.