### PR TITLE
Fix 2D Particle Editor bug where the tint timeline does not update the emitter

### DIFF
--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/GradientPanel.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/GradientPanel.java
@@ -243,6 +243,7 @@ class GradientPanel extends EditorPanel {
 							colors.add(i, colors.get(i - 1));
 							dragIndex = selectedIndex = i;
 							handleSelected(colors.get(selectedIndex));
+							updateColor();
 							repaint();
 							break;
 						}
@@ -256,6 +257,7 @@ class GradientPanel extends EditorPanel {
 					percent = Math.max(percent, percentages.get(dragIndex - 1) + 0.01f);
 					percent = Math.min(percent, percentages.get(dragIndex + 1) - 0.01f);
 					percentages.set(dragIndex, percent);
+					updateColor();
 					repaint();
 				}
 			});


### PR DESCRIPTION
Reproduce steps...

1. Duplicate an emitter
2. Add a new marker to emitter 2's Tint timeline or drag an existing marker to a new spot on the timeline
3. Select emitter 1
4. Select emitter 2 (and see the marker is gone)