### PR TITLE
Fix 3D Particles for GWT : loader and GLSL bug

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gwtref/GwtReflect.gwt.xml
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gwtref/GwtReflect.gwt.xml
@@ -39,19 +39,26 @@
 		value="com.badlogic.gdx.Net" />
 	
 	<extend-configuration-property name="gdx.reflect.include"
+		value="com.badlogic.gdx.graphics.g3d.particles.ParticleEffect" />
+	<extend-configuration-property name="gdx.reflect.include"
+		value="com.badlogic.gdx.graphics.g3d.particles.ParticleController" />
+	<extend-configuration-property name="gdx.reflect.include"
+		value="com.badlogic.gdx.graphics.g3d.particles.ResourceData" />
+	<extend-configuration-property name="gdx.reflect.include"
+		value="com.badlogic.gdx.graphics.g3d.particles.ResourceData.SaveData" />
+	<extend-configuration-property name="gdx.reflect.include"
+		value="com.badlogic.gdx.graphics.g3d.particles.ResourceData.AssetData" />
+	<extend-configuration-property name="gdx.reflect.include"
 		value="com.badlogic.gdx.graphics.g3d.particles.ParallelArray" />
-		
+	<extend-configuration-property name="gdx.reflect.include"
+		value="com.badlogic.gdx.graphics.g3d.particles.values" />
+	<extend-configuration-property name="gdx.reflect.include"
+		value="com.badlogic.gdx.graphics.g3d.particles.emitters" />
 	<extend-configuration-property name="gdx.reflect.include"
 		value="com.badlogic.gdx.graphics.g3d.particles.influencers" />
+	<extend-configuration-property name="gdx.reflect.include"
+		value="com.badlogic.gdx.graphics.g3d.particles.renderers" />
 	
-	<extend-configuration-property name="gdx.reflect.include"
-		value="com.badlogic.gdx.graphics.g3d.particles.renderers.BillboardControllerRenderData" />
-	<extend-configuration-property name="gdx.reflect.include"
-		value="com.badlogic.gdx.graphics.g3d.particles.renderers.ModelInstanceControllerRenderData" />
-	<extend-configuration-property name="gdx.reflect.include"
-		value="com.badlogic.gdx.graphics.g3d.particles.renderers.ParticleControllerRenderData" />
-	<extend-configuration-property name="gdx.reflect.include"
-		value="com.badlogic.gdx.graphics.g3d.particles.renderers.PointSpriteControllerRenderData" />
     <extend-configuration-property name="gdx.reflect.include"
         value="java.util.Collection" />
 	<extend-configuration-property name="gdx.reflect.include"

--- a/backends/gdx-backends-gwt/src/com/badlogic/gwtref/gen/ReflectionCacheSourceCreator.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gwtref/gen/ReflectionCacheSourceCreator.java
@@ -147,6 +147,16 @@ public class ReflectionCacheSourceCreator {
 			}
 		}
 
+		// gather all types from explicitely requested packages
+		try {
+			ConfigurationProperty prop = context.getPropertyOracle().getConfigurationProperty("gdx.reflect.include");
+			for (String s : prop.getValues()) {
+				JClassType type = typeOracle.findType(s);
+				if (type != null) gatherTypes(type.getErasedType(), types);
+			}
+		} catch (BadPropertyValueException e) {
+		}
+
 		gatherTypes(typeOracle.findType("java.util.List").getErasedType(), types);
 		gatherTypes(typeOracle.findType("java.util.ArrayList").getErasedType(), types);
 		gatherTypes(typeOracle.findType("java.util.HashMap").getErasedType(), types);

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/particles/ParticleEffectLoader.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/particles/ParticleEffectLoader.java
@@ -1,3 +1,4 @@
+
 package com.badlogic.gdx.graphics.g3d.particles;
 
 import java.io.File;
@@ -5,6 +6,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Writer;
 
+import com.badlogic.gdx.Application.ApplicationType;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.assets.AssetDescriptor;
 import com.badlogic.gdx.assets.AssetLoaderParameters;
@@ -19,22 +21,24 @@ import com.badlogic.gdx.utils.Json;
 import com.badlogic.gdx.utils.ObjectMap;
 import com.badlogic.gdx.utils.reflect.ClassReflection;
 
-/**This class can save and load a {@link ParticleEffect}.
- * It should be added as {@link AsynchronousAssetLoader} to the {@link AssetManager} so it will be able to load the effects.
- * It's important to note that the two classes {@link ParticleEffectLoadParameter} and {@link ParticleEffectSaveParameter} should
- * be passed in whenever possible, because when present the batches settings will be loaded automatically.
- * When the load and save parameters are absent, once the effect will be created, one will have to set the required batches
- * manually otherwise the {@link ParticleController} instances contained inside the effect will not be able to render themselves. 
+/** This class can save and load a {@link ParticleEffect}. It should be added as {@link AsynchronousAssetLoader} to the
+ * {@link AssetManager} so it will be able to load the effects. It's important to note that the two classes
+ * {@link ParticleEffectLoadParameter} and {@link ParticleEffectSaveParameter} should be passed in whenever possible, because when
+ * present the batches settings will be loaded automatically. When the load and save parameters are absent, once the effect will
+ * be created, one will have to set the required batches manually otherwise the {@link ParticleController} instances contained
+ * inside the effect will not be able to render themselves.
  * @author inferno */
-public class ParticleEffectLoader extends AsynchronousAssetLoader<ParticleEffect, ParticleEffectLoader.ParticleEffectLoadParameter> {
-	protected Array<ObjectMap.Entry<String, ResourceData<ParticleEffect>>> items = new Array<ObjectMap.Entry<String, ResourceData<ParticleEffect>>>(); 
-	
+public class ParticleEffectLoader extends
+	AsynchronousAssetLoader<ParticleEffect, ParticleEffectLoader.ParticleEffectLoadParameter> {
+	protected Array<ObjectMap.Entry<String, ResourceData<ParticleEffect>>> items = new Array<ObjectMap.Entry<String, ResourceData<ParticleEffect>>>();
+
 	public ParticleEffectLoader (FileHandleResolver resolver) {
 		super(resolver);
 	}
 
 	@Override
-	public void loadAsync (AssetManager manager, String fileName, FileHandle file, ParticleEffectLoadParameter parameter) {}
+	public void loadAsync (AssetManager manager, String fileName, FileHandle file, ParticleEffectLoadParameter parameter) {
+	}
 
 	@Override
 	public Array<AssetDescriptor> getDependencies (String fileName, FileHandle file, ParticleEffectLoadParameter parameter) {
@@ -48,61 +52,62 @@ public class ParticleEffectLoader extends AsynchronousAssetLoader<ParticleEffect
 			items.add(entry);
 			assets = data.getAssets();
 		}
-		
+
 		Array<AssetDescriptor> descriptors = new Array<AssetDescriptor>();
-		for(AssetData<?> assetData : assets){
-			
-			//If the asset doesn't exist try to load it from loading effect directory
-			if (!resolve(assetData.filename).exists()){
+		for (AssetData<?> assetData : assets) {
+
+			// If the asset doesn't exist try to load it from loading effect directory
+			if (!resolve(assetData.filename).exists()) {
+				if (Gdx.app.getType() == ApplicationType.WebGL)
+					Gdx.app.error("ParticleEffectLoader", "Failed to find asset '" + assetData.filename
+						+ "' specified in ParticleEffect file '" + fileName + "'");
 				assetData.filename = file.parent().child(Gdx.files.absolute(assetData.filename).name()).path();
 			}
 
-			if(assetData.type == ParticleEffect.class){
+			if (assetData.type == ParticleEffect.class) {
 				descriptors.add(new AssetDescriptor(assetData.filename, assetData.type, parameter));
-			}
-			else 
+			} else
 				descriptors.add(new AssetDescriptor(assetData.filename, assetData.type));
 		}
-		
+
 		return descriptors;
-		
+
 	}
-	
+
 	/** Saves the effect to the given file contained in the passed in parameter. */
-	public void save(ParticleEffect effect, ParticleEffectSaveParameter parameter) throws IOException{
-		ResourceData<ParticleEffect> data =  new ResourceData<ParticleEffect>(effect);
-		
-		//effect assets
+	public void save (ParticleEffect effect, ParticleEffectSaveParameter parameter) throws IOException {
+		ResourceData<ParticleEffect> data = new ResourceData<ParticleEffect>(effect);
+
+		// effect assets
 		effect.save(parameter.manager, data);
-		
-		//Batches configurations
-		if(parameter.batches != null){
-			for(ParticleBatch<?> batch : parameter.batches){
+
+		// Batches configurations
+		if (parameter.batches != null) {
+			for (ParticleBatch<?> batch : parameter.batches) {
 				boolean save = false;
-				for(ParticleController controller : effect.getControllers()){
-					if(controller.renderer.isCompatible(batch)){
+				for (ParticleController controller : effect.getControllers()) {
+					if (controller.renderer.isCompatible(batch)) {
 						save = true;
 						break;
 					}
 				}
-				
-				if(save)
-					batch.save(parameter.manager, data);
+
+				if (save) batch.save(parameter.manager, data);
 			}
 		}
-		
-		//save
+
+		// save
 		Json json = new Json();
 		json.toJson(data, parameter.file);
 	}
-	
+
 	@Override
 	public ParticleEffect loadSync (AssetManager manager, String fileName, FileHandle file, ParticleEffectLoadParameter parameter) {
 		ResourceData<ParticleEffect> effectData = null;
-		synchronized(items) {
-			for(int i=0; i < items.size; ++i){
+		synchronized (items) {
+			for (int i = 0; i < items.size; ++i) {
 				ObjectMap.Entry<String, ResourceData<ParticleEffect>> entry = items.get(i);
-				if(entry.key.equals(fileName)){
+				if (entry.key.equals(fileName)) {
 					effectData = entry.value;
 					items.removeIndex(i);
 					break;
@@ -111,45 +116,45 @@ public class ParticleEffectLoader extends AsynchronousAssetLoader<ParticleEffect
 		}
 
 		effectData.resource.load(manager, effectData);
-		if(parameter != null){
-			if(parameter.batches != null){
-				for(ParticleBatch<?> batch : parameter.batches){
+		if (parameter != null) {
+			if (parameter.batches != null) {
+				for (ParticleBatch<?> batch : parameter.batches) {
 					batch.load(manager, effectData);
 				}
 			}
-			effectData.resource.setBatch(parameter.batches);	
+			effectData.resource.setBatch(parameter.batches);
 		}
 		return effectData.resource;
 	}
-	
-	private <T> T find(Array<?> array, Class<T> type){
-		for(Object object : array){
-			if(ClassReflection.isAssignableFrom(type, object.getClass()))
-				return (T)object;
+
+	private <T> T find (Array<?> array, Class<T> type) {
+		for (Object object : array) {
+			if (ClassReflection.isAssignableFrom(type, object.getClass())) return (T)object;
 		}
 		return null;
 	}
-	
+
 	public static class ParticleEffectLoadParameter extends AssetLoaderParameters<ParticleEffect> {
 		Array<ParticleBatch<?>> batches;
-		
-		public ParticleEffectLoadParameter(Array<ParticleBatch<?>>batches){
+
+		public ParticleEffectLoadParameter (Array<ParticleBatch<?>> batches) {
 			this.batches = batches;
 		}
 	}
-	
+
 	public static class ParticleEffectSaveParameter extends AssetLoaderParameters<ParticleEffect> {
-		/**Optional parameters, but should be present to correctly load the settings*/
+		/** Optional parameters, but should be present to correctly load the settings */
 		Array<ParticleBatch<?>> batches;
-		
+
 		/** Required parameters */
 		FileHandle file;
 		AssetManager manager;
-		public ParticleEffectSaveParameter(FileHandle file, AssetManager manager, Array<ParticleBatch<?>> batches){
+
+		public ParticleEffectSaveParameter (FileHandle file, AssetManager manager, Array<ParticleBatch<?>> batches) {
 			this.batches = batches;
 			this.file = file;
 			this.manager = manager;
 		}
 	}
-	
+
 }

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/particles/ParticleEffectLoader.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/particles/ParticleEffectLoader.java
@@ -58,10 +58,7 @@ public class ParticleEffectLoader extends
 
 			// If the asset doesn't exist try to load it from loading effect directory
 			if (!resolve(assetData.filename).exists()) {
-				if (Gdx.app.getType() == ApplicationType.WebGL)
-					Gdx.app.error("ParticleEffectLoader", "Failed to find asset '" + assetData.filename
-						+ "' specified in ParticleEffect file '" + fileName + "'");
-				assetData.filename = file.parent().child(Gdx.files.absolute(assetData.filename).name()).path();
+				assetData.filename = file.parent().child(Gdx.files.internal(assetData.filename).name()).path();
 			}
 
 			if (assetData.type == ParticleEffect.class) {

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/particles/ResourceData.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/particles/ResourceData.java
@@ -209,7 +209,7 @@ public class ResourceData<T> implements Json.Serializable{
 			saveData.resources = this;
 		}
 		
-		sharedAssets.addAll(json.readValue("assets", AssetData[].class, jsonData));
+		sharedAssets.addAll(json.readValue("assets", Array.class, AssetData.class, jsonData));
 		resource = json.readValue("resource", null, jsonData);
 	}
 

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/particles/particles.vertex.glsl
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/particles/particles.vertex.glsl
@@ -1,3 +1,14 @@
+#ifdef GL_ES 
+#define LOWP lowp
+#define MED mediump
+#define HIGH highp
+precision mediump float;
+#else
+#define MED
+#define LOWP
+#define HIGH
+#endif
+
 #ifdef billboard
 //Billboard particles
 //In
@@ -7,7 +18,7 @@ attribute vec4 a_sizeAndRotation;
 attribute vec4 a_color;
 
 //out
-varying vec2 v_texCoords0;
+varying MED vec2 v_texCoords0;
 varying vec4 v_color;
 
 //Camera
@@ -72,7 +83,7 @@ attribute vec4 a_region;
 //out
 varying vec4 v_color;
 varying mat2 v_rotation;
-varying vec4 v_region;
+varying MED vec4 v_region;
 varying vec2 v_uvRegionCenter;
 
 //Camera


### PR DESCRIPTION
On GWT, the particle 3D loader did not work since ResourceData.AssetData class was not feed to the ReflectionCache, other classes needed to be added manually, and there was missing precision specification for GLSL (Firefox rejected it).

This PR fixes this by:
- forcing inclusion of explicitely declared reflection includes (i.e. they don't need to be used by an accesible class, which is the case here since AssetData is only used in generics) - Note that this will only work when the gdx.reflect.include property is set to a class (and not a package)
- adding the needed includes to the reflection cache spec of GWT backend module definition
- adding the precision marker expected in GLSL
- adding an explicit message when loading fail due to absolute path (used by default in Flame) - Note: when formatting this file has quite a lot of whitespace change, don't know why.