### PR TITLE
Added getSkin() method to Table

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Table.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Table.java
@@ -1197,6 +1197,11 @@ public class Table extends WidgetGroup {
 		}
 	}
 
+	/** @return The skin that was passed to this table in its constructor, or null if none was given. */
+	public Skin getSkin () {
+		return skin;
+	}
+
 	/** @author Nathan Sweet */
 	static public class DebugRect extends Rectangle {
 		static Pool<DebugRect> pool = Pools.get(DebugRect.class);


### PR DESCRIPTION
I don't know why this method is missing from the Table class, but I have run into multiple situations where it would have been useful. This method simply returns the private Skin field that has always been present in the Table class.