### PR TITLE
Refactoring Window#getButtonTable

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,7 @@
 - API Change: Removed Mesh.create(...), use MeshBuilder instead
 - API Change: BitmapFontData, BitmapFont, and BitmapFontCache have been refactored. http://www.badlogicgames.com/wordpress/?p=3658
 - FreeTypeFontGenerator can now render glyphs on the fly.
+- API Change: Removed Window#getButtonTable, use Window#getTitleTable and Dialog#getButtonTable instead
 
 [1.5.5]
 - Added iOS ARM-64 bit support for Bullet physics

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Window.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Window.java
@@ -50,7 +50,7 @@ public class Window extends Table {
 	boolean dragging;
 	private int titleAlignment = Align.center;
 	boolean keepWithinStage = true;
-	Table buttonTable;
+	Table titleTable;
 
 	public Window (String title, Skin skin) {
 		this(title, skin.get(WindowStyle.class));
@@ -72,8 +72,8 @@ public class Window extends Table {
 		setHeight(150);
 		setTitle(title);
 
-		buttonTable = new Table();
-		addActor(buttonTable);
+		titleTable = new Table();
+		addActor(titleTable);
 
 		addCaptureListener(new InputListener() {
 			public boolean touchDown (InputEvent event, float x, float y, int pointer, int button) {
@@ -205,7 +205,7 @@ public class Window extends Table {
 		Stage stage = getStage();
 		Camera camera = stage.getCamera();
 		if (camera instanceof OrthographicCamera) {
-			OrthographicCamera orthographicCamera = (OrthographicCamera) camera;
+			OrthographicCamera orthographicCamera = (OrthographicCamera)camera;
 			float parentWidth = stage.getWidth();
 			float parentHeight = stage.getHeight();
 			if (getX(Align.right) - camera.position.x > parentWidth / 2 / orthographicCamera.zoom)
@@ -255,10 +255,10 @@ public class Window extends Table {
 		super.drawBackground(batch, parentAlpha, x, y);
 
 		// Draw button table.
-		buttonTable.getColor().a = getColor().a;
-		buttonTable.pack();
-		buttonTable.setPosition(width - buttonTable.getWidth(), Math.min(height - padTop, height - buttonTable.getHeight()));
-		buttonTable.draw(batch, parentAlpha);
+		titleTable.getColor().a = getColor().a;
+		titleTable.pack();
+		titleTable.setPosition(width - titleTable.getWidth(), Math.min(height - padTop, height - titleTable.getHeight()));
+		titleTable.draw(batch, parentAlpha);
 
 		// Draw the title without the batch transformed or clipping applied.
 		y += height;
@@ -353,8 +353,8 @@ public class Window extends Table {
 		return Math.max(super.getPrefWidth(), getTitleWidth() + getPadLeft() + getPadRight());
 	}
 
-	public Table getButtonTable () {
-		return buttonTable;
+	public Table getTitleTable () {
+		return titleTable;
 	}
 
 	/** The style for a window, see {@link Window}.

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/UITest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/UITest.java
@@ -132,7 +132,7 @@ public class UITest extends GdxTest {
 
 		// window.debug();
 		Window window = new Window("Dialog", skin);
-		window.getButtonTable().add(new TextButton("X", skin)).height(window.getPadTop());
+		window.getTitleTable().add(new TextButton("X", skin)).height(window.getPadTop());
 		window.setPosition(0, 0);
 		window.defaults().spaceBottom(10);
 		window.row().fill().expandX();


### PR DESCRIPTION
This PR refactors really confusing thing in scene2d.ui: `Window#getButtonTable` and its override in Dialog class. In Window this method returns actual title table used for adding 'X' buttons, etc, in Dialog however it returns table for dialog buttons like 'Yes, No, Cancel'. 

Current fix is to completely remove `getButtonTable` from Window and add instead `getTitleTable`. In Dialog `getButtonsTable` was added.

If that PR can't be merged, at least some Javadoc should be added to describe what those method really return.