### PR TITLE
FreeTypeFontGenerator with user-supplied PixmapPacker improvements

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,9 @@
 - FreeTypeFontGenerator can now render glyphs on the fly.
 - Attribute now implements Comparable, custom attributes might need to be updated, see: https://github.com/libgdx/libgdx/wiki/Material-and-environment#custom-attributes
 - API Change: Removed (previously deprecated) GLTexture#createTextureData/createGLHandle, Ray#getEndPoint(float), Color#tmp, Node#parent/children, VertexAttribute#Color(), Usage#Color, ModelBuilder#createFromMesh, BoundingBox#getCenter()/updateCorners()/getCorners(), Matrix4.tmp
+- Added PixmapPacker.getTextureRegions() method.
+- API Change: PixmapPacker.generateTextureAtlas(...) now returns an atlas which can be updated with subsequent calls to PixmapPacker.updateTextureAtlas(...)
+- API Change: FreeTypeFontGenerator.generateFont(...) now works with a user-provided PixmapPacker.
 
 [1.5.5]
 - Added iOS ARM-64 bit support for Bullet physics

--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@
 - API Change: BitmapFontData, BitmapFont, and BitmapFontCache have been refactored. http://www.badlogicgames.com/wordpress/?p=3658
 - FreeTypeFontGenerator can now render glyphs on the fly.
 - Attribute now implements Comparable, custom attributes might need to be updated, see: https://github.com/libgdx/libgdx/wiki/Material-and-environment#custom-attributes
+- API Change: Removed (previously deprecated) GLTexture#createTextureData/createGLHandle, Ray#getEndPoint(float), Color#tmp, Node#parent/children, VertexAttribute#Color(), Usage#Color, ModelBuilder#createFromMesh, BoundingBox#getCenter()/updateCorners()/getCorners(), Matrix4.tmp
 
 [1.5.5]
 - Added iOS ARM-64 bit support for Bullet physics

--- a/CHANGES
+++ b/CHANGES
@@ -6,7 +6,9 @@
 - FreeTypeFontGenerator can now render glyphs on the fly.
 - Attribute now implements Comparable, custom attributes might need to be updated, see: https://github.com/libgdx/libgdx/wiki/Material-and-environment#custom-attributes
 - API Change: Removed (previously deprecated) GLTexture#createTextureData/createGLHandle, Ray#getEndPoint(float), Color#tmp, Node#parent/children, VertexAttribute#Color(), Usage#Color, ModelBuilder#createFromMesh, BoundingBox#getCenter()/updateCorners()/getCorners(), Matrix4.tmp
-- Added PixmapPacker.getTextureRegions() method.
+- Added PixmapPacker.updateTextureRegions() method.
+- Added ability to pack "anonymous" pixmaps into PixmapPacker, which will appear in the generated texture but not a generated or updated TextureAtlas
+- Added PixmapPacker.packDirectToTexture() methods.
 - API Change: PixmapPacker.generateTextureAtlas(...) now returns an atlas which can be updated with subsequent calls to PixmapPacker.updateTextureAtlas(...)
 - API Change: FreeTypeFontGenerator.generateFont(...) now works with a user-provided PixmapPacker.
 

--- a/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGenerator.java
+++ b/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGenerator.java
@@ -16,6 +16,10 @@
 
 package com.badlogic.gdx.graphics.g2d.freetype;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.Color;
@@ -38,11 +42,11 @@ import com.badlogic.gdx.graphics.g2d.freetype.FreeType.SizeMetrics;
 import com.badlogic.gdx.graphics.g2d.freetype.FreeType.Stroker;
 import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.math.Rectangle;
-import com.badlogic.gdx.utils.*;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.ByteBuffer;
+import com.badlogic.gdx.utils.Array;
+import com.badlogic.gdx.utils.BufferUtils;
+import com.badlogic.gdx.utils.Disposable;
+import com.badlogic.gdx.utils.GdxRuntimeException;
+import com.badlogic.gdx.utils.StreamUtils;
 
 /** Generates {@link BitmapFont} and {@link BitmapFontData} instances from TrueType, OTF, and other FreeType supported fonts.</p>
  * 

--- a/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGenerator.java
+++ b/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGenerator.java
@@ -16,6 +16,10 @@
 
 package com.badlogic.gdx.graphics.g2d.freetype;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.Color;
@@ -29,14 +33,20 @@ import com.badlogic.gdx.graphics.g2d.BitmapFont.BitmapFontData;
 import com.badlogic.gdx.graphics.g2d.BitmapFont.Glyph;
 import com.badlogic.gdx.graphics.g2d.PixmapPacker;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
-import com.badlogic.gdx.graphics.g2d.freetype.FreeType.*;
+import com.badlogic.gdx.graphics.g2d.freetype.FreeType.Bitmap;
+import com.badlogic.gdx.graphics.g2d.freetype.FreeType.Face;
+import com.badlogic.gdx.graphics.g2d.freetype.FreeType.GlyphMetrics;
+import com.badlogic.gdx.graphics.g2d.freetype.FreeType.GlyphSlot;
+import com.badlogic.gdx.graphics.g2d.freetype.FreeType.Library;
+import com.badlogic.gdx.graphics.g2d.freetype.FreeType.SizeMetrics;
+import com.badlogic.gdx.graphics.g2d.freetype.FreeType.Stroker;
 import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.math.Rectangle;
-import com.badlogic.gdx.utils.*;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.ByteBuffer;
+import com.badlogic.gdx.utils.Array;
+import com.badlogic.gdx.utils.BufferUtils;
+import com.badlogic.gdx.utils.Disposable;
+import com.badlogic.gdx.utils.GdxRuntimeException;
+import com.badlogic.gdx.utils.StreamUtils;
 
 /** Generates {@link BitmapFont} and {@link BitmapFontData} instances from TrueType, OTF, and other FreeType supported fonts.</p>
  * 

--- a/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGenerator.java
+++ b/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGenerator.java
@@ -16,10 +16,6 @@
 
 package com.badlogic.gdx.graphics.g2d.freetype;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.ByteBuffer;
-
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.Color;
@@ -42,11 +38,11 @@ import com.badlogic.gdx.graphics.g2d.freetype.FreeType.SizeMetrics;
 import com.badlogic.gdx.graphics.g2d.freetype.FreeType.Stroker;
 import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.math.Rectangle;
-import com.badlogic.gdx.utils.Array;
-import com.badlogic.gdx.utils.BufferUtils;
-import com.badlogic.gdx.utils.Disposable;
-import com.badlogic.gdx.utils.GdxRuntimeException;
-import com.badlogic.gdx.utils.StreamUtils;
+import com.badlogic.gdx.utils.*;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
 
 /** Generates {@link BitmapFont} and {@link BitmapFontData} instances from TrueType, OTF, and other FreeType supported fonts.</p>
  * 

--- a/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGenerator.java
+++ b/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGenerator.java
@@ -26,7 +26,6 @@ import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.Pixmap.Blending;
 import com.badlogic.gdx.graphics.Pixmap.Format;
-import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.Texture.TextureFilter;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.graphics.g2d.BitmapFont.BitmapFontData;
@@ -162,13 +161,11 @@ public class FreeTypeFontGenerator implements Disposable {
 	 * @param parameter configures how the font is generated */
 	public BitmapFont generateFont (FreeTypeFontParameter parameter, FreeTypeBitmapFontData data) {
 		generateData(parameter, data);
-		Array<TextureRegion> regions;
-		if (parameter.packer != null) {
-			regions = parameter.packer.getTextureRegions(parameter.minFilter, parameter.magFilter, parameter.genMipMaps);
-		} else {
-			regions = data.regions;
+		if (data.regions == null && parameter.packer != null) {
+			data.regions = new Array<TextureRegion>();
+			parameter.packer.updateTextureRegions(data.regions, parameter.minFilter, parameter.magFilter, parameter.genMipMaps, false);
 		}
-		BitmapFont font = new BitmapFont(data, regions, false);
+		BitmapFont font = new BitmapFont(data, data.regions, false);
 		font.setOwnsTexture(parameter.packer == null);
 		return font;
 	}
@@ -388,9 +385,6 @@ public class FreeTypeFontGenerator implements Disposable {
 			packer = new PixmapPacker(size, size, Format.RGBA8888, 2, false);
 		}
 
-		// to minimize collisions we'll use this format : pathWithoutExtension_size[_flip]_glyph
-		String packPrefix = ownsAtlas ? "" : (name + '_' + parameter.size + (parameter.flip ? "_flip_" : '_'));
-
 		Stroker stroker = null;
 		if (parameter.borderWidth > 0) {
 			stroker = library.createStroker();
@@ -403,14 +397,13 @@ public class FreeTypeFontGenerator implements Disposable {
 			data.generator = this;
 			data.parameter = parameter;
 			data.stroker = stroker;
-			data.packPrefix = packPrefix;
 			data.packer = packer;
 			data.glyphs = new Array(charactersLength + 32);
 		}
 
 		for (int i = 0; i < charactersLength; i++) {
 			char c = characters.charAt(i);
-			Glyph glyph = createGlyph(c, data, parameter, stroker, baseLine, packPrefix, packer);
+			Glyph glyph = createGlyph(c, data, parameter, stroker, baseLine, packer);
 			if (glyph != null) {
 				data.setGlyph(c, glyph);
 				if (incremental) data.glyphs.add(glyph);
@@ -443,14 +436,15 @@ public class FreeTypeFontGenerator implements Disposable {
 
 		// Generate texture regions.
 		if (ownsAtlas) {
-			data.regions = packer.getTextureRegions(parameter.minFilter, parameter.magFilter, parameter.genMipMaps);
+			data.regions = new Array<TextureRegion>();
+			packer.updateTextureRegions(data.regions, parameter.minFilter, parameter.magFilter, parameter.genMipMaps, true);
 		}
 
 		return data;
 	}
 
 	Glyph createGlyph (char c, FreeTypeBitmapFontData data, FreeTypeFontParameter parameter, Stroker stroker, float baseLine,
-		String packPrefix, PixmapPacker packer) {
+		PixmapPacker packer) {
 
 		boolean missing = face.getCharIndex(c) == 0;
 		if (missing) {
@@ -537,29 +531,17 @@ public class FreeTypeFontGenerator implements Disposable {
 
 		}
 
-		String name = packPrefix + c;
-		Rectangle rect = packer.pack(name, mainPixmap);
+		Rectangle rect = packer.packDirectToTexture(mainPixmap);
 
 		// determine which page it was packed into
-		int pageIndex = packer.getPageIndex(name);
-		if (pageIndex == -1) // we should not get here
-			throw new IllegalStateException("Packer was not able to insert glyph into a page: " + name);
-
-		glyph.page = pageIndex;
+		glyph.page = packer.getPages().size - 1;
 		glyph.srcX = (int)rect.x;
 		glyph.srcY = (int)rect.y;
 
 		// If the data already has regions then this glyph is being added incrementally.
-		// Create a new texture for the new glyph or update the existing texture with the new glyph.
-		if (data.regions != null) {
-			if (pageIndex >= data.regions.size)
-				data.regions = packer.getTextureRegions(parameter.minFilter, parameter.magFilter, parameter.genMipMaps);
-			else {
-				Texture texture = data.regions.get(pageIndex).getTexture();
-				texture.bind();
-				Gdx.gl.glTexSubImage2D(texture.glTarget, 0, glyph.srcX, glyph.srcY, glyph.width, glyph.height,
-					mainPixmap.getGLFormat(), mainPixmap.getGLType(), mainPixmap.getPixels());
-			}
+		// Create a new texture for the new glyph if necessary.
+		if (data.regions != null && data.regions.size <= glyph.page) {
+			packer.updateTextureRegions(data.regions, parameter.minFilter, parameter.magFilter, parameter.genMipMaps, false);
 		}
 
 		mainPixmap.dispose();
@@ -610,7 +592,6 @@ public class FreeTypeFontGenerator implements Disposable {
 		FreeTypeFontGenerator generator;
 		FreeTypeFontParameter parameter;
 		Stroker stroker;
-		String packPrefix;
 		PixmapPacker packer;
 		Array<Glyph> glyphs;
 
@@ -619,7 +600,7 @@ public class FreeTypeFontGenerator implements Disposable {
 			Glyph glyph = super.getGlyph(ch);
 			if (glyph == null && generator != null && ch != 0) {
 				generator.setPixelSizes(0, parameter.size);
-				glyph = generator.createGlyph(ch, this, parameter, stroker, (ascent + capHeight) / scaleY, packPrefix, packer);
+				glyph = generator.createGlyph(ch, this, parameter, stroker, (ascent + capHeight) / scaleY, packer);
 				if (glyph == null) return null;
 
 				setGlyph(ch, glyph);

--- a/gdx/src/com/badlogic/gdx/graphics/Color.java
+++ b/gdx/src/com/badlogic/gdx/graphics/Color.java
@@ -43,8 +43,6 @@ public class Color {
 	public static final Color TEAL = new Color(0, 0.5f, 0.5f, 1);
 	public static final Color NAVY = new Color(0, 0, 0.5f, 1);
 
-	@Deprecated public static Color tmp = new Color();
-
 	/** the red, green, blue and alpha components **/
 	public float r, g, b, a;
 
@@ -456,13 +454,6 @@ public class Color {
 		color.r = ((value & 0x00ff0000) >>> 16) / 255f;
 		color.g = ((value & 0x0000ff00) >>> 8) / 255f;
 		color.b = ((value & 0x000000ff)) / 255f;
-	}
-
-	/** Returns a temporary copy of this color. This is not thread safe, do not save a reference to this instance.
-	 * 
-	 * @return a temporary copy of this color */
-	public Color tmp () {
-		return tmp.set(this);
 	}
 
 	/** @return a copy of this color */

--- a/gdx/src/com/badlogic/gdx/graphics/Cubemap.java
+++ b/gdx/src/com/badlogic/gdx/graphics/Cubemap.java
@@ -89,9 +89,9 @@ public class Cubemap extends GLTexture {
 	/** Construct a Cubemap with the specified texture files for the sides, optionally generating mipmaps. */
 	public Cubemap (FileHandle positiveX, FileHandle negativeX, FileHandle positiveY, FileHandle negativeY, FileHandle positiveZ,
 		FileHandle negativeZ, boolean useMipMaps) {
-		this(createTextureData(positiveX, useMipMaps), createTextureData(negativeX, useMipMaps), createTextureData(positiveY,
-			useMipMaps), createTextureData(negativeY, useMipMaps), createTextureData(positiveZ, useMipMaps), createTextureData(
-			negativeZ, useMipMaps));
+		this(TextureData.Factory.loadFromFile(positiveX, useMipMaps), TextureData.Factory.loadFromFile(negativeX, useMipMaps),
+			TextureData.Factory.loadFromFile(positiveY, useMipMaps), TextureData.Factory.loadFromFile(negativeY, useMipMaps),
+			TextureData.Factory.loadFromFile(positiveZ, useMipMaps), TextureData.Factory.loadFromFile(negativeZ, useMipMaps));
 	}
 
 	/** Construct a Cubemap with the specified {@link Pixmap}s for the sides, does not generate mipmaps. */
@@ -151,7 +151,7 @@ public class Cubemap extends GLTexture {
 	@Override
 	protected void reload () {
 		if (!isManaged()) throw new GdxRuntimeException("Tried to reload an unmanaged Cubemap");
-		glHandle = createGLHandle();
+		glHandle = Gdx.gl.glGenTexture();
 		load(data);
 	}
 
@@ -243,7 +243,7 @@ public class Cubemap extends GLTexture {
 
 					// unload the c, create a new gl handle then reload it.
 					assetManager.unload(fileName);
-					cubemap.glHandle = GLTexture.createGLHandle();
+					cubemap.glHandle = Gdx.gl.glGenTexture();
 					assetManager.load(fileName, Cubemap.class, params);
 				}
 			}

--- a/gdx/src/com/badlogic/gdx/graphics/GLTexture.java
+++ b/gdx/src/com/badlogic/gdx/graphics/GLTexture.java
@@ -17,9 +17,7 @@
 package com.badlogic.gdx.graphics;
 
 import com.badlogic.gdx.Gdx;
-import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.Pixmap.Blending;
-import com.badlogic.gdx.graphics.Pixmap.Format;
 import com.badlogic.gdx.graphics.Texture.TextureFilter;
 import com.badlogic.gdx.graphics.Texture.TextureWrap;
 import com.badlogic.gdx.graphics.TextureData.TextureDataType;
@@ -179,24 +177,6 @@ public abstract class GLTexture implements Disposable {
 		delete();
 	}
 
-	/** @deprecated Use {@link TextureData.Factory#loadFromFile(FileHandle, Format, boolean)} instead. */
-	@Deprecated
-	protected static TextureData createTextureData (FileHandle file, Format format, boolean useMipMaps) {
-		return TextureData.Factory.loadFromFile(file, format, useMipMaps);
-	}
-
-	/** @deprecated Use {@link TextureData.Factory#loadFromFile(FileHandle, boolean)} instead. */
-	@Deprecated
-	protected static TextureData createTextureData (FileHandle file, boolean useMipMaps) {
-		return createTextureData(file, null, useMipMaps);
-	}
-
-	/** @deprecated Use {@link GL20#glGenTexture()} instead. */
-	@Deprecated
-	protected static int createGLHandle () {
-		return Gdx.gl.glGenTexture ();
-	}
-	
 	protected static void uploadImageData (int target, TextureData data) {
 		uploadImageData(target, data, 0);
 	}

--- a/gdx/src/com/badlogic/gdx/graphics/Texture.java
+++ b/gdx/src/com/badlogic/gdx/graphics/Texture.java
@@ -16,6 +16,9 @@
 
 package com.badlogic.gdx.graphics;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import com.badlogic.gdx.Application;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.assets.AssetLoaderParameters.LoadedCallback;
@@ -24,15 +27,9 @@ import com.badlogic.gdx.assets.loaders.AssetLoader;
 import com.badlogic.gdx.assets.loaders.TextureLoader.TextureParameter;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.Pixmap.Format;
-import com.badlogic.gdx.graphics.glutils.ETC1TextureData;
-import com.badlogic.gdx.graphics.glutils.FileTextureData;
-import com.badlogic.gdx.graphics.glutils.KTXTextureData;
 import com.badlogic.gdx.graphics.glutils.PixmapTextureData;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.GdxRuntimeException;
-
-import java.util.HashMap;
-import java.util.Map;
 
 /** A Texture wraps a standard OpenGL ES texture.
  * <p>
@@ -100,7 +97,7 @@ public class Texture extends GLTexture {
 	}
 
 	public Texture (FileHandle file, Format format, boolean useMipMaps) {
-		this(createTextureData(file, format, useMipMaps));
+		this(TextureData.Factory.loadFromFile(file, format, useMipMaps));
 	}
 
 	public Texture (Pixmap pixmap) {
@@ -120,7 +117,7 @@ public class Texture extends GLTexture {
 	}
 
 	public Texture (TextureData data) {
-		super(GL20.GL_TEXTURE_2D, createGLHandle());
+		super(GL20.GL_TEXTURE_2D, Gdx.gl.glGenTexture());
 		load(data);
 		if (data.isManaged()) addManagedTexture(Gdx.app, this);
 	}
@@ -145,7 +142,7 @@ public class Texture extends GLTexture {
 	@Override
 	protected void reload () {
 		if (!isManaged()) throw new GdxRuntimeException("Tried to reload unmanaged Texture");
-		glHandle = createGLHandle();
+		glHandle = Gdx.gl.glGenTexture();
 		load(data);
 	}
 
@@ -261,7 +258,7 @@ public class Texture extends GLTexture {
 
 					// unload the texture, create a new gl handle then reload it.
 					assetManager.unload(fileName);
-					texture.glHandle = Texture.createGLHandle();
+					texture.glHandle = Gdx.gl.glGenTexture();
 					assetManager.load(fileName, Texture.class, params);
 				}
 			}

--- a/gdx/src/com/badlogic/gdx/graphics/VertexAttribute.java
+++ b/gdx/src/com/badlogic/gdx/graphics/VertexAttribute.java
@@ -89,19 +89,13 @@ public final class VertexAttribute {
 	public static VertexAttribute Normal () {
 		return new VertexAttribute(Usage.Normal, 3, ShaderProgram.NORMAL_ATTRIBUTE);
 	}
-
-	/** @deprecated use {@link #ColorPacked()} */
-	@Deprecated
-	public static VertexAttribute Color () {
-		return ColorPacked();
-	}
 	
 	public static VertexAttribute ColorPacked () {
 		return new VertexAttribute(Usage.ColorPacked, 4, GL20.GL_UNSIGNED_BYTE, true, ShaderProgram.COLOR_ATTRIBUTE);
 	}
 
 	public static VertexAttribute ColorUnpacked () {
-		return new VertexAttribute(Usage.Color, 4, GL20.GL_FLOAT, false, ShaderProgram.COLOR_ATTRIBUTE);
+		return new VertexAttribute(Usage.ColorUnpacked, 4, GL20.GL_FLOAT, false, ShaderProgram.COLOR_ATTRIBUTE);
 	}
 
 	public static VertexAttribute Tangent () {

--- a/gdx/src/com/badlogic/gdx/graphics/VertexAttributes.java
+++ b/gdx/src/com/badlogic/gdx/graphics/VertexAttributes.java
@@ -31,8 +31,6 @@ public final class VertexAttributes implements Iterable<VertexAttribute>, Compar
 	 * @author mzechner */
 	public static final class Usage {
 		public static final int Position = 1;
-		/** @deprecated use {@link #ColorUnpacked} instead. */
-		@Deprecated public static final int Color = 2;
 		public static final int ColorUnpacked = 2;
 		public static final int ColorPacked = 4;
 		public static final int Normal = 8;

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/PixmapPacker.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/PixmapPacker.java
@@ -363,10 +363,13 @@ public class PixmapPacker implements Disposable {
 
 	/** Return an ordered array of texture regions corresponding with the pages of the packer, creating new textures
 	 * if necessary.  The same array will be returned from successive calls to this method, possibly modified with
-	 * additional texture regions if more pages have been added since the last call.
+	 * additional texture regions if more pages have been added since the last call.  Once this method has been called,
+	 * you must dispose of the resulting texture regions (or equivalently, any atlas generated or updated by this packer)
+	 * yourself - disposing the PixmapPacker will no longer dispose these textures or their backing pixmaps.
 	 */
 	public Array<TextureRegion> getTextureRegions(TextureFilter minFilter, TextureFilter magFilter, boolean useMipMaps) {
 		while (textureRegions.size < pages.size) {
+			if (disposed) return null;
 			Page page = pages.get(textureRegions.size);
 			if (page.texture == null) {
 				generatePageTexture(page, minFilter, magFilter, useMipMaps);

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/loader/ObjLoader.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/loader/ObjLoader.java
@@ -90,27 +90,6 @@ public class ObjLoader extends ModelLoader<ObjLoader.ObjLoaderParameters> {
 		super(resolver);
 	}
 
-	/** @deprecated Use {@link ObjLoader#loadModel(FileHandle)} instead.
-	 *             <p>
-	 *             Loads a Wavefront OBJ file from a given file handle.
-	 * 
-	 * @param file the FileHandle */
-	@Deprecated
- 	public Model loadObj (FileHandle file) {
-		return loadModel(file);
-	}
-
-	/** @deprecated Use {@link ObjLoader#loadModel(FileHandle, boolean)} instead.
-	 *             <p>
-	 *             Loads a Wavefront OBJ file from a given file handle.
-	 * 
-	 * @param file the FileHandle
-	 * @param flipV whether to flip the v texture coordinate (Blender, Wings3D, et al) */
-	@Deprecated
- 	public Model loadObj (FileHandle file, boolean flipV) {
-		return loadModel(file, flipV);
-	}
-
 	/** Directly load the model on the calling thread. The model with not be managed by an {@link AssetManager}. */
 	public Model loadModel (final FileHandle fileHandle, boolean flipV) {
 		return loadModel(fileHandle, new ObjLoaderParameters(flipV));

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/model/Node.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/model/Node.java
@@ -31,10 +31,6 @@ import com.badlogic.gdx.utils.GdxRuntimeException;
 public class Node {
 	/** the id, may be null, FIXME is this unique? **/
 	public String id;
-	/** @deprecated Use {@link #getParent()} instead. **/
-	@Deprecated public Node parent; // TODO: Make private
-	/** @deprecated Use {@link #getChildren()} instead. **/
-	@Deprecated public final Array<Node> children = new Array<Node>(2); // TODO: Make private
 	/** Whether this node should inherit the transformation of its parent node, defaults to true. When this flag is false the value
 	 * of {@link #globalTransform} will be the same as the value of {@link #localTransform} causing the transform to be independent
 	 * of its parent transform. */
@@ -54,6 +50,9 @@ public class Node {
 	public final Matrix4 globalTransform = new Matrix4();
 
 	public Array<NodePart> parts = new Array<NodePart>(2);
+	
+	private Node parent;
+	private final Array<Node> children = new Array<Node>(2);
 
 	/** Calculates the local transform based on the translation, scale and rotation
 	 * @return the local transform */

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/particles/batches/BillboardParticleBatch.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/particles/batches/BillboardParticleBatch.java
@@ -44,7 +44,7 @@ public class BillboardParticleBatch extends BufferedParticleBatch<BillboardContr
 	private static final VertexAttributes 
 		GPU_ATTRIBUTES = new VertexAttributes(new VertexAttribute(Usage.Position, 3, ShaderProgram.POSITION_ATTRIBUTE), 
 															new VertexAttribute(Usage.TextureCoordinates, 2, ShaderProgram.TEXCOORD_ATTRIBUTE+"0"), 
-															new VertexAttribute(Usage.Color, 4, ShaderProgram.COLOR_ATTRIBUTE), 
+															new VertexAttribute(Usage.ColorUnpacked, 4, ShaderProgram.COLOR_ATTRIBUTE), 
 															new VertexAttribute(sizeAndRotationUsage, 4, "a_sizeAndRotation")),
 															/*
 		GPU_EXT_ATTRIBUTES = new VertexAttributes(new VertexAttribute(Usage.Position, 3, ShaderProgram.POSITION_ATTRIBUTE), 
@@ -55,13 +55,13 @@ public class BillboardParticleBatch extends BufferedParticleBatch<BillboardContr
 									*/
 		CPU_ATTRIBUTES = new VertexAttributes(	new VertexAttribute(Usage.Position, 3, ShaderProgram.POSITION_ATTRIBUTE), 
 															new VertexAttribute(Usage.TextureCoordinates, 2, ShaderProgram.TEXCOORD_ATTRIBUTE+"0"), 
-															new VertexAttribute(Usage.Color, 4, ShaderProgram.COLOR_ATTRIBUTE) );
+															new VertexAttribute(Usage.ColorUnpacked, 4, ShaderProgram.COLOR_ATTRIBUTE) );
 	
 	//Offsets
 	private static final int 	GPU_POSITION_OFFSET = (short)(GPU_ATTRIBUTES.findByUsage(Usage.Position).offset/4),
 										GPU_UV_OFFSET = (short)(GPU_ATTRIBUTES.findByUsage(Usage.TextureCoordinates).offset/4),
 										GPU_SIZE_ROTATION_OFFSET = (short)(GPU_ATTRIBUTES.findByUsage(sizeAndRotationUsage).offset/4),
-										GPU_COLOR_OFFSET = (short)(GPU_ATTRIBUTES.findByUsage(Usage.Color).offset/4),
+										GPU_COLOR_OFFSET = (short)(GPU_ATTRIBUTES.findByUsage(Usage.ColorUnpacked).offset/4),
 										GPU_VERTEX_SIZE = GPU_ATTRIBUTES.vertexSize/4,
 
 										//Ext
@@ -77,7 +77,7 @@ public class BillboardParticleBatch extends BufferedParticleBatch<BillboardContr
 										//Cpu
 										CPU_POSITION_OFFSET = (short)(CPU_ATTRIBUTES.findByUsage(Usage.Position).offset/4),
 										CPU_UV_OFFSET = (short)(CPU_ATTRIBUTES.findByUsage(Usage.TextureCoordinates).offset/4),
-										CPU_COLOR_OFFSET = (short)(CPU_ATTRIBUTES.findByUsage(Usage.Color).offset/4),
+										CPU_COLOR_OFFSET = (short)(CPU_ATTRIBUTES.findByUsage(Usage.ColorUnpacked).offset/4),
 										CPU_VERTEX_SIZE= CPU_ATTRIBUTES.vertexSize/4;
 	private final static int 	MAX_PARTICLES_PER_MESH = Short.MAX_VALUE/4,
 										MAX_VERTICES_PER_MESH = MAX_PARTICLES_PER_MESH*4;

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/particles/batches/PointSpriteParticleBatch.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/particles/batches/PointSpriteParticleBatch.java
@@ -34,12 +34,12 @@ public class PointSpriteParticleBatch extends BufferedParticleBatch<PointSpriteC
 	protected static final int sizeAndRotationUsage = 1 << 9;
 	protected static final VertexAttributes CPU_ATTRIBUTES = new VertexAttributes(
 		new VertexAttribute(Usage.Position, 3, ShaderProgram.POSITION_ATTRIBUTE),
-		new VertexAttribute(Usage.Color, 4, ShaderProgram.COLOR_ATTRIBUTE),
+		new VertexAttribute(Usage.ColorUnpacked, 4, ShaderProgram.COLOR_ATTRIBUTE),
 		new VertexAttribute(Usage.TextureCoordinates, 4, "a_region"),
 		new VertexAttribute(sizeAndRotationUsage, 3, "a_sizeAndRotation"));
 	protected static final int CPU_VERTEX_SIZE = (short)(CPU_ATTRIBUTES.vertexSize / 4),
 										CPU_POSITION_OFFSET = (short)(CPU_ATTRIBUTES.findByUsage(Usage.Position).offset/4),
-										CPU_COLOR_OFFSET = (short)(CPU_ATTRIBUTES.findByUsage(Usage.Color).offset/4),
+										CPU_COLOR_OFFSET = (short)(CPU_ATTRIBUTES.findByUsage(Usage.ColorUnpacked).offset/4),
 										CPU_REGION_OFFSET = (short)(CPU_ATTRIBUTES.findByUsage(Usage.TextureCoordinates).offset/4),
 										CPU_SIZE_AND_ROTATION_OFFSET = (short)(CPU_ATTRIBUTES.findByUsage(sizeAndRotationUsage).offset/4);
 

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/particles/values/MeshSpawnShapeValue.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/particles/values/MeshSpawnShapeValue.java
@@ -14,7 +14,7 @@ import com.badlogic.gdx.utils.GdxRuntimeException;
 /** The base class of all the {@link ParticleValue} values which spawn a particle on a mesh shape.
 * @author Inferno */
 public abstract class MeshSpawnShapeValue extends SpawnShapeValue {
-	protected static class Triangle{
+	public static class Triangle{
 		float x1, y1, z1,
 				x2, y2, z2,
 				x3, y3, z3;

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/DefaultShader.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/DefaultShader.java
@@ -593,7 +593,7 @@ public class DefaultShader extends BaseShader {
 		final long attributesMask = attributes.getMask();
 		final long vertexMask = renderable.mesh.getVertexAttributes().getMask();
 		if (and(vertexMask, Usage.Position)) prefix += "#define positionFlag\n";
-		if (or(vertexMask, Usage.Color | Usage.ColorPacked)) prefix += "#define colorFlag\n";
+		if (or(vertexMask, Usage.ColorUnpacked | Usage.ColorPacked)) prefix += "#define colorFlag\n";
 		if (and(vertexMask, Usage.BiNormal)) prefix += "#define binormalFlag\n";
 		if (and(vertexMask, Usage.Tangent)) prefix += "#define tangentFlag\n";
 		if (and(vertexMask, Usage.Normal)) prefix += "#define normalFlag\n";

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/utils/MeshBuilder.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/utils/MeshBuilder.java
@@ -119,7 +119,7 @@ public class MeshBuilder implements MeshPartBuilder {
 		final Array<VertexAttribute> attrs = new Array<VertexAttribute>();
 		if ((usage & Usage.Position) == Usage.Position)
 			attrs.add(new VertexAttribute(Usage.Position, 3, ShaderProgram.POSITION_ATTRIBUTE));
-		if ((usage & Usage.Color) == Usage.Color) attrs.add(new VertexAttribute(Usage.Color, 4, ShaderProgram.COLOR_ATTRIBUTE));
+		if ((usage & Usage.ColorUnpacked) == Usage.ColorUnpacked) attrs.add(new VertexAttribute(Usage.ColorUnpacked, 4, ShaderProgram.COLOR_ATTRIBUTE));
 		if ((usage & Usage.ColorPacked) == Usage.ColorPacked)
 			attrs.add(new VertexAttribute(Usage.ColorPacked, 4, ShaderProgram.COLOR_ATTRIBUTE));
 		if ((usage & Usage.Normal) == Usage.Normal)
@@ -170,7 +170,7 @@ public class MeshBuilder implements MeshPartBuilder {
 		posSize = a.numComponents;
 		a = attributes.findByUsage(Usage.Normal);
 		norOffset = a == null ? -1 : a.offset / 4;
-		a = attributes.findByUsage(Usage.Color);
+		a = attributes.findByUsage(Usage.ColorUnpacked);
 		colOffset = a == null ? -1 : a.offset / 4;
 		colSize = a == null ? 0 : a.numComponents;
 		a = attributes.findByUsage(Usage.ColorPacked);

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/utils/ModelBuilder.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/utils/ModelBuilder.java
@@ -19,7 +19,6 @@ package com.badlogic.gdx.graphics.g3d.utils;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Mesh;
-import com.badlogic.gdx.graphics.VertexAttribute;
 import com.badlogic.gdx.graphics.VertexAttributes;
 import com.badlogic.gdx.graphics.g3d.Material;
 import com.badlogic.gdx.graphics.g3d.Model;
@@ -378,47 +377,6 @@ public class ModelBuilder {
 		}
 		for (final Node child : node.getChildren())
 			rebuildReferences(model, child);
-	}
-
-	// Old code below this line, as for now still useful for testing.
-	@Deprecated
-	public static Model createFromMesh (final Mesh mesh, int primitiveType, final Material material) {
-		return createFromMesh(mesh, 0, mesh.getNumIndices(), primitiveType, material);
-	}
-
-	@Deprecated
-	public static Model createFromMesh (final Mesh mesh, int indexOffset, int vertexCount, int primitiveType,
-		final Material material) {
-		Model result = new Model();
-		MeshPart meshPart = new MeshPart();
-		meshPart.id = "part1";
-		meshPart.indexOffset = indexOffset;
-		meshPart.numVertices = vertexCount;
-		meshPart.primitiveType = primitiveType;
-		meshPart.mesh = mesh;
-
-		NodePart partMaterial = new NodePart();
-		partMaterial.material = material;
-		partMaterial.meshPart = meshPart;
-		Node node = new Node();
-		node.id = "node1";
-		node.parts.add(partMaterial);
-
-		result.meshes.add(mesh);
-		result.materials.add(material);
-		result.nodes.add(node);
-		result.meshParts.add(meshPart);
-		result.manageDisposable(mesh);
-		return result;
-	}
-
-	@Deprecated
-	public static Model createFromMesh (final float[] vertices, final VertexAttribute[] attributes, final short[] indices,
-		int primitiveType, final Material material) {
-		final Mesh mesh = new Mesh(false, vertices.length, indices.length, attributes);
-		mesh.setVertices(vertices);
-		mesh.setIndices(indices);
-		return createFromMesh(mesh, 0, indices.length, primitiveType, material);
 	}
 
 	/** Convenience method to create a model with three orthonormal vectors shapes. The resources the Material might contain are not

--- a/gdx/src/com/badlogic/gdx/math/Frustum.java
+++ b/gdx/src/com/badlogic/gdx/math/Frustum.java
@@ -38,6 +38,8 @@ public class Frustum {
 			clipSpacePlanePointsArray[j++] = v.z;
 		}
 	}
+	
+	private final static Vector3 tmpV = new Vector3();
 
 	/** the six clipping planes, near, far, left, right, top, bottom **/
 	public final Plane[] planes = new Plane[6];
@@ -155,16 +157,16 @@ public class Frustum {
 	 * @param bounds The bounding box
 	 * @return Whether the bounding box is in the frustum */
 	public boolean boundsInFrustum (BoundingBox bounds) {
-		Vector3[] corners = bounds.getCorners();
-		int len = corners.length;
-
 		for (int i = 0, len2 = planes.length; i < len2; i++) {
-			int out = 0;
-
-			for (int j = 0; j < len; j++)
-				if (planes[i].testPoint(corners[j]) == PlaneSide.Back) out++;
-
-			if (out == 8) return false;
+			if (planes[i].testPoint(bounds.getCorner000(tmpV)) != PlaneSide.Back) continue;
+			if (planes[i].testPoint(bounds.getCorner001(tmpV)) != PlaneSide.Back) continue;
+			if (planes[i].testPoint(bounds.getCorner010(tmpV)) != PlaneSide.Back) continue;
+			if (planes[i].testPoint(bounds.getCorner011(tmpV)) != PlaneSide.Back) continue;
+			if (planes[i].testPoint(bounds.getCorner100(tmpV)) != PlaneSide.Back) continue;
+			if (planes[i].testPoint(bounds.getCorner101(tmpV)) != PlaneSide.Back) continue;
+			if (planes[i].testPoint(bounds.getCorner110(tmpV)) != PlaneSide.Back) continue;
+			if (planes[i].testPoint(bounds.getCorner111(tmpV)) != PlaneSide.Back) continue;
+			return false;
 		}
 
 		return true;

--- a/gdx/src/com/badlogic/gdx/math/Intersector.java
+++ b/gdx/src/com/badlogic/gdx/math/Intersector.java
@@ -16,13 +16,13 @@
 
 package com.badlogic.gdx.math;
 
+import java.util.Arrays;
+import java.util.List;
+
 import com.badlogic.gdx.math.Plane.PlaneSide;
 import com.badlogic.gdx.math.collision.BoundingBox;
 import com.badlogic.gdx.math.collision.Ray;
 import com.badlogic.gdx.utils.Array;
-
-import java.util.Arrays;
-import java.util.List;
 
 /** Class offering various static methods for intersection testing between different geometric objects.
  * 
@@ -460,7 +460,7 @@ public final class Intersector {
 	 * @param box The bounding box
 	 * @return Whether the ray and the bounding box intersect. */
 	static public boolean intersectRayBoundsFast (Ray ray, BoundingBox box) {
-		return intersectRayBoundsFast(ray, box.getCenter(), box.getDimensions());
+		return intersectRayBoundsFast(ray, box.getCenter(tmp1), box.getDimensions(tmp2));
 	}
 
 	/** Quick check whether the given {@link Ray} and {@link BoundingBox} intersect.

--- a/gdx/src/com/badlogic/gdx/math/Matrix4.java
+++ b/gdx/src/com/badlogic/gdx/math/Matrix4.java
@@ -70,8 +70,7 @@ public class Matrix4 implements Serializable {
 	/** WW: Typically the value one. On Vector3 multiplication this value is ignored. */
 	public static final int M33 = 15;
 
-	/** @Deprecated Do not use this member, instead use a temporary Matrix4 instance, or create a temporary float array. */
-	@Deprecated public static final float tmp[] = new float[16]; // FIXME Change to private access
+	private static final float tmp[] = new float[16];
 	public final float val[] = new float[16];
 
 	/** Constructs an identity matrix */

--- a/gdx/src/com/badlogic/gdx/math/collision/BoundingBox.java
+++ b/gdx/src/com/badlogic/gdx/math/collision/BoundingBox.java
@@ -37,15 +37,6 @@ public class BoundingBox implements Serializable {
 	private final Vector3 cnt = new Vector3();
 	private final Vector3 dim = new Vector3();
 
-	@Deprecated private Vector3[] corners;
-
-	/** @deprecated Use {@link #getCenter(Vector3)}
-	 * @return the center of the bounding box */
-	@Deprecated
-	public Vector3 getCenter () {
-		return cnt;
-	}
-
 	/** @param out The {@link Vector3} to receive the center of the bounding box.
 	 * @return The vector specified with the out argument. */
 	public Vector3 getCenter (Vector3 out) {
@@ -62,30 +53,6 @@ public class BoundingBox implements Serializable {
 
 	public float getCenterZ () {
 		return cnt.z;
-	}
-
-	@Deprecated
-	protected void updateCorners () {
-	}
-
-	/** @deprecated Use the getCornerXYZ methods instead
-	 * @return the corners of this bounding box */
-	@Deprecated
-	public Vector3[] getCorners () {
-		if (corners == null) {
-			corners = new Vector3[8];
-			for (int i = 0; i < 8; i++)
-				corners[i] = new Vector3();
-		}
-		corners[0].set(min.x, min.y, min.z);
-		corners[1].set(max.x, min.y, min.z);
-		corners[2].set(max.x, max.y, min.z);
-		corners[3].set(min.x, max.y, min.z);
-		corners[4].set(min.x, min.y, max.z);
-		corners[5].set(max.x, min.y, max.z);
-		corners[6].set(max.x, max.y, max.z);
-		corners[7].set(min.x, max.y, max.z);
-		return corners;
 	}
 
 	public Vector3 getCorner000 (final Vector3 out) {
@@ -120,13 +87,6 @@ public class BoundingBox implements Serializable {
 		return out.set(max.x, max.y, max.z);
 	}
 
-	/** @deprecated Use {@link #getDimensions(Vector3)} instead
-	 * @return The dimensions of this bounding box on all three axis */
-	@Deprecated
-	public Vector3 getDimensions () {
-		return dim;
-	}
-
 	/** @param out The {@link Vector3} to receive the dimensions of this bounding box on all three axis.
 	 * @return The vector specified with the out argument */
 	public Vector3 getDimensions (final Vector3 out) {
@@ -145,24 +105,10 @@ public class BoundingBox implements Serializable {
 		return dim.z;
 	}
 
-	/** @deprecated Use {@link #getMin(Vector3)} instead.
-	 * @return The minimum vector */
-	@Deprecated
-	public Vector3 getMin () {
-		return min;
-	}
-
 	/** @param out The {@link Vector3} to receive the minimum values.
 	 * @return The vector specified with the out argument */
 	public Vector3 getMin (final Vector3 out) {
 		return out.set(min);
-	}
-
-	/** @deprecated Use {@link #getMax(Vector3)} instead
-	 * @return The maximum vector */
-	@Deprecated
-	public Vector3 getMax () {
-		return max;
 	}
 
 	/** @param out The {@link Vector3} to receive the maximum values.

--- a/gdx/src/com/badlogic/gdx/math/collision/Ray.java
+++ b/gdx/src/com/badlogic/gdx/math/collision/Ray.java
@@ -43,15 +43,6 @@ public class Ray implements Serializable {
 		return new Ray(this.origin, this.direction);
 	}
 
-	/** @deprecated Use {@link #getEndPoint(Vector3, float)} instead. Returns the endpoint given the distance. This is calculated as
-	 *             startpoint + distance * direction.
-	 * @param distance The distance from the end point to the start point.
-	 * @return The end point */
-	@Deprecated
-	public Vector3 getEndPoint (float distance) {
-		return getEndPoint(new Vector3(), distance);
-	}
-
 	/** Returns the endpoint given the distance. This is calculated as startpoint + distance * direction.
 	 * @param out The vector to set to the result
 	 * @param distance The distance from the end point to the start point.

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/Event.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/Event.java
@@ -43,7 +43,7 @@ public class Event implements Poolable {
 	private boolean cancelled; // true means propagation was stopped and any action that this event would cause should not happen
 
 	/** Marks this event as handled. This does not affect event propagation inside scene2d, but causes the {@link Stage} event
-	 * methods to return false, which will eat the event so it is not passed on to the application under the stage. */
+	 * methods to return true, which will eat the event so it is not passed on to the application under the stage. */
 	public void handle () {
 		handled = true;
 	}

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/SpriteDrawable.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/SpriteDrawable.java
@@ -43,6 +43,7 @@ public class SpriteDrawable extends BaseDrawable implements TransformDrawable {
 		draw(batch, x, y, width / 2f, height / 2f, width, height, 1f, 1f, 0f);
 	}
 
+	private static Color tmpColor = new Color();
 	public void draw (Batch batch, float x, float y, float originX, float originY, float width, float height, float scaleX,
 		float scaleY, float rotation) {
 		sprite.setOrigin(originX, originY);
@@ -50,7 +51,7 @@ public class SpriteDrawable extends BaseDrawable implements TransformDrawable {
 		sprite.setScale(scaleX, scaleY);
 		sprite.setBounds(x, y, width, height);
 		Color color = sprite.getColor();
-		sprite.setColor(Color.tmp.set(color).mul(batch.getColor()));
+		sprite.setColor(tmpColor.set(color).mul(batch.getColor()));
 		sprite.draw(batch);
 		sprite.setColor(color);
 	}

--- a/gdx/src/com/badlogic/gdx/utils/JsonWriter.java
+++ b/gdx/src/com/badlogic/gdx/utils/JsonWriter.java
@@ -78,7 +78,7 @@ public class JsonWriter extends Writer {
 	public JsonWriter value (Object value) throws IOException {
 		if (quoteLongValues
 			&& (value instanceof Long || value instanceof Double || value instanceof BigDecimal || value instanceof BigInteger)) {
-			value = String.valueOf(value);
+			value = value.toString();
 		} else if (value instanceof Number) {
 			Number number = (Number)value;
 			long longValue = number.longValue();
@@ -183,9 +183,10 @@ public class JsonWriter extends Writer {
 		static private Pattern minimalValuePattern = Pattern.compile("^[^\":,{\\[\\]/ ][^}\\],]*$");
 
 		public String quoteValue (Object value) {
-			if (value == null || value instanceof Number || value instanceof Boolean) return String.valueOf(value);
-			String string = String.valueOf(value).replace("\\", "\\\\").replace("\r", "\\r").replace("\n", "\\n")
-				.replace("\t", "\\t");
+			if (value == null) return "null";
+			String string = value.toString();
+			if (value instanceof Number || value instanceof Boolean) return string;
+			string = string.replace("\\", "\\\\").replace("\r", "\\r").replace("\n", "\\n").replace("\t", "\\t");
 			if (this == OutputType.minimal && !string.equals("true") && !string.equals("false") && !string.equals("null")
 				&& !string.contains("//") && !string.contains("/*")) {
 				int length = string.length();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/EdgeDetectionTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/EdgeDetectionTest.java
@@ -67,7 +67,7 @@ public class EdgeDetectionTest extends GdxTest {
 		}
 
 		ObjLoader objLoader = new ObjLoader();
-		scene = objLoader.loadObj(Gdx.files.internal("data/scene.obj"));
+		scene = objLoader.loadModel(Gdx.files.internal("data/scene.obj"));
 		sceneInstance = new ModelInstance(scene);
 		modelBatch = new ModelBatch();
 		fbo = new FrameBuffer(Format.RGB565, Gdx.graphics.getWidth(), Gdx.graphics.getHeight(), true);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/FloatTextureTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/FloatTextureTest.java
@@ -139,7 +139,7 @@ public class FloatTextureTest extends GdxTest {
 
 	private void createQuad () {
 		if (quad != null) return;
-		quad = new Mesh(true, 4, 6, new VertexAttribute(Usage.Position, 3, "a_position"), new VertexAttribute(Usage.Color, 4,
+		quad = new Mesh(true, 4, 6, new VertexAttribute(Usage.Position, 3, "a_position"), new VertexAttribute(Usage.ColorUnpacked, 4,
 			"a_color"), new VertexAttribute(Usage.TextureCoordinates, 2, "a_texCoords"));
 
 		quad.setVertices(new float[] {-1, -1, 0, 1, 1, 1, 1, 0, 1, 1, -1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 0, -1, 1, 0,
@@ -149,7 +149,7 @@ public class FloatTextureTest extends GdxTest {
 
 	private void createScreenQuad () {
 		if (screenQuad != null) return;
-		screenQuad = new Mesh(true, 4, 6, new VertexAttribute(Usage.Position, 3, "a_position"), new VertexAttribute(Usage.Color, 4,
+		screenQuad = new Mesh(true, 4, 6, new VertexAttribute(Usage.Position, 3, "a_position"), new VertexAttribute(Usage.ColorUnpacked, 4,
 			"a_color"), new VertexAttribute(Usage.TextureCoordinates, 2, "a_texCoords"));
 
 		Vector3 vec0 = new Vector3(0, 0, 0);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/FramebufferToTextureTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/FramebufferToTextureTest.java
@@ -52,7 +52,7 @@ public class FramebufferToTextureTest extends GdxTest {
 		texture = new Texture(Gdx.files.internal("data/badlogic.jpg"), true);
 		texture.setFilter(TextureFilter.MipMap, TextureFilter.Linear);
 		ObjLoader objLoader = new ObjLoader();
-		mesh = objLoader.loadObj(Gdx.files.internal("data/cube.obj"));
+		mesh = objLoader.loadModel(Gdx.files.internal("data/cube.obj"));
 		mesh.materials.get(0).set(new TextureAttribute(TextureAttribute.Diffuse, texture));
 		modelInstance = new ModelInstance(mesh);
 		modelBatch = new ModelBatch();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/PixmapPackerTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/PixmapPackerTest.java
@@ -17,52 +17,95 @@
 package com.badlogic.gdx.tests;
 
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Input;
+import com.badlogic.gdx.InputAdapter;
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.Pixmap.Format;
-import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.Texture.TextureFilter;
 import com.badlogic.gdx.graphics.g2d.PixmapPacker;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.graphics.g2d.TextureAtlas;
+import com.badlogic.gdx.graphics.g2d.TextureRegion;
+import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
 import com.badlogic.gdx.tests.utils.GdxTest;
+import com.badlogic.gdx.utils.Array;
 
 public class PixmapPackerTest extends GdxTest {
 
 	OrthographicCamera camera;
 	SpriteBatch batch;
+    ShapeRenderer shapeRenderer;
 
-	Texture texture;
 	TextureAtlas atlas;
+
+	int pageToShow = 0;
+	private Array<TextureRegion> textureRegions;
 
 	@Override
 	public void create () {
 		batch = new SpriteBatch();
+		shapeRenderer = new ShapeRenderer();
 
 		camera = new OrthographicCamera(Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
 		camera.position.set(Gdx.graphics.getWidth() / 2, Gdx.graphics.getHeight() / 2, 0);
 		camera.update();
 
 		Pixmap pixmap1 = new Pixmap(Gdx.files.internal("data/badlogic.jpg"));
-		Pixmap pixmap2 = new Pixmap(Gdx.files.internal("data/wheel.png"));
-		Pixmap pixmap3 = new Pixmap(Gdx.files.internal("data/egg.png"));
+		Pixmap pixmap2 = new Pixmap(Gdx.files.internal("data/particle-fire.png"));
+		Pixmap pixmap3 = new Pixmap(Gdx.files.internal("data/isotile.png"));
 
 		PixmapPacker packer = new PixmapPacker(1024, 1024, Format.RGBA8888, 2, true);
-		packer.pack("badlogic", pixmap1);
-		packer.pack("wheel", pixmap1);
-		packer.pack("egg", pixmap1);
+		for (int count = 1; count <= 3; ++count) {
+			packer.pack("badlogic " + count, pixmap1);
+			packer.pack("fire " + count, pixmap2);
+			packer.pack("isotile " + count, pixmap3);
+		}
+
+		atlas = packer.generateTextureAtlas(TextureFilter.Nearest, TextureFilter.Nearest, false);
+		Gdx.app.log("PixmapPackerTest", "Number of initial textures: " + atlas.getTextures().size);
+
+		for (int count = 4; count <= 10; ++count) {
+			packer.pack("badlogic " + count, pixmap1);
+			packer.pack("fire " + count, pixmap2);
+			packer.pack("isotile " + count, pixmap3);
+		}
 
 		pixmap1.dispose();
 		pixmap2.dispose();
 		pixmap3.dispose();
 
-		atlas = packer.generateTextureAtlas(TextureFilter.Nearest, TextureFilter.Nearest, false);
-		Gdx.app.log("PixmaPackerTest", "Number of textures: " + atlas.getTextures().size);
+		packer.updateTextureAtlas(atlas, TextureFilter.Nearest, TextureFilter.Nearest, false);
+		textureRegions = packer.getTextureRegions(TextureFilter.Nearest, TextureFilter.Nearest, false);
+		Gdx.app.log("PixmapPackerTest", "Number of updated textures: " + atlas.getTextures().size);
+		Gdx.input.setInputProcessor(new InputAdapter() {
+			@Override
+			public boolean keyDown(int keycode) {
+				if (keycode >= Input.Keys.NUM_0 && keycode <= Input.Keys.NUM_9) {
+					int number = keycode - Input.Keys.NUM_0;
+					if (number < textureRegions.size) {
+						pageToShow = number;
+					}
+				}
+				return super.keyDown(keycode);
+			}
+		});
 	}
 
 	@Override
 	public void render () {
-
+		Gdx.gl.glClearColor(0.2f, 0.2f, 0.2f, 1);
+		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		int size = Math.min(Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+		batch.begin();
+		batch.draw(textureRegions.get(pageToShow), 0, 0, size, size);
+		batch.end();
+		shapeRenderer.begin(ShapeRenderer.ShapeType.Line);
+		shapeRenderer.setColor(Color.GREEN);
+		shapeRenderer.rect(0, 0, size, size);
+		shapeRenderer.end();
 	}
 
 	@Override

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/PixmapPackerTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/PixmapPackerTest.java
@@ -78,7 +78,8 @@ public class PixmapPackerTest extends GdxTest {
 		pixmap3.dispose();
 
 		packer.updateTextureAtlas(atlas, TextureFilter.Nearest, TextureFilter.Nearest, false);
-		textureRegions = packer.getTextureRegions(TextureFilter.Nearest, TextureFilter.Nearest, false);
+		textureRegions = new Array<TextureRegion>();
+		packer.updateTextureRegions(textureRegions, TextureFilter.Nearest, TextureFilter.Nearest, false, true);
 		Gdx.app.log("PixmapPackerTest", "Number of updated textures: " + atlas.getTextures().size);
 		Gdx.input.setInputProcessor(new InputAdapter() {
 			@Override

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ProjectTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ProjectTest.java
@@ -50,7 +50,7 @@ public class ProjectTest extends GdxTest {
 	@Override
 	public void create () {
 		ObjLoader objLoader = new ObjLoader();
-		sphere = objLoader.loadObj(Gdx.files.internal("data/sphere.obj"));
+		sphere = objLoader.loadModel(Gdx.files.internal("data/sphere.obj"));
 		sphere.materials.get(0).set(new ColorAttribute(ColorAttribute.Diffuse, Color.WHITE));
 		cam = new PerspectiveCamera(45, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
 		cam.far = 200;

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/BulletConstructor.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/BulletConstructor.java
@@ -57,8 +57,7 @@ public class BulletConstructor extends BaseWorld.Constructor<BulletEntity> {
 	public BulletConstructor (final Model model, final float mass) {
 		final BoundingBox boundingBox = new BoundingBox();
 		model.calculateBoundingBox(boundingBox);
-		final Vector3 dimensions = boundingBox.getDimensions();
-		create(model, mass, dimensions.x, dimensions.y, dimensions.z);
+		create(model, mass, boundingBox.getWidth(), boundingBox.getHeight(), boundingBox.getDepth());
 	}
 
 	/** Creates a btBoxShape with the same dimensions as the shape and NO rigidbody. */

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/FrustumCullingTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/FrustumCullingTest.java
@@ -25,6 +25,7 @@ import com.badlogic.gdx.graphics.VertexAttributes.Usage;
 import com.badlogic.gdx.graphics.g3d.Material;
 import com.badlogic.gdx.graphics.g3d.Model;
 import com.badlogic.gdx.graphics.g3d.attributes.ColorAttribute;
+import com.badlogic.gdx.graphics.g3d.utils.MeshPartBuilder;
 import com.badlogic.gdx.graphics.g3d.utils.ModelBuilder;
 import com.badlogic.gdx.math.Matrix4;
 import com.badlogic.gdx.math.Vector3;
@@ -110,14 +111,17 @@ public class FrustumCullingTest extends BaseBulletTest {
 	}
 
 	public static Model createFrustumModel (final Vector3... p) {
-		return ModelBuilder.createFromMesh(new float[] {p[0].x, p[0].y, p[0].z, 0, 0, 1, p[1].x, p[1].y, p[1].z, 0, 0, 1, p[2].x,
+		ModelBuilder builder = new ModelBuilder();
+		MeshPartBuilder mpb = builder.part("", GL20.GL_LINES, Usage.Position | Usage.Normal, new Material(new ColorAttribute(ColorAttribute.Diffuse, Color.WHITE)));
+		mpb.vertex(p[0].x, p[0].y, p[0].z, 0, 0, 1, p[1].x, p[1].y, p[1].z, 0, 0, 1, p[2].x,
 			p[2].y, p[2].z, 0, 0, 1, p[3].x, p[3].y, p[3].z, 0, 0,
 			1, // near
 			p[4].x, p[4].y, p[4].z, 0, 0, -1, p[5].x, p[5].y, p[5].z, 0, 0, -1, p[6].x, p[6].y, p[6].z, 0, 0, -1, p[7].x, p[7].y,
-			p[7].z, 0, 0, -1},// far
-			new VertexAttribute[] {new VertexAttribute(Usage.Position, 3, "a_position"),
-				new VertexAttribute(Usage.Normal, 3, "a_normal")}, new short[] {0, 1, 1, 2, 2, 3, 3, 0, 4, 5, 5, 6, 6, 7, 7, 4, 0, 4,
-				1, 5, 2, 6, 3, 7}, GL20.GL_LINES, new Material(new ColorAttribute(ColorAttribute.Diffuse, Color.WHITE)));
+			p[7].z, 0, 0, -1);
+		mpb.index((short)0, (short)1, (short)1, (short)2, (short)2, (short)3, (short)3, (short)0);
+		mpb.index((short)4, (short)5, (short)5, (short)6, (short)6, (short)7, (short)7, (short)4);
+		mpb.index((short)0, (short)4, (short)1, (short)5, (short)2, (short)6, (short)3, (short)7);
+		return builder.end();
 	}
 
 	private float angleX, angleY, angleZ;

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/SoftBodyTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/SoftBodyTest.java
@@ -30,6 +30,7 @@ import com.badlogic.gdx.graphics.g3d.attributes.ColorAttribute;
 import com.badlogic.gdx.graphics.g3d.attributes.FloatAttribute;
 import com.badlogic.gdx.graphics.g3d.attributes.IntAttribute;
 import com.badlogic.gdx.graphics.g3d.attributes.TextureAttribute;
+import com.badlogic.gdx.graphics.g3d.model.MeshPart;
 import com.badlogic.gdx.graphics.g3d.utils.ModelBuilder;
 import com.badlogic.gdx.graphics.glutils.ShaderProgram;
 import com.badlogic.gdx.math.Matrix4;
@@ -116,8 +117,14 @@ public class SoftBodyTest extends BaseBulletTest {
 		mesh.setVertices(verts);
 		texture = new Texture(Gdx.files.internal("data/badlogic.jpg"));
 
-		model = ModelBuilder.createFromMesh(mesh, GL20.GL_TRIANGLES, new Material(TextureAttribute.createDiffuse(texture),
-			ColorAttribute.createSpecular(Color.WHITE), FloatAttribute.createShininess(64f), IntAttribute.createCullFace(0)));
+		ModelBuilder builder = new ModelBuilder();
+		builder.begin();
+		builder.part(
+			new MeshPart("", mesh, 0, mesh.getNumIndices(), GL20.GL_TRIANGLES),
+			new Material(TextureAttribute.createDiffuse(texture), ColorAttribute.createSpecular(Color.WHITE), FloatAttribute
+				.createShininess(64f), IntAttribute.createCullFace(0)));
+		model = builder.end();
+
 		instance = new ModelInstance(model);
 		world.add(new BulletEntity(instance, null));
 	}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/VehicleTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/VehicleTest.java
@@ -80,8 +80,8 @@ public class VehicleTest extends BaseBulletTest {
 		world.addConstructor("largeground", new BulletConstructor(largeGroundModel, 0f));
 
 		BoundingBox bounds = new BoundingBox();
-		Vector3 chassisHalfExtents = new Vector3(chassisModel.calculateBoundingBox(bounds).getDimensions()).scl(0.5f);
-		Vector3 wheelHalfExtents = new Vector3(wheelModel.calculateBoundingBox(bounds).getDimensions()).scl(0.5f);
+		Vector3 chassisHalfExtents = chassisModel.calculateBoundingBox(bounds).getDimensions(new Vector3()).scl(0.5f);
+		Vector3 wheelHalfExtents = wheelModel.calculateBoundingBox(bounds).getDimensions(new Vector3()).scl(0.5f);
 
 		world.addConstructor("chassis", new BulletConstructor(chassisModel, 5f, new btBoxShape(chassisHalfExtents)));
 		world.addConstructor("wheel", new BulletConstructor(wheelModel, 0, null));

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/extensions/FreeTypeAtlasTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/extensions/FreeTypeAtlasTest.java
@@ -148,8 +148,8 @@ public class FreeTypeAtlasTest extends GdxTest {
 		// 1. Create a new PixmapPacker big enough to fit all your desired glyphs
 		// 2. Create a new FreeTypeFontGenerator for each TTF file (i.e. font styles/families)
 		// 3. For each size and style, call generator.generateFont() with the packer set on the parameter
-		// 4. Generate the final texture atlas from the packer.
-		// 9. Dispose of the atlas upon application exit or when you are done using the font atlas
+		// 4. Generate the texture atlas using packer.generateTextureAtlas or packer.updateTextureAtlas.
+		// 5. Dispose of the atlas upon application exit or when you are done using the fonts
 		// //////////////////////////////////////////////////////////////////////////////////////////////////////
 
 		// create the pixmap packer

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/extensions/FreeTypeAtlasTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/extensions/FreeTypeAtlasTest.java
@@ -1,0 +1,208 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogic.gdx.tests.extensions;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.OrthographicCamera;
+import com.badlogic.gdx.graphics.Pixmap.Format;
+import com.badlogic.gdx.graphics.Texture.TextureFilter;
+import com.badlogic.gdx.graphics.g2d.*;
+import com.badlogic.gdx.graphics.g2d.freetype.FreeTypeFontGenerator;
+import com.badlogic.gdx.tests.utils.GdxTest;
+
+import java.util.EnumMap;
+
+/**
+ * An example of packing many glyphs into a single texture atlas, using FreeTypeFontGenerator.
+ * <p/>
+ * This example uses enum ordinals for fast access to a two-dimensional array, which stores BitmapFonts by size and style. A more
+ * flexible solution might be to use an ObjectMap and and IntMap instead.
+ * <p/>
+ * This test uses a less efficient but more convenient way to pack multiple generated fonts into a single texture atlas
+ * compared with FreeTypePackTest - the texture atlas pages will be refreshed once for each font generated, which can be
+ * slow on mobile devices.
+ */
+public class FreeTypeAtlasTest extends GdxTest {
+
+	// Define font sizes here...
+	static enum FontSize {
+		Tiny(10), Small(12), Medium(16), Large(20), Huge(24), ReallyHuge(28), JustTooBig(64);
+
+		public final int size;
+
+		FontSize(int size) {
+			this.size = size;
+		}
+	}
+
+	// Define font styles here...
+	static enum FontStyle {
+		Regular("data/arial.ttf"), Italic("data/arial-italic.ttf");
+
+		public final String path;
+
+		FontStyle(String path) {
+			this.path = path;
+		}
+	}
+
+	OrthographicCamera camera;
+	SpriteBatch batch;
+	TextureAtlas atlas;
+	String text;
+	TextureRegion firstPage;
+
+	FontMap<BitmapFont> fontMap;
+
+	public static final int FONT_ATLAS_WIDTH = 1024;
+	public static final int FONT_ATLAS_HEIGHT = 512;
+
+	// whether to use integer coords for BitmapFont...
+	private static final boolean INTEGER = false;
+
+	// Our demo doesn't need any fancy characters.
+	// Note: the set in FreeTypeFontGenerator.DEFAULT_CHARS is more extensive
+	// Also note that this string must be contained of unique characters; no duplicates!
+	public static final String CHARACTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ" + "abcdefghijklmnopqrstuvwxyz\n1234567890"
+			+ "\"!`?'.,;:()[]{}<>|/@\\^$-%+=#_&~*";
+
+	@Override
+	public void create() {
+		camera = new OrthographicCamera();
+		batch = new SpriteBatch();
+
+		long start = System.currentTimeMillis();
+		int glyphCount = createFonts();
+		long time = System.currentTimeMillis() - start;
+		text = glyphCount + " glyphs packed in " + atlas.getRegions().size + " page(s) in " + time + " ms";
+
+	}
+
+	@Override
+	public void render() {
+		Gdx.gl.glClearColor(0.2f, 0.2f, 0.2f, 1);
+		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+
+		camera.setToOrtho(false, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+		batch.setProjectionMatrix(camera.combined);
+		batch.begin();
+
+		float x = 10;
+		float y = Gdx.graphics.getHeight() - 10;
+
+		int renderCalls = 0;
+
+		// NOTE: Before production release on mobile, you should cache the array from values()
+		// inside the Enum in order to reduce allocations in the render loop.
+		for (FontStyle style : FontStyle.values()) {
+			for (FontSize size : FontSize.values()) {
+				BitmapFont fnt = getFont(style, size);
+
+				fnt.draw(batch, style.name() + " " + size.size + "pt: The quick brown fox jumps over the lazy dog", x, y);
+				y -= fnt.getLineHeight() + 10;
+			}
+			y -= 20;
+		}
+
+		BitmapFont font = getFont(FontStyle.Regular, FontSize.Medium);
+		font.draw(batch, text, 10, font.getCapHeight() + 10);
+
+		// draw all glyphs in background
+		batch.setColor(1f, 1f, 1f, 0.15f);
+		batch.draw(firstPage, 0, 0);
+		batch.setColor(1f, 1f, 1f, 1f);
+		batch.end();
+	}
+
+	@Override
+	public void dispose() {
+		super.dispose();
+		atlas.dispose();
+		batch.dispose();
+	}
+
+	// Utility method to grab a font by style/size pair
+	public BitmapFont getFont(FontStyle style, FontSize size) {
+		return fontMap.get(style).get(size);
+	}
+
+	protected int createFonts() {
+		// This test uses a less efficient but more convenient way to pack multiple generated fonts into a single
+		// texture atlas.
+		//
+		// 1. Create a new PixmapPacker big enough to fit all your desired glyphs
+		// 2. Create a new FreeTypeFontGenerator for each TTF file (i.e. font styles/families)
+		// 3. For each size and style, call generator.generateFont() with the packer set on the parameter
+		// 4. Generate the final texture atlas from the packer.
+		// 9. Dispose of the atlas upon application exit or when you are done using the font atlas
+		// //////////////////////////////////////////////////////////////////////////////////////////////////////
+
+		// create the pixmap packer
+		PixmapPacker packer = new PixmapPacker(FONT_ATLAS_WIDTH, FONT_ATLAS_HEIGHT, Format.RGBA8888, 2, false);
+
+		fontMap = new FontMap<BitmapFont>();
+		int fontCount = 0;
+
+		// for each style...
+		for (FontStyle style : FontStyle.values()) {
+			// get the file for this style
+			FreeTypeFontGenerator gen = new FreeTypeFontGenerator(Gdx.files.internal(style.path));
+
+			// For each size...
+			for (FontSize size : FontSize.values()) {
+				// pack the glyphs into the atlas using the default chars
+				FreeTypeFontGenerator.FreeTypeFontParameter fontParameter = new FreeTypeFontGenerator.FreeTypeFontParameter();
+				fontParameter.size = size.size;
+				fontParameter.packer = packer;
+				fontParameter.characters = CHARACTERS;
+				BitmapFont bmFont = gen.generateFont(fontParameter);
+
+				fontMap.get(style).put(size, bmFont);
+				fontCount++;
+			}
+
+			// dispose of the generator once we're finished with this family
+			gen.dispose();
+		}
+
+		// Generate the atlas.
+		atlas = packer.generateTextureAtlas(TextureFilter.Nearest, TextureFilter.Nearest, false);
+
+		// Get the first page's texture region for the demo so we can display it as the background
+		firstPage = packer.getTextureRegions(TextureFilter.Nearest, TextureFilter.Nearest, false).first();
+
+		// No more need for our CPU-based pixmap packer, as our textures are now on GPU
+		packer.dispose();
+
+		// for the demo, show how many glyphs we loaded
+		return fontCount * CHARACTERS.length();
+	}
+
+	// We use a nested EnumMap for fast access
+	class FontMap<T> extends EnumMap<FontStyle, EnumMap<FontSize, T>> {
+
+		public FontMap() {
+			super(FontStyle.class);
+
+			// create the enum map for each FontSize
+			for (FontStyle style : FontStyle.values()) {
+				put(style, new EnumMap<FontSize, T>(FontSize.class));
+			}
+		}
+	}
+}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/extensions/FreeTypePackTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/extensions/FreeTypePackTest.java
@@ -186,7 +186,8 @@ public class FreeTypePackTest extends GdxTest {
 		}
 
 		// Get regions from our packer
-		regions = packer.getTextureRegions(TextureFilter.Nearest, TextureFilter.Nearest, false);
+		regions = new Array<TextureRegion>();
+		packer.updateTextureRegions(regions, TextureFilter.Nearest, TextureFilter.Nearest, false, true);
 
 		// No more need for our CPU-based pixmap packer, as our textures are now on GPU
 		packer.dispose();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/extensions/FreeTypePackTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/extensions/FreeTypePackTest.java
@@ -16,6 +16,8 @@
 
 package com.badlogic.gdx.tests.extensions;
 
+import java.util.EnumMap;
+
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.OrthographicCamera;
@@ -29,8 +31,6 @@ import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.graphics.g2d.freetype.FreeTypeFontGenerator;
 import com.badlogic.gdx.tests.utils.GdxTest;
 import com.badlogic.gdx.utils.Array;
-
-import java.util.EnumMap;
 
 /** An advanced example of packing many glyphs into a single texture atlas, using FreeTypeFontGenerator.
  * 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/extensions/FreeTypePackTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/extensions/FreeTypePackTest.java
@@ -16,8 +16,6 @@
 
 package com.badlogic.gdx.tests.extensions;
 
-import java.util.EnumMap;
-
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.OrthographicCamera;
@@ -31,6 +29,8 @@ import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.graphics.g2d.freetype.FreeTypeFontGenerator;
 import com.badlogic.gdx.tests.utils.GdxTest;
 import com.badlogic.gdx.utils.Array;
+
+import java.util.EnumMap;
 
 /** An advanced example of packing many glyphs into a single texture atlas, using FreeTypeFontGenerator.
  * 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/extensions/FreeTypePackTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/extensions/FreeTypePackTest.java
@@ -16,23 +16,21 @@
 
 package com.badlogic.gdx.tests.extensions;
 
-import java.util.EnumMap;
-
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.graphics.Pixmap.Format;
-import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.Texture.TextureFilter;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.graphics.g2d.BitmapFont.BitmapFontData;
 import com.badlogic.gdx.graphics.g2d.PixmapPacker;
-import com.badlogic.gdx.graphics.g2d.PixmapPacker.Page;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.graphics.g2d.freetype.FreeTypeFontGenerator;
 import com.badlogic.gdx.tests.utils.GdxTest;
 import com.badlogic.gdx.utils.Array;
+
+import java.util.EnumMap;
 
 /** An advanced example of packing many glyphs into a single texture atlas, using FreeTypeFontGenerator.
  * 
@@ -153,7 +151,7 @@ public class FreeTypePackTest extends GdxTest {
 		// Keep hold of the returned BitmapFontData for later
 		// 4. Repeat for other sizes.
 		// 5. Dispose the generator and repeat for other font styles/families
-		// 6. Create new Texture(s) and TextureRegion(s) from the Pixmap object from pixmapPacker.getPages()
+		// 6. Get the TextureRegion(s) from the packer using packer.getTextureRegions()
 		// 7. Dispose the PixmapPacker
 		// 8. Use each BitmapFontData to construct a new BitmapFont, and specify your TextureRegion(s) to the font constructor
 		// 9. Dispose of the Texture upon application exit or when you are done using the font atlas
@@ -173,7 +171,11 @@ public class FreeTypePackTest extends GdxTest {
 			// For each size...
 			for (FontSize size : FontSize.values()) {
 				// pack the glyphs into the atlas using the default chars
-				BitmapFontData data = gen.generateData(size.size, CHARACTERS, false, packer);
+				FreeTypeFontGenerator.FreeTypeFontParameter fontParameter = new FreeTypeFontGenerator.FreeTypeFontParameter();
+				fontParameter.size = size.size;
+				fontParameter.packer = packer;
+				fontParameter.characters = CHARACTERS;
+				BitmapFontData data = gen.generateData(fontParameter);
 
 				// store the info for later, when we generate the texture
 				dataMap.get(style).put(size, data);
@@ -183,22 +185,8 @@ public class FreeTypePackTest extends GdxTest {
 			gen.dispose();
 		}
 
-		// The pages of pixmaps from our packer
-		Array<Page> pages = packer.getPages();
-
-		// our resulting regions
-		regions = new Array(pages.size);
-
-		// Now generate a TextureRegion from each pixmap page
-		for (int i = 0; i < pages.size; i++) {
-			Page page = pages.get(i);
-
-			// create a Texture from the pixmap
-			Texture tex = new Texture(page.getPixmap());
-			tex.setFilter(TextureFilter.Nearest, TextureFilter.Nearest);
-
-			regions.add(new TextureRegion(tex));
-		}
+		// Get regions from our packer
+		regions = packer.getTextureRegions(TextureFilter.Nearest, TextureFilter.Nearest, false);
 
 		// No more need for our CPU-based pixmap packer, as our textures are now on GPU
 		packer.dispose();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/BaseG3dTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/BaseG3dTest.java
@@ -69,13 +69,13 @@ public abstract class BaseG3dTest extends GdxTest {
 	private void createAxes () {
 		ModelBuilder modelBuilder = new ModelBuilder();
 		modelBuilder.begin();
-		MeshPartBuilder builder = modelBuilder.part("grid", GL20.GL_LINES, Usage.Position | Usage.Color, new Material());
+		MeshPartBuilder builder = modelBuilder.part("grid", GL20.GL_LINES, Usage.Position | Usage.ColorUnpacked, new Material());
 		builder.setColor(Color.LIGHT_GRAY);
 		for (float t = GRID_MIN; t <= GRID_MAX; t += GRID_STEP) {
 			builder.line(t, 0, GRID_MIN, t, 0, GRID_MAX);
 			builder.line(GRID_MIN, 0, t, GRID_MAX, 0, t);
 		}
-		builder = modelBuilder.part("axes", GL20.GL_LINES, Usage.Position | Usage.Color, new Material());
+		builder = modelBuilder.part("axes", GL20.GL_LINES, Usage.Position | Usage.ColorUnpacked, new Material());
 		builder.setColor(Color.RED);
 		builder.line(0, 0, 0, 100, 0, 0);
 		builder.setColor(Color.GREEN);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/LightsTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/LightsTest.java
@@ -56,8 +56,8 @@ public class LightsTest extends ModelTest {
 	protected void onLoaded () {
 		super.onLoaded();
 		BoundingBox bounds = instances.get(0).calculateBoundingBox(new BoundingBox());
-		center.set(bounds.getCenter());
-		radius = bounds.getDimensions().len() * .5f;
+		bounds.getCenter(center);
+		radius = bounds.getDimensions(tmpV).len() * .5f;
 		pointLight.position.set(0, radius, 0).add(transformedCenter.set(center).mul(transform));
 		pointLight.intensity = radius * radius;
 		((ColorAttribute)pLight.material.get(ColorAttribute.Diffuse)).color.set(pointLight.color);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/ModelTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/ModelTest.java
@@ -53,7 +53,7 @@ public class ModelTest extends BaseG3dHudTest {
 		onModelClicked("g3d/teapot.g3db");
 	}
 
-	private final Vector3 tmpV = new Vector3();
+	private final Vector3 tmpV1 = new Vector3(), tmpV2 = new Vector3();
 	private final Quaternion tmpQ = new Quaternion();
 	private final BoundingBox bounds = new BoundingBox();
 
@@ -100,10 +100,10 @@ public class ModelTest extends BaseG3dHudTest {
 		currentlyLoading = null;
 
 		instance.calculateBoundingBox(bounds);
-		cam.position.set(1, 1, 1).nor().scl(bounds.getDimensions().len() * 0.75f + bounds.getCenter().len());
+		cam.position.set(1, 1, 1).nor().scl(bounds.getDimensions(tmpV1).len() * 0.75f + bounds.getCenter(tmpV2).len());
 		cam.up.set(0, 1, 0);
 		cam.lookAt(0, 0, 0);
-		cam.far = 50f + bounds.getDimensions().len() * 2.0f;
+		cam.far = 50f + bounds.getDimensions(tmpV1).len() * 2.0f;
 		cam.update();
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/ShaderCollectionTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/ShaderCollectionTest.java
@@ -288,12 +288,12 @@ public class ShaderCollectionTest extends BaseG3dHudTest {
 			if (instance.animations.size > 0) animationControllers.put(instance, new AnimationController(instance));
 
 			instance.calculateBoundingBox(bounds);
-			cam.position.set(1, 1, 1).nor().scl(bounds.getDimensions().len() * 0.75f).add(bounds.getCenter());
+			cam.position.set(1, 1, 1).nor().scl(bounds.getDimensions(tmpV).len() * 0.75f).add(bounds.getCenter(tmpV));
 			cam.up.set(0, 1, 0);
-			cam.lookAt(inputController.target.set(bounds.getCenter()));
-			cam.far = Math.max(100f, bounds.getDimensions().len() * 2.0f);
+			cam.lookAt(inputController.target.set(bounds.getCenter(tmpV)));
+			cam.far = Math.max(100f, bounds.getDimensions(tmpV).len() * 2.0f);
 			cam.update();
-			moveRadius = bounds.getDimensions().len() * 0.25f;
+			moveRadius = bounds.getDimensions(tmpV).len() * 0.25f;
 		}
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/ShadowMappingTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/ShadowMappingTest.java
@@ -65,7 +65,7 @@ public class ShadowMappingTest extends GdxTest {
 
 		ModelBuilder modelBuilder = new ModelBuilder();
 		modelBuilder.begin();
-		MeshPartBuilder mpb = modelBuilder.part("parts", GL20.GL_TRIANGLES, Usage.Position | Usage.Normal | Usage.Color,
+		MeshPartBuilder mpb = modelBuilder.part("parts", GL20.GL_TRIANGLES, Usage.Position | Usage.Normal | Usage.ColorUnpacked,
 			new Material(ColorAttribute.createDiffuse(Color.WHITE)));
 		mpb.setColor(1f, 1f, 1f, 1f);
 		mpb.box(0, -1.5f, 0, 10, 1, 10);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
@@ -28,14 +28,6 @@
 
 package com.badlogic.gdx.tests.utils;
 
-import java.io.BufferedReader;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-
 import com.badlogic.gdx.tests.*;
 import com.badlogic.gdx.tests.bench.TiledMapBench;
 import com.badlogic.gdx.tests.examples.MoveSpriteExample;
@@ -68,6 +60,14 @@ import com.badlogic.gdx.tests.net.NetAPITest;
 import com.badlogic.gdx.tests.superkoalio.SuperKoalio;
 import com.badlogic.gdx.utils.ObjectMap;
 import com.badlogic.gdx.utils.StreamUtils;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 /** List of GdxTest classes. To be used by the test launchers. If you write your own test, add it in here!
  * 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
@@ -28,6 +28,18 @@
 
 package com.badlogic.gdx.tests.utils;
 
+import com.badlogic.gdx.tests.*;
+import com.badlogic.gdx.tests.bench.TiledMapBench;
+import com.badlogic.gdx.tests.examples.MoveSpriteExample;
+import com.badlogic.gdx.tests.extensions.*;
+import com.badlogic.gdx.tests.g3d.*;
+import com.badlogic.gdx.tests.gles2.HelloTriangle;
+import com.badlogic.gdx.tests.gles2.SimpleVertexShader;
+import com.badlogic.gdx.tests.net.NetAPITest;
+import com.badlogic.gdx.tests.superkoalio.SuperKoalio;
+import com.badlogic.gdx.utils.ObjectMap;
+import com.badlogic.gdx.utils.StreamUtils;
+
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -35,38 +47,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-
-import com.badlogic.gdx.tests.*;
-import com.badlogic.gdx.tests.bench.TiledMapBench;
-import com.badlogic.gdx.tests.examples.MoveSpriteExample;
-import com.badlogic.gdx.tests.extensions.ControllersTest;
-import com.badlogic.gdx.tests.extensions.FreeTypeDisposeTest;
-import com.badlogic.gdx.tests.extensions.FreeTypeFontLoaderTest;
-import com.badlogic.gdx.tests.extensions.FreeTypeIncrementalTest;
-import com.badlogic.gdx.tests.extensions.FreeTypePackTest;
-import com.badlogic.gdx.tests.extensions.FreeTypeTest;
-import com.badlogic.gdx.tests.extensions.InternationalFontsTest;
-import com.badlogic.gdx.tests.g3d.Animation3DTest;
-import com.badlogic.gdx.tests.g3d.Basic3DSceneTest;
-import com.badlogic.gdx.tests.g3d.Basic3DTest;
-import com.badlogic.gdx.tests.g3d.Benchmark3DTest;
-import com.badlogic.gdx.tests.g3d.FogTest;
-import com.badlogic.gdx.tests.g3d.LightsTest;
-import com.badlogic.gdx.tests.g3d.MaterialTest;
-import com.badlogic.gdx.tests.g3d.MeshBuilderTest;
-import com.badlogic.gdx.tests.g3d.ModelTest;
-import com.badlogic.gdx.tests.g3d.ParticleControllerTest;
-import com.badlogic.gdx.tests.g3d.ShaderCollectionTest;
-import com.badlogic.gdx.tests.g3d.ShaderTest;
-import com.badlogic.gdx.tests.g3d.ShadowMappingTest;
-import com.badlogic.gdx.tests.g3d.SkeletonTest;
-import com.badlogic.gdx.tests.g3d.TextureRegion3DTest;
-import com.badlogic.gdx.tests.gles2.HelloTriangle;
-import com.badlogic.gdx.tests.gles2.SimpleVertexShader;
-import com.badlogic.gdx.tests.net.NetAPITest;
-import com.badlogic.gdx.tests.superkoalio.SuperKoalio;
-import com.badlogic.gdx.utils.ObjectMap;
-import com.badlogic.gdx.utils.StreamUtils;
 
 /** List of GdxTest classes. To be used by the test launchers. If you write your own test, add it in here!
  * 
@@ -238,6 +218,7 @@ public class GdxTests {
 		FreeTypeDisposeTest.class,
 		FreeTypeIncrementalTest.class,
 		FreeTypePackTest.class,
+		FreeTypeAtlasTest.class,
 		FreeTypeTest.class,
 		InternationalFontsTest.class,
 		PngTest.class,

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
@@ -28,6 +28,14 @@
 
 package com.badlogic.gdx.tests.utils;
 
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import com.badlogic.gdx.tests.*;
 import com.badlogic.gdx.tests.bench.TiledMapBench;
 import com.badlogic.gdx.tests.examples.MoveSpriteExample;
@@ -60,14 +68,6 @@ import com.badlogic.gdx.tests.net.NetAPITest;
 import com.badlogic.gdx.tests.superkoalio.SuperKoalio;
 import com.badlogic.gdx.utils.ObjectMap;
 import com.badlogic.gdx.utils.StreamUtils;
-
-import java.io.BufferedReader;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 
 /** List of GdxTest classes. To be used by the test launchers. If you write your own test, add it in here!
  * 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
@@ -28,18 +28,6 @@
 
 package com.badlogic.gdx.tests.utils;
 
-import com.badlogic.gdx.tests.*;
-import com.badlogic.gdx.tests.bench.TiledMapBench;
-import com.badlogic.gdx.tests.examples.MoveSpriteExample;
-import com.badlogic.gdx.tests.extensions.*;
-import com.badlogic.gdx.tests.g3d.*;
-import com.badlogic.gdx.tests.gles2.HelloTriangle;
-import com.badlogic.gdx.tests.gles2.SimpleVertexShader;
-import com.badlogic.gdx.tests.net.NetAPITest;
-import com.badlogic.gdx.tests.superkoalio.SuperKoalio;
-import com.badlogic.gdx.utils.ObjectMap;
-import com.badlogic.gdx.utils.StreamUtils;
-
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -47,6 +35,39 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+
+import com.badlogic.gdx.tests.*;
+import com.badlogic.gdx.tests.bench.TiledMapBench;
+import com.badlogic.gdx.tests.examples.MoveSpriteExample;
+import com.badlogic.gdx.tests.extensions.ControllersTest;
+import com.badlogic.gdx.tests.extensions.FreeTypeAtlasTest;
+import com.badlogic.gdx.tests.extensions.FreeTypeDisposeTest;
+import com.badlogic.gdx.tests.extensions.FreeTypeFontLoaderTest;
+import com.badlogic.gdx.tests.extensions.FreeTypeIncrementalTest;
+import com.badlogic.gdx.tests.extensions.FreeTypePackTest;
+import com.badlogic.gdx.tests.extensions.FreeTypeTest;
+import com.badlogic.gdx.tests.extensions.InternationalFontsTest;
+import com.badlogic.gdx.tests.g3d.Animation3DTest;
+import com.badlogic.gdx.tests.g3d.Basic3DSceneTest;
+import com.badlogic.gdx.tests.g3d.Basic3DTest;
+import com.badlogic.gdx.tests.g3d.Benchmark3DTest;
+import com.badlogic.gdx.tests.g3d.FogTest;
+import com.badlogic.gdx.tests.g3d.LightsTest;
+import com.badlogic.gdx.tests.g3d.MaterialTest;
+import com.badlogic.gdx.tests.g3d.MeshBuilderTest;
+import com.badlogic.gdx.tests.g3d.ModelTest;
+import com.badlogic.gdx.tests.g3d.ParticleControllerTest;
+import com.badlogic.gdx.tests.g3d.ShaderCollectionTest;
+import com.badlogic.gdx.tests.g3d.ShaderTest;
+import com.badlogic.gdx.tests.g3d.ShadowMappingTest;
+import com.badlogic.gdx.tests.g3d.SkeletonTest;
+import com.badlogic.gdx.tests.g3d.TextureRegion3DTest;
+import com.badlogic.gdx.tests.gles2.HelloTriangle;
+import com.badlogic.gdx.tests.gles2.SimpleVertexShader;
+import com.badlogic.gdx.tests.net.NetAPITest;
+import com.badlogic.gdx.tests.superkoalio.SuperKoalio;
+import com.badlogic.gdx.utils.ObjectMap;
+import com.badlogic.gdx.utils.StreamUtils;
 
 /** List of GdxTest classes. To be used by the test launchers. If you write your own test, add it in here!
  * 


### PR DESCRIPTION
As discussed in #2980, I've made some changes to the PixmapPacker so that it can provide an array of TextureRegions based on its pages, and FreeTypeFontGenerator so it uses this method if the user provides their own packer as a FreeTypeFontParameter.

I've updated the PixmapPackerTest to both generate and update the TextureAtlas, to use different-sized pixmaps (and not just the same one with three different names despite creating three of them :), and to show the resulting texture atlas (change pages by hitting 0-9).

FreeTypePackTest now uses the new method.  I've also created a new FreeTypeAtlasTest which uses the less efficient (but more convenient) method of just generating the fonts directly.  I ran the tests before and after my changes on my laptop, and the times reported by those tests are comparable (but Nathan said that the performance difference would be worse on mobile).

Before my change, FreeTypePackTest
943 ms, 596 ms, 604 ms, 676 ms

After my change, FreeTypePackTest
608 ms, 666 ms, 640 ms

After my change, new FreeTypeAtlasTest
643 ms, 646 ms, 623 ms
