### PR TITLE
Fix minor bug in CameraInputController

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g3d/utils/CameraInputController.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/utils/CameraInputController.java
@@ -163,7 +163,7 @@ public class CameraInputController extends GestureDetector {
 			startY = screenY;
 			this.button = button;
 		}
-		return super.touchDown(screenX, screenY, pointer, button) || activatePressed;
+		return super.touchDown(screenX, screenY, pointer, button) || (activateKey == 0 || activatePressed);
 	}
 
 	@Override


### PR DESCRIPTION
Fix a small bug where the camera input controller will not report the touchDown event as handled whereas it is (this is always the case when there is no activation key defined).