### PR TITLE
Update gradle distribution to use SSL/TLS

### DIFF
--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/gradle/wrapper/gradle-wrapper.properties
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.2-all.zip


### PR DESCRIPTION
Quick change that increases security by a whole lot. Since gradle is also served over SSL/TLS I don't see a point of using HTTP.