### PR TITLE
Make uniform names for array struct consistent across drivers

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/glutils/ShaderProgram.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/ShaderProgram.java
@@ -788,12 +788,16 @@ public class ShaderProgram implements Disposable {
 
 		uniformNames = new String[numUniforms];
 
+		int arrayPos;
 		for (int i = 0; i < numUniforms; i++) {
 			params.clear();
 			params.put(0, 1);
 			type.clear();
 			String name = Gdx.gl20.glGetActiveUniform(program, i, params, type);
 			int location = Gdx.gl20.glGetUniformLocation(program, name);
+			while ((arrayPos = name.indexOf("[0]")) != -1) {
+				name = name.substring(0, arrayPos) + name.substring(arrayPos + 3);
+			}
 			uniforms.put(name, location);
 			uniformTypes.put(name, type.get(0));
 			uniformSizes.put(name, params.get(0));


### PR DESCRIPTION
Sadly, as far as I understand, OpenGL ES spec does not specify if first element name of struct array must be reported as ````struct[0].field```` or ````struct.field````. Of course most driver use the first syntax but I found an Intel embed GPU driver that use the second under Windows...

SInce the spec allows it, I think this should be considered as a LibGdx bug and not a driver bug. With this PR, the name are reported without the [0] for the first element.

Note that **this PR breaks things and should not be merged** since all code using this type of behavior has to be adapted to request ````struct.field```` instead of ````struct[0].field```` (for example the 3D lighting API).

I propose it to open discussion on choosing a solution between ;
- making the proposed change in the PR (and do the API breaking change)
- don't do it and handle both type of names in all library/user code and add clear info in the Wiki.