### PR TITLE
SelectBox ignores fontColor in style

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/SelectBox.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/SelectBox.java
@@ -237,7 +237,7 @@ public class SelectBox<T> extends Widget implements Disableable {
 				y += (int)(height / 2 + font.getData().capHeight / 2);
 			}
 			font.setColor(fontColor.r, fontColor.g, fontColor.b, fontColor.a * parentAlpha);
-			layout.setText(font, string, 0, string.length(), Color.WHITE, width, Align.left, false, "...");
+			layout.setText(font, string, 0, string.length(), font.getColor(), width, Align.left, false, "...");
 			font.draw(batch, layout, x, y);
 		}
 	}


### PR DESCRIPTION
This can be reproduced changing the fontColor in the SelecBoxStyle of the test uiskin.json, to something different from white, and launching the UITest. The text in the SelectBox will stay white.

This PR passes the font color as the default color for the GlyphLayout.