### PR TITLE
Correct error in VertexBufferObjectWithVAO

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/glutils/VertexBufferObjectWithVAO.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/VertexBufferObjectWithVAO.java
@@ -138,19 +138,20 @@ public class VertexBufferObjectWithVAO implements VertexData {
 	public void bind(ShaderProgram shader, int[] locations) {
 		GL30 gl = Gdx.gl30;
 		if (vaoDirty || !gl.glIsVertexArray(vaoHandle)) {
+			//initialize the VAO with our vertex attributes and buffer:
 			tmpHandle.clear();
 			gl.glGenVertexArrays(1, tmpHandle);
 			vaoHandle = tmpHandle.get(0);
 			gl.glBindVertexArray(vaoHandle);
-
-			//initialize the VAO with our vertex attributes and buffer:
-			bindAttributes(shader, locations);
 			vaoDirty = false;
 
 		} else {
 			//else simply bind the VAO.
 			gl.glBindVertexArray(vaoHandle);
 		}
+
+		bindAttributes(shader, locations);
+
 		//if our data has changed upload it:
 		bindData(gl);
 
@@ -169,7 +170,7 @@ public class VertexBufferObjectWithVAO implements VertexData {
 				shader.enableVertexAttribute(location);
 
 				shader.setVertexAttribute(location, attribute.numComponents, attribute.type, attribute.normalized, attributes.vertexSize,
-						attribute.offset);
+					attribute.offset);
 			}
 
 		} else {
@@ -180,7 +181,7 @@ public class VertexBufferObjectWithVAO implements VertexData {
 				shader.enableVertexAttribute(location);
 
 				shader.setVertexAttribute(location, attribute.numComponents, attribute.type, attribute.normalized, attributes.vertexSize,
-						attribute.offset);
+					attribute.offset);
 			}
 		}
 	}


### PR DESCRIPTION
Move "bindAttributes" out of the condition in "bind" function.

This Pull Request is linked to this issue: https://github.com/libgdx/libgdx/issues/3050