### PR TITLE
Add merge button to ParticleEditor

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,8 @@
 [1.5.7]
 - API Change: GlyphLayout xAdvances now have an additional entry at the beginning. This was required to implement tighter text bounds. #3034
 - API Change: Label#getTextBounds changed to getGlyphLayout. This exposes all the runs, not just the width and height.
+- In the 2D ParticleEditor, all chart points can be dragged at once by holding ctrl. They can be dragged proportionally by holding ctrl-shift.
+- Added Merge button to the 2D ParticleEditor, for merging a loaded particle effect file with the currently open particle effect.
 
 [1.5.6]
 - API Change: Refactored Window. https://github.com/libgdx/libgdx/commit/7d372b3c67d4fcfe4e82546b0ad6891d14d03242

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/EffectPanel.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/EffectPanel.java
@@ -137,7 +137,7 @@ class EffectPanel extends JPanel {
 		editor.reloadRows();
 	}
 
-	void openEffect () {
+	void openEffect (boolean mergeIntoCurrent) {
 		FileDialog dialog = new FileDialog(editor, "Open Effect", FileDialog.LOAD);
 		if (lastDir != null) dialog.setDirectory(lastDir);
 		dialog.setVisible(true);
@@ -149,8 +149,14 @@ class EffectPanel extends JPanel {
 		try {
 			File effectFile = new File(dir, file);
 			effect.loadEmitters(Gdx.files.absolute(effectFile.getAbsolutePath()));
-			editor.effect = effect;
-			editor.effectFile = effectFile;
+			if (mergeIntoCurrent){
+				for (ParticleEmitter emitter : effect.getEmitters()){
+					addEmitter(emitter.getName(), false, emitter);
+				}
+			} else {
+				editor.effect = effect;
+				editor.effectFile = effectFile;
+			}
 			emitterTableModel.getDataVector().removeAllElements();
 			editor.particleData.clear();
 		} catch (Exception ex) {
@@ -159,7 +165,7 @@ class EffectPanel extends JPanel {
 			JOptionPane.showMessageDialog(editor, "Error opening effect.");
 			return;
 		}
-		for (ParticleEmitter emitter : effect.getEmitters()) {
+		for (ParticleEmitter emitter : editor.effect.getEmitters()) {
 			emitter.setPosition(editor.worldCamera.viewportWidth / 2, editor.worldCamera.viewportHeight / 2);
 			emitterTableModel.addRow(new Object[] {emitter.getName(), true});
 		}
@@ -303,7 +309,17 @@ class EffectPanel extends JPanel {
 					GridBagConstraints.HORIZONTAL, new Insets(0, 0, 6, 0), 0, 0));
 				openButton.addActionListener(new ActionListener() {
 					public void actionPerformed (ActionEvent event) {
-						openEffect();
+						openEffect(false);
+					}
+				});
+			}
+			{
+				JButton mergeButton = new JButton("Merge");
+				sideButtons.add(mergeButton, new GridBagConstraints(0, -1, 1, 1, 0, 0, GridBagConstraints.CENTER,
+					GridBagConstraints.HORIZONTAL, new Insets(0, 0, 6, 0), 0, 0));
+				mergeButton.addActionListener(new ActionListener() {
+					public void actionPerformed (ActionEvent event) {
+						openEffect(true);
 					}
 				});
 			}

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/ParticleEditor.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/ParticleEditor.java
@@ -287,7 +287,7 @@ public class ParticleEditor extends JFrame {
 					emittersPanel.add(effectPanel);
 				}
 			}
-			leftSplit.setDividerLocation(625);
+			leftSplit.setDividerLocation(575);
 		}
 		splitPane.setDividerLocation(325);
 	}


### PR DESCRIPTION
This is for ease of use when making many variations of a ParticleEffect, or when reusing particular ParticleEmitters in several different ParticleEffects. The Merge button opens a particle file and adds all its emitters to the ParticleEffect that is already loaded.