### PR TITLE
Added isDisabled() to Disableable.

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/SelectBox.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/SelectBox.java
@@ -16,7 +16,10 @@
 
 package com.badlogic.gdx.scenes.scene2d.ui;
 
-import static com.badlogic.gdx.scenes.scene2d.actions.Actions.*;
+import static com.badlogic.gdx.scenes.scene2d.actions.Actions.fadeIn;
+import static com.badlogic.gdx.scenes.scene2d.actions.Actions.fadeOut;
+import static com.badlogic.gdx.scenes.scene2d.actions.Actions.removeActor;
+import static com.badlogic.gdx.scenes.scene2d.actions.Actions.sequence;
 
 import com.badlogic.gdx.Input.Keys;
 import com.badlogic.gdx.graphics.Color;
@@ -277,6 +280,10 @@ public class SelectBox<T> extends Widget implements Disableable {
 	public void setDisabled (boolean disabled) {
 		if (disabled && !this.disabled) hideList();
 		this.disabled = disabled;
+	}
+
+	public boolean isDisabled () {
+		return disabled;
 	}
 
 	public float getPrefWidth () {

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/Disableable.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/Disableable.java
@@ -18,4 +18,6 @@ package com.badlogic.gdx.scenes.scene2d.utils;
 
 public interface Disableable {
 	public void setDisabled (boolean isDisabled);
+
+	public boolean isDisabled ();
 }


### PR DESCRIPTION
A small addition to the `Disableable` interface. All but a single implementation of this class had this anyway, but the interface is not that useful without that method I think.

In my case I wanted to have a generic method that sets the colour of actors to `Colour.GRAY` when an actor is disabled, and to `Color.WHITE` when it's not. I was searching and found that neat interface for exactly that usecase. However, without the getter I would have to do lots of `instanceof` tests.