### PR TITLE
Add distance field support to font rendering

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g2d/Batch.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/Batch.java
@@ -213,6 +213,10 @@ public interface Batch extends Disposable {
 	 * @param shader the {@link ShaderProgram} or null to use the default shader. */
 	public void setShader (ShaderProgram shader);
 
+	/**
+	 * @return the current custom shader set with {@link #setShader(ShaderProgram)} */
+	public ShaderProgram getShader();
+	
 	/** @return true if blending for sprites is enabled */
 	public boolean isBlendingEnabled ();
 

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFont.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFont.java
@@ -234,7 +234,14 @@ public class BitmapFont implements Disposable {
 			ownsTexture = false;
 		}
 
-		cache = (distanceField ? new DistanceFieldBitmapFontCache(this) : new BitmapFontCache(this));
+		if (distanceField) {
+			cache = new DistanceFieldBitmapFontCache(this);
+			for (int i = 0; i < regions.size; i++) {
+				this.regions.get(i).getTexture().setFilter(TextureFilter.Linear, TextureFilter.Linear);
+			}
+		} else {
+			cache = new BitmapFontCache(this);
+		}
 
 		this.flipped = data.flipped;
 		this.data = data;

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFont.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFont.java
@@ -64,6 +64,9 @@ public class BitmapFont implements Disposable {
 	private boolean flipped;
 	private boolean integer;
 	private boolean ownsTexture;
+	
+	private boolean distanceField;
+	private float distanceFieldSmoothing;
 
 	/** Creates a BitmapFont using the default 15pt Arial font included in the libgdx JAR file. This is convenient to easily display
 	 * text without bothering without generating a bitmap font yourself. */
@@ -101,6 +104,18 @@ public class BitmapFont implements Disposable {
 	public BitmapFont (FileHandle fontFile, TextureRegion region, boolean flip) {
 		this(new BitmapFontData(fontFile, flip), region, true);
 	}
+	
+	/** Creates a BitmapFont with the glyphs relative to the specified region. If the region is null, the glyph textures are loaded
+	 * from the image file given in the font file. The {@link #dispose()} method will not dispose the region's texture in this
+	 * case!
+	 * @param region The texture region containing the glyphs. The glyphs must be relative to the lower left corner (ie, the region
+	 *           should not be flipped). If the region is null the glyph images are loaded from the image path in the font file.
+	 * @param flip If true, the glyphs will be flipped for use with a perspective where 0,0 is the upper left corner.
+	 * @param distanceField If true, font will be rendered with distance field shader
+	 * @param distanceFieldSmoothing Smoothing factor for distance field shader */
+	public BitmapFont (FileHandle fontFile, TextureRegion region, boolean flip, boolean distanceField, float distanceFieldSmoothing) {
+		this(new BitmapFontData(fontFile, flip), region, true);
+	}
 
 	/** Creates a BitmapFont from a BMFont file. The image file name is read from the BMFont file and the image is loaded from the
 	 * same directory. The font data is not flipped. */
@@ -114,12 +129,30 @@ public class BitmapFont implements Disposable {
 	public BitmapFont (FileHandle fontFile, boolean flip) {
 		this(new BitmapFontData(fontFile, flip), (TextureRegion)null, true);
 	}
+	
+	/** Creates a BitmapFont from a BMFont file. The image file name is read from the BMFont file and the image is loaded from the
+	 * same directory.
+	 * @param flip If true, the glyphs will be flipped for use with a perspective where 0,0 is the upper left corner.
+	 * @param distanceField If true, font will be rendered with distance field shader
+	 * @param distanceFieldSmoothing Smoothing factor for distance field shader */
+	public BitmapFont (FileHandle fontFile, boolean flip, boolean distanceField, float distanceFieldSmoothing) {
+		this(new BitmapFontData(fontFile, flip), (TextureRegion)null, true, distanceField, distanceFieldSmoothing);
+	}
 
 	/** Creates a BitmapFont from a BMFont file, using the specified image for glyphs. Any image specified in the BMFont file is
 	 * ignored.
 	 * @param flip If true, the glyphs will be flipped for use with a perspective where 0,0 is the upper left corner. */
 	public BitmapFont (FileHandle fontFile, FileHandle imageFile, boolean flip) {
 		this(fontFile, imageFile, flip, true);
+	}
+	
+	/** Creates a BitmapFont from a BMFont file, using the specified image for glyphs. Any image specified in the BMFont file is
+	 * ignored.
+	 * @param flip If true, the glyphs will be flipped for use with a perspective where 0,0 is the upper left corner.
+	 * @param distanceField If true, font will be rendered with distance field shader
+	 * @param distanceFieldSmoothing Smoothing factor for distance field shader */
+	public BitmapFont (FileHandle fontFile, FileHandle imageFile, boolean flip, boolean distanceField, float distanceFieldSmoothing) {
+		this(fontFile, imageFile, flip, true, distanceField, distanceFieldSmoothing);
 	}
 
 	/** Creates a BitmapFont from a BMFont file, using the specified image for glyphs. Any image specified in the BMFont file is
@@ -128,6 +161,17 @@ public class BitmapFont implements Disposable {
 	 * @param integer If true, rendering positions will be at integer values to avoid filtering artifacts. */
 	public BitmapFont (FileHandle fontFile, FileHandle imageFile, boolean flip, boolean integer) {
 		this(new BitmapFontData(fontFile, flip), new TextureRegion(new Texture(imageFile, false)), integer);
+		ownsTexture = true;
+	}
+	
+	/** Creates a BitmapFont from a BMFont file, using the specified image for glyphs. Any image specified in the BMFont file is
+	 * ignored.
+	 * @param flip If true, the glyphs will be flipped for use with a perspective where 0,0 is the upper left corner.
+	 * @param integer If true, rendering positions will be at integer values to avoid filtering artifacts.
+	 * @param distanceField If true, font will be rendered with distance field shader
+	 * @param distanceFieldSmoothing Smoothing factor for distance field shader */
+	public BitmapFont (FileHandle fontFile, FileHandle imageFile, boolean flip, boolean integer, boolean distanceField, float distanceFieldSmoothing) {
+		this(new BitmapFontData(fontFile, flip), new TextureRegion(new Texture(imageFile, false)), integer, distanceField, distanceFieldSmoothing);
 		ownsTexture = true;
 	}
 
@@ -142,12 +186,36 @@ public class BitmapFont implements Disposable {
 	public BitmapFont (BitmapFontData data, TextureRegion region, boolean integer) {
 		this(data, region != null ? Array.with(region) : null, integer);
 	}
-
+	
+	/** Constructs a new BitmapFont from the given {@link BitmapFontData} and {@link TextureRegion}. If the TextureRegion is null,
+	 * the image path(s) will be read from the BitmapFontData. The dispose() method will not dispose the texture of the region(s)
+	 * if the region is != null.
+	 * <p>
+	 * Passing a single TextureRegion assumes that your font only needs a single texture page. If you need to support multiple
+	 * pages, either let the Font read the images themselves (by specifying null as the TextureRegion), or by specifying each page
+	 * manually with the TextureRegion[] constructor.
+	 * @param integer If true, rendering positions will be at integer values to avoid filtering artifacts.
+	 * @param distanceField If true, font will be rendered with distance field shader
+	 * @param distanceFieldSmoothing Smoothing factor for distance field shader */
+	public BitmapFont (BitmapFontData data, TextureRegion region, boolean integer, boolean distanceField, float distanceFieldSmoothing) {
+		this(data, region != null ? Array.with(region) : null, integer, distanceField, distanceFieldSmoothing);
+	}
+	
 	/** Constructs a new BitmapFont from the given {@link BitmapFontData} and array of {@link TextureRegion}. If the TextureRegion
 	 * is null or empty, the image path(s) will be read from the BitmapFontData. The dispose() method will not dispose the texture
 	 * of the region(s) if the regions array is != null and not empty.
-	 * @param integer If true, rendering positions will be at integer values to avoid filtering artifacts. */
+	 * @param integer If true, rendering positions will be at integer values to avoid filtering artifacts.*/ 
 	public BitmapFont (BitmapFontData data, Array<TextureRegion> pageRegions, boolean integer) {
+		this(data, pageRegions, integer, false, 0);
+	}
+	
+	/** Constructs a new BitmapFont from the given {@link BitmapFontData} and array of {@link TextureRegion}. If the TextureRegion
+	 * is null or empty, the image path(s) will be read from the BitmapFontData. The dispose() method will not dispose the texture
+	 * of the region(s) if the regions array is != null and not empty.
+	 * @param integer If true, rendering positions will be at integer values to avoid filtering artifacts. 
+	 * @param distanceField If true, font will be rendered with distance field shader
+	 * @param distanceFieldSmoothing Smoothing factor for distance field shader */
+	public BitmapFont (BitmapFontData data, Array<TextureRegion> pageRegions, boolean integer, boolean distanceField, float distanceFieldSmoothing) {
 		if (pageRegions == null || pageRegions.size == 0) {
 			// Load each path.
 			int n = data.imagePaths.length;
@@ -166,11 +234,15 @@ public class BitmapFont implements Disposable {
 			ownsTexture = false;
 		}
 
-		cache = new BitmapFontCache(this, integer);
+		cache = (distanceField ? new DistanceFieldBitmapFontCache(this) : new BitmapFontCache(this));
 
 		this.flipped = data.flipped;
 		this.data = data;
 		this.integer = integer;
+		
+		this.distanceField = distanceField;
+		this.distanceFieldSmoothing = distanceFieldSmoothing;
+		
 		load(data);
 	}
 
@@ -370,6 +442,25 @@ public class BitmapFont implements Disposable {
 	public String toString () {
 		if (data.fontFile != null) return data.fontFile.nameWithoutExtension();
 		return super.toString();
+	}
+	
+	/**
+	 *  @return The smoothing factor for this font for the distance field shader
+	 */
+	public float getDistanceFieldSmoothing () {
+		return distanceFieldSmoothing;
+	}
+
+	/**
+	 *  @param distanceFieldSmoothing The smoothing factor for this font for the distance field shader*/
+	public void setDistanceFieldSmoothing (float distanceFieldSmoothing) {
+		this.distanceFieldSmoothing = distanceFieldSmoothing;
+	}
+
+	/**
+	 *  @return Is this a distance field font*/
+	public boolean isDistanceField () {
+		return distanceField;
 	}
 
 	/** Represents a single character in a font page. */
@@ -835,5 +926,7 @@ public class BitmapFont implements Disposable {
 		public void scale (float amount) {
 			setScale(scaleX + amount, scaleY + amount);
 		}
+		
+
 	}
 }

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/DistanceFieldBitmapFontCache.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/DistanceFieldBitmapFontCache.java
@@ -1,0 +1,101 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogic.gdx.graphics.g2d;
+
+import com.badlogic.gdx.graphics.glutils.ShaderProgram;
+
+
+/** 
+ * Caches and renders distance field font with custom shader. 
+ * Inspired by https://github.com/libgdx/libgdx/wiki/Distance-field-fonts
+ * @author Florian Falkner
+ */
+public class DistanceFieldBitmapFontCache extends BitmapFontCache {
+	private static ShaderProgram shader;
+	
+	/*
+	 * Needs to be done in a static block, otherwise doesn't work
+	 */
+	static {
+		shader = createDistanceFieldShader();
+	}
+	
+	public DistanceFieldBitmapFontCache (BitmapFont font, boolean integer) {
+		super(font, integer);
+	}
+
+	public DistanceFieldBitmapFontCache (BitmapFont font) {
+		super(font);
+	}
+	
+	@Override
+	public void draw (Batch spriteBatch) {
+		spriteBatch.setShader(shader);
+		shader.setUniformf("u_smoothing", getFont().getDistanceFieldSmoothing() * getFont().getScaleX());
+		
+		super.draw(spriteBatch);
+		spriteBatch.setShader(null);
+	}
+	
+	@Override
+	public void draw (Batch spriteBatch, int start, int end) {
+		spriteBatch.setShader(shader);
+		shader.setUniformf("u_smoothing", getFont().getDistanceFieldSmoothing() * getFont().getScaleX());
+		
+		super.draw(spriteBatch, start, end);
+		spriteBatch.setShader(null);
+	}
+	
+	/** Returns a new instance of the distance field shader, see https://github.com/libgdx/libgdx/wiki/Distance-field-fonts. */
+	static public ShaderProgram createDistanceFieldShader () {
+		String vertexShader = "attribute vec4 " + ShaderProgram.POSITION_ATTRIBUTE + ";\n" //
+			+ "attribute vec4 " + ShaderProgram.COLOR_ATTRIBUTE + ";\n" //
+			+ "attribute vec2 " + ShaderProgram.TEXCOORD_ATTRIBUTE + "0;\n" //
+			+ "uniform mat4 u_projTrans;\n" //
+			+ "varying vec4 v_color;\n" //
+			+ "varying vec2 v_texCoords;\n" //
+			+ "\n" //
+			+ "void main()\n" //
+			+ "{\n" //
+			+ "   v_color = " + ShaderProgram.COLOR_ATTRIBUTE + ";\n" //
+			+ "   v_color.a = v_color.a * (255.0/254.0);\n" //
+			+ "   v_texCoords = " + ShaderProgram.TEXCOORD_ATTRIBUTE + "0;\n" //
+			+ "   gl_Position =  u_projTrans * " + ShaderProgram.POSITION_ATTRIBUTE + ";\n" //
+			+ "}\n";
+		
+		String fragmentShader = "#ifdef GL_ES\n"
+			+ "	precision mediump float;\n"
+			+ "	precision mediump int;\n"
+			+ "#endif\n"
+			+ "\n"
+			+ "uniform sampler2D u_texture;\n"
+			+ "uniform float u_smoothing;\n"
+			+ "varying vec4 v_color;\n" //
+			+ "varying vec2 v_texCoords;\n" //
+			+ "\n"
+			+ "void main() {\n"
+			+ "	float smoothing = 0.25 / u_smoothing;\n"
+			+ "	float distance = texture2D(u_texture, v_texCoords).a;\n"
+			+ "	float alpha = smoothstep(0.5 - smoothing, 0.5 + smoothing, distance);\n"
+			+ "	gl_FragColor = vec4(v_color.rgb, alpha * v_color.a);\n"
+			+ "}\n";
+		
+		ShaderProgram shader = new ShaderProgram(vertexShader, fragmentShader);
+		if (shader.isCompiled() == false) throw new IllegalArgumentException("Error compiling shader: " + shader.getLog());
+		return shader;
+	}
+}

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/DistanceFieldBitmapFontCache.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/DistanceFieldBitmapFontCache.java
@@ -44,20 +44,34 @@ public class DistanceFieldBitmapFontCache extends BitmapFontCache {
 	
 	@Override
 	public void draw (Batch spriteBatch) {
-		spriteBatch.setShader(shader);
-		shader.setUniformf("u_smoothing", getFont().getDistanceFieldSmoothing() * getFont().getScaleX());
+		final ShaderProgram lastShader = spriteBatch.getShader();
 		
+		if (lastShader != shader) {
+			spriteBatch.setShader(shader);
+		}
+		
+		shader.setUniformf("u_smoothing", getFont().getDistanceFieldSmoothing() * getFont().getScaleX());
 		super.draw(spriteBatch);
-		spriteBatch.setShader(null);
+		
+		if (lastShader != shader) {
+			spriteBatch.setShader(lastShader);
+		}
 	}
 	
 	@Override
 	public void draw (Batch spriteBatch, int start, int end) {
-		spriteBatch.setShader(shader);
-		shader.setUniformf("u_smoothing", getFont().getDistanceFieldSmoothing() * getFont().getScaleX());
+		final ShaderProgram lastShader = spriteBatch.getShader();
 		
+		if (lastShader != shader) {
+			spriteBatch.setShader(shader);
+		}
+		
+		shader.setUniformf("u_smoothing", getFont().getDistanceFieldSmoothing() * getFont().getScaleX());
 		super.draw(spriteBatch, start, end);
-		spriteBatch.setShader(null);
+		
+		if (lastShader != shader) {
+			spriteBatch.setShader(lastShader);
+		}
 	}
 	
 	/** Returns a new instance of the distance field shader, see https://github.com/libgdx/libgdx/wiki/Distance-field-fonts. */

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/PolygonSpriteBatch.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/PolygonSpriteBatch.java
@@ -16,7 +16,8 @@
 
 package com.badlogic.gdx.graphics.g2d;
 
-import static com.badlogic.gdx.graphics.g2d.Sprite.*;
+import static com.badlogic.gdx.graphics.g2d.Sprite.SPRITE_SIZE;
+import static com.badlogic.gdx.graphics.g2d.Sprite.VERTEX_SIZE;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
@@ -1299,6 +1300,11 @@ public class PolygonSpriteBatch implements Batch {
 				this.shader.begin();
 			setupMatrices();
 		}
+	}
+	
+	@Override
+	public ShaderProgram getShader () {
+		return customShader;
 	}
 
 	@Override

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/SpriteBatch.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/SpriteBatch.java
@@ -20,7 +20,6 @@ import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Mesh;
-import com.badlogic.gdx.graphics.Mesh.VertexDataType;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.VertexAttribute;
 import com.badlogic.gdx.graphics.VertexAttributes.Usage;
@@ -1071,6 +1070,11 @@ public class SpriteBatch implements Batch {
 				this.shader.begin();
 			setupMatrices();
 		}
+	}
+	
+	@Override
+	public ShaderProgram getShader () {
+		return customShader;
 	}
 
 	@Override

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Label.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Label.java
@@ -20,6 +20,7 @@ import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.g2d.Batch;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.graphics.g2d.BitmapFontCache;
+import com.badlogic.gdx.graphics.g2d.DistanceFieldBitmapFontCache;
 import com.badlogic.gdx.graphics.g2d.GlyphLayout;
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.scenes.scene2d.utils.Drawable;
@@ -76,7 +77,7 @@ public class Label extends Widget {
 		if (style == null) throw new IllegalArgumentException("style cannot be null.");
 		if (style.font == null) throw new IllegalArgumentException("Missing LabelStyle font.");
 		this.style = style;
-		cache = new BitmapFontCache(style.font, style.font.usesIntegerPositions());
+		cache = style.font.isDistanceField() ? new DistanceFieldBitmapFontCache(style.font, style.font.usesIntegerPositions()) : new BitmapFontCache(style.font, style.font.usesIntegerPositions());
 		invalidateHierarchy();
 	}
 

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Skin.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Skin.java
@@ -440,6 +440,8 @@ public class Skin implements Disposable {
 				int scaledSize = json.readValue("scaledSize", int.class, -1, jsonData);
 				Boolean flip = json.readValue("flip", Boolean.class, false, jsonData);
 				Boolean markupEnabled = json.readValue("markupEnabled", Boolean.class, false, jsonData);
+				Boolean distanceField = json.readValue("distanceField", Boolean.class, false, jsonData);
+				float distanceFieldSmoothing = json.readValue("distanceFieldSmoothing", Float.class, 1f, jsonData);
 
 				FileHandle fontFile = skinFile.parent().child(path);
 				if (!fontFile.exists()) fontFile = Gdx.files.internal(path);
@@ -451,13 +453,13 @@ public class Skin implements Disposable {
 					BitmapFont font;
 					TextureRegion region = skin.optional(regionName, TextureRegion.class);
 					if (region != null)
-						font = new BitmapFont(fontFile, region, flip);
+						font = new BitmapFont(fontFile, region, flip, distanceField, distanceFieldSmoothing);
 					else {
 						FileHandle imageFile = fontFile.parent().child(regionName + ".png");
 						if (imageFile.exists())
-							font = new BitmapFont(fontFile, imageFile, flip);
+							font = new BitmapFont(fontFile, imageFile, flip, distanceField, distanceFieldSmoothing);
 						else
-							font = new BitmapFont(fontFile, flip);
+							font = new BitmapFont(fontFile, flip, distanceField, distanceFieldSmoothing);
 					}
 					font.getData().markupEnabled = markupEnabled;
 					// Scaled size is the desired cap height to scale the font to.


### PR DESCRIPTION
Hi folks,

this pull request would add direct support for distance field fonts to libgdx. Added a new DistanceFieldBitmapFontCache class that renders the distance field font and a flag to BitmapFont when it should be rendered by  DistanceFieldBitmapFontCache. Shader and info was taken from the great Wiki entry about distance font fields https://github.com/libgdx/libgdx/wiki/Distance-field-fonts.

I needed to overload quite some BitmapFont constructors, because the cache is always generated in the constructor.

I originally wrote & tested this patch against 1.5.3 and now ported it to current master. 

Take a look if it feeds your needs and adheres to your standards, would be great if this could be merged.

Regards,
Florian
