### PR TITLE
Adds animated tiles to output texture atlas

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -11,6 +11,7 @@
 - API Change: FreeTypeFontGenerator.generateFont(...) now works with a user-provided PixmapPacker.
 - Added DirectionalLightsAttribute, PointLightsAttribute and SpotLightsAttribute, removed Environment#directionalLights/pointLights/spotLights, added Environment#remove, lights are now just like any other attribute. See also https://github.com/libgdx/libgdx/wiki/Material-and-environment#lights
 - API Change: BitmapFont metrics now respect padding. #3074
+- Added AnimatedTiledMapTile.getFrameTiles() method
 
 [1.5.6]
 - API Change: Refactored Window. https://github.com/libgdx/libgdx/commit/7d372b3c67d4fcfe4e82546b0ad6891d14d03242

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tiledmappacker/TiledMapPacker.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tiledmappacker/TiledMapPacker.java
@@ -49,9 +49,12 @@ import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.g2d.TextureAtlas;
 import com.badlogic.gdx.maps.MapLayer;
 import com.badlogic.gdx.maps.tiled.TiledMap;
+import com.badlogic.gdx.maps.tiled.TiledMapTile;
 import com.badlogic.gdx.maps.tiled.TiledMapTileLayer;
 import com.badlogic.gdx.maps.tiled.TiledMapTileSet;
 import com.badlogic.gdx.maps.tiled.TmxMapLoader;
+import com.badlogic.gdx.maps.tiled.tiles.AnimatedTiledMapTile;
+import com.badlogic.gdx.maps.tiled.tiles.StaticTiledMapTile;
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.tools.texturepacker.TexturePacker;
 import com.badlogic.gdx.tools.texturepacker.TexturePacker.Settings;
@@ -60,15 +63,15 @@ import com.badlogic.gdx.utils.IntArray;
 import com.badlogic.gdx.utils.ObjectMap;
 
 /** Given one or more TMX tilemaps, packs all tileset resources used across the maps into a <b>single</b> {@link TextureAtlas} and
- * produces a new TMX file to be loaded with an AtlasTiledMapLoader loader. Optionally, it can keep track of unused tiles
- * and omit them from the generated atlas, reducing the resource size.
+ * produces a new TMX file to be loaded with an AtlasTiledMapLoader loader. Optionally, it can keep track of unused tiles and omit
+ * them from the generated atlas, reducing the resource size.
  * 
  * The original TMX map file will be parsed by using the {@link TmxMapLoader} loader, thus access to a valid OpenGL context is
  * <b>required</b>, that's why an LwjglApplication is created by this preprocessor: this is probably subject to change in the
  * future, where loading both maps metadata and graphics resources should be made conditional.
  * 
- * The new TMX map file will contains a new property, namely "atlas", whose value will enable the AtlasTiledMapLoader to
- * correctly read the associated TextureAtlas representing the tileset.
+ * The new TMX map file will contains a new property, namely "atlas", whose value will enable the AtlasTiledMapLoader to correctly
+ * read the associated TextureAtlas representing the tileset.
  * 
  * @author David Fraska and others (initial implementation, tell me who you are!)
  * @author Manuel Bua */
@@ -170,15 +173,15 @@ public class TiledMapPacker {
 						for (int y = 0; y < mapHeight; ++y) {
 							for (int x = 0; x < mapWidth; ++x) {
 								if (tlayer.getCell(x, y) != null) {
-									int tileid = tlayer.getCell(x, y).getTile().getId() & ~0xE0000000;
-									String tilesetName = tilesetNameFromTileId(map, tileid);
-									IntArray usedIds = getUsedIdsBucket(tilesetName, bucketSize);
-									usedIds.add(tileid);
-
-									// track this tileset to be packed if not already tracked
-									if (!tilesetsToPack.containsKey(tilesetName)) {
-										tilesetsToPack.put(tilesetName, map.getTileSets().getTileSet(tilesetName));
+									TiledMapTile tile = tlayer.getCell(x, y).getTile();
+									if (tileIsAnimatedTiledMapTile(tile)) {
+										AnimatedTiledMapTile aTile = (AnimatedTiledMapTile)tile;
+										for (StaticTiledMapTile t : aTile.getFrameTiles()) {
+											addTile(t, bucketSize, tilesetsToPack);
+										}
 									}
+									// Adds non-Animated tiles and the base AnimatedTiledMapTile if it wasn't added in the animation
+									addTile(tile, bucketSize, tilesetsToPack);
 								}
 							}
 						}
@@ -198,6 +201,22 @@ public class TiledMapPacker {
 		}
 
 		packTilesets(tilesetsToPack, inputDirHandle, outputDir, settings);
+	}
+
+	private boolean tileIsAnimatedTiledMapTile (TiledMapTile tile) {
+		return tile.getClass().equals(AnimatedTiledMapTile.class);
+	}
+
+	private void addTile (TiledMapTile tile, int bucketSize, ObjectMap<String, TiledMapTileSet> tilesetsToPack) {
+		int tileid = tile.getId() & ~0xE0000000;
+		String tilesetName = tilesetNameFromTileId(map, tileid);
+		IntArray usedIds = getUsedIdsBucket(tilesetName, bucketSize);
+		usedIds.add(tileid);
+
+		// track this tileset to be packed if not already tracked
+		if (!tilesetsToPack.containsKey(tilesetName)) {
+			tilesetsToPack.put(tilesetName, map.getTileSets().getTileSet(tilesetName));
+		}
 	}
 
 	/** Returns the tileset name associated with the specified tile id
@@ -279,7 +298,7 @@ public class TiledMapPacker {
 				if (isBlended(tile)) setBlended(gid);
 				System.out.println("Adding " + tileWidth + "x" + tileHeight + " (" + (int)tileLocation.x + ", " + (int)tileLocation.y
 					+ ")");
-				packer.addImage(tile, this.settings.atlasOutputName + "_" + (gid-1));
+				packer.addImage(tile, this.settings.atlasOutputName + "_" + (gid - 1));
 			}
 		}
 

--- a/gdx/src/com/badlogic/gdx/maps/tiled/tiles/AnimatedTiledMapTile.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/tiles/AnimatedTiledMapTile.java
@@ -19,10 +19,9 @@ package com.badlogic.gdx.maps.tiled.tiles;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.maps.MapProperties;
 import com.badlogic.gdx.maps.tiled.TiledMapTile;
-import com.badlogic.gdx.maps.tiled.tiles.StaticTiledMapTile;
 import com.badlogic.gdx.utils.Array;
-import com.badlogic.gdx.utils.IntArray;
 import com.badlogic.gdx.utils.GdxRuntimeException;
+import com.badlogic.gdx.utils.IntArray;
 import com.badlogic.gdx.utils.TimeUtils;
 
 /** @brief Represents a changing {@link TiledMapTile}. */
@@ -63,19 +62,20 @@ public class AnimatedTiledMapTile implements TiledMapTile {
 		this.blendMode = blendMode;
 	}
 
-	public int getCurrentFrameIndex() {
+	public int getCurrentFrameIndex () {
 		int currentTime = (int)(lastTiledMapRenderTime % loopDuration);
 
-		for (int i = 0; i < animationIntervals.length; ++i){
+		for (int i = 0; i < animationIntervals.length; ++i) {
 			int animationInterval = animationIntervals[i];
 			if (currentTime <= animationInterval) return i;
 			currentTime -= animationInterval;
 		}
 
-		throw new GdxRuntimeException("Could not determine current animation frame in AnimatedTiledMapTile.  This should never happen.");
+		throw new GdxRuntimeException(
+			"Could not determine current animation frame in AnimatedTiledMapTile.  This should never happen.");
 	}
 
-	public TiledMapTile getCurrentFrame() {
+	public TiledMapTile getCurrentFrame () {
 		return frameTiles[getCurrentFrameIndex()];
 	}
 
@@ -85,10 +85,10 @@ public class AnimatedTiledMapTile implements TiledMapTile {
 	}
 
 	@Override
-	public void setTextureRegion(TextureRegion textureRegion) {
+	public void setTextureRegion (TextureRegion textureRegion) {
 		throw new GdxRuntimeException("Cannot set the texture region of AnimatedTiledMapTile.");
 	}
-	
+
 	@Override
 	public float getOffsetX () {
 		return getCurrentFrame().getOffsetX();
@@ -109,10 +109,10 @@ public class AnimatedTiledMapTile implements TiledMapTile {
 		throw new GdxRuntimeException("Cannot set offset of AnimatedTiledMapTile.");
 	}
 
-	public int[] getAnimationIntervals(){
+	public int[] getAnimationIntervals () {
 		return animationIntervals;
 	}
-	
+
 	public void setAnimationIntervals (int[] intervals) {
 		if (intervals.length == animationIntervals.length) {
 			this.animationIntervals = intervals;
@@ -152,7 +152,7 @@ public class AnimatedTiledMapTile implements TiledMapTile {
 
 		this.loopDuration = frameTiles.size * (int)(interval * 1000f);
 		this.animationIntervals = new int[frameTiles.size];
-		for (int i = 0; i < frameTiles.size; ++i){
+		for (int i = 0; i < frameTiles.size; ++i) {
 			this.frameTiles[i] = frameTiles.get(i);
 			this.animationIntervals[i] = (int)(interval * 1000f);
 		}
@@ -169,10 +169,13 @@ public class AnimatedTiledMapTile implements TiledMapTile {
 		this.animationIntervals = intervals.toArray();
 		this.loopDuration = 0;
 
-		for (int i = 0; i < intervals.size; ++i){
+		for (int i = 0; i < intervals.size; ++i) {
 			this.frameTiles[i] = frameTiles.get(i);
 			this.loopDuration += intervals.get(i);
 		}
 	}
 
+	public StaticTiledMapTile[] getFrameTiles () {
+		return frameTiles;
+	}
 }


### PR DESCRIPTION
This allows TiledMapPacker to add animated Tiled map tiles. 

Currently, if you try to process a Tiled map containing animated tiles with TiledMapPacker you'd get an NPE since it only adds the base tile and none of the animated tiles.

The extra formatted lines were formatted according to the libGDX Eclipse formatter since I have a save action, format all lines. I also have organize imports save action.