### PR TITLE
Key repeat bug in TextField and TextArea

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextField.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextField.java
@@ -36,6 +36,7 @@ import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.scenes.scene2d.utils.ClickListener;
 import com.badlogic.gdx.scenes.scene2d.utils.Disableable;
 import com.badlogic.gdx.scenes.scene2d.utils.Drawable;
+import com.badlogic.gdx.scenes.scene2d.utils.FocusListener;
 import com.badlogic.gdx.scenes.scene2d.utils.UIUtils;
 import com.badlogic.gdx.utils.Align;
 import com.badlogic.gdx.utils.Array;
@@ -129,6 +130,14 @@ public class TextField extends Widget implements Disableable {
 
 	protected void initialize () {
 		addListener(inputListener = createInputListener());
+		addListener(new FocusListener() {
+			@Override
+			public void keyboardFocusChanged (FocusEvent event, Actor actor, boolean focused) {
+				if (focused == false) {
+					keyRepeatTask.cancel();
+				}
+			}
+		});
 	}
 
 	protected InputListener createInputListener () {


### PR DESCRIPTION
Key is repeated indefinitely when field loses keyboard focus while user still holds that key. Happens for every key using `keyRepeatTask` in `TextField`/`TextArea`.

Reproducing: 
1. Run `TextAreaTest`
2. Click on text area, hold left arrow.
3. Click on text field while still holding left arrow then release key.
4. Click on text area again without pressing any key, left arrow key will be repeated indefinitely.