### PR TITLE
Enable classpath file handle resolver to GWT backend

### DIFF
--- a/gdx/src/com/badlogic/gdx.gwt.xml
+++ b/gdx/src/com/badlogic/gdx.gwt.xml
@@ -51,6 +51,7 @@
 	<!-- assets/loaders/resolvers -->		
 		<include name="assets/loaders/resolvers/ExternalFileHandleResolver.java"/>
 		<include name="assets/loaders/resolvers/InternalFileHandleResolver.java"/>
+		<include name="assets/loaders/resolvers/ClasspathFileHandleResolver.java"/>
 		<include name="assets/loaders/resolvers/ResolutionFileResolver.java"/> <!-- Emulated -->
 
 	<!-- audio -->		


### PR DESCRIPTION
Since classpath file handle are supported in GWT, I think this resolver should be enabled as well.

It is usefull when you have resources in your src folders (in my case, string localization for a library project used by other projects) and declare them through ```<extend-configuration-property name="gdx.files.classpath" value=".../res/strings.properties" />``` for example. Then you can use them through ```ClasspathFileHandleResolver``` or ```Gdx.files.classpath("strings.properties")``` on all backends.