### PR TITLE
Methods for scaled width and height of a sprite

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g2d/Sprite.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/Sprite.java
@@ -530,6 +530,16 @@ public class Sprite extends TextureRegion {
 		return y;
 	}
 
+	/** @return the width of the sprite, accounting for scale. */
+	public float getScaledWidth () {
+		return width * scaleX;
+	}
+	
+	/** @return the height of the sprite, accounting for scale. */
+	public float getScaledHeight () {
+		return height * scaleY;
+	}
+	
 	/** @return the width of the sprite, not accounting for scale. */
 	public float getWidth () {
 		return width;


### PR DESCRIPTION
After scaling sprites in my game and trying to use getWidth() and getHeight(), I wondered why they weren't accounting for scale until I looked at the javadocs. From then on I had to use getWidth() * getScaleX() and getHeight() * getScaleY(). I decided that it would be nice to have two methods in sprite that return the width and height accounting for scale.