### PR TITLE
Update default Android API level and build tools to Android 5.0.

### DIFF
--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/DependencyBank.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/DependencyBank.java
@@ -1,6 +1,5 @@
 package com.badlogic.gdx.setup;
 
-
 import java.util.HashMap;
 
 public class DependencyBank {
@@ -10,8 +9,8 @@ public class DependencyBank {
 	//Temporary snapshot version, we need a more dynamic solution for pointing to the latest nightly
 	static String libgdxNightlyVersion = "1.6.1-SNAPSHOT";
 	static String roboVMVersion = "1.2.0";
-	static String buildToolsVersion = "20.0.0";
-	static String androidAPILevel = "20";
+	static String buildToolsVersion = "21.1.2";
+	static String androidAPILevel = "21";
 	static String gwtVersion = "2.6.0";
 
 	//Repositories


### PR DESCRIPTION
Currently the default is set to Android API level 20 and this is now 2 API levels off from the most recent version. I propose we bump this up to API level 21.