### PR TITLE
Update default Android API level & build tools to Android 5.1

### DIFF
--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/DependencyBank.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/DependencyBank.java
@@ -10,8 +10,8 @@ public class DependencyBank {
 	//Temporary snapshot version, we need a more dynamic solution for pointing to the latest nightly
 	static String libgdxNightlyVersion = "1.6.1-SNAPSHOT";
 	static String roboVMVersion = "1.2.0";
-	static String buildToolsVersion = "20.0.0";
-	static String androidAPILevel = "20";
+	static String buildToolsVersion = "22.0.0";
+	static String androidAPILevel = "22";
 	static String gwtVersion = "2.6.0";
 
 	//Repositories


### PR DESCRIPTION
Updating the default recommended API level and build tools version to Android 5.1. This change will stop users from seeing this dialog when attempting to use the latest version of the build tools.
![dialog](https://cloud.githubusercontent.com/assets/7663987/7671408/d9573f6a-fc83-11e4-9d91-1d26ac964702.PNG)

@Tom-Ski @MobiDevelop @badlogic 