### PR TITLE
Corrected FileHandle JavaDoc

### DIFF
--- a/gdx/src/com/badlogic/gdx/files/FileHandle.java
+++ b/gdx/src/com/badlogic/gdx/files/FileHandle.java
@@ -32,7 +32,6 @@ import java.io.OutputStreamWriter;
 import java.io.Reader;
 import java.io.UnsupportedEncodingException;
 import java.io.Writer;
-import java.nio.ByteBuffer;
 
 import com.badlogic.gdx.Files;
 import com.badlogic.gdx.Files.FileType;
@@ -486,17 +485,14 @@ public class FileHandle {
 		return file().isDirectory();
 	}
 
-	/** Returns a handle to the child with the specified name.
-	 * @throws GdxRuntimeException if this file handle is a {@link FileType#Classpath} or {@link FileType#Internal} and the child
-	 *            doesn't exist. */
+	/** Returns a handle to the child with the specified name. */
 	public FileHandle child (String name) {
 		if (file.getPath().length() == 0) return new FileHandle(new File(name), type);
 		return new FileHandle(new File(file, name), type);
 	}
 
 	/** Returns a handle to the sibling with the specified name.
-	 * @throws GdxRuntimeException if this file handle is a {@link FileType#Classpath} or {@link FileType#Internal} and the sibling
-	 *            doesn't exist, or this file is the root. */
+	 * @throws GdxRuntimeException if this file is the root. */
 	public FileHandle sibling (String name) {
 		if (file.getPath().length() == 0) throw new GdxRuntimeException("Cannot get the sibling of the root.");
 		return new FileHandle(new File(file.getParent(), name), type);


### PR DESCRIPTION
There are no such checks.

To be sure, I've tried both `FileHandle.sibling(...)` as well as `FileHandle.child(...)` with internal, non-existant files and no exceptions were thrown.