### PR TITLE
Changes TiledMapPacker Behavior, Adds new functionality. Closes #3127

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+[1.6.1]
+- TiledMapPacker outputs one texture atlas per map with default settings, options changed
+
 [1.6.0]
 - API Change: GlyphLayout xAdvances now have an additional entry at the beginning. This was required to implement tighter text bounds. #3034
 - API Change: Label#getTextBounds changed to getGlyphLayout. This exposes all the runs, not just the width and height.

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tiledmappacker/TiledMapPackerTest.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tiledmappacker/TiledMapPackerTest.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright 2015 See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogic.gdx.tiledmappacker;
+
+/** Processes the maps located in gdx-tests-android: "assets/data/maps/tiled-atlas-src" Creates the directory
+ * "assets/data/maps/tiled-atlas-processed/deleteMe" which contains processed maps. Run TiledMapPackerTestRender to render the
+ * maps and, optionally, delete the created folder on exit. */
+public class TiledMapPackerTest {
+
+	// TestTypes "NoArgs" and "BadOption" do not create/process maps.
+	public enum TestType {
+		NoArgs, DefaultUsage, Verbose, IncludeUnused, CombineTilesets, UnusedAndCombine, BadOption
+	}
+
+	public static void main (String[] args) throws Exception {
+		String path = "../../tests/gdx-tests-android/assets/data/maps/";
+		String input = path + "tiled-atlas-src";
+		String output = path + "tiled-atlas-processed/deleteMe";
+		String verboseOpt = "-v";
+		String unused = "--include-unused";
+		String combine = "--combine-tilesets";
+		String badOpt = "bad";
+
+		TestType testType = TestType.DefaultUsage;
+
+		String[] noArgs = {};
+		String[] defaultUsage = {input, output};
+		String[] verbose = {input, output, verboseOpt};
+		String[] includeUnused = {input, output, unused};
+		String[] combineTilesets = {input, output, combine};
+		String[] unusedAndCombine = {input, output, unused, combine};
+		String[] badOption = {input, output, unused, verboseOpt, combine, badOpt};
+
+		switch (testType) {
+		case NoArgs:
+			TiledMapPacker.main(noArgs);
+			break;
+		case DefaultUsage:
+			TiledMapPacker.main(defaultUsage);
+			break;
+		case Verbose:
+			TiledMapPacker.main(verbose);
+			break;
+		case IncludeUnused:
+			TiledMapPacker.main(includeUnused);
+			break;
+		case CombineTilesets:
+			TiledMapPacker.main(combineTilesets);
+			break;
+		case UnusedAndCombine:
+			TiledMapPacker.main(unusedAndCombine);
+			break;
+		case BadOption:
+			TiledMapPacker.main(badOption);
+			break;
+		default:
+			break;
+		}
+	}
+}

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tiledmappacker/TiledMapPackerTestRender.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tiledmappacker/TiledMapPackerTestRender.java
@@ -1,0 +1,101 @@
+/*******************************************************************************
+ * Copyright 2015 See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogic.gdx.tiledmappacker;
+
+import com.badlogic.gdx.ApplicationAdapter;
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Input.Keys;
+import com.badlogic.gdx.assets.loaders.resolvers.InternalFileHandleResolver;
+import com.badlogic.gdx.backends.lwjgl.LwjglApplication;
+import com.badlogic.gdx.files.FileHandle;
+import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.OrthographicCamera;
+import com.badlogic.gdx.maps.tiled.AtlasTmxMapLoader;
+import com.badlogic.gdx.maps.tiled.TiledMap;
+import com.badlogic.gdx.maps.tiled.renderers.OrthogonalTiledMapRenderer;
+import com.badlogic.gdx.utils.viewport.FitViewport;
+import com.badlogic.gdx.utils.viewport.Viewport;
+
+/** Renders and, optionally, deletes maps processed by TiledMapPackerTest. Run TiledMapPackerTest before running this */
+public class TiledMapPackerTestRender extends ApplicationAdapter {
+	final boolean DELETE_DELETEME_FOLDER_ON_EXIT = true;
+
+	final String PATH = "../../tests/gdx-tests-android/assets/data/maps/tiled-atlas-processed/deleteMe/";
+	final String MAP = "test.tmx";
+	final String TMX_LOC = PATH + MAP;
+	final boolean CENTER_CAM = false;
+	final float WORLD_WIDTH = 32;
+	final float WORLD_HEIGHT = 18;
+	final float PIXELS_PER_METER = 32;
+	final float UNIT_SCALE = 1f / PIXELS_PER_METER;
+	AtlasTmxMapLoader.AtlasTiledMapLoaderParameters params;
+	AtlasTmxMapLoader atlasTmxMapLoader;
+	TiledMap map;
+	Viewport viewport;
+	OrthogonalTiledMapRenderer mapRenderer;
+	OrthographicCamera cam;
+
+	@Override
+	public void create () {
+		atlasTmxMapLoader = new AtlasTmxMapLoader(new InternalFileHandleResolver());
+		params = new AtlasTmxMapLoader.AtlasTiledMapLoaderParameters();
+
+		params.generateMipMaps = false;
+		params.convertObjectToTileSpace = false;
+		params.flipY = true;
+
+		viewport = new FitViewport(WORLD_WIDTH, WORLD_HEIGHT);
+		cam = (OrthographicCamera)viewport.getCamera();
+
+		map = atlasTmxMapLoader.load(TMX_LOC, params);
+		mapRenderer = new OrthogonalTiledMapRenderer(map, UNIT_SCALE);
+	}
+
+	@Override
+	public void render () {
+		Gdx.gl.glClearColor(0.5f, 0, 0, 1f);
+		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+
+		viewport.apply();
+		mapRenderer.setView(cam);
+		mapRenderer.render();
+
+		if (Gdx.input.isKeyPressed(Keys.ESCAPE)) {
+			if (DELETE_DELETEME_FOLDER_ON_EXIT) {
+				FileHandle handle = Gdx.files.local(PATH);
+				handle.deleteDirectory();
+			}
+
+			dispose();
+			Gdx.app.exit();
+		}
+	}
+
+	@Override
+	public void resize (int width, int height) {
+		viewport.update(width, height, CENTER_CAM);
+	}
+
+	@Override
+	public void dispose () {
+		map.dispose();
+	}
+
+	public static void main (String[] args) throws Exception {
+		new LwjglApplication(new TiledMapPackerTestRender(), "", 640, 480);
+	}
+}


### PR DESCRIPTION
Changes TiledMapPacker to create one texture atlas per map, adds two classes to
test that I haven't messed things up more than they were.

##### Adds/Changes the following

 * Default behavior now strips unused tiles and creates an atlas for each map.
 * Searches for maps in nested folders, regardless of depth
 * Creates an individual atlas for each map (uses the map name sans extension)
 * Fixes the problem of not locating tilesets with ../ in the map Note: This has only been fixed with the      new functionality (not --combine-tilesets) The old method of combining tilesets into one atlas still has this problem.
 * Old functionality can be called with the option "--combine-tilesets"
 * Adds two classes to test the options and renders the processed maps
 * Changes usage to: Usage: INPUTDIR [OUTPUTDIR] [--include-unused] [--combine-tilesets] [-v]
 * Adds a new usage prompt that lists/hints at issues:

        Usage: INPUTDIR [OUTPUTDIR] [--include-unused] [--combine-tilesets] [-v] 
        Processes a directory of Tiled .tmx maps. Unable to process XML encoded tmx maps. Problems processing or loading tilesets with different tile size from those specified in the map.

            --include-unused 
                 creates a tileset with every tile, not just the used tiles. This can take a long time.           
            --combine-tilesets 
                 instead of creating a tileset for each map, this combines the tilesets into some kind of monster tileset. Has problems with tileset location. Has problems with nested folders. Not recommended. 
             -v 
                 outputs which tiles are stripped and included

##### Example:

Running TiledMapPacker on "./in ./out" with an "in" directory with the following structure:

* in/overworld.tmx
* in/dawn/Examples/Blank.tmx
* in/dawn/Examples/Dungeon.tmx
* in/dawn/Examples/Logo.tmx
* in/dawn/Examples/Mine.tmx
* in/dawn/Examples/Town.tmx
* in/dawn/Examples/Underworld.tmx
* in/world1Maps/dungeon1.tmx
* in/world1Maps/dungeon2.tmx
* in/world2Maps/town1.tmx
* in/world2Maps/town2.tmx

would have the following structure in the "out" directory:

* out/Blank.tmx
* out/dungeon1.tmx
* out/dungeon2.tmx
* out/Dungeon.tmx
* out/Logo.tmx
* out/Mine.tmx
* out/overworld.tmx
* out/town1.tmx
* out/town2.tmx
* out/Town.tmx
* out/Underworld.tmx
* out/tileset/Blank.atlas
* out/tileset/dungeon1.atlas
* out/tileset/dungeon1.png
* out/tileset/dungeon2.atlas
* out/tileset/dungeon2.png
* out/tileset/Dungeon.atlas
* out/tileset/Dungeon.png
* out/tileset/Logo.atlas
* out/tileset/Logo.png
* out/tileset/Mine.atlas
* out/tileset/Mine.png
* out/tileset/overworld.atlas
* out/tileset/overworld.png
* out/tileset/town1.atlas
* out/tileset/town2.atlas
* out/tileset/town2.png
* out/tileset/Town.atlas
* out/tileset/Town.png
* out/tileset/Underworld.atlas
* out/tileset/Underworld.png

(Note: maps without a tileset .png were completely empty maps)

Old functionality (now --combine-tilesets) can't handle the nested directories or parent (../) paths for tilesets but if it could run on the same in/out directories it would have the following output:

 * out/{same maps here}
 * out/tileset/packed.atlas
 * out/tileset/packed.png

With all of the tiles from every map inside the packed.png.

##### TL;DR

Changes TiledMapPacker to create one texture atlas per map, adds two classes to
test that I haven't messed things up more than they were.. I think.
 * modified:   CHANGES
 * modified:   extensions/gdx-tools/src/com/badlogic/gdx/tiledmappacker/TiledMapPacker.java
 * new file:   extensions/gdx-tools/src/com/badlogic/gdx/tiledmappacker/TiledMapPackerTest.java
 * new file:   extensions/gdx-tools/src/com/badlogic/gdx/tiledmappacker/TiledMapPackerTestRender.java