### PR TITLE
DragAndDrop event firing order fix

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/DragAndDrop.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/DragAndDrop.java
@@ -89,13 +89,17 @@ public class DragAndDrop {
 						if (!target.actor.isAscendantOf(hit)) continue;
 						newTarget = target;
 						target.actor.stageToLocalCoordinates(tmpVector.set(stageX, stageY));
-						isValidTarget = target.drag(source, payload, tmpVector.x, tmpVector.y, pointer);
 						break;
 					}
 				}
+				//if over a new target, notify the former target that it's being left behind.
 				if (newTarget != target) {
 					if (target != null) target.reset(source, payload);
 					target = newTarget;
+				}
+				//with any reset out of the way, notify new targets of drag.
+				if (newTarget != null) {
+					isValidTarget = newTarget.drag(source, payload, tmpVector.x, tmpVector.y, pointer);
 				}
 
 				if (dragActor != null) dragActor.setTouchable(dragActorTouchable);


### PR DESCRIPTION
Before this commit, `DragAndDrop` fired events just a bit out of order when dragging a Source object across two registered Target objects. 
Formerly, as we drug a source over two targets A then B these firings occurred in this order(hyphens separate the frames):

* targetA:drag()
* -----
* targetA:drag()
* -----                 <--- transition occurs here
* targetB:drag()
* targetA:reset()
* -----
* targetB:drag()
* ...so on

Though probably not a big deal, this could have been a problem if `reset` contained any state regarding the entire drag and drop operation. For example, `reset` may want to turn off a temporary visual indicator which showed where the dragged item would fall amongst a set of sorted targets (drag-sorting a list). But it doesn't want this indicator to turn off when leaving one target immediately for the next. 

As it was, the `drag` event which should have kept the indicator visible was negated by a late-to-the-party `reset` event that turns it back off. In our example this creates flicker and confusion when the indicator flashes or even disappears.

Workarounds exist, namely holding our last-dragged-over target in a field and seeing if it DOESN'T match our reset target but ERMAHGERD DERTS INSERN!

The small edit included here simply re-orders the event firing. So that, as we move over target A then B:

* targetA:drag()
* -----
* targetA:drag()
* -----                 <--- transition occurs here
* targetA:reset()
* targetB:drag()
* -----
* targetB:drag()
* .... so on

Ahh. Order.