### PR TITLE
Fixed a NPE.

### DIFF
--- a/gdx/src/com/badlogic/gdx/net/NetJavaImpl.java
+++ b/gdx/src/com/badlogic/gdx/net/NetJavaImpl.java
@@ -57,6 +57,12 @@ public class NetJavaImpl {
 		@Override
 		public byte[] getResult () {
 			InputStream input = getInputStream();
+
+			// If the response does not contain any content, input will be null.
+			if (input == null) {
+				return StreamUtils.EMPTY_BYTES;
+			}
+
 			try {
 				return StreamUtils.copyStreamToByteArray(input, connection.getContentLength());
 			} catch (IOException e) {


### PR DESCRIPTION
Added the same check as in `getResultAsString()`, for the same reason...

	java.lang.NullPointerException
		at com.badlogic.gdx.utils.StreamUtils.copyStream(StreamUtils.java:49)
		at com.badlogic.gdx.utils.StreamUtils.copyStream(StreamUtils.java:36)
		at com.badlogic.gdx.utils.StreamUtils.copyStreamToByteArray(StreamUtils.java:91)
		at com.badlogic.gdx.net.NetJavaImpl$HttpClientResponse.getResult(NetJavaImpl.java:61)