### PR TITLE
New TiledMapPacker output, fixes multiple tileset problem

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,7 @@
 [1.6.2]
 - API  Change: TiledMapImageLayer now uses floats instead of ints for positioning
+- Fixes AtlasTmxMapLoader region name loading to tileset name instead of filename
+- Changes TiledMapPacker output, region names are tileset names, adjusts gid, defaults to one atlas per map
 
 [1.6.1]
 - Added optional hostname argument to Net.newServerSocket method to allow specific ip bindings for server applications made with gdx.

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tiledmappacker/TiledMapPacker.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tiledmappacker/TiledMapPacker.java
@@ -18,10 +18,8 @@ import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.StringTokenizer;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -42,7 +40,7 @@ import org.xml.sax.SAXException;
 
 import com.badlogic.gdx.ApplicationListener;
 import com.badlogic.gdx.Gdx;
-import com.badlogic.gdx.assets.loaders.FileHandleResolver;
+import com.badlogic.gdx.assets.loaders.resolvers.AbsoluteFileHandleResolver;
 import com.badlogic.gdx.backends.lwjgl.LwjglApplication;
 import com.badlogic.gdx.backends.lwjgl.LwjglApplicationConfiguration;
 import com.badlogic.gdx.files.FileHandle;
@@ -62,13 +60,12 @@ import com.badlogic.gdx.utils.GdxRuntimeException;
 import com.badlogic.gdx.utils.IntArray;
 import com.badlogic.gdx.utils.ObjectMap;
 
-/** Given one or more TMX tilemaps, packs all tileset resources used across the maps into a <b>single</b> {@link TextureAtlas} and
- * produces a new TMX file to be loaded with an AtlasTiledMapLoader loader. Optionally, it can keep track of unused tiles and omit
- * them from the generated atlas, reducing the resource size.
+/** Given one or more TMX tilemaps, packs all tileset resources used across the maps, or the resources used per map, into a single,
+ * or multiple (one per map), {@link TextureAtlas} and produces a new TMX file to be loaded with an AtlasTiledMapLoader loader.
+ * Optionally, it can keep track of unused tiles and omit them from the generated atlas, reducing the resource size.
  * 
  * The original TMX map file will be parsed by using the {@link TmxMapLoader} loader, thus access to a valid OpenGL context is
- * <b>required</b>, that's why an LwjglApplication is created by this preprocessor: this is probably subject to change in the
- * future, where loading both maps metadata and graphics resources should be made conditional.
+ * <b>required</b>, that's why an LwjglApplication is created by this preprocessor.
  * 
  * The new TMX map file will contains a new property, namely "atlas", whose value will enable the AtlasTiledMapLoader to correctly
  * read the associated TextureAtlas representing the tileset.
@@ -76,22 +73,21 @@ import com.badlogic.gdx.utils.ObjectMap;
  * @author David Fraska and others (initial implementation, tell me who you are!)
  * @author Manuel Bua */
 public class TiledMapPacker {
-
 	private TexturePacker packer;
 	private TiledMap map;
 
-	private ArrayList<Integer> blendedTiles = new ArrayList<Integer>();
-	private TmxMapLoader mapLoader = new TmxMapLoader(new PackerFileHandleResolver());
+	private TmxMapLoader mapLoader = new TmxMapLoader(new AbsoluteFileHandleResolver());
 	private TiledMapPackerSettings settings;
 
-	// the tilesets output directory, relative to the global output directory
 	private static final String TilesetsOutputDir = "tileset";
+	static String AtlasOutputName = "packed";
 
-	// the generate atlas' name
-	private static final String AtlasOutputName = "packed";
-
-	// a map tracking tileids usage for any given tileset, across multiple maps
 	private HashMap<String, IntArray> tilesetUsedIds = new HashMap<String, IntArray>();
+	private ObjectMap<String, TiledMapTileSet> tilesetsToPack;
+
+	static File inputDir;
+	static File outputDir;
+	private FileHandle currentDir;
 
 	private static class TmxFilter implements FilenameFilter {
 		public TmxFilter () {
@@ -99,19 +95,17 @@ public class TiledMapPacker {
 
 		@Override
 		public boolean accept (File dir, String name) {
-			if (name.endsWith(".tmx")) return true;
-
-			return false;
+			return (name.endsWith(".tmx"));
 		}
 	}
 
-	private static class PackerFileHandleResolver implements FileHandleResolver {
-		public PackerFileHandleResolver () {
+	private static class DirFilter implements FilenameFilter {
+		public DirFilter () {
 		}
 
 		@Override
-		public FileHandle resolve (String fileName) {
-			return new FileHandle(fileName);
+		public boolean accept (File f, String s) {
+			return (new File(f, s).isDirectory());
 		}
 	}
 
@@ -126,84 +120,130 @@ public class TiledMapPacker {
 	}
 
 	/** You can either run the {@link TiledMapPacker#main(String[])} method or reference this class in your own project and call
-	 * this method.
+	 * this method. If working with libGDX sources, you can also run this file to create a run configuration then export it as a
+	 * Runnable Jar. To run from a nightly build:
+	 * 
+	 * <code> <br><br>
+	 * Linux / OS X <br>
+	   java -cp gdx.jar:gdx-natives.jar:gdx-backend-lwjgl.jar:gdx-backend-lwjgl-natives.jar:gdx-tiled-preprocessor.jar:extensions/gdx-tools/gdx-tools.jar
+	    com.badlogic.gdx.tiledmappacker.TiledMapPacker inputDir [outputDir]  [--strip-unused] [--combine-tilesets] [-v]
+	 * <br><br>
+	 * 
+	 * Windows <br>
+	   java -cp gdx.jar;gdx-natives.jar;gdx-backend-lwjgl.jar;gdx-backend-lwjgl-natives.jar;gdx-tiled-preprocessor.jar;extensions/gdx-tools/gdx-tools.jar
+	    com.badlogic.gdx.tiledmappacker.TiledMapPacker inputDir [outputDir]  [--strip-unused] [--combine-tilesets] [-v]
+	 * <br><br> </code>
 	 * 
 	 * Keep in mind that this preprocessor will need to load the maps by using the {@link TmxMapLoader} loader and this in turn
-	 * will need a valid OpenGL context to work: this is probably subject to change in the future, where loading both maps metadata
-	 * and graphics resources should be made conditional.
+	 * will need a valid OpenGL context to work.
 	 * 
-	 * Process a directory containing TMX map files representing Tiled maps and produce a single TextureAtlas as well as new
-	 * processed TMX map files, correctly referencing the generated {@link TextureAtlas} by using the "atlas" custom map property.
-	 * 
-	 * Typically, your maps will lie in a directory, such as "maps/" and your tilesets in a subdirectory such as "maps/city": this
-	 * layout will ensure that MapEditor will reference your tileset with a very simple relative path and no parent directory
-	 * names, such as "..", will ever happen in your TMX file definition avoiding much of the confusion caused by the preprocessor
-	 * working with relative paths.
-	 * 
-	 * <strong>WARNING!</strong> Use caution if you have a "../" in the path of your tile sets! The output for these tile sets will
-	 * be relative to the output directory. For example, if your output directory is "C:\mydir\maps" and you have a tileset with
-	 * the path "../tileset.png", the tileset will be output to "C:\mydir\" and the maps will be in "C:\mydir\maps".
-	 * 
-	 * @param inputDir the input directory containing the tmx files (and tile sets, relative to the path listed in the tmx file)
-	 * @param outputDir The output directory for the TMX files, <strong>should be empty before running</strong>.
-	 * @param settings the settings used in the TexturePacker */
-	public void processMaps (File inputDir, File outputDir, Settings settings) throws IOException {
-		FileHandle inputDirHandle = new FileHandle(inputDir.getAbsolutePath());
-		File[] files = inputDir.listFiles(new TmxFilter());
-		ObjectMap<String, TiledMapTileSet> tilesetsToPack = new ObjectMap<String, TiledMapTileSet>();
+	 * Process a directory containing TMX map files representing Tiled maps and produce multiple, or a single, TextureAtlas as well
+	 * as new processed TMX map files, correctly referencing the generated {@link TextureAtlas} by using the "atlas" custom map
+	 * property. */
+	public void processInputDir (Settings texturePackerSettings) throws IOException {
+		FileHandle inputDirHandle = new FileHandle(inputDir.getCanonicalPath());
+		File[] mapFilesInCurrentDir = inputDir.listFiles(new TmxFilter());
+		tilesetsToPack = new ObjectMap<String, TiledMapTileSet>();
 
-		for (File file : files) {
-			map = mapLoader.load(file.getAbsolutePath());
+		// Processes the maps inside inputDir
+		for (File mapFile : mapFilesInCurrentDir) {
+			processSingleMap(mapFile, inputDirHandle, texturePackerSettings);
+		}
 
-			// if enabled, build a list of used tileids for the tileset used by this map
-			if (this.settings.stripUnusedTiles) {
-				int mapWidth = map.getProperties().get("width", Integer.class);
-				int mapHeight = map.getProperties().get("height", Integer.class);
-				int numlayers = map.getLayers().getCount();
-				int bucketSize = mapWidth * mapHeight * numlayers;
+		processSubdirectories(inputDirHandle, texturePackerSettings);
 
-				Iterator<MapLayer> it = map.getLayers().iterator();
-				while (it.hasNext()) {
-					MapLayer layer = it.next();
+		boolean combineTilesets = this.settings.combineTilesets;
+		if (combineTilesets == true) {
+			packTilesets(inputDirHandle, texturePackerSettings);
+		}
+	}
 
-					// some layers can be plain MapLayer instances (ie. object groups), just ignore them
-					if (layer instanceof TiledMapTileLayer) {
-						TiledMapTileLayer tlayer = (TiledMapTileLayer)layer;
+	/** Looks for subdirectories inside parentHandle, processes maps in subdirectory, repeat.
+	 * @param currentDir The directory to look for maps and other directories
+	 * @throws IOException */
+	private void processSubdirectories (FileHandle currentDir, Settings texturePackerSettings) throws IOException {
+		File parentPath = new File(currentDir.path());
+		File[] directories = parentPath.listFiles(new DirFilter());
 
-						for (int y = 0; y < mapHeight; ++y) {
-							for (int x = 0; x < mapWidth; ++x) {
-								if (tlayer.getCell(x, y) != null) {
-									TiledMapTile tile = tlayer.getCell(x, y).getTile();
-									if (tile instanceof AnimatedTiledMapTile) {
-										AnimatedTiledMapTile aTile = (AnimatedTiledMapTile)tile;
-										for (StaticTiledMapTile t : aTile.getFrameTiles()) {
-											addTile(t, bucketSize, tilesetsToPack);
-										}
-									}
-									// Adds non-animated tiles and the base animated tile
-									addTile(tile, bucketSize, tilesetsToPack);
+		for (File directory : directories) {
+			currentDir = new FileHandle(directory.getCanonicalPath());
+			File[] mapFilesInCurrentDir = directory.listFiles(new TmxFilter());
+
+			for (File mapFile : mapFilesInCurrentDir) {
+				processSingleMap(mapFile, currentDir, texturePackerSettings);
+			}
+
+			processSubdirectories(currentDir, texturePackerSettings);
+		}
+	}
+
+	private void processSingleMap (File mapFile, FileHandle dirHandle, Settings texturePackerSettings) throws IOException {
+		boolean combineTilesets = this.settings.combineTilesets;
+		if (combineTilesets == false) {
+			tilesetUsedIds = new HashMap<String, IntArray>();
+			tilesetsToPack = new ObjectMap<String, TiledMapTileSet>();
+		}
+
+		map = mapLoader.load(mapFile.getCanonicalPath());
+
+		// if enabled, build a list of used tileids for the tileset used by this map
+		boolean stripUnusedTiles = this.settings.stripUnusedTiles;
+		if (stripUnusedTiles) {
+			stripUnusedTiles();
+		} else {
+			for (TiledMapTileSet tileset : map.getTileSets()) {
+				String tilesetName = tileset.getName();
+				if (!tilesetsToPack.containsKey(tilesetName)) {
+					tilesetsToPack.put(tilesetName, tileset);
+				}
+			}
+		}
+
+		if (combineTilesets == false) {
+			FileHandle tmpHandle = new FileHandle(mapFile.getName());
+			this.settings.atlasOutputName = tmpHandle.nameWithoutExtension();
+
+			packTilesets(dirHandle, texturePackerSettings);
+		}
+
+		FileHandle tmxFile = new FileHandle(mapFile.getCanonicalPath());
+		writeUpdatedTMX(map, tmxFile);
+	}
+
+	private void stripUnusedTiles () {
+		int mapWidth = map.getProperties().get("width", Integer.class);
+		int mapHeight = map.getProperties().get("height", Integer.class);
+		int numlayers = map.getLayers().getCount();
+		int bucketSize = mapWidth * mapHeight * numlayers;
+
+		Iterator<MapLayer> it = map.getLayers().iterator();
+		while (it.hasNext()) {
+			MapLayer layer = it.next();
+
+			// some layers can be plain MapLayer instances (ie. object groups), just ignore them
+			if (layer instanceof TiledMapTileLayer) {
+				TiledMapTileLayer tlayer = (TiledMapTileLayer)layer;
+
+				for (int y = 0; y < mapHeight; ++y) {
+					for (int x = 0; x < mapWidth; ++x) {
+						if (tlayer.getCell(x, y) != null) {
+							TiledMapTile tile = tlayer.getCell(x, y).getTile();
+							if (tile instanceof AnimatedTiledMapTile) {
+								AnimatedTiledMapTile aTile = (AnimatedTiledMapTile)tile;
+								for (StaticTiledMapTile t : aTile.getFrameTiles()) {
+									addTile(t, bucketSize);
 								}
 							}
+							// Adds non-animated tiles and the base animated tile
+							addTile(tile, bucketSize);
 						}
 					}
 				}
-			} else {
-				for (TiledMapTileSet tileset : map.getTileSets()) {
-					String tilesetName = tileset.getName();
-					if (!tilesetsToPack.containsKey(tilesetName)) {
-						tilesetsToPack.put(tilesetName, tileset);
-					}
-				}
 			}
-
-			FileHandle tmxFile = new FileHandle(file.getAbsolutePath());
-			writeUpdatedTMX(map, outputDir, tmxFile);
 		}
-
-		packTilesets(tilesetsToPack, inputDirHandle, outputDir, settings);
 	}
 
-	private void addTile (TiledMapTile tile, int bucketSize, ObjectMap<String, TiledMapTileSet> tilesetsToPack) {
+	private void addTile (TiledMapTile tile, int bucketSize) {
 		int tileid = tile.getId() & ~0xE0000000;
 		String tilesetName = tilesetNameFromTileId(map, tileid);
 		IntArray usedIds = getUsedIdsBucket(tilesetName, bucketSize);
@@ -215,8 +255,6 @@ public class TiledMapPacker {
 		}
 	}
 
-	/** Returns the tileset name associated with the specified tile id
-	 * @return a tileset name */
 	private String tilesetNameFromTileId (TiledMap map, int tileid) {
 		String name = "";
 		if (tileid == 0) {
@@ -257,18 +295,17 @@ public class TiledMapPacker {
 
 	/** Traverse the specified tilesets, optionally lookup the used ids and pass every tile image to the {@link TexturePacker},
 	 * optionally ignoring unused tile ids */
-	private void packTilesets (ObjectMap<String, TiledMapTileSet> sets, FileHandle inputDirHandle, File outputDir,
-		Settings texturePackerSettings) throws IOException {
+	private void packTilesets (FileHandle inputDirHandle, Settings texturePackerSettings) throws IOException {
 		BufferedImage tile;
 		Vector2 tileLocation;
-		TileSetLayout packerTileSet;
 		Graphics g;
 
 		packer = new TexturePacker(texturePackerSettings);
 
-		for (TiledMapTileSet set : sets.values()) {
+		for (TiledMapTileSet set : tilesetsToPack.values()) {
 			String tilesetName = set.getName();
 			System.out.println("Processing tileset " + tilesetName);
+
 			IntArray usedIds = this.settings.stripUnusedTiles ? getUsedIdsBucket(tilesetName, -1) : null;
 
 			int tileWidth = set.getProperties().get("tilewidth", Integer.class);
@@ -279,8 +316,12 @@ public class TiledMapPacker {
 			TileSetLayout layout = new TileSetLayout(firstgid, set, inputDirHandle);
 
 			for (int gid = layout.firstgid, i = 0; i < layout.numTiles; gid++, i++) {
+				boolean verbose = this.settings.verbose;
+
 				if (usedIds != null && !usedIds.contains(gid)) {
-					System.out.println("Stripped id #" + gid + " from tileset \"" + tilesetName + "\"");
+					if (verbose) {
+						System.out.println("Stripped id #" + gid + " from tileset \"" + tilesetName + "\"");
+					}
 					continue;
 				}
 
@@ -291,64 +332,28 @@ public class TiledMapPacker {
 				g.drawImage(layout.image, 0, 0, tileWidth, tileHeight, (int)tileLocation.x, (int)tileLocation.y, (int)tileLocation.x
 					+ tileWidth, (int)tileLocation.y + tileHeight, null);
 
-				if (isBlended(tile)) setBlended(gid);
-				System.out.println("Adding " + tileWidth + "x" + tileHeight + " (" + (int)tileLocation.x + ", " + (int)tileLocation.y
-					+ ")");
-				packer.addImage(tile, this.settings.atlasOutputName + "_" + (gid - 1));
+				if (verbose) {
+					System.out.println("Adding " + tileWidth + "x" + tileHeight + " (" + (int)tileLocation.x + ", "
+						+ (int)tileLocation.y + ")");
+				}
+				// AtlasTmxMapLoader expects every tileset's index to begin at zero for the first tile in every tileset.
+				// so the region's adjusted gid is (gid - layout.firstgid). firstgid will be added back in AtlasTmxMapLoader on load
+				int adjustedGid = gid - layout.firstgid;
+				final String separator = "_";
+				String regionName = tilesetName + separator + adjustedGid;
+
+				packer.addImage(tile, regionName);
 			}
 		}
+		String tilesetOutputDir = outputDir.toString() + "/" + this.settings.tilesetOutputDirectory;
+		File relativeTilesetOutputDir = new File(tilesetOutputDir);
+		File outputDirTilesets = new File(relativeTilesetOutputDir.getCanonicalPath());
 
-		File outputDirTilesets = getRelativeFile(outputDir, this.settings.tilesetOutputDirectory);
 		outputDirTilesets.mkdirs();
 		packer.pack(outputDirTilesets, this.settings.atlasOutputName + ".atlas");
 	}
 
-	private static String removeExtension (String s) {
-		int extensionIndex = s.lastIndexOf(".");
-		if (extensionIndex == -1) return s;
-
-		return s.substring(0, extensionIndex);
-	}
-
-	private static String removePath (String s) {
-		String temp;
-
-		int index = s.lastIndexOf('\\');
-		if (index != -1)
-			temp = s.substring(index + 1);
-		else
-			temp = s;
-
-		index = temp.lastIndexOf('/');
-		if (index != -1)
-			return s.substring(index + 1);
-		else
-			return s;
-	}
-
-	private static File getRelativeFile (File path, String relativePath) {
-		if (relativePath.trim().length() == 0) return path;
-
-		File child = path;
-
-		StringTokenizer tokenizer = new StringTokenizer(relativePath, "\\/");
-		while (tokenizer.hasMoreElements()) {
-			String token = tokenizer.nextToken();
-			if (token.equals(".."))
-				child = child.getParentFile();
-			else {
-				child = new File(child, token);
-			}
-		}
-
-		return child;
-	}
-
-	private void setBlended (int tileNum) {
-		blendedTiles.add(tileNum);
-	}
-
-	private void writeUpdatedTMX (TiledMap tiledMap, File outputDir, FileHandle tmxFileHandle) throws IOException {
+	private void writeUpdatedTMX (TiledMap tiledMap, FileHandle tmxFileHandle) throws IOException {
 		Document doc;
 		DocumentBuilder docBuilder;
 		DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
@@ -364,7 +369,6 @@ public class TiledMapPacker {
 				}
 			}
 
-			setProperty(doc, map, "blended tiles", toCSV(blendedTiles));
 			setProperty(doc, map, "atlas", settings.tilesetOutputDirectory + "/" + settings.atlasOutputName + ".atlas");
 
 			TransformerFactory transformerFactory = TransformerFactory.newInstance();
@@ -401,15 +405,6 @@ public class TiledMapPacker {
 		}
 	}
 
-	private static String toCSV (ArrayList<Integer> values) {
-		String temp = "";
-		for (int i = 0; i < values.size() - 1; i++) {
-			temp += values.get(i) + ",";
-		}
-		if (values.size() > 0) temp += values.get(values.size() - 1);
-		return temp;
-	}
-
 	/** If the child node doesn't exist, it is created. */
 	private static Node getFirstChildNodeByName (Node parent, String child) {
 		NodeList childNodes = parent.getChildNodes();
@@ -427,19 +422,8 @@ public class TiledMapPacker {
 			return parent.appendChild(newNode);
 	}
 
-	private static boolean isBlended (BufferedImage tile) {
-		int[] rgbArray = new int[tile.getWidth() * tile.getHeight()];
-		tile.getRGB(0, 0, tile.getWidth(), tile.getHeight(), rgbArray, 0, tile.getWidth());
-		for (int i = 0; i < tile.getWidth() * tile.getHeight(); i++) {
-			if (((rgbArray[i] >> 24) & 0xff) != 255) {
-				return true;
-			}
-		}
-		return false;
-	}
-
 	/** If the child node or attribute doesn't exist, it is created. Usage example: Node property =
-	 * getFirstChildByAttrValue(properties, "property", "name", "blended tiles"); */
+	 * getFirstChildByAttrValue(properties, "property", "name"); */
 	private static Node getFirstChildByNameAttrValue (Node node, String childName, String attr, String value) {
 		NodeList childNodes = node.getChildNodes();
 		for (int i = 0; i < childNodes.getLength(); i++) {
@@ -464,17 +448,10 @@ public class TiledMapPacker {
 		}
 	}
 
-	static File inputDir;
-	static File outputDir;
-
 	/** Processes a directory of Tile Maps, compressing each tile set contained in any map once.
 	 * 
 	 * @param args args[0]: the input directory containing the tmx files (and tile sets, relative to the path listed in the tmx
-	 *           file). args[1]: The output directory for the tmx files, should be empty before running. WARNING: Use caution if
-	 *           you have a "../" in the path of your tile sets! The output for these tile sets will be relative to the output
-	 *           directory. For example, if your output directory is "C:\mydir\output" and you have a tileset with the path
-	 *           "../tileset.png", the tileset will be output to "C:\mydir\" and the maps will be in "C:\mydir\output". args[2]:
-	 *           --strip-unused (optional, include to let the TiledMapPacker remove tiles which are not used. */
+	 *           file). args[1]: The output directory for the tmx files, should be empty before running. args[2-4] options */
 	public static void main (String[] args) {
 		final Settings texturePackerSettings = new Settings();
 		texturePackerSettings.paddingX = 2;
@@ -487,29 +464,19 @@ public class TiledMapPacker {
 
 		final TiledMapPackerSettings packerSettings = new TiledMapPackerSettings();
 
-		switch (args.length) {
-		case 3: {
-			inputDir = new File(args[0]);
-			outputDir = new File(args[1]);
-			if ("--strip-unused".equals(args[2])) {
-				packerSettings.stripUnusedTiles = true;
-			}
-			break;
-		}
-		case 2: {
-			inputDir = new File(args[0]);
-			outputDir = new File(args[1]);
-			break;
-		}
-		case 1: {
-			inputDir = new File(args[0]);
-			outputDir = new File(inputDir, "output/");
-			break;
-		}
-		default: {
-			System.out.println("Usage: INPUTDIR [OUTPUTDIR] [--strip-unused]");
+		if (args.length == 0) {
+			printUsage();
 			System.exit(0);
-		}
+		} else if (args.length == 1) {
+			inputDir = new File(args[0]);
+			outputDir = new File(inputDir, "../output/");
+		} else if (args.length == 2) {
+			inputDir = new File(args[0]);
+			outputDir = new File(args[1]);
+		} else {
+			inputDir = new File(args[0]);
+			outputDir = new File(args[1]);
+			processExtraArgs(args, packerSettings);
 		}
 
 		TiledMapPacker packer = new TiledMapPacker(packerSettings);
@@ -545,22 +512,67 @@ public class TiledMapPacker {
 				TiledMapPacker packer = new TiledMapPacker(packerSettings);
 
 				if (!inputDir.exists()) {
+					System.out.println(inputDir.getAbsolutePath());
 					throw new RuntimeException("Input directory does not exist: " + inputDir);
 				}
 
 				try {
-					packer.processMaps(inputDir, outputDir, texturePackerSettings);
+					packer.processInputDir(texturePackerSettings);
 				} catch (IOException e) {
 					throw new RuntimeException("Error processing map: " + e.getMessage());
 				}
-
+				System.out.println("Finished processing.");
 				Gdx.app.exit();
 			}
 		}, config);
 	}
 
+	private static void processExtraArgs (String[] args, TiledMapPackerSettings packerSettings) {
+		String stripUnused = "--strip-unused";
+		String combineTilesets = "--combine-tilesets";
+		String verbose = "-v";
+
+		int length = args.length - 2;
+		String[] argsNotDir = new String[length];
+		System.arraycopy(args, 2, argsNotDir, 0, length);
+
+		for (String string : argsNotDir) {
+			if (stripUnused.equals(string)) {
+				packerSettings.stripUnusedTiles = true;
+
+			} else if (combineTilesets.equals(string)) {
+				packerSettings.combineTilesets = true;
+
+			} else if (verbose.equals(string)) {
+				packerSettings.verbose = true;
+
+			} else {
+				System.out.println("\nOption \"" + string + "\" not recognized.\n");
+				printUsage();
+				System.exit(0);
+			}
+		}
+	}
+
+	private static void printUsage () {
+		System.out.println("Usage: INPUTDIR [OUTPUTDIR] [--strip-unused] [--combine-tilesets] [-v]");
+		System.out.println("Processes a directory of Tiled .tmx maps. Unable to process maps with XML");
+		System.out.println("tile layer format.");
+		System.out.println("  --strip-unused             omits all tiles that are not used. Speeds up");
+		System.out.println("                             the processing. Smaller tilesets.");
+		System.out.println("  --combine-tilesets         instead of creating a tileset for each map,");
+		System.out.println("                             this combines the tilesets into some kind");
+		System.out.println("                             of monster tileset. Has problems with tileset");
+		System.out.println("                             location. Has problems with nested folders.");
+		System.out.println("                             Not recommended.");
+		System.out.println("  -v                         outputs which tiles are stripped and included");
+		System.out.println();
+	}
+
 	public static class TiledMapPackerSettings {
 		public boolean stripUnusedTiles = false;
+		public boolean combineTilesets = false;
+		public boolean verbose = false;
 		public String tilesetOutputDirectory = TilesetsOutputDir;
 		public String atlasOutputName = AtlasOutputName;
 	}

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tiledmappacker/TiledMapPackerTest.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tiledmappacker/TiledMapPackerTest.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright 2015 See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogic.gdx.tiledmappacker;
+
+import java.io.File;
+
+/** Processes the maps located in gdx-tests-android: "assets/data/maps/tiled-atlas-src" Creates the directory
+ * "assets/data/maps/tiled-atlas-processed/deleteMe" which contains processed maps. Run TiledMapPackerTestRender to render the
+ * maps and, optionally, delete the created folder on exit. */
+public class TiledMapPackerTest {
+
+	// TestTypes "NoArgs" and "BadOption" do not create/process maps.
+	public enum TestType {
+		NoArgs, DefaultUsage, Verbose, StripUnused, CombineTilesets, UnusedAndCombine, BadOption
+	}
+
+	public static void main (String[] args) throws Exception {
+		String path = "../../tests/gdx-tests-android/assets/data/maps/";
+		String input = path + "tiled-atlas-src";
+		String output = path + "tiled-atlas-processed/deleteMe";
+		String verboseOpt = "-v";
+		String unused = "--strip-unused";
+		String combine = "--combine-tilesets";
+		String badOpt = "bad";
+
+		File outputDir = new File(output);
+		if (outputDir.exists()) {
+			System.out.println("Please run TiledMapPackerTestRender or delete \"deleteMe\" folder located in");
+			System.out.println("gdx-tests-android: assets/data/maps/tiled-atlas-processed/deleteMe");
+			return;
+		}
+
+		TestType testType = TestType.DefaultUsage;
+
+		String[] noArgs = {};
+		String[] defaultUsage = {input, output};
+		String[] verbose = {input, output, verboseOpt};
+		String[] stripUnused = {input, output, unused};
+		String[] combineTilesets = {input, output, combine};
+		String[] unusedAndCombine = {input, output, unused, combine};
+		String[] badOption = {input, output, unused, verboseOpt, combine, badOpt};
+
+		switch (testType) {
+		case NoArgs:
+			TiledMapPacker.main(noArgs);
+			break;
+		case DefaultUsage:
+			TiledMapPacker.main(defaultUsage);
+			break;
+		case Verbose:
+			TiledMapPacker.main(verbose);
+			break;
+		case StripUnused:
+			TiledMapPacker.main(stripUnused);
+			break;
+		case CombineTilesets:
+			TiledMapPacker.main(combineTilesets);
+			break;
+		case UnusedAndCombine:
+			TiledMapPacker.main(unusedAndCombine);
+			break;
+		case BadOption:
+			TiledMapPacker.main(badOption);
+			break;
+		default:
+			break;
+		}
+	}
+}

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tiledmappacker/TiledMapPackerTestRender.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tiledmappacker/TiledMapPackerTestRender.java
@@ -1,0 +1,113 @@
+/*******************************************************************************
+ * Copyright 2015 See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogic.gdx.tiledmappacker;
+
+import java.io.File;
+
+import com.badlogic.gdx.ApplicationAdapter;
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Input.Keys;
+import com.badlogic.gdx.assets.loaders.resolvers.InternalFileHandleResolver;
+import com.badlogic.gdx.backends.lwjgl.LwjglApplication;
+import com.badlogic.gdx.files.FileHandle;
+import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.OrthographicCamera;
+import com.badlogic.gdx.maps.tiled.AtlasTmxMapLoader;
+import com.badlogic.gdx.maps.tiled.TiledMap;
+import com.badlogic.gdx.maps.tiled.renderers.OrthogonalTiledMapRenderer;
+import com.badlogic.gdx.utils.viewport.FitViewport;
+import com.badlogic.gdx.utils.viewport.Viewport;
+
+/** Renders and, optionally, deletes maps processed by TiledMapPackerTest. Run TiledMapPackerTest before running this */
+public class TiledMapPackerTestRender extends ApplicationAdapter {
+
+	// --WARNING!--
+	// Please do not edit the MAP_PATH. This deletes the folder recursively and could be very dangerous. The default location is:
+	// MAP_PATH = "../../tests/gdx-tests-android/assets/data/maps/tiled-atlas-processed/deleteMe/";
+
+	private final boolean DELETE_DELETEME_FOLDER_ON_EXIT = false; // read warning before setting to true
+	private final static String MAP_PATH = "../../tests/gdx-tests-android/assets/data/maps/tiled-atlas-processed/deleteMe/";
+
+	private final String MAP_NAME = "test.tmx";
+	private final String TMX_LOC = MAP_PATH + MAP_NAME;
+	private final boolean CENTER_CAM = true;
+	private final float WORLD_WIDTH = 32;
+	private final float WORLD_HEIGHT = 18;
+	private final float PIXELS_PER_METER = 32;
+	private final float UNIT_SCALE = 1f / PIXELS_PER_METER;
+	private AtlasTmxMapLoader.AtlasTiledMapLoaderParameters params;
+	private AtlasTmxMapLoader atlasTmxMapLoader;
+	private TiledMap map;
+	private Viewport viewport;
+	private OrthogonalTiledMapRenderer mapRenderer;
+	private OrthographicCamera cam;
+
+	@Override
+	public void create () {
+		atlasTmxMapLoader = new AtlasTmxMapLoader(new InternalFileHandleResolver());
+		params = new AtlasTmxMapLoader.AtlasTiledMapLoaderParameters();
+
+		params.generateMipMaps = false;
+		params.convertObjectToTileSpace = false;
+		params.flipY = true;
+
+		viewport = new FitViewport(WORLD_WIDTH, WORLD_HEIGHT);
+		cam = (OrthographicCamera)viewport.getCamera();
+
+		map = atlasTmxMapLoader.load(TMX_LOC, params);
+		mapRenderer = new OrthogonalTiledMapRenderer(map, UNIT_SCALE);
+	}
+
+	@Override
+	public void render () {
+		Gdx.gl.glClearColor(0, 0, 0, 1f);
+		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+
+		viewport.apply();
+		mapRenderer.setView(cam);
+		mapRenderer.render();
+
+		if (Gdx.input.isKeyPressed(Keys.ESCAPE)) {
+			if (DELETE_DELETEME_FOLDER_ON_EXIT) {
+				FileHandle deleteMeHandle = Gdx.files.local(MAP_PATH);
+				deleteMeHandle.deleteDirectory();
+			}
+
+			dispose();
+			Gdx.app.exit();
+		}
+	}
+
+	@Override
+	public void resize (int width, int height) {
+		viewport.update(width, height, CENTER_CAM);
+	}
+
+	@Override
+	public void dispose () {
+		map.dispose();
+	}
+
+	public static void main (String[] args) throws Exception {
+		File file = new File(MAP_PATH);
+		if (!file.exists()) {
+			System.out.println("Please run TiledMapPackerTest.");
+			return;
+		}
+		new LwjglApplication(new TiledMapPackerTestRender(), "", 640, 480);
+	}
+}

--- a/gdx/src/com/badlogic/gdx/maps/tiled/AtlasTmxMapLoader.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/AtlasTmxMapLoader.java
@@ -348,7 +348,7 @@ public class AtlasTmxMapLoader extends BaseTmxMapLoader<AtlasTmxMapLoader.AtlasT
 			FileHandle atlasHandle = getRelativeFileHandle(tmxFile, atlasFilePath);
 			atlasHandle = resolve(atlasHandle.path());
 			TextureAtlas atlas = resolver.getAtlas(atlasHandle.path());
-			String regionsName = atlasHandle.nameWithoutExtension();
+			String regionsName = name;
 
 			for (Texture texture : atlas.getTextures()) {
 				trackedTextures.add(texture);

--- a/tests/gdx-tests-android/assets/data/maps/tiled-atlas-processed/test.tmx
+++ b/tests/gdx-tests-android/assets/data/maps/tiled-atlas-processed/test.tmx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?><map height="10" orientation="orthogonal" tileheight="16" tilewidth="16" version="1.0" width="20"><properties><property name="atlas" value="tileset/packed.atlas"/><property name="blended tiles" value=""/></properties>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><map height="10" orientation="orthogonal" tileheight="16" tilewidth="16" version="1.0" width="20"><properties><property name="atlas" value="tileset/packed.atlas"/></properties>
  <tileset firstgid="1" name="ts1" tileheight="16" tilewidth="16">
   <image height="256" source="tilesets/tileset1.png" width="256"/>
  </tileset>

--- a/tests/gdx-tests-android/assets/data/maps/tiled-atlas-processed/tileset/packed.atlas
+++ b/tests/gdx-tests-android/assets/data/maps/tiled-atlas-processed/tileset/packed.atlas
@@ -1,264 +1,321 @@
 
 packed.png
+size: 128,128
 format: RGBA8888
 filter: Nearest,Nearest
 repeat: none
-packed
-  rotate: false
-  xy: 1, 91
-  size: 32, 32
-  orig: 32, 32
-  offset: 0, 0
-  index: 265
-packed
-  rotate: false
-  xy: 1, 57
-  size: 32, 32
-  orig: 32, 32
-  offset: 0, 0
-  index: 266
-packed
-  rotate: false
-  xy: 35, 91
-  size: 32, 32
-  orig: 32, 32
-  offset: 0, 0
-  index: 267
-packed
+ts1
   rotate: false
   xy: 1, 39
   size: 16, 16
   orig: 16, 16
   offset: 0, 0
   index: 9
-packed
+ts1
   rotate: false
   xy: 1, 39
   size: 16, 16
   orig: 16, 16
   offset: 0, 0
-  index: 9
-packed
+  index: 10
+ts1
+  rotate: false
+  xy: 1, 39
+  size: 16, 16
+  orig: 16, 16
+  offset: 0, 0
+  index: 41
+ts1
+  rotate: false
+  xy: 1, 39
+  size: 16, 16
+  orig: 16, 16
+  offset: 0, 0
+  index: 25
+ts1
+  rotate: false
+  xy: 1, 39
+  size: 16, 16
+  orig: 16, 16
+  offset: 0, 0
+  index: 15
+ts1
+  rotate: false
+  xy: 1, 39
+  size: 16, 16
+  orig: 16, 16
+  offset: 0, 0
+  index: 26
+ts1
+  rotate: false
+  xy: 1, 39
+  size: 16, 16
+  orig: 16, 16
+  offset: 0, 0
+  index: 30
+ts1
+  rotate: false
+  xy: 1, 39
+  size: 16, 16
+  orig: 16, 16
+  offset: 0, 0
+  index: 31
+ts1
+  rotate: false
+  xy: 1, 39
+  size: 16, 16
+  orig: 16, 16
+  offset: 0, 0
+  index: 47
+ts1
+  rotate: false
+  xy: 1, 39
+  size: 16, 16
+  orig: 16, 16
+  offset: 0, 0
+  index: 14
+ts1
   rotate: false
   xy: 35, 73
   size: 16, 16
   orig: 16, 16
   offset: 0, 0
   index: 11
-packed
+ts1
   rotate: false
   xy: 69, 107
   size: 16, 16
   orig: 16, 16
   offset: 0, 0
   index: 12
-packed
+ts1
   rotate: false
   xy: 1, 21
   size: 16, 16
   orig: 16, 16
   offset: 0, 0
   index: 13
-packed
+ts1
   rotate: false
   xy: 87, 107
   size: 16, 16
   orig: 16, 16
   offset: 0, 0
   index: 27
-packed
+ts1
   rotate: false
   xy: 1, 3
   size: 16, 16
   orig: 16, 16
   offset: 0, 0
   index: 28
-packed
+ts1
   rotate: false
   xy: 105, 107
   size: 16, 16
   orig: 16, 16
   offset: 0, 0
   index: 29
-packed
+ts1
   rotate: false
   xy: 19, 39
   size: 16, 16
   orig: 16, 16
   offset: 0, 0
   index: 42
-packed
+ts1
   rotate: false
   xy: 19, 21
   size: 16, 16
   orig: 16, 16
   offset: 0, 0
   index: 43
-packed
+ts1
   rotate: false
   xy: 19, 3
   size: 16, 16
   orig: 16, 16
   offset: 0, 0
   index: 44
-packed
+ts1
   rotate: false
   xy: 53, 73
   size: 16, 16
   orig: 16, 16
   offset: 0, 0
   index: 45
-packed
+ts1
   rotate: false
   xy: 37, 55
   size: 16, 16
   orig: 16, 16
   offset: 0, 0
   index: 46
-packed
+ts1
   rotate: false
   xy: 37, 37
   size: 16, 16
   orig: 16, 16
   offset: 0, 0
   index: 57
-packed
+ts1
   rotate: false
   xy: 37, 19
   size: 16, 16
   orig: 16, 16
   offset: 0, 0
   index: 58
-packed
+ts1
   rotate: false
   xy: 55, 55
   size: 16, 16
   orig: 16, 16
   offset: 0, 0
   index: 59
-packed
+ts1
   rotate: false
   xy: 55, 37
   size: 16, 16
   orig: 16, 16
   offset: 0, 0
   index: 60
-packed
+ts1
   rotate: false
   xy: 55, 19
   size: 16, 16
   orig: 16, 16
   offset: 0, 0
   index: 61
-packed
+ts1
   rotate: false
   xy: 37, 1
   size: 16, 16
   orig: 16, 16
   offset: 0, 0
   index: 62
-packed
+ts1
   rotate: false
   xy: 55, 1
   size: 16, 16
   orig: 16, 16
   offset: 0, 0
   index: 63
-packed
+ts1
   rotate: false
   xy: 71, 89
   size: 16, 16
   orig: 16, 16
   offset: 0, 0
   index: 73
-packed
+ts1
   rotate: false
   xy: 89, 89
   size: 16, 16
   orig: 16, 16
   offset: 0, 0
   index: 74
-packed
+ts1
   rotate: false
   xy: 107, 89
   size: 16, 16
   orig: 16, 16
   offset: 0, 0
   index: 75
-packed
+ts1
   rotate: false
   xy: 73, 71
   size: 16, 16
   orig: 16, 16
   offset: 0, 0
   index: 76
-packed
+ts1
   rotate: false
   xy: 73, 53
   size: 16, 16
   orig: 16, 16
   offset: 0, 0
   index: 77
-packed
+ts1
   rotate: false
   xy: 91, 71
   size: 16, 16
   orig: 16, 16
   offset: 0, 0
   index: 78
-packed
+ts1
   rotate: false
   xy: 73, 35
   size: 16, 16
   orig: 16, 16
   offset: 0, 0
   index: 79
-packed
+ts1
   rotate: false
   xy: 91, 53
   size: 16, 16
   orig: 16, 16
   offset: 0, 0
   index: 94
-packed
+ts1
   rotate: false
   xy: 73, 17
   size: 16, 16
   orig: 16, 16
   offset: 0, 0
   index: 95
-packed
+ts1
   rotate: false
   xy: 91, 35
   size: 16, 16
   orig: 16, 16
   offset: 0, 0
   index: 110
-packed
+ts1
   rotate: false
   xy: 91, 17
   size: 16, 16
   orig: 16, 16
   offset: 0, 0
   index: 111
-packed
+ts1
   rotate: false
   xy: 109, 71
   size: 16, 16
   orig: 16, 16
   offset: 0, 0
   index: 127
-packed
+ts1
   rotate: false
   xy: 109, 53
   size: 16, 16
   orig: 16, 16
   offset: 0, 0
   index: 142
-packed
+ts1
   rotate: false
   xy: 109, 35
   size: 16, 16
   orig: 16, 16
   offset: 0, 0
   index: 143
+ts2
+  rotate: false
+  xy: 1, 91
+  size: 32, 32
+  orig: 32, 32
+  offset: 0, 0
+  index: 9
+ts2
+  rotate: false
+  xy: 1, 57
+  size: 32, 32
+  orig: 32, 32
+  offset: 0, 0
+  index: 10
+ts2
+  rotate: false
+  xy: 35, 91
+  size: 32, 32
+  orig: 32, 32
+  offset: 0, 0
+  index: 11


### PR DESCRIPTION
##### Adds/Changes the following

 * Searches for maps in nested folders, regardless of depth
 * Creates an individual atlas for each map (uses the map name sans extension)
 * Fixes loading/rendering problems with multiple tilesets
 * Removes isBlended checking and addition of blended property
 * Removes unused methods, broken methods, minor cleanup throughout TiledMapPacker class
 * Fixes the problem of not locating tilesets with ../ in the map Note: This has only been fixed with the      new functionality (not --combine-tilsets) The old method of combining tilesets into one atlas still has this problem.
 * Old functionality can be called with the option "--combine-tilesets"
 * Adds two classes to test the options and renders the processed maps
 * Changes usage to: Usage: INPUTDIR [OUTPUTDIR] [--strip-unused] [--combine-tilesets] [-v]
 * Adds a new usage prompt:

        Usage: INPUTDIR [OUTPUTDIR] [--strip-unused] [--combine-tilesets] [-v] 
        Processes a directory of Tiled .tmx maps. Unable to process maps with XML tile layer format.

            --strip-unused 
                 omits all tiles that are not used. Speeds up the processing. Smaller tilesets.           
            --combine-tilesets 
                 instead of creating a tileset for each map, this combines the tilesets into some kind of monster tileset. Has problems with tileset location. Has problems with nested folders. Not recommended. 
             -v 
                 outputs which tiles are stripped and included

##### Example:

Running TiledMapPacker on "./in ./out" with an "in" directory with the following structure:

* in/overworld.tmx
* in/dawn/Examples/Blank.tmx
* in/dawn/Examples/Dungeon.tmx
* in/dawn/Examples/Logo.tmx
* in/dawn/Examples/Mine.tmx
* in/dawn/Examples/Town.tmx
* in/dawn/Examples/Underworld.tmx
* in/world1Maps/dungeon1.tmx
* in/world1Maps/dungeon2.tmx
* in/world2Maps/town1.tmx
* in/world2Maps/town2.tmx

would have the following structure in the "out" directory:

* out/Blank.tmx
* out/dungeon1.tmx
* out/dungeon2.tmx
* out/Dungeon.tmx
* out/Logo.tmx
* out/Mine.tmx
* out/overworld.tmx
* out/town1.tmx
* out/town2.tmx
* out/Town.tmx
* out/Underworld.tmx
* out/tileset/Blank.atlas
* out/tileset/dungeon1.atlas
* out/tileset/dungeon1.png
* out/tileset/dungeon2.atlas
* out/tileset/dungeon2.png
* out/tileset/Dungeon.atlas
* out/tileset/Dungeon.png
* out/tileset/Logo.atlas
* out/tileset/Logo.png
* out/tileset/Mine.atlas
* out/tileset/Mine.png
* out/tileset/overworld.atlas
* out/tileset/overworld.png
* out/tileset/town1.atlas
* out/tileset/town2.atlas
* out/tileset/town2.png
* out/tileset/Town.atlas
* out/tileset/Town.png
* out/tileset/Underworld.atlas
* out/tileset/Underworld.png

(Note: maps without a tileset .png were completely empty maps)

Old functionality (now --combine-tilesets) can't handle the nested directories or parent (../) paths for tilesets but if it could run on the same in/out directories it would have the following output:

 * out/{same maps here}
 * out/tileset/packed.atlas
 * out/tileset/packed.png

With all of the tiles from every map inside the packed.png.

##### TL;DR

Changes TiledMapPacker to create one texture atlas per map, adds two classes to
test that I haven't messed things up more than they were.. I think. Fixes multiple tileset loading/rendering problem. Removes isBlended checking, property addition.
 * modified:   CHANGES
 * modified:   extensions/gdx-tools/src/com/badlogic/gdx/tiledmappacker/TiledMapPacker.java
 * new file:   extensions/gdx-tools/src/com/badlogic/gdx/tiledmappacker/TiledMapPackerTest.java
 * new file:   extensions/gdx-tools/src/com/badlogic/gdx/tiledmappacker/TiledMapPackerTestRender.java
 * modified: gdx/src/com/badlogic/gdx/maps/tiled/AtlasTmxMapLoader.java
