### PR TITLE
Bind server socket to a specific hostname or ip address (v2)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,5 @@
 [1.6.0]
+- API Change: Added optional hostname argument to Net.newServerSocket method to allow specific ip bindings for server applications made with gdx.
 - API Change: GlyphLayout xAdvances now have an additional entry at the beginning. This was required to implement tighter text bounds. #3034
 - API Change: Label#getTextBounds changed to getGlyphLayout. This exposes all the runs, not just the width and height.
 - In the 2D ParticleEditor, all chart points can be dragged at once by holding ctrl. They can be dragged proportionally by holding ctrl-shift.

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidNet.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidNet.java
@@ -54,6 +54,11 @@ public class AndroidNet implements Net {
 	public void cancelHttpRequest (HttpRequest httpRequest) {
 		netJavaImpl.cancelHttpRequest(httpRequest);
 	}
+	
+	@Override
+	public ServerSocket newServerSocket (Protocol protocol, String hostname, int port, ServerSocketHints hints) {
+		return new NetJavaServerSocketImpl(protocol, hostname, port, hints);
+	}
 
 	@Override
 	public ServerSocket newServerSocket (Protocol protocol, int port, ServerSocketHints hints) {

--- a/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/HeadlessNet.java
+++ b/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/HeadlessNet.java
@@ -49,6 +49,11 @@ public class HeadlessNet implements Net {
 	}
 	
 	@Override
+	public ServerSocket newServerSocket (Protocol protocol, String hostname, int port, ServerSocketHints hints) {
+		return new NetJavaServerSocketImpl(protocol, hostname, port, hints);
+	}
+	
+	@Override
 	public ServerSocket newServerSocket (Protocol protocol, int port, ServerSocketHints hints) {
 		return new NetJavaServerSocketImpl(protocol, port, hints);
 	}

--- a/backends/gdx-backend-jglfw/src/com/badlogic/gdx/backends/jglfw/JglfwNet.java
+++ b/backends/gdx-backend-jglfw/src/com/badlogic/gdx/backends/jglfw/JglfwNet.java
@@ -19,6 +19,7 @@ package com.badlogic.gdx.backends.jglfw;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Net;
 import com.badlogic.gdx.Net.HttpRequest;
+import com.badlogic.gdx.Net.Protocol;
 import com.badlogic.gdx.net.NetJavaImpl;
 import com.badlogic.gdx.net.ServerSocket;
 import com.badlogic.gdx.net.ServerSocketHints;
@@ -43,6 +44,11 @@ public class JglfwNet implements Net {
 	@Override
 	public void cancelHttpRequest (HttpRequest httpRequest) {
 		netJavaImpl.cancelHttpRequest(httpRequest);
+	}
+	
+	@Override
+	public ServerSocket newServerSocket (Protocol protocol, String hostname, int port, ServerSocketHints hints) {
+		return new NetJavaServerSocketImpl(protocol, hostname, port, hints);
 	}
 
 	public ServerSocket newServerSocket (Protocol protocol, int port, ServerSocketHints hints) {

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglNet.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglNet.java
@@ -45,6 +45,11 @@ public class LwjglNet implements Net {
 	public void cancelHttpRequest (HttpRequest httpRequest) {
 		netJavaImpl.cancelHttpRequest(httpRequest);
 	}
+	
+	@Override
+	public ServerSocket newServerSocket (Protocol protocol, String ipAddress, int port, ServerSocketHints hints) {
+		return new NetJavaServerSocketImpl(protocol, ipAddress, port, hints);
+	}
 
 	@Override
 	public ServerSocket newServerSocket (Protocol protocol, int port, ServerSocketHints hints) {

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSNet.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSNet.java
@@ -20,6 +20,7 @@ import org.robovm.apple.foundation.NSURL;
 import org.robovm.apple.uikit.UIApplication;
 
 import com.badlogic.gdx.Net;
+import com.badlogic.gdx.Net.Protocol;
 import com.badlogic.gdx.net.NetJavaImpl;
 import com.badlogic.gdx.net.NetJavaServerSocketImpl;
 import com.badlogic.gdx.net.NetJavaSocketImpl;
@@ -45,6 +46,11 @@ public class IOSNet implements Net {
 	@Override
 	public void cancelHttpRequest (HttpRequest httpRequest) {
 		netJavaImpl.cancelHttpRequest(httpRequest);
+	}
+	
+	@Override
+	public ServerSocket newServerSocket (Protocol protocol, String hostname, int port, ServerSocketHints hints) {
+		return new NetJavaServerSocketImpl(protocol, hostname, port, hints);
 	}
 
 	@Override

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtNet.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtNet.java
@@ -24,7 +24,9 @@ import java.util.Map;
 import java.util.Set;
 
 import com.badlogic.gdx.Net;
+import com.badlogic.gdx.Net.Protocol;
 import com.badlogic.gdx.net.HttpStatus;
+import com.badlogic.gdx.net.NetJavaServerSocketImpl;
 import com.badlogic.gdx.net.ServerSocket;
 import com.badlogic.gdx.net.ServerSocketHints;
 import com.badlogic.gdx.net.Socket;
@@ -181,6 +183,11 @@ public class GwtNet implements Net {
 			requests.remove(httpRequest);
 			listeners.remove(httpRequest);
 		}
+	}
+	
+	@Override
+	public ServerSocket newServerSocket (Protocol protocol, String hostname, int port, ServerSocketHints hints) {
+		throw new UnsupportedOperationException("Not implemented");
 	}
 
 	@Override

--- a/gdx/src/com/badlogic/gdx/Net.java
+++ b/gdx/src/com/badlogic/gdx/Net.java
@@ -320,6 +320,16 @@ public interface Net {
 	public enum Protocol {
 		TCP
 	}
+	
+	/** Creates a new server socket on the given address and port, using the given {@link Protocol}, waiting for incoming connections.
+	 * 
+	 * @param hostname the hostname or ip address to bind the socket to
+	 * @param port the port to listen on
+	 * @param hints additional {@link ServerSocketHints} used to create the socket. Input null to use the default setting provided
+	 *           by the system.
+	 * @return the {@link ServerSocket}
+	 * @throws GdxRuntimeException in case the socket couldn't be opened */
+	public ServerSocket newServerSocket (Protocol protocol, String hostname, int port, ServerSocketHints hints);
 
 	/** Creates a new server socket on the given port, using the given {@link Protocol}, waiting for incoming connections.
 	 * 

--- a/gdx/src/com/badlogic/gdx/net/NetJavaServerSocketImpl.java
+++ b/gdx/src/com/badlogic/gdx/net/NetJavaServerSocketImpl.java
@@ -38,6 +38,10 @@ public class NetJavaServerSocketImpl implements ServerSocket {
 	private java.net.ServerSocket server;
 
 	public NetJavaServerSocketImpl (Protocol protocol, int port, ServerSocketHints hints) {
+		this(protocol, null, port, hints);
+	}
+	
+	public NetJavaServerSocketImpl (Protocol protocol, String hostname, int port, ServerSocketHints hints) {
 		this.protocol = protocol;
 
 		// create the server socket
@@ -53,7 +57,13 @@ public class NetJavaServerSocketImpl implements ServerSocket {
 			}
 
 			// and bind the server...
-			InetSocketAddress address = new InetSocketAddress(port);
+			InetSocketAddress address;
+			if( hostname != null ) {
+				address = new InetSocketAddress(hostname, port); 
+			} else {
+				address = new InetSocketAddress(port);
+			}
+			
 			if (hints != null) {
 				server.bind(address, hints.backlog);
 			} else {

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/net/PingPongSocketExample.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/net/PingPongSocketExample.java
@@ -43,7 +43,7 @@ public class PingPongSocketExample extends GdxTest {
 			@Override
 			public void run () {
 				ServerSocketHints hints = new ServerSocketHints();
-				ServerSocket server = Gdx.net.newServerSocket(Protocol.TCP, 9999, hints);
+				ServerSocket server = Gdx.net.newServerSocket(Protocol.TCP, "localhost", 9999, hints);
 				// wait for the next client connection
 				Socket client = server.accept(null);
 				// read message and send it back

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
@@ -65,7 +65,6 @@ import com.badlogic.gdx.tests.g3d.TextureRegion3DTest;
 import com.badlogic.gdx.tests.gles2.HelloTriangle;
 import com.badlogic.gdx.tests.gles2.SimpleVertexShader;
 import com.badlogic.gdx.tests.net.NetAPITest;
-import com.badlogic.gdx.tests.net.PingPongSocketExample;
 import com.badlogic.gdx.tests.superkoalio.SuperKoalio;
 import com.badlogic.gdx.utils.ObjectMap;
 import com.badlogic.gdx.utils.StreamUtils;
@@ -165,7 +164,6 @@ public class GdxTests {
 		ParticleControllerTest.class,
 		ParticleEmitterTest.class,
 		ParticleEmittersTest.class,
-		PingPongSocketExample.class,
 		PixelsPerInchTest.class,
 		PixmapBlendingTest.class,
 		PixmapPackerTest.class,

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
@@ -65,6 +65,7 @@ import com.badlogic.gdx.tests.g3d.TextureRegion3DTest;
 import com.badlogic.gdx.tests.gles2.HelloTriangle;
 import com.badlogic.gdx.tests.gles2.SimpleVertexShader;
 import com.badlogic.gdx.tests.net.NetAPITest;
+import com.badlogic.gdx.tests.net.PingPongSocketExample;
 import com.badlogic.gdx.tests.superkoalio.SuperKoalio;
 import com.badlogic.gdx.utils.ObjectMap;
 import com.badlogic.gdx.utils.StreamUtils;
@@ -164,6 +165,7 @@ public class GdxTests {
 		ParticleControllerTest.class,
 		ParticleEmitterTest.class,
 		ParticleEmittersTest.class,
+		PingPongSocketExample.class,
 		PixelsPerInchTest.class,
 		PixmapBlendingTest.class,
 		PixmapPackerTest.class,


### PR DESCRIPTION
I thought this might be useful for gdx-based applications that runs as a server on multi-domain platforms (i.e. game servers).
Added an optional argument "hostname" to method Net.newServerSocket to allow specific domain / ip address binding, it maps 1:1 to Java.net binding interface.

(Re-opening from #3040 because I made a mess. Sorry about that.)