### PR TITLE
Do not scale NinePatch padding if not set

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g2d/NinePatch.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/NinePatch.java
@@ -499,10 +499,10 @@ public class NinePatch {
 		rightWidth *= scaleX;
 		topHeight *= scaleY;
 		bottomHeight *= scaleY;
-		padLeft *= scaleX;
-		padRight *= scaleX;
-		padTop *= scaleY;
-		padBottom *= scaleY;
+		if (padLeft != -1) padLeft *= scaleX;
+		if (padRight != -1) padRight *= scaleX;
+		if (padTop != -1) padTop *= scaleY;
+		if (padBottom != -1) padBottom *= scaleY;
 	}
 
 	public Texture getTexture () {


### PR DESCRIPTION
Stumbled upon an easy-to-fix but hard-to-spot bug in NinePatch code. There is a public method *scale(float, float)* which multiplies all corner and side patches, and padding by given factor. If there is no padding set for this NinePatch, however, all padding numbers are ruined as they get multiplied by *scaleX* and *scaleY* (floating-point numbers), then automatically truncated by Java (as class fields are declared as integers). Moreover, by essentially enabling padding for a NinePatch, its left/right/top/bottom sections and their dimensions are always ignored...

Unless someone has a really good reason why we might want to mutliply "magic number" minus-one by an arbitrary floating-point scale factor, then let Java truncate the outcome, it is better to fix this asap.