### PR TITLE
Fix problem with running already finished actions by ParallelAction.

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/ParallelAction.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/ParallelAction.java
@@ -68,7 +68,11 @@ public class ParallelAction extends Action {
 		try {
 			Array<Action> actions = this.actions;
 			for (int i = 0, n = actions.size; i < n && actor != null; i++) {
-				if (!actions.get(i).act(delta)) complete = false;
+				if (actions.get(i).act(delta)) {
+					actions.swap(i, actions.size-1);
+					actions.pop();
+				} else
+					complete = false;
 				if (actor == null) return true; // This action was removed.
 			}
 			return complete;

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/ParallelAction.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/ParallelAction.java
@@ -68,11 +68,7 @@ public class ParallelAction extends Action {
 		try {
 			Array<Action> actions = this.actions;
 			for (int i = 0, n = actions.size; i < n && actor != null; i++) {
-				if (actions.get(i).act(delta)) {
-					actions.swap(i, actions.size-1);
-					actions.pop();
-				} else
-					complete = false;
+				if (!actions.get(i).act(delta)) complete = false;
 				if (actor == null) return true; // This action was removed.
 			}
 			return complete;

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/ParallelAction.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/ParallelAction.java
@@ -68,7 +68,9 @@ public class ParallelAction extends Action {
 		try {
 			Array<Action> actions = this.actions;
 			for (int i = 0, n = actions.size; i < n && actor != null; i++) {
-				if (!actions.get(i).act(delta)) complete = false;
+				if (currentAction.getActor()!=null && !currentAction.act(delta))
+					complete = false;
+				if (actor == null) return true; // This action was removed.
 				if (actor == null) return true; // This action was removed.
 			}
 			return complete;


### PR DESCRIPTION
When you have code like this: Actions.parallel(Actions.moveTo(x, y, 1f), Actions.addAction(Actions.moveTo(x2, y2, 1f), someActor)) then libgdx crahses.

Actions.addAction is executed several times. "someActor" has several references to same action, when first action is removed, all other have null pointer inside and crashes.