### PR TITLE
Custom shader in modelBatch is no longer ignored

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g3d/ModelBatch.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/ModelBatch.java
@@ -291,7 +291,6 @@ public class ModelBatch implements Disposable {
 		for (int i = offset; i < renderables.size; i++) {
 			Renderable renderable = renderables.get(i);
 			renderable.shader = shader;
-			renderable.shader = shaderProvider.getShader(renderable);
 		}
 	}
 
@@ -319,7 +318,6 @@ public class ModelBatch implements Disposable {
 			Renderable renderable = renderables.get(i);
 			renderable.environment = environment;
 			renderable.shader = shader;
-			renderable.shader = shaderProvider.getShader(renderable);
 		}
 	}
 


### PR DESCRIPTION
Im trying to pass a custom shader to the modelBatch render but it seems it will always take the shader from the shaderProvider. 
Isn't the whole point of these shader parameters to bypass the shaderProvider?