### PR TITLE
Fix bugs in Bits

### DIFF
--- a/gdx/src/com/badlogic/gdx/utils/Bits.java
+++ b/gdx/src/com/badlogic/gdx/utils/Bits.java
@@ -125,7 +125,7 @@ public class Bits {
 			if (bitsAtWord != 0) {
 				for (int bit = 63; bit >= 0; --bit) {
 					if ((bitsAtWord & (1L << (bit & 0x3F))) != 0L) {
-						return (word << 6) + bit;
+						return (word << 6) + bit + 1;
 					}
 				}
 			}

--- a/gdx/src/com/badlogic/gdx/utils/Bits.java
+++ b/gdx/src/com/badlogic/gdx/utils/Bits.java
@@ -260,11 +260,7 @@ public class Bits {
 			bits[i] ^= other.bits[i];
 		}
 		
-		if (bits.length > commonWords) {
-			for (int i = other.bits.length, s = bits.length; s > i; i++) {
-				bits[i] = 0L;
-			}
-		} else if (commonWords < other.bits.length) {
+		if (commonWords < other.bits.length) {
 			checkCapacity(other.bits.length);
 			for (int i = commonWords, s = other.bits.length; s > i; i++) {
 				bits[i] = other.bits[i];


### PR DESCRIPTION
I was working on ashley and found a couple of bugs in the `Bits` class. First, `length()` returns the index of the last bit set, rather than the length. Second, `xor(Bits)` clear bits that exceed the argument's internal buffer size. I put together some small code snippets to demonstrate this:
```java
// length() bug
Bits bits = new Bits();
bits.set(0);
System.out.println(bits.length()); // 0

// xor() bug
Bits first = new Bits();
first.set(200);
Bits second = new Bits();
first.xor(second);
System.out.println(first.get(200)); // false
```
This pull request fixes these issues.