### PR TITLE
Added callback for loading failed in AssetManager

### DIFF
--- a/gdx/src/com/badlogic/gdx/assets/AssetLoaderParameters.java
+++ b/gdx/src/com/badlogic/gdx/assets/AssetLoaderParameters.java
@@ -27,7 +27,7 @@ public class AssetLoaderParameters<T> {
 	/** Callback interface that will be invoked when the {@link AssetManager} failed loading an asset.
 	 * @author gstupar */
 	public interface LoadingFailedCallback {
-		public void loadingFailed (AssetManager assetManager, String filename, Class type);
+		public void loadingFailed (AssetManager assetManager, String filename, Class type, Throwable cause);
 	}
 
 	public LoadedCallback loadedCallback;

--- a/gdx/src/com/badlogic/gdx/assets/AssetLoaderParameters.java
+++ b/gdx/src/com/badlogic/gdx/assets/AssetLoaderParameters.java
@@ -24,5 +24,13 @@ public class AssetLoaderParameters<T> {
 		public void finishedLoading (AssetManager assetManager, String fileName, Class type);
 	}
 
+	/** Callback interface that will be invoked when the {@link AssetManager} failed loading an asset.
+	 * @author gstupar */
+	public interface LoadingFailedCallback {
+		public void loadingFailed (AssetManager assetManager, String filename, Class type);
+	}
+
 	public LoadedCallback loadedCallback;
+	public LoadingFailedCallback loadingFailedCallback;
+
 }

--- a/gdx/src/com/badlogic/gdx/assets/AssetManager.java
+++ b/gdx/src/com/badlogic/gdx/assets/AssetManager.java
@@ -482,17 +482,17 @@ public class AssetManager implements Disposable {
 			taskFinished = task.update();
 		} catch (GdxRuntimeException exception) {
 
-			// gstupar TODO: check what loaded++ represents?
 			if (tasks.size() == 1) loaded++;
 			tasks.pop();
 
 			// if a loading failed listener was found, invoke it
 			if (task.assetDesc.params != null && task.assetDesc.params.loadingFailedCallback != null) {
-				task.assetDesc.params.loadingFailedCallback.loadingFailed(this, task.assetDesc.fileName, task.assetDesc.type);
+				task.assetDesc.params.loadingFailedCallback.loadingFailed(this, task.assetDesc.fileName, task.assetDesc.type,
+					exception.getCause());
 			}
 
-			// gstupar TODO: what should I return if loading failed!?
-			return true;
+			// re throw exception
+			throw exception;
 		}
 
 		// if the task has been cancelled or has finished loading

--- a/gdx/src/com/badlogic/gdx/assets/AssetManager.java
+++ b/gdx/src/com/badlogic/gdx/assets/AssetManager.java
@@ -486,13 +486,14 @@ public class AssetManager implements Disposable {
 			tasks.pop();
 
 			// if a loading failed listener was found, invoke it
+			// otherwise re throw exception
 			if (task.assetDesc.params != null && task.assetDesc.params.loadingFailedCallback != null) {
 				task.assetDesc.params.loadingFailedCallback.loadingFailed(this, task.assetDesc.fileName, task.assetDesc.type,
 					exception.getCause());
+			} else {
+				throw exception;
 			}
 
-			// re throw exception
-			throw exception;
 		}
 
 		// if the task has been cancelled or has finished loading


### PR DESCRIPTION
**What Have I Done?**
I added callback that will be invoked when loading of an asset fails. 

I added it as a separate interface, because otherwise users that used LoadedCallback should implement another method. I think it is "nicer" to add it as a separate interface, and not change API (add new method in the interface).

**Why Have I Done It?**
When I try to load asset with bad path or to load corrupted file, libgdx throws GdxRuntimeException on AssetManager's update() method. There is no way to catch which asset failed to be loaded. That is why I added this callback.

**Test**
I tested it on android and desktop with corrupted file, and bad url.

**TODO**
Can anyone help me what should I do with variable **loaded**? As I can see, it is used only for progress, so I think it should be incremented? Everything seems to be fine, but I just need someone to check it for me.