### PR TITLE
Inconsistent GlyphLayout in Label

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Label.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Label.java
@@ -32,6 +32,7 @@ import com.badlogic.gdx.utils.StringBuilder;
  * @author Nathan Sweet */
 public class Label extends Widget {
 	static private final Color tempColor = new Color();
+	static private final GlyphLayout tempLayout = new GlyphLayout();
 
 	private LabelStyle style;
 	private final GlyphLayout layout = new GlyphLayout();
@@ -135,10 +136,10 @@ public class Label extends Widget {
 		if (wrap && !ellipsis) {
 			float width = getWidth();
 			if (style.background != null) width -= style.background.getLeftWidth() + style.background.getRightWidth();
-			layout.setText(cache.getFont(), text, Color.WHITE, width, Align.left, true);
+			tempLayout.setText(cache.getFont(), text, Color.WHITE, width, Align.left, true);
 		} else
-			layout.setText(cache.getFont(), text);
-		prefSize.set(layout.width, layout.height);
+			tempLayout.setText(cache.getFont(), text);
+		prefSize.set(tempLayout.width, tempLayout.height);
 	}
 
 	public void layout () {


### PR DESCRIPTION
When a Label has the ellipsis set to true, and computePrefSize() is called but layout() is not, the GlyphLayout is left in an inconsistent state, because computePrefSize() updates the cache without considering the ellipsis to calculate the pref height.

So this is not usually problem, because the chances of calling computePrefSize without calling layout after are low. However, it is still possible and I encountered it developing my app. This is how the problem can be reproduced:

```java
public class Test implements ApplicationListener {

	private Stage stage;
	private Container<Label> container;
	private Label label;

	@Override
	public void create() {
		Gdx.gl.glClearColor(1.0f, 1.0f, 1.0f, 1.0f);
		stage = new Stage();
		LabelStyle style = new LabelStyle();
		style.font = new BitmapFont();
		style.fontColor = Color.BLACK;
		label = new Label("", style);
		label.setEllipsis(true);
		container = new Container<Label>(label);
		container.setPosition(50.0f, 40.0f);
		container.size(50.0f);
		stage.addActor(container);
	}

	@Override
	public void resize(int width, int height) {
		stage.getViewport().update(width, height, true);
	}

	@Override
	public void render() {
		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
		stage.act();
		stage.draw();
		label.setText("Very long text long text long text long text");
		stage.draw();

		label.getPrefHeight();
		label.getStyle().fontColor = Color.BLUE;

		stage.draw();
	}

	@Override
	public void pause() {

	}

	@Override
	public void resume() {

	}

	@Override
	public void dispose() {

	}

}
```
I propose as solution using a static tempLayout to calculate the preferred size, so the layout owned by the label is always kept consistent.