### PR TITLE
fix the OrthograhicCamera unprojection problem

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/OrthographicCamera.java
+++ b/gdx/src/com/badlogic/gdx/graphics/OrthographicCamera.java
@@ -110,4 +110,40 @@ public class OrthographicCamera extends Camera {
 	public void translate (Vector2 vec) {
 		translate(vec.x, vec.y, 0);
 	}
+
+	/** Function to translate a point given in screen coordinates to world space. It's the same as GLU gluUnProject, but does not
+	* rely on OpenGL. The x- and y-coordinate of vec are assumed to be in screen coordinates (origin is the top left corner, y
+	* pointing down, x pointing to the right) as reported by the touch methods in {@link Input}. A z-coordinate of 0 will return a
+	* point on the near plane, a z-coordinate of 1 will return a point on the far plane. This method allows you to specify the
+	* viewport position and dimensions in the coordinate system expected by {@link GL20#glViewport(int, int, int, int)}, with the
+	* origin in the bottom left corner of the screen.
+	* @param screenCoords the point in screen coordinates (origin top left)
+	* @param viewportX the coordinate of the bottom left corner of the viewport in glViewport coordinates.
+	* @param viewportY the coordinate of the bottom left corner of the viewport in glViewport coordinates.
+	* @param viewportWidth the width of the viewport in pixels
+	* @param viewportHeight the height of the viewport in pixels */
+	@Override
+	public Vector3 unproject (Vector3 screenCoords, float viewportX, float viewportY, float viewportWidth, float viewportHeight) {
+		float x = screenCoords.x, y = screenCoords.y;
+		x = x - viewportX;
+		y = viewportHeight - y - 1;
+		y = y - viewportY;
+		screenCoords.x = (2 * x) / viewportWidth - 1;
+		screenCoords.y = (2 * y) / viewportHeight - 1;
+		screenCoords.z = 2 * screenCoords.z - 1;
+		screenCoords.prj(invProjectionView);
+		return screenCoords;
+	}
+
+	/** Function to translate a point given in screen coordinates to world space. It's the same as GLU gluUnProject but does not
+	* rely on OpenGL. The viewport is assumed to span the whole screen and is fetched from {@link Graphics#getWidth()} and
+	* {@link Graphics#getHeight()}. The x- and y-coordinate of vec are assumed to be in screen coordinates (origin is the top left
+	* corner, y pointing down, x pointing to the right) as reported by the touch methods in {@link Input}. A z-coordinate of 0
+	* will return a point on the near plane, a z-coordinate of 1 will return a point on the far plane.
+	* @param screenCoords the point in screen coordinates */
+	@Override
+	public Vector3 unproject (Vector3 screenCoords) {
+		unproject(screenCoords, 0, 0, viewportWidth, viewportHeight);
+		return screenCoords;
+	}
 }


### PR DESCRIPTION
the OrthographicCamera use Gdx.graphic width and height to do the unprojection,
but actually should use its own viewportWidth and viewportHeight to do the unprojection

Change-Id: I12e48ee4bb8360d1100760338f273e4d0bb80bc8