### PR TITLE
Label layout color glitch fix

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/glutils/ShapeRenderer.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/ShapeRenderer.java
@@ -1006,35 +1006,69 @@ public class ShapeRenderer implements Disposable {
 		}
 	}
 
-	/** Draws a polygon in the x/y plane using {@link ShapeType#Line}. The vertices must contain at least 3 points (6 floats x,y). */
+	/** Draws a polygon in the x/y plane using {@link ShapeType#Line} or {@link ShapeType#Filled}. The vertices must contain at least 3 points (6 floats x,y). */
 	public void polygon (float[] vertices, int offset, int count) {
 		if (count < 6) throw new IllegalArgumentException("Polygons must contain at least 3 points.");
 		if (count % 2 != 0) throw new IllegalArgumentException("Polygons must have an even number of vertices.");
 
-		check(ShapeType.Line, null, count);
+		check(ShapeType.Line, ShapeType.Filled, count);
 		float colorBits = color.toFloatBits();
 		float firstX = vertices[0];
 		float firstY = vertices[1];
+		if (shapeType == ShapeType.Line) {
+			for (int i = offset, n = offset + count; i < n; i += 2) {
+				float x1 = vertices[i];
+				float y1 = vertices[i + 1];
 
-		for (int i = offset, n = offset + count; i < n; i += 2) {
-			float x1 = vertices[i];
-			float y1 = vertices[i + 1];
+				float x2;
+				float y2;
 
-			float x2;
-			float y2;
+				if (i + 2 >= count) {
+					x2 = firstX;
+					y2 = firstY;
+				} else {
+					x2 = vertices[i + 2];
+					y2 = vertices[i + 3];
+				}
 
-			if (i + 2 >= count) {
-				x2 = firstX;
-				y2 = firstY;
-			} else {
-				x2 = vertices[i + 2];
-				y2 = vertices[i + 3];
+				renderer.color(colorBits);
+				renderer.vertex(x1, y1, 0);
+				renderer.color(colorBits);
+				renderer.vertex(x2, y2, 0);
+
 			}
+		} else {
 
-			renderer.color(colorBits);
-			renderer.vertex(x1, y1, 0);
-			renderer.color(colorBits);
-			renderer.vertex(x2, y2, 0);
+			for (int i = offset, n = offset + count; i < n; i += 4) {
+				float x1 = vertices[i];
+				float y1 = vertices[i + 1];
+
+				if (i + 2 >= count) {
+					break;
+				}
+
+				float x2 = vertices[i + 2];
+				float y2 = vertices[i + 3];
+
+				float x3;
+				float y3;
+
+				if (i + 4 >= count) {
+					x3 = firstX;
+					y3 = firstY;
+				} else {
+					x3 = vertices[i + 4];
+					y3 = vertices[i + 5];
+				}
+
+				renderer.color(colorBits);
+				renderer.vertex(x1, y1, 0);
+				renderer.color(colorBits);
+				renderer.vertex(x2, y2, 0);
+				renderer.color(colorBits);
+				renderer.vertex(x3, y3, 0);
+
+			}
 		}
 	}
 

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Label.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Label.java
@@ -136,8 +136,10 @@ public class Label extends Widget {
 			float width = getWidth();
 			if (style.background != null) width -= style.background.getLeftWidth() + style.background.getRightWidth();
 			layout.setText(cache.getFont(), text, Color.WHITE, width, Align.left, true);
-		} else
+		} else{
+			cache.getFont().setColor(Color.WHITE);
 			layout.setText(cache.getFont(), text);
+		}
 		prefSize.set(layout.width, layout.height);
 	}
 

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/DragAndDrop.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/DragAndDrop.java
@@ -89,13 +89,17 @@ public class DragAndDrop {
 						if (!target.actor.isAscendantOf(hit)) continue;
 						newTarget = target;
 						target.actor.stageToLocalCoordinates(tmpVector.set(stageX, stageY));
-						isValidTarget = target.drag(source, payload, tmpVector.x, tmpVector.y, pointer);
 						break;
 					}
 				}
+				//if over a new target, notify the former target that it's being left behind.
 				if (newTarget != target) {
 					if (target != null) target.reset(source, payload);
 					target = newTarget;
+				}
+				//with any reset out of the way, notify new targets of drag.
+				if (newTarget != null) {
+					isValidTarget = newTarget.drag(source, payload, tmpVector.x, tmpVector.y, pointer);
 				}
 
 				if (dragActor != null) dragActor.setTouchable(dragActorTouchable);


### PR DESCRIPTION
If a tinted label (having its color set via setColor instead of style font) was not wrapped or had ellipses set then the label’s layout’s font color would not be set to white but would instead be set to it’s last used color. Therefore when draw() tinted the layout you ended up with compounded and incorrect tinting.