### PR TITLE
Fixes incorrect label colors under certain circumstances.

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Label.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Label.java
@@ -136,8 +136,10 @@ public class Label extends Widget {
 			float width = getWidth();
 			if (style.background != null) width -= style.background.getLeftWidth() + style.background.getRightWidth();
 			layout.setText(cache.getFont(), text, Color.WHITE, width, Align.left, true);
-		} else
+		} else{
+			cache.getFont().setColor(Color.WHITE);
 			layout.setText(cache.getFont(), text);
+		}
 		prefSize.set(layout.width, layout.height);
 	}
 


### PR DESCRIPTION
Fixes incorrect tint color occurring if label has a non-white setColor tint applied and label’s computePrefSize method called while label is in non-wrapping state or has ellipses set.

Problem with improper label colors occurring on non-white labels in a scrollpane when scrollbar appears has been traced to here. We shouldn’t ignore resetting color to white upon compute size, otherwise the cache font’s current color is used which, if not white, will not provide a proper base for tinting when drawn.