### PR TITLE
Fix problem with running already finished actions by ParallelAction.

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/ParallelAction.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/ParallelAction.java
@@ -68,9 +68,9 @@ public class ParallelAction extends Action {
 		try {
 			Array<Action> actions = this.actions;
 			for (int i = 0, n = actions.size; i < n && actor != null; i++) {
+				Action currentAction = actions.get(i);
 				if (currentAction.getActor()!=null && !currentAction.act(delta))
 					complete = false;
-				if (actor == null) return true; // This action was removed.
 				if (actor == null) return true; // This action was removed.
 			}
 			return complete;

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/ParallelAction.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/ParallelAction.java
@@ -68,7 +68,9 @@ public class ParallelAction extends Action {
 		try {
 			Array<Action> actions = this.actions;
 			for (int i = 0, n = actions.size; i < n && actor != null; i++) {
-				if (!actions.get(i).act(delta)) complete = false;
+				if (currentAction.getActor()!=null && !currentAction.act(delta))
+					complete = false;
+				if (actor == null) return true; // This action was removed.
 				if (actor == null) return true; // This action was removed.
 			}
 			return complete;


### PR DESCRIPTION
### What Have I Done?
This is fix for issue found in Actions.parallel. Issue may cause crash or malfunction. 

### Issue description 
In some cases, when actions to not track it when they are finished and such action is used together with actions that works longer than just one execution (eg. Actions.moveTo(x, y, 1f)). 
Than Actions.parallel() will not care if this small Actions was finished or not, and run it multiple times or even crashes is some cases.

### Example
When you have code like this: 
Actions.parallel( Actions.moveTo(x, y, 1f), Actions.addAction( Actions.moveTo(x2, y2, 1f), someActor)); then libgdx crahses.
Actions.addAction is executed several times. "someActor" has several references to same action, when first action is remover, all other have null pointer inside and crashes.

