### PR TITLE
overlap2d-runtime to support libgdx 1.6.2

### DIFF
--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/data/extensions.xml
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/data/extensions.xml
@@ -4,8 +4,8 @@
 		<name>Overlap2D</name>
 		<description>Level and UI Editor Runtime</description>
 		<package>com.underwaterapps.overlap2druntime</package>
-		<version>0.0.8</version>
-		<compatibility>1.5.3</compatibility>
+		<version>0.1.0</version>
+		<compatibility>1.6.2</compatibility>
 		<website>http://overlap2d.com/</website>
 		<gwtInherits></gwtInherits>
 		<projects>


### PR DESCRIPTION
Updating overlap2d-runtime version to 0.1.0 to be compatible with libgdx 1.6.2 

Changes in runtime include:
1) BitmapFonts refactorings
2) box2dlights setCombinedMatrix(Matrix) method deprication
3) version updates in gradle