### PR TITLE
Add screen transitions

### DIFF
--- a/gdx/src/com/badlogic/gdx/FadingGame.java
+++ b/gdx/src/com/badlogic/gdx/FadingGame.java
@@ -16,12 +16,10 @@
 
 package com.badlogic.gdx;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.g2d.Batch;
 import com.badlogic.gdx.graphics.glutils.FrameBuffer;
+import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.transition.ScreenTransition;
 import com.badlogic.gdx.utils.transition.TransitionListener;
 
@@ -34,10 +32,10 @@ public class FadingGame extends Game {
 
 	protected FrameBuffer currentScreenFBO;
 	protected FrameBuffer nextScreenFBO;
+	final protected Batch batch;
 	protected Screen nextScreen;
-	protected Batch batch;
 
-	private List<TransitionListener> listerns;
+	private final Array<TransitionListener> listeners;
 
 	private float transitionDuration;
 	private float currentTransitionTime;
@@ -46,19 +44,22 @@ public class FadingGame extends Game {
 
 	public FadingGame (Batch batch) {
 		this.batch = batch;
+		this.listeners = new Array<TransitionListener>();
 	}
 
 	@Override
 	public void create () {
-		currentScreenFBO = new FrameBuffer(Pixmap.Format.RGBA8888, Gdx.graphics.getWidth(), Gdx.graphics.getHeight(), false);
-		nextScreenFBO = new FrameBuffer(Pixmap.Format.RGBA8888, Gdx.graphics.getWidth(), Gdx.graphics.getHeight(), false);
-		listerns = new ArrayList<TransitionListener>();
+		this.currentScreenFBO = new FrameBuffer(Pixmap.Format.RGBA8888, Gdx.graphics.getWidth(), Gdx.graphics.getHeight(), false);
+		this.nextScreenFBO = new FrameBuffer(Pixmap.Format.RGBA8888, Gdx.graphics.getWidth(), Gdx.graphics.getHeight(), false);
 	}
 
 	@Override
 	public void dispose () {
 		if (screen != null) screen.hide();
 		if (nextScreen != null) nextScreen.hide();
+
+		this.currentScreenFBO.dispose();
+		this.nextScreenFBO.dispose();
 
 	}
 
@@ -118,7 +119,7 @@ public class FadingGame extends Game {
 	}
 
 	@Override
-	public void resize (int width, int height) {				
+	public void resize (int width, int height) {
 		if (screen != null) screen.resize(width, height);
 		if (nextScreen != null) nextScreen.resize(width, height);
 	}
@@ -173,26 +174,31 @@ public class FadingGame extends Game {
 		return nextScreen;
 	}
 
-	/** @param listener to get transition events
-	 * @return {@code true} if successful */
-	public boolean addTransitionListener (TransitionListener listener) {
-		return listerns.add(listener);
+	/** @param listener to get transition events */
+	public void addTransitionListener (TransitionListener listener) {
+		listeners.add(listener);
+		return;
 	}
 
 	/** @param listener to remove
 	 * @return {@code true} if successful */
 	public boolean removeTransitionListener (TransitionListener listener) {
-		return listerns.remove(listener);
+		return listeners.removeValue(listener, true);
+	}
+
+	/** Clear listeners */
+	public void clearTransitionListeners () {
+		listeners.clear();
 	}
 
 	private void notifyFinished () {
-		for (TransitionListener transitionListener : listerns) {
+		for (TransitionListener transitionListener : listeners) {
 			transitionListener.onTransitionFinished();
 		}
 	}
 
 	private void notifyStarted () {
-		for (TransitionListener transitionListener : listerns) {
+		for (TransitionListener transitionListener : listeners) {
 			transitionListener.onTransitionStart();
 		}
 	}

--- a/gdx/src/com/badlogic/gdx/FadingGame.java
+++ b/gdx/src/com/badlogic/gdx/FadingGame.java
@@ -1,0 +1,210 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *	 http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogic.gdx;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.badlogic.gdx.graphics.Pixmap;
+import com.badlogic.gdx.graphics.g2d.Batch;
+import com.badlogic.gdx.graphics.glutils.FrameBuffer;
+import com.badlogic.gdx.utils.transition.ScreenTransition;
+import com.badlogic.gdx.utils.transition.TransitionListener;
+
+/** An {@link Game} that delegates to a {@link Screen}. Allows to apply different transitions to screens. </p>
+ * <p>
+ * Screens are not disposed automatically. You must handle whether you want to keep screens around or dispose of them when another
+ * screen is set.
+ * @author iXeption */
+public class FadingGame extends Game {
+
+	protected FrameBuffer currentScreenFBO;
+	protected FrameBuffer nextScreenFBO;
+	protected Screen nextScreen;
+	protected Batch batch;
+
+	private List<TransitionListener> listerns;
+
+	private float transitionDuration;
+	private float currentTransitionTime;
+	private boolean transitionRunning;
+	private ScreenTransition screenTransition;
+
+	public FadingGame (Batch batch) {
+		this.batch = batch;
+	}
+
+	@Override
+	public void create () {
+		currentScreenFBO = new FrameBuffer(Pixmap.Format.RGBA8888, Gdx.graphics.getWidth(), Gdx.graphics.getHeight(), false);
+		nextScreenFBO = new FrameBuffer(Pixmap.Format.RGBA8888, Gdx.graphics.getWidth(), Gdx.graphics.getHeight(), false);
+		listerns = new ArrayList<TransitionListener>();
+	}
+
+	@Override
+	public void dispose () {
+		if (screen != null) screen.hide();
+		if (nextScreen != null) nextScreen.hide();
+
+	}
+
+	@Override
+	public void pause () {
+		if (screen != null) screen.pause();
+		if (nextScreen != null) nextScreen.pause();
+	}
+
+	@Override
+	public void resume () {
+		if (screen != null) screen.resume();
+		if (nextScreen != null) nextScreen.resume();
+	}
+
+	@Override
+	public void render () {
+
+		float delta = Gdx.graphics.getDeltaTime();
+
+		if (nextScreen == null) {
+			// no other screen
+			screen.render(delta);
+		} else {
+			if (transitionRunning && currentTransitionTime >= transitionDuration) {
+				// is active and time limit reached
+				this.screen.hide();
+				this.screen = this.nextScreen;
+				this.screen.resume();
+				transitionRunning = false;
+				this.nextScreen = null;
+				notifyFinished();
+
+			} else {
+				// transition is active
+				if (screenTransition != null) {
+					currentScreenFBO.begin();
+					this.screen.render(delta);
+					currentScreenFBO.end();
+
+					nextScreenFBO.begin();
+					this.nextScreen.render(delta);
+					nextScreenFBO.end();
+
+					float percent = currentTransitionTime / transitionDuration;
+
+					screenTransition.render(batch, currentScreenFBO.getColorBufferTexture(), nextScreenFBO.getColorBufferTexture(),
+						percent);
+					currentTransitionTime += delta;
+
+				}
+
+			}
+
+		}
+
+	}
+
+	@Override
+	public void resize (int width, int height) {
+		boolean resize = currentScreenFBO.getHeight() != height || currentScreenFBO.getWidth() != width
+			|| nextScreenFBO.getHeight() != height || nextScreenFBO.getWidth() != width;
+
+		if (false) {
+			currentScreenFBO.dispose();
+			nextScreenFBO.dispose();
+
+			currentScreenFBO = new FrameBuffer(Pixmap.Format.RGBA8888, width, height, false);
+			nextScreenFBO = new FrameBuffer(Pixmap.Format.RGBA8888, width, height, false);
+		}
+
+		if (screen != null) screen.resize(width, height);
+		if (nextScreen != null) nextScreen.resize(width, height);
+	}
+
+	/** Sets the current screen. {@link Screen#hide()} is called on any old screen, and {@link Screen#show()} is called on the new
+	 * screen, if any.
+	 * @param screen may be {@code null} */
+	@Override
+	public void setScreen (Screen screen) {
+		if (transitionRunning) Gdx.app.log(FadingGame.class.getSimpleName(), "Changed Screen while transition in progress");
+		screen.show();
+		screen.resize(Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+		if (this.screen == null) {
+			this.screen = screen;
+		} else {
+			if (screenTransition == null) {
+				this.screen.hide();
+				this.screen = screen;
+			} else {
+				this.nextScreen = screen;
+				this.screen.pause();
+				this.nextScreen.pause();
+				currentTransitionTime = 0;
+				transitionRunning = true;
+				notifyStarted();
+			}
+
+		}
+
+	}
+
+	/** Sets the {@link ScreenTransition} which is used. May be {@code null} to use instant switching.
+	 * @param screenTransition may be {@code null}
+	 * @param duration the transition duration in seconds
+	 * @return {@code true} if successful false if transition is running */
+	public boolean setTransition (ScreenTransition screenTransition, float duration) {
+		if (transitionRunning) return false;
+		this.screenTransition = screenTransition;
+		this.transitionDuration = duration;
+		return true;
+
+	}
+
+	/** @return the currently active {@link Screen}. */
+	@Override
+	public Screen getScreen () {
+		return screen;
+	}
+
+	/** @return the next {@link Screen}. */
+	public Screen getNextScreen () {
+		return nextScreen;
+	}
+
+	/** @param listener to get transition events
+	 * @return {@code true} if successful */
+	public boolean addTransitionListener (TransitionListener listener) {
+		return listerns.add(listener);
+	}
+
+	/** @param listener to remove
+	 * @return {@code true} if successful */
+	public boolean removeTransitionListener (TransitionListener listener) {
+		return listerns.remove(listener);
+	}
+
+	private void notifyFinished () {
+		for (TransitionListener transitionListener : listerns) {
+			transitionListener.onTransitionFinished();
+		}
+	}
+
+	private void notifyStarted () {
+		for (TransitionListener transitionListener : listerns) {
+			transitionListener.onTransitionStart();
+		}
+	}
+}

--- a/gdx/src/com/badlogic/gdx/FadingGame.java
+++ b/gdx/src/com/badlogic/gdx/FadingGame.java
@@ -118,18 +118,7 @@ public class FadingGame extends Game {
 	}
 
 	@Override
-	public void resize (int width, int height) {
-		boolean resize = currentScreenFBO.getHeight() != height || currentScreenFBO.getWidth() != width
-			|| nextScreenFBO.getHeight() != height || nextScreenFBO.getWidth() != width;
-
-		if (false) {
-			currentScreenFBO.dispose();
-			nextScreenFBO.dispose();
-
-			currentScreenFBO = new FrameBuffer(Pixmap.Format.RGBA8888, width, height, false);
-			nextScreenFBO = new FrameBuffer(Pixmap.Format.RGBA8888, width, height, false);
-		}
-
+	public void resize (int width, int height) {				
 		if (screen != null) screen.resize(width, height);
 		if (nextScreen != null) nextScreen.resize(width, height);
 	}

--- a/gdx/src/com/badlogic/gdx/utils/transition/AlphaFadingTransition.java
+++ b/gdx/src/com/badlogic/gdx/utils/transition/AlphaFadingTransition.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *	 http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogic.gdx.utils.transition;
+
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.Batch;
+import com.badlogic.gdx.math.Interpolation;
+
+/** @author iXeption */
+
+/** A simple alpha fade transition
+ * @author iXeption */
+public class AlphaFadingTransition implements ScreenTransition {
+
+	@Override
+	public void render (Batch batch, Texture currentScreenTexture, Texture nextScreenTexture, float alpha) {
+		alpha = Interpolation.fade.apply(alpha);
+		batch.begin();
+		batch.setColor(1, 1, 1, 1);
+		batch.draw(currentScreenTexture, 0, 0, 0, 0, currentScreenTexture.getWidth(), currentScreenTexture.getHeight(), 1, 1, 0, 0,
+			0, currentScreenTexture.getWidth(), currentScreenTexture.getHeight(), false, true);
+		batch.setColor(1, 1, 1, alpha);
+		batch.draw(nextScreenTexture, 0, 0, 0, 0, nextScreenTexture.getWidth(), nextScreenTexture.getHeight(), 1, 1, 0, 0, 0,
+			nextScreenTexture.getWidth(), nextScreenTexture.getHeight(), false, true);
+		batch.end();
+
+	}
+}

--- a/gdx/src/com/badlogic/gdx/utils/transition/ColorFadeTransition.java
+++ b/gdx/src/com/badlogic/gdx/utils/transition/ColorFadeTransition.java
@@ -29,14 +29,14 @@ import com.badlogic.gdx.math.Interpolation;
  * @author iXeption */
 public class ColorFadeTransition implements ScreenTransition {
 
-	private Color color;
-	private Interpolation interpolation;
-	private Texture texture;
+	private final Color color;
+	private final Interpolation interpolation;
+	private final Texture texture;
 
 	/** @param color the {@link Color} to fade to
 	 * @param interpolation the {@link Interpolation} method */
 	public ColorFadeTransition (Color color, Interpolation interpolation) {
-		this.color = color;
+		this.color = new Color(Color.WHITE);
 		this.interpolation = interpolation;
 
 		texture = new Texture(1, 1, Format.RGBA8888);
@@ -64,32 +64,27 @@ public class ColorFadeTransition implements ScreenTransition {
 
 		if (fade > 1.0f) {
 			fade = 1.0f - (percent * 2 - 1.0f);
-			Color fadeIn = new Color(Color.WHITE);
-			fadeIn.a = 1.0f - fade;
-			batch.setColor(fadeIn);
+			color.a = 1.0f - fade;
+			batch.setColor(color);
 
 			batch.draw(nextScreenTexture, 0, 0, width / 2, height / 2, nextScreenTexture.getWidth(), nextScreenTexture.getHeight(),
 				1, 1, 0, 0, 0, nextScreenTexture.getWidth(), nextScreenTexture.getHeight(), false, true);
 
 		} else {
 
-			Color fadeOut = new Color(Color.WHITE);
-			fadeOut.a = 1.0f - fade;
-			batch.setColor(fadeOut);
+			color.a = 1.0f - fade;
+			batch.setColor(color);
 
 			batch.draw(currentScreenTexture, 0, 0, width / 2, height / 2, width, height, 1, 1, 0, 0, 0, (int)width, (int)height,
 				false, true);
 
 		}
 
-		Color c = new Color(Color.WHITE);
-		c.a = fade;
+		color.a = fade;
 
-		batch.setColor(c);
+		batch.setColor(color);
 		batch.draw(texture, 0, 0, width, height);
-
 		batch.end();
-
 		batch.setColor(Color.WHITE);
 
 	}

--- a/gdx/src/com/badlogic/gdx/utils/transition/ColorFadeTransition.java
+++ b/gdx/src/com/badlogic/gdx/utils/transition/ColorFadeTransition.java
@@ -1,0 +1,97 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *	 http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogic.gdx.utils.transition;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.Pixmap;
+import com.badlogic.gdx.graphics.Pixmap.Format;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.Batch;
+import com.badlogic.gdx.math.Interpolation;
+
+/** A color fading transition
+ * @author iXeption */
+public class ColorFadeTransition implements ScreenTransition {
+
+	private Color color;
+	private Interpolation interpolation;
+	private Texture texture;
+
+	/** @param color the {@link Color} to fade to
+	 * @param interpolation the {@link Interpolation} method */
+	public ColorFadeTransition (Color color, Interpolation interpolation) {
+		this.color = color;
+		this.interpolation = interpolation;
+
+		texture = new Texture(1, 1, Format.RGBA8888);
+		Pixmap pixmap = new Pixmap(1, 1, Format.RGBA8888);
+		pixmap.setColor(color);
+		pixmap.fillRectangle(0, 0, 1, 1);
+		texture.draw(pixmap, 0, 0);
+	}
+
+	@Override
+	public void render (Batch batch, Texture currentScreenTexture, Texture nextScreenTexture, float percent) {
+		float width = currentScreenTexture.getWidth();
+		float height = currentScreenTexture.getHeight();
+		float x = 0;
+		float y = 0;
+
+		if (interpolation != null) percent = interpolation.apply(percent);
+
+		Gdx.gl.glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+
+		batch.begin();
+
+		float fade = percent * 2;
+
+		if (fade > 1.0f) {
+			fade = 1.0f - (percent * 2 - 1.0f);
+			Color fadeIn = new Color(Color.WHITE);
+			fadeIn.a = 1.0f - fade;
+			batch.setColor(fadeIn);
+
+			batch.draw(nextScreenTexture, 0, 0, width / 2, height / 2, nextScreenTexture.getWidth(), nextScreenTexture.getHeight(),
+				1, 1, 0, 0, 0, nextScreenTexture.getWidth(), nextScreenTexture.getHeight(), false, true);
+
+		} else {
+
+			Color fadeOut = new Color(Color.WHITE);
+			fadeOut.a = 1.0f - fade;
+			batch.setColor(fadeOut);
+
+			batch.draw(currentScreenTexture, 0, 0, width / 2, height / 2, width, height, 1, 1, 0, 0, 0, (int)width, (int)height,
+				false, true);
+
+		}
+
+		Color c = new Color(Color.WHITE);
+		c.a = fade;
+
+		batch.setColor(c);
+		batch.draw(texture, 0, 0, width, height);
+
+		batch.end();
+
+		batch.setColor(Color.WHITE);
+
+	}
+
+}

--- a/gdx/src/com/badlogic/gdx/utils/transition/RotatingTransition.java
+++ b/gdx/src/com/badlogic/gdx/utils/transition/RotatingTransition.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *	 http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogic.gdx.utils.transition;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.Batch;
+import com.badlogic.gdx.math.Interpolation;
+
+/** A Rotating transition
+ * @author iXeption */
+public class RotatingTransition implements ScreenTransition {
+
+	private Interpolation interpolation;
+	private float angle;
+	private TransitionScaling scaling;
+
+	public enum TransitionScaling {
+		NONE, IN, OUT
+	}
+
+	/** @param interpolation the {@link Interpolation} method
+	 * @param angle the amount of rotation
+	 * @param scaling apply {@link TransitionScaling} */
+	public RotatingTransition (Interpolation interpolation, float angle, TransitionScaling scaling) {
+		this.interpolation = interpolation;
+		this.angle = angle;
+		this.scaling = scaling;
+	}
+
+	@Override
+	public void render (Batch batch, Texture currentScreenTexture, Texture nextScreenTexture, float percent) {
+		float width = currentScreenTexture.getWidth();
+		float height = currentScreenTexture.getHeight();
+		float x = 0;
+		float y = 0;
+
+		float scalefactor;
+
+		switch (scaling) {
+		case IN:
+			scalefactor = percent;
+			break;
+		case OUT:
+			scalefactor = 1.0f - percent;
+			break;
+		case NONE:
+		default:
+			scalefactor = 1.0f;
+			break;
+		}
+
+		float rotation = 1;
+		if (interpolation != null) rotation = interpolation.apply(percent);
+
+		Gdx.gl.glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+
+		batch.begin();
+		batch.draw(currentScreenTexture, 0, 0, width / 2, height / 2, width, height, 1, 1, 0, 0, 0, (int)width, (int)height, false,
+			true);
+		batch.draw(nextScreenTexture, 0, 0, width / 2, height / 2, nextScreenTexture.getWidth(), nextScreenTexture.getHeight(),
+			scalefactor, scalefactor, rotation * angle, 0, 0, nextScreenTexture.getWidth(), nextScreenTexture.getHeight(), false,
+			true);
+		batch.end();
+
+	}
+
+}

--- a/gdx/src/com/badlogic/gdx/utils/transition/ScreenTransition.java
+++ b/gdx/src/com/badlogic/gdx/utils/transition/ScreenTransition.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *	 http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogic.gdx.utils.transition;
+
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.Batch;
+import com.badlogic.gdx.graphics.glutils.FrameBuffer;
+
+public interface ScreenTransition {
+	/** Renders two textures to the given batch
+	 * @param batch the {@link Batch}
+	 * @param currentScreenTexture {@link Texture} from a {@link FrameBuffer}
+	 * @param nextScreenTexture {@link Texture} from a {@link FrameBuffer}
+	 * @param percent the current progress 0.0 - 1.0 */
+	void render (Batch batch, Texture currentScreenTexture, Texture nextScreenTexture, float percent);
+
+}

--- a/gdx/src/com/badlogic/gdx/utils/transition/SlicingTransition.java
+++ b/gdx/src/com/badlogic/gdx/utils/transition/SlicingTransition.java
@@ -1,0 +1,90 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *	 http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogic.gdx.utils.transition;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.Batch;
+import com.badlogic.gdx.math.Interpolation;
+import com.badlogic.gdx.utils.Array;
+
+/** A Slicing transition
+ * @author iXeption */
+public class SlicingTransition implements ScreenTransition {
+
+	public enum Direction {
+		UP, DOWN, UPDOWN
+	}
+
+	private Direction direction;
+	private Interpolation interpolation;
+	private Array<Integer> slices = new Array<Integer>();
+
+	/** @param direction the {@link Direction} of the transition
+	 * @param numSlices the number of slices
+	 * @param interpolation the {@link Interpolation} method */
+	public SlicingTransition (Direction direction, int numSlices, Interpolation interpolation) {
+		this.direction = direction;
+		this.interpolation = interpolation;
+
+		slices.clear();
+		for (int i = 0; i < numSlices; i++)
+			slices.add(i);
+		slices.shuffle();
+
+	}
+
+	@Override
+	public void render (Batch batch, Texture currentScreenTexture, Texture nextScreenTexture, float percent) {
+		float width = currentScreenTexture.getWidth();
+		float height = currentScreenTexture.getHeight();
+		float x = 0;
+		float y = 0;
+		int sliceWidth = (int)(width / slices.size);
+		Gdx.gl.glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		batch.begin();
+		batch.draw(currentScreenTexture, 0, 0, 0, 0, width, height, 1, 1, 0, 0, 0, (int)width, (int)height, false, true);
+		if (interpolation != null) percent = interpolation.apply(percent);
+		for (int i = 0; i < slices.size; i++) {
+
+			x = i * sliceWidth;
+
+			float offsetY = height * (1 + slices.get(i) / (float)slices.size);
+			switch (direction) {
+			case UP:
+				y = -offsetY + offsetY * percent;
+				break;
+			case DOWN:
+				y = offsetY - offsetY * percent;
+				break;
+			case UPDOWN:
+				if (i % 2 == 0) {
+					y = -offsetY + offsetY * percent;
+				} else {
+					y = offsetY - offsetY * percent;
+				}
+				break;
+			}
+			batch.draw(nextScreenTexture, x, y, 0, 0, sliceWidth, nextScreenTexture.getHeight(), 1, 1, 0, i * sliceWidth, 0,
+				sliceWidth, nextScreenTexture.getHeight(), false, true);
+		}
+		batch.end();
+	}
+
+}

--- a/gdx/src/com/badlogic/gdx/utils/transition/SlidingTransition.java
+++ b/gdx/src/com/badlogic/gdx/utils/transition/SlidingTransition.java
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *	 http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogic.gdx.utils.transition;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.Batch;
+import com.badlogic.gdx.math.Interpolation;
+
+/** A sliding transition
+ * @author iXeption */
+public class SlidingTransition implements ScreenTransition {
+
+	public enum Direction {
+		LEFT, RIGHT, UP, DOWN
+	}
+
+	private Direction direction;
+	private boolean slideOut;
+	private Interpolation interpolation;
+
+	/** @param direction the {@link Direction} of the transition
+	 * @param interpolation the {@link Interpolation} method
+	 * @param slideOut slide out or slide in */
+	public SlidingTransition (Direction direction, Interpolation interpolation, boolean slideOut) {
+		this.direction = direction;
+		this.interpolation = interpolation;
+		this.slideOut = slideOut;
+	}
+
+	@Override
+	public void render (Batch batch, Texture currentScreenTexture, Texture nextScreenTexture, float percent) {
+		float width = currentScreenTexture.getWidth();
+		float height = currentScreenTexture.getHeight();
+		float x = 0;
+		float y = 0;
+		if (interpolation != null) percent = interpolation.apply(percent);
+
+		switch (direction) {
+		case LEFT:
+			x = -width * percent;
+			if (!slideOut) x += width;
+			break;
+		case RIGHT:
+			x = width * percent;
+			if (!slideOut) x -= width;
+			break;
+		case UP:
+			y = height * percent;
+			if (!slideOut) y -= height;
+			break;
+		case DOWN:
+			y = -height * percent;
+			if (!slideOut) y += height;
+			break;
+		}
+		Texture texBottom = slideOut ? nextScreenTexture : currentScreenTexture;
+		Texture texTop = slideOut ? currentScreenTexture : nextScreenTexture;
+
+		Gdx.gl.glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		batch.begin();
+		batch.draw(texBottom, 0, 0, 0, 0, width, height, 1, 1, 0, 0, 0, (int)width, (int)height, false, true);
+		batch.draw(texTop, x, y, 0, 0, nextScreenTexture.getWidth(), nextScreenTexture.getHeight(), 1, 1, 0, 0, 0,
+			nextScreenTexture.getWidth(), nextScreenTexture.getHeight(), false, true);
+		batch.end();
+
+	}
+
+}

--- a/gdx/src/com/badlogic/gdx/utils/transition/TransitionListener.java
+++ b/gdx/src/com/badlogic/gdx/utils/transition/TransitionListener.java
@@ -1,0 +1,13 @@
+package com.badlogic.gdx.utils.transition;
+
+/**
+ * A listener for transition events
+ * @author iXeption
+ *
+ */
+public interface TransitionListener {
+	
+	void onTransitionStart();
+	void onTransitionFinished();
+
+}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ScreenTransitionTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ScreenTransitionTest.java
@@ -1,0 +1,248 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *	 http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogic.gdx.tests;
+
+import java.util.ArrayList;
+
+import com.badlogic.gdx.FadingGame;
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Input;
+import com.badlogic.gdx.Screen;
+import com.badlogic.gdx.ScreenAdapter;
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.Batch;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.graphics.g2d.TextureRegion;
+import com.badlogic.gdx.math.Interpolation;
+import com.badlogic.gdx.scenes.scene2d.Actor;
+import com.badlogic.gdx.scenes.scene2d.InputEvent;
+import com.badlogic.gdx.scenes.scene2d.Stage;
+import com.badlogic.gdx.scenes.scene2d.utils.ClickListener;
+import com.badlogic.gdx.tests.utils.GdxTest;
+import com.badlogic.gdx.utils.Logger;
+import com.badlogic.gdx.utils.Scaling;
+import com.badlogic.gdx.utils.transition.AlphaFadingTransition;
+import com.badlogic.gdx.utils.transition.ColorFadeTransition;
+import com.badlogic.gdx.utils.transition.RotatingTransition;
+import com.badlogic.gdx.utils.transition.RotatingTransition.TransitionScaling;
+import com.badlogic.gdx.utils.transition.ScreenTransition;
+import com.badlogic.gdx.utils.transition.SlicingTransition;
+import com.badlogic.gdx.utils.transition.SlidingTransition;
+import com.badlogic.gdx.utils.transition.TransitionListener;
+import com.badlogic.gdx.utils.viewport.ScalingViewport;
+
+public class ScreenTransitionTest extends GdxTest {
+
+	final String tag = ScreenTransitionTest.class.getSimpleName();
+
+	FadingGame fadingGame;
+	Screen firstScreen;
+	Screen secondScreen;
+
+	boolean toggle = false;
+	int index = 0;
+
+	ArrayList<ScreenTransition> transitions = new ArrayList<ScreenTransition>();
+
+	public class SimpleScreen extends ScreenAdapter {
+
+		Stage simpleStage;
+		String name;
+		boolean paused = false;
+
+		public SimpleScreen (String name, String bgImage, final float offset) {
+			this.name = name;
+			simpleStage = new Stage(new ScalingViewport(Scaling.fill, 640, 480));
+			final TextureRegion region = new TextureRegion(new Texture("data/badlogic.jpg"));
+			final Actor actor = new Actor() {
+
+				public void draw (Batch batch, float parentAlpha) {
+					Color color = getColor();
+					batch.setColor(color.r, color.g, color.b, parentAlpha);
+					batch.draw(region, getX(), getY(), getOriginX(), getOriginY(), getWidth(), getHeight(), getScaleX(), getScaleY(),
+						getRotation());
+				}
+
+				@Override
+				public void act (float delta) {
+					if (!paused) {
+						setPosition(getX() + 50 * delta, offset);
+						if (getX() > Gdx.graphics.getWidth()) setX(0);
+					}
+				}
+			};
+
+			actor.setBounds(15, 15, 200, 200);
+			actor.setOrigin(50, 50);
+
+			final TextureRegion regionBG = new TextureRegion(new Texture(bgImage));
+			final Actor bg = new Actor() {
+
+				public void draw (Batch batch, float parentAlpha) {
+					Color color = getColor();
+					batch.setColor(color.r, color.g, color.b, parentAlpha);
+					batch.draw(regionBG, getX(), getY(), getOriginX(), getOriginY(), getWidth(), getHeight(), getScaleX(),
+						getScaleY(), getRotation());
+				}
+			};
+
+			bg.setBounds(0, 0, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+
+			simpleStage.addActor(bg);
+			simpleStage.addActor(actor);
+
+			simpleStage.addListener(new ClickListener(Input.Buttons.LEFT) {
+				@Override
+				public void clicked (InputEvent event, float x, float y) {
+					Gdx.app.debug(tag, "Toggle Screen");
+					fadingGame.setScreen(getNextScreen());
+
+				}
+			});
+
+			simpleStage.addListener(new ClickListener(Input.Buttons.RIGHT) {
+				@Override
+				public void clicked (InputEvent event, float x, float y) {
+					Gdx.app.debug(tag, "Change Transition");
+					if (fadingGame.setTransition(getNextTransition(), 2))
+						Gdx.app.debug(tag, "Sucess");
+					else
+						Gdx.app.error(tag, "failed");
+
+				}
+			});
+
+		}
+
+		@Override
+		public void render (float delta) {
+			Gdx.gl.glClearColor(0, 0, 0, 0);
+			Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+			simpleStage.act(delta);
+			simpleStage.draw();
+		}
+
+		@Override
+		public void resize (int width, int height) {
+			Gdx.app.debug(tag, "Resize W:" + width + " H: " + height + " " + name);
+			simpleStage.getViewport().update(width, height, true);
+		}
+
+		@Override
+		public void show () {
+			Gdx.app.debug(tag, "Show " + name);
+			Gdx.input.setInputProcessor(simpleStage);
+		}
+
+		@Override
+		public void hide () {
+			Gdx.app.debug(tag, "Hide " + name);
+		}
+
+		@Override
+		public void resume () {
+			Gdx.app.debug(tag, "Resume " + name);
+			paused = false;
+
+		}
+
+		@Override
+		public void pause () {
+			Gdx.app.debug(tag, "Pause " + name);
+			paused = true;
+		}
+
+	}
+
+	@Override
+	public void create () {
+		Gdx.app.setLogLevel(Logger.DEBUG);
+		fadingGame = new FadingGame(new SpriteBatch());
+		fadingGame.create();
+		firstScreen = new SimpleScreen("Screen1", "data/stones.jpg", 10);
+		secondScreen = new SimpleScreen("Screen2", "data/planet_earth.png", 200);
+		transitions.add(new AlphaFadingTransition());
+		transitions.add(new SlidingTransition(SlidingTransition.Direction.LEFT, Interpolation.linear, true));
+		transitions.add(new SlidingTransition(SlidingTransition.Direction.UP, Interpolation.bounce, false));
+		transitions.add(new SlicingTransition(SlicingTransition.Direction.UPDOWN, 128, Interpolation.pow4));
+		transitions.add(new SlicingTransition(SlicingTransition.Direction.DOWN, 8, Interpolation.bounce));
+		transitions.add(new RotatingTransition(Interpolation.pow2Out, 720, TransitionScaling.IN));
+		transitions.add(new RotatingTransition(Interpolation.bounce, 360, TransitionScaling.IN));
+		transitions.add(new ColorFadeTransition(Color.WHITE, Interpolation.sine));
+
+		fadingGame.addTransitionListener(new TransitionListener() {
+
+			@Override
+			public void onTransitionStart () {
+				Gdx.app.debug(tag, "TransitionListener: Start detected");
+
+			}
+
+			@Override
+			public void onTransitionFinished () {
+				Gdx.app.debug(tag, "TransitionListener: Finish detected");
+
+			}
+		});
+
+		fadingGame.setScreen(firstScreen);
+
+	}
+
+	@Override
+	public void render () {
+		fadingGame.render();
+	}
+
+	@Override
+	public void resize (int width, int height) {
+		fadingGame.resize(width, height);
+	}
+
+	@Override
+	public void dispose () {
+		fadingGame.dispose();
+	}
+
+	@Override
+	public void pause () {
+		fadingGame.pause();
+	}
+
+	@Override
+	public void resume () {
+		fadingGame.resume();
+	}
+
+	Screen getNextScreen () {
+		toggle = !toggle;
+		if (toggle) {
+			return secondScreen;
+		} else
+			return firstScreen;
+
+	}
+
+	ScreenTransition getNextTransition () {
+		if (++index >= transitions.size()) index = 0;
+		return transitions.get(index);
+
+	}
+
+}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ScreenTransitionTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ScreenTransitionTest.java
@@ -127,6 +127,15 @@ public class ScreenTransitionTest extends GdxTest {
 
 				}
 			});
+			
+			simpleStage.addListener(new ClickListener(Input.Buttons.MIDDLE) {
+				@Override
+				public void clicked (InputEvent event, float x, float y) {
+					Gdx.app.debug(tag, "Clear Listeners");
+					fadingGame.clearTransitionListeners();
+
+				}
+			});
 
 		}
 
@@ -175,6 +184,7 @@ public class ScreenTransitionTest extends GdxTest {
 		Gdx.app.setLogLevel(Logger.DEBUG);
 		fadingGame = new FadingGame(new SpriteBatch());
 		fadingGame.create();
+		fadingGame.setTransition(new ColorFadeTransition(Color.BLACK, Interpolation.exp10), 3.0f);
 		firstScreen = new SimpleScreen("Screen1", "data/stones.jpg", 10);
 		secondScreen = new SimpleScreen("Screen2", "data/planet_earth.png", 200);
 		transitions.add(new AlphaFadingTransition());

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
@@ -69,6 +69,7 @@ import com.badlogic.gdx.tests.gles2.HelloTriangle;
 import com.badlogic.gdx.tests.gles2.SimpleVertexShader;
 import com.badlogic.gdx.tests.net.NetAPITest;
 import com.badlogic.gdx.tests.superkoalio.SuperKoalio;
+import com.badlogic.gdx.tests.ScreenTransitionTest;
 import com.badlogic.gdx.utils.ObjectMap;
 import com.badlogic.gdx.utils.StreamUtils;
 
@@ -249,7 +250,8 @@ public class GdxTests {
 		FreeTypeTest.class,
 		InternationalFontsTest.class,
 		PngTest.class,
-		JsonTest.class
+		JsonTest.class,
+		ScreenTransitionTest.class
 		// @on
 
 		// SoundTouchTest.class, Mpg123Test.class, WavTest.class, FreeTypeTest.class,


### PR DESCRIPTION
Adds frame buffer based screen transitions like, alpha-fading, color-fading, sliding and slicing.
The Game class has been extended to FadingGame, which applies transitions, when setScreen is called. Allows callbacks on start and end of the transitions.

ScreenTransition Test included:
left Mouse - toggle Screen
right Mouse - change transition

Be free to contact me for wiki tutorial or something if you want to accept the pull request.