### PR TITLE
Font rendering problem in Label

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Label.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Label.java
@@ -194,7 +194,7 @@ public class Label extends Widget {
 			y += cache.getFont().isFlipped() ? height - textHeight : 0;
 			y -= style.font.getDescent();
 		} else {
-			y += (height - textHeight) / 2;
+			y += Math.round((height - textHeight) / 2);
 		}
 		if (!cache.getFont().isFlipped()) y += textHeight;
 


### PR DESCRIPTION
When a Label has its text vertically aligned in the center and the difference between the label height and text height is an uneven number, the text is displaced by X.5, which provokes the same effect in the font rendering produced when the label's position is not an integer.

![Problem](http://i.imgur.com/Hc9VxkV.png)