### PR TITLE
gdx-setup: Updated libgdx-utils 3rd party extension (again)

### DIFF
--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/data/extensions.xml
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/data/extensions.xml
@@ -44,7 +44,7 @@
 		<name>libgdx-utils</name>
 		<description>additional features and helper classes</description>
 		<package>net.dermetfan.gdx</package>
-		<version>0.12.2</version>
+		<version>0.13.0</version>
 		<compatibility>1.6.3</compatibility>
 		<website>http://dermetfan.net/libgdx-utils.php</website>
 		<gwtInherits>
@@ -66,7 +66,7 @@
 		<name>libgdx-utils-box2d</name>
 		<description>additional features and helper classes for the official Box2D extension</description>
 		<package>net.dermetfan.gdx</package>
-		<version>0.12.2</version>
+		<version>0.13.0</version>
 		<compatibility>1.6.3</compatibility>
 		<website>http://dermetfan.net/libgdx-utils.php</website>
 		<gwtInherits>


### PR DESCRIPTION
Sorry, the version you just merged didn't work with HTML5. This release is just a fix.