### PR TITLE
Make all worker threads daemon, so they can't prevent termination

### DIFF
--- a/gdx/src/com/badlogic/gdx/utils/Timer.java
+++ b/gdx/src/com/badlogic/gdx/utils/Timer.java
@@ -240,7 +240,9 @@ public class Timer {
 				}
 			}
 			app = Gdx.app;
-			new Thread(this, "Timer").start();
+			Thread t = new Thread(this, "Timer");
+			t.setDaemon(true);
+			t.start();
 			thread = this;
 		}
 


### PR DESCRIPTION
This pull request makes all worker threads daemon, so they can't prevent termination of the application if the main thread unexpectedly exits. Fixes #3240, fixes #3226.