### PR TITLE
Remove unnecessary check for boolean

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidAudio.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidAudio.java
@@ -79,7 +79,7 @@ public final class AndroidAudio implements Audio {
 		}
 		synchronized (musics) {
 			for (int i = 0; i < musics.size(); i++) {
-				if (musics.get(i).wasPlaying == true) musics.get(i).play();
+				if (musics.get(i).wasPlaying) musics.get(i).play();
 			}
 		}
 		this.soundPool.autoResume();


### PR DESCRIPTION
`musics.get(i).wasPlaying` is a boolean value, no need to use `== true` to check it.