### PR TITLE
More flexible way to manage Box2d contacts

### DIFF
--- a/extensions/gdx-box2d/gdx-box2d/src/com/badlogic/gdx/physics/box2d/Contact.java
+++ b/extensions/gdx-box2d/gdx-box2d/src/com/badlogic/gdx/physics/box2d/Contact.java
@@ -41,10 +41,22 @@ public class Contact {
 		this.world = world;
 	}
 
-	private final float[] tmp = new float[8];
+	public Contact (Contact contact) {
+		this(contact.world, contact.addr);
+	}
+
+	@Override
+	public boolean equals (Object obj) {
+		if (this == obj) return true;
+		if (obj instanceof Contact) return ((Contact)obj).addr == this.addr && ((Contact)obj).world == this.world;
+		return super.equals(obj);
+	}
+
+	private float[] tmp;
 
 	/** Get the world manifold. */
 	public WorldManifold getWorldManifold () {
+		if (tmp == null) tmp = new float[8];
 		int numContactPoints = jniGetWorldManifold(addr, tmp);
 
 		worldManifold.numContactPoints = numContactPoints;


### PR DESCRIPTION
Currently, there is no way to save a contact object from a beginContact() or endContact() callback because all parameter contacts are the same instance.  I would like the ability to save the contact object and be able to use it's methods beyond the callback.

Use case: ability to keep track of all the contacts on a Body without having to search for them via World.getContactList().

Solution:
Add a constructor to create a contact from a contact object.
Add an equals() method to check if a two contacts are representing the same.
Removed some allocation for getWorldManifold() to lighten the impact of creating many contact objects

There may be a good reason for not allowing this kind of functionality that I am unaware of.  This just seemed like the most logical fix.