### PR TITLE
setVolume without ID for Sound

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidSound.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidSound.java
@@ -27,6 +27,7 @@ final class AndroidSound implements Sound {
 	final AudioManager manager;
 	final int soundId;
 	final IntArray streamIds = new IntArray(8);
+	private float volume = 1;
 
 	AndroidSound (SoundPool pool, AudioManager manager, int soundId) {
 		this.soundPool = pool;
@@ -41,7 +42,7 @@ final class AndroidSound implements Sound {
 
 	@Override
 	public long play () {
-		return play(1);
+		return play(volume);
 	}
 
 	@Override
@@ -96,7 +97,7 @@ final class AndroidSound implements Sound {
 
 	@Override
 	public long loop () {
-		return loop(1);
+		return loop(volume);
 	}
 
 	@Override
@@ -165,5 +166,10 @@ final class AndroidSound implements Sound {
 	@Override
 	public void setPriority (long soundId, int priority) {
 		soundPool.setPriority((int)soundId, priority);
+	}
+
+	@Override
+	public void setVolume (float volume) {
+		this.volume = volume;
 	}
 }

--- a/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/mock/audio/MockSound.java
+++ b/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/mock/audio/MockSound.java
@@ -111,4 +111,9 @@ public class MockSound implements Sound {
 	public void setPriority(long soundId, int priority) {
 
 	}
+
+	@Override
+	public void setVolume(float volume) {
+		
+	}
 }

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/audio/OpenALSound.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/audio/OpenALSound.java
@@ -28,6 +28,7 @@ public class OpenALSound implements Sound {
 	private int bufferID = -1;
 	private final OpenALAudio audio;
 	private float duration;
+	private float volume = 1;
 
 	public OpenALSound (OpenALAudio audio) {
 		this.audio = audio;
@@ -50,7 +51,7 @@ public class OpenALSound implements Sound {
 	}
 
 	public long play () {
-		return play(1);
+		return play(volume);
 	}
 
 	public long play (float volume) {
@@ -72,7 +73,7 @@ public class OpenALSound implements Sound {
 	}
 
 	public long loop () {
-		return loop(1);
+		return loop(volume);
 	}
 
 	@Override
@@ -180,5 +181,10 @@ public class OpenALSound implements Sound {
 	@Override
 	public void setPriority (long soundId, int priority) {
 		// TODO Auto-generated method stub
+	}
+
+	@Override
+	public void setVolume (float volume) {
+		this.volume = volume;
 	}
 }

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSSound.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSSound.java
@@ -39,6 +39,7 @@ public class IOSSound implements Sound {
 	private ALChannelSource channel;
 	private NSArray<ALSource> sourcePool;
 	private IntArray streamIds = new IntArray(8);
+	private float volume = 1;
 	
 	public IOSSound (FileHandle filePath) {
 		soundPath = filePath.file().getPath().replace('\\', '/');
@@ -49,7 +50,7 @@ public class IOSSound implements Sound {
 
 	@Override
 	public long play () {
-		return play(1, 1, 0, false);
+		return play(volume, 1, 0, false);
 	}
 
 	@Override
@@ -73,7 +74,7 @@ public class IOSSound implements Sound {
 
 	@Override
 	public long loop () {
-		return play(1, 1, 0, true);
+		return play(volume, 1, 0, true);
 	}
 
 	@Override
@@ -171,5 +172,10 @@ public class IOSSound implements Sound {
 			if (source.getSourceId() == soundId) return source;			
 		}
 		return null;
+	}
+
+	@Override
+	public void setVolume(float volume) {
+		this.volume = volume;
 	}
 }

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtSound.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtSound.java
@@ -36,12 +36,15 @@ public class GwtSound implements Sound {
 	private int soundIndex;
 	/** The path to the sound file. */
 	private FileHandle soundFile;
+	/** Default volune */
+	private float volume;
 	
 	public GwtSound (FileHandle file) {
 		soundFile = file;
 		sounds = new GwtMusic[MAX_SOUNDS];
 		sounds[0] = new GwtMusic(file);
 		soundIndex = 0;
+		volume = 1;
 	}
 	
 	/** Let's find a sound that isn't currently playing.
@@ -66,7 +69,7 @@ public class GwtSound implements Sound {
 
 	@Override
 	public long play () {
-		return play(1.0f, 1.0f, 0.0f, false);
+		return play(volume, 1.0f, 0.0f, false);
 	}
 
 	@Override
@@ -97,7 +100,7 @@ public class GwtSound implements Sound {
 
 	@Override
 	public long loop () {
-		return play(1.0f, 1.0f, 0.0f, true);
+		return play(volume, 1.0f, 0.0f, true);
 	}
 
 	@Override
@@ -189,5 +192,10 @@ public class GwtSound implements Sound {
 	@Override
 	public void setPriority (long soundId, int priority) {
 		// FIXME
+	}
+
+	@Override
+	public void setVolume (float volume) {
+		this.volume = volume;
 	}
 }

--- a/gdx/src/com/badlogic/gdx/audio/Sound.java
+++ b/gdx/src/com/badlogic/gdx/audio/Sound.java
@@ -111,6 +111,10 @@ public interface Sound extends Disposable {
 	 * @param soundId the sound id
 	 * @param pitch the pitch multiplier, 1 == default, >1 == faster, <1 == slower, the value has to be between 0.5 and 2.0 */
 	public void setPitch (long soundId, float pitch);
+	
+	/** Changes the default sound volume used by {@link #play()}. Does not update playing sounds.
+	 * @param volume the volume in the range 0 (silent) to 1 (max volume). */
+	public void setVolume (float volume);
 
 	/** Changes the volume of the sound instance with the given id as returned by {@link #play()} or {@link #play(float)}. If the
 	 * sound is no longer playing, this has no effect.


### PR DESCRIPTION
One limitation I had with LibGDX sound interface is the lack of the ability to set volume without specifying an ID. Default volume.

In my game for example, there are utility classes that handle sound fall off. These need to alter the volume of sounds without playing it, which is done by the entities. So these small changes would be nice.