### PR TITLE
TextField's cursor doesn't blink in GWT backend

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtGraphics.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtGraphics.java
@@ -250,7 +250,7 @@ public class GwtGraphics implements Graphics {
 
 	@Override
 	public boolean isContinuousRendering () {
-		return false;
+		return true;
 	}
 
 	@Override


### PR DESCRIPTION
TextField and TextArea cursor doesn't blink in GWT due to this:
https://github.com/libgdx/libgdx/blob/master/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextField.java#L397
```java
		if (!Gdx.graphics.isContinuousRendering()) {
			cursorOn = true;
			return;
		}
```
and `Gdx.graphics.isContinuousRendering()` returning always `false` in GWT backend, so I changed it to return true, which solves this problem and also makes more sense, since other backends starts with continuous rendering set to true.