### PR TITLE
Make Android preferences unblocking

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidPreferences.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidPreferences.java
@@ -149,7 +149,11 @@ public class AndroidPreferences implements Preferences {
 	@Override
 	public void flush () {
 		if (editor != null) {
-			editor.apply();
+			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.GINGERBREAD) {
+    				editor.apply();
+			} else {
+				editor.commit();
+			}
 			editor = null;
 		}
 	}

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidPreferences.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidPreferences.java
@@ -149,7 +149,7 @@ public class AndroidPreferences implements Preferences {
 	@Override
 	public void flush () {
 		if (editor != null) {
-			editor.commit();
+			editor.apply();
 			editor = null;
 		}
 	}


### PR DESCRIPTION
Accordingly to [Android ref](http://developer.android.com/reference/android/content/SharedPreferences.Editor.html), we should prefer `apply()` over `commit()`. `apply()` will save the state to the object synchronously, but will start an async task to save the object to the disk, while `commit()` will do both synchronously, where it can block if done in the main thread.