### PR TITLE
Make GridPoint classes implement Serializable and provide toString()

### DIFF
--- a/gdx/src/com/badlogic/gdx/math/GridPoint2.java
+++ b/gdx/src/com/badlogic/gdx/math/GridPoint2.java
@@ -16,12 +16,14 @@
 
 package com.badlogic.gdx.math;
 
-import com.badlogic.gdx.utils.NumberUtils;
+import java.io.Serializable;
 
 /** A point in a 2D grid, with integer x and y coordinates
  * 
  * @author badlogic */
-public class GridPoint2 {
+public class GridPoint2 implements Serializable {
+	private static final long serialVersionUID = -4019969926331717380L;
+
 	public int x;
 	public int y;
 
@@ -84,5 +86,10 @@ public class GridPoint2 {
 		result = prime * result + this.x;
 		result = prime * result + this.y;
 		return result;
+	}
+
+	@Override
+	public String toString() {
+		return "(" + x + ", " + y + ")";
 	}
 }

--- a/gdx/src/com/badlogic/gdx/math/GridPoint3.java
+++ b/gdx/src/com/badlogic/gdx/math/GridPoint3.java
@@ -16,12 +16,14 @@
 
 package com.badlogic.gdx.math;
 
-import com.badlogic.gdx.utils.NumberUtils;
+import java.io.Serializable;
 
 /** A point in a 3D grid, with integer x and y coordinates
  * 
  * @author badlogic */
-public class GridPoint3 {
+public class GridPoint3 implements Serializable {
+	private static final long serialVersionUID = 5922187982746752830L;
+
 	public int x;
 	public int y;
 	public int z;
@@ -92,5 +94,10 @@ public class GridPoint3 {
 		result = prime * result + this.y;
 		result = prime * result + this.z;
 		return result;
+	}
+
+	@Override
+	public String toString() {
+		return "(" + x + ", " + y + ", " + z + ")";
 	}
 }


### PR DESCRIPTION
This was more of just a really simple quick fix so that:
 * Serialization libraries don't choke on GridPoints since they previously did not implement `Serializable`
 * The coordinates of a GridPoint can easily be accessed for debugging purposes with a simple `toString()`

And of course, the Vector class already has both of these anyways.