### PR TITLE
Added TiledMapTileMapObject

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidPreferences.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidPreferences.java
@@ -21,6 +21,7 @@ import java.util.Map.Entry;
 
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
+import android.os.Build;
 
 import com.badlogic.gdx.Preferences;
 
@@ -149,7 +150,11 @@ public class AndroidPreferences implements Preferences {
 	@Override
 	public void flush () {
 		if (editor != null) {
-			editor.commit();
+			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.GINGERBREAD) {
+    				editor.apply();
+			} else {
+				editor.commit();
+			}
 			editor = null;
 		}
 	}

--- a/gdx/src/com/badlogic/gdx/graphics/PixmapIO.java
+++ b/gdx/src/com/badlogic/gdx/graphics/PixmapIO.java
@@ -186,7 +186,6 @@ public class PixmapIO {
 		static private final byte PAETH = 4;
 
 		private final ChunkBuffer buffer;
-		private final DeflaterOutputStream deflaterOutput;
 		private final Deflater deflater;
 		private ByteArray lineOutBytes, curLineBytes, prevLineBytes;
 		private boolean flipY = true;
@@ -199,7 +198,6 @@ public class PixmapIO {
 		public PNG (int initialBufferSize) {
 			buffer = new ChunkBuffer(initialBufferSize);
 			deflater = new Deflater();
-			deflaterOutput = new DeflaterOutputStream(buffer, deflater);
 		}
 
 		/** If true, the resulting PNG is flipped vertically. Default is true. */
@@ -223,6 +221,7 @@ public class PixmapIO {
 
 		/** Writes the pixmap to the stream without closing the stream. */
 		public void write (OutputStream output, Pixmap pixmap) throws IOException {
+			DeflaterOutputStream deflaterOutput = new DeflaterOutputStream(buffer, deflater);
 			DataOutputStream dataOutput = new DataOutputStream(output);
 			dataOutput.write(SIGNATURE);
 

--- a/gdx/src/com/badlogic/gdx/maps/tiled/AtlasTmxMapLoader.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/AtlasTmxMapLoader.java
@@ -366,15 +366,20 @@ public class AtlasTmxMapLoader extends BaseTmxMapLoader<AtlasTmxMapLoader.AtlasT
 			props.put("margin", margin);
 			props.put("spacing", spacing);
 
-			for (AtlasRegion region : atlas.findRegions(regionsName)) {
-				// handle unused tile ids
-				if (region != null) {
-					StaticTiledMapTile tile = new StaticTiledMapTile(region);
-					int tileid = firstgid + region.index;
-					tile.setId(tileid);
-					tile.setOffsetX(offsetX);
-					tile.setOffsetY(flipY ? -offsetY : offsetY);
-					tileset.putTile(tileid, tile);
+			if (imageSource != null && imageSource.length() > 0) {
+				int lastgid = firstgid + ((imageWidth / tilewidth) * (imageHeight / tileheight)) - 1;
+				for (AtlasRegion region : atlas.findRegions(regionsName)) {
+					// handle unused tile ids
+					if (region != null) {
+						int tileid = region.index + 1;
+						if (tileid >= firstgid && tileid <= lastgid) {
+							StaticTiledMapTile tile = new StaticTiledMapTile(region);
+							tile.setId(tileid);
+							tile.setOffsetX(offsetX);
+							tile.setOffsetY(flipY ? -offsetY : offsetY);
+							tileset.putTile(tileid, tile);
+						}
+					}
 				}
 			}
 

--- a/gdx/src/com/badlogic/gdx/maps/tiled/BaseTmxMapLoader.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/BaseTmxMapLoader.java
@@ -1,6 +1,14 @@
 
 package com.badlogic.gdx.maps.tiled;
 
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.StringTokenizer;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.InflaterInputStream;
+
 import com.badlogic.gdx.assets.AssetLoaderParameters;
 import com.badlogic.gdx.assets.loaders.AsynchronousAssetLoader;
 import com.badlogic.gdx.assets.loaders.FileHandleResolver;
@@ -15,8 +23,8 @@ import com.badlogic.gdx.maps.objects.EllipseMapObject;
 import com.badlogic.gdx.maps.objects.PolygonMapObject;
 import com.badlogic.gdx.maps.objects.PolylineMapObject;
 import com.badlogic.gdx.maps.objects.RectangleMapObject;
-import com.badlogic.gdx.maps.objects.TextureMapObject;
 import com.badlogic.gdx.maps.tiled.TiledMapTileLayer.Cell;
+import com.badlogic.gdx.maps.tiled.objects.TiledMapTileMapObject;
 import com.badlogic.gdx.math.Polygon;
 import com.badlogic.gdx.math.Polyline;
 import com.badlogic.gdx.utils.Base64Coder;
@@ -24,12 +32,6 @@ import com.badlogic.gdx.utils.GdxRuntimeException;
 import com.badlogic.gdx.utils.StreamUtils;
 import com.badlogic.gdx.utils.XmlReader;
 import com.badlogic.gdx.utils.XmlReader.Element;
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.StringTokenizer;
-import java.util.zip.GZIPInputStream;
-import java.util.zip.InflaterInputStream;
 
 public abstract class BaseTmxMapLoader<P extends AssetLoaderParameters<TiledMap>> extends AsynchronousAssetLoader<TiledMap, P> {
 
@@ -212,16 +214,17 @@ public abstract class BaseTmxMapLoader<P extends AssetLoaderParameters<TiledMap>
 					boolean flipVertically = ((id & FLAG_FLIP_VERTICALLY) != 0);
 
 					TiledMapTile tile = map.getTileSets().getTile(id & ~MASK_CLEAR);
-					TextureRegion textureRegion = new TextureRegion(tile.getTextureRegion());
-					textureRegion.flip(flipHorizontally, flipVertically);
-					TextureMapObject textureMapObject = new TextureMapObject(textureRegion);
-					textureMapObject.getProperties().put("gid", id);
-					textureMapObject.setX(x);
-					textureMapObject.setY(flipY ? y - height : y);
-					textureMapObject.setScaleX(scaleX);
-					textureMapObject.setScaleY(scaleY);
-					textureMapObject.setRotation(element.getFloatAttribute("rotation", 0));
-					object = textureMapObject;
+					TiledMapTileMapObject tiledMapTileMapObject = new TiledMapTileMapObject(tile, flipHorizontally, flipVertically);
+					TextureRegion textureRegion = tiledMapTileMapObject.getTextureRegion();
+					tiledMapTileMapObject.getProperties().put("gid", id);
+					tiledMapTileMapObject.setX(x);
+					tiledMapTileMapObject.setY(flipY ? y : y - height);
+					float objectWidth = element.getFloatAttribute("width", textureRegion.getRegionWidth());
+					float objectHeight = element.getFloatAttribute("height", textureRegion.getRegionHeight());
+					tiledMapTileMapObject.setScaleX(scaleX * (objectWidth / textureRegion.getRegionWidth()));
+					tiledMapTileMapObject.setScaleY(scaleY * (objectHeight / textureRegion.getRegionHeight()));
+					tiledMapTileMapObject.setRotation(element.getFloatAttribute("rotation", 0));
+					object = tiledMapTileMapObject;
 				} else {
 					object = new RectangleMapObject(x, flipY ? y - height : y, width, height);
 				}
@@ -308,9 +311,9 @@ public abstract class BaseTmxMapLoader<P extends AssetLoaderParameters<TiledMap>
 						if (compression == null)
 							is = new ByteArrayInputStream(bytes);
 						else if (compression.equals("gzip"))
-							is = new GZIPInputStream(new ByteArrayInputStream(bytes), bytes.length);
+							is = new BufferedInputStream(new GZIPInputStream(new ByteArrayInputStream(bytes), bytes.length));
 						else if (compression.equals("zlib"))
-							is = new InflaterInputStream(new ByteArrayInputStream(bytes));
+							is = new BufferedInputStream(new InflaterInputStream(new ByteArrayInputStream(bytes)));
 						else
 							throw new GdxRuntimeException("Unrecognised compression (" + compression + ") for TMX Layer Data");
 
@@ -344,7 +347,7 @@ public abstract class BaseTmxMapLoader<P extends AssetLoaderParameters<TiledMap>
 	}
 
 	protected static int unsignedByteToInt (byte b) {
-		return (int)b & 0xFF;
+		return b & 0xFF;
 	}
 
 	protected static FileHandle getRelativeFileHandle (FileHandle file, String path) {

--- a/gdx/src/com/badlogic/gdx/maps/tiled/objects/TiledMapTileMapObject.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/objects/TiledMapTileMapObject.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogic.gdx.maps.tiled.objects;
+
+import com.badlogic.gdx.graphics.g2d.TextureRegion;
+import com.badlogic.gdx.maps.MapObject;
+import com.badlogic.gdx.maps.objects.TextureMapObject;
+import com.badlogic.gdx.maps.tiled.TiledMapTile;
+import com.badlogic.gdx.maps.tiled.tiles.AnimatedTiledMapTile;
+import com.badlogic.gdx.maps.tiled.tiles.StaticTiledMapTile;
+
+/** A {@link MapObject} with a {@link TiledMapTile}. Can be both {@link StaticTiledMapTile} or {@link AnimatedTiledMapTile}. For
+ * compatibility reasons, this extends {@link TextureMapObject}. Use {@link TiledMapTile#getTextureRegion()} instead of
+ * {@link #getTextureRegion()}.
+ * @author Daniel Holderbaum */
+public class TiledMapTileMapObject extends TextureMapObject {
+
+	private boolean flipHorizontally;
+	private boolean flipVertically;
+
+	private TiledMapTile tile;
+
+	public TiledMapTileMapObject (TiledMapTile tile, boolean flipHorizontally, boolean flipVertically) {
+		this.flipHorizontally = flipHorizontally;
+		this.flipVertically = flipVertically;
+		this.tile = tile;
+
+		TextureRegion textureRegion = new TextureRegion(tile.getTextureRegion());
+		textureRegion.flip(flipHorizontally, flipVertically);
+		setTextureRegion(textureRegion);
+	}
+
+	public boolean isFlipHorizontally () {
+		return flipHorizontally;
+	}
+
+	public void setFlipHorizontally (boolean flipHorizontally) {
+		this.flipHorizontally = flipHorizontally;
+	}
+
+	public boolean isFlipVertically () {
+		return flipVertically;
+	}
+
+	public void setFlipVertically (boolean flipVertically) {
+		this.flipVertically = flipVertically;
+	}
+
+	public TiledMapTile getTile () {
+		return tile;
+	}
+
+	public void setTile (TiledMapTile tile) {
+		this.tile = tile;
+	}
+
+}

--- a/tests/gdx-tests-android/assets/data/maps/tiled-objects/test-load-mapobjects.tmx
+++ b/tests/gdx-tests-android/assets/data/maps/tiled-objects/test-load-mapobjects.tmx
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="16" height="16" tilewidth="32" tileheight="32" nextobjectid="14">
+<map version="1.0" orientation="orthogonal" renderorder="right-down" width="16" height="16" tilewidth="32" tileheight="32" nextobjectid="17">
  <tileset firstgid="1" name="Test" tilewidth="256" tileheight="256">
   <tile id="0">
    <image width="32" height="32" source="Start.bmp"/>
+   <animation>
+    <frame tileid="0" duration="500"/>
+    <frame tileid="1" duration="500"/>
+   </animation>
   </tile>
   <tile id="1">
    <image width="32" height="32" source="../../badlogicsmall.jpg"/>
@@ -19,6 +23,7 @@
    <polygon points="0,0 78,-4 32,73"/>
   </object>
   <object id="9" name="Rectangle" x="340" y="341.333" width="118.667" height="100"/>
-  <object id="12" name="Texture" gid="3" x="128" y="298.667"/>
+  <object id="12" name="Texture" gid="3" x="128" y="298.667" width="256" height="33.667"/>
+  <object id="14" gid="1073741825" x="384" y="256" width="64" height="32"/>
  </objectgroup>
 </map>

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/PngTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/PngTest.java
@@ -55,6 +55,7 @@ public class PngTest extends GdxTest {
 				PNG writer = new PNG((int)(pixmap.getWidth() * pixmap.getHeight() * 1.5f));
 				// writer.setCompression(Deflater.NO_COMPRESSION);
 				writer.write(file, pixmap);
+				writer.write(file, pixmap); // Write twice to make sure the object is reusable.
 				writer.dispose();
 			} catch (IOException ex) {
 				throw new RuntimeException(ex);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapObjectLoadingTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapObjectLoadingTest.java
@@ -24,6 +24,7 @@ import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
 import com.badlogic.gdx.maps.MapLayer;
 import com.badlogic.gdx.maps.MapObject;
@@ -34,6 +35,8 @@ import com.badlogic.gdx.maps.objects.RectangleMapObject;
 import com.badlogic.gdx.maps.objects.TextureMapObject;
 import com.badlogic.gdx.maps.tiled.TiledMap;
 import com.badlogic.gdx.maps.tiled.TmxMapLoader;
+import com.badlogic.gdx.maps.tiled.objects.TiledMapTileMapObject;
+import com.badlogic.gdx.maps.tiled.tiles.AnimatedTiledMapTile;
 import com.badlogic.gdx.math.Ellipse;
 import com.badlogic.gdx.math.Polygon;
 import com.badlogic.gdx.math.Rectangle;
@@ -79,13 +82,23 @@ public class TiledMapObjectLoadingTest extends GdxTest {
 		shapeRenderer.setColor(Color.BLUE);
 		Gdx.gl20.glLineWidth(2);
 		MapLayer layer = map.getLayers().get("Objects");
+		AnimatedTiledMapTile.updateAnimationBaseTime();
 		for (MapObject mapObject : layer.getObjects()) {
-			if (mapObject instanceof TextureMapObject) {
-				TextureMapObject tmObject = (TextureMapObject)mapObject;
+			if (mapObject instanceof TiledMapTileMapObject) {
 				batch.begin();
-				batch.draw(tmObject.getTextureRegion(), tmObject.getX(), tmObject.getY(), tmObject.getOriginX(),
-					tmObject.getOriginY(), tmObject.getTextureRegion().getRegionWidth(),
-					tmObject.getTextureRegion().getRegionHeight(), tmObject.getScaleX(), tmObject.getScaleY(), tmObject.getOpacity());
+				TiledMapTileMapObject tmtObject = (TiledMapTileMapObject)mapObject;
+				TextureRegion textureRegion = tmtObject.getTile().getTextureRegion();
+				// TilEd rotation is clockwise, we need counter-clockwise.
+				float rotation = -tmtObject.getRotation();
+				float scaleX = tmtObject.getScaleX();
+				float scaleY = tmtObject.getScaleY();
+				float xPos = tmtObject.getX();
+				float yPos = tmtObject.getY();
+				textureRegion.flip(tmtObject.isFlipHorizontally(), tmtObject.isFlipVertically());
+				batch.draw(textureRegion, xPos, yPos, tmtObject.getOriginX() * scaleX, tmtObject.getOriginY() * scaleY,
+					textureRegion.getRegionWidth() * scaleX, textureRegion.getRegionHeight() * scaleY, 1f, 1f, rotation);
+				// We flip back to the original state.
+				textureRegion.flip(tmtObject.isFlipHorizontally(), tmtObject.isFlipVertically());
 				batch.end();
 			} else if (mapObject instanceof EllipseMapObject) {
 				shapeRenderer.begin(ShapeRenderer.ShapeType.Filled);


### PR DESCRIPTION
TilEd is able to have animated tiles and create objects from those. The current implementation in libgdx can only handle single texture regions via `TextureMapObject` though.

This PR adds a new kind of `MapObject` in the `tiled` package. The `TmxMapLoader` will now create `TiledMapTileMapObjects` instead of `TextureMapObjects`. These reference either a `StaticTiledMapTile` or an `AnimatedTiledMapTile`.

For compatibility reasons, it also `extends TextureMapObject` and should work exactly the same.