### PR TITLE
Fixed GWT by adding TiledMapTileMapObject.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,5 @@
 [1.6.5]
+- Objects from animated tiles in TMX maps are now supported.
 - Made possible to use any actor for tooltips.
 - Improved cross-platform reflection api for annotations.
 - NinePatch#scale now also scales middle patch size.

--- a/gdx/src/com/badlogic/gdx.gwt.xml
+++ b/gdx/src/com/badlogic/gdx.gwt.xml
@@ -289,10 +289,13 @@
 		<include name="maps/tiled/renderers/OrthoCachedTiledMapRenderer.java"/>
 		<include name="maps/tiled/renderers/OrthogonalTiledMapRenderer.java"/>
 
-	<!-- maps/tiles/tiles -->
+	<!-- maps/tiled/tiles -->
 		<include name="maps/tiled/tiles/AnimatedTiledMapTile.java"/>
 		<include name="maps/tiled/tiles/StaticTiledMapTile.java"/>
 	
+	<!-- maps/tiled/objects -->
+		<include name="maps/tiled/objects/TiledMapTileMapObject.java"/>	
+		
 	<!-- math -->
 		<include name="math/Affine2.java"/>
 		<include name="math/Bezier.java"/>


### PR DESCRIPTION
The title says it all. Fixes https://github.com/libgdx/libgdx/issues/3313

Sorry about that. I keep assuming that all libgdx classes would be added automatically there for some unknown reason.