### PR TITLE
fixed bug where copying a directory into another directory wasn't creating the correct file hierarchy.

### DIFF
--- a/gdx/src/com/badlogic/gdx/files/FileHandle.java
+++ b/gdx/src/com/badlogic/gdx/files/FileHandle.java
@@ -688,6 +688,8 @@ public class FileHandle {
 
 	static private void copyDirectory (FileHandle sourceDir, FileHandle destDir) {
 		destDir.mkdirs();
+		destDir = destDir.child(sourceDir.name());
+		destDir.mkdirs();
 		FileHandle[] files = sourceDir.list();
 		for (int i = 0, n = files.length; i < n; i++) {
 			FileHandle srcFile = files[i];


### PR DESCRIPTION
So basically, if you had a file tree like so:
````
/tmp
    /foo
        /test.txt
    /bar
````

where foo and bar are both sub directories of tmp and you tried to move foo into bar using FileHandle.moveTo(), the resulting hierarchy would look like this:

````
/tmp
    /bar
        /test.txt
````

the foo directory would just disappear. The expected file hierarchy would be:

````
/tmp
    /bar
        /foo
            /test.txt
````
This is what the changes in this PR accomplishes.