### PR TITLE
Added Slider knowDown and knobOver drawable

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Button.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Button.java
@@ -156,7 +156,7 @@ public class Button extends Table implements Disableable {
 		this.isDisabled = isDisabled;
 	}
 
-	/** If false, {@link #setChecked(boolean)} and {@link #toggle()} will not fire {@link ChangeEvent}, event will be fired only when user clicked the checkbox */
+	/** If false, {@link #setChecked(boolean)} and {@link #toggle()} will not fire {@link ChangeEvent}, event will be fired only when user clicked the button */
 	public void setProgrammaticChangeEvents (boolean programmaticChangeEvents) {
 		this.programmaticChangeEvents = programmaticChangeEvents;
 	}

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ProgressBar.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ProgressBar.java
@@ -111,7 +111,7 @@ public class ProgressBar extends Widget implements Disableable {
 	public void draw (Batch batch, float parentAlpha) {
 		ProgressBarStyle style = this.style;
 		boolean disabled = this.disabled;
-		final Drawable knob = (disabled && style.disabledKnob != null) ? style.disabledKnob : style.knob;
+		final Drawable knob = getKnobDrawable();
 		final Drawable bg = (disabled && style.disabledBackground != null) ? style.disabledBackground : style.background;
 		final Drawable knobBefore = (disabled && style.disabledKnobBefore != null) ? style.disabledKnobBefore : style.knobBefore;
 		final Drawable knobAfter = (disabled && style.disabledKnobAfter != null) ? style.disabledKnobAfter : style.knobAfter;
@@ -218,6 +218,10 @@ public class ProgressBar extends Widget implements Disableable {
 		return visualInterpolation.apply((getVisualValue() - min) / (max - min));
 	}
 
+	protected Drawable getKnobDrawable () {
+		return (disabled && style.disabledKnob != null) ? style.disabledKnob : style.knob;
+	}
+
 	/** Returns progress bar visual position within the range. */
 	protected float getKnobPosition () {
 		return this.position;
@@ -269,7 +273,7 @@ public class ProgressBar extends Widget implements Disableable {
 
 	public float getPrefWidth () {
 		if (vertical) {
-			final Drawable knob = (disabled && style.disabledKnob != null) ? style.disabledKnob : style.knob;
+			final Drawable knob = getKnobDrawable();
 			final Drawable bg = (disabled && style.disabledBackground != null) ? style.disabledBackground : style.background;
 			return Math.max(knob == null ? 0 : knob.getMinWidth(), bg.getMinWidth());
 		} else
@@ -280,7 +284,7 @@ public class ProgressBar extends Widget implements Disableable {
 		if (vertical)
 			return 140;
 		else {
-			final Drawable knob = (disabled && style.disabledKnob != null) ? style.disabledKnob : style.knob;
+			final Drawable knob = getKnobDrawable();
 			final Drawable bg = (disabled && style.disabledBackground != null) ? style.disabledBackground : style.background;
 			return Math.max(knob == null ? 0 : knob.getMinHeight(), bg == null ? 0 : bg.getMinHeight());
 		}

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Slider.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Slider.java
@@ -19,6 +19,7 @@ package com.badlogic.gdx.scenes.scene2d.ui;
 import com.badlogic.gdx.graphics.g2d.NinePatch;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.math.Interpolation;
+import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.InputEvent;
 import com.badlogic.gdx.scenes.scene2d.InputListener;
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener.ChangeEvent;
@@ -36,6 +37,7 @@ import com.badlogic.gdx.utils.Pools;
  * @author Nathan Sweet */
 public class Slider extends ProgressBar {
 	int draggingPointer = -1;
+	boolean mouseOver;
 	private Interpolation visualInterpolationInverse = Interpolation.linear;
 
 	public Slider (float min, float max, float stepSize, boolean vertical, Skin skin) {
@@ -82,6 +84,16 @@ public class Slider extends ProgressBar {
 			public void touchDragged (InputEvent event, float x, float y, int pointer) {
 				calculatePositionAndValue(x, y);
 			}
+
+			@Override
+			public void enter (InputEvent event, float x, float y, int pointer, Actor fromActor) {
+				if (pointer == -1) mouseOver = true;
+			}
+
+			@Override
+			public void exit (InputEvent event, float x, float y, int pointer, Actor toActor) {
+				if (pointer == -1) mouseOver = false;
+			}
 		});
 	}
 
@@ -97,9 +109,16 @@ public class Slider extends ProgressBar {
 		return (SliderStyle)super.getStyle();
 	}
 
+	protected Drawable getKnobDrawable () {
+		SliderStyle style = getStyle();
+		return (disabled && style.disabledKnob != null) ? style.disabledKnob
+			: (isDragging() && style.knobDown != null) ? style.knobDown : ((mouseOver && style.knobOver != null) ? style.knobOver
+				: style.knob);
+	}
+
 	boolean calculatePositionAndValue (float x, float y) {
 		final SliderStyle style = getStyle();
-		final Drawable knob = (disabled && style.disabledKnob != null) ? style.disabledKnob : style.knob;
+		final Drawable knob = getKnobDrawable();
 		final Drawable bg = (disabled && style.disabledBackground != null) ? style.disabledBackground : style.background;
 
 		float value;
@@ -145,6 +164,9 @@ public class Slider extends ProgressBar {
 	 * @author mzechner
 	 * @author Nathan Sweet */
 	static public class SliderStyle extends ProgressBarStyle {
+		/** Optional. */
+		public Drawable knobOver, knobDown;
+
 		public SliderStyle () {
 		}
 
@@ -154,6 +176,8 @@ public class Slider extends ProgressBar {
 
 		public SliderStyle (SliderStyle style) {
 			super(style);
+			this.knobOver = style.knobOver;
+			this.knobDown = style.knobDown;
 		}
 	}
 }


### PR DESCRIPTION
This PR adds ability to set knowDown and knobOver drawable for Slider. Those are both optional so it does not affect existing sliders. 

I added protected method `getKnobDrawable` in ProgressBar and Slider overrides it, I'm not sure if there is some better way to do it.

Also fixed small Javadoc mistake.