### PR TITLE
Fix paste method in TextField. Fixes #3337.

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextField.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextField.java
@@ -430,6 +430,8 @@ public class TextField extends Widget implements Disableable {
 		if (content == null) return;
 		StringBuilder buffer = new StringBuilder();
 		int textLength = text.length();
+		if (hasSelection)
+			textLength -= Math.abs(cursor - selectionStart);
 		BitmapFontData data = style.font.getData();
 		for (int i = 0, n = content.length(); i < n; i++) {
 			if (!withinMaxLength(textLength + buffer.length())) break;


### PR DESCRIPTION
The paste method now takes into account that the selected text is deleted before the pasted text is inserted.