### PR TITLE
Implement parsing methods for vectors and rectangles

### DIFF
--- a/gdx/src/com/badlogic/gdx/math/Rectangle.java
+++ b/gdx/src/com/badlogic/gdx/math/Rectangle.java
@@ -365,10 +365,10 @@ public class Rectangle implements Serializable, Shape2D {
 		return "[" + x + "," + y + "," + width + "," + height + "]";
 	}
 
-	/** Parses the {@code Rectangle} represented by the given string according to the format of {@link #toString()}.
+	/** Sets this {@code Rectangle} to the value represented by the specified string according to the format of {@link #toString()}.
 	 * @param v the string.
-	 * @return the {@code Rectangle} represented by the given string. */
-	public static Rectangle fromString (String v) {
+	 * @return this rectangle for chaining */
+	public Rectangle fromString (String v) {
 		int s0 = v.indexOf(',', 1);
 		int s1 = v.indexOf(',', s0 + 1);
 		int s2 = v.indexOf(',', s1 + 1);
@@ -378,7 +378,7 @@ public class Rectangle implements Serializable, Shape2D {
 				float y = Float.parseFloat(v.substring(s0 + 1, s1));
 				float width = Float.parseFloat(v.substring(s1 + 1, s2));
 				float height = Float.parseFloat(v.substring(s2 + 1, v.length() - 1));
-				return new Rectangle(x, y, width, height);
+				return this.set(x, y, width, height);
 			} catch (NumberFormatException ex) {
 				// Throw a GdxRuntimeException
 			}

--- a/gdx/src/com/badlogic/gdx/math/Rectangle.java
+++ b/gdx/src/com/badlogic/gdx/math/Rectangle.java
@@ -14,6 +14,8 @@
 package com.badlogic.gdx.math;
 
 import java.io.Serializable;
+
+import com.badlogic.gdx.utils.GdxRuntimeException;
 import com.badlogic.gdx.utils.NumberUtils;
 
 /** Encapsulates a 2D rectangle defined by its corner point in the bottom left and its extents in x (width) and y (height).
@@ -358,7 +360,28 @@ public class Rectangle implements Serializable, Shape2D {
 	}
 
 	public String toString () {
-		return x + "," + y + "," + width + "," + height;
+		return "[" + x + "," + y + "," + width + "," + height + "]";
+	}
+
+	/** Sets this {@code Rectangle} to the value represented by the specified string according to the format of {@link #toString()}.
+	 * @param v the string.
+	 * @return this rectangle for chaining */
+	public Rectangle fromString (String v) {
+		int s0 = v.indexOf(',', 1);
+		int s1 = v.indexOf(',', s0 + 1);
+		int s2 = v.indexOf(',', s1 + 1);
+		if (s0 != -1 && s1 != -1 && s2 != -1 && v.charAt(0) == '[' && v.charAt(v.length() - 1) == ']') {
+			try {
+				float x = Float.parseFloat(v.substring(1, s0));
+				float y = Float.parseFloat(v.substring(s0 + 1, s1));
+				float width = Float.parseFloat(v.substring(s1 + 1, s2));
+				float height = Float.parseFloat(v.substring(s2 + 1, v.length() - 1));
+				return this.set(x, y, width, height);
+			} catch (NumberFormatException ex) {
+				// Throw a GdxRuntimeException
+			}
+		}
+		throw new GdxRuntimeException("Malformed Rectangle: " + v);
 	}
 
 	public float area () {

--- a/gdx/src/com/badlogic/gdx/math/Rectangle.java
+++ b/gdx/src/com/badlogic/gdx/math/Rectangle.java
@@ -365,10 +365,10 @@ public class Rectangle implements Serializable, Shape2D {
 		return "[" + x + "," + y + "," + width + "," + height + "]";
 	}
 
-	/** Sets this {@code Rectangle} to the value represented by the specified string according to the format of {@link #toString()}.
+	/** Parses the {@code Rectangle} represented by the given string according to the format of {@link #toString()}.
 	 * @param v the string.
-	 * @return this rectangle for chaining */
-	public Rectangle fromString (String v) {
+	 * @return the {@code Rectangle} represented by the given string. */
+	public static Rectangle fromString (String v) {
 		int s0 = v.indexOf(',', 1);
 		int s1 = v.indexOf(',', s0 + 1);
 		int s2 = v.indexOf(',', s1 + 1);
@@ -378,7 +378,7 @@ public class Rectangle implements Serializable, Shape2D {
 				float y = Float.parseFloat(v.substring(s0 + 1, s1));
 				float width = Float.parseFloat(v.substring(s1 + 1, s2));
 				float height = Float.parseFloat(v.substring(s2 + 1, v.length() - 1));
-				return this.set(x, y, width, height);
+				return new Rectangle(x, y, width, height);
 			} catch (NumberFormatException ex) {
 				// Throw a GdxRuntimeException
 			}

--- a/gdx/src/com/badlogic/gdx/math/Rectangle.java
+++ b/gdx/src/com/badlogic/gdx/math/Rectangle.java
@@ -359,6 +359,8 @@ public class Rectangle implements Serializable, Shape2D {
 		return this;
 	}
 
+	/** Converts this {@code Rectangle} to a string in the format {@code [x,y,width,height]}.
+	 * @return a string representation of this object. */
 	public String toString () {
 		return "[" + x + "," + y + "," + width + "," + height + "]";
 	}

--- a/gdx/src/com/badlogic/gdx/math/Vector2.java
+++ b/gdx/src/com/badlogic/gdx/math/Vector2.java
@@ -18,6 +18,7 @@ package com.badlogic.gdx.math;
 
 import java.io.Serializable;
 
+import com.badlogic.gdx.utils.GdxRuntimeException;
 import com.badlogic.gdx.utils.NumberUtils;
 
 /** Encapsulates a 2D vector. Allows chaining methods by returning a reference to itself
@@ -272,7 +273,24 @@ public class Vector2 implements Serializable, Vector<Vector2> {
 
 	@Override
 	public String toString () {
-		return "[" + x + ":" + y + "]";
+		return "(" + x + "," + y + ")";
+	}
+
+	/** Sets this {@code Vector2} to the value represented by the specified string according to the format of {@link #toString()}.
+	 * @param v the string.
+	 * @return this vector for chaining */
+	public Vector2 fromString (String v) {
+		int s = v.indexOf(',', 1);
+		if (s != -1 && v.charAt(0) == '(' && v.charAt(v.length() - 1) == ')') {
+			try {
+				float x = Float.parseFloat(v.substring(1, s));
+				float y = Float.parseFloat(v.substring(s + 1, v.length() - 1));
+				return this.set(x, y);
+			} catch (NumberFormatException ex) {
+				// Throw a GdxRuntimeException
+			}
+		}
+		throw new GdxRuntimeException("Malformed Vector2: " + v);
 	}
 
 	/** Left-multiplies this vector by the given matrix

--- a/gdx/src/com/badlogic/gdx/math/Vector2.java
+++ b/gdx/src/com/badlogic/gdx/math/Vector2.java
@@ -278,16 +278,16 @@ public class Vector2 implements Serializable, Vector<Vector2> {
 		return "(" + x + "," + y + ")";
 	}
 
-	/** Sets this {@code Vector2} to the value represented by the specified string according to the format of {@link #toString()}.
+	/** Parses the {@code Vector2} represented by the given string according to the format of {@link #toString()}.
 	 * @param v the string.
-	 * @return this vector for chaining */
-	public Vector2 fromString (String v) {
+	 * @return the {@code Vector2} represented by the given string. */
+	public static Vector2 fromString (String v) {
 		int s = v.indexOf(',', 1);
 		if (s != -1 && v.charAt(0) == '(' && v.charAt(v.length() - 1) == ')') {
 			try {
 				float x = Float.parseFloat(v.substring(1, s));
 				float y = Float.parseFloat(v.substring(s + 1, v.length() - 1));
-				return this.set(x, y);
+				return new Vector2(x, y);
 			} catch (NumberFormatException ex) {
 				// Throw a GdxRuntimeException
 			}

--- a/gdx/src/com/badlogic/gdx/math/Vector2.java
+++ b/gdx/src/com/badlogic/gdx/math/Vector2.java
@@ -271,6 +271,8 @@ public class Vector2 implements Serializable, Vector<Vector2> {
 				: scl((float) Math.sqrt( len2 / oldLen2 ));
 	}
 
+	/** Converts this {@code Vector2} to a string in the format {@code (x,y)}.
+	 * @return a string representation of this object. */
 	@Override
 	public String toString () {
 		return "(" + x + "," + y + ")";

--- a/gdx/src/com/badlogic/gdx/math/Vector2.java
+++ b/gdx/src/com/badlogic/gdx/math/Vector2.java
@@ -278,16 +278,16 @@ public class Vector2 implements Serializable, Vector<Vector2> {
 		return "(" + x + "," + y + ")";
 	}
 
-	/** Parses the {@code Vector2} represented by the given string according to the format of {@link #toString()}.
+	/** Sets this {@code Vector2} to the value represented by the specified string according to the format of {@link #toString()}.
 	 * @param v the string.
-	 * @return the {@code Vector2} represented by the given string. */
-	public static Vector2 fromString (String v) {
+	 * @return this vector for chaining */
+	public Vector2 fromString (String v) {
 		int s = v.indexOf(',', 1);
 		if (s != -1 && v.charAt(0) == '(' && v.charAt(v.length() - 1) == ')') {
 			try {
 				float x = Float.parseFloat(v.substring(1, s));
 				float y = Float.parseFloat(v.substring(s + 1, v.length() - 1));
-				return new Vector2(x, y);
+				return this.set(x, y);
 			} catch (NumberFormatException ex) {
 				// Throw a GdxRuntimeException
 			}

--- a/gdx/src/com/badlogic/gdx/math/Vector3.java
+++ b/gdx/src/com/badlogic/gdx/math/Vector3.java
@@ -571,10 +571,10 @@ public class Vector3 implements Serializable, Vector<Vector3> {
 		return "(" + x + "," + y + "," + z + ")";
 	}
 
-	/** Sets this {@code Vector3} to the value represented by the specified string according to the format of {@link #toString()}.
+	/** Parses the {@code Vector3} represented by the given string according to the format of {@link #toString()}.
 	 * @param v the string.
-	 * @return this vector for chaining */
-	public Vector3 fromString (String v) {
+	 * @return the {@code Vector3} represented by the given string. */
+	public static Vector3 fromString (String v) {
 		int s0 = v.indexOf(',', 1);
 		int s1 = v.indexOf(',', s0 + 1);
 		if (s0 != -1 && s1 != -1 && v.charAt(0) == '(' && v.charAt(v.length() - 1) == ')') {
@@ -582,7 +582,7 @@ public class Vector3 implements Serializable, Vector<Vector3> {
 				float x = Float.parseFloat(v.substring(1, s0));
 				float y = Float.parseFloat(v.substring(s0 + 1, s1));
 				float z = Float.parseFloat(v.substring(s1 + 1, v.length() - 1));
-				return this.set(x, y, z);
+				return new Vector3(x, y, z);
 			} catch (NumberFormatException ex) {
 				// Throw a GdxRuntimeException
 			}

--- a/gdx/src/com/badlogic/gdx/math/Vector3.java
+++ b/gdx/src/com/badlogic/gdx/math/Vector3.java
@@ -18,6 +18,7 @@ package com.badlogic.gdx.math;
 
 import java.io.Serializable;
 
+import com.badlogic.gdx.utils.GdxRuntimeException;
 import com.badlogic.gdx.utils.NumberUtils;
 
 /** Encapsulates a 3D vector. Allows chaining operations by returning a reference to itself in all modification methods.
@@ -563,11 +564,29 @@ public class Vector3 implements Serializable, Vector<Vector3> {
 		return scl((float)Math.cos(theta)).add(tx * dl, ty * dl, tz * dl).nor();
 	}
 
-    @Override
+	@Override
 	public String toString () {
-		return "[" + x + ", " + y + ", " + z + "]";
+		return "(" + x + "," + y + "," + z + ")";
 	}
 
+	/** Sets this {@code Vector3} to the value represented by the specified string according to the format of {@link #toString()}.
+	 * @param v the string.
+	 * @return this vector for chaining */
+	public Vector3 fromString (String v) {
+		int s0 = v.indexOf(',', 1);
+		int s1 = v.indexOf(',', s0 + 1);
+		if (s0 != -1 && s1 != -1 && v.charAt(0) == '(' && v.charAt(v.length() - 1) == ')') {
+			try {
+				float x = Float.parseFloat(v.substring(1, s0));
+				float y = Float.parseFloat(v.substring(s0 + 1, s1));
+				float z = Float.parseFloat(v.substring(s1 + 1, v.length() - 1));
+				return this.set(x, y, z);
+			} catch (NumberFormatException ex) {
+				// Throw a GdxRuntimeException
+			}
+		}
+		throw new GdxRuntimeException("Malformed Vector3: " + v);
+	}
 
 	@Override
 	public Vector3 limit (float limit) {

--- a/gdx/src/com/badlogic/gdx/math/Vector3.java
+++ b/gdx/src/com/badlogic/gdx/math/Vector3.java
@@ -564,6 +564,8 @@ public class Vector3 implements Serializable, Vector<Vector3> {
 		return scl((float)Math.cos(theta)).add(tx * dl, ty * dl, tz * dl).nor();
 	}
 
+	/** Converts this {@code Vector3} to a string in the format {@code (x,y,z)}.
+	 * @return a string representation of this object. */
 	@Override
 	public String toString () {
 		return "(" + x + "," + y + "," + z + ")";

--- a/gdx/src/com/badlogic/gdx/math/Vector3.java
+++ b/gdx/src/com/badlogic/gdx/math/Vector3.java
@@ -571,10 +571,10 @@ public class Vector3 implements Serializable, Vector<Vector3> {
 		return "(" + x + "," + y + "," + z + ")";
 	}
 
-	/** Parses the {@code Vector3} represented by the given string according to the format of {@link #toString()}.
+	/** Sets this {@code Vector3} to the value represented by the specified string according to the format of {@link #toString()}.
 	 * @param v the string.
-	 * @return the {@code Vector3} represented by the given string. */
-	public static Vector3 fromString (String v) {
+	 * @return this vector for chaining */
+	public Vector3 fromString (String v) {
 		int s0 = v.indexOf(',', 1);
 		int s1 = v.indexOf(',', s0 + 1);
 		if (s0 != -1 && s1 != -1 && v.charAt(0) == '(' && v.charAt(v.length() - 1) == ')') {
@@ -582,7 +582,7 @@ public class Vector3 implements Serializable, Vector<Vector3> {
 				float x = Float.parseFloat(v.substring(1, s0));
 				float y = Float.parseFloat(v.substring(s0 + 1, s1));
 				float z = Float.parseFloat(v.substring(s1 + 1, v.length() - 1));
-				return new Vector3(x, y, z);
+				return this.set(x, y, z);
 			} catch (NumberFormatException ex) {
 				// Throw a GdxRuntimeException
 			}

--- a/gdx/test/com/badlogic/gdx/math/RectangleTest.java
+++ b/gdx/test/com/badlogic/gdx/math/RectangleTest.java
@@ -1,0 +1,18 @@
+
+package com.badlogic.gdx.math;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class RectangleTest {
+	@Test
+	public void testToString () {
+		assertEquals("[5.0,-4.1,0.03,-0.02]", new Rectangle(5f, -4.1f, 0.03f, -0.02f).toString());
+	}
+
+	@Test
+	public void testFromString () {
+		assertEquals(new Rectangle(5f, -4.1f, 0.03f, -0.02f), new Rectangle().fromString("[5.0,-4.1,0.03,-0.02]"));
+	}
+}

--- a/gdx/test/com/badlogic/gdx/math/RectangleTest.java
+++ b/gdx/test/com/badlogic/gdx/math/RectangleTest.java
@@ -13,6 +13,6 @@ public class RectangleTest {
 
 	@Test
 	public void testFromString () {
-		assertEquals(new Rectangle(5f, -4.1f, 0.03f, -0.02f), new Rectangle().fromString("[5.0,-4.1,0.03,-0.02]"));
+		assertEquals(new Rectangle(5f, -4.1f, 0.03f, -0.02f), Rectangle.fromString("[5.0,-4.1,0.03,-0.02]"));
 	}
 }

--- a/gdx/test/com/badlogic/gdx/math/RectangleTest.java
+++ b/gdx/test/com/badlogic/gdx/math/RectangleTest.java
@@ -13,6 +13,6 @@ public class RectangleTest {
 
 	@Test
 	public void testFromString () {
-		assertEquals(new Rectangle(5f, -4.1f, 0.03f, -0.02f), Rectangle.fromString("[5.0,-4.1,0.03,-0.02]"));
+		assertEquals(new Rectangle(5f, -4.1f, 0.03f, -0.02f), new Rectangle().fromString("[5.0,-4.1,0.03,-0.02]"));
 	}
 }

--- a/gdx/test/com/badlogic/gdx/math/Vector2Test.java
+++ b/gdx/test/com/badlogic/gdx/math/Vector2Test.java
@@ -1,0 +1,18 @@
+
+package com.badlogic.gdx.math;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class Vector2Test {
+	@Test
+	public void testToString () {
+		assertEquals("(-5.0,42.00055)", new Vector2(-5f, 42.00055f).toString());
+	}
+
+	@Test
+	public void testFromString () {
+		assertEquals(new Vector2(-5f, 42.00055f), new Vector2().fromString("(-5,42.00055)"));
+	}
+}

--- a/gdx/test/com/badlogic/gdx/math/Vector2Test.java
+++ b/gdx/test/com/badlogic/gdx/math/Vector2Test.java
@@ -13,6 +13,6 @@ public class Vector2Test {
 
 	@Test
 	public void testFromString () {
-		assertEquals(new Vector2(-5f, 42.00055f), Vector2.fromString("(-5,42.00055)"));
+		assertEquals(new Vector2(-5f, 42.00055f), new Vector2().fromString("(-5,42.00055)"));
 	}
 }

--- a/gdx/test/com/badlogic/gdx/math/Vector2Test.java
+++ b/gdx/test/com/badlogic/gdx/math/Vector2Test.java
@@ -13,6 +13,6 @@ public class Vector2Test {
 
 	@Test
 	public void testFromString () {
-		assertEquals(new Vector2(-5f, 42.00055f), new Vector2().fromString("(-5,42.00055)"));
+		assertEquals(new Vector2(-5f, 42.00055f), Vector2.fromString("(-5,42.00055)"));
 	}
 }

--- a/gdx/test/com/badlogic/gdx/math/Vector3Test.java
+++ b/gdx/test/com/badlogic/gdx/math/Vector3Test.java
@@ -1,0 +1,18 @@
+
+package com.badlogic.gdx.math;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class Vector3Test {
+	@Test
+	public void testToString () {
+		assertEquals("(-5.0,42.00055,44444.32)", new Vector3(-5f, 42.00055f, 44444.32f).toString());
+	}
+
+	@Test
+	public void testFromString () {
+		assertEquals(new Vector3(-5f, 42.00055f, 44444.32f), new Vector3().fromString("(-5,42.00055,44444.32)"));
+	}
+}

--- a/gdx/test/com/badlogic/gdx/math/Vector3Test.java
+++ b/gdx/test/com/badlogic/gdx/math/Vector3Test.java
@@ -13,6 +13,6 @@ public class Vector3Test {
 
 	@Test
 	public void testFromString () {
-		assertEquals(new Vector3(-5f, 42.00055f, 44444.32f), Vector3.fromString("(-5,42.00055,44444.32)"));
+		assertEquals(new Vector3(-5f, 42.00055f, 44444.32f), new Vector3().fromString("(-5,42.00055,44444.32)"));
 	}
 }

--- a/gdx/test/com/badlogic/gdx/math/Vector3Test.java
+++ b/gdx/test/com/badlogic/gdx/math/Vector3Test.java
@@ -13,6 +13,6 @@ public class Vector3Test {
 
 	@Test
 	public void testFromString () {
-		assertEquals(new Vector3(-5f, 42.00055f, 44444.32f), new Vector3().fromString("(-5,42.00055,44444.32)"));
+		assertEquals(new Vector3(-5f, 42.00055f, 44444.32f), Vector3.fromString("(-5,42.00055,44444.32)"));
 	}
 }


### PR DESCRIPTION
Implementation of parseXXX methods for `Vector2`, `Vector3` and `Rectangle`, as well as enhancements of `toString()` format. The format of `Vector2` is changed from `[x:y]` to `(x,y)`, `Vector3` is changed from `[x, y, z]` to `(x,y,z)`, and the format of `Rectangle` is changed from `x,y,w,h` to `[x,y,w,h]`. This was done for consistency and simplified parsing, and shouldn't break too much stuff.