### PR TITLE
Added VisRuntime extension

### DIFF
--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/data/extensions.xml
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/data/extensions.xml
@@ -40,6 +40,28 @@
 			</html>
 		</projects>
 	</extension>
+		<extension>
+		<name>VisRuntime</name>
+		<description>Runtime for VisEditor</description>
+		<package>com.kotcrab.vis.runtime</package>
+		<version>0.2.1</version>
+		<compatibility>1.6.4</compatibility>
+		<website>http://vis.kotcrab.com</website>
+		<gwtInherits>
+		    <inherit>com.kotcrab.vis.vis-runtime</inherit>
+		</gwtInherits>
+		<projects>
+			<core>
+				<dependency>com.kotcrab.vis:vis-runtime</dependency>
+			</core>
+			<desktop></desktop>
+			<android></android>
+			<ios></ios>
+			<html>
+				<dependency>com.kotcrab.vis:vis-runtime:sources</dependency>
+			</html>
+		</projects>
+	</extension>
 	<extension>
 		<name>libgdx-utils</name>
 		<description>additional features and helper classes</description>


### PR DESCRIPTION
Added VisRuntime library to 3rd party extensions. This library is required to load projects exported from [VisEditor](https://github.com/kotcrab/VisEditor).