### PR TITLE
World::destroyBody returns fixtures to pool

### DIFF
--- a/extensions/gdx-box2d/gdx-box2d/src/com/badlogic/gdx/physics/box2d/World.java
+++ b/extensions/gdx-box2d/gdx-box2d/src/com/badlogic/gdx/physics/box2d/World.java
@@ -325,8 +325,11 @@ b2ContactFilter defaultFilter;
 		this.bodies.remove(body.addr);
 		Array<Fixture> fixtureList = body.getFixtureList();
 		while(fixtureList.size > 0) {
-			this.fixtures.remove(fixtureList.removeIndex(0).addr).setUserData(null);
-		}
+			Fixture fixtureToDelete = fixtureList.removeIndex(0);
+ 			this.fixtures.remove(fixtureToDelete.addr).setUserData(null);
+ 			freeFixtures.free(fixtureToDelete);
+ 		}
+		
 		freeBodies.free(body);
 	}
 


### PR DESCRIPTION
Without this the freeFixtures pool is never actually used and new fixtures are always allocated.
When you have many bullets/projectiles/particles getting created/destroyed this causes a lot of GC churn.

Fixes #3364

NOTE: I am placing my code modification in this PR into the Public Domain.  It is small and I don't want to sign the CLA.
