### PR TITLE
Color.valueof(String s)

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/Color.java
+++ b/gdx/src/com/badlogic/gdx/graphics/Color.java
@@ -331,6 +331,7 @@ public class Color {
 	/** Returns a new color from a hex string with the format RRGGBBAA.
 	 * @see #toString() */
 	public static Color valueOf (String hex) {
+		hex = hex.charAt(0).equals('#') ? hex.substring(1) : hex;
 		int r = Integer.valueOf(hex.substring(0, 2), 16);
 		int g = Integer.valueOf(hex.substring(2, 4), 16);
 		int b = Integer.valueOf(hex.substring(4, 6), 16);


### PR DESCRIPTION
I was using libgdx's Color class, specifically to create a color from a hex string. In Java's standard Color class, you are able to enter hex strings that start with a `#`.

I think myself and many others may have been briefly confused because `Color.valueOf(String s)` does not accept strings that start with a `#`.

I believe the following code will fix this. Thanks for the great library! :-)