### PR TITLE
Add preferences directory in headless config

### DIFF
--- a/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/HeadlessApplication.java
+++ b/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/HeadlessApplication.java
@@ -50,6 +50,7 @@ public class HeadlessApplication implements Application {
 	protected final Array<Runnable> executedRunnables = new Array<Runnable>();
 	protected final Array<LifecycleListener> lifecycleListeners = new Array<LifecycleListener>();
 	protected int logLevel = LOG_INFO;
+	private String preferencesdir;
 	private final long renderInterval;
 
 	public HeadlessApplication(ApplicationListener listener) {
@@ -69,6 +70,8 @@ public class HeadlessApplication implements Application {
 		this.graphics = new MockGraphics();
 		this.audio = new MockAudio();
 		this.input = new MockInput();
+
+		this.preferencesdir = config.preferencesDirectory;
 
 		Gdx.app = this;
 		Gdx.files = files;
@@ -209,7 +212,7 @@ public class HeadlessApplication implements Application {
 		if (preferences.containsKey(name)) {
 			return preferences.get(name);
 		} else {
-			Preferences prefs = new HeadlessPreferences(name, ".prefs/");
+			Preferences prefs = new HeadlessPreferences(name, this.preferencesdir);
 			preferences.put(name, prefs);
 			return prefs;
 		}

--- a/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/HeadlessApplicationConfiguration.java
+++ b/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/HeadlessApplicationConfiguration.java
@@ -19,4 +19,6 @@ package com.badlogic.gdx.backends.headless;
 public class HeadlessApplicationConfiguration {
 	/** The minimum time (in seconds) between each call to the render method or negative to not call the render method at all. */
 	public float renderInterval = 1f / 60f;
+	/** Preferences directory for headless. Default is ".prefs/". */
+	public String preferencesDirectory = ".prefs/";
 }

--- a/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/HeadlessFiles.java
+++ b/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/HeadlessFiles.java
@@ -24,7 +24,7 @@ import com.badlogic.gdx.files.FileHandle;
 /** @author mzechner
  * @author Nathan Sweet */
 public final class HeadlessFiles implements Files {
-	static public final String externalPath = System.getProperty("user.home") + "/";
+	static public final String externalPath = System.getProperty("user.home") + File.separator;
 	static public final String localPath = new File("").getAbsolutePath() + File.separator;
 
 	@Override


### PR DESCRIPTION
Hi guys,

I don't know why the config for headless only have one option `renderInterval`, but I need change the `preferencesDirectory` when use headless backend.

I follow the same logic as other backend, it should works.

And a very small fix for HeadlessFiles, it hard code file separator as '/'.