### PR TITLE
Add Gwt support for custom Cursors

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtCursor.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtCursor.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogic.gdx.backends.gwt;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.Cursor;
+import com.badlogic.gdx.graphics.Pixmap;
+import com.badlogic.gdx.utils.GdxRuntimeException;
+import com.google.gwt.dom.client.CanvasElement;
+
+public class GwtCursor implements Cursor {
+	private String cssCursorProperty;
+
+	public GwtCursor (Pixmap pixmap, int xHotspot, int yHotspot) {
+		if (pixmap == null) {
+			this.cssCursorProperty = "auto";
+			return;
+		}
+
+		if (pixmap.getFormat() != Pixmap.Format.RGBA8888) {
+			throw new GdxRuntimeException("Cursor image pixmap is not in RGBA8888 format.");
+		}
+
+		if ((pixmap.getWidth() & (pixmap.getWidth() - 1)) != 0) {
+			throw new GdxRuntimeException("Cursor image pixmap width of " + pixmap.getWidth()
+				+ " is not a power-of-two greater than zero.");
+		}
+
+		if ((pixmap.getHeight() & (pixmap.getHeight() - 1)) != 0) {
+			throw new GdxRuntimeException("Cursor image pixmap height of " + pixmap.getHeight()
+				+ " is not a power-of-two greater than zero.");
+		}
+
+		if (xHotspot < 0 || xHotspot >= pixmap.getWidth()) {
+			throw new GdxRuntimeException("xHotspot coordinate of " + xHotspot + " is not within image width bounds: [0, "
+				+ pixmap.getWidth() + ").");
+		}
+
+		if (yHotspot < 0 || yHotspot >= pixmap.getHeight()) {
+			throw new GdxRuntimeException("yHotspot coordinate of " + yHotspot + " is not within image height bounds: [0, "
+				+ pixmap.getHeight() + ").");
+		}
+		cssCursorProperty = "url('";
+		cssCursorProperty += pixmap.getCanvasElement().toDataUrl("image/png");
+		cssCursorProperty += "')";
+		cssCursorProperty += xHotspot;
+		cssCursorProperty += " ";
+		cssCursorProperty += yHotspot;
+		cssCursorProperty += ",auto";
+	}
+
+	@Override
+	public void setSystemCursor () {
+		((GwtApplication)Gdx.app).graphics.canvas.getStyle().setProperty("cursor", cssCursorProperty);
+	}
+
+	public static void resetCursor () {
+		((GwtApplication)Gdx.app).graphics.canvas.getStyle().setProperty("cursor", "auto");
+	}
+}

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtGraphics.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtGraphics.java
@@ -281,10 +281,15 @@ public class GwtGraphics implements Graphics {
 	
 	@Override
 	public Cursor newCursor (Pixmap pixmap, int xHotspot, int yHotspot) {
-		return null;
+		return new GwtCursor(pixmap, xHotspot, yHotspot);
 	}
 
 	@Override
 	public void setCursor (Cursor cursor) {
+		if (cursor == null) {
+			GwtCursor.resetCursor();
+		} else {
+			cursor.setSystemCursor();
+		}
 	}
 }

--- a/gdx/src/com/badlogic/gdx/Graphics.java
+++ b/gdx/src/com/badlogic/gdx/Graphics.java
@@ -235,9 +235,10 @@ public interface Graphics {
 	 * @return a cursor object that can be used by calling {@link #setCursor(Cursor)} or null if not supported */
 	public Cursor newCursor (Pixmap pixmap, int xHotspot, int yHotspot);
 
-	/** Only viable on the desktop. Will set the mouse cursor image to the image represented by the
-	 * {@link com.badlogic.gdx.graphics.Cursor}. To revert to the default operating system cursor, pass in a null cursor. It is
-	 * recommended to call this function in the main render thread, and maximum one time per frame.
+	/** Only viable on the lwjgl-backend and on the gwt-backend. Browsers that support cursor:url() and support the png format (the
+	 * pixmap is converted to a data-url of type image/png) should also support custom cursors. Will set the mouse cursor image to
+	 * the image represented by the {@link com.badlogic.gdx.graphics.Cursor}. To revert to the default operating system cursor,
+	 * pass in a null cursor. It is recommended to call this function in the main render thread, and maximum one time per frame.
 	 * 
 	 * @param cursor the mouse cursor as a {@link com.badlogic.gdx.graphics.Cursor}, or null to revert to the default operating
 	 *           system cursor */


### PR DESCRIPTION
Added Gwt support for custom Cursors.

Cursors should not work in IE according to
http://reference.sitepoint.com/css/cursor because we convert the canvas
to a data-url of the png format and IE only supports .cur and .ani
files.
IE would also not support setting hotspot coordinates, it only supports
hotspot coords in .cur files.
Not all opera version seem to support cursors using the "cursor:url()"
syntax

Any suggestions?