### PR TITLE
Add APK expansion support

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/APKExpansionSupport.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/APKExpansionSupport.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2012 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.badlogic.gdx.backends.android;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Vector;
+
+import android.content.Context;
+import android.os.Environment;
+
+public class APKExpansionSupport {
+	// The shared path to all app expansion files
+	private final static String EXP_PATH = "/Android/obb/";
+
+	static String[] getAPKExpansionFiles(Context ctx, int mainVersion,
+			int patchVersion) {
+		String packageName = ctx.getPackageName();
+		Vector<String> ret = new Vector<String>();
+		if (Environment.getExternalStorageState().equals(
+				Environment.MEDIA_MOUNTED)) {
+			// Build the full path to the app's expansion files
+			File root = Environment.getExternalStorageDirectory();
+			File expPath = new File(root.toString() + EXP_PATH + packageName);
+
+			// Check that expansion file path exists
+			if (expPath.exists()) {
+				if (mainVersion > 0) {
+					String strMainPath = expPath + File.separator + "main."
+							+ mainVersion + "." + packageName + ".obb";
+					File main = new File(strMainPath);
+					if (main.isFile()) {
+						ret.add(strMainPath);
+					}
+				}
+				if (patchVersion > 0) {
+					String strPatchPath = expPath + File.separator + "patch."
+							+ mainVersion + "." + packageName + ".obb";
+					File main = new File(strPatchPath);
+					if (main.isFile()) {
+						ret.add(strPatchPath);
+					}
+				}
+			}
+		}
+		String[] retArray = new String[ret.size()];
+		ret.toArray(retArray);
+		return retArray;
+	}
+
+	static public ZipResourceFile getResourceZipFile(String[] expansionFiles)
+			throws IOException {
+		ZipResourceFile apkExpansionFile = null;
+		for (String expansionFilePath : expansionFiles) {
+			if (null == apkExpansionFile) {
+				apkExpansionFile = new ZipResourceFile(expansionFilePath);
+			} else {
+				apkExpansionFile.addPatchFile(expansionFilePath);
+			}
+		}
+		return apkExpansionFile;
+	}
+
+	static public ZipResourceFile getAPKExpansionZipFile(Context ctx,
+			int mainVersion, int patchVersion) throws IOException {
+		String[] expansionFiles = getAPKExpansionFiles(ctx, mainVersion,
+				patchVersion);
+		return getResourceZipFile(expansionFiles);
+	}
+}

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidAudio.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidAudio.java
@@ -106,7 +106,7 @@ public final class AndroidAudio implements Audio {
 
 		if (aHandle.type() == FileType.Internal) {
 			try {
-				AssetFileDescriptor descriptor = aHandle.assets.openFd(aHandle.path());
+				AssetFileDescriptor descriptor = aHandle.getAssetFileDescriptor(aHandle.path());
 				mediaPlayer.setDataSource(descriptor.getFileDescriptor(), descriptor.getStartOffset(), descriptor.getLength());
 				descriptor.close();
 				mediaPlayer.prepare();
@@ -144,7 +144,7 @@ public final class AndroidAudio implements Audio {
 		AndroidFileHandle aHandle = (AndroidFileHandle)file;
 		if (aHandle.type() == FileType.Internal) {
 			try {
-				AssetFileDescriptor descriptor = aHandle.assets.openFd(aHandle.path());
+				AssetFileDescriptor descriptor = aHandle.getAssetFileDescriptor(aHandle.path());
 				AndroidSound sound = new AndroidSound(soundPool, manager, soundPool.load(descriptor, 1));
 				descriptor.close();
 				return sound;

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidFileHandle.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidFileHandle.java
@@ -34,7 +34,7 @@ import com.badlogic.gdx.utils.GdxRuntimeException;
  * @author Nathan Sweet */
 public class AndroidFileHandle extends FileHandle {
 	// The asset manager, or null if this is not an internal file.
-	final AssetManager assets;
+	final private AssetManager assets;
 
 	AndroidFileHandle (AssetManager assets, String fileName, FileType type) {
 		super(fileName.replace('\\', '/'), type);
@@ -229,4 +229,7 @@ public class AndroidFileHandle extends FileHandle {
 		return super.file();
 	}
 
+	public AssetFileDescriptor getAssetFileDescriptor(String path) throws IOException {
+		return assets.openFd(path);
+	}
 }

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidZipFileHandle.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidZipFileHandle.java
@@ -1,0 +1,184 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogic.gdx.backends.android;
+
+import java.io.*;
+
+import android.content.res.AssetFileDescriptor;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Files.FileType;
+import com.badlogic.gdx.backends.android.ZipResourceFile.ZipEntryRO;
+import com.badlogic.gdx.files.FileHandle;
+import com.badlogic.gdx.utils.GdxRuntimeException;
+
+/** @author sarkanyi */
+public class AndroidZipFileHandle extends AndroidFileHandle {
+	private AssetFileDescriptor assetFd;
+	private ZipResourceFile expansionFile;
+	private String path;
+
+	public AndroidZipFileHandle(String fileName) {
+		super(null, fileName, FileType.Internal);
+		initialize();
+	}
+
+	public AndroidZipFileHandle(File file, FileType type) {
+		super(null, file, type);
+		initialize();
+	}
+
+	private void initialize() {
+		path = file.getPath().replace('\\', '/');
+		expansionFile = ((AndroidFiles) Gdx.files).getExpansionFile();
+		assetFd = expansionFile.getAssetFileDescriptor(getPath());
+
+		// needed for listing entries and exists() of directories
+		if (isDirectory())
+			path += "/";
+	}
+
+	public AssetFileDescriptor getAssetFileDescriptor(String path) throws IOException {
+		return assetFd;
+	}
+
+	private String getPath() {
+		return path;
+	}
+
+	@Override
+	public InputStream read() {
+		InputStream input = null;
+
+		try {
+			input = expansionFile.getInputStream(getPath());
+		} catch (IOException ex) {
+			throw new GdxRuntimeException("Error reading file: " + file + " (ZipResourceFile)", ex);
+		}
+		return input;
+	}
+
+	@Override
+	public FileHandle child(String name) {
+		if (file.getPath().length() == 0)
+			return new AndroidZipFileHandle(new File(name), type);
+		return new AndroidZipFileHandle(new File(file, name), type);
+	}
+
+	@Override
+	public FileHandle sibling(String name) {
+		if (file.getPath().length() == 0)
+			throw new GdxRuntimeException("Cannot get the sibling of the root.");
+		return new AndroidZipFileHandle(new File(file.getParent(), name), type);
+	}
+
+	@Override
+	public FileHandle parent() {
+		File parent = file.getParentFile();
+		if (parent == null)
+			parent = new File("");
+		return new AndroidZipFileHandle(parent.getPath());
+	}
+
+	@Override
+	public FileHandle[] list() {
+		ZipEntryRO[] zipEntries = expansionFile.getEntriesAt(getPath());
+		FileHandle[] handles = new FileHandle[zipEntries.length];
+		for (int i = 0, n = handles.length; i < n; i++)
+			handles[i] = new AndroidZipFileHandle(zipEntries[i].mFileName);
+		return handles;
+	}
+
+	@Override
+	public FileHandle[] list(FileFilter filter) {
+		ZipEntryRO[] zipEntries = expansionFile.getEntriesAt(getPath());
+		FileHandle[] handles = new FileHandle[zipEntries.length];
+		int count = 0;
+		for (int i = 0, n = handles.length; i < n; i++) {
+			FileHandle child = new AndroidZipFileHandle(zipEntries[i].mFileName);
+			if (!filter.accept(child.file()))
+				continue;
+			handles[count] = child;
+			count++;
+		}
+		if (count < zipEntries.length) {
+			FileHandle[] newHandles = new FileHandle[count];
+			System.arraycopy(handles, 0, newHandles, 0, count);
+			handles = newHandles;
+		}
+		return handles;
+	}
+
+	@Override
+	public FileHandle[] list(FilenameFilter filter) {
+		ZipEntryRO[] zipEntries = expansionFile.getEntriesAt(getPath());
+		FileHandle[] handles = new FileHandle[zipEntries.length];
+		int count = 0;
+		for (int i = 0, n = handles.length; i < n; i++) {
+			String path = zipEntries[i].mFileName;
+			if (!filter.accept(file, path))
+				continue;
+			handles[count] = new AndroidZipFileHandle(path);
+			count++;
+		}
+		if (count < zipEntries.length) {
+			FileHandle[] newHandles = new FileHandle[count];
+			System.arraycopy(handles, 0, newHandles, 0, count);
+			handles = newHandles;
+		}
+		return handles;
+	}
+
+	@Override
+	public FileHandle[] list(String suffix) {
+		ZipEntryRO[] zipEntries = expansionFile.getEntriesAt(getPath());
+		FileHandle[] handles = new FileHandle[zipEntries.length];
+		int count = 0;
+		for (int i = 0, n = handles.length; i < n; i++) {
+			String path = zipEntries[i].mFileName;
+			if (!path.endsWith(suffix))
+				continue;
+			handles[count] = new AndroidZipFileHandle(path);
+			count++;
+		}
+		if (count < zipEntries.length) {
+			FileHandle[] newHandles = new FileHandle[count];
+			System.arraycopy(handles, 0, newHandles, 0, count);
+			handles = newHandles;
+		}
+		return handles;
+	}
+
+	@Override
+	public boolean isDirectory() {
+		return assetFd == null;
+	}
+
+	@Override
+	public long length() {
+		try {
+			return getAssetFileDescriptor("").getLength();
+		} catch (IOException e) {
+		}
+		return 0;
+	}
+
+	@Override
+	public boolean exists() {
+		return expansionFile.getEntriesAt(getPath()).length != 0;
+	}
+}

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/ZipResourceFile.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/ZipResourceFile.java
@@ -1,0 +1,437 @@
+/*
+ * Copyright (C) 2012 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.badlogic.gdx.backends.android;
+
+import android.content.res.AssetFileDescriptor;
+import android.os.ParcelFileDescriptor;
+import android.util.Log;
+
+import java.io.EOFException;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Vector;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+public class ZipResourceFile {
+
+	//
+	// Read-only access to Zip archives, with minimal heap allocation.
+	//
+	static final String LOG_TAG = "zipro";
+	static final boolean LOGV = false;
+
+	// 4-byte number
+	static private int swapEndian(int i) {
+		return ((i & 0xff) << 24) + ((i & 0xff00) << 8)
+				+ ((i & 0xff0000) >>> 8) + ((i >>> 24) & 0xff);
+	}
+
+	// 2-byte number
+	static private int swapEndian(short i) {
+		return ((i & 0x00FF) << 8 | (i & 0xFF00) >>> 8);
+	}
+
+	/*
+	 * Zip file constants.
+	 */
+	static final int kEOCDSignature = 0x06054b50;
+	static final int kEOCDLen = 22;
+	static final int kEOCDNumEntries = 8; // offset to #of entries in file
+	static final int kEOCDSize = 12; // size of the central directory
+	static final int kEOCDFileOffset = 16; // offset to central directory
+
+	static final int kMaxCommentLen = 65535; // longest possible in ushort
+	static final int kMaxEOCDSearch = (kMaxCommentLen + kEOCDLen);
+
+	static final int kLFHSignature = 0x04034b50;
+	static final int kLFHLen = 30; // excluding variable-len fields
+	static final int kLFHNameLen = 26; // offset to filename length
+	static final int kLFHExtraLen = 28; // offset to extra length
+
+	static final int kCDESignature = 0x02014b50;
+	static final int kCDELen = 46; // excluding variable-len fields
+	static final int kCDEMethod = 10; // offset to compression method
+	static final int kCDEModWhen = 12; // offset to modification timestamp
+	static final int kCDECRC = 16; // offset to entry CRC
+	static final int kCDECompLen = 20; // offset to compressed length
+	static final int kCDEUncompLen = 24; // offset to uncompressed length
+	static final int kCDENameLen = 28; // offset to filename length
+	static final int kCDEExtraLen = 30; // offset to extra length
+	static final int kCDECommentLen = 32; // offset to comment length
+	static final int kCDELocalOffset = 42; // offset to local hdr
+
+	static final int kCompressStored = 0; // no compression
+	static final int kCompressDeflated = 8; // standard deflate
+
+	/*
+	 * The values we return for ZipEntryRO use 0 as an invalid value, so we want
+	 * to adjust the hash table index by a fixed amount. Using a large value
+	 * helps insure that people don't mix & match arguments, e.g. to
+	 * findEntryByIndex().
+	 */
+	static final int kZipEntryAdj = 10000;
+
+	static public final class ZipEntryRO {
+		public ZipEntryRO(final String zipFileName, final File file,
+				final String fileName) {
+			mFileName = fileName;
+			mZipFileName = zipFileName;
+			mFile = file;
+		}
+
+		public final File mFile;
+		public final String mFileName;
+		public final String mZipFileName;
+		public long mLocalHdrOffset; // offset of local file header
+
+		/* useful stuff from the directory entry */
+		public int mMethod;
+		public long mWhenModified;
+		public long mCRC32;
+		public long mCompressedLength;
+		public long mUncompressedLength;
+
+		public long mOffset = -1;
+
+		public void setOffsetFromFile(RandomAccessFile f, ByteBuffer buf)
+				throws IOException {
+			long localHdrOffset = mLocalHdrOffset;
+			try {
+				f.seek(localHdrOffset);
+				f.readFully(buf.array());
+				if (buf.getInt(0) != kLFHSignature) {
+					Log.w(LOG_TAG, "didn't find signature at start of lfh");
+					throw new IOException();
+				}
+				int nameLen = buf.getShort(kLFHNameLen) & 0xFFFF;
+				int extraLen = buf.getShort(kLFHExtraLen) & 0xFFFF;
+				mOffset = localHdrOffset + kLFHLen + nameLen + extraLen;
+			} catch (FileNotFoundException e) {
+				e.printStackTrace();
+			} catch (IOException ioe) {
+				ioe.printStackTrace();
+			}
+		}
+
+		/**
+		 * Calculates the offset of the start of the Zip file entry within the
+		 * Zip file.
+		 * 
+		 * @return the offset, in bytes from the start of the file of the entry
+		 */
+		public long getOffset() {
+			return mOffset;
+		}
+
+		/**
+		 * isUncompressed
+		 * 
+		 * @return true if the file is stored in uncompressed form
+		 */
+		public boolean isUncompressed() {
+			return mMethod == kCompressStored;
+		}
+
+		public AssetFileDescriptor getAssetFileDescriptor() {
+			if (mMethod == kCompressStored) {
+				ParcelFileDescriptor pfd;
+				try {
+					pfd = ParcelFileDescriptor.open(mFile,
+							ParcelFileDescriptor.MODE_READ_ONLY);
+					return new AssetFileDescriptor(pfd, getOffset(),
+							mUncompressedLength);
+				} catch (FileNotFoundException e) {
+					// TODO Auto-generated catch block
+					e.printStackTrace();
+				}
+			}
+			return null;
+		}
+
+		public String getZipFileName() {
+			return mZipFileName;
+		}
+
+		public File getZipFile() {
+			return mFile;
+		}
+
+	}
+
+	private HashMap<String, ZipEntryRO> mHashMap = new HashMap<String, ZipEntryRO>();
+
+	/* for reading compressed files */
+	public HashMap<File, ZipFile> mZipFiles = new HashMap<File, ZipFile>();
+
+	public ZipResourceFile(String zipFileName) throws IOException {
+		addPatchFile(zipFileName);
+	}
+
+	ZipEntryRO[] getEntriesAt(String path) {
+		Vector<ZipEntryRO> zev = new Vector<ZipEntryRO>();
+		Collection<ZipEntryRO> values = mHashMap.values();
+		if (null == path)
+			path = "";
+		int length = path.length();
+		for (ZipEntryRO ze : values) {
+			if (ze.mFileName.startsWith(path)) {
+				if (-1 == ze.mFileName.indexOf('/', length)) {
+					zev.add(ze);
+				}
+			}
+		}
+		ZipEntryRO[] entries = new ZipEntryRO[zev.size()];
+		return zev.toArray(entries);
+	}
+
+	public ZipEntryRO[] getAllEntries() {
+		Collection<ZipEntryRO> values = mHashMap.values();
+		return values.toArray(new ZipEntryRO[values.size()]);
+	}
+
+	/**
+	 * getAssetFileDescriptor allows for ZipResourceFile to directly feed
+	 * Android API's that want an fd, offset, and length such as the
+	 * MediaPlayer. It also allows for the class to be used in a content
+	 * provider that can feed video players. The file must be stored
+	 * (non-compressed) in the Zip file for this to work.
+	 * 
+	 * @param assetPath
+	 * @return the asset file descriptor for the file, or null if the file isn't
+	 *         present or is stored compressed
+	 */
+	public AssetFileDescriptor getAssetFileDescriptor(String assetPath) {
+		ZipEntryRO entry = mHashMap.get(assetPath);
+		if (null != entry) {
+			return entry.getAssetFileDescriptor();
+		}
+		return null;
+	}
+
+	/**
+	 * getInputStream returns an AssetFileDescriptor.AutoCloseInputStream
+	 * associated with the asset that is contained in the Zip file, or a
+	 * standard ZipInputStream if necessary to uncompress the file
+	 * 
+	 * @param assetPath
+	 * @return an input stream for the named asset path, or null if not found
+	 * @throws IOException
+	 */
+	public InputStream getInputStream(String assetPath) throws IOException {
+		ZipEntryRO entry = mHashMap.get(assetPath);
+		if (null != entry) {
+			if (entry.isUncompressed()) {
+				return entry.getAssetFileDescriptor().createInputStream();
+			} else {
+				ZipFile zf = mZipFiles.get(entry.getZipFile());
+				/** read compressed files **/
+				if (null == zf) {
+					zf = new ZipFile(entry.getZipFile(), ZipFile.OPEN_READ);
+					mZipFiles.put(entry.getZipFile(), zf);
+				}
+				ZipEntry zi = zf.getEntry(assetPath);
+				if (null != zi)
+					return zf.getInputStream(zi);
+			}
+		}
+		return null;
+	}
+
+	ByteBuffer mLEByteBuffer = ByteBuffer.allocate(4);
+
+	static private int read4LE(RandomAccessFile f) throws EOFException,
+			IOException {
+		return swapEndian(f.readInt());
+	}
+
+	/*
+	 * Opens the specified file read-only. We memory-map the entire thing and
+	 * close the file before returning.
+	 */
+	void addPatchFile(String zipFileName) throws IOException {
+		File file = new File(zipFileName);
+		RandomAccessFile f = new RandomAccessFile(file, "r");
+		long fileLength = f.length();
+
+		if (fileLength < kEOCDLen) {
+			f.close();
+			throw new java.io.IOException();
+		}
+
+		long readAmount = kMaxEOCDSearch;
+		if (readAmount > fileLength)
+			readAmount = fileLength;
+
+		/*
+		 * Make sure this is a Zip archive.
+		 */
+		f.seek(0);
+
+		int header = read4LE(f);
+		if (header == kEOCDSignature) {
+			Log.i(LOG_TAG, "Found Zip archive, but it looks empty");
+			throw new IOException();
+		} else if (header != kLFHSignature) {
+			Log.v(LOG_TAG, "Not a Zip archive");
+			throw new IOException();
+		}
+
+		/*
+		 * Perform the traditional EOCD snipe hunt. We're searching for the End
+		 * of Central Directory magic number, which appears at the start of the
+		 * EOCD block. It's followed by 18 bytes of EOCD stuff and up to 64KB of
+		 * archive comment. We need to read the last part of the file into a
+		 * buffer, dig through it to find the magic number, parse some values
+		 * out, and use those to determine the extent of the CD. We start by
+		 * pulling in the last part of the file.
+		 */
+		long searchStart = fileLength - readAmount;
+
+		f.seek(searchStart);
+		ByteBuffer bbuf = ByteBuffer.allocate((int) readAmount);
+		byte[] buffer = bbuf.array();
+		f.readFully(buffer);
+		bbuf.order(ByteOrder.LITTLE_ENDIAN);
+
+		/*
+		 * Scan backward for the EOCD magic. In an archive without a trailing
+		 * comment, we'll find it on the first try. (We may want to consider
+		 * doing an initial minimal read; if we don't find it, retry with a
+		 * second read as above.)
+		 */
+
+		// EOCD == 0x50, 0x4b, 0x05, 0x06
+		int eocdIdx;
+		for (eocdIdx = buffer.length - kEOCDLen; eocdIdx >= 0; eocdIdx--) {
+			if (buffer[eocdIdx] == 0x50
+					&& bbuf.getInt(eocdIdx) == kEOCDSignature) {
+				if (LOGV) {
+					Log.v(LOG_TAG, "+++ Found EOCD at index: " + eocdIdx);
+				}
+				break;
+			}
+		}
+
+		if (eocdIdx < 0) {
+			Log.d(LOG_TAG, "Zip: EOCD not found, " + zipFileName
+					+ " is not zip");
+		}
+
+		/*
+		 * Grab the CD offset and size, and the number of entries in the
+		 * archive. After that, we can release our EOCD hunt buffer.
+		 */
+
+		int numEntries = bbuf.getShort(eocdIdx + kEOCDNumEntries);
+		long dirSize = bbuf.getInt(eocdIdx + kEOCDSize) & 0xffffffffL;
+		long dirOffset = bbuf.getInt(eocdIdx + kEOCDFileOffset) & 0xffffffffL;
+
+		// Verify that they look reasonable.
+		if (dirOffset + dirSize > fileLength) {
+			Log.w(LOG_TAG, "bad offsets (dir " + dirOffset + ", size "
+					+ dirSize + ", eocd " + eocdIdx + ")");
+			throw new IOException();
+		}
+		if (numEntries == 0) {
+			Log.w(LOG_TAG, "empty archive?");
+			throw new IOException();
+		}
+
+		if (LOGV) {
+			Log.v(LOG_TAG, "+++ numEntries=" + numEntries + " dirSize="
+					+ dirSize + " dirOffset=" + dirOffset);
+		}
+
+		MappedByteBuffer directoryMap = f.getChannel().map(
+				FileChannel.MapMode.READ_ONLY, dirOffset, dirSize);
+		directoryMap.order(ByteOrder.LITTLE_ENDIAN);
+
+		byte[] tempBuf = new byte[0xffff];
+
+		/*
+		 * Walk through the central directory, adding entries to the hash table.
+		 */
+
+		int currentOffset = 0;
+
+		/*
+		 * Allocate the local directory information
+		 */
+		ByteBuffer buf = ByteBuffer.allocate(kLFHLen);
+		buf.order(ByteOrder.LITTLE_ENDIAN);
+
+		for (int i = 0; i < numEntries; i++) {
+			if (directoryMap.getInt(currentOffset) != kCDESignature) {
+				Log.w(LOG_TAG, "Missed a central dir sig (at " + currentOffset
+						+ ")");
+				throw new IOException();
+			}
+
+			/* useful stuff from the directory entry */
+			int fileNameLen = directoryMap
+					.getShort(currentOffset + kCDENameLen) & 0xffff;
+			int extraLen = directoryMap.getShort(currentOffset + kCDEExtraLen) & 0xffff;
+			int commentLen = directoryMap.getShort(currentOffset
+					+ kCDECommentLen) & 0xffff;
+
+			/* get the CDE filename */
+
+			directoryMap.position(currentOffset + kCDELen);
+			directoryMap.get(tempBuf, 0, fileNameLen);
+			directoryMap.position(0);
+
+			/* UTF-8 on Android */
+			String str = new String(tempBuf, 0, fileNameLen);
+			if (LOGV) {
+				Log.v(LOG_TAG, "Filename: " + str);
+			}
+
+			ZipEntryRO ze = new ZipEntryRO(zipFileName, file, str);
+			ze.mMethod = directoryMap.getShort(currentOffset + kCDEMethod) & 0xffff;
+			ze.mWhenModified = directoryMap.getInt(currentOffset + kCDEModWhen) & 0xffffffffL;
+			ze.mCRC32 = directoryMap.getLong(currentOffset + kCDECRC) & 0xffffffffL;
+			ze.mCompressedLength = directoryMap.getLong(currentOffset
+					+ kCDECompLen) & 0xffffffffL;
+			ze.mUncompressedLength = directoryMap.getLong(currentOffset
+					+ kCDEUncompLen) & 0xffffffffL;
+			ze.mLocalHdrOffset = directoryMap.getInt(currentOffset
+					+ kCDELocalOffset) & 0xffffffffL;
+
+			// set the offsets
+			buf.clear();
+			ze.setOffsetFromFile(f, buf);
+
+			// put file into hash
+			mHashMap.put(str, ze);
+
+			// go to next directory entry
+			currentOffset += kCDELen + fileNameLen + extraLen + commentLen;
+		}
+		if (LOGV) {
+			Log.v(LOG_TAG, "+++ zip good scan " + numEntries + " entries");
+		}
+	}
+}

--- a/tests/gdx-tests-android/assets/data/testpackobb
+++ b/tests/gdx-tests-android/assets/data/testpackobb
@@ -1,0 +1,33 @@
+
+obbasset-Textures1.png
+format: RGBA8888
+filter: Nearest,Nearest
+repeat: none
+water
+  rotate: false
+  xy: 0, 0
+  size: 64, 64
+  orig: 64, 64
+  offset: 0, 0
+  index: -1
+grass
+  rotate: false
+  xy: 0, 66
+  size: 64, 64
+  orig: 64, 64
+  offset: 0, 0
+  index: -1
+dirt
+  rotate: false
+  xy: 0, 132
+  size: 64, 64
+  orig: 64, 64
+  offset: 0, 0
+  index: -1
+blank
+  rotate: false
+  xy: 0, 198
+  size: 64, 64
+  orig: 64, 64
+  offset: 0, 0
+  index: -1

--- a/tests/gdx-tests-android/build.gradle
+++ b/tests/gdx-tests-android/build.gradle
@@ -71,3 +71,59 @@ idea {
 		}
 	}
 }
+
+// used to create obb file
+task copyAssets << {
+	def assets = fileTree('assets')
+	copy {
+		from assets
+		into "build/obbassets"
+		rename { fileName ->
+			fileName = "obbasset-" + fileName
+		}
+	}
+}
+
+task zipAssets(type: Zip) {
+	destinationDir = file("build/obb")
+	entryCompression = ZipEntryCompression.STORED
+	from "build/obbassets"
+	baseName = "main.1.com.badlogic.gdx.tests.android"
+	extension = "obb"
+}
+
+def getADBPath() {
+	def path
+	def localProperties = new File("local.properties")
+	if (localProperties.exists()) {
+		Properties properties = new Properties()
+		localProperties.withInputStream { instr ->
+			properties.load(instr)
+	}
+	def sdkDir = properties.getProperty('sdk.dir')
+	if (sdkDir) {
+	    path = sdkDir
+	} else {
+	    path = "$System.env.ANDROID_HOME"
+	}
+	} else {
+		path = "$System.env.ANDROID_HOME"
+	}
+
+	def adb = path + "/platform-tools/adb"
+	adb
+}
+
+task createOBBDir(type: Exec) {
+	def adb = getADBPath();
+	commandLine "$adb", 'shell', 'mkdir', '-p', '/mnt/sdcard/Android/obb/com.badlogic.gdx.tests.android'
+}
+task uploadOBB(type: Exec) {
+	def adb = getADBPath();
+	commandLine "$adb", 'push', 'build/obb/main.1.com.badlogic.gdx.tests.android.obb', '/mnt/sdcard/Android/obb/com.badlogic.gdx.tests.android'
+}
+
+copyAssets.dependsOn clean
+zipAssets.dependsOn copyAssets
+createOBBDir.dependsOn zipAssets
+uploadOBB.dependsOn createOBBDir

--- a/tests/gdx-tests-android/src/com/badlogic/gdx/tests/android/APKExpansionTest.java
+++ b/tests/gdx-tests-android/src/com/badlogic/gdx/tests/android/APKExpansionTest.java
@@ -1,0 +1,80 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ * <p/>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogic.gdx.tests.android;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.assets.AssetManager;
+import com.badlogic.gdx.assets.loaders.FileHandleResolver;
+import com.badlogic.gdx.audio.Sound;
+import com.badlogic.gdx.backends.android.AndroidFiles;
+import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.graphics.g2d.TextureAtlas;
+import com.badlogic.gdx.graphics.g2d.TextureRegion;
+import com.badlogic.gdx.tests.utils.GdxTest;
+
+/* 
+ * To use this test, an APK expansion file must be present on the device
+ * run: gradlew tests:gdx-tests-android:uploadOBB
+ * to generate and upload the aforementioned file
+ */
+public class APKExpansionTest extends GdxTest {
+    FileHandleResolver resolver;
+    Sound sound;
+    SpriteBatch batch;
+    Texture texture;
+    TextureRegion atlasTextureRegion;
+    AssetManager assetManager;
+
+    /** The OBB zip assets are taken from the android tests assets directory
+     Extension prefix is prepended to each asset and zipped up into a obb.
+     Extension prefix is required so we can be certain the assets are coming
+     from the obb, while keeping the structure of the assets file tree for easier testing
+     **/
+    String extensionPrefix = "obbasset-";
+
+    @Override
+    public void create () {
+        if ((((AndroidFiles)Gdx.files)).setAPKExpansion(1, 0)) {
+            resolver = new ZipFileHandleResolver();
+        } else {
+            Gdx.app.error("libgdx", "No Expansion can be opened");
+        }
+
+        assetManager = new AssetManager();
+        assetManager.load("data/" + extensionPrefix + "testpackobb", TextureAtlas.class);
+        assetManager.finishLoading();
+
+        sound = Gdx.audio.newSound(Gdx.files.internal("data/" + extensionPrefix + "chirp.ogg"));
+        sound.play();
+        texture = new Texture(resolver.resolve("data/" + extensionPrefix + "badlogic.jpg"));
+        batch = new SpriteBatch();
+        TextureAtlas atlas = assetManager.get("data/" + extensionPrefix + "testpackobb");
+        atlasTextureRegion = new TextureRegion(atlas.findRegion("water"));
+    }
+
+    @Override
+    public void render () {
+        Gdx.gl.glClearColor(1, 0, 0, 1);
+        Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+        batch.begin();
+        batch.draw(texture, 0, 0);
+        batch.draw(atlasTextureRegion, 0, 0);
+        batch.end();
+    }
+}

--- a/tests/gdx-tests-android/src/com/badlogic/gdx/tests/android/AndroidTestStarter.java
+++ b/tests/gdx-tests-android/src/com/badlogic/gdx/tests/android/AndroidTestStarter.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests.android;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import android.app.ListActivity;
@@ -38,6 +37,8 @@ public class AndroidTestStarter extends ListActivity {
 	public void onCreate (Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 		GdxTests.tests.add(MatrixTest.class);
+		if (!GdxTests.tests.contains(APKExpansionTest.class))
+			GdxTests.tests.add(APKExpansionTest.class);
 		List<String> testNames = GdxTests.getNames();
 		setListAdapter(new ArrayAdapter<String>(this, android.R.layout.simple_list_item_1, testNames));
 

--- a/tests/gdx-tests-android/src/com/badlogic/gdx/tests/android/ZipFileHandleResolver.java
+++ b/tests/gdx-tests-android/src/com/badlogic/gdx/tests/android/ZipFileHandleResolver.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogic.gdx.tests.android;
+
+import com.badlogic.gdx.assets.loaders.FileHandleResolver;
+import com.badlogic.gdx.backends.android.AndroidZipFileHandle;
+import com.badlogic.gdx.files.FileHandle;
+
+/** @author sarkanyi */
+public class ZipFileHandleResolver implements FileHandleResolver {
+
+	@Override
+	public FileHandle resolve(String fileName) {
+		return new AndroidZipFileHandle(fileName);
+	}
+
+}


### PR DESCRIPTION
The change is transparent to the user, Gdx.files.internal() can be used to access assets inside expansion files.
The application must call ((AndroidFiles)Gdx.files).setAPKExpansion() first, to open the expansion file(s). The function returns true if it was opened successfully.
This replaces https://github.com/libgdx/libgdx/pull/3381