### PR TITLE
Fixes onKey ArrayIndexOutOfBoundsException on negative keycodes

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidInput.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidInput.java
@@ -477,7 +477,9 @@ public class AndroidInput implements Input, OnKeyListener, OnTouchListener {
 			char character = (char)e.getUnicodeChar();
 			// Android doesn't report a unicode char for back space. hrm...
 			if (keyCode == 67) character = '\b';
-			if (e.getKeyCode() >= SUPPORTED_KEYS) return false;
+			if (e.getKeyCode() < 0 || e.getKeyCode() >= SUPPORTED_KEYS) {
+				return false;
+			}
 			
 			switch (e.getAction()) {
 			case android.view.KeyEvent.ACTION_DOWN:


### PR DESCRIPTION
Issue #2807 already partially fixed this issue but an additional check is not being made for negative keycodes in onKey causing crashes on some Chinese devices that send -2

```
java.lang.ArrayIndexOutOfBoundsException: length=260; index=-2
       at com.badlogic.gdx.backends.android.AndroidInput.onKey(SourceFile:498)
       at android.view.View.dispatchKeyEvent(View.java:7338)
```

(The issue also happens in a number of flavors further down onKey)

```
java.lang.ArrayIndexOutOfBoundsException: length=260; index=-2
       at com.badlogic.gdx.backends.android.AndroidInput.onKey(SourceFile:530)
```