### PR TITLE
Fix #3340. TextField ignores input on mac if command is pressed.

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextField.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextField.java
@@ -933,6 +933,8 @@ public class TextField extends Widget implements Disableable {
 
 			Stage stage = getStage();
 			if (stage == null || stage.getKeyboardFocus() != TextField.this) return false;
+			
+			if (UIUtils.isMac && Gdx.input.isKeyPressed(Keys.SYM)) return true;
 
 			if ((character == TAB || character == ENTER_ANDROID) && focusTraversal) {
 				next(UIUtils.shift());


### PR DESCRIPTION
This fixes cut, copy, paste and select-all keyboard shortcuts not working on mac as discussed in issue #3340.