### PR TITLE
Check status before binding to default frame buffer again.

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/glutils/GLFrameBuffer.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/GLFrameBuffer.java
@@ -171,9 +171,10 @@ public abstract class GLFrameBuffer<T extends GLTexture> implements Disposable {
 
 		gl.glBindRenderbuffer(GL20.GL_RENDERBUFFER, 0);
 		gl.glBindTexture(GL20.GL_TEXTURE_2D, 0);
-		gl.glBindFramebuffer(GL20.GL_FRAMEBUFFER, defaultFramebufferHandle);
 
 		int result = gl.glCheckFramebufferStatus(GL20.GL_FRAMEBUFFER);
+
+		gl.glBindFramebuffer(GL20.GL_FRAMEBUFFER, defaultFramebufferHandle);
 
 		if (result != GL20.GL_FRAMEBUFFER_COMPLETE) {
 			disposeColorTexture(colorTexture);


### PR DESCRIPTION
glCheckFramebufferStatus() was always called with the default frame buffer bound.