### PR TITLE
Remove wrong keyboard shortcut

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextField.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextField.java
@@ -831,7 +831,7 @@ public class TextField extends Widget implements Disableable {
 					copy();
 					return true;
 				}
-				if (keycode == Keys.X || keycode == Keys.DEL) {
+				if (keycode == Keys.X) {
 					cut(true);
 					return true;
 				}


### PR DESCRIPTION
Ctrl + Backspace is not a shortcut for cut, the right shorcut is 
Shift + Forward_Delete, which is already implemented.
Reference:https://en.wikipedia.org/wiki/Cut,_copy,_and_paste#Common_keyboard_shortcuts