### PR TITLE
Fix false-positive of vibration support

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidInput.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidInput.java
@@ -712,7 +712,7 @@ public class AndroidInput implements Input, OnKeyListener, OnTouchListener {
 		if (peripheral == Peripheral.Compass) return compassAvailable;
 		if (peripheral == Peripheral.HardwareKeyboard) return keyboardAvailable;
 		if (peripheral == Peripheral.OnscreenKeyboard) return true;
-		if (peripheral == Peripheral.Vibrator) return vibrator != null;
+		if (peripheral == Peripheral.Vibrator) return vibrator != null && vibrator.hasVibrator();
 		if (peripheral == Peripheral.MultitouchScreen) return hasMultitouch;
 		return false;
 	}


### PR DESCRIPTION
We get our vibrator with
context.getSystemService(Context.VIBRATOR_SERVIBE).

The previous check tested if(vibrator != null), but according to 
http://developer.android.com/reference/android/content/Context.html#getSystemService(java.lang.String)  
it returns "The service or null if the name does not exist.". So it
should only return null if the name does not exist, which should be
never the case.
Instead of that we now use vibrator.hasVibrator()