### PR TITLE
fixed CumulativeDistribution class returned wrong values

### DIFF
--- a/gdx/src/com/badlogic/gdx/math/CumulativeDistribution.java
+++ b/gdx/src/com/badlogic/gdx/math/CumulativeDistribution.java
@@ -88,7 +88,7 @@ public class CumulativeDistribution <T>{
 			else break;
 		}
 
-		return value.value;
+		return values.items[imin].value;
 	}
 
 	/** @return the value whose interval contains a random probability in [0,1] */


### PR DESCRIPTION
Class CumulativeDistribution returned wrong values. Can be easily checked with the next code:
```java
CumulativeDistribution<Integer> cdf = new CumulativeDistribution<Integer>();
cdf.add(1, 1);
cdf.add(2, 1);
cdf.add(3, 1);
cdf.generateNormalized();
int one = 0, two = 0, three = 0;
for (int i = 0; i < 100000; i++) {
    int v = cdf.value();
    if (v == 1) one++;
    else if (v == 2) two++;
    else if (v == 3) three++;
}
System.out.println("1: " + one + " 2: " + two + " 3: " + three);
```
Prints before fix:
1: 66714 2: 0 3: 33286
After fix:
1: 33383 2: 33489 3: 33128