### PR TITLE
IsometricTiledMapRenderer amendment to accept a unit scale value for tile height

### DIFF
--- a/gdx/src/com/badlogic/gdx/maps/tiled/renderers/IsometricStaggeredTiledMapRenderer.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/renderers/IsometricStaggeredTiledMapRenderer.java
@@ -95,9 +95,9 @@ public class IsometricStaggeredTiledMapRenderer extends BatchTiledMapRenderer {
 					TextureRegion region = tile.getTextureRegion();
 
 					float x1 = x * layerTileWidth - offsetX + tile.getOffsetX() * unitScale;
-					float y1 = y * layerTileHeight50 + tile.getOffsetY() * unitScale;
+					float y1 = y * layerTileHeight50 + tile.getOffsetY() * unitScaleY;
 					float x2 = x1 + region.getRegionWidth() * unitScale;
-					float y2 = y1 + region.getRegionHeight() * unitScale;
+					float y2 = y1 + region.getRegionHeight() * unitScaleY;
 
 					float u1 = region.getU();
 					float v1 = region.getV2();

--- a/gdx/src/com/badlogic/gdx/maps/tiled/renderers/IsometricStaggeredTiledMapRenderer.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/renderers/IsometricStaggeredTiledMapRenderer.java
@@ -28,20 +28,36 @@ import com.badlogic.gdx.maps.tiled.TiledMapTileLayer.Cell;
 
 public class IsometricStaggeredTiledMapRenderer extends BatchTiledMapRenderer {
 
+	private float unitScaleY;
+	
 	public IsometricStaggeredTiledMapRenderer (TiledMap map) {
 		super(map);
+		unitScaleY = 1.0f;
 	}
 
 	public IsometricStaggeredTiledMapRenderer (TiledMap map, Batch batch) {
 		super(map, batch);
+		unitScaleY = 1.0f;
 	}
 
 	public IsometricStaggeredTiledMapRenderer (TiledMap map, float unitScale) {
 		super(map, unitScale);
+		unitScaleY = unitScale;
 	}
 
+	public IsometricStaggeredTiledMapRenderer (TiledMap map, float unitScale, float unitScaleY) {
+		super(map, unitScale);
+		this.unitScaleY = unitScaleY;
+	}
+	
 	public IsometricStaggeredTiledMapRenderer (TiledMap map, float unitScale, Batch batch) {
 		super(map, unitScale, batch);
+		unitScaleY = unitScale;
+	}
+
+	public IsometricStaggeredTiledMapRenderer (TiledMap map, float unitScale, float unitScaleY, Batch batch) {
+		super(map, unitScale, batch);
+		this.unitScaleY = unitScaleY;
 	}
 
 	@Override
@@ -53,7 +69,7 @@ public class IsometricStaggeredTiledMapRenderer extends BatchTiledMapRenderer {
 		final int layerHeight = layer.getHeight();
 
 		final float layerTileWidth = layer.getTileWidth() * unitScale;
-		final float layerTileHeight = layer.getTileHeight() * unitScale;
+		final float layerTileHeight = layer.getTileHeight() * unitScaleY;
 
 		final float layerTileWidth50 = layerTileWidth * 0.50f;
 		final float layerTileHeight50 = layerTileHeight * 0.50f;

--- a/gdx/src/com/badlogic/gdx/maps/tiled/renderers/IsometricTiledMapRenderer.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/renderers/IsometricTiledMapRenderer.java
@@ -40,26 +40,44 @@ public class IsometricTiledMapRenderer extends BatchTiledMapRenderer {
 	private Vector2 topLeft = new Vector2();
 	private Vector2 bottomRight = new Vector2();
 
+	private float unitScaleY;
+	
 	public IsometricTiledMapRenderer (TiledMap map) {
 		super(map);
+		unitScaleY = 1.0f;
 		init();
 	}
 
 	public IsometricTiledMapRenderer (TiledMap map, Batch batch) {
 		super(map, batch);
+		unitScaleY = 1.0f;
 		init();
 	}
 
 	public IsometricTiledMapRenderer (TiledMap map, float unitScale) {
 		super(map, unitScale);
+		unitScaleY = unitScale;
 		init();
 	}
 
+	public IsometricTiledMapRenderer (TiledMap map, float unitScale, float unitScaleY) {
+		super(map, unitScale);
+		this.unitScaleY = unitScaleY;
+		init();
+	}
+	
 	public IsometricTiledMapRenderer (TiledMap map, float unitScale, Batch batch) {
 		super(map, unitScale, batch);
+		unitScaleY = unitScale;
 		init();
 	}
 
+	public IsometricTiledMapRenderer (TiledMap map, float unitScale, float unitScaleY, Batch batch) {
+		super(map, unitScale, batch);
+		this.unitScaleY = unitScaleY;
+		init();
+	}
+	
 	private void init () {
 		// create the isometric transform
 		isoTransform = new Matrix4();
@@ -87,7 +105,7 @@ public class IsometricTiledMapRenderer extends BatchTiledMapRenderer {
 		final float color = Color.toFloatBits(batchColor.r, batchColor.g, batchColor.b, batchColor.a * layer.getOpacity());
 
 		float tileWidth = layer.getTileWidth() * unitScale;
-		float tileHeight = layer.getTileHeight() * unitScale;
+		float tileHeight = layer.getTileHeight() * unitScaleY;
 		float halfTileWidth = tileWidth * 0.5f;
 		float halfTileHeight = tileHeight * 0.5f;
 
@@ -227,3 +245,4 @@ public class IsometricTiledMapRenderer extends BatchTiledMapRenderer {
 		}
 	}
 }
+	

--- a/gdx/src/com/badlogic/gdx/maps/tiled/renderers/IsometricTiledMapRenderer.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/renderers/IsometricTiledMapRenderer.java
@@ -143,9 +143,9 @@ public class IsometricTiledMapRenderer extends BatchTiledMapRenderer {
 					TextureRegion region = tile.getTextureRegion();
 
 					float x1 = x + tile.getOffsetX() * unitScale;
-					float y1 = y + tile.getOffsetY() * unitScale;
+					float y1 = y + tile.getOffsetY() * unitScaleY;
 					float x2 = x1 + region.getRegionWidth() * unitScale;
-					float y2 = y1 + region.getRegionHeight() * unitScale;
+					float y2 = y1 + region.getRegionHeight() * unitScaleY;
 
 					float u1 = region.getU();
 					float v1 = region.getV2();


### PR DESCRIPTION
Currently, tiled maps in LibGdx only covers tiles that have the same width and length. In this case, the isometric renderer applies the same value for unit scale to a tile's height, which will then render the whole map vertically off-center. For applications that rely on screen coordinates matching to world coordinates, that match to an underlying structure such as a graph for pathfinding or a grid, this situation throws things out of whack. It forces users to restrict themselves to tilesets with tiles of the same width and height.

This simple modifications to the isometric renderers provides constructors to pass a unit scale for height, a separate field to reference it, and applies this value in the rendering process. 