### PR TITLE
Fixed incorrectly ended bold tag on special note.

### DIFF
--- a/gdx/src/com/badlogic/gdx/audio/Sound.java
+++ b/gdx/src/com/badlogic/gdx/audio/Sound.java
@@ -35,7 +35,7 @@ import com.badlogic.gdx.utils.Disposable;
  * </p>
  * 
  * <p>
- * <b>Note<b>: any values provided will not be clamped, it is the developer's responsibility to do so
+ * <b>Note</b>: any values provided will not be clamped, it is the developer's responsibility to do so
  * </p>
  * 
  * @author badlogicgames@gmail.com */


### PR DESCRIPTION
Just addressing a very small error in the javadoc for Sound where \</b\> is incorrectly written as \<b\>, causing the rest of the document to be rendered bold.