### PR TITLE
Use group names instead of generated ids in ObjLoader

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g3d/loader/ObjLoader.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/loader/ObjLoader.java
@@ -243,9 +243,10 @@ public class ObjLoader extends ModelLoader<ObjLoader.ObjLoaderParameters> {
 			if (hasNorms) attributes.add(new VertexAttribute(Usage.Normal, 3, ShaderProgram.NORMAL_ATTRIBUTE));
 			if (hasUVs) attributes.add(new VertexAttribute(Usage.TextureCoordinates, 2, ShaderProgram.TEXCOORD_ATTRIBUTE + "0"));
 
-			String nodeId = "node" + (++id);
-			String meshId = "mesh" + id;
-			String partId = "part" + id;
+			String stringId = "" + (++id);
+			String nodeId = group.name != "default" ? group.name : "node" + stringId;
+			String meshId = group.name != "default" ? group.name : "mesh" + stringId;
+			String partId = group.name != "default" ? group.name : "part" + stringId;
 			ModelNode node = new ModelNode();
 			node.id = nodeId;
 			node.meshId = meshId;

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/loader/ObjLoader.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/loader/ObjLoader.java
@@ -243,10 +243,10 @@ public class ObjLoader extends ModelLoader<ObjLoader.ObjLoaderParameters> {
 			if (hasNorms) attributes.add(new VertexAttribute(Usage.Normal, 3, ShaderProgram.NORMAL_ATTRIBUTE));
 			if (hasUVs) attributes.add(new VertexAttribute(Usage.TextureCoordinates, 2, ShaderProgram.TEXCOORD_ATTRIBUTE + "0"));
 
-			String stringId = "" + (++id);
-			String nodeId = group.name.equals("default") ? "node" + stringId : group.name;
-			String meshId = group.name.equals("default") ? "mesh" + stringId : group.name;
-			String partId = group.name.equals("default") ? "part" + stringId : group.name;
+			String stringId = Integer.toString(++id);
+			String nodeId = "default".equals(group.name) ? "node" + stringId : group.name;
+			String meshId = "default".equals(group.name) ? "mesh" + stringId : group.name;
+			String partId = "default".equals(group.name) ? "part" + stringId : group.name;
 			ModelNode node = new ModelNode();
 			node.id = nodeId;
 			node.meshId = meshId;

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/loader/ObjLoader.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/loader/ObjLoader.java
@@ -244,9 +244,9 @@ public class ObjLoader extends ModelLoader<ObjLoader.ObjLoaderParameters> {
 			if (hasUVs) attributes.add(new VertexAttribute(Usage.TextureCoordinates, 2, ShaderProgram.TEXCOORD_ATTRIBUTE + "0"));
 
 			String stringId = "" + (++id);
-			String nodeId = group.name != "default" ? group.name : "node" + stringId;
-			String meshId = group.name != "default" ? group.name : "mesh" + stringId;
-			String partId = group.name != "default" ? group.name : "part" + stringId;
+			String nodeId = group.name.equals("default") ? "node" + stringId : group.name;
+			String meshId = group.name.equals("default") ? "mesh" + stringId : group.name;
+			String partId = group.name.equals("default") ? "part" + stringId : group.name;
 			ModelNode node = new ModelNode();
 			node.id = nodeId;
 			node.meshId = meshId;


### PR DESCRIPTION
This is particularly useful when one needs the original mesh names exported from the 3d editor. In case the "default" group is used, the ids are still autogenerated.