### PR TITLE
Fix bug causing ObjLoader to not load materials with dots in name

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g3d/loader/ObjLoader.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/loader/ObjLoader.java
@@ -177,7 +177,7 @@ public class ObjLoader extends ModelLoader<ObjLoader.ObjLoaderParameters> {
 					if (tokens.length == 1)
 						activeGroup.materialName = "default";
 					else
-						activeGroup.materialName = tokens[1];
+						activeGroup.materialName = tokens[1].replace('.', '_');
 				}
 			}
 			reader.close();


### PR DESCRIPTION
The mtl loader replaces dots with underscored, but ObjLoader does not. Thus ObjLoader is unable to load materials with dots in their name ("Material.001").