### PR TITLE
Make APK expansion initialization faster. Make exists() faster for files

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidAudio.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidAudio.java
@@ -106,7 +106,7 @@ public final class AndroidAudio implements Audio {
 
 		if (aHandle.type() == FileType.Internal) {
 			try {
-				AssetFileDescriptor descriptor = aHandle.getAssetFileDescriptor(aHandle.path());
+				AssetFileDescriptor descriptor = aHandle.getAssetFileDescriptor();
 				mediaPlayer.setDataSource(descriptor.getFileDescriptor(), descriptor.getStartOffset(), descriptor.getLength());
 				descriptor.close();
 				mediaPlayer.prepare();
@@ -144,7 +144,7 @@ public final class AndroidAudio implements Audio {
 		AndroidFileHandle aHandle = (AndroidFileHandle)file;
 		if (aHandle.type() == FileType.Internal) {
 			try {
-				AssetFileDescriptor descriptor = aHandle.getAssetFileDescriptor(aHandle.path());
+				AssetFileDescriptor descriptor = aHandle.getAssetFileDescriptor();
 				AndroidSound sound = new AndroidSound(soundPool, manager, soundPool.load(descriptor, 1));
 				descriptor.close();
 				return sound;

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidFileHandle.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidFileHandle.java
@@ -229,7 +229,11 @@ public class AndroidFileHandle extends FileHandle {
 		return super.file();
 	}
 
-	public AssetFileDescriptor getAssetFileDescriptor(String path) throws IOException {
-		return assets.openFd(path);
+	/**
+	 * @return an AssetFileDescriptor for this file or null if the file is not of type Internal
+	 * @throws IOException - thrown by AssetManager.openFd()
+	 */
+	public AssetFileDescriptor getAssetFileDescriptor() throws IOException {
+		return assets != null ? assets.openFd(path()) : null;
 	}
 }

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidFiles.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidFiles.java
@@ -48,11 +48,9 @@ public class AndroidFiles implements Files {
 	@Override
 	public FileHandle getFileHandle (String path, FileType type) {
 		FileHandle handle = new AndroidFileHandle(type == FileType.Internal ? assets : null, path, type);
-		if (!handle.exists() && expansionFile != null) {
+		if (type == FileType.Internal && !handle.exists() && expansionFile != null) {
 			// try APK expansion instead
-			FileHandle zipHandle = new AndroidZipFileHandle(path);
-			if (zipHandle.exists())
-				handle = zipHandle;
+			handle = new AndroidZipFileHandle(path);
 		}
 		return handle;
 	}
@@ -67,9 +65,7 @@ public class AndroidFiles implements Files {
 		FileHandle handle = new AndroidFileHandle(assets, path, FileType.Internal);
 		if (!handle.exists() && expansionFile != null) {
 			// try APK expansion instead
-			FileHandle zipHandle = new AndroidZipFileHandle(path);
-			if (zipHandle.exists())
-				handle = zipHandle;
+			handle = new AndroidZipFileHandle(path);
 		}
 		return handle;
 	}

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidZipFileHandle.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidZipFileHandle.java
@@ -52,7 +52,8 @@ public class AndroidZipFileHandle extends AndroidFileHandle {
 			path += "/";
 	}
 
-	public AssetFileDescriptor getAssetFileDescriptor(String path) throws IOException {
+	@Override
+	public AssetFileDescriptor getAssetFileDescriptor() throws IOException {
 		return assetFd;
 	}
 
@@ -171,7 +172,7 @@ public class AndroidZipFileHandle extends AndroidFileHandle {
 	@Override
 	public long length() {
 		try {
-			return getAssetFileDescriptor("").getLength();
+			return getAssetFileDescriptor().getLength();
 		} catch (IOException e) {
 		}
 		return 0;
@@ -179,6 +180,6 @@ public class AndroidZipFileHandle extends AndroidFileHandle {
 
 	@Override
 	public boolean exists() {
-		return expansionFile.getEntriesAt(getPath()).length != 0;
+		return assetFd != null || expansionFile.getEntriesAt(getPath()).length != 0;
 	}
 }


### PR DESCRIPTION
It seems that if there are lots of entries in the obb file, exists() is rather slow because it has to search a large HashMap. This should make it much faster.