### PR TITLE
Fix AndroidZipFileHandle.length() throwing NullPointerException

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidZipFileHandle.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidZipFileHandle.java
@@ -171,11 +171,7 @@ public class AndroidZipFileHandle extends AndroidFileHandle {
 
 	@Override
 	public long length() {
-		try {
-			return getAssetFileDescriptor().getLength();
-		} catch (IOException e) {
-		}
-		return 0;
+		return assetFd != null ? assetFd.getLength() : 0;
 	}
 
 	@Override


### PR DESCRIPTION
If the file doesn't exists AndroidZipFileHandle.length() throws a NullPointerException which is wrong. Looks like the FreetypeFontGenerator uses FileHandle.length() to check if a font is an actual file or has to be generated so that is the most obvious way to catch this.