### PR TITLE
Add Renderable#meshPart, MeshPart bounds, rename to #offset and #size

### DIFF
--- a/extensions/gdx-bullet/jni/swig-src/collision/com/badlogic/gdx/physics/bullet/collision/btIndexedMesh.java
+++ b/extensions/gdx-bullet/jni/swig-src/collision/com/badlogic/gdx/physics/bullet/collision/btIndexedMesh.java
@@ -163,7 +163,7 @@ public class btIndexedMesh extends BulletBase {
 	public void set(final MeshPart meshPart) {
 		if (meshPart.primitiveType != com.badlogic.gdx.graphics.GL20.GL_TRIANGLES)
 			throw new com.badlogic.gdx.utils.GdxRuntimeException("Mesh must be indexed and triangulated");
-		set(meshPart, meshPart.mesh, meshPart.indexOffset, meshPart.numVertices);
+		set(meshPart, meshPart.mesh, meshPart.offset, meshPart.size);
 	}
 	
 	/** Convenience method to set this btIndexedMesh to the specified {@link Mesh} 

--- a/extensions/gdx-bullet/jni/swig/collision/btTriangleIndexVertexArray.i
+++ b/extensions/gdx-bullet/jni/swig/collision/btTriangleIndexVertexArray.i
@@ -141,7 +141,7 @@ import java.nio.ShortBuffer;
 	public void set(final MeshPart meshPart) {
 		if (meshPart.primitiveType != com.badlogic.gdx.graphics.GL20.GL_TRIANGLES)
 			throw new com.badlogic.gdx.utils.GdxRuntimeException("Mesh must be indexed and triangulated");
-		set(meshPart, meshPart.mesh, meshPart.indexOffset, meshPart.numVertices);
+		set(meshPart, meshPart.mesh, meshPart.offset, meshPart.size);
 	}
 	
 	/** Convenience method to set this btIndexedMesh to the specified {@link Mesh} 

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/Model.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/Model.java
@@ -251,11 +251,11 @@ public class Model implements Disposable {
 			MeshPart meshPart = new MeshPart();
 			meshPart.id = part.id;
 			meshPart.primitiveType = part.primitiveType;
-			meshPart.indexOffset = offset;
-			meshPart.numVertices = part.indices.length;
+			meshPart.offset = offset;
+			meshPart.size = part.indices.length;
 			meshPart.mesh = mesh;
 			mesh.getIndicesBuffer().put(part.indices);
-			offset += meshPart.numVertices;
+			offset += meshPart.size;
 			meshParts.add(meshPart);
 		}
 		mesh.getIndicesBuffer().position(0);

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/Model.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/Model.java
@@ -259,6 +259,8 @@ public class Model implements Disposable {
 			meshParts.add(meshPart);
 		}
 		mesh.getIndicesBuffer().position(0);
+		for (MeshPart part : meshParts)
+			part.update();
 	}
 
 	private void loadMaterials (Iterable<ModelMaterial> modelMaterials, TextureProvider textureProvider) {

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/ModelBatch.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/ModelBatch.java
@@ -54,7 +54,7 @@ public class ModelBatch implements Disposable {
 			Renderable renderable = super.obtain();
 			renderable.environment = null;
 			renderable.material = null;
-			renderable.mesh = null;
+			renderable.meshPart.set("", null, 0, 0, 0);
 			renderable.shader = null;
 			obtained.add(renderable);
 			return renderable;
@@ -231,7 +231,7 @@ public class ModelBatch implements Disposable {
 	 * @param renderable The {@link Renderable} to be added. */
 	public void render (final Renderable renderable) {
 		renderable.shader = shaderProvider.getShader(renderable);
-		renderable.mesh.setAutoBind(false);
+		renderable.meshPart.mesh.setAutoBind(false);
 		renderables.add(renderable);
 	}
 

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/ModelInstance.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/ModelInstance.java
@@ -294,12 +294,7 @@ public class ModelInstance implements RenderableProvider {
 
 	private NodePart copyNodePart (NodePart nodePart) {
 		NodePart copy = new NodePart();
-		copy.meshPart = new MeshPart();
-		copy.meshPart.id = nodePart.meshPart.id;
-		copy.meshPart.indexOffset = nodePart.meshPart.indexOffset;
-		copy.meshPart.numVertices = nodePart.meshPart.numVertices;
-		copy.meshPart.primitiveType = nodePart.meshPart.primitiveType;
-		copy.meshPart.mesh = nodePart.meshPart.mesh;
+		copy.meshPart = new MeshPart(nodePart.meshPart);
 
 		if (nodePart.invBoneBindTransforms != null) nodePartBones.put(copy, nodePart.invBoneBindTransforms);
 

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/Renderable.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/Renderable.java
@@ -67,17 +67,8 @@ public class Renderable {
 	/** Used to specify the transformations (like translation, scale and rotation) to apply to the shape. In other words: it is used
 	 * to transform the vertices from model space into world space. **/
 	public final Matrix4 worldTransform = new Matrix4();
-	/** The {@link Mesh} which contains the part to render **/
-	public Mesh mesh;
-	/** The offset in the {@link #mesh} to the part to render. If the mesh is indexed ({@link Mesh#getNumIndices()} > 0), this is
-	 * the offset in the indices array, otherwise it is the offset in the vertices array. **/
-	public int meshPartOffset;
-	/** The size (in total number of vertices) of the part in the {@link #mesh} to render. When the mesh is indexed (
-	 * {@link Mesh#getNumIndices()} > 0), this is the number of indices, otherwise it is the number of vertices. **/
-	public int meshPartSize;
-	/** The primitive type, OpenGL constant e.g: {@link GL20#GL_TRIANGLES}, {@link GL20#GL_POINTS}, {@link GL20#GL_LINES},
-	 * {@link GL20#GL_LINE_STRIP}, {@link GL20#GL_TRIANGLE_STRIP} **/
-	public int primitiveType;
+	/** The {@link MeshPart} that contains the shape to render **/
+	public final MeshPart meshPart = new MeshPart();
 	/** The {@link Material} to be applied to the shape (part of the mesh), must not be null.
 	 * @see #environment **/
 	public Material material;
@@ -101,10 +92,7 @@ public class Renderable {
 	public Renderable set(Renderable renderable) {
 		worldTransform.set(renderable.worldTransform);
 		material = renderable.material;
-		mesh = renderable.mesh;
-		meshPartOffset = renderable.meshPartOffset;
-		meshPartSize = renderable.meshPartSize;
-		primitiveType = renderable.primitiveType;
+		meshPart.set(renderable.meshPart);
 		bones = renderable.bones;
 		environment = renderable.environment;
 		shader = renderable.shader;

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/model/MeshPart.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/model/MeshPart.java
@@ -18,7 +18,9 @@ package com.badlogic.gdx.graphics.g3d.model;
 
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Mesh;
+import com.badlogic.gdx.graphics.VertexAttributes;
 import com.badlogic.gdx.graphics.g3d.Model;
+import com.badlogic.gdx.graphics.glutils.ShaderProgram;
 
 /** A MeshPart is composed of a subset of vertices of a {@link Mesh}, along with the primitive type. The vertices subset is
  * described by an offset and size. When the mesh is indexed (which is when {@link Mesh#getNumIndices()} > 0), then the
@@ -63,19 +65,33 @@ public class MeshPart {
 	 * @param size The size (in total number of vertices) of the part.
 	 * @param type The primitive type of the part (e.g. GL_TRIANGLES, GL_LINE_STRIP, etc.). */
 	public MeshPart (final String id, final Mesh mesh, final int offset, final int size, final int type) {
+		set(id, mesh, offset, size, type);
+	}
+
+	/** Construct a new MeshPart which is an exact copy of the provided MeshPart.
+	 * @param copyFrom The MeshPart to copy. */
+	public MeshPart (final MeshPart copyFrom) {
+		set(copyFrom);
+	}
+
+	/** Set this MeshPart to be a copy of the other MeshPart 
+	 * @param other The MeshPart from which to copy the values */
+	public void set (final MeshPart other) {
+		this.id = other.id;
+		this.mesh = other.mesh;
+		this.indexOffset = other.indexOffset;
+		this.numVertices = other.numVertices;
+		this.primitiveType = other.primitiveType;
+	}
+	
+	public void set (final String id, final Mesh mesh, final int offset, final int size, final int type) {
 		this.id = id;
 		this.mesh = mesh;
 		this.indexOffset = offset;
 		this.numVertices = size;
 		this.primitiveType = type;
 	}
-
-	/** Construct a new MeshPart which is an exact copy of the provided MeshPart.
-	 * @param copyFrom The MeshPart to copy. */
-	public MeshPart (final MeshPart copyFrom) {
-		this(copyFrom.id, copyFrom.mesh, copyFrom.indexOffset, copyFrom.numVertices, copyFrom.primitiveType);
-	}
-
+	
 	/** Compares this MeshPart to the specified MeshPart and returns true if they both reference the same {@link Mesh} and the
 	 * {@link #indexOffset}, {@link #numVertices} and {@link #primitiveType} members are equal. The {@link #id} member is ignored.
 	 * @param other The other MeshPart to compare this MeshPart to.
@@ -91,5 +107,20 @@ public class MeshPart {
 		if (arg0 == this) return true;
 		if (!(arg0 instanceof MeshPart)) return false;
 		return equals((MeshPart)arg0);
+	}
+
+	/** Renders the mesh part using the specified shader, must be called in between {@link ShaderProgram#begin()} and
+	 * {@link ShaderProgram#end()}.
+	 * @param shader the shader to be used
+	 * @param autoBind overrides the autoBind member of the Mesh */
+	public void render (ShaderProgram shader, boolean autoBind) {
+		mesh.render(shader, primitiveType, indexOffset, numVertices, autoBind);
+	}
+	
+	/** Renders the mesh part using the specified shader, must be called in between {@link ShaderProgram#begin()} and
+	 * {@link ShaderProgram#end()}.
+	 * @param shader the shader to be used */
+	public void render (ShaderProgram shader) {
+		mesh.render(shader, primitiveType, indexOffset, numVertices);
 	}
 }

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/model/Node.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/model/Node.java
@@ -127,9 +127,9 @@ public class Node {
 			if (part.enabled) {
 				final MeshPart meshPart = part.meshPart;
 				if (transform)
-					meshPart.mesh.extendBoundingBox(out, meshPart.indexOffset, meshPart.numVertices, globalTransform);
+					meshPart.mesh.extendBoundingBox(out, meshPart.offset, meshPart.size, globalTransform);
 				else
-					meshPart.mesh.extendBoundingBox(out, meshPart.indexOffset, meshPart.numVertices);
+					meshPart.mesh.extendBoundingBox(out, meshPart.offset, meshPart.size);
 			}
 		}
 		final int childCount = children.size;

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/model/NodePart.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/model/NodePart.java
@@ -62,10 +62,7 @@ public class NodePart {
 	 * @param out The Renderable of which to set the members to the values of this NodePart. */
 	public Renderable setRenderable (final Renderable out) {
 		out.material = material;
-		out.mesh = meshPart.mesh;
-		out.meshPartOffset = meshPart.indexOffset;
-		out.meshPartSize = meshPart.numVertices;
-		out.primitiveType = meshPart.primitiveType;
+		out.meshPart.set(meshPart);
 		out.bones = bones;
 		return out;
 	}

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/particles/ParticleShader.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/particles/ParticleShader.java
@@ -179,7 +179,7 @@ public class ParticleShader extends BaseShader {
 		this.program = shaderProgram;
 		this.renderable = renderable;
 		materialMask = renderable.material.getMask() | optionalAttributes;
-		vertexMask = renderable.mesh.getVertexAttributes().getMask();
+		vertexMask = renderable.meshPart.mesh.getVertexAttributes().getMask();
 
 		if (!config.ignoreUnimplemented && (implementedFlags & materialMask) != materialMask)
 			throw new GdxRuntimeException("Some attributes not implemented yet ("+materialMask+")");
@@ -227,7 +227,7 @@ public class ParticleShader extends BaseShader {
 	@Override
 	public boolean canRender(final Renderable renderable) {
 		return (materialMask == (renderable.material.getMask() | optionalAttributes)) && 
-			(vertexMask == renderable.mesh.getVertexAttributes().getMask());
+			(vertexMask == renderable.meshPart.mesh.getVertexAttributes().getMask());
 	}
 	
 	@Override

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/particles/batches/BillboardParticleBatch.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/particles/batches/BillboardParticleBatch.java
@@ -164,7 +164,7 @@ public class BillboardParticleBatch extends BufferedParticleBatch<BillboardContr
 	protected Renderable allocRenderable(){
 		Renderable renderable = new Renderable();
 		renderable.meshPart.primitiveType = GL20.GL_TRIANGLES;
-		renderable.meshPart.indexOffset = 0;
+		renderable.meshPart.offset = 0;
 		renderable.material = new Material(this.blendingAttribute, this.depthTestAttribute,
 			TextureAttribute.createDiffuse(texture));
 		renderable.meshPart.mesh = new Mesh(false, MAX_VERTICES_PER_MESH, MAX_PARTICLES_PER_MESH*6, currentAttributes);
@@ -675,7 +675,7 @@ public class BillboardParticleBatch extends BufferedParticleBatch<BillboardContr
 		for(int v = 0; v < vCount; v += addedVertexCount){
 			addedVertexCount = Math.min(vCount-v, MAX_VERTICES_PER_MESH);
 			Renderable renderable = renderablePool.obtain();
-			renderable.meshPart.numVertices = (addedVertexCount/4)*6;
+			renderable.meshPart.size = (addedVertexCount/4)*6;
 			renderable.meshPart.mesh.setVertices(vertices, currentVertexSize *v, currentVertexSize * addedVertexCount);
 			renderable.meshPart.update();
 			renderables.add(renderable);

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/particles/batches/BillboardParticleBatch.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/particles/batches/BillboardParticleBatch.java
@@ -163,12 +163,12 @@ public class BillboardParticleBatch extends BufferedParticleBatch<BillboardContr
 
 	protected Renderable allocRenderable(){
 		Renderable renderable = new Renderable();
-		renderable.primitiveType = GL20.GL_TRIANGLES;
-		renderable.meshPartOffset = 0;
+		renderable.meshPart.primitiveType = GL20.GL_TRIANGLES;
+		renderable.meshPart.indexOffset = 0;
 		renderable.material = new Material(this.blendingAttribute, this.depthTestAttribute,
 			TextureAttribute.createDiffuse(texture));
-		renderable.mesh = new Mesh(false, MAX_VERTICES_PER_MESH, MAX_PARTICLES_PER_MESH*6, currentAttributes);
-		renderable.mesh.setIndices(indices);
+		renderable.meshPart.mesh = new Mesh(false, MAX_VERTICES_PER_MESH, MAX_PARTICLES_PER_MESH*6, currentAttributes);
+		renderable.meshPart.mesh.setIndices(indices);
 		renderable.shader = shader;
 		return renderable;
 	}
@@ -213,7 +213,7 @@ public class BillboardParticleBatch extends BufferedParticleBatch<BillboardContr
 		renderablePool.freeAll(renderables);
 		for(int i=0, free = renderablePool.getFree(); i < free; ++i){
 			Renderable renderable = renderablePool.obtain();
-			renderable.mesh.dispose();
+			renderable.meshPart.mesh.dispose();
 		}
 		renderables.clear();
 	}
@@ -675,8 +675,8 @@ public class BillboardParticleBatch extends BufferedParticleBatch<BillboardContr
 		for(int v = 0; v < vCount; v += addedVertexCount){
 			addedVertexCount = Math.min(vCount-v, MAX_VERTICES_PER_MESH);
 			Renderable renderable = renderablePool.obtain();
-			renderable.meshPartSize = (addedVertexCount/4)*6;
-			renderable.mesh.setVertices(vertices, currentVertexSize *v, currentVertexSize * addedVertexCount);
+			renderable.meshPart.numVertices = (addedVertexCount/4)*6;
+			renderable.meshPart.mesh.setVertices(vertices, currentVertexSize *v, currentVertexSize * addedVertexCount);
 			renderables.add(renderable);
 		}
 	}

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/particles/batches/BillboardParticleBatch.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/particles/batches/BillboardParticleBatch.java
@@ -677,6 +677,7 @@ public class BillboardParticleBatch extends BufferedParticleBatch<BillboardContr
 			Renderable renderable = renderablePool.obtain();
 			renderable.meshPart.numVertices = (addedVertexCount/4)*6;
 			renderable.meshPart.mesh.setVertices(vertices, currentVertexSize *v, currentVertexSize * addedVertexCount);
+			renderable.meshPart.update();
 			renderables.add(renderable);
 		}
 	}

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/particles/batches/PointSpriteParticleBatch.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/particles/batches/PointSpriteParticleBatch.java
@@ -73,15 +73,15 @@ public class PointSpriteParticleBatch extends BufferedParticleBatch<PointSpriteC
 	@Override
 	protected void allocParticlesData(int capacity){
 		vertices = new float[capacity * CPU_VERTEX_SIZE];
-		if(renderable.mesh != null) 
-			renderable.mesh.dispose();
-		renderable.mesh = new Mesh(false, capacity, 0, CPU_ATTRIBUTES);
+		if(renderable.meshPart.mesh != null) 
+			renderable.meshPart.mesh.dispose();
+		renderable.meshPart.mesh = new Mesh(false, capacity, 0, CPU_ATTRIBUTES);
 	}
 	
 	protected void allocRenderable(){
 		renderable = new Renderable();
-		renderable.primitiveType = GL20.GL_POINTS;
-		renderable.meshPartOffset = 0;
+		renderable.meshPart.primitiveType = GL20.GL_POINTS;
+		renderable.meshPart.indexOffset = 0;
 		renderable.material = new Material(	new BlendingAttribute(GL20.GL_ONE, GL20.GL_ONE_MINUS_SRC_ALPHA, 1f),
 			new DepthTestAttribute(GL20.GL_LEQUAL, false),
 			TextureAttribute.createDiffuse((Texture)null));
@@ -131,8 +131,8 @@ public class PointSpriteParticleBatch extends BufferedParticleBatch<PointSpriteC
 			}
 		}
 
-		renderable.meshPartSize = bufferedParticlesCount;
-		renderable.mesh.setVertices(vertices, 0, bufferedParticlesCount*CPU_VERTEX_SIZE);
+		renderable.meshPart.numVertices = bufferedParticlesCount;
+		renderable.meshPart.mesh.setVertices(vertices, 0, bufferedParticlesCount*CPU_VERTEX_SIZE);
 	}
 
 	@Override

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/particles/batches/PointSpriteParticleBatch.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/particles/batches/PointSpriteParticleBatch.java
@@ -81,7 +81,7 @@ public class PointSpriteParticleBatch extends BufferedParticleBatch<PointSpriteC
 	protected void allocRenderable(){
 		renderable = new Renderable();
 		renderable.meshPart.primitiveType = GL20.GL_POINTS;
-		renderable.meshPart.indexOffset = 0;
+		renderable.meshPart.offset = 0;
 		renderable.material = new Material(	new BlendingAttribute(GL20.GL_ONE, GL20.GL_ONE_MINUS_SRC_ALPHA, 1f),
 			new DepthTestAttribute(GL20.GL_LEQUAL, false),
 			TextureAttribute.createDiffuse((Texture)null));
@@ -131,7 +131,7 @@ public class PointSpriteParticleBatch extends BufferedParticleBatch<PointSpriteC
 			}
 		}
 
-		renderable.meshPart.numVertices = bufferedParticlesCount;
+		renderable.meshPart.size = bufferedParticlesCount;
 		renderable.meshPart.mesh.setVertices(vertices, 0, bufferedParticlesCount*CPU_VERTEX_SIZE);
 		renderable.meshPart.update();
 	}

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/particles/batches/PointSpriteParticleBatch.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/particles/batches/PointSpriteParticleBatch.java
@@ -133,6 +133,7 @@ public class PointSpriteParticleBatch extends BufferedParticleBatch<PointSpriteC
 
 		renderable.meshPart.numVertices = bufferedParticlesCount;
 		renderable.meshPart.mesh.setVertices(vertices, 0, bufferedParticlesCount*CPU_VERTEX_SIZE);
+		renderable.meshPart.update();
 	}
 
 	@Override

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/BaseShader.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/BaseShader.java
@@ -190,7 +190,7 @@ public abstract class BaseShader implements Shader {
 			}
 		}
 		if (renderable != null) {
-			final VertexAttributes attrs = renderable.mesh.getVertexAttributes();
+			final VertexAttributes attrs = renderable.meshPart.mesh.getVertexAttributes();
 			final int c = attrs.size();
 			for (int i = 0; i < c; i++) {
 				final VertexAttribute attr = attrs.get(i);
@@ -235,12 +235,12 @@ public abstract class BaseShader implements Shader {
 	public void render (Renderable renderable, final Attributes combinedAttributes) {
 		for (int u, i = 0; i < localUniforms.size; ++i)
 			if (setters.get(u = localUniforms.get(i)) != null) setters.get(u).set(this, u, renderable, combinedAttributes);
-		if (currentMesh != renderable.mesh) {
+		if (currentMesh != renderable.meshPart.mesh) {
 			if (currentMesh != null) currentMesh.unbind(program, tempArray.items);
-			currentMesh = renderable.mesh;
-			currentMesh.bind(program, getAttributeLocations(renderable.mesh.getVertexAttributes()));
+			currentMesh = renderable.meshPart.mesh;
+			currentMesh.bind(program, getAttributeLocations(renderable.meshPart.mesh.getVertexAttributes()));
 		}
-		renderable.mesh.render(program, renderable.primitiveType, renderable.meshPartOffset, renderable.meshPartSize, false);
+		renderable.meshPart.render(program, false);
 	}
 
 	@Override

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/DefaultShader.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/DefaultShader.java
@@ -523,7 +523,7 @@ public class DefaultShader extends BaseShader {
 		this.shadowMap = lighting && renderable.environment.shadowMap != null;
 		this.renderable = renderable;
 		attributesMask = attributes.getMask() | optionalAttributes;
-		vertexMask = renderable.mesh.getVertexAttributes().getMask();
+		vertexMask = renderable.meshPart.mesh.getVertexAttributes().getMask();
 
 		this.directionalLights = new DirectionalLight[lighting && config.numDirectionalLights > 0 ? config.numDirectionalLights : 0];
 		for (int i = 0; i < directionalLights.length; i++)
@@ -632,7 +632,7 @@ public class DefaultShader extends BaseShader {
 		final Attributes attributes = combineAttributes(renderable);
 		String prefix = "";
 		final long attributesMask = attributes.getMask();
-		final long vertexMask = renderable.mesh.getVertexAttributes().getMask();
+		final long vertexMask = renderable.meshPart.mesh.getVertexAttributes().getMask();
 		if (and(vertexMask, Usage.Position)) prefix += "#define positionFlag\n";
 		if (or(vertexMask, Usage.ColorUnpacked | Usage.ColorPacked)) prefix += "#define colorFlag\n";
 		if (and(vertexMask, Usage.BiNormal)) prefix += "#define binormalFlag\n";
@@ -652,9 +652,9 @@ public class DefaultShader extends BaseShader {
 				if (attributes.has(CubemapAttribute.EnvironmentMap)) prefix += "#define environmentCubemapFlag\n";
 			}
 		}
-		final int n = renderable.mesh.getVertexAttributes().size();
+		final int n = renderable.meshPart.mesh.getVertexAttributes().size();
 		for (int i = 0; i < n; i++) {
-			final VertexAttribute attr = renderable.mesh.getVertexAttributes().get(i);
+			final VertexAttribute attr = renderable.meshPart.mesh.getVertexAttributes().get(i);
 			if (attr.usage == Usage.BoneWeight)
 				prefix += "#define boneWeight" + attr.unit + "Flag\n";
 			else if (attr.usage == Usage.TextureCoordinates) prefix += "#define texCoord" + attr.unit + "Flag\n";
@@ -705,7 +705,7 @@ public class DefaultShader extends BaseShader {
 	public boolean canRender (final Renderable renderable) {
 		final Attributes attributes = combineAttributes(renderable);
 		return (attributesMask == (attributes.getMask() | optionalAttributes))
-			&& (vertexMask == renderable.mesh.getVertexAttributes().getMask()) && (renderable.environment != null) == lighting;
+			&& (vertexMask == renderable.meshPart.mesh.getVertexAttributes().getMask()) && (renderable.environment != null) == lighting;
 	}
 
 	@Override

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/DepthShader.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/DepthShader.java
@@ -93,9 +93,9 @@ public class DepthShader extends DefaultShader {
 		final Attributes attributes = combineAttributes(renderable);
 		this.numBones = renderable.bones == null ? 0 : config.numBones;
 		int w = 0;
-		final int n = renderable.mesh.getVertexAttributes().size();
+		final int n = renderable.meshPart.mesh.getVertexAttributes().size();
 		for (int i = 0; i < n; i++) {
-			final VertexAttribute attr = renderable.mesh.getVertexAttributes().get(i);
+			final VertexAttribute attr = renderable.meshPart.mesh.getVertexAttributes().get(i);
 			if (attr.usage == Usage.BoneWeight) w |= (1 << attr.unit);
 		}
 		weights = w;
@@ -124,13 +124,13 @@ public class DepthShader extends DefaultShader {
 			if (attributes.has(TextureAttribute.Diffuse) != ((attributesMask & TextureAttribute.Diffuse) == TextureAttribute.Diffuse))
 				return false;
 		}
-		final boolean skinned = ((renderable.mesh.getVertexAttributes().getMask() & Usage.BoneWeight) == Usage.BoneWeight);
+		final boolean skinned = ((renderable.meshPart.mesh.getVertexAttributes().getMask() & Usage.BoneWeight) == Usage.BoneWeight);
 		if (skinned != (numBones > 0)) return false;
 		if (!skinned) return true;
 		int w = 0;
-		final int n = renderable.mesh.getVertexAttributes().size();
+		final int n = renderable.meshPart.mesh.getVertexAttributes().size();
 		for (int i = 0; i < n; i++) {
-			final VertexAttribute attr = renderable.mesh.getVertexAttributes().get(i);
+			final VertexAttribute attr = renderable.meshPart.mesh.getVertexAttributes().get(i);
 			if (attr.usage == Usage.BoneWeight) w |= (1 << attr.unit);
 		}
 		return w == weights;

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/utils/MeshBuilder.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/utils/MeshBuilder.java
@@ -192,8 +192,8 @@ public class MeshBuilder implements MeshPartBuilder {
 			bounds.getDimensions(part.halfExtents).scl(0.5f);
 			part.radius = part.halfExtents.len();
 			bounds.inf();
-			part.indexOffset = istart;
-			part.numVertices = indices.size - istart;
+			part.offset = istart;
+			part.size = indices.size - istart;
 			istart = indices.size;
 			part = null;
 		}
@@ -1291,7 +1291,7 @@ public class MeshBuilder implements MeshPartBuilder {
 	@Override
 	public void addMesh (MeshPart meshpart) {
 		if (meshpart.primitiveType != primitiveType) throw new GdxRuntimeException("Primitive type doesn't match");
-		addMesh(meshpart.mesh, meshpart.indexOffset, meshpart.numVertices);
+		addMesh(meshpart.mesh, meshpart.offset, meshpart.size);
 	}
 
 	@Override

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/utils/MeshBuilder.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/utils/MeshBuilder.java
@@ -30,6 +30,7 @@ import com.badlogic.gdx.math.Matrix3;
 import com.badlogic.gdx.math.Matrix4;
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.math.Vector3;
+import com.badlogic.gdx.math.collision.BoundingBox;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.FloatArray;
 import com.badlogic.gdx.utils.GdxRuntimeException;
@@ -112,6 +113,7 @@ public class MeshBuilder implements MeshPartBuilder {
 	private boolean vertexTransformationEnabled = false;
 	private final Matrix4 positionTransform = new Matrix4();
 	private final Matrix3 normalTransform = new Matrix3();
+	private final BoundingBox bounds = new BoundingBox();
 
 	/** @param usage bitwise mask of the {@link com.badlogic.gdx.graphics.VertexAttributes.Usage}, only Position, Color, Normal and
 	 *           TextureCoordinates is supported. */
@@ -181,10 +183,15 @@ public class MeshBuilder implements MeshPartBuilder {
 		setVertexTransform(null);
 		setUVRange(null);
 		this.primitiveType = primitiveType;
+		bounds.inf();
 	}
 
 	private void endpart () {
 		if (part != null) {
+			bounds.getCenter(part.center);
+			bounds.getDimensions(part.halfExtents).scl(0.5f);
+			part.radius = part.halfExtents.len();
+			bounds.inf();
 			part.indexOffset = istart;
 			part.numVertices = indices.size - istart;
 			istart = indices.size;
@@ -553,6 +560,11 @@ public class MeshBuilder implements MeshPartBuilder {
 			transformPosition(vertices.items, o + posOffset, posSize, positionTransform);
 			if (norOffset >= 0) transformNormal(vertices.items, o + norOffset, 3, normalTransform);
 		}
+		
+		final float x = vertices.items[o+posOffset];
+		final float y = (posSize > 1) ? vertices.items[o+posOffset+1] : 0f;
+		final float z = (posSize > 2) ? vertices.items[o+posOffset+2] : 0f;
+		bounds.ext(x, y, z);
 
 		if (hasColor) {
 			if (colOffset >= 0) {

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/utils/ModelBuilder.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/utils/ModelBuilder.java
@@ -144,8 +144,8 @@ public class ModelBuilder {
 		meshPart.id = id;
 		meshPart.primitiveType = primitiveType;
 		meshPart.mesh = mesh;
-		meshPart.indexOffset = offset;
-		meshPart.numVertices = size;
+		meshPart.offset = offset;
+		meshPart.size = size;
 		part(meshPart, material);
 		return meshPart;
 	}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/SoftMeshTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/SoftMeshTest.java
@@ -77,13 +77,13 @@ public class SoftMeshTest extends BaseBulletTest {
 
 		meshPart.mesh.scale(6, 6, 6);
 
-		indexMap = BufferUtils.newShortBuffer(meshPart.numVertices);
+		indexMap = BufferUtils.newShortBuffer(meshPart.size);
 
 		positionOffset = meshPart.mesh.getVertexAttribute(Usage.Position).offset;
 		normalOffset = meshPart.mesh.getVertexAttribute(Usage.Normal).offset;
 
 		softBody = new btSoftBody(worldInfo, meshPart.mesh.getVerticesBuffer(), meshPart.mesh.getVertexSize(), positionOffset,
-			normalOffset, meshPart.mesh.getIndicesBuffer(), meshPart.indexOffset, meshPart.numVertices, indexMap, 0);
+			normalOffset, meshPart.mesh.getIndicesBuffer(), meshPart.offset, meshPart.size, indexMap, 0);
 		// Set mass of the first vertex to zero so its unmovable, comment out this line to make it a fully dynamic body.
 		softBody.setMass(0, 0);
 		com.badlogic.gdx.physics.bullet.softbody.btSoftBody.Material pm = softBody.appendMaterial();
@@ -121,7 +121,7 @@ public class SoftMeshTest extends BaseBulletTest {
 		if (world.renderMeshes) {
 			MeshPart meshPart = model.nodes.get(0).parts.get(0).meshPart;
 			softBody.getVertices(meshPart.mesh.getVerticesBuffer(), meshPart.mesh.getVertexSize(), positionOffset, normalOffset,
-				meshPart.mesh.getIndicesBuffer(), meshPart.indexOffset, meshPart.numVertices, indexMap, 0);
+				meshPart.mesh.getIndicesBuffer(), meshPart.offset, meshPart.size, indexMap, 0);
 			softBody.getWorldTransform(entity.transform);
 		}
 		super.render();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/HeightMapTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/HeightMapTest.java
@@ -57,8 +57,8 @@ public class HeightMapTest extends BaseG3dTest {
 		ground.environment = environment;
 		ground.meshPart.mesh = field.mesh;
 		ground.meshPart.primitiveType = GL20.GL_TRIANGLES;
-		ground.meshPart.indexOffset = 0;
-		ground.meshPart.numVertices = field.mesh.getNumIndices();
+		ground.meshPart.offset = 0;
+		ground.meshPart.size = field.mesh.getNumIndices();
 		ground.meshPart.update();
 		ground.material = new Material(TextureAttribute.createDiffuse(texture));
 	}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/HeightMapTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/HeightMapTest.java
@@ -55,14 +55,12 @@ public class HeightMapTest extends BaseG3dTest {
 
 		ground = new Renderable();
 		ground.environment = environment;
-		ground.mesh = field.mesh;
-		ground.primitiveType = GL20.GL_TRIANGLES;
-		ground.meshPartOffset = 0;
-		ground.meshPartSize = field.mesh.getNumIndices();
+		ground.meshPart.mesh = field.mesh;
+		ground.meshPart.primitiveType = GL20.GL_TRIANGLES;
+		ground.meshPart.indexOffset = 0;
+		ground.meshPart.numVertices = field.mesh.getNumIndices();
+		ground.meshPart.update();
 		ground.material = new Material(TextureAttribute.createDiffuse(texture));
-
-		BoundingBox bb = field.mesh.calculateBoundingBox();
-		Gdx.app.log("BB", bb.toString());
 	}
 
 	@Override

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/ModelCache.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/ModelCache.java
@@ -198,8 +198,8 @@ public class ModelCache implements Disposable, RenderableProvider {
 		result.environment = null;
 		result.material = material;
 		result.meshPart.mesh = null;
-		result.meshPart.indexOffset = 0;
-		result.meshPart.numVertices = 0;
+		result.meshPart.offset = 0;
+		result.meshPart.size = 0;
 		result.meshPart.primitiveType = primitiveType;
 		result.meshPart.center.set(0, 0, 0);
 		result.meshPart.halfExtents.set(0, 0, 0);
@@ -240,7 +240,7 @@ public class ModelCache implements Disposable, RenderableProvider {
 			final int pt = renderable.meshPart.primitiveType;
 
 			final boolean sameMesh = va.equals(vertexAttributes)
-				&& renderable.meshPart.numVertices + meshBuilder.getNumVertices() < Short.MAX_VALUE; // comparing indices and vertices...
+				&& renderable.meshPart.size + meshBuilder.getNumVertices() < Short.MAX_VALUE; // comparing indices and vertices...
 			final boolean samePart = sameMesh && pt == primitiveType && mat.same(material, true);
 
 			if (!samePart) {
@@ -254,15 +254,15 @@ public class ModelCache implements Disposable, RenderableProvider {
 
 				final MeshPart newPart = meshBuilder.part("", pt, meshPartPool.obtain());
 				final Renderable previous = renderables.get(renderables.size - 1);
-				previous.meshPart.indexOffset = part.indexOffset;
-				previous.meshPart.numVertices = part.numVertices;
+				previous.meshPart.offset = part.offset;
+				previous.meshPart.size = part.size;
 				part = newPart;
 
 				renderables.add(obtainRenderable(material = mat, primitiveType = pt));
 			}
 
 			meshBuilder.setVertexTransform(renderable.worldTransform);
-			meshBuilder.addMesh(renderable.meshPart.mesh, renderable.meshPart.indexOffset, renderable.meshPart.numVertices);
+			meshBuilder.addMesh(renderable.meshPart.mesh, renderable.meshPart.offset, renderable.meshPart.size);
 		}
 
 		final Mesh mesh = meshBuilder.end(meshPool.obtain(vertexAttributes, meshBuilder.getNumVertices(),
@@ -271,8 +271,8 @@ public class ModelCache implements Disposable, RenderableProvider {
 			renderables.get(offset++).meshPart.mesh = mesh;
 
 		final Renderable previous = renderables.get(renderables.size - 1);
-		previous.meshPart.indexOffset = part.indexOffset;
-		previous.meshPart.numVertices = part.numVertices;
+		previous.meshPart.offset = part.offset;
+		previous.meshPart.size = part.size;
 	}
 
 	/** Adds the specified {@link Renderable} to the cache. Must be called in between a call to {@link #begin()} and {@link #end()}.

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/ShaderTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/ShaderTest.java
@@ -169,7 +169,7 @@ public class ShaderTest extends GdxTest {
 				set(u_color, colorAttr.color);
 			}
 
-			renderable.mesh.render(program, renderable.primitiveType, renderable.meshPartOffset, renderable.meshPartSize);
+			renderable.meshPart.render(program);
 		}
 
 		@Override

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/shaders/MultiPassShader.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/shaders/MultiPassShader.java
@@ -38,7 +38,7 @@ public class MultiPassShader extends DefaultShader {
 			context.setBlending(true, GL20.GL_SRC_ALPHA, GL20.GL_ONE_MINUS_SRC_ALPHA);
 			for (int i = 1; i < passes; ++i) {
 				set(u_pass, (float)i / (float)passes);
-				renderable.mesh.render(program, renderable.primitiveType, renderable.meshPartOffset, renderable.meshPartSize, false);
+				renderable.meshPart.render(program, false);
 			}
 		}
 	}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/voxel/VoxelWorld.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/voxel/VoxelWorld.java
@@ -193,10 +193,10 @@ public class VoxelWorld implements RenderableProvider {
 			if (numVertices[i] == 0) continue;
 			Renderable renderable = pool.obtain();
 			renderable.material = materials[i];
-			renderable.mesh = mesh;
-			renderable.meshPartOffset = 0;
-			renderable.meshPartSize = numVertices[i];
-			renderable.primitiveType = GL20.GL_TRIANGLES;
+			renderable.meshPart.mesh = mesh;
+			renderable.meshPart.indexOffset = 0;
+			renderable.meshPart.numVertices = numVertices[i];
+			renderable.meshPart.primitiveType = GL20.GL_TRIANGLES;
 			renderables.add(renderable);
 			renderedChunks++;
 		}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/voxel/VoxelWorld.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/voxel/VoxelWorld.java
@@ -194,8 +194,8 @@ public class VoxelWorld implements RenderableProvider {
 			Renderable renderable = pool.obtain();
 			renderable.material = materials[i];
 			renderable.meshPart.mesh = mesh;
-			renderable.meshPart.indexOffset = 0;
-			renderable.meshPart.numVertices = numVertices[i];
+			renderable.meshPart.offset = 0;
+			renderable.meshPart.size = numVertices[i];
 			renderable.meshPart.primitiveType = GL20.GL_TRIANGLES;
 			renderables.add(renderable);
 			renderedChunks++;


### PR DESCRIPTION
**This is an API breaking change**
* Removes the `mesh`, `meshPartOffset`, `meshPartSize` and `primitiveType` members of `Renderable` and adds the `meshPart` member instead. 
* Adds the `center`, `halfExtents` and `radius` members to `MeshPart`.
* Rename `MeshPart#indexOffset` to `MeshPart#offset` and `MeshPart#numVertices` to `MeshPart#size`.

The bounds are (and should be) calculated as soon as possible and not more than needed. In case of `Model` this is when the model is loaded from file or created using `ModelBuilder`. Custom implementation that create `MeshPart` instances should be updated accordingly.

Calculating the bounds of the entire `Model`/`ModelInstance` is not affected by these values. That is still a costly operation that takes into account the node transformation.

The naming (`indexOffset` and `numVertices`) always have been confusing and the actual meaning depends on whether the mesh is indexed or not. Since this is already API breaking change, I thought this would be a good moment to change those names as well. The `offset` is the offset in the mesh to the start of the part and `size` is the size of the part.

*Custom shader changes:*
`MeshPart` now contains a convenience method to easily render the part:
```java
renderable.meshPart.render(program);
```

For more info about the reason for these changes, see also #3474