### PR TITLE
Fix SwingLwjglTest crash.

### DIFF
--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglAWTCanvas.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglAWTCanvas.java
@@ -211,7 +211,7 @@ public class LwjglAWTCanvas implements Application {
 	void create () {
 		try {
 			setGlobals();
-			graphics.initiateGLInstances();
+			graphics.initiateGL();
 			listener.create();
 			lastWidth = Math.max(1, graphics.getWidth());
 			lastHeight = Math.max(1, graphics.getHeight());

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGraphics.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGraphics.java
@@ -177,6 +177,13 @@ public class LwjglGraphics implements Graphics {
 
 		Display.setLocation(config.x, config.y);
 		createDisplayPixelFormat(config.useGL30, config.gles30ContextMajorVersion, config.gles30ContextMinorVersion);
+		initiateGL();
+	}
+	
+	/**
+	 * Only needed when setupDisplay() is not called.
+	 */
+	void initiateGL() {
 		extractVersion();
 		extractExtensions();
 		initiateGLInstances();


### PR DESCRIPTION
There are a few new steps in initializing LwjglGraphics that were not carried over to LwjglAWTCanvas.

As a result, SwingLwjglTest currently crashes in the tip of tree.

This patch fixes that.