### PR TITLE
fix misuse of glDeleteBuffer for glDeleteRenderBuffer in dispose

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/glutils/GLFrameBuffer.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/GLFrameBuffer.java
@@ -238,7 +238,7 @@ public abstract class GLFrameBuffer<T extends GLTexture> implements Disposable {
 		disposeColorTexture(colorTexture);
 
 		if (hasDepthStencilPackedBuffer) {
-			gl.glDeleteBuffer(depthStencilPackedBufferHandle);
+			gl.glDeleteRenderbuffer(depthStencilPackedBufferHandle);
 		} else {
 			if (hasDepth) gl.glDeleteRenderbuffer(depthbufferHandle);
 			if (hasStencil) gl.glDeleteRenderbuffer(stencilbufferHandle);


### PR DESCRIPTION
this error may cause some mistakes in rendering afterward