### PR TITLE
Add Queue collection

### DIFF
--- a/gdx/src/com/badlogic/gdx/utils/Queue.java
+++ b/gdx/src/com/badlogic/gdx/utils/Queue.java
@@ -65,13 +65,13 @@ public class Queue<T> {
 
 	/** Enqueue given object (append after tail). Unless backing array needs resizing, operates in O(1) time.
 	 * @param object can be null
-	 * @return true if added, false if full (can only happen when resizable is false) */
-	public boolean push (T object) {
+	 * @throws IllegalStateException when full and not resizable */
+	public void push (T object) {
 		T[] values = this.values;
 
 		if (size == values.length) {
 			if (!resizable) {
-				return false;
+				throw new IllegalStateException("Queue is full");
 			} else {
 				resize(values.length << 1);// *2
 				values = this.values;
@@ -83,19 +83,18 @@ public class Queue<T> {
 			tail = 0;
 		}
 		size++;
-		return true;
 	}
 
 	/** Add given object to the deque, prepending to head. Is very similar to {@link #push(Object)} but the object is added to the
 	 * other side. Can be thought of as jumping the queue.
 	 * @param object can be null
-	 * @return true if added, false if full (can only happen when resizable is false) */
-	public boolean pushFront (T object) {
+	 * @throws IllegalStateException when full and not resizable */
+	public void pushFront (T object) {
 		T[] values = this.values;
 
 		if (size == values.length) {
 			if (!resizable) {
-				return false;
+				throw new IllegalStateException("Deque is full");
 			} else {
 				resize(values.length << 1);// *2
 				values = this.values;
@@ -111,7 +110,6 @@ public class Queue<T> {
 
 		this.head = head;
 		this.size++;
-		return true;
 	}
 
 	/** Optionally resize backing array so adding `additional` amount of entries won't cause resize.
@@ -151,17 +149,8 @@ public class Queue<T> {
 	 * @throws NoSuchElementException when queue is empty */
 	public T pop () {
 		if (size == 0) {
-			throw new NoSuchElementException("Queue is empty");
-		}
-		return pop(null);
-	}
-
-	/** Dequeue next object in queue
-	 * @return next item in queue or `defaultValue` if empty */
-	public T pop (T defaultValue) {
-		if (size == 0) {
 			// Underflow
-			return defaultValue;
+			throw new NoSuchElementException("Queue is empty");
 		}
 
 		final T[] values = this.values;
@@ -225,6 +214,22 @@ public class Queue<T> {
 		return values[tail];
 	}
 
+	/** Retrieves the value in Queue without removing it. Indexing is from the front to back, zero based. Therefore get(0) is the
+	 * same as peek().
+	 * @throws NoSuchElementException when the index is negative or >= size */
+	public T get (int index) {
+		if (index < 0 || index >= size) {
+			throw new NoSuchElementException("Index " + index + " does not exist, size is " + size);
+		}
+		final T[] values = this.values;
+
+		int i = head + index;
+		if (i >= values.length) {
+			i -= values.length;
+		}
+		return values[i];
+	}
+
 	/** @return true if this queue can't hold any more values (always false when resizable) */
 	public boolean isFull () {
 		return !resizable && size == values.length;
@@ -264,14 +269,14 @@ public class Queue<T> {
 
 	public String toString () {
 		if (size == 0) {
-			return "Queue []";
+			return "[]";
 		}
 		final T[] values = this.values;
 		final int head = this.head;
 		final int tail = this.tail;
 
 		StringBuilder sb = new StringBuilder(64);
-		sb.append("Queue [");
+		sb.append('[');
 		sb.append(values[head]);
 		for (int i = (head + 1) % values.length; i != tail; i = (i + 1) % values.length) {
 			sb.append(", ").append(values[i]);

--- a/gdx/src/com/badlogic/gdx/utils/Queue.java
+++ b/gdx/src/com/badlogic/gdx/utils/Queue.java
@@ -261,4 +261,53 @@ public class Queue<T> {
 		sb.append(']');
 		return sb.toString();
 	}
+
+	public int hashCode () {
+		final int size = this.size;
+		final T[] values = this.values;
+		final int backingLength = values.length;
+		int index = this.head;
+
+		int hash = size + 1;
+		for (int s = 0; s < size; s++) {
+			final T value = values[index];
+
+			hash *= 31;
+			if (value != null) hash += value.hashCode();
+
+			index++;
+			if (index == backingLength) index = 0;
+		}
+
+		return hash;
+	}
+
+	public boolean equals (Object o) {
+		if (this == o) return true;
+		if (o == null || !(o instanceof Queue)) return false;
+
+		Queue<?> q = (Queue<?>)o;
+		final int size = this.size;
+
+		if (q.size != size) return false;
+
+		final T[] myValues = this.values;
+		final int myBackingLength = myValues.length;
+		final Object[] itsValues = q.values;
+		final int itsBackingLength = itsValues.length;
+
+		int myIndex = head;
+		int itsIndex = q.head;
+		for (int s = 0; s < size; s++) {
+			T myValue = myValues[myIndex];
+			Object itsValue = itsValues[itsIndex];
+
+			if (!(myValue == null ? itsValue == null : myValue.equals(itsValue))) return false;
+			myIndex++;
+			itsIndex++;
+			if (myIndex == myBackingLength) myIndex = 0;
+			if (itsIndex == itsBackingLength) itsIndex = 0;
+		}
+		return true;
+	}
 }

--- a/gdx/src/com/badlogic/gdx/utils/Queue.java
+++ b/gdx/src/com/badlogic/gdx/utils/Queue.java
@@ -1,0 +1,181 @@
+/*******************************************************************************
+ * Copyright 2015 See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogic.gdx.utils;
+
+import com.badlogic.gdx.utils.reflect.ArrayReflection;
+
+/** Automatically resizing FIFO queue.
+ * Values in backing queue rotate around so push and pop are O(1) (unless resizing in push).
+ * This collection is not thread-safe. */
+public class Queue <T> {
+
+    /** Contains values waiting in this queue.
+     * Pop and push indices go in circle around this array, wrapping at the end.
+     * For simplicity, one index (pointed at by pushIndex) is always kept empty.
+     * Therefore, values.length = 8 can only hold 7 queued values. */
+    protected T[] values;
+
+    /** Index to pop from. Logically smaller than pushIndex.
+     * Unless popIndex == pushIndex, it points to a valid element inside queue. */
+    protected int popIndex = 0;
+    /** Index to push to. Logically bigger than popIndex.
+     * Always points to an empty values position. */
+    protected int pushIndex = 0;
+
+    /** Create a new Queue which can hold 15 values without resizing. */
+    public Queue(){
+        this(16);
+    }
+
+    /** Create a new Queue which can hold `initialSize` values without resizing. */
+    public Queue(int initialSize) {
+        //noinspection unchecked
+        values = (T[]) new Object[initialSize + 1];
+    }
+
+    /** Create a new Queue which can hold `initialSize` values without resizing.
+     * This creates backing array of correct type via reflection.
+     * Use this only if you are accessing backing array directly.
+     * <p/>
+     * NOTE: Worth using only if you know what are you doing. */
+    public Queue(int initialSize, Class<T> type) {
+        //noinspection unchecked
+        values = (T[]) ArrayReflection.newInstance(type, initialSize + 1);
+    }
+
+    /** Enqueue given object.
+     * Unless backing array needs resizing, operates in O(1) time.
+     * @param object can be null
+     */
+    public void add(T object){
+        final T[] values = this.values;
+        int pushIndex = this.pushIndex;
+        final int popIndex = this.popIndex;
+
+        values[pushIndex] = object;
+        pushIndex++;
+        if(pushIndex == values.length){
+            pushIndex = 0;
+        }
+
+        if(pushIndex == popIndex){
+            //Must resize
+            final int newSize = values.length << 1;
+            //noinspection unchecked
+            final T[] newArray = (T[]) ArrayReflection.newInstance(values.getClass().getComponentType(), newSize);
+            final int currentSize = values.length;
+            for (int i = 0; i < currentSize; i++) {
+                newArray[i] = values[(popIndex + i) % currentSize];
+            }
+            this.popIndex = 0;
+            pushIndex = currentSize;
+
+            this.values = newArray;
+        }
+        this.pushIndex = pushIndex;
+    }
+
+    /** Dequeue next object in queue
+     * @return next object in queue or null if empty */
+    public T remove(){
+        return remove(null);
+    }
+
+    /** Dequeue next object in queue
+     * @return next object in queue or `defaultValue` if empty */
+    public T remove(T defaultValue){
+        final T[] values = this.values;
+        int popIndex = this.popIndex;
+
+        if(popIndex == pushIndex){
+            //Underflow
+            return defaultValue;
+        }
+        T result = values[popIndex];
+        values[popIndex] = null;
+
+        popIndex++;
+        if(popIndex == values.length){
+            popIndex = 0;
+        }
+        this.popIndex = popIndex;
+
+        return result;
+    }
+
+    /** Same as {@link Queue#remove()} but the value is kept in the queue. */
+    public T peek(){
+        return peek(null);
+    }
+
+    /** Same as {@link Queue#remove(T)} but the value is kept in the queue. */
+    public T peek(T defaultValue){
+        final int popIndex = this.popIndex;
+
+        if(popIndex == pushIndex){
+            //Underflow
+            return defaultValue;
+        }
+        return values[popIndex];
+    }
+
+    /** @return true if this queue holds no values to remove */
+    public boolean isEmpty(){
+        return popIndex == pushIndex;
+    }
+
+    /** @return amount of values waiting in this queue */
+    public int size(){
+        final int pushIndex = this.pushIndex;
+        final int popIndex = this.popIndex;
+
+        if(pushIndex == popIndex)return 0;
+        if(popIndex < pushIndex)return (pushIndex - popIndex);
+        return values.length - (popIndex - pushIndex);
+    }
+
+    /** Removes all values from this queue.
+     * (Values in backing array are set to null to prevent memory leak, so this operates in O(n).)*/
+    public void clear(){
+        final T[] values = this.values;
+        while(popIndex != pushIndex){
+            values[popIndex] = null;
+            popIndex++;
+            if(popIndex == values.length){
+                popIndex = 0;
+            }
+        }
+    }
+
+    public String toString(){
+        if(isEmpty()){
+            return "Queue []";
+        }
+        final T[] values = this.values;
+        final int popIndex = this.popIndex;
+        final int pushIndex = this.pushIndex;
+
+        StringBuilder sb = new StringBuilder(64);
+        sb.append("Queue [");
+        sb.append(values[popIndex]);
+        for (int i = popIndex+1; i != pushIndex; i = (i+1) % values.length) {
+            sb.append(", ").append(values[i]);
+        }
+        sb.append(']');
+        return sb.toString();
+    }
+}

--- a/gdx/src/com/badlogic/gdx/utils/Queue.java
+++ b/gdx/src/com/badlogic/gdx/utils/Queue.java
@@ -105,7 +105,7 @@ public class Queue<T> {
 		if (head < tail) {
 			// Continuous
 			System.arraycopy(values, head, newArray, 0, tail - head);
-		} else {
+		} else if (size > 0) {
 			// Wrapped
 			final int rest = values.length - head;
 			System.arraycopy(values, head, newArray, 0, rest);

--- a/gdx/test/com/badlogic/gdx/utils/QueueTest.java
+++ b/gdx/test/com/badlogic/gdx/utils/QueueTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 import java.util.NoSuchElementException;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -127,16 +128,51 @@ public class QueueTest {
 
 	@Test
 	public void toStringTest () {
-		{// Resizable
-			Queue<Integer> q = new Queue<Integer>(1);
-			assertTrue(q.toString().equals("[]"));
-			q.addLast(4);
-			assertTrue(q.toString().equals("[4]"));
-			q.addLast(5);
-			q.addLast(6);
-			q.addLast(7);
-			assertTrue(q.toString().equals("[4, 5, 6, 7]"));
+		Queue<Integer> q = new Queue<Integer>(1);
+		assertTrue(q.toString().equals("[]"));
+		q.addLast(4);
+		assertTrue(q.toString().equals("[4]"));
+		q.addLast(5);
+		q.addLast(6);
+		q.addLast(7);
+		assertTrue(q.toString().equals("[4, 5, 6, 7]"));
+	}
+
+	@Test
+	public void hashEqualsText () {
+		Queue<Integer> q1 = new Queue<Integer>();
+		Queue<Integer> q2 = new Queue<Integer>();
+
+		assertEqualsAndHash(q1, q2);
+		q1.addFirst(1);
+		assertNotEquals(q1, q2);
+		q2.addFirst(1);
+		assertEqualsAndHash(q1, q2);
+
+		q1.clear();
+		q1.addLast(1);
+		q1.addLast(2);
+		q2.addLast(2);
+		assertEqualsAndHash(q1, q2);
+
+		for (int i = 0; i < 100; i++) {
+			q1.addLast(i);
+			q1.addLast(i);
+			q1.removeFirst();
+
+			assertNotEquals(q1, q2);
+
+			q2.addLast(i);
+			q2.addLast(i);
+			q2.removeFirst();
+
+			assertEqualsAndHash(q1, q2);
 		}
+	}
+
+	private void assertEqualsAndHash (Queue<?> q1, Queue<?> q2) {
+		assertEquals(q1, q2);
+		assertEquals("Hash codes are not equal", q1.hashCode(), q2.hashCode());
 	}
 
 }

--- a/gdx/test/com/badlogic/gdx/utils/QueueTest.java
+++ b/gdx/test/com/badlogic/gdx/utils/QueueTest.java
@@ -1,0 +1,59 @@
+
+package com.badlogic.gdx.utils;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class QueueTest {
+
+	@Test
+	public void queueStressTest () {
+		Queue<Integer> q = new Queue<Integer>(8);
+
+		assertTrue("New queue is not empty!", q.isEmpty());
+
+		for (int i = 0; i < 100; i++) {
+
+			for (int j = 0; j < i; j++) {
+				q.add(j);
+				final int size = q.size();
+				assertTrue("Size should be " + (j + 1) + " but is " + size + " (" + i + ")", size == j + 1);
+			}
+
+			if (i != 0) {
+				final Integer peek = q.peek();
+				assertTrue("First thing is not zero but " + peek + " (" + i + ")", peek == 0);
+			}
+
+			for (int j = 0; j < i; j++) {
+				final Integer pop = q.remove();
+				assertTrue("Popped should be " + j + " but is " + pop + " (" + i + ")", pop == j);
+
+				final int size = q.size();
+				assertTrue("Size should be " + (i - 1 - j) + " but is " + size + " (" + i + ")", size == i - 1 - j);
+			}
+
+			assertTrue("Not empty after cycle " + i, q.isEmpty());
+		}
+
+		for (int i = 0; i < 56; i++) {
+			q.add(42);
+		}
+		q.clear();
+		assertTrue("Clear did not clear properly", q.isEmpty());
+	}
+
+    @Test
+    public void toStringTest(){
+        Queue<Integer> q = new Queue<Integer>();
+        assertTrue(q.toString().equals("Queue []"));
+        q.add(4);
+        assertTrue(q.toString().equals("Queue [4]"));
+        q.add(5);
+        q.add(6);
+        q.add(7);
+        assertTrue(q.toString().equals("Queue [4, 5, 6, 7]"));
+    }
+
+}

--- a/gdx/test/com/badlogic/gdx/utils/QueueTest.java
+++ b/gdx/test/com/badlogic/gdx/utils/QueueTest.java
@@ -8,15 +8,15 @@ import org.junit.Test;
 public class QueueTest {
 
 	@Test
-	public void queueStressTest () {
-		Queue<Integer> q = new Queue<Integer>(8);
+	public void resizableQueueTest () {
+		final Queue<Integer> q = new Queue<Integer>(8, true);
 
 		assertTrue("New queue is not empty!", q.isEmpty());
 
 		for (int i = 0; i < 100; i++) {
 
 			for (int j = 0; j < i; j++) {
-				q.add(j);
+				assertTrue("Failed to add element " + j + " (" + i + ")", q.add(j));
 				final int size = q.size();
 				assertTrue("Size should be " + (j + 1) + " but is " + size + " (" + i + ")", size == j + 1);
 			}
@@ -44,16 +44,48 @@ public class QueueTest {
 		assertTrue("Clear did not clear properly", q.isEmpty());
 	}
 
-    @Test
-    public void toStringTest(){
-        Queue<Integer> q = new Queue<Integer>();
-        assertTrue(q.toString().equals("Queue []"));
-        q.add(4);
-        assertTrue(q.toString().equals("Queue [4]"));
-        q.add(5);
-        q.add(6);
-        q.add(7);
-        assertTrue(q.toString().equals("Queue [4, 5, 6, 7]"));
-    }
+	@Test
+	public void nonResizableQueueTest () {
+		final Queue<Integer> q = new Queue<Integer>(5, false);
+		for (int i = 0; i < 5; i++) {
+			assertTrue("Failed to add element " + i, q.add(i));
+			assertTrue("Wrong size after " + i, q.size() == i + 1);
+		}
+		assertTrue("Not full when should be full", q.isFull());
+		for (int i = 5; i < 10; i++) {
+			assertFalse("Added element " + i, q.add(i));
+			assertTrue("Wrong size after " + i, q.size() == 5);
+			assertTrue("Not full when should be full (" + i + ")", q.isFull());
+		}
+
+		q.clear();
+		assertTrue("Wrong size after clear", q.size() == 0);
+		assertTrue("Not empty when should be empty", q.isEmpty());
+		assertFalse("Full when should be empty", q.isFull());
+	}
+
+	@Test
+	public void toStringTest () {
+		{// Resizable
+			Queue<Integer> q = new Queue<Integer>(1, true);
+			assertTrue(q.toString().equals("Queue []"));
+			q.add(4);
+			assertTrue(q.toString().equals("Queue [4]"));
+			q.add(5);
+			q.add(6);
+			q.add(7);
+			assertTrue(q.toString().equals("Queue [4, 5, 6, 7]"));
+		}
+
+		{// Non-resizable
+			Queue<Integer> nonResQ = new Queue<Integer>(4, false);
+			nonResQ.add(1);
+			nonResQ.add(2);
+			nonResQ.add(3);
+			nonResQ.add(4);
+			nonResQ.add(5);
+			assertTrue(nonResQ.toString().equals("Queue [1, 2, 3, 4]"));
+		}
+	}
 
 }

--- a/gdx/test/com/badlogic/gdx/utils/QueueTest.java
+++ b/gdx/test/com/badlogic/gdx/utils/QueueTest.java
@@ -5,143 +5,116 @@ import org.junit.Test;
 
 import java.util.NoSuchElementException;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class QueueTest {
 
 	@Test
 	public void resizableQueueTest () {
-		final Queue<Integer> q = new Queue<Integer>(8, true);
+		final Queue<Integer> q = new Queue<Integer>(8);
 
-		assertTrue("New queue is not empty!", q.size() == 0);
+		assertTrue("New queue is not empty!", q.size == 0);
 
 		for (int i = 0; i < 100; i++) {
 
 			for (int j = 0; j < i; j++) {
 				try {
-					q.push(j);
+					q.addLast(j);
 				} catch (IllegalStateException e) {
 					fail("Failed to add element " + j + " (" + i + ")");
 				}
-				final Integer peeked = q.peekLast();
+				final Integer peeked = q.last();
 				assertTrue("peekLast shows " + peeked + ", should be " + j + " (" + i + ")", peeked.equals(j));
-				final int size = q.size();
+				final int size = q.size;
 				assertTrue("Size should be " + (j + 1) + " but is " + size + " (" + i + ")", size == j + 1);
 			}
 
 			if (i != 0) {
-				final Integer peek = q.peek();
+				final Integer peek = q.first();
 				assertTrue("First thing is not zero but " + peek + " (" + i + ")", peek == 0);
 			}
 
 			for (int j = 0; j < i; j++) {
-				final Integer pop = q.pop();
+				final Integer pop = q.removeFirst();
 				assertTrue("Popped should be " + j + " but is " + pop + " (" + i + ")", pop == j);
 
-				final int size = q.size();
+				final int size = q.size;
 				assertTrue("Size should be " + (i - 1 - j) + " but is " + size + " (" + i + ")", size == i - 1 - j);
 			}
 
-			assertTrue("Not empty after cycle " + i, q.size() == 0);
+			assertTrue("Not empty after cycle " + i, q.size == 0);
 		}
 
 		for (int i = 0; i < 56; i++) {
-			q.push(42);
+			q.addLast(42);
 		}
 		q.clear();
-		assertTrue("Clear did not clear properly", q.size() == 0);
+		assertTrue("Clear did not clear properly", q.size == 0);
 	}
 
 	/** Same as resizableQueueTest, but in reverse */
 	@Test
 	public void resizableDequeTest () {
-		final Queue<Integer> q = new Queue<Integer>(8, true);
+		final Queue<Integer> q = new Queue<Integer>(8);
 
-		assertTrue("New deque is not empty!", q.size() == 0);
+		assertTrue("New deque is not empty!", q.size == 0);
 
 		for (int i = 0; i < 100; i++) {
 
 			for (int j = 0; j < i; j++) {
 				try {
-					q.pushFront(j);
+					q.addFirst(j);
 				} catch (IllegalStateException e) {
 					fail("Failed to add element " + j + " (" + i + ")");
 				}
-				final Integer peeked = q.peek();
+				final Integer peeked = q.first();
 				assertTrue("peek shows " + peeked + ", should be " + j + " (" + i + ")", peeked.equals(j));
-				final int size = q.size();
+				final int size = q.size;
 				assertTrue("Size should be " + (j + 1) + " but is " + size + " (" + i + ")", size == j + 1);
 			}
 
 			if (i != 0) {
-				final Integer peek = q.peekLast();
+				final Integer peek = q.last();
 				assertTrue("Last thing is not zero but " + peek + " (" + i + ")", peek == 0);
 			}
 
 			for (int j = 0; j < i; j++) {
-				final Integer pop = q.popLast();
+				final Integer pop = q.removeLast();
 				assertTrue("Popped should be " + j + " but is " + pop + " (" + i + ")", pop == j);
 
-				final int size = q.size();
+				final int size = q.size;
 				assertTrue("Size should be " + (i - 1 - j) + " but is " + size + " (" + i + ")", size == i - 1 - j);
 			}
 
-			assertTrue("Not empty after cycle " + i, q.size() == 0);
+			assertTrue("Not empty after cycle " + i, q.size == 0);
 		}
 
 		for (int i = 0; i < 56; i++) {
-			q.pushFront(42);
+			q.addFirst(42);
 		}
 		q.clear();
-		assertTrue("Clear did not clear properly", q.size() == 0);
-	}
-
-	@Test
-	public void nonResizableQueueTest () {
-		final Queue<Integer> q = new Queue<Integer>(5, false);
-		for (int i = 0; i < 5; i++) {
-			try {
-				q.push(i);
-			} catch (IllegalStateException ise) {
-				fail("Failed to add element " + i);
-			}
-			assertTrue("Wrong size after " + i, q.size() == i + 1);
-		}
-		assertTrue("Not full when should be full", q.isFull());
-		for (int i = 5; i < 10; i++) {
-			try {
-				q.push(i);
-				fail("Added element " + i);
-			} catch (IllegalStateException e) {
-				// This is expected
-			}
-			assertTrue("Wrong size after " + i, q.size() == 5);
-			assertTrue("Not full when should be full (" + i + ")", q.isFull());
-		}
-
-		q.clear();
-		assertTrue("Wrong size after clear", q.size() == 0);
-		assertTrue("Not empty when should be empty", q.size() == 0);
-		assertFalse("Full when should be empty", q.isFull());
+		assertTrue("Clear did not clear properly", q.size == 0);
 	}
 
 	@Test
 	public void getTest () {
-		final Queue<Integer> q = new Queue<Integer>(7, true);
+		final Queue<Integer> q = new Queue<Integer>(7);
 		for (int i = 0; i < 5; i++) {
 			for (int j = 0; j < 4; j++) {
-				q.push(j);
+				q.addLast(j);
 			}
-			assertEquals("get(0) is not equal to peek (" + i + ")", q.get(0), q.peek());
-			assertEquals("get(size-1) is not equal to peekLast (" + i + ")", q.get(q.size - 1), q.peekLast());
+			assertEquals("get(0) is not equal to peek (" + i + ")", q.get(0), q.first());
+			assertEquals("get(size-1) is not equal to peekLast (" + i + ")", q.get(q.size - 1), q.last());
 			for (int j = 0; j < 4; j++) {
 				assertTrue(q.get(j) == j);
 			}
 			for (int j = 0; j < 4 - 1; j++) {
-				q.pop();
-				assertEquals("get(0) is not equal to peek (" + i + ")", q.get(0), q.peek());
+				q.removeFirst();
+				assertEquals("get(0) is not equal to peek (" + i + ")", q.get(0), q.first());
 			}
-			q.pop();
+			q.removeFirst();
 			assert q.size == 0; // Failing this means broken test
 			try {
 				q.get(0);
@@ -155,28 +128,14 @@ public class QueueTest {
 	@Test
 	public void toStringTest () {
 		{// Resizable
-			Queue<Integer> q = new Queue<Integer>(1, true);
+			Queue<Integer> q = new Queue<Integer>(1);
 			assertTrue(q.toString().equals("[]"));
-			q.push(4);
+			q.addLast(4);
 			assertTrue(q.toString().equals("[4]"));
-			q.push(5);
-			q.push(6);
-			q.push(7);
+			q.addLast(5);
+			q.addLast(6);
+			q.addLast(7);
 			assertTrue(q.toString().equals("[4, 5, 6, 7]"));
-		}
-
-		{// Non-resizable
-			Queue<Integer> nonResQ = new Queue<Integer>(4, false);
-			nonResQ.push(1);
-			nonResQ.push(2);
-			nonResQ.push(3);
-			nonResQ.push(4);
-			try {
-				nonResQ.push(5);
-			} catch (IllegalStateException e) {
-				// Expected
-			}
-			assertTrue(nonResQ.toString().equals("[1, 2, 3, 4]"));
 		}
 	}
 

--- a/gdx/test/com/badlogic/gdx/utils/QueueTest.java
+++ b/gdx/test/com/badlogic/gdx/utils/QueueTest.java
@@ -11,12 +11,14 @@ public class QueueTest {
 	public void resizableQueueTest () {
 		final Queue<Integer> q = new Queue<Integer>(8, true);
 
-		assertTrue("New queue is not empty!", q.isEmpty());
+		assertTrue("New queue is not empty!", q.size() == 0);
 
 		for (int i = 0; i < 100; i++) {
 
 			for (int j = 0; j < i; j++) {
-				assertTrue("Failed to add element " + j + " (" + i + ")", q.add(j));
+				assertTrue("Failed to add element " + j + " (" + i + ")", q.push(j));
+				final Integer peeked = q.peekLast();
+				assertTrue("peekLast shows " + peeked + ", should be " + j + " (" + i + ")", peeked.equals(j));
 				final int size = q.size();
 				assertTrue("Size should be " + (j + 1) + " but is " + size + " (" + i + ")", size == j + 1);
 			}
@@ -27,40 +29,80 @@ public class QueueTest {
 			}
 
 			for (int j = 0; j < i; j++) {
-				final Integer pop = q.remove();
+				final Integer pop = q.pop();
 				assertTrue("Popped should be " + j + " but is " + pop + " (" + i + ")", pop == j);
 
 				final int size = q.size();
 				assertTrue("Size should be " + (i - 1 - j) + " but is " + size + " (" + i + ")", size == i - 1 - j);
 			}
 
-			assertTrue("Not empty after cycle " + i, q.isEmpty());
+			assertTrue("Not empty after cycle " + i, q.size() == 0);
 		}
 
 		for (int i = 0; i < 56; i++) {
-			q.add(42);
+			q.push(42);
 		}
 		q.clear();
-		assertTrue("Clear did not clear properly", q.isEmpty());
+		assertTrue("Clear did not clear properly", q.size() == 0);
+	}
+
+	/** Same as resizableQueueTest, but in reverse */
+	@Test
+	public void resizableDequeTest () {
+		final Queue<Integer> q = new Queue<Integer>(8, true);
+
+		assertTrue("New deque is not empty!", q.size() == 0);
+
+		for (int i = 0; i < 100; i++) {
+
+			for (int j = 0; j < i; j++) {
+				assertTrue("Failed to add element " + j + " (" + i + ")", q.pushFront(j));
+				final Integer peeked = q.peek();
+				assertTrue("peek shows " + peeked + ", should be " + j + " (" + i + ")", peeked.equals(j));
+				final int size = q.size();
+				assertTrue("Size should be " + (j + 1) + " but is " + size + " (" + i + ")", size == j + 1);
+			}
+
+			if (i != 0) {
+				final Integer peek = q.peekLast();
+				assertTrue("Last thing is not zero but " + peek + " (" + i + ")", peek == 0);
+			}
+
+			for (int j = 0; j < i; j++) {
+				final Integer pop = q.popLast();
+				assertTrue("Popped should be " + j + " but is " + pop + " (" + i + ")", pop == j);
+
+				final int size = q.size();
+				assertTrue("Size should be " + (i - 1 - j) + " but is " + size + " (" + i + ")", size == i - 1 - j);
+			}
+
+			assertTrue("Not empty after cycle " + i, q.size() == 0);
+		}
+
+		for (int i = 0; i < 56; i++) {
+			q.pushFront(42);
+		}
+		q.clear();
+		assertTrue("Clear did not clear properly", q.size() == 0);
 	}
 
 	@Test
 	public void nonResizableQueueTest () {
 		final Queue<Integer> q = new Queue<Integer>(5, false);
 		for (int i = 0; i < 5; i++) {
-			assertTrue("Failed to add element " + i, q.add(i));
+			assertTrue("Failed to add element " + i, q.push(i));
 			assertTrue("Wrong size after " + i, q.size() == i + 1);
 		}
 		assertTrue("Not full when should be full", q.isFull());
 		for (int i = 5; i < 10; i++) {
-			assertFalse("Added element " + i, q.add(i));
+			assertFalse("Added element " + i, q.push(i));
 			assertTrue("Wrong size after " + i, q.size() == 5);
 			assertTrue("Not full when should be full (" + i + ")", q.isFull());
 		}
 
 		q.clear();
 		assertTrue("Wrong size after clear", q.size() == 0);
-		assertTrue("Not empty when should be empty", q.isEmpty());
+		assertTrue("Not empty when should be empty", q.size() == 0);
 		assertFalse("Full when should be empty", q.isFull());
 	}
 
@@ -69,21 +111,21 @@ public class QueueTest {
 		{// Resizable
 			Queue<Integer> q = new Queue<Integer>(1, true);
 			assertTrue(q.toString().equals("Queue []"));
-			q.add(4);
+			q.push(4);
 			assertTrue(q.toString().equals("Queue [4]"));
-			q.add(5);
-			q.add(6);
-			q.add(7);
+			q.push(5);
+			q.push(6);
+			q.push(7);
 			assertTrue(q.toString().equals("Queue [4, 5, 6, 7]"));
 		}
 
 		{// Non-resizable
 			Queue<Integer> nonResQ = new Queue<Integer>(4, false);
-			nonResQ.add(1);
-			nonResQ.add(2);
-			nonResQ.add(3);
-			nonResQ.add(4);
-			nonResQ.add(5);
+			nonResQ.push(1);
+			nonResQ.push(2);
+			nonResQ.push(3);
+			nonResQ.push(4);
+			nonResQ.push(5);
 			assertTrue(nonResQ.toString().equals("Queue [1, 2, 3, 4]"));
 		}
 	}


### PR DESCRIPTION
Adds a simple but efficient queue implementation.

__Motivation:__
`Array` is good for lists and stacks, but it is inefficient for building queues.

__Implementation:__
Queue is implemented as a java array with two indexes which rotate around, wrapping at the end. Details are documented in the code. All basic methods for queue manipulation are present (add/enqueue, remove/dequeue and peek). Queue can't overflow, grows when not enough space in the backing array. On underflow it returns null or specified default value, no exceptions are thrown.

PR includes unit test for the Queue.