### PR TITLE
Smooth TemporalAction interruptions via SplineInterpolation

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+[1.7.2]
+- Can now smoothly blend from interrupted TemporalActions with their new setBlendFrom methods. There is a new Interpolation, smooth, based on smoothstep.
+
 [1.7.1]
 - Fixes AtlasTmxMapLoader region name loading to tileset name instead of filename
 - Changes TiledMapPacker output, region names are tileset names, adjusts gid, defaults to one atlas per map

--- a/gdx/src/com/badlogic/gdx/math/Interpolation.java
+++ b/gdx/src/com/badlogic/gdx/math/Interpolation.java
@@ -27,24 +27,91 @@ public abstract class Interpolation {
 		return start + (end - start) * apply(a);
 	}
 
-	//
+	/** Speeds are expressed in terms of units of "total change" over "duration". To prepare inputs for this method, you may use:
+	 * <p>
+	 * {@code speed = worldSpeed * duration / (end - start)}
+	 * @param startSpeed Beginning rate of change. Used only by {@linkplain SplineInterpolation SplineInterpolations}.
+	 * @param endSpeed Ending rate of change. Used only by {@linkplain SplineInterpolation SplineInterpolations}.
+	 * @param a Alpha value between 0 and 1, where 1 maps to the total duration.
+	 * @return The current rate of change. To convert this to world speed, you may use:
+	 *         <p>
+	 *         {@code worldSpeed = speed * (end - start) / duration} */
+	public abstract float speed (float startSpeed, float endSpeed, float a);
 
 	static public final Interpolation linear = new Interpolation() {
 		public float apply (float a) {
 			return a;
 		}
+
+		public float speed (float startSpeed, float endSpeed, float a) {
+			return 1f;
+		}
 	};
 
-	static public final Interpolation fade = new Interpolation() {
+	/** A third-order Hermite spline interpolation. When left unspecified, the starting and ending speeds are zero, and the
+	 * function is equivalent to the {@code smoothstep} function in GLSL. */
+	static public final SplineInterpolation smooth = new SplineInterpolation() {
+		public float apply (float a) {
+			return MathUtils.clamp(a * a * (a * (-2) + 3), 0, 1);
+		}
+
+		public float applyWithSpeed (float startSpeed, float a) {
+			return a * (a * (a * (startSpeed - 2) + 3 - 2 * startSpeed) + startSpeed);
+		}
+
+		public float applyWithSpeed (float startSpeed, float endSpeed, float a) {
+			return a * (a * (a * (startSpeed + endSpeed - 2) + 3 - 2 * startSpeed - endSpeed) + startSpeed);
+		}
+
+		public float speed (float startSpeed, float endSpeed, float a) {
+			if (startSpeed == 0) if (endSpeed == 0)
+				return a * (a * (-6) + 6);
+			else
+				return a * (a * (3 * endSpeed - 6) + 6 - 2 * endSpeed);
+			if (endSpeed == 0)
+				return a * (a * (3 * startSpeed - 6) + 6 - 4 * startSpeed) + startSpeed;
+			else
+				return a * (a * (3 * (startSpeed + endSpeed) - 6) + 6 - 4 * startSpeed - 2 * endSpeed) + startSpeed;
+		}
+	};
+
+	/** A fifth-order Hermite spline interpolation. When left unspecified, the starting and ending speeds are zero. The starting
+	 * and ending accelerations are always zero. */
+	static public final SplineInterpolation fade = new SplineInterpolation() {
 		public float apply (float a) {
 			return MathUtils.clamp(a * a * a * (a * (a * 6 - 15) + 10), 0, 1);
+		}
+
+		public float applyWithSpeed (float startSpeed, float a) {
+			return a * (a * a * (a * (a * (6 - 3 * startSpeed) + 8 * startSpeed - 15) + 10 - 6 * startSpeed) + startSpeed);
+		}
+
+		public float applyWithSpeed (float startSpeed, float endSpeed, float a) {
+			return a * (a * a * (a * (a * (6 - 3 * (startSpeed + endSpeed)) + 8 * startSpeed + 7 * endSpeed - 15) + 10
+				- 6 * startSpeed - 4 * endSpeed) + startSpeed);
+		}
+
+		public float speed (float startSpeed, float endSpeed, float a) {
+			if (startSpeed == 0) {
+				if (endSpeed == 0) {
+					return a * a * (a * (a * 30 - 60) + 30);
+				} else {
+					return a * a * (a * (a * (30 - 15 * endSpeed) + 28 * endSpeed - 60) + 30 - 12 * endSpeed);
+				}
+			}
+			if (endSpeed == 0) {
+				return a * a * (a * (a * (30 - 15 * startSpeed) + 32 * startSpeed - 60) + 30 - 18 * startSpeed) + startSpeed;
+			} else {
+				return a * a * (a * (a * (30 - 15 * (startSpeed + endSpeed)) + 32 * startSpeed + 28 * endSpeed - 60) + 30
+					- 18 * startSpeed - 12 * endSpeed) + startSpeed;
+			}
 		}
 	};
 
 	static public final Pow pow2 = new Pow(2);
 	/** Fast, then slow. */
 	static public final PowIn pow2In = new PowIn(2);
-	/** Slow, then falst. */
+	/** Slow, then fast. */
 	static public final PowOut pow2Out = new PowOut(2);
 
 	static public final Pow pow3 = new Pow(3);
@@ -59,9 +126,15 @@ public abstract class Interpolation {
 	static public final PowIn pow5In = new PowIn(5);
 	static public final PowOut pow5Out = new PowOut(5);
 
+	private static final float PI_HALF = MathUtils.PI / 2f;
+
 	static public final Interpolation sine = new Interpolation() {
 		public float apply (float a) {
 			return (1 - MathUtils.cos(a * MathUtils.PI)) / 2;
+		}
+
+		public float speed (float startSpeed, float endSpeed, float a) {
+			return PI_HALF * MathUtils.sin(a * MathUtils.PI);
 		}
 	};
 
@@ -69,11 +142,19 @@ public abstract class Interpolation {
 		public float apply (float a) {
 			return 1 - MathUtils.cos(a * MathUtils.PI / 2);
 		}
+
+		public float speed (float startSpeed, float endSpeed, float a) {
+			return PI_HALF * MathUtils.sin(a * PI_HALF);
+		}
 	};
 
 	static public final Interpolation sineOut = new Interpolation() {
 		public float apply (float a) {
 			return MathUtils.sin(a * MathUtils.PI / 2);
+		}
+
+		public float speed (float startSpeed, float endSpeed, float a) {
+			return PI_HALF * MathUtils.cos(a * PI_HALF);
 		}
 	};
 
@@ -95,11 +176,25 @@ public abstract class Interpolation {
 			a *= 2;
 			return ((float)Math.sqrt(1 - a * a) + 1) / 2;
 		}
+
+		public float speed (float startSpeed, float endSpeed, float a) {
+			if (a <= 0.5f) {
+				a = Math.min(0.99f, 2 * a);
+				return a / (float)Math.sqrt(1 - a * a);
+			}
+			a = Math.max(-0.99f, 2 * (a - 1));
+			return -a / (float)Math.sqrt(1 - a * a);
+		}
 	};
 
 	static public final Interpolation circleIn = new Interpolation() {
 		public float apply (float a) {
 			return 1 - (float)Math.sqrt(1 - a * a);
+		}
+
+		public float speed (float startSpeed, float endSpeed, float a) {
+			a = Math.min(a, 0.99f);
+			return a / (float)Math.sqrt(1 - a * a);
 		}
 	};
 
@@ -107,6 +202,11 @@ public abstract class Interpolation {
 		public float apply (float a) {
 			a--;
 			return (float)Math.sqrt(1 - a * a);
+		}
+
+		public float speed (float startSpeed, float endSpeed, float a) {
+			a = Math.max(-0.99f, a - 1);
+			return -a / (float)Math.sqrt(1 - a * a);
 		}
 	};
 
@@ -135,6 +235,11 @@ public abstract class Interpolation {
 			if (a <= 0.5f) return (float)Math.pow(a * 2, power) / 2;
 			return (float)Math.pow((a - 1) * 2, power) / (power % 2 == 0 ? -2 : 2) + 1;
 		}
+
+		public float speed (float startSpeed, float endSpeed, float a) {
+			if (a <= 0.5f) return power * (float)Math.pow(a * 2, power - 11);
+			return (power % 2 == 0 ? -power : power) * (float)Math.pow((a - 1) * 2, power - 1);
+		}
 	}
 
 	static public class PowIn extends Pow {
@@ -145,6 +250,10 @@ public abstract class Interpolation {
 		public float apply (float a) {
 			return (float)Math.pow(a, power);
 		}
+
+		public float speed (float startSpeed, float endSpeed, float a) {
+			return power * (float)Math.pow(a, power - 1);
+		}
 	}
 
 	static public class PowOut extends Pow {
@@ -154,6 +263,10 @@ public abstract class Interpolation {
 
 		public float apply (float a) {
 			return (float)Math.pow(a - 1, power) * (power % 2 == 0 ? -1 : 1) + 1;
+		}
+
+		public float speed (float startSpeed, float endSpeed, float a) {
+			return (power % 2 == 0 ? -power : power) * (float)Math.pow(a - 1, power - 1);
 		}
 	}
 
@@ -173,6 +286,11 @@ public abstract class Interpolation {
 			if (a <= 0.5f) return ((float)Math.pow(value, power * (a * 2 - 1)) - min) * scale / 2;
 			return (2 - ((float)Math.pow(value, -power * (a * 2 - 1)) - min) * scale) / 2;
 		}
+
+		public float speed (float startSpeed, float endSpeed, float a) {
+			if (a <= 0.5f) return (float)Math.log(value) * (float)Math.pow(value, power * (a * 2 - 1)) * power * scale;
+			return (float)Math.log(value) * (float)Math.pow(value, power * (1 - a * 2)) * power * scale;
+		}
 	};
 
 	static public class ExpIn extends Exp {
@@ -182,6 +300,10 @@ public abstract class Interpolation {
 
 		public float apply (float a) {
 			return ((float)Math.pow(value, power * (a - 1)) - min) * scale;
+		}
+
+		public float speed (float startSpeed, float endSpeed, float a) {
+			return (float)Math.log(value) * (float)Math.pow(value, power * (a - 1)) * power * scale;
 		}
 	}
 
@@ -193,18 +315,46 @@ public abstract class Interpolation {
 		public float apply (float a) {
 			return 1 - ((float)Math.pow(value, -power * a) - min) * scale;
 		}
+
+		public float speed (float startSpeed, float endSpeed, float a) {
+			return (float)Math.log(value) * (float)Math.pow(value, -power * a) * power * scale;
+		}
+	}
+
+	//
+
+	/** An interpolation that supports specific starting and ending speeds. If unspecified, the starting and/or ending speeds are
+	 * set to zero. */
+	public abstract static class SplineInterpolation extends Interpolation {
+		/** Speed is expressed in terms of units of "total change" over "duration". To prepare the input for this method, you may
+		 * use:
+		 * <p>
+		 * {@code speed = worldSpeed * duration / (end - start)}
+		 * @param startSpeed Beginning rate of change.
+		 * @param a Alpha value between 0 and 1, where 1 maps to the total duration. */
+		abstract public float applyWithSpeed (float startSpeed, float a);
+
+		/** Speed is expressed in terms of units of "total change" over "duration". To prepare the input for this method, you may
+		 * use:
+		 * <p>
+		 * {@code speed = worldSpeed * duration / (end - start)}
+		 * @param startSpeed Beginning rate of change.
+		 * @param endSpeed Ending rate of change.
+		 * @param a Alpha value between 0 and 1, where 1 maps to the total duration. */
+		abstract public float applyWithSpeed (float startSpeed, float endSpeed, float a);
 	}
 
 	//
 
 	static public class Elastic extends Interpolation {
-		final float value, power, scale, bounces;
+		final float value, power, scale, bounces, lnValue;
 
 		public Elastic (float value, float power, int bounces, float scale) {
 			this.value = value;
 			this.power = power;
 			this.scale = scale;
 			this.bounces = bounces * MathUtils.PI * (bounces % 2 == 0 ? 1 : -1);
+			this.lnValue = (float)Math.log(value);
 		}
 
 		public float apply (float a) {
@@ -214,7 +364,21 @@ public abstract class Interpolation {
 			}
 			a = 1 - a;
 			a *= 2;
-			return 1 - (float)Math.pow(value, power * (a - 1)) * MathUtils.sin((a) * bounces) * scale / 2;
+			return 1 - (float)Math.pow(value, power * (a - 1)) * MathUtils.sin(a * bounces) * scale / 2;
+		}
+
+		public float speed (float startSpeed, float endSpeed, float a) {
+			if (a <= 0.5f) {
+				a *= 2;
+				float aBounces = a * bounces;
+				return (float)Math.pow(value, power * (a - 1))
+					* (lnValue * MathUtils.sin(aBounces) + bounces * MathUtils.cos(aBounces)) * scale / 2;
+			}
+			a = 1 - a;
+			a *= 2;
+			float aBounces = a * bounces;
+			return (float)Math.pow(value, power * (a - 1)) * (lnValue * MathUtils.sin(aBounces) + bounces * MathUtils.cos(aBounces))
+				* scale / 2;
 		}
 	}
 
@@ -227,6 +391,13 @@ public abstract class Interpolation {
 			if (a >= 0.99) return 1;
 			return (float)Math.pow(value, power * (a - 1)) * MathUtils.sin(a * bounces) * scale;
 		}
+
+		public float speed (float startSpeed, float endSpeed, float a) {
+			if (a >= 0.99) return (1 - (float)Math.pow(value, power * (-0.01)) * MathUtils.sin(0.99f * bounces) * scale) * 100;
+			float aBounces = a * bounces;
+			return (float)Math.pow(value, power * (a - 1)) * (lnValue * MathUtils.sin(aBounces) + bounces * MathUtils.cos(aBounces))
+				* scale;
+		}
 	}
 
 	static public class ElasticOut extends Elastic {
@@ -237,6 +408,13 @@ public abstract class Interpolation {
 		public float apply (float a) {
 			a = 1 - a;
 			return (1 - (float)Math.pow(value, power * (a - 1)) * MathUtils.sin(a * bounces) * scale);
+		}
+
+		public float speed (float startSpeed, float endSpeed, float a) {
+			a = 1 - a;
+			float aBounces = a * bounces;
+			return -(float)Math.pow(value, power * (a - 1))
+				* (power * lnValue * MathUtils.sin(aBounces) + bounces * MathUtils.cos(aBounces)) * scale;
 		}
 	}
 
@@ -260,6 +438,15 @@ public abstract class Interpolation {
 		public float apply (float a) {
 			if (a <= 0.5f) return (1 - out(1 - a * 2)) / 2;
 			return out(a * 2 - 1) / 2 + 0.5f;
+		}
+
+		private boolean speedOutTest (float a) {
+			return a + widths[0] / 2 < widths[0];
+		}
+
+		public float speed (float startSpeed, float endSpeed, float a) {
+			if (a <= 0.5f) return speedOutTest(1 - a * 2) ? 2 / widths[0] : super.speed(0, 0, a);
+			return speedOutTest(a * 2 - 1) ? 1 / widths[0] : super.speed(0, 0, a);
 		}
 	}
 
@@ -330,6 +517,20 @@ public abstract class Interpolation {
 			float z = 4 / width * height * a;
 			return 1 - (z - z * a) * width;
 		}
+
+		public float speed (float startSpeed, float endSpeed, float a) {
+			a += widths[0] / 2;
+			float width = 0, height = 0;
+			for (int i = 0, n = widths.length; i < n; i++) {
+				width = widths[i];
+				if (a <= width) {
+					height = heights[i];
+					break;
+				}
+				a -= width;
+			}
+			return 8 * height / (width * width) * (a - width / 2);
+		}
 	}
 
 	static public class BounceIn extends BounceOut {
@@ -343,6 +544,10 @@ public abstract class Interpolation {
 
 		public float apply (float a) {
 			return 1 - super.apply(1 - a);
+		}
+
+		public float speed (float startSpeed, float endSpeed, float a) {
+			return super.speed(0, 0, 1 - a);
 		}
 	}
 
@@ -364,6 +569,12 @@ public abstract class Interpolation {
 			a *= 2;
 			return a * a * ((scale + 1) * a + scale) / 2 + 1;
 		}
+
+		public float speed (float startSpeed, float endSpeed, float a) {
+			if (a <= 0.5f) return 4 * a * (a * (3 * scale + 3) - scale);
+			a--;
+			return 4 * a * (a * (3 * scale + 3) + scale);
+		}
 	}
 
 	static public class SwingOut extends Interpolation {
@@ -377,6 +588,11 @@ public abstract class Interpolation {
 			a--;
 			return a * a * ((scale + 1) * a + scale) + 1;
 		}
+
+		public float speed (float startSpeed, float endSpeed, float a) {
+			a--;
+			return a * (a * (3 * scale + 3) + 2 * scale);
+		}
 	}
 
 	static public class SwingIn extends Interpolation {
@@ -388,6 +604,10 @@ public abstract class Interpolation {
 
 		public float apply (float a) {
 			return a * a * ((scale + 1) * a - scale);
+		}
+
+		public float speed (float startSpeed, float endSpeed, float a) {
+			return a * (a * (3 * scale + 3) - 2 * scale);
 		}
 	}
 }

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/AlphaAction.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/AlphaAction.java
@@ -17,6 +17,8 @@
 package com.badlogic.gdx.scenes.scene2d.actions;
 
 import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.math.Interpolation.SplineInterpolation;
+import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 
 /** Sets the alpha for an actor's color (or a specified color), from the current alpha to the new alpha. Note this action
@@ -25,19 +27,29 @@ import com.badlogic.gdx.scenes.scene2d.Actor;
 public class AlphaAction extends TemporalAction {
 	private float start, end;
 	private Color color;
+	private float worldStartSpeed;
+	private boolean blending;
 
 	protected void begin () {
 		if (color == null) color = target.getColor();
 		start = color.a;
+		if (blending) {
+			setStartSpeed(1, worldStartSpeed * getDuration() / (end - start), 0, 0, 0);
+		}
 	}
 
 	protected void update (float percent) {
 		color.a = start + (end - start) * percent;
 	}
 
+	protected void updateIndependently (float percent0, float percent1, float percent2, float percent3) {
+		color.a = MathUtils.clamp(start + (end - start) * percent0, 0, 1);
+	};
+
 	public void reset () {
 		super.reset();
 		color = null;
+		blending = false;
 	}
 
 	public Color getColor () {
@@ -56,5 +68,23 @@ public class AlphaAction extends TemporalAction {
 
 	public void setAlpha (float alpha) {
 		this.end = alpha;
+	}
+
+	public float getWorldSpeed () {
+		if (getDuration() <= 0) return 0;
+		return getSpeed0() * (end - start) / getDuration();
+	}
+
+	/** Set this interpolation to begin at a speed matching the current speed of an action that it is interrupting, so the
+	 * transition will appear smooth. This must be called before removing the interrupted action from the actor. The interrupted
+	 * action should be removed from the actor after calling this method. A {@linkplain SplineInterpolation} must be used. */
+	public void setBlendFrom (AlphaAction interruptedAction, SplineInterpolation interpolation) {
+		setInterpolation(interpolation);
+		worldStartSpeed = interruptedAction.getWorldSpeed();
+		blending = true;
+	}
+
+	public void cancelBlendFrom () {
+		blending = false;
 	}
 }

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/ColorAction.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/ColorAction.java
@@ -17,6 +17,7 @@
 package com.badlogic.gdx.scenes.scene2d.actions;
 
 import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.math.Interpolation.SplineInterpolation;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 
 /** Sets the actor's color (or a specified color), from the current to the new color. Note this action transitions from the color
@@ -26,6 +27,8 @@ public class ColorAction extends TemporalAction {
 	private float startR, startG, startB, startA;
 	private Color color;
 	private final Color end = new Color();
+	private float worldStartSpeedR, worldStartSpeedG, worldStartSpeedB, worldStartSpeedA;
+	private boolean blending = false;
 
 	protected void begin () {
 		if (color == null) color = target.getColor();
@@ -33,6 +36,11 @@ public class ColorAction extends TemporalAction {
 		startG = color.g;
 		startB = color.b;
 		startA = color.a;
+		if (blending) {
+			setStartSpeed(4, worldStartSpeedR * getDuration() / (end.r - startR),
+				worldStartSpeedG * getDuration() / (end.g - startG), worldStartSpeedB * getDuration() / (end.b - startB),
+				worldStartSpeedA * getDuration() / (end.a - startA));
+		}
 	}
 
 	protected void update (float percent) {
@@ -43,9 +51,18 @@ public class ColorAction extends TemporalAction {
 		color.set(r, g, b, a);
 	}
 
+	protected void updateIndependently (float percent0, float percent1, float percent2, float percent3) {
+		float r = startR + (end.r - startR) * percent0;
+		float g = startG + (end.g - startG) * percent1;
+		float b = startB + (end.b - startB) * percent2;
+		float a = startA + (end.a - startA) * percent3;
+		color.set(r, g, b, a);
+	};
+
 	public void reset () {
 		super.reset();
 		color = null;
+		blending = false;
 	}
 
 	public Color getColor () {
@@ -65,5 +82,41 @@ public class ColorAction extends TemporalAction {
 	/** Sets the color to transition to. Required. */
 	public void setEndColor (Color color) {
 		end.set(color);
+	}
+
+	public float getWorldSpeedRed () {
+		if (getDuration() <= 0) return 0;
+		return getSpeed0() * (end.r - startR) / getDuration();
+	}
+
+	public float getWorldSpeedGreen () {
+		if (getDuration() <= 0) return 0;
+		return getSpeed1() * (end.g - startG) / getDuration();
+	}
+
+	public float getWorldSpeedBlue () {
+		if (getDuration() <= 0) return 0;
+		return getSpeed2() * (end.b - startB) / getDuration();
+	}
+
+	public float getWorldSpeedAlpha () {
+		if (getDuration() <= 0) return 0;
+		return getSpeed3() * (end.a - startA) / getDuration();
+	}
+
+	/** Set this interpolation to begin at a speed matching the current speed of an action that it is interrupting, so the
+	 * transition will appear smooth. This must be called before removing the interrupted action from the actor. The interrupted
+	 * action should be removed from the actor after calling this method. A {@linkplain SplineInterpolation} must be used. */
+	public void setBlendFrom (ColorAction interruptedAction, SplineInterpolation interpolation) {
+		setInterpolation(interpolation);
+		worldStartSpeedR = interruptedAction.getWorldSpeedRed();
+		worldStartSpeedG = interruptedAction.getWorldSpeedGreen();
+		worldStartSpeedB = interruptedAction.getWorldSpeedBlue();
+		worldStartSpeedA = interruptedAction.getWorldSpeedAlpha();
+		blending = true;
+	}
+
+	public void cancelBlendFrom () {
+		blending = false;
 	}
 }

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/FloatAction.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/FloatAction.java
@@ -16,11 +16,15 @@
 
 package com.badlogic.gdx.scenes.scene2d.actions;
 
+import com.badlogic.gdx.math.Interpolation.SplineInterpolation;
+
 /** An action that has a float, whose value is transitioned over time.
  * @author Nathan Sweet */
 public class FloatAction extends TemporalAction {
 	private float start, end;
 	private float value;
+	private float worldStartSpeed;
+	private boolean blending = false;
 
 	/** Creates a FloatAction that transitions from 0 to 1. */
 	public FloatAction () {
@@ -36,10 +40,17 @@ public class FloatAction extends TemporalAction {
 
 	protected void begin () {
 		value = start;
+		if (blending) {
+			setStartSpeed(1, worldStartSpeed * getDuration() / (end - start), 0, 0, 0);
+		}
 	}
 
 	protected void update (float percent) {
 		value = start + (end - start) * percent;
+	}
+
+	protected void updateIndependently (float percent0, float percent1, float percent2, float percent3) {
+		value = start + (end - start) * percent0;
 	}
 
 	/** Gets the current float value. */
@@ -68,5 +79,23 @@ public class FloatAction extends TemporalAction {
 	/** Sets the value to transition to. */
 	public void setEnd (float end) {
 		this.end = end;
+	}
+
+	public float getWorldSpeed () {
+		if (getDuration() <= 0) return 0;
+		return getSpeed0() * (end - start) / getDuration();
+	}
+
+	/** Set this interpolation to begin at a speed matching the current speed of an action that it is interrupting, so the
+	 * transition will appear smooth. This must be called before removing the interrupted action from the actor. The interrupted
+	 * action should be removed from the actor after calling this method. A {@linkplain SplineInterpolation} must be used. */
+	public void setBlendFrom (FloatAction interruptedAction, SplineInterpolation interpolation) {
+		setInterpolation(interpolation);
+		worldStartSpeed = interruptedAction.getWorldSpeed();
+		blending = true;
+	}
+
+	public void cancelBlendFrom () {
+		blending = false;
 	}
 }

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/IntAction.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/IntAction.java
@@ -16,11 +16,15 @@
 
 package com.badlogic.gdx.scenes.scene2d.actions;
 
+import com.badlogic.gdx.math.Interpolation.SplineInterpolation;
+
 /** An action that has an int, whose value is transitioned over time.
  * @author Nathan Sweet */
 public class IntAction extends TemporalAction {
 	private int start, end;
 	private int value;
+	private float worldStartSpeed;
+	private boolean blending = false;
 
 	/** Creates an IntAction that transitions from 0 to 1. */
 	public IntAction () {
@@ -36,10 +40,17 @@ public class IntAction extends TemporalAction {
 
 	protected void begin () {
 		value = start;
+		if (blending) {
+			setStartSpeed(1, worldStartSpeed * getDuration() / (end - start), 0, 0, 0);
+		}
 	}
 
 	protected void update (float percent) {
 		value = (int)(start + (end - start) * percent);
+	}
+
+	protected void updateIndependently (float percent0, float percent1, float percent2, float percent3) {
+		value = (int)(start + (end - start) * percent0);
 	}
 
 	/** Gets the current int value. */
@@ -68,5 +79,23 @@ public class IntAction extends TemporalAction {
 	/** Sets the value to transition to. */
 	public void setEnd (int end) {
 		this.end = end;
+	}
+
+	public float getWorldSpeed () {
+		if (getDuration() <= 0) return 0;
+		return getSpeed0() * (end - start) / getDuration();
+	}
+
+	/** Set this interpolation to begin at a speed matching the current speed of an action that it is interrupting, so the
+	 * transition will appear smooth. This must be called before removing the interrupted action from the actor. The interrupted
+	 * action should be removed from the actor after calling this method. A {@linkplain SplineInterpolation} must be used. */
+	public void setBlendFrom (IntAction interruptedAction, SplineInterpolation interpolation) {
+		setInterpolation(interpolation);
+		worldStartSpeed = interruptedAction.getWorldSpeed();
+		blending = true;
+	}
+
+	public void cancelBlendFrom () {
+		blending = false;
 	}
 }

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/MoveByAction.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/MoveByAction.java
@@ -16,13 +16,34 @@
 
 package com.badlogic.gdx.scenes.scene2d.actions;
 
+import com.badlogic.gdx.math.Interpolation.SplineInterpolation;
+
 /** Moves an actor to a relative position.
  * @author Nathan Sweet */
-public class MoveByAction extends RelativeTemporalAction {
+public class MoveByAction extends RelativeTemporalAction implements TemporalAction.MoveAction {
 	private float amountX, amountY;
+	private float worldStartSpeedX, worldStartSpeedY;
+	private boolean blending = false;
+
+	protected void begin () {
+		super.begin();
+		if (blending) {
+			setStartSpeed(2, worldStartSpeedX * getDuration() / amountX, worldStartSpeedY * getDuration() / amountY, 0, 0);
+		}
+	}
 
 	protected void updateRelative (float percentDelta) {
 		target.moveBy(amountX * percentDelta, amountY * percentDelta);
+	}
+
+	protected void updateRelativeIndependently (float percentDelta0, float percentDelta1, float percentDelta2,
+		float percentDelta3) {
+		target.moveBy(amountX * percentDelta0, amountY * percentDelta1);
+	}
+
+	public void reset () {
+		super.reset();
+		blending = false;
 	}
 
 	public void setAmount (float x, float y) {
@@ -44,5 +65,29 @@ public class MoveByAction extends RelativeTemporalAction {
 
 	public void setAmountY (float y) {
 		amountY = y;
+	}
+
+	public float getWorldSpeedX () {
+		if (getDuration() <= 0) return 0;
+		return getSpeed0() * amountX / getDuration();
+	}
+
+	public float getWorldSpeedY () {
+		if (getDuration() <= 0) return 0;
+		return getSpeed1() * amountY / getDuration();
+	}
+
+	/** Set this interpolation to begin at a speed matching the current speed of an action that it is interrupting, so the
+	 * transition will appear smooth. This must be called before removing the interrupted action from the actor. The interrupted
+	 * action should be removed from the actor after calling this method. A {@linkplain SplineInterpolation} must be used. */
+	public void setBlendFrom (MoveAction interruptedAction, SplineInterpolation interpolation) {
+		setInterpolation(interpolation);
+		worldStartSpeedX = interruptedAction.getWorldSpeedX();
+		worldStartSpeedY = interruptedAction.getWorldSpeedY();
+		blending = true;
+	}
+
+	public void cancelBlendFrom () {
+		blending = false;
 	}
 }

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/RelativeTemporalAction.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/RelativeTemporalAction.java
@@ -20,15 +20,30 @@ package com.badlogic.gdx.scenes.scene2d.actions;
  * @author Nathan Sweet */
 abstract public class RelativeTemporalAction extends TemporalAction {
 	private float lastPercent;
+	private float lastPercent1;
+	private float lastPercent2;
+	private float lastPercent3;
 
 	protected void begin () {
 		lastPercent = 0;
+		lastPercent1 = 0;
+		lastPercent2 = 0;
+		lastPercent3 = 0;
 	}
 
 	protected void update (float percent) {
 		updateRelative(percent - lastPercent);
 		lastPercent = percent;
 	}
+	
+	protected void updateIndependently (float percent0, float percent1, float percent2, float percent3){
+		updateRelativeIndependently(percent0 - lastPercent, percent1 - lastPercent1, percent2 - lastPercent2, percent3 - lastPercent3);
+		lastPercent = percent0;
+		lastPercent1 = percent1;
+		lastPercent2 = percent2;
+		lastPercent3 = percent3;
+	};
 
 	abstract protected void updateRelative (float percentDelta);
+	protected void updateRelativeIndependently (float percentDelta0, float percentDelta1, float percentDelta2, float percentDelta3){};
 }

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/RotateByAction.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/RotateByAction.java
@@ -16,13 +16,29 @@
 
 package com.badlogic.gdx.scenes.scene2d.actions;
 
+import com.badlogic.gdx.math.Interpolation.SplineInterpolation;
+
 /** Sets the actor's rotation from its current value to a relative value.
  * @author Nathan Sweet */
-public class RotateByAction extends RelativeTemporalAction {
+public class RotateByAction extends RelativeTemporalAction implements TemporalAction.RotateAction {
 	private float amount;
+	private float worldStartSpeed;
+	private boolean blending = false;
+
+	protected void begin () {
+		super.begin();
+		if (blending) {
+			setStartSpeed(2, worldStartSpeed * getDuration() / amount, 0, 0, 0);
+		}
+	}
 
 	protected void updateRelative (float percentDelta) {
 		target.rotateBy(amount * percentDelta);
+	}
+
+	protected void updateRelativeIndependently (float percentDelta0, float percentDelta1, float percentDelta2,
+		float precentDelta3) {
+		target.rotateBy(amount * percentDelta0);
 	}
 
 	public float getAmount () {
@@ -31,5 +47,23 @@ public class RotateByAction extends RelativeTemporalAction {
 
 	public void setAmount (float rotationAmount) {
 		amount = rotationAmount;
+	}
+
+	public float getWorldSpeed () {
+		if (getDuration() <= 0) return 0;
+		return getSpeed0() * amount / getDuration();
+	}
+
+	/** Set this interpolation to begin at a speed matching the current speed of an action that it is interrupting, so the
+	 * transition will appear smooth. This must be called before removing the interrupted action from the actor. The interrupted
+	 * action should be removed from the actor after calling this method. A {@linkplain SplineInterpolation} must be used. */
+	public void setBlendFrom (RotateAction interruptedAction, SplineInterpolation interpolation) {
+		setInterpolation(interpolation);
+		worldStartSpeed = interruptedAction.getWorldSpeed();
+		blending = true;
+	}
+
+	public void cancelBlendFrom () {
+		blending = false;
 	}
 }

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/RotateToAction.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/RotateToAction.java
@@ -16,17 +16,33 @@
 
 package com.badlogic.gdx.scenes.scene2d.actions;
 
+import com.badlogic.gdx.math.Interpolation.SplineInterpolation;
+
 /** Sets the actor's rotation from its current value to a specific value.
  * @author Nathan Sweet */
-public class RotateToAction extends TemporalAction {
+public class RotateToAction extends TemporalAction implements TemporalAction.RotateAction {
 	private float start, end;
+	private float worldStartSpeed;
+	private boolean blending = false;
 
 	protected void begin () {
 		start = target.getRotation();
+		if (blending) {
+			setStartSpeed(2, worldStartSpeed * getDuration() / (end - start), 0, 0, 0);
+		}
 	}
 
 	protected void update (float percent) {
 		target.setRotation(start + (end - start) * percent);
+	}
+
+	protected void updateIndependently (float percent0, float percent1, float percent2, float percent3) {
+		target.setRotation(start + (end - start) * percent0);
+	};
+
+	public void reset () {
+		super.reset();
+		blending = false;
 	}
 
 	public float getRotation () {
@@ -35,5 +51,23 @@ public class RotateToAction extends TemporalAction {
 
 	public void setRotation (float rotation) {
 		this.end = rotation;
+	}
+
+	public float getWorldSpeed () {
+		if (getDuration() <= 0) return 0;
+		return getSpeed0() * (end - start) / getDuration();
+	}
+
+	/** Set this interpolation to begin at a speed matching the current speed of an action that it is interrupting, so the
+	 * transition will appear smooth. This must be called before removing the interrupted action from the actor. The interrupted
+	 * action should be removed from the actor after calling this method. A {@linkplain SplineInterpolation} must be used. */
+	public void setBlendFrom (RotateAction interruptedAction, SplineInterpolation interpolation) {
+		setInterpolation(interpolation);
+		worldStartSpeed = interruptedAction.getWorldSpeed();
+		blending = true;
+	}
+
+	public void cancelBlendFrom () {
+		blending = false;
 	}
 }

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/ScaleByAction.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/ScaleByAction.java
@@ -16,13 +16,34 @@
 
 package com.badlogic.gdx.scenes.scene2d.actions;
 
+import com.badlogic.gdx.math.Interpolation.SplineInterpolation;
+
 /** Scales an actor's scale to a relative size.
  * @author Nathan Sweet */
-public class ScaleByAction extends RelativeTemporalAction {
+public class ScaleByAction extends RelativeTemporalAction implements TemporalAction.ScaleAction {
 	private float amountX, amountY;
+	private float worldStartSpeedX, worldStartSpeedY;
+	private boolean blending = false;
+
+	protected void begin () {
+		super.begin();
+		if (blending) {
+			setStartSpeed(2, worldStartSpeedX * getDuration() / amountX, worldStartSpeedY * getDuration() / amountY, 0, 0);
+		}
+	}
 
 	protected void updateRelative (float percentDelta) {
 		target.scaleBy(amountX * percentDelta, amountY * percentDelta);
+	}
+
+	protected void updateRelativeIndependently (float percentDelta0, float percentDelta1, float percentDelta2,
+		float precentDelta3) {
+		target.scaleBy(amountX * percentDelta0, amountY * percentDelta1);
+	}
+
+	public void reset () {
+		super.reset();
+		blending = false;
 	}
 
 	public void setAmount (float x, float y) {
@@ -51,4 +72,27 @@ public class ScaleByAction extends RelativeTemporalAction {
 		this.amountY = y;
 	}
 
+	public float getWorldSpeedX () {
+		if (getDuration() <= 0) return 0;
+		return getSpeed0() * amountX / getDuration();
+	}
+
+	public float getWorldSpeedY () {
+		if (getDuration() <= 0) return 0;
+		return getSpeed1() * amountY / getDuration();
+	}
+
+	/** Set this interpolation to begin at a speed matching the current speed of an action that it is interrupting, so the
+	 * transition will appear smooth. This must be called before removing the interrupted action from the actor. The interrupted
+	 * action should be removed from the actor after calling this method. A {@linkplain SplineInterpolation} must be used. */
+	public void setBlendFrom (ScaleAction interruptedAction, SplineInterpolation interpolation) {
+		setInterpolation(interpolation);
+		worldStartSpeedX = interruptedAction.getWorldSpeedX();
+		worldStartSpeedY = interruptedAction.getWorldSpeedY();
+		blending = true;
+	}
+
+	public void cancelBlendFrom () {
+		blending = false;
+	}
 }

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/ScaleToAction.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/ScaleToAction.java
@@ -16,19 +16,37 @@
 
 package com.badlogic.gdx.scenes.scene2d.actions;
 
+import com.badlogic.gdx.math.Interpolation.SplineInterpolation;
+import com.badlogic.gdx.utils.Align;
+
 /** Sets the actor's scale from its current value to a specific value.
  * @author Nathan Sweet */
-public class ScaleToAction extends TemporalAction {
+public class ScaleToAction extends TemporalAction implements TemporalAction.ScaleAction {
 	private float startX, startY;
 	private float endX, endY;
+	private float worldStartSpeedX, worldStartSpeedY;
+	private boolean blending = false;
 
 	protected void begin () {
 		startX = target.getScaleX();
 		startY = target.getScaleY();
+		if (blending) {
+			setStartSpeed(2, worldStartSpeedX * getDuration() / (endX - startX), worldStartSpeedY * getDuration() / (endY - startY),
+				0, 0);
+		}
 	}
 
 	protected void update (float percent) {
 		target.setScale(startX + (endX - startX) * percent, startY + (endY - startY) * percent);
+	}
+
+	protected void updateIndependently (float percent0, float percent1, float percent2, float percent3) {
+		target.setScale(startX + (endX - startX) * percent0, startY + (endY - startY) * percent1);
+	};
+
+	public void reset () {
+		super.reset();
+		blending = false;
 	}
 
 	public void setScale (float x, float y) {
@@ -55,5 +73,29 @@ public class ScaleToAction extends TemporalAction {
 
 	public void setY (float y) {
 		this.endY = y;
+	}
+
+	public float getWorldSpeedX () {
+		if (getDuration() <= 0) return 0;
+		return getSpeed0() * (endX - startX) / getDuration();
+	}
+
+	public float getWorldSpeedY () {
+		if (getDuration() <= 0) return 0;
+		return getSpeed1() * (endY - startY) / getDuration();
+	}
+
+	/** Set this interpolation to begin at a speed matching the current speed of an action that it is interrupting, so the
+	 * transition will appear smooth. This must be called before removing the interrupted action from the actor. The interrupted
+	 * action should be removed from the actor after calling this method. A {@linkplain SplineInterpolation} must be used. */
+	public void setBlendFrom (ScaleAction interruptedAction, SplineInterpolation interpolation) {
+		setInterpolation(interpolation);
+		worldStartSpeedX = interruptedAction.getWorldSpeedX();
+		worldStartSpeedY = interruptedAction.getWorldSpeedY();
+		blending = true;
+	}
+
+	public void cancelBlendFrom () {
+		blending = false;
 	}
 }

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/SizeToAction.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/SizeToAction.java
@@ -16,19 +16,37 @@
 
 package com.badlogic.gdx.scenes.scene2d.actions;
 
+import com.badlogic.gdx.math.Interpolation.SplineInterpolation;
+import com.badlogic.gdx.utils.Align;
+
 /** Moves an actor from its current size to a specific size.
  * @author Nathan Sweet */
-public class SizeToAction extends TemporalAction {
+public class SizeToAction extends TemporalAction implements TemporalAction.SizeAction {
 	private float startWidth, startHeight;
 	private float endWidth, endHeight;
+	private float worldStartSpeedWidth, worldStartSpeedHeight;
+	private boolean blending = false;
 
 	protected void begin () {
 		startWidth = target.getWidth();
 		startHeight = target.getHeight();
+		if (blending) {
+			setStartSpeed(2, worldStartSpeedWidth * getDuration() / (endWidth - startWidth),
+				worldStartSpeedHeight * getDuration() / (endHeight - startHeight), 0, 0);
+		}
 	}
 
 	protected void update (float percent) {
 		target.setSize(startWidth + (endWidth - startWidth) * percent, startHeight + (endHeight - startHeight) * percent);
+	}
+
+	protected void updateIndependently (float percent0, float percent1, float percent2, float percent3) {
+		target.setSize(startWidth + (endWidth - startWidth) * percent0, startHeight + (endHeight - startHeight) * percent1);
+	};
+
+	public void reset () {
+		super.reset();
+		blending = false;
 	}
 
 	public void setSize (float width, float height) {
@@ -50,5 +68,29 @@ public class SizeToAction extends TemporalAction {
 
 	public void setHeight (float height) {
 		endHeight = height;
+	}
+
+	public float getWorldSpeedWidth () {
+		if (getDuration() <= 0) return 0;
+		return getSpeed0() * (endWidth - startWidth) / getDuration();
+	}
+
+	public float getWorldSpeedHeight () {
+		if (getDuration() <= 0) return 0;
+		return getSpeed1() * (endHeight - startHeight) / getDuration();
+	}
+
+	/** Set this interpolation to begin at a speed matching the current speed of an action that it is interrupting, so the
+	 * transition will appear smooth. This must be called before removing the interrupted action from the actor. The interrupted
+	 * action should be removed from the actor after calling this method. A {@linkplain SplineInterpolation} must be used. */
+	public void setBlendFrom (SizeAction interruptedAction, SplineInterpolation interpolation) {
+		setInterpolation(interpolation);
+		worldStartSpeedWidth = interruptedAction.getWorldSpeedWidth();
+		worldStartSpeedHeight = interruptedAction.getWorldSpeedHeight();
+		blending = true;
+	}
+
+	public void cancelBlendFrom () {
+		blending = false;
 	}
 }

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/TemporalAction.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/TemporalAction.java
@@ -17,6 +17,7 @@
 package com.badlogic.gdx.scenes.scene2d.actions;
 
 import com.badlogic.gdx.math.Interpolation;
+import com.badlogic.gdx.math.Interpolation.SplineInterpolation;
 import com.badlogic.gdx.scenes.scene2d.Action;
 import com.badlogic.gdx.utils.Pool;
 
@@ -25,6 +26,10 @@ import com.badlogic.gdx.utils.Pool;
 abstract public class TemporalAction extends Action {
 	private float duration, time;
 	private Interpolation interpolation;
+	private SplineInterpolation splineInterpolation; // To avoid repeated casts. Non-null if and only if there are starting speeds
+																		// and interpolation is a spline interpolation.
+	private float startSpeed0, startSpeed1, startSpeed2, startSpeed3;
+	private int startSpeedsUsed;
 	private boolean reverse, began, complete;
 
 	public TemporalAction () {
@@ -50,14 +55,33 @@ abstract public class TemporalAction extends Action {
 			}
 			time += delta;
 			complete = time >= duration;
-			float percent;
-			if (complete)
-				percent = 1;
-			else {
-				percent = time / duration;
+			if (complete) {
+				update(reverse ? 0f : 1f);
+			} else if (splineInterpolation == null) {
+				float percent = time / duration;
 				if (interpolation != null) percent = interpolation.apply(percent);
+				update(reverse ? 1 - percent : percent);
+			} else {
+				float percent = time / duration;
+				float percent0 = splineInterpolation.applyWithSpeed(startSpeed0, percent);
+				if (startSpeedsUsed == 1) {
+					update(reverse ? 1 - percent0 : percent0);
+				} else {
+					float percent1 = 0f, percent2 = 0f, percent3 = 0f;
+					switch (startSpeedsUsed) {
+					case 4:
+						percent3 = splineInterpolation.applyWithSpeed(startSpeed3, percent);
+					case 3:
+						percent2 = splineInterpolation.applyWithSpeed(startSpeed2, percent);
+					case 2:
+						percent1 = splineInterpolation.applyWithSpeed(startSpeed1, percent);
+					}
+					if (reverse)
+						updateIndependently(1 - percent0, 1 - percent1, 1 - percent2, 1 - percent3);
+					else
+						updateIndependently(percent0, percent1, percent2, percent3);
+				}
 			}
-			update(reverse ? 1 - percent : percent);
 			if (complete) end();
 			return complete;
 		} finally {
@@ -79,6 +103,16 @@ abstract public class TemporalAction extends Action {
 	 *           {@link #setReverse(boolean) reversed}, this will shrink from 1 to 0. */
 	abstract protected void update (float percent);
 
+	/** Called each frame if the interpolation affects more than one value (such as a translation, scale, or color) and the
+	 * starting speeds of the interpolation have been customized. Any excess percents are ignored. This only needs to be overridden
+	 * by actions that affect more than one value.
+	 * @param percent0 The percentage of completion for the first channel, such as X, width, or red.
+	 * @param percent1 The percentage of completion for the second channel, such as Y, height, or green.
+	 * @param percent2 The percentage of completion for the third channel, such as blue.
+	 * @param percent3 The percentage of completion for the fourth channel, such as alpha. */
+	protected void updateIndependently (float percent0, float percent1, float percent2, float percent3) {
+	};
+
 	/** Skips to the end of the transition. */
 	public void finish () {
 		time = duration;
@@ -94,6 +128,8 @@ abstract public class TemporalAction extends Action {
 		super.reset();
 		reverse = false;
 		interpolation = null;
+		splineInterpolation = null;
+		startSpeedsUsed = 0;
 	}
 
 	/** Gets the transition time so far. */
@@ -123,6 +159,56 @@ abstract public class TemporalAction extends Action {
 		this.interpolation = interpolation;
 	}
 
+	public void setInterpolation (SplineInterpolation interpolation) {
+		this.interpolation = interpolation;
+		if (startSpeedsUsed > 0) splineInterpolation = (SplineInterpolation)interpolation;
+	}
+
+	/** Start speeds are used only if the interpolation is a {@linkplain SplineInterpolation}. They are expressed in terms of unit
+	 * change over unit duration. Subclasses can expose a more intuitive method. To prepare the input for this method, you may use:
+	 * <p>
+	 * {@code speed = worldSpeed * duration / (totalChange)}
+	 * @param numberUsed The number of start speeds to be used, which is the same as the number of values this Action impacts. For
+	 *           example, an Action that affects position impacts two elements, X and Y. Excess inputs will be ignored. Maximum of
+	 *           4. */
+	protected void setStartSpeed (int numberUsed, float startSpeed0, float startSpeed1, float startSpeed2, float startSpeed3) {
+		this.startSpeed0 = startSpeed0;
+		this.startSpeed1 = startSpeed1;
+		this.startSpeed2 = startSpeed2;
+		this.startSpeed3 = startSpeed3;
+		startSpeedsUsed = numberUsed;
+		if (interpolation instanceof SplineInterpolation) splineInterpolation = (SplineInterpolation)interpolation;
+	}
+
+	protected void clearStartSpeeds () {
+		startSpeedsUsed = 0;
+		splineInterpolation = null;
+	}
+
+	protected float getSpeed0 () {
+		if (splineInterpolation != null) return splineInterpolation.speed(startSpeed0, 0, time / duration);
+		if (interpolation != null) return interpolation.speed(0, 0, time / duration);
+		return 1f;
+	}
+
+	protected float getSpeed1 () {
+		if (splineInterpolation != null) return splineInterpolation.speed(startSpeed1, 0, time / duration);
+		if (interpolation != null) return interpolation.speed(0, 0, time / duration);
+		return 1f;
+	}
+
+	protected float getSpeed2 () {
+		if (splineInterpolation != null) return splineInterpolation.speed(startSpeed2, 0, time / duration);
+		if (interpolation != null) return interpolation.speed(0, 0, time / duration);
+		return 1f;
+	}
+
+	protected float getSpeed3 () {
+		if (splineInterpolation != null) return splineInterpolation.speed(startSpeed3, 0, time / duration);
+		if (interpolation != null) return interpolation.speed(0, 0, time / duration);
+		return 1f;
+	}
+
 	public boolean isReverse () {
 		return reverse;
 	}
@@ -130,5 +216,27 @@ abstract public class TemporalAction extends Action {
 	/** When true, the action's progress will go from 100% to 0%. */
 	public void setReverse (boolean reverse) {
 		this.reverse = reverse;
+	}
+
+	public interface MoveAction {
+		public float getWorldSpeedX ();
+
+		public float getWorldSpeedY ();
+	}
+
+	public interface ScaleAction {
+		public float getWorldSpeedX ();
+
+		public float getWorldSpeedY ();
+	}
+
+	public interface SizeAction {
+		public float getWorldSpeedWidth ();
+
+		public float getWorldSpeedHeight ();
+	}
+
+	public interface RotateAction {
+		public float getWorldSpeed ();
 	}
 }

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/InterpolationInterruptionTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/InterpolationInterruptionTest.java
@@ -1,0 +1,282 @@
+
+package com.badlogic.gdx.tests;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Input;
+import com.badlogic.gdx.InputAdapter;
+import com.badlogic.gdx.InputMultiplexer;
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
+import com.badlogic.gdx.math.Interpolation;
+import com.badlogic.gdx.math.MathUtils;
+import com.badlogic.gdx.math.Interpolation.SplineInterpolation;
+import com.badlogic.gdx.math.Vector2;
+import com.badlogic.gdx.math.Vector3;
+import com.badlogic.gdx.scenes.scene2d.Action;
+import com.badlogic.gdx.scenes.scene2d.Actor;
+import com.badlogic.gdx.scenes.scene2d.Event;
+import com.badlogic.gdx.scenes.scene2d.EventListener;
+import com.badlogic.gdx.scenes.scene2d.Stage;
+import com.badlogic.gdx.scenes.scene2d.actions.Actions;
+import com.badlogic.gdx.scenes.scene2d.actions.ColorAction;
+import com.badlogic.gdx.scenes.scene2d.actions.MoveByAction;
+import com.badlogic.gdx.scenes.scene2d.actions.MoveToAction;
+import com.badlogic.gdx.scenes.scene2d.actions.RotateByAction;
+import com.badlogic.gdx.scenes.scene2d.actions.RotateToAction;
+import com.badlogic.gdx.scenes.scene2d.actions.ScaleByAction;
+import com.badlogic.gdx.scenes.scene2d.actions.ScaleToAction;
+import com.badlogic.gdx.scenes.scene2d.actions.SizeByAction;
+import com.badlogic.gdx.scenes.scene2d.actions.SizeToAction;
+import com.badlogic.gdx.scenes.scene2d.actions.TemporalAction.*;
+import com.badlogic.gdx.scenes.scene2d.ui.CheckBox;
+import com.badlogic.gdx.scenes.scene2d.ui.Image;
+import com.badlogic.gdx.scenes.scene2d.ui.Label;
+import com.badlogic.gdx.scenes.scene2d.ui.List;
+import com.badlogic.gdx.scenes.scene2d.ui.List.ListStyle;
+import com.badlogic.gdx.scenes.scene2d.ui.ScrollPane;
+import com.badlogic.gdx.scenes.scene2d.ui.Skin;
+import com.badlogic.gdx.scenes.scene2d.ui.Table;
+import com.badlogic.gdx.scenes.scene2d.ui.VerticalGroup;
+import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
+import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener.ChangeEvent;
+import com.badlogic.gdx.scenes.scene2d.utils.TextureRegionDrawable;
+import com.badlogic.gdx.tests.utils.GdxTest;
+import com.badlogic.gdx.utils.Align;
+import com.badlogic.gdx.utils.Array;
+import com.badlogic.gdx.utils.reflect.ClassReflection;
+import com.badlogic.gdx.utils.reflect.Field;
+import com.badlogic.gdx.utils.viewport.ExtendViewport;
+import com.badlogic.gdx.utils.viewport.FitViewport;
+import com.badlogic.gdx.utils.viewport.Viewport;
+
+import static com.badlogic.gdx.scenes.scene2d.actions.Actions.*;
+
+@SuppressWarnings("synthetic-access")
+public class InterpolationInterruptionTest extends GdxTest {
+
+	private Stage stage;
+	private String selectedStart, selectedInterrupt;
+	private SupportedAction selectedAction;
+	private boolean shouldBlend;
+	private Label durationLabel;
+	private Image imageActor;
+	private final Vector2 tmp2 = new Vector2();
+	private final Vector3 tmp3 = new Vector3();
+	private final Color tmpC = new Color();
+	private float duration = 1.0f;
+	private static final float IMG_SIZE = 20;
+
+	private enum SupportedAction { // action types this test can apply to the actor
+		Color(ColorAction.class), MoveBy(MoveAction.class), MoveTo(MoveAction.class), RotateBy(RotateAction.class), RotateTo(
+			RotateAction.class), ScaleBy(ScaleAction.class), ScaleTo(ScaleAction.class);
+
+		public final Class effectType;
+
+		private SupportedAction (Class effectType) {
+			this.effectType = effectType;
+		}
+	}
+
+	private InputAdapter scrollAdapter = new InputAdapter() {
+		@Override
+		public boolean scrolled (int amount) {
+			if (!Gdx.input.isKeyPressed(Input.Keys.CONTROL_LEFT) && !Gdx.input.isKeyPressed(Input.Keys.CONTROL_RIGHT)) return false;
+			duration -= amount * 0.2f;
+			duration = Math.max(0, Math.round(duration * 5) / 5f); // sanitize value
+			return true;
+		}
+	};
+
+	private InputAdapter touchAdapter = new InputAdapter() {
+		@Override
+		public boolean touchUp (int x, int y, int pointer, int newParam) {
+			stage.getViewport().unproject(tmp3.set(x, y, 0));
+
+			tmp3.sub(IMG_SIZE / 2); // shift image to be centered on touch point.
+
+			Action interruptedAction = findActionOfSameEffectType(imageActor, selectedAction);
+			startNewAction(shouldBlend ? interruptedAction : null, tmp3.x, tmp3.y,
+				interruptedAction == null ? selectedStart : selectedInterrupt);
+			imageActor.removeAction(interruptedAction);
+			return true;
+		}
+	};
+
+	/** @return An action on the actor that is of the same type as the input action, or null if none is found. */
+	private Action findActionOfSameEffectType (Actor actor, SupportedAction action) {
+		Class effectType = action.effectType;
+		for (Action a : actor.getActions()) {
+			if (effectType.isAssignableFrom(a.getClass())) return a;
+		}
+		return null;
+	}
+
+	/** @param interruptedAction Can be null if nothing to interrupt. Must match the effect type of the interpolationName. */
+	private void startNewAction (Action interruptedAction, float x, float y, String interpolationName) {
+		tmp2.set(imageActor.getX(), imageActor.getY());
+
+		Interpolation interpolation = getInterpolation(interpolationName);
+		SplineInterpolation interruptingInterpolation = interruptedAction != null ? (SplineInterpolation)interpolation : null;
+
+		switch (selectedAction) {
+		case Color:
+			tmpC.set(x / stage.getViewport().getWorldWidth(), y / stage.getViewport().getWorldHeight(),
+				MathUtils.clamp(2 * tmp2.dst(x, y) / stage.getViewport().getWorldWidth(), 0, 1), 0.5f + 0.5f * (float)Math.random());
+			ColorAction colorAction = color(tmpC, duration, interpolation);
+			if (interruptingInterpolation != null)
+				colorAction.setBlendFrom((ColorAction)interruptedAction, interruptingInterpolation);
+			imageActor.addAction(colorAction);
+			break;
+		case MoveBy:
+			MoveByAction moveByAction = moveBy(x - tmp2.x, y - tmp2.y, duration, interpolation);
+			if (interruptingInterpolation != null)
+				moveByAction.setBlendFrom((MoveAction)interruptedAction, interruptingInterpolation);
+			imageActor.addAction(moveByAction);
+			break;
+		case MoveTo:
+			MoveToAction moveToction = moveTo(x, y, duration, interpolation);
+			if (interruptingInterpolation != null)
+				moveToction.setBlendFrom((MoveAction)interruptedAction, interruptingInterpolation);
+			imageActor.addAction(moveToction);
+			break;
+		case RotateBy:
+			float deltaAngle = -MathUtils.atan2(x - tmp2.x, y - tmp2.y) * MathUtils.radDeg - imageActor.getRotation();
+			RotateByAction rotateByAction = rotateBy(deltaAngle, duration, interpolation);
+			if (interruptingInterpolation != null)
+				rotateByAction.setBlendFrom((RotateAction)interruptedAction, interruptingInterpolation);
+			imageActor.addAction(rotateByAction);
+			break;
+		case RotateTo:
+			float angle = -MathUtils.atan2(x - tmp2.x, y - tmp2.y) * MathUtils.radDeg;
+			RotateToAction rotateToAction = rotateTo(angle, duration, interpolation);
+			if (interruptingInterpolation != null)
+				rotateToAction.setBlendFrom((RotateAction)interruptedAction, interruptingInterpolation);
+			imageActor.addAction(rotateToAction);
+			break;
+		case ScaleBy:
+			float deltaXScale = Math.abs((x - tmp2.x) / (imageActor.getWidth() / 2)) - imageActor.getScaleX();
+			float deltaYScale = Math.abs((y - tmp2.y) / (imageActor.getHeight() / 2)) - imageActor.getScaleY();
+			ScaleByAction scaleByAction = scaleBy(deltaXScale, deltaYScale, duration, interpolation);
+			if (interruptingInterpolation != null)
+				scaleByAction.setBlendFrom((ScaleAction)interruptedAction, interruptingInterpolation);
+			imageActor.addAction(scaleByAction);
+			break;
+		case ScaleTo:
+			float targetX = Math.abs((x - tmp2.x) / (imageActor.getWidth() / 2));
+			float targetY = Math.abs((y - tmp2.y) / (imageActor.getHeight() / 2));
+			ScaleToAction scaleToction = scaleTo(targetX, targetY, duration, interpolation);
+			if (interruptingInterpolation != null)
+				scaleToction.setBlendFrom((ScaleAction)interruptedAction, interruptingInterpolation);
+			imageActor.addAction(scaleToction);
+			break;
+		}
+	}
+
+	private Interpolation getInterpolation (String name) {
+		try {
+			return (Interpolation)Interpolation.class.getField(name).get(null);
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@Override
+	public void create () {
+		Skin skin = new Skin(Gdx.files.internal("data/uiskin.json"));
+		stage = new Stage(new ExtendViewport(640, 480));
+		imageActor = new Image(skin, "white");
+		imageActor.setSize(IMG_SIZE, IMG_SIZE);
+		imageActor.setOrigin(IMG_SIZE / 2, IMG_SIZE / 2);
+		stage.addActor(imageActor);
+
+		Gdx.input.setInputProcessor(new InputMultiplexer(scrollAdapter, stage, touchAdapter));
+
+		Field[] interpolationFields = ClassReflection.getFields(Interpolation.class);
+
+		Array<String> startNames = new Array<String>();
+		Array<String> interruptNames = new Array<String>();
+		for (int i = 0; i < interpolationFields.length; i++) {
+			if (Interpolation.class.isAssignableFrom(interpolationFields[i].getDeclaringClass()))
+				startNames.add(interpolationFields[i].getName());
+			if (SplineInterpolation.class.isAssignableFrom(interpolationFields[i].getType()))
+				interruptNames.add(interpolationFields[i].getName());
+		}
+		selectedStart = startNames.first();
+		selectedInterrupt = interruptNames.first();
+
+		final List<String> startList = new List(skin);
+		startList.setItems(startNames);
+		startList.addListener(new ChangeListener() {
+			public void changed (ChangeEvent event, Actor actor) {
+				selectedStart = startList.getSelected();
+			}
+		});
+
+		final List<String> interruptList = new List(skin);
+		interruptList.setItems(interruptNames);
+		interruptList.addListener(new ChangeListener() {
+			public void changed (ChangeEvent event, Actor actor) {
+				selectedInterrupt = interruptList.getSelected();
+			}
+		});
+
+		final List<SupportedAction> actionList = new List<SupportedAction>(skin);
+		actionList.setItems(SupportedAction.values());
+		actionList.addListener(new ChangeListener() {
+			public void changed (ChangeEvent event, Actor actor) {
+				selectedAction = actionList.getSelected();
+			}
+		});
+		actionList.setSelected(SupportedAction.MoveTo);
+
+		final CheckBox blendCheckBox = new CheckBox("Blend", skin);
+		blendCheckBox.addListener(new ChangeListener() {
+			public void changed (ChangeEvent event, Actor actor) {
+				shouldBlend = blendCheckBox.isChecked();
+			}
+		});
+		blendCheckBox.setChecked(true);
+		durationLabel = new Label(" ", skin);
+
+		ListStyle listStyle = skin.get(ListStyle.class);
+		listStyle.background = skin.getDrawable("default-rect");
+
+		ScrollPane scrollStarts = new ScrollPane(startList, skin);
+		scrollStarts.setFadeScrollBars(false);
+		scrollStarts.setScrollingDisabled(true, false);
+
+		Table rightCol = new Table(skin);
+		rightCol.add(interruptList).width(100).row();
+		rightCol.add(blendCheckBox).left().row();
+		rightCol.add("Action type:").padTop(10).left().row();
+		rightCol.add(actionList).width(100).expandX().left().top();
+
+		Table mainTable = new Table(skin);
+		mainTable.setFillParent(true);
+		mainTable.add("Start with:").left();
+		mainTable.add("Interrupt with:").left().row();
+		mainTable.add(scrollStarts).width(100).padRight(10).top();
+		mainTable.add(rightCol).width(100).expandX().left().top().row();
+		mainTable.add(durationLabel).left().colspan(2);
+		stage.addActor(mainTable);
+	}
+
+	@Override
+	public void resize (int width, int height) {
+		stage.getViewport().update(width, height, true);
+		imageActor.clearActions();
+		imageActor.setPosition(width / 2, height / 2);
+	}
+
+	@Override
+	public void render () {
+		Gdx.gl.glClearColor(0.25f, 0.25f, 0.25f, 1);
+		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+
+		durationLabel.setText("Duration: " + duration + "s. Ctrl + mouse wheel to adjust.");
+
+		stage.act();
+		stage.draw();
+	}
+}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
@@ -100,6 +100,7 @@ public class GdxTests {
 		BitmapFontMetricsTest.class,
 		BitmapFontTest.class,
 		BitmapFontAtlasRegionTest.class,
+		InterpolationInterruptionTest.class,
 		BlitTest.class,
 		Box2DTest.class,
 		Box2DTestCollection.class,


### PR DESCRIPTION
This lets you interrupt a currently running TemporalAction using the current rate of change as the starting rate of change for the new TemporalAction. Typically, if you need to add a new MoveToAction to an object that is already moving, there is a jarring change in velocity as the new Action begins its interpolation. Now you can take the old MoveToAction or MoveByAction and pass it to the new Action to automatically start the new Action at the same speed as the interrupted Action was currently moving.

This change to the Actions requires a different start speed for each component of the temporal action (for example, X and Y). As such there is an impact of one additional `if` statement in the `update` method of TemporalAction.

I added interfaces for MoveAction, RotationAction, etc, to make it easier to find Actions that affect the same properties that should be interrupted, and to reduce the number of overloaded `setBlendFrom` methods.

A typical usage:

    void moveActor (Actor actor, float targetX, float targetY, float duration){
        MoveAction interruptedAction = findMoveAction(actor);
        MoveToAction newAction = Actions.moveTo(targetX, targetY, duration);
        if (interruptedAction != null) newAction.setBlendFrom(interruptedAction, Interpolation.fade);
        actor.removeAction(interruptedAction); //in case its duration was long enough to outlive new one
        actor.addAction(newAction);
    }

    MoveAction findMoveAction(Actor actor){
        for (Action a : actor.getActions())
            if (action instanceof MoveAction) return (MoveAction)action;
        return null;
    }

There is a new SplineInterpolation subclass to signify the interpolations that support a starting speed. I added a `speed` method to all existing Interpolations so that any type of Interpolation can be smoothly interrupted.

Video comparison with and without blending from the interrupted interpolation:
https://youtu.be/ZY_gq5k9lJE