### PR TITLE
Opening access to the BitmapFontCache.idx field for custom render

### DIFF
--- a/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeType.java
+++ b/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeType.java
@@ -622,8 +622,12 @@ public class FreeType {
 					int yWidth = y * width;
 					for (int x = 0; x < width; x++) {
 						//use the color value of the foreground color, blend alpha
-						byte alpha = src.get(ySrcPitch + x);
-						dst.put(yWidth + x, (srcRGBA & 0xffffff00) | (int)((srcRGBA & 0xff) * (alpha & 0xff)/255f));
+						final byte alpha = src.get(ySrcPitch + x);
+						final int src_aplha = srcRGBA & 0xff;
+						final int blend = alpha & 0xff;
+						final int tmp_alpha = (int)(src_aplha * blend/255f);
+						final int value = (srcRGBA & 0xffffff00) | tmp_alpha;
+						dst.put(yWidth + x, value);
 					}
 				}
 			}

--- a/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeType.java
+++ b/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeType.java
@@ -622,12 +622,8 @@ public class FreeType {
 					int yWidth = y * width;
 					for (int x = 0; x < width; x++) {
 						//use the color value of the foreground color, blend alpha
-						final byte alpha = src.get(ySrcPitch + x);
-						final int src_aplha = srcRGBA & 0xff;
-						final int blend = alpha & 0xff;
-						final int tmp_alpha = (int)(src_aplha * blend/255f);
-						final int value = (srcRGBA & 0xffffff00) | tmp_alpha;
-						dst.put(yWidth + x, value);
+						byte alpha = src.get(ySrcPitch + x);
+						dst.put(yWidth + x, (srcRGBA & 0xffffff00) | (int)((srcRGBA & 0xff) * (alpha & 0xff)/255f));
 					}
 				}
 			}

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFontCache.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFontCache.java
@@ -525,4 +525,11 @@ public class BitmapFontCache {
 	public Array<GlyphLayout> getLayouts () {
 		return layouts;
 	}
+
+	/** For expert usage -- returns indexes for vertex data entries. Using this method allows external implementations for custom
+	 * rendering.
+	 * @return array with numbers of vertex data entries per page. */
+	public int[] getIDX () {
+		return this.idx;
+	}
 }

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFontCache.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFontCache.java
@@ -532,4 +532,5 @@ public class BitmapFontCache {
 	public int[] getIDX () {
 		return this.idx;
 	}
+	
 }


### PR DESCRIPTION
Hello,

For custom rendering I need access to the IDX field of the BitmapFontCache class.
One simple method added:
```
public int[] getIDX () {
		return this.idx;
}
```

Have a nice day,
J