### PR TITLE
Opening access to the BitmapFontCache.idx field for custom render

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFontCache.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFontCache.java
@@ -526,7 +526,7 @@ public class BitmapFontCache {
 		return layouts;
 	}
 
-	final public int getVertexCount (final int j) {
-		return this.idx[j];
+	public final  int getVertexCount (final int page) {
+		return this.idx[page];
 	}
 }

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFontCache.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFontCache.java
@@ -526,7 +526,7 @@ public class BitmapFontCache {
 		return layouts;
 	}
 
-	final public int getVertexCount (int j) {
+	final public int getVertexCount (final int j) {
 		return this.idx[j];
 	}
 }

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFontCache.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFontCache.java
@@ -525,4 +525,11 @@ public class BitmapFontCache {
 	public Array<GlyphLayout> getLayouts () {
 		return layouts;
 	}
+
+	/** For expert usage -- returns indexes for vertex data entries. Using this method allows external implementations for custom
+	 * rendering.
+	 * @return array with numbers of vertex data entries per page. */
+	public int[] getIDX () {
+		return this.idx;
+	}
 }

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFontCache.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFontCache.java
@@ -530,6 +530,6 @@ public class BitmapFontCache {
 	 * rendering.
 	 * @return array with numbers of vertex data entries per page. */
         public int getVertexCount (int page) {
-            return idx[page];
+            return this.idx[page];
         }
 }

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFontCache.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFontCache.java
@@ -526,7 +526,7 @@ public class BitmapFontCache {
 		return layouts;
 	}
 
-	public int getVertexCount (int j) {
+	final public int getVertexCount (int j) {
 		return this.idx[j];
 	}
 }

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFontCache.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFontCache.java
@@ -526,10 +526,7 @@ public class BitmapFontCache {
 		return layouts;
 	}
 
-	/** For expert usage -- returns indexes for vertex data entries. Using this method allows external implementations for custom
-	 * rendering.
-	 * @return array with numbers of vertex data entries per page. */
-	public int[] getIDX () {
-		return this.idx;
+	public int getVertexCount (int j) {
+		return this.idx[j];
 	}
 }

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFontCache.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFontCache.java
@@ -526,7 +526,7 @@ public class BitmapFontCache {
 		return layouts;
 	}
 
-	public final  int getVertexCount (final int page) {
-		return this.idx[page];
+	public final  int getVertexCount (final int region) {
+		return this.idx[region];
 	}
 }

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFontCache.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFontCache.java
@@ -529,7 +529,7 @@ public class BitmapFontCache {
 	/** For expert usage -- returns indexes for vertex data entries. Using this method allows external implementations for custom
 	 * rendering.
 	 * @return array with numbers of vertex data entries per page. */
-	public int[] getIDX () {
-		return this.idx;
-	}
+        public int getVertexCount (int page) {
+            return idx[page];
+        }
 }

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFontCache.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFontCache.java
@@ -529,7 +529,7 @@ public class BitmapFontCache {
 	/** For expert usage -- returns indexes for vertex data entries. Using this method allows external implementations for custom
 	 * rendering.
 	 * @return array with numbers of vertex data entries per page. */
-        public int getVertexCount (int page) {
-            return this.idx[page];
-        }
+	public int[] getIDX () {
+		return this.idx;
+	}
 }


### PR DESCRIPTION
Hello,

For custom rendering I need access to the IDX field of the BitmapFontCache class.
One simple method added:
```
public int[] getIDX () {
        return this.idx;
}
```
Have a nice day,
J