### PR TITLE
Allow custom shaders in ShapeRenderer

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -14,6 +14,8 @@
 - Fixed BitmapFont color tags changing glyph spacing versus not using color tags. BitmapFont#getGlyphs has a new paramter. See #3455.
 - Skin's TintedDrawable now works with TiledDrawable. #3627
 - Updated jnigen to Java Parser 2.3.0 (http://javaparser.github.io/javaparser/).
+- A custom shader can be set on ShapeRenderer by calling getRenderer().setShader(shader);.
+- API Change: ImmediateModeRenderer20.setShader(shader) does not dispose the default shader. ImmediateModeRenderer20.setShader(null) reapplies the default shader.
 
 [1.7.1]
 - Fixes AtlasTmxMapLoader region name loading to tileset name instead of filename

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/ImmediateModeRenderer.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/ImmediateModeRenderer.java
@@ -18,16 +18,17 @@ package com.badlogic.gdx.graphics.glutils;
 
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.math.Matrix4;
+import com.badlogic.gdx.utils.Disposable;
 
-public interface ImmediateModeRenderer {
+public interface ImmediateModeRenderer extends Disposable {
 	public void begin (Matrix4 projModelView, int primitiveType);
 
 	public void flush ();
-	
+
 	public void color (Color color);
 
 	public void color (float r, float g, float b, float a);
-	
+
 	public void color (float colorBits);
 
 	public void texCoord (float u, float v);
@@ -42,5 +43,9 @@ public interface ImmediateModeRenderer {
 
 	public int getMaxVertices ();
 
-	public void dispose ();
+	/** Set a custom shader to use instead of the default shader.
+	 * @param shader A custom shader, or null to return to using the default shader. */
+	public void setShader (ShaderProgram shader);
+
+	public ShaderProgram getShader ();
 }


### PR DESCRIPTION
Exposes `setShader()` in the ImmediateModeRenderer interface so the shader can be changed in ShapeRenderer. I figure this is fine now that ES 1.0 is no longer supported.

Previously, ImmediateModeRenderer20 disposes its default shader if you try to change its shader with `setShader`. This seems to me like it would be undesired behavior in almost all cases, and it is clunky to work around if you want to keep that original shader alive. I am suggesting changing its behavior to be like SpriteBatch, i.e. the default shader is only disposed when the renderer is disposed. And the shader can be changed in between `begin` and `end` without issue.

I think this is unlikely to affect existing projects, since most of ImmediateModeRenderer20's members were private and ImmediateModeRenderer20 needs to be disposed anyway. I suppose it could result in a shader hanging around longer than desired if someone was counting on it getting disposed when swapping to a different one, but this seems to me like a rare use case. If someone does need to maintain that behavior, they only need to call dispose manually on the original default shader the first time it is changed out.