### PR TITLE
Fixing memory leak related to TouchFocus and pooling

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/Stage.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/Stage.java
@@ -822,6 +822,7 @@ public class Stage extends InputAdapter implements Disposable {
 		public void reset () {
 			listenerActor = null;
 			listener = null;
+			target = null;
 		}
 	}
 }


### PR DESCRIPTION
Generally doesn't seem to be too big an issue since the TouchFocus objects seem to get pulled out of the pool and overwritten fairly often (at least in my case), but still a leak.