### PR TITLE
Changed music object reference to protected access

### DIFF
--- a/gdx/src/com/badlogic/gdx/assets/loaders/MusicLoader.java
+++ b/gdx/src/com/badlogic/gdx/assets/loaders/MusicLoader.java
@@ -28,7 +28,7 @@ import com.badlogic.gdx.utils.Array;
  * @author mzechner */
 public class MusicLoader extends AsynchronousAssetLoader<Music, MusicLoader.MusicParameter> {
 
-	private Music music;
+	protected Music music;
 
 	public MusicLoader (FileHandleResolver resolver) {
 		super(resolver);


### PR DESCRIPTION
Changed currently created music object to protected access to allow for extensions of MusicLoader grab it after loading.