### PR TITLE
Changed sound object reference to protected access

### DIFF
--- a/gdx/src/com/badlogic/gdx/assets/loaders/SoundLoader.java
+++ b/gdx/src/com/badlogic/gdx/assets/loaders/SoundLoader.java
@@ -28,7 +28,7 @@ import com.badlogic.gdx.utils.Array;
  * @author mzechner */
 public class SoundLoader extends AsynchronousAssetLoader<Sound, SoundLoader.SoundParameter> {
 
-	private Sound sound;
+	protected Sound sound;
 
 	public SoundLoader (FileHandleResolver resolver) {
 		super(resolver);


### PR DESCRIPTION
Changed currently created sound object to protected access to allow for extensions of SoundLoader grab it after loading.