### PR TITLE
Created protected methods so that subclasses of MusicLoader and SoundLoader can get asset reference

### DIFF
--- a/gdx/src/com/badlogic/gdx/assets/loaders/MusicLoader.java
+++ b/gdx/src/com/badlogic/gdx/assets/loaders/MusicLoader.java
@@ -33,6 +33,15 @@ public class MusicLoader extends AsynchronousAssetLoader<Music, MusicLoader.Musi
 	public MusicLoader (FileHandleResolver resolver) {
 		super(resolver);
 	}
+	
+	/** Returns the {@link Music} instance currently loaded by this
+	 * {@link MusicLoader}.
+	 * 
+	 * @return the currently loaded {@link Music}, otherwise {@code null} if
+	 *         no {@link Music} has been loaded yet. */
+	protected Music getLoadedMusic () {
+		return music;
+	}
 
 	@Override
 	public void loadAsync (AssetManager manager, String fileName, FileHandle file, MusicParameter parameter) {

--- a/gdx/src/com/badlogic/gdx/assets/loaders/SoundLoader.java
+++ b/gdx/src/com/badlogic/gdx/assets/loaders/SoundLoader.java
@@ -34,6 +34,15 @@ public class SoundLoader extends AsynchronousAssetLoader<Sound, SoundLoader.Soun
 		super(resolver);
 	}
 
+	/** Returns the {@link Sound} instance currently loaded by this
+	 * {@link SoundLoader}.
+	 * 
+	 * @return the currently loaded {@link Sound}, otherwise {@code null} if
+	 *         no {@link Sound} has been loaded yet. */
+	protected Sound getLoadedSound () {
+		return sound;
+	}
+	
 	@Override
 	public void loadAsync (AssetManager manager, String fileName, FileHandle file, SoundParameter parameter) {
 		sound = Gdx.audio.newSound(file);


### PR DESCRIPTION
Added protected methods to get the currently loaded Sound or Music object reference. This is nice so that subclasses of these AssetLoaders can override loadAsync and call the superclass method and then grab the asset reference for use. This cleans up subclasses who want to take advantage of the behavior of SoundLoader and MusicLoader greatly.

This PR replaces #3541 and #3542 