### PR TITLE
Added final reference to the FileHandleResolver for which an AssetManager was created using

### DIFF
--- a/gdx/src/com/badlogic/gdx/assets/AssetManager.java
+++ b/gdx/src/com/badlogic/gdx/assets/AssetManager.java
@@ -75,6 +75,8 @@ public class AssetManager implements Disposable {
 	AssetErrorListener listener = null;
 	int loaded = 0;
 	int toLoad = 0;
+        
+	final FileHandleResolver resolver;
 
 	Logger log = new Logger("AssetManager", Application.LOG_NONE);
 
@@ -92,6 +94,7 @@ public class AssetManager implements Disposable {
 	 * manually add the loaders you need, including any loaders they might depend on.
 	 * @param defaultLoaders whether to add the default loaders */
 	public AssetManager (FileHandleResolver resolver, boolean defaultLoaders) {
+		this.resolver = resolver;
 		if (defaultLoaders) {
 			setLoader(BitmapFont.class, new BitmapFontLoader(resolver));
 			setLoader(Music.class, new MusicLoader(resolver));
@@ -110,6 +113,13 @@ public class AssetManager implements Disposable {
 			setLoader(Model.class, ".obj", new ObjLoader(resolver));
 		}
 		executor = new AsyncExecutor(1);
+	}
+
+	/** Returns the {@link FileHandleResolver} for which this AssetManager
+	 * was loaded with.
+	 * @return the file handle resolver which this AssetManager uses */
+	public FileHandleResolver getFileHandleResolver () {
+		return resolver;
 	}
 
 	/** @param fileName the asset file name


### PR DESCRIPTION
Added final reference to the FileHandleResolver for which an AssetManager was created using. This is useful if custom AssetLoaders would like to use the same FileHandleResolver as the AssetManager for which they will belong.