### PR TITLE
Added checkedOffset fields to ButtonStyle

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Button.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Button.java
@@ -215,6 +215,9 @@ public class Button extends Table implements Disableable {
 		if (isPressed && !isDisabled) {
 			offsetX = style.pressedOffsetX;
 			offsetY = style.pressedOffsetY;
+		} else if (isChecked && !isDisabled) {
+			offsetX = style.checkedOffsetX;
+			offsetY = style.checkedOffsetY;
 		} else {
 			offsetX = style.unpressedOffsetX;
 			offsetY = style.unpressedOffsetY;
@@ -262,7 +265,7 @@ public class Button extends Table implements Disableable {
 		/** Optional. */
 		public Drawable up, down, over, checked, checkedOver, disabled;
 		/** Optional. */
-		public float pressedOffsetX, pressedOffsetY, unpressedOffsetX, unpressedOffsetY;
+		public float pressedOffsetX, pressedOffsetY, unpressedOffsetX, unpressedOffsetY, checkedOffsetX, checkedOffsetY;
 
 		public ButtonStyle () {
 		}
@@ -284,6 +287,9 @@ public class Button extends Table implements Disableable {
 			this.pressedOffsetY = style.pressedOffsetY;
 			this.unpressedOffsetX = style.unpressedOffsetX;
 			this.unpressedOffsetY = style.unpressedOffsetY;
+			this.checkedOffsetX = style.checkedOffsetX;
+			this.checkedOffsetY = style.checkedOffsetY;
+			
 		}
 	}
 }


### PR DESCRIPTION
Added checkedOffset fields to button style. In my use-case, I use the pressed button to represent the checked state, and since my pressed button requires a label offset, I needed to add the following code to make the button look correct in the checked state as well.