### PR TITLE
adds rotationChanged method for Actor class

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 [1.7.2]
 - Added AndroidAudio#newMusic(FileDescriptor) to allow loading music from a file descriptor, see #2970
 - Added GLOnlyTextureData, which is now the default for FrameBuffer and FrameBufferCubemap, see #3539
+- Added rotationChanged() for Actor class, called when rotation changes, see https://github.com/libgdx/libgdx/pull/3563
 
 [1.7.1]
 - Fixes AtlasTmxMapLoader region name loading to tileset name instead of filename

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/Actor.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/Actor.java
@@ -491,6 +491,10 @@ public class Actor {
 	protected void sizeChanged () {
 	}
 
+	/** Called when the actor's rotation has been changed. */
+	protected void rotationChanged () {
+	}
+
 	/** Sets the width and height. */
 	public void setSize (float width, float height) {
 		float oldWidth = this.width;
@@ -612,12 +616,16 @@ public class Actor {
 	}
 
 	public void setRotation (float degrees) {
+		float oldRotation = this.rotation;
 		this.rotation = degrees;
+		if (degrees != oldRotation) rotationChanged();
 	}
 
 	/** Adds the specified rotation to the current rotation. */
 	public void rotateBy (float amountInDegrees) {
 		rotation += amountInDegrees;
+		if (amountInDegrees != 0)
+			rotationChanged();
 	}
 
 	public void setColor (Color color) {


### PR DESCRIPTION
The actor class has an existing `positionChanged` method that can be overridden to check for position changes.  In addition, there's one for `sizeChanged`.  However, I noticed there was no option for rotation changes so I added it.

I apologize, I haven't actually been able to test these changes because of a Maven issue so if someone could review this that would be great.  In addition, this is my first pull request for libgdx (I have the CLA sent in already).  