### PR TITLE
Add check for isLongPress on back button event forward

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidInput.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidInput.java
@@ -540,7 +540,7 @@ public class AndroidInput implements Input, OnKeyListener, OnTouchListener {
 
 		// circle button on Xperia Play shouldn't need catchBack == true
 		if (keyCode == Keys.BUTTON_CIRCLE) return true;
-		if (catchBack && keyCode == android.view.KeyEvent.KEYCODE_BACK) return true;
+		if (catchBack && keyCode == android.view.KeyEvent.KEYCODE_BACK && !e.isLongPress()) return true;
 		if (catchMenu && keyCode == android.view.KeyEvent.KEYCODE_MENU) return true;
 		return false;
 	}


### PR DESCRIPTION
Added extra logic to return the back button key press on Android only if it does not have [FLAG_LONG_PRESS](https://developer.android.com/reference/android/view/KeyEvent.html#isLongPress()) the set as per issue #3529 

I am having difficulty verifying this fix as I am unable to compile libgdx locally.