### PR TITLE
Fixes setPosition issue on NuPlayer (part 2)

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidMusic.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidMusic.java
@@ -16,17 +16,18 @@
 
 package com.badlogic.gdx.backends.android;
 
-import java.io.IOException;
-
 import android.media.MediaPlayer;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.audio.Music;
 
+import java.io.IOException;
+
 public class AndroidMusic implements Music, MediaPlayer.OnCompletionListener {
 	private final AndroidAudio audio;
 	private MediaPlayer player;
 	private boolean isPrepared = true;
+	private boolean isPaused = false;
 	protected boolean wasPlaying = false;
 	private float volume = 1f;
 	protected OnCompletionListener onCompletionListener;
@@ -69,8 +70,9 @@ public class AndroidMusic implements Music, MediaPlayer.OnCompletionListener {
 	@Override
 	public void pause () {
 		if (player == null) return;
-		if (player.isPlaying()) {			
+		if (player.isPlaying()) {
 			player.pause();
+			isPaused = true;
 		}
 		wasPlaying = false;
 	}
@@ -84,6 +86,11 @@ public class AndroidMusic implements Music, MediaPlayer.OnCompletionListener {
 			if (!isPrepared) {
 				player.prepare();
 				isPrepared = true;
+			}
+			if (isPaused) {
+				isPaused = false;
+			} else if (player.getCurrentPosition() != 0) {
+				player.seekTo(0);
 			}
 			player.start();
 		} catch (IllegalStateException e) {
@@ -130,10 +137,8 @@ public class AndroidMusic implements Music, MediaPlayer.OnCompletionListener {
 	@Override
 	public void stop () {
 		if (player == null) return;
-		if (isPrepared) {
-			player.seekTo(0);
-		}
 		player.stop();
+		isPaused = false;
 		isPrepared = false;
 	}
 


### PR DESCRIPTION
This is a follow up on the following PR

https://github.com/libgdx/libgdx/pull/3399

As it wasn't generating any activity for more than 3 months I've added a self contained project to make the testing easier than can be downloaded here:

https://drive.google.com/file/d/0B7OWuDw42TLSQi1pQ0p0RXFSRVU/view?usp=sharing

The project is basically a simple music player with a play, pause, stop and a "play from second 30" buttons.

It includes a backend-android jar with the fix and it's easy to switch between default and the fix version from the android dependencies in the build.gradle file.

Issues will most probably appear on Nu Player devices where the "play from second 30" (that uses the setPosition() method) doesn't work after the first time. Just playing around, pausing, playing, playing from 30 and stopping the inconsistent behaviours should manifest on the non fixed version.