### PR TITLE
Fix iOS touch mapping

### DIFF
--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSApplication.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSApplication.java
@@ -16,9 +16,22 @@
 
 package com.badlogic.gdx.backends.iosrobovm;
 
-import java.io.File;
-
-import org.robovm.apple.coregraphics.CGSize;
+import com.badlogic.gdx.Application;
+import com.badlogic.gdx.ApplicationListener;
+import com.badlogic.gdx.Audio;
+import com.badlogic.gdx.Files;
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Graphics;
+import com.badlogic.gdx.Input;
+import com.badlogic.gdx.LifecycleListener;
+import com.badlogic.gdx.Net;
+import com.badlogic.gdx.Preferences;
+import com.badlogic.gdx.backends.iosrobovm.objectal.OALAudioSession;
+import com.badlogic.gdx.backends.iosrobovm.objectal.OALSimpleAudio;
+import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.utils.Array;
+import com.badlogic.gdx.utils.Clipboard;
+import org.robovm.apple.coregraphics.CGRect;
 import org.robovm.apple.foundation.Foundation;
 import org.robovm.apple.foundation.NSMutableDictionary;
 import org.robovm.apple.foundation.NSObject;
@@ -36,21 +49,7 @@ import org.robovm.apple.uikit.UIViewController;
 import org.robovm.apple.uikit.UIWindow;
 import org.robovm.rt.bro.Bro;
 
-import com.badlogic.gdx.Application;
-import com.badlogic.gdx.ApplicationListener;
-import com.badlogic.gdx.Audio;
-import com.badlogic.gdx.Files;
-import com.badlogic.gdx.Gdx;
-import com.badlogic.gdx.Graphics;
-import com.badlogic.gdx.Input;
-import com.badlogic.gdx.LifecycleListener;
-import com.badlogic.gdx.Net;
-import com.badlogic.gdx.Preferences;
-import com.badlogic.gdx.backends.iosrobovm.objectal.OALAudioSession;
-import com.badlogic.gdx.backends.iosrobovm.objectal.OALSimpleAudio;
-import com.badlogic.gdx.graphics.GL20;
-import com.badlogic.gdx.utils.Array;
-import com.badlogic.gdx.utils.Clipboard;
+import java.io.File;
 
 public class IOSApplication implements Application {
 
@@ -102,6 +101,8 @@ public class IOSApplication implements Application {
 	/** The display scale factor (1.0f for normal; 2.0f to use retina coordinates/dimensions). */
 	float displayScaleFactor;
 
+	private CGRect lastScreenBounds = null;
+
 	Array<Runnable> runnables = new Array<Runnable>();
 	Array<Runnable> executedRunnables = new Array<Runnable>();
 	Array<LifecycleListener> lifecycleListeners = new Array<LifecycleListener>();
@@ -152,7 +153,7 @@ public class IOSApplication implements Application {
 
 		// setup libgdx
 		this.input = new IOSInput(this);
-		this.graphics = new IOSGraphics(getBounds(null), scale, this, config, input, gl20);
+		this.graphics = new IOSGraphics(scale, this, config, input, gl20);
 		this.files = new IOSFiles();
 		this.audio = new IOSAudio(config);
 		this.net = new IOSNet(this);
@@ -190,57 +191,55 @@ public class IOSApplication implements Application {
 		return uiWindow;
 	}
 
-	/** Returns our real display dimension based on screen orientation.
+	/** GL View spans whole screen, that is, even under the status bar. iOS can also rotate the screen, which is not handled
+	 * consistently over iOS versions. This method returns, in pixels, rectangle in which libGDX draws.
 	 *
-	 * @param viewController The view controller.
-	 * @return Or real display dimension. */
-	CGSize getBounds (UIViewController viewController) {
-		// or screen size (always portrait)
-		CGSize bounds = UIScreen.getMainScreen().getApplicationFrame().getSize();
+	 * @return dimensions of space we draw to, adjusted for device orientation */
+	protected CGRect getBounds () {
+		final CGRect screenBounds = UIScreen.getMainScreen().getBounds();
+		final CGRect statusBarFrame = uiApp.getStatusBarFrame();
+		final UIInterfaceOrientation statusBarOrientation = uiApp.getStatusBarOrientation();
 
-		// determine orientation and resulting width + height
-		UIInterfaceOrientation orientation;
-		if (viewController != null) {
-			orientation = viewController.getInterfaceOrientation();
-		} else if (config.orientationLandscape == config.orientationPortrait) {
-			/*
-			 * if the app has orientation in any side then we can only check status bar orientation
-			 */
-			orientation = uiApp.getStatusBarOrientation();
-		} else if (config.orientationLandscape) {// is landscape true and portrait false
-			orientation = UIInterfaceOrientation.LandscapeRight;
-		} else {// is portrait true and landscape false
-			orientation = UIInterfaceOrientation.Portrait;
-		}
-		int width;
-		int height;
-		switch (orientation) {
+		double statusBarHeight = Math.min(statusBarFrame.getWidth(), statusBarFrame.getHeight());
+
+		double screenWidth = screenBounds.getWidth();
+		double screenHeight = screenBounds.getHeight();
+
+		// Make sure that the orientation is consistent with ratios. Should be, but may not be on older iOS versions
+		switch (statusBarOrientation) {
 		case LandscapeLeft:
 		case LandscapeRight:
-			height = (int)bounds.getWidth();
-			width = (int)bounds.getHeight();
-			if (width < height) {
-				width = (int)bounds.getWidth();
-				height = (int)bounds.getHeight();
+			if (screenHeight > screenWidth) {
+				debug("IOSApplication", "Switching reported width and height (w=" + screenWidth + " h=" + screenHeight + ")");
+				double tmp = screenHeight;
+				// noinspection SuspiciousNameCombination
+				screenHeight = screenWidth;
+				screenWidth = tmp;
 			}
-			break;
-		default:
-			// assume portrait
-			width = (int)bounds.getWidth();
-			height = (int)bounds.getHeight();
 		}
 
-		Gdx.app.debug("IOSApplication", "Unscaled View: " + orientation.toString() + " " + width + "x" + height);
-
 		// update width/height depending on display scaling selected
-		width *= displayScaleFactor;
-		height *= displayScaleFactor;
+		screenWidth *= displayScaleFactor;
+		screenHeight *= displayScaleFactor;
 
-		// log screen dimensions
-		Gdx.app.debug("IOSApplication", "View: " + orientation.toString() + " " + width + "x" + height);
+		if (statusBarHeight != 0.0) {
+			debug("IOSApplication", "Status bar is visible (height = " + statusBarHeight + ")");
+			statusBarHeight *= displayScaleFactor;
+			screenHeight -= statusBarHeight;
+		} else {
+			debug("IOSApplication", "Status bar is not visible");
+		}
 
-		// return resulting view size (based on orientation)
-		return new CGSize(width, height);
+		debug("IOSApplication", "Total computed bounds are w=" + screenWidth + " h=" + screenHeight);
+
+		return lastScreenBounds = new CGRect(0.0, statusBarHeight, screenWidth, screenHeight);
+	}
+
+	protected CGRect getCachedBounds () {
+		if (lastScreenBounds == null)
+			return getBounds();
+		else
+			return lastScreenBounds;
 	}
 
 	final void didBecomeActive (UIApplication uiApp) {

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
@@ -16,9 +16,16 @@
 
 package com.badlogic.gdx.backends.iosrobovm;
 
-import org.robovm.apple.coregraphics.CGPoint;
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Graphics;
+import com.badlogic.gdx.LifecycleListener;
+import com.badlogic.gdx.backends.iosrobovm.custom.HWMachine;
+import com.badlogic.gdx.graphics.Cursor;
+import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.GL30;
+import com.badlogic.gdx.graphics.Pixmap;
+import com.badlogic.gdx.utils.Array;
 import org.robovm.apple.coregraphics.CGRect;
-import org.robovm.apple.coregraphics.CGSize;
 import org.robovm.apple.foundation.NSObject;
 import org.robovm.apple.glkit.GLKView;
 import org.robovm.apple.glkit.GLKViewController;
@@ -39,16 +46,6 @@ import org.robovm.objc.annotation.Method;
 import org.robovm.rt.bro.annotation.Callback;
 import org.robovm.rt.bro.annotation.Pointer;
 
-import com.badlogic.gdx.Gdx;
-import com.badlogic.gdx.Graphics;
-import com.badlogic.gdx.LifecycleListener;
-import com.badlogic.gdx.backends.iosrobovm.custom.HWMachine;
-import com.badlogic.gdx.graphics.Cursor;
-import com.badlogic.gdx.graphics.GL20;
-import com.badlogic.gdx.graphics.GL30;
-import com.badlogic.gdx.graphics.Pixmap;
-import com.badlogic.gdx.utils.Array;
-
 public class IOSGraphics extends NSObject implements Graphics, GLKViewDelegate, GLKViewControllerDelegate {
 
 	private static final String tag = "IOSGraphics";
@@ -56,7 +53,6 @@ public class IOSGraphics extends NSObject implements Graphics, GLKViewDelegate, 
 	static class IOSUIViewController extends GLKViewController {
 		final IOSApplication app;
 		final IOSGraphics graphics;
-		boolean created = false;
 
 		IOSUIViewController (IOSApplication app, IOSGraphics graphics) {
 			this.app = app;
@@ -74,21 +70,6 @@ public class IOSGraphics extends NSObject implements Graphics, GLKViewDelegate, 
 		@Override
 		public void viewDidAppear (boolean animated) {
 			if (app.viewControllerListener != null) app.viewControllerListener.viewDidAppear(animated);
-		}
-
-		@Override
-		public void didRotate (UIInterfaceOrientation orientation) {
-			super.didRotate(orientation);
-			// get the view size and update graphics
-			// FIXME: supporting BOTH (landscape+portrait at same time) is
-			// currently not working correctly (needs fix)
-			// FIXME screen orientation needs to be stored for
-			// Input#getNativeOrientation
-			CGSize bounds = app.getBounds(this);
-			graphics.width = (int)bounds.getWidth();
-			graphics.height = (int)bounds.getHeight();
-			graphics.makeCurrent();
-			app.listener.resize(graphics.width, graphics.height);
 		}
 
 		@Override
@@ -126,15 +107,20 @@ public class IOSGraphics extends NSObject implements Graphics, GLKViewDelegate, 
 			UIInterfaceOrientation orientation) {
 			return self.shouldAutorotateToInterfaceOrientation(orientation);
 		}
-	}
 
-	static class IOSUIView extends GLKView {
-
-		public IOSUIView (CGRect frame, EAGLContext context) {
-			super(frame, context);
+		@Override
+		public void viewDidLayoutSubviews () {
+			super.viewDidLayoutSubviews();
+			// get the view size and update graphics
+			CGRect bounds = app.getBounds();
+			graphics.width = (int)bounds.getWidth();
+			graphics.height = (int)bounds.getHeight();
+			graphics.makeCurrent();
+			app.listener.resize(graphics.width, graphics.height);
 		}
+
 	}
-	
+
 	IOSApplication app;
 	IOSInput input;
 	GL20 gl20;
@@ -164,43 +150,42 @@ public class IOSGraphics extends NSObject implements Graphics, GLKViewDelegate, 
 	GLKView view;
 	IOSUIViewController viewController;
 
-	public IOSGraphics (CGSize bounds, float scale, IOSApplication app, IOSApplicationConfiguration config, IOSInput input,
-		GL20 gl20) {
+	public IOSGraphics (float scale, IOSApplication app, IOSApplicationConfiguration config, IOSInput input, GL20 gl20) {
 		this.config = config;
+
+		final CGRect bounds = app.getBounds();
 		// setup view and OpenGL
 		width = (int)bounds.getWidth();
 		height = (int)bounds.getHeight();
-		app.debug(tag, bounds.getWidth() + "x" + bounds.getHeight() + ", " + scale);
 		this.gl20 = gl20;
 
 		context = new EAGLContext(EAGLRenderingAPI.OpenGLES2);
 
-		view = new GLKView(new CGRect(new CGPoint(0, 0), bounds), context) {
+		view = new GLKView(new CGRect(0, 0, bounds.getWidth(), bounds.getHeight()), context) {
 			@Method(selector = "touchesBegan:withEvent:")
 			public void touchesBegan (@Pointer long touches, UIEvent event) {
-				IOSGraphics.this.input.touchDown(touches, event);
+				IOSGraphics.this.input.onTouch(touches);
 			}
 
 			@Method(selector = "touchesCancelled:withEvent:")
 			public void touchesCancelled (@Pointer long touches, UIEvent event) {
-				IOSGraphics.this.input.touchUp(touches, event);
+				IOSGraphics.this.input.onTouch(touches);
 			}
 
 			@Method(selector = "touchesEnded:withEvent:")
 			public void touchesEnded (@Pointer long touches, UIEvent event) {
-				IOSGraphics.this.input.touchUp(touches, event);
+				IOSGraphics.this.input.onTouch(touches);
 			}
 
 			@Method(selector = "touchesMoved:withEvent:")
 			public void touchesMoved (@Pointer long touches, UIEvent event) {
-				IOSGraphics.this.input.touchMoved(touches, event);
+				IOSGraphics.this.input.onTouch(touches);
 			}
 
 			@Override
 			public void draw (CGRect rect) {
 				IOSGraphics.this.draw(this, rect);
 			}
-
 		};
 		view.setDelegate(this);
 		view.setDrawableColorFormat(config.colorFormat);
@@ -209,7 +194,7 @@ public class IOSGraphics extends NSObject implements Graphics, GLKViewDelegate, 
 		view.setDrawableMultisample(config.multisample);
 		view.setMultipleTouchEnabled(true);
 
-		viewController = new IOSUIViewController(app, this);
+		IOSUIViewController viewController = this.viewController = new IOSUIViewController(app, this);
 		viewController.setView(view);
 		viewController.setDelegate(this);
 		viewController.setPreferredFramesPerSecond(config.preferredFramesPerSecond);
@@ -246,7 +231,7 @@ public class IOSGraphics extends NSObject implements Graphics, GLKViewDelegate, 
 		IOSDevice device = IOSDevice.getDevice(machineString);
 		if (device == null) app.error(tag, "Machine ID: " + machineString + " not found, please report to LibGDX");
 		int ppi = device != null ? device.ppi : 163;
-		density = device != null ? device.ppi/160f : scale;
+		density = device != null ? device.ppi / 160f : scale;
 		ppiX = ppi;
 		ppiY = ppi;
 		ppcX = ppiX / 2.54f;
@@ -493,7 +478,7 @@ public class IOSGraphics extends NSObject implements Graphics, GLKViewDelegate, 
 	public long getFrameId () {
 		return frameId;
 	}
-	
+
 	@Override
 	public Cursor newCursor (Pixmap pixmap, int xHotspot, int yHotspot) {
 		return null;


### PR DESCRIPTION
iOS backend did not map touch coordinates to libGDX correctly. libGDX's GL View is stretched over whole screen, but libGDX draws only on a subset of that, because it excludes status bar, if present. Touch mapping was however completely oblivious to this fact - this worked well when the status bar was not visible, but was inaccurate when the status bar was indeed visible.

This PR rewrites rotation/resize handling and touch coordinate mapping to explicitly handle mentioned problems. It also removes some unused code and cleans up existing code, fixing some obsolete TODOs.

This is somewhat related to issues:
#2105 - although this seems to be the opposite issue, it is not present after this PR
#3278 - does not fix this, but allows it to be fixed in user code by overriding `IOSApplication.getBounds` and providing correct bounds

Note that I am not an iOS expert, but I have tested it and it works.