### PR TITLE
Fix iOS touch mapping

### DIFF
--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSApplication.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSApplication.java
@@ -18,7 +18,7 @@ package com.badlogic.gdx.backends.iosrobovm;
 
 import java.io.File;
 
-import org.robovm.apple.coregraphics.CGSize;
+import org.robovm.apple.coregraphics.CGRect;
 import org.robovm.apple.foundation.Foundation;
 import org.robovm.apple.foundation.NSMutableDictionary;
 import org.robovm.apple.foundation.NSObject;
@@ -102,6 +102,8 @@ public class IOSApplication implements Application {
 	/** The display scale factor (1.0f for normal; 2.0f to use retina coordinates/dimensions). */
 	float displayScaleFactor;
 
+	private CGRect lastScreenBounds = null;
+
 	Array<Runnable> runnables = new Array<Runnable>();
 	Array<Runnable> executedRunnables = new Array<Runnable>();
 	Array<LifecycleListener> lifecycleListeners = new Array<LifecycleListener>();
@@ -152,7 +154,7 @@ public class IOSApplication implements Application {
 
 		// setup libgdx
 		this.input = new IOSInput(this);
-		this.graphics = new IOSGraphics(getBounds(null), scale, this, config, input, gl20);
+		this.graphics = new IOSGraphics(scale, this, config, input, gl20);
 		this.files = new IOSFiles();
 		this.audio = new IOSAudio(config);
 		this.net = new IOSNet(this);
@@ -190,57 +192,55 @@ public class IOSApplication implements Application {
 		return uiWindow;
 	}
 
-	/** Returns our real display dimension based on screen orientation.
+	/** GL View spans whole screen, that is, even under the status bar. iOS can also rotate the screen, which is not handled
+	 * consistently over iOS versions. This method returns, in pixels, rectangle in which libGDX draws.
 	 *
-	 * @param viewController The view controller.
-	 * @return Or real display dimension. */
-	CGSize getBounds (UIViewController viewController) {
-		// or screen size (always portrait)
-		CGSize bounds = UIScreen.getMainScreen().getApplicationFrame().getSize();
+	 * @return dimensions of space we draw to, adjusted for device orientation */
+	protected CGRect getBounds () {
+		final CGRect screenBounds = UIScreen.getMainScreen().getBounds();
+		final CGRect statusBarFrame = uiApp.getStatusBarFrame();
+		final UIInterfaceOrientation statusBarOrientation = uiApp.getStatusBarOrientation();
 
-		// determine orientation and resulting width + height
-		UIInterfaceOrientation orientation;
-		if (viewController != null) {
-			orientation = viewController.getInterfaceOrientation();
-		} else if (config.orientationLandscape == config.orientationPortrait) {
-			/*
-			 * if the app has orientation in any side then we can only check status bar orientation
-			 */
-			orientation = uiApp.getStatusBarOrientation();
-		} else if (config.orientationLandscape) {// is landscape true and portrait false
-			orientation = UIInterfaceOrientation.LandscapeRight;
-		} else {// is portrait true and landscape false
-			orientation = UIInterfaceOrientation.Portrait;
-		}
-		int width;
-		int height;
-		switch (orientation) {
+		double statusBarHeight = Math.min(statusBarFrame.getWidth(), statusBarFrame.getHeight());
+
+		double screenWidth = screenBounds.getWidth();
+		double screenHeight = screenBounds.getHeight();
+
+		// Make sure that the orientation is consistent with ratios. Should be, but may not be on older iOS versions
+		switch (statusBarOrientation) {
 		case LandscapeLeft:
 		case LandscapeRight:
-			height = (int)bounds.getWidth();
-			width = (int)bounds.getHeight();
-			if (width < height) {
-				width = (int)bounds.getWidth();
-				height = (int)bounds.getHeight();
+			if (screenHeight > screenWidth) {
+				debug("IOSApplication", "Switching reported width and height (w=" + screenWidth + " h=" + screenHeight + ")");
+				double tmp = screenHeight;
+				// noinspection SuspiciousNameCombination
+				screenHeight = screenWidth;
+				screenWidth = tmp;
 			}
-			break;
-		default:
-			// assume portrait
-			width = (int)bounds.getWidth();
-			height = (int)bounds.getHeight();
 		}
 
-		Gdx.app.debug("IOSApplication", "Unscaled View: " + orientation.toString() + " " + width + "x" + height);
-
 		// update width/height depending on display scaling selected
-		width *= displayScaleFactor;
-		height *= displayScaleFactor;
+		screenWidth *= displayScaleFactor;
+		screenHeight *= displayScaleFactor;
 
-		// log screen dimensions
-		Gdx.app.debug("IOSApplication", "View: " + orientation.toString() + " " + width + "x" + height);
+		if (statusBarHeight != 0.0) {
+			debug("IOSApplication", "Status bar is visible (height = " + statusBarHeight + ")");
+			statusBarHeight *= displayScaleFactor;
+			screenHeight -= statusBarHeight;
+		} else {
+			debug("IOSApplication", "Status bar is not visible");
+		}
 
-		// return resulting view size (based on orientation)
-		return new CGSize(width, height);
+		debug("IOSApplication", "Total computed bounds are w=" + screenWidth + " h=" + screenHeight);
+
+		return lastScreenBounds = new CGRect(0.0, statusBarHeight, screenWidth, screenHeight);
+	}
+
+	protected CGRect getCachedBounds () {
+		if (lastScreenBounds == null)
+			return getBounds();
+		else
+			return lastScreenBounds;
 	}
 
 	final void didBecomeActive (UIApplication uiApp) {

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSInput.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSInput.java
@@ -26,10 +26,7 @@ import org.robovm.apple.uikit.UIAlertView;
 import org.robovm.apple.uikit.UIAlertViewDelegate;
 import org.robovm.apple.uikit.UIAlertViewDelegateAdapter;
 import org.robovm.apple.uikit.UIAlertViewStyle;
-import org.robovm.apple.uikit.UIApplication;
 import org.robovm.apple.uikit.UIDevice;
-import org.robovm.apple.uikit.UIEvent;
-import org.robovm.apple.uikit.UIInterfaceOrientation;
 import org.robovm.apple.uikit.UIKeyboardType;
 import org.robovm.apple.uikit.UIReturnKeyType;
 import org.robovm.apple.uikit.UITextAutocapitalizationType;
@@ -53,7 +50,6 @@ import com.badlogic.gdx.backends.iosrobovm.custom.UIAcceleration;
 import com.badlogic.gdx.backends.iosrobovm.custom.UIAccelerometer;
 import com.badlogic.gdx.backends.iosrobovm.custom.UIAccelerometerDelegate;
 import com.badlogic.gdx.backends.iosrobovm.custom.UIAccelerometerDelegateAdapter;
-import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.GdxRuntimeException;
 import com.badlogic.gdx.utils.Pool;
@@ -562,19 +558,29 @@ public class IOSInput implements Input {
 
 	@Override
 	public int getRotation () {
-		UIInterfaceOrientation orientation = app.graphics.viewController != null ? app.graphics.viewController
-			.getInterfaceOrientation() : UIApplication.getSharedApplication().getStatusBarOrientation();
 		// we measure orientation counter clockwise, just like on Android
-		if (orientation == UIInterfaceOrientation.Portrait) return 0;
-		if (orientation == UIInterfaceOrientation.LandscapeLeft) return 270;
-		if (orientation == UIInterfaceOrientation.PortraitUpsideDown) return 180;
-		if (orientation == UIInterfaceOrientation.LandscapeRight) return 90;
-		return 0;
+		switch (app.uiApp.getStatusBarOrientation()) {
+		case LandscapeLeft:
+			return 270;
+		case PortraitUpsideDown:
+			return 180;
+		case LandscapeRight:
+			return 90;
+		case Portrait:
+		default:
+			return 0;
+		}
 	}
 
 	@Override
 	public Orientation getNativeOrientation () {
-		return Orientation.Portrait;
+		switch (app.uiApp.getStatusBarOrientation()) {
+		case LandscapeLeft:
+		case LandscapeRight:
+			return Orientation.Landscape;
+		default:
+			return Orientation.Portrait;
+		}
 	}
 
 	@Override
@@ -590,18 +596,8 @@ public class IOSInput implements Input {
 	public void setCursorPosition (int x, int y) {
 	}
 
-	public void touchDown (long touches, UIEvent event) {
-		toTouchEvents(touches, event);
-		Gdx.graphics.requestRendering();
-	}
-
-	public void touchUp (long touches, UIEvent event) {
-		toTouchEvents(touches, event);
-		Gdx.graphics.requestRendering();
-	}
-
-	public void touchMoved (long touches, UIEvent event) {
-		toTouchEvents(touches, event);
+	protected void onTouch (long touches) {
+		toTouchEvents(touches);
 		Gdx.graphics.requestRendering();
 	}
 
@@ -658,18 +654,27 @@ public class IOSInput implements Input {
 		public static native @MachineSizedUInt long count (@Pointer long thiz);
 	}
 
-	private void toTouchEvents (long touches, UIEvent uiEvent) {
+	private void toTouchEvents (long touches) {
 		long array = NSSetExtensions.allObjects(touches);
 		int length = (int)NSArrayExtensions.count(array);
 		for (int i = 0; i < length; i++) {
 			long touchHandle = NSArrayExtensions.objectAtIndex$(array, i);
 			UITouch touch = UI_TOUCH_WRAPPER.wrap(touchHandle);
-			CGPoint loc = touch.getLocationInView(touch.getView());
+			final int locX, locY;
+			// Get and map the location to our drawing space
+			{
+				CGPoint loc = touch.getLocationInView(touch.getWindow());
+				final CGRect bounds = app.getCachedBounds();
+				locX = (int)(loc.getX() * app.displayScaleFactor - bounds.getMinX());
+				locY = (int)(loc.getY() * app.displayScaleFactor - bounds.getMinY());
+				// app.debug("IOSInput","pos= "+loc+"  bounds= "+bounds+" x= "+locX+" locY= "+locY);
+			}
+
 			synchronized (touchEvents) {
 				UITouchPhase phase = touch.getPhase();
 				TouchEvent event = touchEventPool.obtain();
-				event.x = (int)(loc.getX() * app.displayScaleFactor);
-				event.y = (int)(loc.getY() * app.displayScaleFactor);
+				event.x = locX;
+				event.y = locY;
 				event.phase = phase;
 				event.timestamp = (long)(touch.getTimestamp() * 1000000000);
 				touchEvents.add(event);


### PR DESCRIPTION
iOS backend did not map touch coordinates to libGDX correctly. libGDX's GL View is stretched over whole screen, but libGDX draws only on a subset of that, because it excludes status bar, if present. Touch mapping was however completely oblivious to this fact - this worked well when the status bar was not visible, but was inaccurate when the status bar was indeed visible.

This PR rewrites rotation/resize handling and touch coordinate mapping to explicitly handle mentioned problems.

This is somewhat related to issues:
#2105 - although this seems to be the opposite issue, it is not present after this PR
#3278 - does not fix this, but allows it to be fixed in user code by overriding `IOSApplication.getBounds` and providing correct bounds

Note that I am not an iOS expert, but I have tested it and it works.