### PR TITLE
Bugfix for GdxSetupUI on Linux when needing a SDK update

### DIFF
--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetupUI.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetupUI.java
@@ -169,13 +169,15 @@ public class GdxSetupUI extends JFrame {
 		}
 
 		if (modules.contains(ProjectType.ANDROID)) {
-			if (!GdxSetup.isSdkUpToDate(sdkLocation)) { 
+			if (!GdxSetup.isSdkUpToDate(sdkLocation)) {
+				File sdkLocationFile = new File(sdkLocation);
 				try {  //give them a poke in the right direction
 					if (System.getProperty("os.name").contains("Windows")) {
 						String replaced = sdkLocation.replace("\\", "\\\\");
 						Runtime.getRuntime().exec("\"" + replaced + "\\SDK Manager.exe\"");
 					} else {
-						Runtime.getRuntime().exec("\"" + sdkLocation + "tools/android sdk\"");
+						File sdkManager = new File(sdkLocation, "tools/android");
+						Runtime.getRuntime().exec(new String[] {sdkManager.getAbsolutePath(), "sdk"});
 					}
 				} catch (IOException e) {
 					e.printStackTrace();


### PR DESCRIPTION
This fixes a bug with the current Setup UI on Linux:

```
java.io.IOException: Cannot run program ""/home/theboss/Software/Android-SDK/tools/android": error=2, Datei oder Verzeichnis nicht gefunden
	at java.lang.ProcessBuilder.start(ProcessBuilder.java:1048)
	at java.lang.Runtime.exec(Runtime.java:620)
	at java.lang.Runtime.exec(Runtime.java:450)
	at java.lang.Runtime.exec(Runtime.java:347)
	at com.badlogic.gdx.setup.GdxSetupUI.generate(Unknown Source)
	at com.badlogic.gdx.setup.GdxSetupUI$UI$4.actionPerformed(Unknown Source)
```

The problem comes from manipulating file names directly instead of using the java.io.File API.
I didn't change the Windows branch because I'm not able to test it at the moment.