### PR TITLE
Only call free() on malloc()'d strings.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,7 @@
 - Added AndroidAudio#newMusic(FileDescriptor) to allow loading music from a file descriptor, see #2970
 - Added GLOnlyTextureData, which is now the default for FrameBuffer and FrameBufferCubemap, see #3539
 - Added rotationChanged() for Actor class, called when rotation changes, see https://github.com/libgdx/libgdx/pull/3563
+- Fixed crash on MacOS when enumerating connected gamepads.
 
 [1.7.1]
 - Fixes AtlasTmxMapLoader region name loading to tileset name instead of filename

--- a/extensions/gdx-controllers/gdx-controllers-desktop/jni/ois-v1-4svn/src/mac/MacHIDManager.cpp
+++ b/extensions/gdx-controllers/gdx-controllers-desktop/jni/ois-v1-4svn/src/mac/MacHIDManager.cpp
@@ -205,9 +205,10 @@ void MacHIDManager::iterateAndOpenDevices(io_iterator_t iterator)
 	IOObjectRelease(iterator);
 }
 
-const char* getCString(CFStringRef cfString) {
+const char* getCString(CFStringRef cfString, bool* requireFree) {
 	const char *useUTF8StringPtr = NULL;
 	UInt8 *freeUTF8StringPtr = NULL;
+	*requireFree = false;
 
 	CFIndex stringLength = CFStringGetLength(cfString), usedBytes = 0L;
 
@@ -218,6 +219,7 @@ const char* getCString(CFStringRef cfString) {
 					stringLength, &usedBytes);
 			freeUTF8StringPtr[usedBytes] = 0;
 			useUTF8StringPtr = (const char *) freeUTF8StringPtr;
+			*requireFree = true;
 		}
 	}
 
@@ -228,15 +230,17 @@ const char* getCString(CFStringRef cfString) {
 HidInfo* MacHIDManager::enumerateDeviceProperties(CFMutableDictionaryRef propertyMap)
 {
 	HidInfo* info = new HidInfo();
+	bool requireFree;
 	
 	info->type = OISJoyStick;
 
 	CFStringRef str = getDictionaryItemAsRef<CFStringRef>(propertyMap, kIOHIDManufacturerKey);
 	if (str) {
-		const char* str_c = getCString(str);
+		const char* str_c = getCString(str, &requireFree);
 		if(str_c) {
 			info->vendor = str_c;
-			free((char*)str_c);
+			if (requireFree)
+				free((char*)str_c);
 		} else {
 			info->vendor = "Unknown Vendor";
 		}
@@ -244,14 +248,11 @@ HidInfo* MacHIDManager::enumerateDeviceProperties(CFMutableDictionaryRef propert
 
 	str = getDictionaryItemAsRef<CFStringRef>(propertyMap, kIOHIDProductKey);
 	if (str) {
-		const char* str_c = getCString(str);
+		const char* str_c = getCString(str, &requireFree);
 		if(str_c) {
 			info->productKey = str_c;
-            // mzechner: we leak this so packr packaged apps
-            // works. I have no idea why this would fail in
-            // case of packr. My guess it register allocation
-            // and aliasing with str_c above.
-			// free((char*)str_c);
+			if (requireFree)
+				free((char*)str_c);
 		} else {
 			info->productKey = "Unknown Product";
 		}


### PR DESCRIPTION
Bug report (and actually the bug fix description too):
http://steamcommunity.com/app/371430/discussions/1/490121928343760774/

Caused by calling free() on results of getCString() which hasn't always been allocated with malloc().

I was able to reproduce the crash, and test the fix with Space Grunts.