### PR TITLE
Fix #3604 - missing enter after stopping exit event

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/Stage.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/Stage.java
@@ -229,24 +229,30 @@ public class Stage extends InputAdapter implements Disposable {
 		Actor over = hit(tempCoords.x, tempCoords.y, true);
 		if (over == overLast) return overLast;
 
-		InputEvent event = Pools.obtain(InputEvent.class);
-		event.setStage(this);
-		event.setStageX(tempCoords.x);
-		event.setStageY(tempCoords.y);
-		event.setPointer(pointer);
 		// Exit overLast.
 		if (overLast != null) {
+			InputEvent event = Pools.obtain(InputEvent.class);
+			event.setStage(this);
+			event.setStageX(tempCoords.x);
+			event.setStageY(tempCoords.y);
+			event.setPointer(pointer);
 			event.setType(InputEvent.Type.exit);
 			event.setRelatedActor(over);
 			overLast.fire(event);
+			Pools.free(event);
 		}
 		// Enter over.
 		if (over != null) {
+			InputEvent event = Pools.obtain(InputEvent.class);
+			event.setStage(this);
+			event.setStageX(tempCoords.x);
+			event.setStageY(tempCoords.y);
+			event.setPointer(pointer);
 			event.setType(InputEvent.Type.enter);
 			event.setRelatedActor(overLast);
 			over.fire(event);
+			Pools.free(event);
 		}
-		Pools.free(event);
 		return over;
 	}
 


### PR DESCRIPTION
The same event object is being used for `enter` and `exit` in `fireEnterAndExit()`. If the user decides to `stop()` the `exit` event, then `enter` will be stopped as well.

Fix: fire `enter` with a fresh event object.