### PR TITLE
Support TextureRegionDrawable in Skin Json and tinting TiledDrawable.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -10,6 +10,8 @@
 - API Change: FreeTypeFontParameter has new fields for rendering borders and shadows.
 - FreeTypeFontParameter can render much better fonts at small sizes using gamma settings.
 - BitmapFont can now render missing (tofu) glyph for glyphs not in the font.
+- Can specify TextureRegionDrawable in Skin from Json so its padding can be explicitly defined from Json.
+- Skin's TintedDrawable now works with TiledDrawable.
 
 [1.7.1]
 - Fixes AtlasTmxMapLoader region name loading to tileset name instead of filename

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Skin.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Skin.java
@@ -51,7 +51,7 @@ import com.badlogic.gdx.utils.reflect.ReflectionException;
  * regions in the atlas as ninepatches, sprites, drawables, etc. The get* methods return an instance of the object in the skin.
  * The new* methods return a copy of an instance in the skin.
  * <p>
- * See the <a href="https://code.google.com/p/libgdx/wiki/Skin">documentation</a> for more.
+ * See the <a href="https://github.com/libgdx/libgdx/wiki/Skin">documentation</a> for more.
  * @author Nathan Sweet */
 public class Skin implements Disposable {
 	ObjectMap<Class, ObjectMap<String, Object>> resources = new ObjectMap();
@@ -255,6 +255,9 @@ public class Skin implements Disposable {
 
 		drawable = optional(name, TiledDrawable.class);
 		if (drawable != null) return drawable;
+		
+		drawable = optional(name, TextureRegionDrawable.class);
+		if (drawable != null) return drawable;
 
 		// Use texture or texture region. If it has splits, use ninepatch. If it has rotation or whitespace stripping, use sprite.
 		try {
@@ -270,7 +273,7 @@ public class Skin implements Disposable {
 		} catch (GdxRuntimeException ignored) {
 		}
 
-		// Check for explicit registration of ninepatch, sprite, or tiled drawable.
+		// Check for explicit registration of ninepatch or sprite
 		if (drawable == null) {
 			NinePatch patch = optional(name, NinePatch.class);
 			if (patch != null)
@@ -331,7 +334,9 @@ public class Skin implements Disposable {
 	/** Returns a tinted copy of a drawable found in the skin via {@link #getDrawable(String)}. */
 	public Drawable newDrawable (Drawable drawable, Color tint) {
 		Drawable newDrawable;
-		if (drawable instanceof TextureRegionDrawable)
+		if (drawable instanceof TiledDrawable)
+			newDrawable = ((TiledDrawable)drawable).tintTiled(tint);
+		else if (drawable instanceof TextureRegionDrawable)
 			newDrawable = ((TextureRegionDrawable)drawable).tint(tint);
 		else if (drawable instanceof NinePatchDrawable)
 			newDrawable = ((NinePatchDrawable)drawable).tint(tint);

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/TextureRegionDrawable.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/TextureRegionDrawable.java
@@ -68,6 +68,11 @@ public class TextureRegionDrawable extends BaseDrawable implements TransformDraw
 		else
 			sprite = new Sprite(region);
 		sprite.setColor(tint);
-		return new SpriteDrawable(sprite);
+		SpriteDrawable drawable = new SpriteDrawable(sprite);
+		drawable.setLeftWidth(getLeftWidth());
+		drawable.setRightWidth(getRightWidth());
+		drawable.setTopHeight(getTopHeight());
+		drawable.setBottomHeight(getBottomHeight());
+		return drawable;
 	}
 }

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/TiledDrawable.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/TiledDrawable.java
@@ -16,6 +16,7 @@
 
 package com.badlogic.gdx.scenes.scene2d.utils;
 
+import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.Batch;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
@@ -23,6 +24,8 @@ import com.badlogic.gdx.graphics.g2d.TextureRegion;
 /** Draws a {@link TextureRegion} repeatedly to fill the area, instead of stretching it.
  * @author Nathan Sweet */
 public class TiledDrawable extends TextureRegionDrawable {
+	private float tint = Color.WHITE.toFloatBits();
+
 	public TiledDrawable () {
 		super();
 	}
@@ -36,6 +39,8 @@ public class TiledDrawable extends TextureRegionDrawable {
 	}
 
 	public void draw (Batch batch, float x, float y, float width, float height) {
+		float batchColor = batch.getPackedColor();
+		batch.setColor(tint);
 		TextureRegion region = getRegion();
 		float regionWidth = region.getRegionWidth(), regionHeight = region.getRegionHeight();
 		int fullX = (int)(width / regionWidth), fullY = (int)(height / regionHeight);
@@ -78,5 +83,17 @@ public class TiledDrawable extends TextureRegionDrawable {
 				x += regionWidth;
 			}
 		}
+		batch.setColor(batchColor);
+	}
+
+	/** Creates a new drawable that renders the same as this drawable tinted the specified color. */
+	public TiledDrawable tintTiled (Color tint) {
+		TiledDrawable drawable = new TiledDrawable(this);
+		drawable.tint = tint.toFloatBits();
+		drawable.setLeftWidth(getLeftWidth());
+		drawable.setRightWidth(getRightWidth());
+		drawable.setTopHeight(getTopHeight());
+		drawable.setBottomHeight(getBottomHeight());
+		return drawable;
 	}
 }


### PR DESCRIPTION
Formerly, trying to explicitly define a TextureRegionDrawable in Json (so padding can be specified) resulted in a runtime exception because `skin.getDrawable` didn't look for TextureRegionDrawables.

I tested it and padding does work when specified like this:

    com.badlogic.gdx.scenes.scene2d.utils.TextureRegionDrawable: {
    	paddedWhite: {region: white, leftWidth: 4, rightWidth: 40, topHeight: 4, bottomHeight: 4}
    },

I've had need of this a few times when using a solid white texture region for solid color highlights, such as in a List of a SelectBox.

This doesn't work with TiledDrawable, which behaves like a stretched TextureRegionDrawable if it has any padding, but this apparently was already a bug or unsupported feature. I haven't looked into that.