### PR TITLE
Added support for locking the screen orientation in the GWT backend

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplicationConfiguration.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplicationConfiguration.java
@@ -16,6 +16,7 @@
 
 package com.badlogic.gdx.backends.gwt;
 
+import com.badlogic.gdx.backends.gwt.GwtGraphics.OrientationLockType;
 import com.google.gwt.user.client.ui.Panel;
 import com.google.gwt.user.client.ui.TextArea;
 
@@ -47,6 +48,9 @@ public class GwtApplicationConfiguration {
 	public boolean alpha = false;
 	/** whether to use premultipliedalpha, may have performance impact  **/
 	public boolean premultipliedAlpha = false;
+	/** screen-orientation to attempt locking as the application enters full-screen-mode. Note that on mobile browsers, full-screen
+	 * mode can typically only be entered on a user gesture (click, tap, key-stroke) **/
+	public OrientationLockType fullscreenOrientation;
 
 	public GwtApplicationConfiguration (int width, int height) {
 		this.width = width;


### PR DESCRIPTION
This enables locking the orientation of the web application on mobile browsers that support the API. For now this includes Chrome on Android, Firefox and the latest mobile IE. 

The patch does not change the default behaviour, but if fullscreenOrientation is set in GwtApplicationConfiguration, the orientation will be locked when the app enters fullscreen mode. When fullscreen mode is exited, the orientation is unlocked.

Should the user wish to trigger orientation changes manually, there are public methods available in GwtGraphics.