### PR TITLE
Added option into settings to ignore red border pixels

### DIFF
--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/texturepacker/ImageProcessor.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/texturepacker/ImageProcessor.java
@@ -21,9 +21,8 @@ import com.badlogic.gdx.tools.texturepacker.TexturePacker.Rect;
 import com.badlogic.gdx.tools.texturepacker.TexturePacker.Settings;
 import com.badlogic.gdx.utils.Array;
 
-import java.awt.Graphics2D;
-import java.awt.Image;
-import java.awt.RenderingHints;
+import javax.imageio.ImageIO;
+import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.awt.image.WritableRaster;
 import java.io.File;
@@ -35,8 +34,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import javax.imageio.ImageIO;
 
 public class ImageProcessor {
 	static private final BufferedImage emptyImage = new BufferedImage(1, 1, BufferedImage.TYPE_4BYTE_ABGR);
@@ -400,7 +397,7 @@ public class ImageProcessor {
 			raster.getPixel(x, y, rgba);
 			if (rgba[3] == breakA) return next;
 
-			if (!startPoint && (isNinePatchBlackPixel(rgba) || (ignoreRed && isNinePatchRedPixel(rgba))))
+			if (!startPoint && (isNotNinePatchBlackPixel(rgba) || (ignoreRed && isNotNinePatchRedPixel(rgba))))
 				splitError(x, y, rgba, name);
 
 			next++;
@@ -409,11 +406,11 @@ public class ImageProcessor {
 		return 0;
 	}
 
-	private static boolean isNinePatchBlackPixel(int[] rgba) {
+	private static boolean isNotNinePatchBlackPixel(int[] rgba) {
 		return rgba[0] != 0 || rgba[1] != 0 || rgba[2] != 0 || rgba[3] != 255;
 	}
 
-	private static boolean isNinePatchRedPixel(int[] rgba) {
+	private static boolean isNotNinePatchRedPixel(int[] rgba) {
 		return rgba[0] != 255 || rgba[1] != 0 || rgba[2] != 0 || rgba[3] != 255;
 	}
 

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/texturepacker/ImageProcessor.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/texturepacker/ImageProcessor.java
@@ -21,8 +21,9 @@ import com.badlogic.gdx.tools.texturepacker.TexturePacker.Rect;
 import com.badlogic.gdx.tools.texturepacker.TexturePacker.Settings;
 import com.badlogic.gdx.utils.Array;
 
-import javax.imageio.ImageIO;
-import java.awt.*;
+import java.awt.Graphics2D;
+import java.awt.Image;
+import java.awt.RenderingHints;
 import java.awt.image.BufferedImage;
 import java.awt.image.WritableRaster;
 import java.io.File;
@@ -34,6 +35,8 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import javax.imageio.ImageIO;
 
 public class ImageProcessor {
 	static private final BufferedImage emptyImage = new BufferedImage(1, 1, BufferedImage.TYPE_4BYTE_ABGR);

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/texturepacker/TexturePacker.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/texturepacker/TexturePacker.java
@@ -7,7 +7,7 @@
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
+ * Unless required by applicabl:e law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
@@ -15,6 +15,24 @@
  ******************************************************************************/
 
 package com.badlogic.gdx.tools.texturepacker;
+
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+
+import javax.imageio.IIOImage;
+import javax.imageio.ImageIO;
+import javax.imageio.ImageWriteParam;
+import javax.imageio.ImageWriter;
+import javax.imageio.stream.ImageOutputStream;
 
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.Pixmap.Format;
@@ -26,22 +44,6 @@ import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.GdxRuntimeException;
 import com.badlogic.gdx.utils.Json;
-
-import javax.imageio.IIOImage;
-import javax.imageio.ImageIO;
-import javax.imageio.ImageWriteParam;
-import javax.imageio.ImageWriter;
-import javax.imageio.stream.ImageOutputStream;
-import java.awt.*;
-import java.awt.image.BufferedImage;
-import java.io.File;
-import java.io.FileReader;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.util.Comparator;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.Set;
 
 /** @author Nathan Sweet */
 public class TexturePacker {

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/texturepacker/TexturePacker.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/texturepacker/TexturePacker.java
@@ -16,24 +16,6 @@
 
 package com.badlogic.gdx.tools.texturepacker;
 
-import java.awt.Color;
-import java.awt.Graphics2D;
-import java.awt.image.BufferedImage;
-import java.io.File;
-import java.io.FileReader;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.util.Comparator;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.Set;
-
-import javax.imageio.IIOImage;
-import javax.imageio.ImageIO;
-import javax.imageio.ImageWriteParam;
-import javax.imageio.ImageWriter;
-import javax.imageio.stream.ImageOutputStream;
-
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.Pixmap.Format;
 import com.badlogic.gdx.graphics.Texture.TextureFilter;
@@ -44,6 +26,22 @@ import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.GdxRuntimeException;
 import com.badlogic.gdx.utils.Json;
+
+import javax.imageio.IIOImage;
+import javax.imageio.ImageIO;
+import javax.imageio.ImageWriteParam;
+import javax.imageio.ImageWriter;
+import javax.imageio.stream.ImageOutputStream;
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
 
 /** @author Nathan Sweet */
 public class TexturePacker {
@@ -553,6 +551,7 @@ public class TexturePacker {
 		public float[] scale = {1};
 		public String[] scaleSuffix = {""};
 		public String atlasExtension = ".atlas";
+		public boolean ignoreRedPixels;
 
 		public Settings () {
 		}
@@ -594,6 +593,7 @@ public class TexturePacker {
 			scale = settings.scale;
 			scaleSuffix = settings.scaleSuffix;
 			atlasExtension = settings.atlasExtension;
+			ignoreRedPixels = settings.ignoreRedPixels;
 		}
 
 		public String getScaledPackFileName (String packFileName, int scaleIndex) {


### PR DESCRIPTION
********************
WARNING

Guys, i am blind :smile: please point into the TexturePacker tests file.
There're no tests for the feature
********************

Android provides red 9patch boundaries for "optical boundaries"
http://developer.android.com/intl/ru/about/versions/android-4.3.html#OpticalBounds

I've been trying to use 9patches generated by this website http://android-holo-colors.com/

Like in this file  ![one](http://i.stack.imgur.com/w7qeu.png)

Unfortunately, if we will use texture packer with such 9patches, then we will end up with exception
```java.lang.RuntimeException: Invalid /Users/sergii/work/workspace/pandorum/design-ui/assets/orig/images/appthemebtndefaultdisabledfocusedholodark ninepatch split pixel at 2, 97, rgba: 255, 0, 0, 255
	at com.badlogic.gdx.tools.texturepacker.ImageProcessor.splitError(ImageProcessor.java:266)
	at com.badlogic.gdx.tools.texturepacker.ImageProcessor.getSplitPoint(ImageProcessor.java:403)
	at com.badlogic.gdx.tools.texturepacker.ImageProcessor.getPads(ImageProcessor.java:327)
	at com.badlogic.gdx.tools.texturepacker.ImageProcessor.processImage(ImageProcessor.java:148)
	at com.badlogic.gdx.tools.texturepacker.ImageProcessor.addImage(ImageProcessor.java:94)
	at com.badlogic.gdx.tools.texturepacker.ImageProcessor.addImage(ImageProcessor.java:87)
	at com.badlogic.gdx.tools.texturepacker.TexturePacker.pack(TexturePacker.java:101)```

So, i've patched the Settings and TexturePacker to provide the ability to ignore red border pixels on demand.

- added setting field ignoreRedPixels - to ignore red pixels 9patches used in android 4.3=<
- added ignore red pixel in 9patch logic in ImageProcessor