### PR TITLE
Add pixmap.getPixels() method, clean tests

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@
 - Higher quality FreeType font rendering.
 - Hiero updated to v5, now with FreeType support and other new features!
 - GlyphLayout now allocates much, much less memory when processing long text that wraps.
+- Pixmap.getPixels() in the GWT emulation now returns a real ByteBuffer, not an faked IntBuffer!
 
 [1.7.2]
 - Added AndroidAudio#newMusic(FileDescriptor) to allow loading music from a file descriptor, see #2970

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtGL20.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtGL20.java
@@ -460,21 +460,14 @@ public class GwtGL20 implements GL20 {
 		if (pixels == null) {
 			gl.texImage2D(target, level, internalformat, width, height, border, format, type, null);
 		} else {
-			if (pixels.limit() > 1) {
-				HasArrayBufferView arrayHolder = (HasArrayBufferView)pixels;
+			HasArrayBufferView arrayHolder = (HasArrayBufferView)pixels;
 
-				ArrayBufferView webGLArray = arrayHolder.getTypedArray();
-				int remainingBytes = pixels.remaining() * 4;
+			ArrayBufferView webGLArray = arrayHolder.getTypedArray();
 
-				int byteOffset = webGLArray.byteOffset() + pixels.position() * 4;
+			Uint8Array buffer = Uint8ArrayNative.create(webGLArray.buffer());
 
-				Uint8Array buffer = Uint8ArrayNative.create(webGLArray.buffer(), byteOffset, remainingBytes);
+			gl.texImage2D(target, level, internalformat, width, height, border, format, type, buffer);
 
-				gl.texImage2D(target, level, internalformat, width, height, border, format, type, buffer);
-			} else {
-				Pixmap pixmap = Pixmap.pixmaps.get(((IntBuffer)pixels).get(0));
-				gl.texImage2D(target, level, internalformat, format, type, pixmap.getCanvasElement());
-			}
 		}
 	}
 
@@ -486,21 +479,13 @@ public class GwtGL20 implements GL20 {
 	@Override
 	public void glTexSubImage2D (int target, int level, int xoffset, int yoffset, int width, int height, int format, int type,
 		Buffer pixels) {
-        if (pixels.limit() > 1) {
-            HasArrayBufferView arrayHolder = (HasArrayBufferView) pixels;
+		HasArrayBufferView arrayHolder = (HasArrayBufferView)pixels;
 
-            ArrayBufferView webGLArray = arrayHolder.getTypedArray();
-            int remainingBytes = pixels.remaining() * 4;
+		ArrayBufferView webGLArray = arrayHolder.getTypedArray();
+		Uint8Array buffer = Uint8ArrayNative.create(webGLArray.buffer());
 
-            int byteOffset = webGLArray.byteOffset() + pixels.position() * 4;
+		gl.texSubImage2D(target, level, xoffset, yoffset, width, height, format, type, buffer);
 
-            Uint8Array buffer = Uint8ArrayNative.create(webGLArray.buffer(), byteOffset, remainingBytes);
-
-            gl.texSubImage2D(target, level, xoffset, yoffset, width, height, format, type, buffer);
-        } else {
-            Pixmap pixmap = Pixmap.pixmaps.get(((IntBuffer) pixels).get(0));
-            gl.texSubImage2D(target, level, xoffset, yoffset, format, type, pixmap.getCanvasElement());
-        }
 	}
 
 	@Override

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/graphics/Pixmap.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/graphics/Pixmap.java
@@ -17,6 +17,8 @@
 package com.badlogic.gdx.graphics;
 
 import java.nio.Buffer;
+import java.nio.ByteBuffer;
+import java.nio.DirectReadWriteByteBuffer;
 import java.nio.IntBuffer;
 import java.util.HashMap;
 import java.util.Map;
@@ -32,6 +34,7 @@ import com.google.gwt.canvas.dom.client.Context2d;
 import com.google.gwt.canvas.dom.client.Context2d.Composite;
 import com.google.gwt.dom.client.CanvasElement;
 import com.google.gwt.dom.client.ImageElement;
+import com.google.gwt.typedarrays.shared.Uint8ClampedArray;
 
 public class Pixmap implements Disposable {
 	public static Map<Integer, Pixmap> pixmaps = new HashMap<Integer, Pixmap>();
@@ -85,7 +88,7 @@ public class Pixmap implements Disposable {
 	Canvas canvas;
 	Context2d context;
 	int id;
-	IntBuffer buffer;
+	ByteBuffer buffer;
 	int r = 255, g = 255, b = 255;
 	float a;
 	String color = make(r, g, b, a);
@@ -125,9 +128,7 @@ public class Pixmap implements Disposable {
 		canvas.getCanvasElement().setHeight(height);
 		context = canvas.getContext2d();
 		context.setGlobalCompositeOperation(getComposite());
-		buffer = BufferUtils.newIntBuffer(1);
 		id = nextId++;
-		buffer.put(0, id);
 		pixmaps.put(id, this);
 	}
 
@@ -180,7 +181,11 @@ public class Pixmap implements Disposable {
 		return height;
 	}
 
-	public Buffer getPixels () {
+	public ByteBuffer getPixels () {
+		if (pixels == null) pixels = context.getImageData(0, 0, width, height).getData();
+		if (buffer == null) {
+			buffer = new DirectReadWriteByteBuffer(((Uint8ClampedArray)pixels).buffer());
+		}
 		return buffer;
 	}
 

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/java/nio/DirectReadWriteByteBuffer.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/java/nio/DirectReadWriteByteBuffer.java
@@ -38,7 +38,7 @@ public final class DirectReadWriteByteBuffer extends DirectByteBuffer {
 		return buf;
 	}
 
-	DirectReadWriteByteBuffer (ArrayBuffer backingArray) {
+	public DirectReadWriteByteBuffer (ArrayBuffer backingArray) {
 		super(backingArray);
 	}
 
@@ -98,7 +98,7 @@ public final class DirectReadWriteByteBuffer extends DirectByteBuffer {
 	}
 
 	protected boolean protectedHasArray () {
-		return true;
+		return false;
 	}
 
 	public ByteBuffer put (byte b) {

--- a/gdx/src/com/badlogic/gdx.gwt.xml
+++ b/gdx/src/com/badlogic/gdx.gwt.xml
@@ -417,7 +417,7 @@
 		<include name="utils/QuickSelect.java"/>
 		<include name="utils/ReflectionPool.java"/>
 		<include name="utils/Scaling.java"/>
-		<exclude name="utils/ScreenUtils.java"/> <!-- Reason: Type mismatch Buffer->ByteBuffer -->
+		<include name="utils/ScreenUtils.java"/>
 		<include name="utils/Select.java"/>
 		<include name="utils/SerializationException.java"/> <!-- Emulated: Reflection -->
 		<exclude name="utils/SharedLibraryLoader.java"/> <!-- Reason: Natives -->

--- a/tests/gdx-tests/src/com/badlogic/gdx/GdxTests.gwt.xml
+++ b/tests/gdx-tests/src/com/badlogic/gdx/GdxTests.gwt.xml
@@ -12,11 +12,8 @@
 		<exclude name="**/KTXTest.java"/> <!-- use ECT1 which is native -->
 		<exclude name="**/ETC1Test.java"/> <!-- native -->
 		<exclude name="**/FFTTest.java"/> <!-- native -->
-		<exclude name="**/FramebufferToTextureTest.java"/> <!-- ScreenUtils missing -->
 		<exclude name="**/FreeType*.java"/> <!-- native  -->
 		<exclude name="**/Gdx2DTest.java"/> <!-- native -->
-		<exclude name="**/HeightField.java"/> <!-- Incompatible type due to emulation -->
-		<exclude name="**/HeightMapTest.java"/> <!-- Incompatible type due to emulation -->
 		<exclude name="**/I18NMessageTest.java"/> <!-- MessageBundle -->
 		<exclude name="**/InterpolationTest.java"/> <!-- reflection -->
 		<exclude name="**/JpegTest.java"/> <!-- native -->
@@ -24,8 +21,6 @@
 		<exclude name="**/Mpg123Test.java"/> <!-- native -->
 		<exclude name="**/PngTest.java"/> <!-- Not compatible -->
 		<exclude name="**/RemoteTest.java"/> <!-- networking -->
-		<exclude name="**/ScreenCaptureTest.java"/> <!-- ScreenUtils -->
-		<exclude name="**/ScreenshotTest.java"/> <!-- ScreenUtils -->
 		<exclude name="**/SelectTest.java"/> <!-- String.format -->
 		<exclude name="**/SoundTouchTest.java"/> <!-- native -->
 		<exclude name="**/StbTrueTypeTest.java"/> <!-- native -->

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtTestWrapper.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtTestWrapper.java
@@ -60,6 +60,7 @@ import com.badlogic.gdx.tests.DecalTest;
 import com.badlogic.gdx.tests.EdgeDetectionTest;
 import com.badlogic.gdx.tests.FilterPerformanceTest;
 import com.badlogic.gdx.tests.FrameBufferTest;
+import com.badlogic.gdx.tests.FramebufferToTextureTest;
 import com.badlogic.gdx.tests.GLProfilerErrorTest;
 import com.badlogic.gdx.tests.GestureDetectorTest;
 import com.badlogic.gdx.tests.GroupCullingTest;
@@ -103,6 +104,7 @@ import com.badlogic.gdx.tests.TimeUtilsTest;
 import com.badlogic.gdx.tests.UITest;
 import com.badlogic.gdx.tests.VertexBufferObjectShaderTest;
 import com.badlogic.gdx.tests.YDownTest;
+import com.badlogic.gdx.tests.g3d.HeightMapTest;
 import com.badlogic.gdx.tests.g3d.ModelCacheTest;
 import com.badlogic.gdx.tests.g3d.ShadowMappingTest;
 import com.badlogic.gdx.tests.superkoalio.SuperKoalio;
@@ -523,6 +525,10 @@ public class GwtTestWrapper extends GdxTest {
 			}
 		}, new Instancer() {
 			public GdxTest instance () {
+				return new FramebufferToTextureTest();
+			}
+		}, new Instancer() {
+			public GdxTest instance () {
 				return new GestureDetectorTest();
 			}
 		}, new Instancer() {
@@ -536,6 +542,10 @@ public class GwtTestWrapper extends GdxTest {
 		}, new Instancer() {
 			public GdxTest instance () {
 				return new GroupFadeTest();
+			}
+		}, new Instancer() {
+			public GdxTest instance () {
+				return new HeightMapTest();
 			}
 		}, new Instancer() {
 			public GdxTest instance () {


### PR DESCRIPTION
The canvas (used for storing the pixmap) has an CanvasPixelArray, which
basically is an UInt8ClampedArray.
So getPixels() returns a ByteBuffer. This ByteBuffer is an 
DirectByteBuffer, which wraps the ArrayBuffer of the UInt8ClampedArray.