### PR TITLE
Json readValue should not discard typeName

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@
 - Higher quality FreeType font rendering.
 - Hiero updated to v5, now with FreeType support and other new features!
 - GlyphLayout now allocates much, much less memory when processing long text that wraps.
+- Fixed JsonValue losing type data after deserialization, now safe to use multiple times, see #3672
 
 [1.7.2]
 - Added AndroidAudio#newMusic(FileDescriptor) to allow loading music from a file descriptor, see #2970

--- a/gdx/src/com/badlogic/gdx/utils/Json.java
+++ b/gdx/src/com/badlogic/gdx/utils/Json.java
@@ -860,7 +860,6 @@ public class Json {
 		if (jsonData.isObject()) {
 			String className = typeName == null ? null : jsonData.getString(typeName, null);
 			if (className != null) {
-				jsonData.remove(typeName);
 				type = getClass(className);
 				if (type == null) {
 					try {


### PR DESCRIPTION
When deserializing from JsonValue->object, typeName is removed from the the source JsonValue. This makes it impossible to deserialize the same JsonValue multiple times (our use-case: we have some prefab-like types, to save cycles and GC, we cache the JsonValue).

#### before deserialization
```
{
entities: {
  1: {
    components: {
      Operative: {
        operations: [
          {
            operation: {
              class: se.feomedia.orion.operation.ParallelOperation
              operations: [
                {
                  class: se.feomedia.map.operation.LevelPositionLockOperation
                }
                {
                  class: se.feomedia.map.operation.HoverOperation
                  y: 0.2
                  multiplier: 1.1
                }
              ]
            }
          }
        ]
      }
    }
  }
}
}
```

#### after deserialization
```
{
entities: {
  1: {
    components: {
      Operative: {
        operations: [
          {
            operation: {
              operations: [
                {}
                {
                  y: 0.2
                  multiplier: 1.1
                }
              ]
            }
          }
        ]
      }
    }
  }
}
}
```

