### PR TITLE
remove unused boneId variable in ModelNode data class

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g3d/model/data/ModelNode.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/model/data/ModelNode.java
@@ -21,7 +21,6 @@ import com.badlogic.gdx.math.Vector3;
 
 public class ModelNode {
 	public String id;
-	public int boneId = -1;
 	public Vector3 translation;
 	public Quaternion rotation;
 	public Vector3 scale;


### PR DESCRIPTION
I might miss its purpose but this variable is not used at all. 

The same goes for ModelNode.meshId, but I didn't remove it since it is written to (but never read from). Can do another commit if needed.

This is quite a non-important change so feel free to reject it but I thought it would help reduce the complexity of libgdx's node architecture. I'm writing my own model loader right now and the amount of variables in the data classes is a bit overwhelming, and if some of them are not used, it's even more confusing.