### PR TITLE
check for null

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/utils/reflect/Method.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/utils/reflect/Method.java
@@ -136,6 +136,8 @@ public final class Method {
 	 * Does not include parameter annotations. */
 	public Annotation[] getDeclaredAnnotations () {
 		java.lang.annotation.Annotation[] annotations = method.getDeclaredAnnotations();
+		if (annotations == null)
+			return new Annotation[0];
 		Annotation[] result = new Annotation[annotations.length];
 		for (int i = 0; i < annotations.length; i++) {
 			result[i] = new Annotation(annotations[i]);
@@ -148,6 +150,8 @@ public final class Method {
 	 * type he's looking for. */
 	public Annotation getDeclaredAnnotation (Class<? extends java.lang.annotation.Annotation> annotationType) {
 		java.lang.annotation.Annotation[] annotations = method.getDeclaredAnnotations();
+		if (annotations == null)
+			return null;
 		for (java.lang.annotation.Annotation annotation : annotations) {
 			if (annotation.annotationType().equals(annotationType)) {
 				return new Annotation(annotation);


### PR DESCRIPTION
The returned array can be null causing an exception in the GWT backend saying, "Cannot read property 'length' of null"

A simple test

```java
package com.unseenspace.test;

import com.badlogic.gdx.Application;
import com.badlogic.gdx.ApplicationAdapter;
import com.badlogic.gdx.Gdx;
import com.badlogic.gdx.scenes.scene2d.Actor;
import com.badlogic.gdx.utils.reflect.ClassReflection;
import com.badlogic.gdx.utils.reflect.Method;

import java.util.Arrays;

public class AnnotationTest extends ApplicationAdapter {

    @Override
    public void create() {
        Gdx.app.setLogLevel(Application.LOG_DEBUG);
        Gdx.app.error("TEST", "Testing class: " + Arrays.toString(ClassReflection.getAnnotations(Actor.class)));
        Gdx.app.error("TEST", "Class Annotations: " + Arrays.toString(ClassReflection.getAnnotations(Actor.class)));
        Gdx.app.error("TEST", "Methods: " + Arrays.toString(ClassReflection.getMethods(Test.class)));
        Gdx.app.error("TEST", "Declared Methods: " + Arrays.toString(ClassReflection.getDeclaredMethods(Test.class)));
        for (Method method : ClassReflection.getDeclaredMethods(Test.class)) {
            Gdx.app.error("TEST", method.getName() + " " + Arrays.toString(method.getDeclaredAnnotations()));
        }
    }
}
```

Reference for regular file of com.badlogic.gdx.utils.reflect.Method
```java
	/** Returns an array of {@link Annotation} objects reflecting all annotations declared by this method,
	 * or an empty array if there are none. Does not include inherited annotations.
	 * Does not include parameter annotations. */
	public Annotation[] getDeclaredAnnotations () {
		java.lang.annotation.Annotation[] annotations = method.getDeclaredAnnotations();
		Annotation[] result = new Annotation[annotations.length];
		for (int i = 0; i < annotations.length; i++) {
			result[i] = new Annotation(annotations[i]);
		}
		return result;
	}

	/** Returns an {@link Annotation} object reflecting the annotation provided, or null of this method doesn't
	 * have such an annotation. This is a convenience function if the caller knows already which annotation
	 * type he's looking for. */
	public Annotation getDeclaredAnnotation (Class<? extends java.lang.annotation.Annotation> annotationType) {
		java.lang.annotation.Annotation[] annotations = method.getDeclaredAnnotations();
		if (annotations == null) {
			return null;
		}
		for (java.lang.annotation.Annotation annotation : annotations) {
			if (annotation.annotationType().equals(annotationType)) {
				return new Annotation(annotation);
			}
		}
		return null;
	}
```

I am not quite sure why getDeclaredAnnotations() doesn't check for null though.