### PR TITLE
Add system cursors to GWT, fix little error in Lwjgl3Cursor

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,7 @@
 - Added Gyroscope support in Input, implemented for Android, see https://github.com/libgdx/libgdx/pull/3594
 - Fixed touch mapping on iOS, see https://github.com/libgdx/libgdx/pull/3590
 - Added orientation to Box2D Transform class, see https://github.com/libgdx/libgdx/pull/3308
+- Added system cursors to GWT, fix 'Ibeam' system cursor not working on LWJGL3.
 
 [1.8.0]
 - API Change: Rewrote FreeType shadow rendering (much better).

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Cursor.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Cursor.java
@@ -108,7 +108,9 @@ public class Lwjgl3Cursor implements Cursor {
 				handle = GLFW.glfwCreateStandardCursor(GLFW.GLFW_HRESIZE_CURSOR);
 			} else if (systemCursor == SystemCursor.VerticalResize) {
 				handle = GLFW.glfwCreateStandardCursor(GLFW.GLFW_VRESIZE_CURSOR);
-			} else {
+			} else if (systemCursor == SystemCursor.Ibeam) {
+ 				handle = GLFW.glfwCreateStandardCursor(GLFW.GLFW_IBEAM_CURSOR);
+  			} else {
 				throw new GdxRuntimeException("Unknown system cursor " + systemCursor);
 			}
 

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtCursor.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtCursor.java
@@ -62,6 +62,25 @@ public class GwtCursor implements Cursor {
 		cssCursorProperty += yHotspot;
 		cssCursorProperty += ",auto";
 	}
+	
+	static String getNameForSystemCursor (SystemCursor systemCursor) {
+		if (systemCursor == SystemCursor.Arrow) {
+			return "default";
+		} else if (systemCursor == SystemCursor.Crosshair) {
+			return "crosshair";
+		} else if (systemCursor == SystemCursor.Hand) {
+			return "pointer"; // Don't change to 'hand', 'hand' doesn't work in the newer IEs
+		} else if (systemCursor == SystemCursor.HorizontalResize) {
+			return "ew-resize";
+		} else if (systemCursor == SystemCursor.VerticalResize) {
+			return "ns-resize";
+		} else if (systemCursor == SystemCursor.Ibeam) {
+			return "text";
+		} else {
+			throw new GdxRuntimeException("Unknown system cursor " + systemCursor);
+		}
+		
+	}
 
 	@Override
 	public void dispose () {

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtGraphics.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtGraphics.java
@@ -471,7 +471,7 @@ public class GwtGraphics implements Graphics {
 	
 	@Override
 	public void setSystemCursor (SystemCursor systemCursor) {
-		((GwtApplication)Gdx.app).graphics.canvas.getStyle().setProperty("cursor", "auto");
+		((GwtApplication)Gdx.app).graphics.canvas.getStyle().setProperty("cursor", GwtCursor.getNameForSystemCursor(systemCursor));
 	}
 	
 	static class GwtMonitor extends Monitor {


### PR DESCRIPTION
GWT cursors should work everywhere.
@badlogic forgot the 'Ibeam' system cursor, so I added it.

See 
http://caniuse.com/#feat=css3-cursors
http://quirksmode.org/css/user-interface/cursor.html
https://developer.mozilla.org/en-US/docs/Web/CSS/cursor
