### PR TITLE
Get result when calling super in keyDown for later return.

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextArea.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextArea.java
@@ -380,7 +380,7 @@ public class TextArea extends TextField {
 
 		@Override
 		public boolean keyDown (InputEvent event, int keycode) {
-			super.keyDown(event, keycode);
+			boolean result = super.keyDown(event, keycode);
 			Stage stage = getStage();
 			if (stage != null && stage.getKeyboardFocus() == TextArea.this) {
 				boolean repeat = false;
@@ -418,7 +418,7 @@ public class TextArea extends TextField {
 				showCursor();
 				return true;
 			}
-			return false;
+			return result;
 		}
 
 		@Override


### PR DESCRIPTION
Due to not handling the super result in TextArea the key was passed to my parent dialog causing the dialog to close when the ENTER key was enter in the textarea. This is a pull request to fix that bug.