### PR TITLE
Gdx-setup: add support for external dependencies

### DIFF
--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/ExternalExtension.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/ExternalExtension.java
@@ -26,7 +26,7 @@ public class ExternalExtension {
 	private String description;
 	private String version;
 
-	private Map<String, List<String>> dependencies;
+	private Map<String, List<ExternalExtensionDependency>> dependencies;
 
 	public ExternalExtension (String name, String[] gwtInherits, String description, String version) {
 		this.name = name;
@@ -34,8 +34,8 @@ public class ExternalExtension {
 		this.description = description;
 		this.version = version;
 	}
-	
-	public void setDependencies (Map<String, List<String>> dependencies) {
+
+	public void setDependencies (Map<String, List<ExternalExtensionDependency>> dependencies) {
 		this.dependencies = dependencies;
 	}
 
@@ -54,12 +54,16 @@ public class ExternalExtension {
 		} else {
 			String[] arr = new String[dependencies.get(platformName).size()];
 			for (int i = 0; i < dependencies.get(platformName).size(); i++) {
-				String dependencyString = dependencies.get(platformName).get(i);
-				if (dependencyString.split(":").length == 3) {
-					String[] split = dependencyString.split(":");
-					arr[i] = split[0] + ":" + split[1] + ":" + version + ":" + split[2];
+				ExternalExtensionDependency dependency = dependencies.get(platformName).get(i);
+				if (dependency.external) {
+					arr[i] = dependency.text;
 				} else {
-					arr[i] = dependencyString + ":" + version;
+					String[] split = dependency.text.split(":");
+					if (split.length == 3) {
+						arr[i] = split[0] + ":" + split[1] + ":" + version + ":" + split[2];
+					} else {
+						arr[i] = dependency.text + ":" + version;
+					}
 				}
 			}
 			return arr;

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/ExternalExtensionDependency.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/ExternalExtensionDependency.java
@@ -1,0 +1,14 @@
+package com.badlogic.gdx.setup;
+
+/** @author Kotcrab */
+public class ExternalExtensionDependency {
+	public final String text;
+	/** Indicates that this dependency is not internal part of extension. If set to true this dependency text must not
+	 * be modified to append extension version. See {@link ExternalExtension#getPlatformDependencies(String)}*/
+	public final boolean external;
+
+	public ExternalExtensionDependency (String text, boolean external) {
+		this.text = text;
+		this.external = external;
+	}
+}

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/ExternalExtensionsDialog.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/ExternalExtensionsDialog.java
@@ -218,7 +218,7 @@ public class ExternalExtensionsDialog extends JDialog implements TableModelListe
 				for (int j = 0; j < inheritsNode.getLength(); j++)
 					gwtInherits[j] = inheritsNode.item(j).getTextContent();
 
-				final HashMap<String, List<String>> dependencies = new HashMap<String, List<String>>();
+				final HashMap<String, List<ExternalExtensionDependency>> dependencies = new HashMap<String, List<ExternalExtensionDependency>>();
 
 				addToDependencyMapFromXML(dependencies, eElement, "core");
 				addToDependencyMapFromXML(dependencies, eElement, "desktop");
@@ -291,11 +291,11 @@ public class ExternalExtensionsDialog extends JDialog implements TableModelListe
 		}
 	}
 
-	private void addToDependencyMapFromXML (Map<String, List<String>> dependencies, Element eElement, String platform) {
+	private void addToDependencyMapFromXML (Map<String, List<ExternalExtensionDependency>> dependencies, Element eElement, String platform) {
 		if (eElement.getElementsByTagName(platform).item(0) != null) {
 			Element project = (Element)eElement.getElementsByTagName(platform).item(0);
 
-			ArrayList<String> deps = new ArrayList<String>();
+			ArrayList<ExternalExtensionDependency> deps = new ArrayList<ExternalExtensionDependency>();
 
 			if (project.getTextContent().trim().equals("")) {
 				// No dependencies required
@@ -309,7 +309,8 @@ public class ExternalExtensionsDialog extends JDialog implements TableModelListe
 					Node nNode = nList.item(i);
 					if (nNode.getNodeType() == Node.ELEMENT_NODE) {
 						Element dependencyNode = (Element)nNode;
-						deps.add(dependencyNode.getTextContent());
+						boolean external = Boolean.parseBoolean(dependencyNode.getAttribute("external"));
+						deps.add(new ExternalExtensionDependency(dependencyNode.getTextContent(), external));
 					}
 
 				}

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/data/extensions.xml
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/data/extensions.xml
@@ -22,11 +22,11 @@
 		<name>VisUI</name>
 		<description>Flat design skin for scene2d.ui and UI toolkit</description>
 		<package>com.kotcrab.vis.ui</package>
-		<version>0.9.4</version>
+		<version>0.9.5</version>
 		<compatibility>1.7.1</compatibility>
 		<website>https://github.com/kotcrab/VisEditor/wiki/VisUI</website>
 		<gwtInherits>
-		    <inherit>com.kotcrab.vis.vis-ui</inherit>
+			<inherit>com.kotcrab.vis.vis-ui</inherit>
 		</gwtInherits>
 		<projects>
 			<core>
@@ -48,7 +48,7 @@
 		<compatibility>1.7.1</compatibility>
 		<website>http://vis.kotcrab.com</website>
 		<gwtInherits>
-		    <inherit>com.kotcrab.vis.vis-runtime</inherit>
+			<inherit>com.kotcrab.vis.vis-runtime</inherit>
 		</gwtInherits>
 		<projects>
 			<core>
@@ -58,6 +58,9 @@
 			<android></android>
 			<ios></ios>
 			<html>
+				<dependency external="true">net.onedaybeard.artemis:artemis-odb-gwt:1.2.1</dependency>
+				<dependency external="true">net.onedaybeard.artemis:artemis-odb-gwt:1.2.1:sources</dependency>
+				<dependency external="true">net.onedaybeard.artemis:artemis-odb:1.2.1:sources</dependency>
 				<dependency>com.kotcrab.vis:vis-runtime-gwt</dependency>
 				<dependency>com.kotcrab.vis:vis-runtime-gwt:sources</dependency>
 				<dependency>com.kotcrab.vis:vis-runtime:sources</dependency>
@@ -110,14 +113,14 @@
 		</projects>
 	</extension>
 	<extension>
-       <name>gdx-facebook</name>
-       <description>Provides cross-platform support for Facebook Graph API</description>
-       <package>de.tomgrill.gdxfacebook</package>
-       <version>1.1.1</version>
-       <compatibility>1.7.0</compatibility>
-       <website>https://github.com/TomGrill/gdx-facebook</website>
-       <gwtInherits></gwtInherits>
-       <projects>
+	   <name>gdx-facebook</name>
+	   <description>Provides cross-platform support for Facebook Graph API</description>
+	   <package>de.tomgrill.gdxfacebook</package>
+	   <version>1.1.1</version>
+	   <compatibility>1.7.0</compatibility>
+	   <website>https://github.com/TomGrill/gdx-facebook</website>
+	   <gwtInherits></gwtInherits>
+	   <projects>
 			<core>
 				<dependency>de.tomgrill.gdxfacebook:gdx-facebook-core</dependency>
 			</core>
@@ -132,16 +135,16 @@
 			</ios>
 			<html>null</html>
 		</projects>
-    </extension>
+	</extension>
 	<extension>
-       <name>gdx-dialogs</name>
-       <description>Provides cross-platform support for native dialogs</description>
-       <package>de.tomgrill.gdxdialogs</package>
-       <version>1.0.0</version>
-       <compatibility>1.7.0</compatibility>
-       <website>https://github.com/TomGrill/gdx-dialogs</website>
-       <gwtInherits></gwtInherits>
-       <projects>
+	   <name>gdx-dialogs</name>
+	   <description>Provides cross-platform support for native dialogs</description>
+	   <package>de.tomgrill.gdxdialogs</package>
+	   <version>1.0.0</version>
+	   <compatibility>1.7.0</compatibility>
+	   <website>https://github.com/TomGrill/gdx-dialogs</website>
+	   <gwtInherits></gwtInherits>
+	   <projects>
 			<core>
 				<dependency>de.tomgrill.gdxdialogs:gdx-dialogs-core</dependency>
 			</core>
@@ -156,7 +159,7 @@
 			</ios>
 			<html>null</html>
 		</projects>
-    </extension>
+	</extension>
 	<extension>
 		<name>gdx-kiwi</name>
 		<description>Guava-inspired utilities for LibGDX.</description>


### PR DESCRIPTION
This PR allows to add external dependencies for extensions defined in `extensions.xml`. Currently there is no way to do it, declared dependencies can't have version specified (it's inherited from extension version). Why is this change needed? Mostly for GWT, sometimes dependencies have separate gwt library which should be only included in html module and thus can't be included in extension itself. This was also discussed [here](https://github.com/libgdx/libgdx/pull/3537#issuecomment-156844608) and would help avoid issues like #3737.

External dependcies are declared like this:
```xml
<dependency external="true">net.onedaybeard.artemis:artemis-odb:1.2.1:sources</dependency>
```
`external="true"` is added to standard declaration.

I also corrected mixed indention in `extensions.xml`.