### PR TITLE
Fix gwt stack trace.

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplication.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplication.java
@@ -198,7 +198,7 @@ public abstract class GwtApplication implements EntryPoint, Application {
 					mainLoop();
 				} catch (Throwable t) {
 					error("GwtApplication", "exception: " + t.getMessage(), t);
-					throw new RuntimeException(t);
+					throw t;
 				}
 				AnimationScheduler.get().requestAnimationFrame(this, graphics.canvas);
 			}


### PR DESCRIPTION
This fix makes full stack working. 

![stack](https://cloud.githubusercontent.com/assets/6472084/12469606/4c6b4f96-bfd4-11e5-9d66-c0867d3dc69c.png)
"throw new RuntimeException(t);" is not showing full stack. For example, the picture above I cannot tell where the null is coming from. 

with "throw t"
![fullstack](https://cloud.githubusercontent.com/assets/6472084/12470003/e7e80b50-bfd7-11e5-8fd9-ee8c10bab47f.png)
