### PR TITLE
Fix broken kerning for freetype fonts

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,7 @@
 - Added orientation to Box2D Transform class, see https://github.com/libgdx/libgdx/pull/3308
 - Added system cursors to GWT, fix 'Ibeam' system cursor not working on LWJGL3.
 - Added experimental AndroidApplicationConfiguration#useGL30 and IOSApplicationConfiguration#useGL30 for testing OpenGL ES 3.0 support on mobile devices, do not use in production.
+- Fix broken kerning for FreeType fonts, see https://github.com/libgdx/libgdx/pull/3756
 
 [1.8.0]
 - API Change: Rewrote FreeType shadow rendering (much better).

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -174,3 +174,4 @@ nooone https://github.com/nooone
 kotcrab https://github.com/kotcrab
 ClaudiuBele https://github.com/ClaudiuBele
 realitix https://github.com/realitix
+vmilea https://github.com/vmilea

--- a/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGenerator.java
+++ b/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGenerator.java
@@ -389,7 +389,9 @@ public class FreeTypeFontGenerator implements Disposable {
 
 			heightsCount--;
 			heights[best] = heights[heightsCount];
+			char tmpChar = characters[best];
 			characters[best] = characters[heightsCount];
+			characters[heightsCount] = tmpChar;
 		}
 
 		if (stroker != null && !incremental) stroker.dispose();


### PR DESCRIPTION
When rendering true type fonts, I was seeing this:

![kerning_nok](https://cloud.githubusercontent.com/assets/278476/12484184/c9f4dff8-c061-11e5-89bb-08c723ddeaa6.png)

instead of:

![kerning_ok](https://cloud.githubusercontent.com/assets/278476/12484190/cf655710-c061-11e5-92e2-8056008fec5f.png)

Turns out the `FreeTypeFontGenerator` was generating incomplete kerning info. Before kerning, the library creates glyphs in order from highest to lowest for best packing. During this step, the `characters` array becomes corrupted (highest chars get discarded). For example: `['A', 'V', 'L', 'T', 'Y']` turns into `['T', 'T', 'L', 'T', 'Y']`, so `'A'` and `'V'` will not be considered for kerning.

This fix keeps the `characters` array sorted and intact for kerning purposes.