### PR TITLE
FreeType - Allow configuration of hinting algorithm

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,7 @@
 - Added system cursors to GWT, fix 'Ibeam' system cursor not working on LWJGL3.
 - Added experimental AndroidApplicationConfiguration#useGL30 and IOSApplicationConfiguration#useGL30 for testing OpenGL ES 3.0 support on mobile devices, do not use in production.
 - Fix broken kerning for FreeType fonts, see https://github.com/libgdx/libgdx/pull/3756
+- API Addition: FreeTypeFontParameter has an additional field for tweaking hinting, see https://github.com/libgdx/libgdx/pull/3757
 
 [1.8.0]
 - API Change: Rewrote FreeType shadow rendering (much better).

--- a/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeType.java
+++ b/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeType.java
@@ -834,6 +834,12 @@ public class FreeType {
 	public static int FT_LOAD_LINEAR_DESIGN                = 0x2000;
 	public static int FT_LOAD_NO_AUTOHINT                  = 0x8000;
 	
+	public static int FT_LOAD_TARGET_NORMAL                = 0x0;
+	public static int FT_LOAD_TARGET_LIGHT                 = 0x10000;
+	public static int FT_LOAD_TARGET_MONO                  = 0x20000;
+	public static int FT_LOAD_TARGET_LCD                   = 0x30000;
+	public static int FT_LOAD_TARGET_LCD_V                 = 0x40000;
+
    public static int FT_RENDER_MODE_NORMAL = 0;
    public static int FT_RENDER_MODE_LIGHT = 1;
    public static int FT_RENDER_MODE_MONO = 2;


### PR DESCRIPTION
With some fonts, the default FreeType hinter is too aggressive and yields poor results. This commit adds a field to `FreeTypeFontParameter` for configuring the hinting algorithm.