### PR TITLE
Fix Desktop IME input.

### DIFF
--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglInput.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglInput.java
@@ -873,9 +873,9 @@ final public class LwjglInput implements Input {
 
 		if (Keyboard.isCreated()) {
 			while (Keyboard.next()) {
-				if (Keyboard.getEventKeyState()) {
-					int keyCode = getGdxKeyCode(Keyboard.getEventKey());
-					char keyChar = Keyboard.getEventCharacter();
+				int keyCode = getGdxKeyCode(Keyboard.getEventKey());
+				char keyChar = Keyboard.getEventCharacter();
+				if (Keyboard.getEventKeyState() || (keyCode == 0 && keyChar != 0 && Character.isDefined(keyChar))) {
 					long timeStamp = Keyboard.getEventNanoseconds();
 
 					switch (keyCode) {
@@ -888,27 +888,27 @@ final public class LwjglInput implements Input {
 					}
 
 					KeyEvent event = usedKeyEvents.obtain();
-					event.keyCode = keyCode;
-					event.keyChar = 0;
-					event.type = KeyEvent.KEY_DOWN;
-					event.timeStamp = timeStamp;
-					keyEvents.add(event);
-
-					event = usedKeyEvents.obtain();
 					event.keyCode = 0;
 					event.keyChar = keyChar;
 					event.type = KeyEvent.KEY_TYPED;
 					event.timeStamp = timeStamp;
 					keyEvents.add(event);
 
-					pressedKeys++;
-					keyJustPressed = true;
-					justPressedKeys[keyCode] = true;
-					lastKeyCharPressed = keyChar;
-					keyRepeatTimer = keyRepeatInitialTime;
-				} else {
-					int keyCode = LwjglInput.getGdxKeyCode(Keyboard.getEventKey());
+					if (keyCode != 0) {
+						event = usedKeyEvents.obtain();
+						event.keyCode = keyCode;
+						event.keyChar = 0;
+						event.type = KeyEvent.KEY_DOWN;
+						event.timeStamp = timeStamp;
+						keyEvents.add(event);
 
+						pressedKeys++;
+						keyJustPressed = true;
+						justPressedKeys[keyCode] = true;
+						lastKeyCharPressed = keyChar;
+						keyRepeatTimer = keyRepeatInitialTime;
+					}
+				} else {
 					KeyEvent event = usedKeyEvents.obtain();
 					event.keyCode = keyCode;
 					event.keyChar = 0;


### PR DESCRIPTION
Typing with IME only receives a unicode character without keydown event, so I added a KeyChar check.

Note: I only tested it in Windows 7, not sure if it works in other systems.