### PR TITLE
Add binormal and tangent to MeshBuilder

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g3d/utils/MeshBuilder.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/utils/MeshBuilder.java
@@ -88,6 +88,10 @@ public class MeshBuilder implements MeshPartBuilder {
 	private int posSize;
 	/** The offset within an vertex to normal, or -1 if not available */
 	private int norOffset;
+	/** The offset within a vertex to binormal, or -1 if not available */
+	private int biNorOffset;
+	/** The offset within a vertex to tangent, or -1 if not available */
+	private int tangentOffset;
 	/** The offset within an vertex to color, or -1 if not available */
 	private int colOffset;
 	/** The size (in number of floats) of the color attribute */
@@ -173,6 +177,10 @@ public class MeshBuilder implements MeshPartBuilder {
 		posSize = a.numComponents;
 		a = attributes.findByUsage(Usage.Normal);
 		norOffset = a == null ? -1 : a.offset / 4;
+		a = attributes.findByUsage(Usage.BiNormal);
+		biNorOffset = a == null ? -1 : a.offset / 4;
+		a = attributes.findByUsage(Usage.Tangent);
+		tangentOffset = a == null ? -1 : a.offset / 4;
 		a = attributes.findByUsage(Usage.ColorUnpacked);
 		colOffset = a == null ? -1 : a.offset / 4;
 		colSize = a == null ? 0 : a.numComponents;
@@ -561,6 +569,8 @@ public class MeshBuilder implements MeshPartBuilder {
 		if (vertexTransformationEnabled) {
 			transformPosition(vertices.items, o + posOffset, posSize, positionTransform);
 			if (norOffset >= 0) transformNormal(vertices.items, o + norOffset, 3, normalTransform);
+			if (biNorOffset >= 0) transformNormal(vertices.items, o + biNorOffset, 3, normalTransform);
+			if (tangentOffset >= 0) transformNormal(vertices.items, o + tangentOffset, 3, normalTransform);
 		}
 		
 		final float x = vertices.items[o+posOffset];


### PR DESCRIPTION
Allows vertex transformation to handle tangent and binormal correctly. 