### PR TITLE
Don't create garbage in System.currentMillis

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/java/lang/System.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/java/lang/System.java
@@ -116,7 +116,7 @@ public final class System {
   }-*/;
 
   private static native double currentTimeMillis0() /*-{
-    return (new Date()).getTime();
+    return Date.now();
   }-*/;
 
   /**


### PR DESCRIPTION
Date.now() is supported on every browser that supports WebGL, so it's save to use it instead of creating a new object on every call.