### PR TITLE
ParticleEditor in mac & java8

### DIFF
--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/ParticleEditor.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/ParticleEditor.java
@@ -273,13 +273,13 @@ public class ParticleEditor extends JFrame {
 			splitPane.add(leftSplit, JSplitPane.LEFT);
 			{
 				JPanel spacer = new JPanel(new BorderLayout());
-				leftSplit.add(spacer, JSplitPane.TOP);
+				leftSplit.add(spacer, JSplitPane.BOTTOM);
 				spacer.add(lwjglCanvas.getCanvas());
 				spacer.setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 4));
 			}
 			{
 				JPanel emittersPanel = new JPanel(new BorderLayout());
-				leftSplit.add(emittersPanel, JSplitPane.BOTTOM);
+				leftSplit.add(emittersPanel, JSplitPane.TOP);
 				emittersPanel.setBorder(new CompoundBorder(BorderFactory.createEmptyBorder(0, 6, 6, 0), BorderFactory
 					.createTitledBorder("Effect Emitters")));
 				{
@@ -287,7 +287,7 @@ public class ParticleEditor extends JFrame {
 					emittersPanel.add(effectPanel);
 				}
 			}
-			leftSplit.setDividerLocation(575);
+			leftSplit.setDividerLocation(375);
 		}
 		splitPane.setDividerLocation(325);
 	}


### PR DESCRIPTION
In mac Yosemite with java 8, the particle editor can not work.
<img width="400" alt="2016-01-26 16 13 35" src="https://cloud.githubusercontent.com/assets/3417659/12599631/969d5754-c4ce-11e5-8b4f-9c495afb5d20.png">


so I  replace the two panel.
<img width="400" alt="2016-01-26 16 59 45" src="https://cloud.githubusercontent.com/assets/3417659/12599640/a97d58b0-c4ce-11e5-8b2c-bc39d4daaaad.png">

