### PR TITLE
Load BitmapFont split in multiple regions in Skin

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Skin.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Skin.java
@@ -21,6 +21,7 @@ import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
+import com.badlogic.gdx.graphics.g2d.BitmapFont.BitmapFontData;
 import com.badlogic.gdx.graphics.g2d.NinePatch;
 import com.badlogic.gdx.graphics.g2d.Sprite;
 import com.badlogic.gdx.graphics.g2d.TextureAtlas;
@@ -474,15 +475,20 @@ public class Skin implements Disposable {
 				String regionName = fontFile.nameWithoutExtension();
 				try {
 					BitmapFont font;
-					TextureRegion region = skin.optional(regionName, TextureRegion.class);
-					if (region != null)
-						font = new BitmapFont(fontFile, region, flip);
+					Array<TextureRegion> regions = skin.getRegions(regionName);
+					if (regions != null)
+						font = new BitmapFont(new BitmapFontData(fontFile, flip), regions, true);
 					else {
-						FileHandle imageFile = fontFile.parent().child(regionName + ".png");
-						if (imageFile.exists())
-							font = new BitmapFont(fontFile, imageFile, flip);
-						else
-							font = new BitmapFont(fontFile, flip);
+						TextureRegion region = skin.optional(regionName, TextureRegion.class);
+						if (region != null)
+							font = new BitmapFont(fontFile, region, flip);
+						else {
+							FileHandle imageFile = fontFile.parent().child(regionName + ".png");
+							if (imageFile.exists())
+								font = new BitmapFont(fontFile, imageFile, flip);
+							else
+								font = new BitmapFont(fontFile, flip);
+						}
 					}
 					font.getData().markupEnabled = markupEnabled;
 					// Scaled size is the desired cap height to scale the font to.

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Skin.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Skin.java
@@ -103,7 +103,11 @@ public class Skin implements Disposable {
 		Array<AtlasRegion> regions = atlas.getRegions();
 		for (int i = 0, n = regions.size; i < n; i++) {
 			AtlasRegion region = regions.get(i);
-			add(region.name, region, TextureRegion.class);
+			String name = region.name;
+			if (region.index != -1) {
+			    name += "_" + region.index;
+			}
+			add(name, region, TextureRegion.class);
 		}
 	}
 

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Skin.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Skin.java
@@ -198,6 +198,21 @@ public class Skin implements Disposable {
 		return region;
 	}
 
+	/** @return an array with the {@link TextureRegion} that have an index != -1, or null if none are found. */
+	public Array<TextureRegion> getRegions (String regionName) {
+		Array<TextureRegion> regions = null;
+		int i = 0;
+		TextureRegion region = optional(regionName + "_" + (i++), TextureRegion.class);
+		if (region != null) {
+			regions = new Array<TextureRegion>();
+			while (region != null) {
+				regions.add(region);
+				region = optional(regionName + "_" + (i++), TextureRegion.class);
+			}
+		}
+		return regions;
+	}
+
 	/** Returns a registered tiled drawable. If no tiled drawable is found but a region exists with the name, a tiled drawable is
 	 * created from the region and stored in the skin. */
 	public TiledDrawable getTiledDrawable (String name) {


### PR DESCRIPTION
Sometimes it's necessary to have a font atlas split in several images in the form:
```
Arial_0.png
Arial_1.png
Arial_2.png
```
If these images are packed (with other images), the resulting atlas contains regions with repeated names but different indexes, something like this:
```
...
Arial
  rotate: false
  xy: 2, 518
  size: 256, 256
  orig: 256, 256
  offset: 0, 0
  index: 0
Arial
  rotate: false
  xy: 2, 260
  size: 256, 256
  orig: 256, 256
  offset: 0, 0
  index: 1
Arial
  rotate: false
  xy: 260, 518
  size: 256, 256
  orig: 256, 256
  offset: 0, 0
  index: 2
...
```
If we use this atlas as an `Skin` atlas, the loading process ignores region indexes and it ends up with only 1 `TextureRegion` named `Arial` (the last one found). This makes impossible to build a `BitmapFont` using several `TextureRegion` (since the skin only contains 1). This PR fixes this.

To reproduce the problem:
```java
public class LoadFont extends ApplicationAdapter{

    @Override
    public void create() {
        new Skin(Gdx.files.internal("skin.json"));
    }
}
```
using as assets [these files](https://dl.dropboxusercontent.com/u/3300634/bitmapfont-assets.zip).