### PR TITLE
Extract out GLVersion for all backends in preparation for stronger c…

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphics.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphics.java
@@ -32,6 +32,7 @@ import android.util.DisplayMetrics;
 import android.view.Display;
 import android.view.View;
 
+import com.badlogic.gdx.Application;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Graphics;
 import com.badlogic.gdx.LifecycleListener;
@@ -49,6 +50,7 @@ import com.badlogic.gdx.graphics.Mesh;
 import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.glutils.FrameBuffer;
+import com.badlogic.gdx.graphics.glutils.GLVersion;
 import com.badlogic.gdx.graphics.glutils.ShaderProgram;
 import com.badlogic.gdx.math.WindowedMean;
 import com.badlogic.gdx.utils.Array;
@@ -69,9 +71,6 @@ public class AndroidGraphics implements Graphics, Renderer {
 	 * kill the current process to avoid ANR */
 	static volatile boolean enforceContinuousRendering = false;
 
-	/** The OpenGlES version */
-	static int major, minor;
-
 	final View view;
 	int width;
 	int height;
@@ -79,6 +78,7 @@ public class AndroidGraphics implements Graphics, Renderer {
 	GL20 gl20;
 	GL30 gl30;
 	EGLContext eglContext;
+	GLVersion glVersion;
 	String extensions;
 
 	protected long lastFrameTime = System.nanoTime();
@@ -238,8 +238,11 @@ public class AndroidGraphics implements Graphics, Renderer {
 	 * 
 	 * @param gl */
 	private void setupGL (javax.microedition.khronos.opengles.GL10 gl) {
-		extractVersion(gl);
-		if (config.useGL30 && AndroidGraphics.major > 2) {
+		String versionString = gl.glGetString(GL10.GL_VERSION);
+		String vendorString = gl.glGetString(GL10.GL_VENDOR);
+		String rendererString = gl.glGetString(GL10.GL_RENDERER);
+		glVersion = new GLVersion(Application.ApplicationType.Android, versionString, vendorString, rendererString);
+		if (config.useGL30 && glVersion.getMajorVersion() > 2) {
 			if (gl30 != null) return;
 			gl20 = gl30 = new AndroidGL30();
 
@@ -258,25 +261,6 @@ public class AndroidGraphics implements Graphics, Renderer {
 		Gdx.app.log(LOG_TAG, "OGL vendor: " + gl.glGetString(GL10.GL_VENDOR));
 		Gdx.app.log(LOG_TAG, "OGL version: " + gl.glGetString(GL10.GL_VERSION));
 		Gdx.app.log(LOG_TAG, "OGL extensions: " + gl.glGetString(GL10.GL_EXTENSIONS));
-	}
-	
-	// Some manufactures (Samsung) like to add chars to version number, ignore those:
-	private static int parseInt(String v, int defaultValue) {
-		try {
-			return ((Number)NumberFormat.getInstance().parse(v)).intValue();
-		} catch (ParseException e) {
-			Gdx.app.error(LOG_TAG, "Error parsing number: " + v +", assuming: " + defaultValue);
-			return defaultValue;
-		}
-	}
-
-	private static void extractVersion (javax.microedition.khronos.opengles.GL10 gl) {
-		//Returns a version or release number of the form:
-		//OpenGL<space>ES<space><version number><space><vendor-specific information>.
-		String version = gl.glGetString(GL10.GL_VERSION);
-		String[] versionSplit = version.split(" ")[2].split("\\.", 2);
-		major = parseInt(versionSplit[0], 2);
-		minor = versionSplit.length < 2 ? 0 : parseInt(versionSplit[1], 0);
 	}
 
 	@Override
@@ -524,6 +508,12 @@ public class AndroidGraphics implements Graphics, Renderer {
 	@Override
 	public GraphicsType getType () {
 		return GraphicsType.AndroidGL;
+	}
+
+	/** {@inheritDoc} */
+	@Override
+	public GLVersion getGLVersion () {
+		return glVersion;
 	}
 
 	/** {@inheritDoc} */

--- a/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/mock/graphics/MockGraphics.java
+++ b/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/mock/graphics/MockGraphics.java
@@ -16,12 +16,14 @@
 
 package com.badlogic.gdx.backends.headless.mock.graphics;
 
+import com.badlogic.gdx.Application;
 import com.badlogic.gdx.Graphics;
 import com.badlogic.gdx.graphics.Cursor;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.GL30;
 import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.Cursor.SystemCursor;
+import com.badlogic.gdx.graphics.glutils.GLVersion;
 
 /** The headless backend does its best to mock elements. This is intended to make code-sharing between
  * server and client as simple as possible.
@@ -33,7 +35,7 @@ public class MockGraphics implements Graphics {
 	int frames = 0;
 	int fps;
 	long lastTime = System.nanoTime();
-
+	GLVersion glVersion = new GLVersion(Application.ApplicationType.HeadlessDesktop, "", "", "");
 	@Override
 	public boolean isGL30Available() {
 		return false;
@@ -92,6 +94,11 @@ public class MockGraphics implements Graphics {
 	@Override
 	public GraphicsType getType() {
 		return GraphicsType.Mock;
+	}
+
+	@Override
+	public GLVersion getGLVersion () {
+		return glVersion;
 	}
 
 	@Override

--- a/backends/gdx-backend-jglfw/src/com/badlogic/gdx/backends/jglfw/JglfwGraphics.java
+++ b/backends/gdx-backend-jglfw/src/com/badlogic/gdx/backends/jglfw/JglfwGraphics.java
@@ -18,6 +18,7 @@ package com.badlogic.gdx.backends.jglfw;
 
 import static com.badlogic.jglfw.Glfw.*;
 
+import com.badlogic.gdx.Application;
 import com.badlogic.gdx.ApplicationListener;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Graphics;
@@ -27,6 +28,7 @@ import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.GL30;
 import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.Cursor.SystemCursor;
+import com.badlogic.gdx.graphics.glutils.GLVersion;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.GdxRuntimeException;
 import com.badlogic.jglfw.GlfwVideoMode;
@@ -41,7 +43,7 @@ public class JglfwGraphics implements Graphics {
 	static final boolean isWindows = System.getProperty("os.name").contains("Windows");
 	static final boolean isLinux = System.getProperty("os.name").contains("Linux");
 
-	static int glMajorVersion, glMinorVersion;
+	static GLVersion glVersion;
 
 	long window;
 	private boolean fullscreen;
@@ -85,15 +87,17 @@ public class JglfwGraphics implements Graphics {
 		}
 
 		// Create GL.
-		String version = GL.glGetString(GL20.GL_VERSION);
-		glMajorVersion = Integer.parseInt("" + version.charAt(0));
-		glMinorVersion = Integer.parseInt("" + version.charAt(2));
+		String versionString = GL.glGetString(GL20.GL_VERSION);
+		String vendorString = GL.glGetString(GL20.GL_VENDOR);
+		String rendererString = GL.glGetString(GL20.GL_RENDERER);
+		glVersion = new GLVersion(Application.ApplicationType.Desktop, versionString, vendorString, rendererString);
 
-		if (glMajorVersion <= 1)
-			throw new GdxRuntimeException("OpenGL 2.0 or higher with the FBO extension is required. OpenGL version: " + version);
-		if (glMajorVersion == 2 || version.contains("2.1")) {
+
+		if (glVersion.getMajorVersion() <= 1)
+			throw new GdxRuntimeException("OpenGL 2.0 or higher with the FBO extension is required. OpenGL version: " + glVersion.getMajorVersion() + ":" + glVersion.getMinorVersion());
+		if (glVersion.getMajorVersion() == 2) {
 			if (!supportsExtension("GL_EXT_framebuffer_object") && !supportsExtension("GL_ARB_framebuffer_object")) {
-				throw new GdxRuntimeException("OpenGL 2.0 or higher with the FBO extension is required. OpenGL version: " + version
+				throw new GdxRuntimeException("OpenGL 2.0 or higher with the FBO extension is required. OpenGL version: " + glVersion.getMajorVersion() + ":" + glVersion.getMinorVersion()
 					+ ", FBO extension: false");
 			}
 		}
@@ -225,6 +229,10 @@ public class JglfwGraphics implements Graphics {
 
 	public GraphicsType getType () {
 		return GraphicsType.JGLFW;
+	}
+
+	public GLVersion getGLVersion () {
+		return glVersion;
 	}
 
 	public float getPpiX () {

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
@@ -18,6 +18,7 @@ package com.badlogic.gdx.backends.lwjgl3;
 
 import java.io.File;
 
+import com.badlogic.gdx.graphics.glutils.GLVersion;
 import org.lwjgl.glfw.GLFW;
 import org.lwjgl.glfw.GLFWErrorCallback;
 import org.lwjgl.glfw.GLFWVidMode;
@@ -56,7 +57,7 @@ public class Lwjgl3Application implements Application {
 	private final Array<Runnable> executedRunnables = new Array<Runnable>();	
 	private final Array<LifecycleListener> lifecycleListeners = new Array<LifecycleListener>();
 	private static GLFWErrorCallback errorCallback;
-	private static int versionMajor, versionMinor, versionRelease;
+	private static GLVersion glVersion;
 
 	static void initializeGlfw() {
 		if (errorCallback == null) {
@@ -374,14 +375,14 @@ public class Lwjgl3Application implements Application {
 		GLFW.glfwSwapInterval(config.vSyncEnabled ? 1 : 0);
 		GL.createCapabilities();
 
-		extractVersion();
-		if (!isOpenGLOrHigher(2, 0))
+		initiateGL();
+		if (!glVersion.isVersionEqualToOrHigher(2, 0))
 			throw new GdxRuntimeException("OpenGL 2.0 or higher with the FBO extension is required. OpenGL version: "
-					+ GL11.glGetString(GL11.GL_VERSION) + "\n" + glInfo());
+					+ GL11.glGetString(GL11.GL_VERSION) + "\n" + glVersion.getDebugVersionString());
 
 		if (!supportsFBO()) {
 			throw new GdxRuntimeException("OpenGL 2.0 or higher with the FBO extension is required. OpenGL version: "
-					+ GL11.glGetString(GL11.GL_VERSION) + ", FBO extension: false\n" + glInfo());
+					+ GL11.glGetString(GL11.GL_VERSION) + ", FBO extension: false\n" + glVersion.getDebugVersionString());
 		}
 
 		for (int i = 0; i < 2; i++) {
@@ -393,37 +394,17 @@ public class Lwjgl3Application implements Application {
 		return windowHandle;
 	}
 
-	private static void extractVersion () {
-		// See https://www.opengl.org/wiki/GLAPI/glGetString, format is:
-		// <major> "." <minor> ("." <release>) (<space> (<vendor_specific_info>))
-		String version = GL11.glGetString(GL11.GL_VERSION);
-		try {
-			String[] v = version.split(" ", 2)[0].split("\\.", 3);
-			versionMajor = Integer.parseInt(v[0]);
-			versionMinor = Integer.parseInt(v[1]);
-			versionRelease = v.length > 2 ? Integer.parseInt(v[2]) : 0;
-		} catch (Throwable t) {
-			throw new GdxRuntimeException("Error extracting the OpenGL version: " + version, t);
-		}
-	}
-
-	private static boolean isOpenGLOrHigher (int major, int minor) {
-		return versionMajor > major || (versionMajor == major && versionMinor >= minor);
+	private static void initiateGL () {
+		String versionString = GL11.glGetString(GL11.GL_VERSION);
+		String vendorString = GL11.glGetString(GL11.GL_VENDOR);
+		String rendererString = GL11.glGetString(GL11.GL_RENDERER);
+		glVersion = new GLVersion(Application.ApplicationType.Desktop, versionString, vendorString, rendererString);
 	}
 
 	private static boolean supportsFBO () {
 		// FBO is in core since OpenGL 3.0, see https://www.opengl.org/wiki/Framebuffer_Object
-		return isOpenGLOrHigher(3, 0) || GLFW.glfwExtensionSupported("GL_EXT_framebuffer_object") == GLFW.GLFW_TRUE
+		return glVersion.isVersionEqualToOrHigher(3, 0) || GLFW.glfwExtensionSupported("GL_EXT_framebuffer_object") == GLFW.GLFW_TRUE
 				|| GLFW.glfwExtensionSupported("GL_ARB_framebuffer_object") == GLFW.GLFW_TRUE;
 	}
 
-	private static String glInfo () {
-		try {
-			return GL11.glGetString(GL11.GL_VENDOR) + "\n" //
-					+ GL11.glGetString(GL11.GL_RENDERER) + "\n" //
-					+ GL11.glGetString(GL11.GL_VERSION);
-		} catch (Throwable ignored) {
-		}
-		return "";
-	}
 }

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Graphics.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Graphics.java
@@ -18,6 +18,8 @@ package com.badlogic.gdx.backends.lwjgl3;
 
 import java.nio.IntBuffer;
 
+import com.badlogic.gdx.Application;
+import com.badlogic.gdx.graphics.glutils.GLVersion;
 import org.lwjgl.BufferUtils;
 import org.lwjgl.PointerBuffer;
 import org.lwjgl.glfw.GLFW;
@@ -32,11 +34,13 @@ import com.badlogic.gdx.graphics.GL30;
 import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.utils.Disposable;
 import com.badlogic.gdx.utils.GdxRuntimeException;
+import org.lwjgl.opengl.GL11;
 
 public class Lwjgl3Graphics implements Graphics, Disposable {
 	private final Lwjgl3Window window;
 	private final GL20 gl20;
 	private final GL30 gl30;
+	private GLVersion glVersion;
 	private volatile int backBufferWidth;
 	private volatile int backBufferHeight;
 	private volatile int logicalWidth;
@@ -76,7 +80,15 @@ public class Lwjgl3Graphics implements Graphics, Disposable {
 			this.gl30 = null;
 		}
 		updateFramebufferInfo();
+		initiateGL();
 		GLFW.glfwSetFramebufferSizeCallback(window.getWindowHandle(), resizeCallback);
+	}
+
+	private void initiateGL () {
+		String versionString = gl20.glGetString(GL11.GL_VERSION);
+		String vendorString = gl20.glGetString(GL11.GL_VENDOR);
+		String rendererString = gl20.glGetString(GL11.GL_RENDERER);
+		glVersion = new GLVersion(Application.ApplicationType.Desktop, versionString, vendorString, rendererString);
 	}
 
 	public Lwjgl3Window getWindow() {
@@ -185,6 +197,11 @@ public class Lwjgl3Graphics implements Graphics, Disposable {
 	@Override
 	public GraphicsType getType() {
 		return GraphicsType.LWJGL3;
+	}
+
+	@Override
+	public GLVersion getGLVersion () {
+		return glVersion;
 	}
 
 	@Override

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
@@ -16,6 +16,8 @@
 
 package com.badlogic.gdx.backends.iosrobovm;
 
+import com.badlogic.gdx.Application;
+import com.badlogic.gdx.graphics.glutils.GLVersion;
 import org.robovm.apple.coregraphics.CGRect;
 import org.robovm.apple.foundation.NSObject;
 import org.robovm.apple.glkit.GLKView;
@@ -157,6 +159,7 @@ public class IOSGraphics extends NSObject implements Graphics, GLKViewDelegate, 
 
 	IOSApplicationConfiguration config;
 	EAGLContext context;
+	GLVersion glVersion;
 	GLKView view;
 	IOSUIViewController viewController;
 
@@ -181,6 +184,10 @@ public class IOSGraphics extends NSObject implements Graphics, GLKViewDelegate, 
 			gl30 = null;
 		}
 
+		String versionString = gl20.glGetString(GL20.GL_VERSION);
+		String vendorString = gl20.glGetString(GL20.GL_VENDOR);
+		String rendererString = gl20.glGetString(GL20.GL_RENDERER);
+		glVersion = new GLVersion(Application.ApplicationType.iOS, versionString, vendorString, rendererString);
 
 
 		view = new GLKView(new CGRect(0, 0, bounds.getWidth(), bounds.getHeight()), context) {
@@ -391,6 +398,11 @@ public class IOSGraphics extends NSObject implements Graphics, GLKViewDelegate, 
 	@Override
 	public GraphicsType getType () {
 		return GraphicsType.iOSGL;
+	}
+
+	@Override
+	public GLVersion getGLVersion () {
+		return glVersion;
 	}
 
 	@Override

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtGraphics.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtGraphics.java
@@ -16,6 +16,7 @@
 
 package com.badlogic.gdx.backends.gwt;
 
+import com.badlogic.gdx.Application;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Graphics;
 import com.badlogic.gdx.backends.gwt.GwtGraphics.OrientationLockType;
@@ -24,6 +25,7 @@ import com.badlogic.gdx.graphics.Cursor.SystemCursor;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.GL30;
 import com.badlogic.gdx.graphics.Pixmap;
+import com.badlogic.gdx.graphics.glutils.GLVersion;
 import com.badlogic.gdx.utils.GdxRuntimeException;
 import com.google.gwt.canvas.client.Canvas;
 import com.google.gwt.dom.client.CanvasElement;
@@ -51,6 +53,7 @@ public class GwtGraphics implements Graphics {
 
 	CanvasElement canvas;
 	WebGLRenderingContext context;
+	GLVersion glVersion;
 	GL20 gl;
 	String extensions;
 	float fps = 0;
@@ -80,6 +83,11 @@ public class GwtGraphics implements Graphics {
 		context = WebGLRenderingContext.getContext(canvas, attributes);
 		context.viewport(0, 0, config.width, config.height);
 		this.gl = config.useDebugGL ? new GwtGL20Debug(context) : new GwtGL20(context);
+
+		String versionString = gl.glGetString(GL20.GL_VERSION);
+		String vendorString = gl.glGetString(GL20.GL_VENDOR);
+		String rendererString = gl.glGetString(GL20.GL_RENDERER);
+		glVersion = new GLVersion(Application.ApplicationType.WebGL, versionString, vendorString, rendererString);
 	}
 
 	public WebGLRenderingContext getContext () {
@@ -129,6 +137,11 @@ public class GwtGraphics implements Graphics {
 	@Override
 	public GraphicsType getType () {
 		return GraphicsType.WebGL;
+	}
+
+	@Override
+	public GLVersion getGLVersion () {
+		return glVersion;
 	}
 
 	@Override

--- a/gdx/src/com/badlogic/gdx.gwt.xml
+++ b/gdx/src/com/badlogic/gdx.gwt.xml
@@ -225,6 +225,7 @@
 		<include name="graphics/glutils/FrameBufferCubemap.java"/>
 		<include name="graphics/glutils/GLFrameBuffer.java"/>
 		<include name="graphics/glutils/GLOnlyTextureData.java"/>
+		<include name="graphics/glutils/GLVersion.java"/>
 		<include name="graphics/glutils/HdpiUtils.java"/>
 		<include name="graphics/glutils/ImmediateModeRenderer.java"/>
 		<include name="graphics/glutils/ImmediateModeRenderer10.java"/>

--- a/gdx/src/com/badlogic/gdx/Graphics.java
+++ b/gdx/src/com/badlogic/gdx/Graphics.java
@@ -25,6 +25,7 @@ import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.g2d.Batch;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.graphics.glutils.FrameBuffer;
+import com.badlogic.gdx.graphics.glutils.GLVersion;
 import com.badlogic.gdx.graphics.glutils.IndexBufferObject;
 import com.badlogic.gdx.graphics.glutils.ShaderProgram;
 import com.badlogic.gdx.graphics.glutils.VertexArray;
@@ -164,6 +165,9 @@ public interface Graphics {
 
 	/** @return the {@link GraphicsType} of this Graphics instance */
 	public GraphicsType getType ();
+
+	/** @return the {@link GLVersion} of this Graphics instance */
+	public GLVersion getGLVersion ();
 
 	/** @return the pixels per inch on the x-axis */
 	public float getPpiX ();

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/GLVersion.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/GLVersion.java
@@ -1,0 +1,153 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogic.gdx.graphics.glutils;
+
+import com.badlogic.gdx.Application;
+import com.badlogic.gdx.Gdx;
+
+import java.text.NumberFormat;
+import java.text.ParseException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class GLVersion {
+
+	private int majorVersion;
+	private int minorVersion;
+	private int releaseVersion;
+
+	private final String vendorString;
+	private final String rendererString;
+
+	private final Type type;
+
+	private final String TAG = "GLVersion";
+
+	public GLVersion (Application.ApplicationType appType, String versionString, String vendorString, String rendererString) {
+		if (appType == Application.ApplicationType.Android) this.type = Type.GLES;
+		else if (appType == Application.ApplicationType.iOS) this.type = Type.GLES;
+		else if (appType == Application.ApplicationType.Desktop) this.type = Type.OpenGL;
+		else if (appType == Application.ApplicationType.Applet) this.type = Type.OpenGL;
+		else if (appType == Application.ApplicationType.WebGL) this.type = Type.WebGL;
+		else this.type = Type.NONE;
+
+		if (type == Type.GLES) {
+			//OpenGL<space>ES<space><version number><space><vendor-specific information>.
+			extractVersion("OpenGL ES (\\d(\\.\\d){0,2})", versionString);
+		} else if (type == Type.WebGL) {
+			//WebGL<space><version number><space><vendor-specific information>
+			extractVersion("WebGL (\\d(\\.\\d){0,2})", versionString);
+		} else if (type == Type.OpenGL) {
+			//<version number><space><vendor-specific information>
+			extractVersion("(\\d(\\.\\d){0,2})", versionString);
+		} else {
+			majorVersion = -1;
+			minorVersion = -1;
+			releaseVersion = -1;
+			vendorString = "";
+			rendererString = "";
+		}
+
+		this.vendorString = vendorString;
+		this.rendererString = rendererString;
+	}
+
+	private void extractVersion (String patternString, String versionString) {
+		Pattern pattern = Pattern.compile(patternString);
+		Matcher matcher = pattern.matcher(versionString);
+		boolean found = matcher.find();
+		if (found) {
+			String result = matcher.group(1);
+			String[] resultSplit = result.split("\\.");
+			majorVersion = parseInt(resultSplit[0], 2);
+			minorVersion = resultSplit.length < 2 ? 0 : parseInt(resultSplit[1], 0);
+			releaseVersion = resultSplit.length < 3 ? 0 : parseInt(resultSplit[2], 0);
+		} else {
+			Gdx.app.log(TAG, "Invalid version string: " + versionString);
+			majorVersion = 2;
+			minorVersion = 0;
+			releaseVersion = 0;
+		}
+	}
+
+	/** Forgiving parsing of gl major, minor and release versions as some manufacturers don't adhere to spec **/
+	private int parseInt (String v, int defaultValue) {
+		try {
+			return ((Number)NumberFormat.getInstance().parse(v)).intValue();
+		} catch (ParseException e) {
+			Gdx.app.error("LibGDX GL", "Error parsing number: " + v +", assuming: " + defaultValue);
+			return defaultValue;
+		}
+	}
+
+	/** @return what {@link Type} of GL implementation this application has access to, e.g. {@link Type#OpenGL} or {@link Type#GLES}*/
+	public Type getType () {
+		return type;
+	}
+
+	/** @return the major version of current GL connection. -1 if running headless */
+	public int getMajorVersion () {
+		return majorVersion;
+	}
+
+	/** @return the minor version of the current GL connection. -1 if running headless */
+	public int getMinorVersion () {
+		return minorVersion;
+	}
+
+	/** @return the release version of the current GL connection. -1 if running headless */
+	public int getReleaseVersion () {
+		return releaseVersion;
+	}
+
+	/** @return the vendor string associated with the current GL connection */
+	public String getVendorString () {
+		return vendorString;
+	}
+
+	/** @return the name of the renderer associated with the current GL connection.
+	 * This name is typically specific to a particular configuration of a hardware platform. */
+	public String getRendererString () {
+		return rendererString;
+	}
+
+	/**
+	 * Checks to see if the current GL connection version is higher, or equal to the provided test versions.
+	 *
+	 * @param testMajorVersion the major version to test against
+	 * @param testMinorVersion the minor version to test against
+	 * @return true if the current version is higher or equal to the test version
+	 */
+	public boolean isVersionEqualToOrHigher (int testMajorVersion, int testMinorVersion) {
+		return majorVersion > testMajorVersion || (majorVersion == testMajorVersion && minorVersion >= testMinorVersion);
+	}
+
+	/** @return a string with the current GL connection data */
+	public String getDebugVersionString () {
+		return "Type: " + type + "\n" +
+				"Version: " + majorVersion + ":" + minorVersion + ":" + releaseVersion + "\n" +
+				"Vendor: " + vendorString + "\n" +
+				"Renderer: " + rendererString;
+	}
+
+	public enum Type {
+		OpenGL,
+		GLES,
+		WebGL,
+		NONE
+	}
+}


### PR DESCRIPTION
…ross gl version support.

This will provide easy access to information about the GL connection, and allow us to robustly implement GL components that are sensitive to versions and platforms.