### PR TITLE
- Fixed loop in the "letterUnderCursor" method

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextArea.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextArea.java
@@ -86,7 +86,7 @@ public class TextArea extends TextField {
 				x += glyphPositions[start];
 				int end = linesBreak.items[cursorLine * 2 + 1];
 				int i = start;
-				for (; i <= end; i++)
+				for (; i < end; i++)
 					if (glyphPositions[i] > x) break;
 				if (glyphPositions[i] - x <= x - glyphPositions[i - 1]) return i;
 				return Math.max(0, i - 1);


### PR DESCRIPTION
which caused various "out of bounds" errors to occur when selecting text and positioning the cursor

To reproduce the bug (which is visible when selecting multiline text with the mouse, since the cursor tends to jump to the next line when it shouldn't) simply launch the TextArea test, empty the textarea, write a single word in it and double click somewhere to make it select the text, it should immediately crash. Once applied the fix a noticeable improvement to the text selection via mouse can be observed. Not to mention no more crashes.