### PR TITLE
Fix wrong buffer clear

### DIFF
--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGL20.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGL20.java
@@ -60,7 +60,7 @@ class LwjglGL20 implements com.badlogic.gdx.graphics.GL20 {
 
 	private IntBuffer toIntBuffer (int v[], int offset, int count) {
 		ensureBufferCapacity(count << 2);
-		floatBuffer.clear();
+		intBuffer.clear();
 		com.badlogic.gdx.utils.BufferUtils.copy(v, count, offset, intBuffer);
 		return intBuffer;
 	}


### PR DESCRIPTION
In `LwjglGL20.toIntBuffer` use `intBuffer` instance to pass it to `gl*` functions, but before coping clear `floatBuffer` instance.