### PR TITLE
Support for launching libGDX from a native iOS app

### DIFF
--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSFiles.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSFiles.java
@@ -16,6 +16,9 @@
 
 package com.badlogic.gdx.backends.iosrobovm;
 
+import java.io.File;
+
+import org.robovm.apple.foundation.NSArray;
 import org.robovm.apple.foundation.NSBundle;
 
 import com.badlogic.gdx.Files;
@@ -27,13 +30,32 @@ public class IOSFiles implements Files {
 	static final String appDir = System.getenv("HOME");
 	static final String externalPath = appDir + "/Documents/";
 	static final String localPath = appDir + "/Library/local/";
-	static final String internalPath = NSBundle.getMainBundle().getBundlePath();
-
-	public IOSFiles () {
+	static String internalPath = NSBundle.getMainBundle().getBundlePath();
+	
+	private String frameworkName;
+	
+	public IOSFiles (String frameworkName) {
+		this.frameworkName = frameworkName;
 		new FileHandle(externalPath).mkdirs();
 		new FileHandle(localPath).mkdirs();
+		
+		if (frameworkName != null) {
+			// get the path for the framework
+			NSArray<NSBundle>allFrameworks = NSBundle.getAllFrameworks();
+			for (int i = 0; i < allFrameworks.size(); i++) {
+				NSBundle frameworkBundle = allFrameworks.get(i);
+				if (frameworkBundle.getBundlePath().contains(frameworkName)) {
+					internalPath = frameworkBundle.getBundlePath() + "/Resources";
+					break;
+				}
+			} 
+		}
 	}
 
+	public IOSFiles () {
+		this(null);
+	}
+	
 	@Override
 	public FileHandle getFileHandle (String fileName, FileType type) {
 		return new IOSFileHandle(fileName, type);


### PR DESCRIPTION
I implemented the support for launching libGDX from a native iOS application. 

**Example usage:**

The host application must include a framework like in the [MyJavaFramework example](https://github.com/robovm/robovm-samples/tree/master/MyJavaFramework) that embeds the libGDX application.

In the libGDX application I added a class in the iOS module:

```
public class TestApplication {
    private IOSApplication iosApplication;

    public TestApplication() {
    }

    public void createApplication() {
        IOSApplicationConfiguration config = new IOSApplicationConfiguration();
        iosApplication = new IOSApplication(new Main(), config);
        iosApplication.launch("yourFrameworkName");
    }

    public void destroyApplication() {
        Singletons.close();
        iosApplication.destroy();
        iosApplication = null;
        System.gc();
    }

}
```

Inside the iOS application I can now create the TestApplication object and launch it by using the JNI, like in the [MyJavaFramework example](https://github.com/robovm/robovm-samples/tree/master/MyJavaFramework) :

```
- (IBAction)startLibGDX:(id)sender
{
    JavaVMInitArgs vm_args;
    vm_args.version = JNI_VERSION_1_4;
    vm_args.nOptions = 0;
    vm_args.options = NULL;

    jint res;
    JNIEnv *env;
    res = JNI_CreateJavaVM(&vm, &env, &vm_args);
    if (res != JNI_OK)
    {
        [NSException raise:@"JNI_CreateJavaVM() failed" format:@"%d", res];
    }

    _javaVM = javaVM;

    JNIEnv *env;
    jint res = (*[_javaVM vm])->AttachCurrentThread([_javaVM vm], (void**) &env, NULL);
    if (res != JNI_OK) {
        [NSException raise:@"AttachCurrentThread() failed" format:@"%d", res];
    }

    // get the class and methods reference
    testApplicationServiceClass = (*env)->FindClass(env, "net/yourcompany/yourproject/TestApplication");
    if (!testApplicationServiceClass) {
        [NSException raise:@"Failed to find class net.yourcompany.yourproject.TestApplication" format:@""];
    }
    createApplicationMethod = (*env)->GetMethodID(env, testApplicationServiceClass, "createApplication", "()V");
    if (!createApplicationMethod) {
        [NSException raise:@"Failed to find method net.yourcompany.yourproject.TestApplication.createApplication()" format:@""];
    }
    destroyApplicationMethod = (*env)->GetMethodID(env, testApplicationServiceClass, "destroyApplication", "()V");
    if (!destroyApplicationMethod) {
        [NSException raise:@"Failed to find method net.yourcompany.yourproject.TestApplication.destroyApplication()" format:@""];
    }
    constructor = (*env)->GetMethodID(env, testApplicationServiceClass, "<init>", "()V");

    // create the TestApplication object
    object = (*env)->NewObject(env, testApplicationServiceClass, constructor);

    // launch the libGDX application
    (*env)->CallVoidMethod(env, object, createApplicationMethod);
    (*[_javaVM vm])->DetachCurrentThread([_javaVM vm]);

}

- (void)closeLibGDX:()
{
    JNIEnv *env;
    jint res = (*[_javaVM vm])->AttachCurrentThread([_javaVM vm], (void**) &env, NULL);
    if (res != JNI_OK) {
        [NSException raise:@"AttachCurrentThread() failed" format:@"%d", res];
    }
    (*env)->CallVoidMethod(env, object, destroyApplicationMethod);
    (*[_javaVM vm])->DetachCurrentThread([_javaVM vm]);
}
```
