### PR TITLE
Fixed Scene2D window resize bug.

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Window.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Window.java
@@ -110,8 +110,8 @@ public class Window extends Table {
 					dragging = edge != 0;
 					startX = x;
 					startY = y;
-					lastX = x;
-					lastY = y;
+					lastX = x - width;
+					lastY = y - height;
 				}
 				return edge != 0 || isModal;
 			}
@@ -150,20 +150,18 @@ public class Window extends Table {
 					windowY += amountY;
 				}
 				if ((edge & Align.right) != 0) {
-					float amountX = x - lastX;
+					float amountX = x - lastX - width;
 					if (width + amountX < minWidth) amountX = minWidth - width;
 					if (clampPosition && windowX + width + amountX > stage.getWidth()) amountX = stage.getWidth() - windowX - width;
 					width += amountX;
 				}
 				if ((edge & Align.top) != 0) {
-					float amountY = y - lastY;
+					float amountY = y - lastY - height;
 					if (height + amountY < minHeight) amountY = minHeight - height;
 					if (clampPosition && windowY + height + amountY > stage.getHeight())
 						amountY = stage.getHeight() - windowY - height;
 					height += amountY;
 				}
-				lastX = x;
-				lastY = y;
 				setBounds(Math.round(windowX), Math.round(windowY), Math.round(width), Math.round(height));
 			}
 


### PR DESCRIPTION
This is a very old bug that I knew and fixed but never made a PR.

![bugedresize](https://cloud.githubusercontent.com/assets/6472084/12797822/1dbb99d8-caad-11e5-9e81-80e82120fb7d.gif)

The top-left, top-right and bottom-right edges don't seems to synchronize the mouse cursor when going outside of the App border.

And the very simple fix made it work.
![fixedresize](https://cloud.githubusercontent.com/assets/6472084/12797875/5b355ae2-caad-11e5-8bed-35774c7e21b7.gif)
