### PR TITLE
Drag'n Drop support for the lwjgl3 backend.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,5 @@
 [1.9.3]
+- API Change: Lwjgl3WindowListener -> filesDropped(String[] files) adds drag'n drop support for the lwjgl3 backend
 
 [1.9.2]
 - Added TextureArray wrapper see https://github.com/libgdx/libgdx/pull/3807

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Window.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Window.java
@@ -19,10 +19,13 @@ package com.badlogic.gdx.backends.lwjgl3;
 import java.nio.IntBuffer;
 
 import org.lwjgl.BufferUtils;
+import org.lwjgl.PointerBuffer;
 import org.lwjgl.glfw.GLFW;
+import org.lwjgl.glfw.GLFWDropCallback;
 import org.lwjgl.glfw.GLFWWindowCloseCallback;
 import org.lwjgl.glfw.GLFWWindowFocusCallback;
 import org.lwjgl.glfw.GLFWWindowIconifyCallback;
+import org.lwjgl.system.MemoryUtil;
 
 import com.badlogic.gdx.ApplicationListener;
 import com.badlogic.gdx.LifecycleListener;
@@ -100,6 +103,21 @@ public class Lwjgl3Window implements Disposable {
 			});	
 		}
 	};
+	
+	private final GLFWDropCallback dropCallback = new GLFWDropCallback() {
+		@Override
+		public void invoke(final long windowHandle, final int count, final long names) {
+			final String[] files = getNames(count, names);
+			postRunnable(new Runnable() {
+				@Override
+				public void run() {
+					if(windowListener != null) {
+						windowListener.filesDropped(files);
+					}
+				}
+			});	
+		}
+	};
 
 	Lwjgl3Window(long windowHandle, ApplicationListener listener,
 			Lwjgl3ApplicationConfiguration config) {
@@ -115,6 +133,7 @@ public class Lwjgl3Window implements Disposable {
 		GLFW.glfwSetWindowFocusCallback(windowHandle, focusCallback);
 		GLFW.glfwSetWindowIconifyCallback(windowHandle, iconifyCallback);
 		GLFW.glfwSetWindowCloseCallback(windowHandle, closeCallback);
+		GLFW.glfwSetDropCallback(windowHandle, dropCallback);
 	}
 
 	/** @return the {@link ApplicationListener} associated with this window **/	 
@@ -267,11 +286,13 @@ public class Lwjgl3Window implements Disposable {
 		GLFW.glfwSetWindowFocusCallback(windowHandle, null);
 		GLFW.glfwSetWindowIconifyCallback(windowHandle, null);
 		GLFW.glfwSetWindowCloseCallback(windowHandle, null);
+		GLFW.glfwSetDropCallback(windowHandle, null);
 		GLFW.glfwDestroyWindow(windowHandle);
 		
 		focusCallback.release();
 		iconifyCallback.release();
 		closeCallback.release();
+		dropCallback.release();
 	}
 
 	@Override

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3WindowAdapter.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3WindowAdapter.java
@@ -27,4 +27,8 @@ public class Lwjgl3WindowAdapter implements Lwjgl3WindowListener {
 	public boolean windowIsClosing() {
 		return true;
 	}
+	
+	@Override
+	public void filesDropped(String[] files) {	
+	}
 }

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3WindowListener.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3WindowListener.java
@@ -61,4 +61,12 @@ public interface Lwjgl3WindowListener {
 	 *  
 	 * @return whether the window should actually close **/
 	boolean windowIsClosing();
+	
+	/**
+	 * Called when external files are dropped into the window,
+	 * e.g from the Desktop.
+	 * 
+	 * @param files array with absolute paths to the files
+	 */
+	void filesDropped(String[] files);
 }

--- a/tests/gdx-tests-lwjgl3/src/com/badlogic/gdx/tests/lwjgl3/DragNDropTest.java
+++ b/tests/gdx-tests-lwjgl3/src/com/badlogic/gdx/tests/lwjgl3/DragNDropTest.java
@@ -1,0 +1,107 @@
+package com.badlogic.gdx.tests.lwjgl3;
+
+import java.awt.image.BufferedImage;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.InputAdapter;
+import com.badlogic.gdx.Graphics.DisplayMode;
+import com.badlogic.gdx.Input.Keys;
+import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application;
+import com.badlogic.gdx.backends.lwjgl3.Lwjgl3ApplicationConfiguration;
+import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Graphics;
+import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Window;
+import com.badlogic.gdx.backends.lwjgl3.Lwjgl3WindowAdapter;
+import com.badlogic.gdx.backends.lwjgl3.Lwjgl3WindowListener;
+import com.badlogic.gdx.graphics.FPSLogger;
+import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.BitmapFont;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.graphics.glutils.HdpiUtils;
+import com.badlogic.gdx.math.MathUtils;
+import com.badlogic.gdx.scenes.scene2d.Stage;
+import com.badlogic.gdx.scenes.scene2d.ui.Label;
+import com.badlogic.gdx.scenes.scene2d.ui.Skin;
+import com.badlogic.gdx.scenes.scene2d.ui.Table;
+import com.badlogic.gdx.tests.utils.GdxTest;
+import com.badlogic.gdx.utils.Align;
+import com.badlogic.gdx.utils.Array;
+import com.badlogic.gdx.utils.GdxRuntimeException;
+
+/**
+ * Tests for GLFW's drop callback.
+ * 
+ * External files (e.g from the desktop) can be dragged into the GLFW window.
+ * 
+ * @author mbrlabs
+ */
+public class DragNDropTest extends GdxTest {
+		
+	private Skin skin;
+	private Stage stage;
+	private Table root;
+	
+	@Override
+	public void create () {			
+		BufferedImage image = new BufferedImage(10, 10, BufferedImage.TYPE_4BYTE_ABGR);
+		stage = new Stage();
+		skin = new Skin(Gdx.files.internal("data/uiskin.json"));
+		Gdx.input.setInputProcessor(stage);
+      root = new Table();
+      root.setFillParent(true);
+      root.align(Align.left | Align.top);
+      stage.addActor(root);
+	}
+		
+	@Override
+	public void render () {
+		Gdx.gl.glClearColor(1, 0, 0, 1);
+		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		
+		stage.act();
+		stage.draw();
+	}
+
+	@Override
+	public void resize (int width, int height) {
+	}
+
+	@Override
+	public void resume () {
+	}
+
+	@Override
+	public void pause () {
+	}
+
+	@Override
+	public void dispose () {
+	}
+	
+	public void addFiles(String[] files) {
+		for(String file : files) {
+			root.add(new Label(file, skin)).left().row();
+		}
+	}
+
+	public static void main (String[] argv) throws NoSuchFieldException, SecurityException, ClassNotFoundException {
+		final DragNDropTest test = new DragNDropTest();
+		
+		Lwjgl3ApplicationConfiguration config = new Lwjgl3ApplicationConfiguration();
+		config.setWindowedMode(640, 480);
+		config.setTitle("Drag files in this window");
+		config.setWindowListener(new Lwjgl3WindowAdapter() {
+			@Override
+			public void filesDropped (String[] files) {
+				for(String file : files) {					
+					Gdx.app.log("GLWF Drop", file);
+				}
+				test.addFiles(files);
+			}
+			
+		});
+
+		new Lwjgl3Application(test, config);
+	}
+	
+}

--- a/tests/gdx-tests-lwjgl3/src/com/badlogic/gdx/tests/lwjgl3/Lwjgl3DebugStarter.java
+++ b/tests/gdx-tests-lwjgl3/src/com/badlogic/gdx/tests/lwjgl3/Lwjgl3DebugStarter.java
@@ -201,9 +201,13 @@ public class Lwjgl3DebugStarter {
 			}
 
 			@Override
-			public boolean windowIsClosing () {
+			public boolean closeRequested () {
 				Gdx.app.log("Window", "closing");
 				return false;
+			}
+
+			@Override
+			public void filesDropped (String[] files) {				
 			}
 			
 		});


### PR DESCRIPTION
This pull request adds support for external file drag & drop. Files (from e.g. the desktop) can be dragged in a Lwjgl3Window, causing the the Lwjgl3WindowListener to call drop(String[] files).
This is an API change, since i added that drop() method to the Lwjgl3WindowListener interface.

A use case for this are programs like level editors, where you want the user to be able to easily import assets by drag and drop. 
I added a simple test as well.