### PR TITLE
Allow building in the Mac OS X sandbox

### DIFF
--- a/gdx/src/com/badlogic/gdx/utils/SharedLibraryLoader.java
+++ b/gdx/src/com/badlogic/gdx/utils/SharedLibraryLoader.java
@@ -197,6 +197,9 @@ public class SharedLibraryLoader {
 		file = new File(".temp/" + dirName, fileName);
 		if (canWrite(file)) return file;
 
+		// We are running in the OS X sandbox.
+		if (System.getenv("APP_SANDBOX_CONTAINER_ID") != null) return idealFile;
+
 		return null;
 	}
 


### PR DESCRIPTION
I develop an IDE that I distribute [in the Mac app store](https://itunes.apple.com/us/app/nightcode/id827505032?ls=1&mt=12) that includes a template for libGDX projects. It used to build and run the projects, but due to changes in `SharedLibraryLoader` it now gets the following error: `Unable to find writable path to extract file. Is the user home directory writable?`.

It looks like this is because the OS X sandbox causes `canExecute` to return false. I made a change that should have a very low impact on everyone else: It still tests for both write and execute privileges in `getExtractedFile`, but if all attempts fail, it returns a file that *at least* has write privileges. This makes it work in the OS X sandbox.