### PR TITLE
Added getter for FloatTextureData.buffer

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/glutils/FloatTextureData.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/FloatTextureData.java
@@ -115,4 +115,8 @@ public class FloatTextureData implements TextureData {
 	public boolean isManaged () {
 		return true;
 	}
+
+	public FloatBuffer getBuffer () {
+		return buffer;
+	}
 }


### PR DESCRIPTION
Makes it possible to access the FloatBuffer backing the FloatTextureData. Without this it is impossible to alter the contents of the buffer before sending it of to the GPU.