### PR TITLE
Add setUndeocrated/setResizable APIs to Graphics.

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphics.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphics.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -31,6 +31,7 @@ import android.opengl.GLSurfaceView.Renderer;
 import android.util.DisplayMetrics;
 import android.view.Display;
 import android.view.View;
+import android.view.WindowManager.LayoutParams;
 
 import com.badlogic.gdx.Application;
 import com.badlogic.gdx.Gdx;
@@ -59,7 +60,7 @@ import com.badlogic.gdx.utils.GdxRuntimeException;
 import com.badlogic.gdx.utils.SnapshotArray;
 
 /** An implementation of {@link Graphics} for Android.
- * 
+ *
  * @author mzechner */
 public class AndroidGraphics implements Graphics, Renderer {
 
@@ -222,7 +223,7 @@ public class AndroidGraphics implements Graphics, Renderer {
 	public int getWidth () {
 		return width;
 	}
-	
+
 	@Override
 	public int getBackBufferWidth () {
 		return width;
@@ -236,7 +237,7 @@ public class AndroidGraphics implements Graphics, Renderer {
 	/** This instantiates the GL10, GL11 and GL20 instances. Includes the check for certain devices that pretend to support GL11 but
 	 * fuck up vertex buffer objects. This includes the pixelflinger which segfaults when buffers are deleted as well as the
 	 * Motorola CLIQ and the Samsung Behold II.
-	 * 
+	 *
 	 * @param gl */
 	private void setupGL (javax.microedition.khronos.opengles.GL10 gl) {
 		String versionString = gl.glGetString(GL10.GL_VERSION);
@@ -581,7 +582,7 @@ public class AndroidGraphics implements Graphics, Renderer {
 	public boolean setFullscreenMode (DisplayMode displayMode) {
 		return false;
 	}
-	
+
 	@Override
 	public Monitor getPrimaryMonitor () {
 		return new AndroidMonitor(0, 0, "Primary Monitor");
@@ -619,6 +620,17 @@ public class AndroidGraphics implements Graphics, Renderer {
 
 	@Override
 	public void setTitle (String title) {
+
+	}
+
+	@Override
+	public void setUndecorated (boolean undecorated) {
+		final int mask = (undecorated) ? 1 : 0;
+		app.getApplicationWindow().setFlags(LayoutParams.FLAG_FULLSCREEN, mask);
+	}
+
+	@Override
+	public void setResizable (boolean resizable) {
 
 	}
 
@@ -683,7 +695,7 @@ public class AndroidGraphics implements Graphics, Renderer {
 	public GL30 getGL30 () {
 		return gl30;
 	}
-	
+
 	@Override
 	public Cursor newCursor (Pixmap pixmap, int xHotspot, int yHotspot) {
 		return null;
@@ -692,17 +704,17 @@ public class AndroidGraphics implements Graphics, Renderer {
 	@Override
 	public void setCursor (Cursor cursor) {
 	}
-	
+
 	@Override
 	public void setSystemCursor (SystemCursor systemCursor) {
 	}
-	
+
 	private class AndroidDisplayMode extends DisplayMode {
 		protected AndroidDisplayMode (int width, int height, int refreshRate, int bitsPerPixel) {
 			super(width, height, refreshRate, bitsPerPixel);
 		}
 	}
-	
+
 	private class AndroidMonitor extends Monitor {
 		public AndroidMonitor (int virtualX, int virtualY, String name) {
 			super(virtualX, virtualY, name);

--- a/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/mock/graphics/MockGraphics.java
+++ b/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/mock/graphics/MockGraphics.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -60,7 +60,7 @@ public class MockGraphics implements Graphics {
 	public int getHeight() {
 		return 0;
 	}
-	
+
 	@Override
 	public int getBackBufferWidth() {
 		return 0;
@@ -207,7 +207,7 @@ public class MockGraphics implements Graphics {
 	public void incrementFrameId () {
 		frameId++;
 	}
-	
+
 	@Override
 	public Cursor newCursor (Pixmap pixmap, int xHotspot, int yHotspot) {
 		return null;
@@ -216,7 +216,7 @@ public class MockGraphics implements Graphics {
 	@Override
 	public void setCursor (Cursor cursor) {
 	}
-	
+
 	@Override
 	public void setSystemCursor (SystemCursor systemCursor) {
 	}
@@ -244,5 +244,15 @@ public class MockGraphics implements Graphics {
 	@Override
 	public DisplayMode getDisplayMode(Monitor monitor) {
 		return null;
+	}
+
+	@Override
+	public void setUndecorated(boolean undecorated) {
+
+	}
+
+	@Override
+	public void setResizable(boolean resizable) {
+
 	}
 }

--- a/backends/gdx-backend-jglfw/src/com/badlogic/gdx/backends/jglfw/JglfwGraphics.java
+++ b/backends/gdx-backend-jglfw/src/com/badlogic/gdx/backends/jglfw/JglfwGraphics.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -31,6 +31,7 @@ import com.badlogic.gdx.graphics.Cursor.SystemCursor;
 import com.badlogic.gdx.graphics.glutils.GLVersion;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.GdxRuntimeException;
+import com.badlogic.jglfw.Glfw;
 import com.badlogic.jglfw.GlfwVideoMode;
 import com.badlogic.jglfw.gl.GL;
 
@@ -200,7 +201,7 @@ public class JglfwGraphics implements Graphics {
 	public int getHeight () {
 		return height;
 	}
-	
+
 	@Override
 	public int getBackBufferWidth () {
 		return width;
@@ -271,7 +272,7 @@ public class JglfwGraphics implements Graphics {
 	public boolean supportsDisplayModeChange () {
 		return true;
 	}
-	
+
 	@Override
 	public Monitor getPrimaryMonitor () {
 		return new JglfwMonitor(0, 0, "Primary Monitor");
@@ -344,6 +345,22 @@ public class JglfwGraphics implements Graphics {
 		if (title == null) title = "";
 		glfwSetWindowTitle(window, title);
 		this.title = title;
+	}
+
+	/**
+	 * Note: GLFW requires that the window be recreated for this change to take effect.
+	 */
+	@Override
+	public void setUndecorated (boolean undecorated) {
+		this.undecorated = undecorated;
+	}
+
+	/**
+	 * Note: GLFW requires that the window be recreated for this change to take effect.
+	 */
+	@Override
+	public void setResizable (boolean resizable) {
+		this.resizable = resizable;
 	}
 
 	public void setVSync (boolean vsync) {
@@ -444,7 +461,7 @@ public class JglfwGraphics implements Graphics {
 	public GL30 getGL30 () {
 		return null;
 	}
-	
+
 	@Override
 	public Cursor newCursor (Pixmap pixmap, int xHotspot, int yHotspot) {
 		return null;
@@ -453,17 +470,17 @@ public class JglfwGraphics implements Graphics {
 	@Override
 	public void setCursor (Cursor cursor) {
 	}
-	
+
 	@Override
 	public void setSystemCursor (SystemCursor systemCursor) {
 	}
-	
+
 	static class JglfwDisplayMode extends DisplayMode {
 		protected JglfwDisplayMode (int width, int height, int refreshRate, int bitsPerPixel) {
 			super(width, height, refreshRate, bitsPerPixel);
 		}
 	}
-	
+
 	static class JglfwMonitor extends Monitor {
 		public JglfwMonitor (int virtualX, int virtualY, String name) {
 			super(virtualX, virtualY, name);

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGraphics.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGraphics.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -99,7 +99,7 @@ public class LwjglGraphics implements Graphics {
 		else
 			return (int)(Display.getWidth() * Display.getPixelScaleFactor());
 	}
-	
+
 	@Override
 	public int getBackBufferWidth () {
 		return getWidth();
@@ -158,18 +158,18 @@ public class LwjglGraphics implements Graphics {
 
 		if (canvas != null) {
 			Display.setParent(canvas);
-		} else {			
+		} else {
 			boolean displayCreated = false;
-			
+
 			if(!config.fullscreen) {
 				displayCreated = setWindowedMode(config.width, config.height);
-			} else {				
+			} else {
 				DisplayMode bestMode = null;
 				for(DisplayMode mode: getDisplayModes()) {
 					if(mode.width == config.width && mode.height == config.height) {
 						if(bestMode == null || bestMode.refreshRate < this.getDisplayMode().refreshRate) {
 							bestMode = mode;
-						}						
+						}
 					}
 				}
 				if(bestMode == null) {
@@ -214,7 +214,7 @@ public class LwjglGraphics implements Graphics {
 		createDisplayPixelFormat(config.useGL30, config.gles30ContextMajorVersion, config.gles30ContextMinorVersion);
 		initiateGL();
 	}
-	
+
 	/**
 	 * Only needed when setupDisplay() is not called.
 	 */
@@ -384,9 +384,9 @@ public class LwjglGraphics implements Graphics {
 	public boolean supportsDisplayModeChange () {
 		return true;
 	}
-	
+
 	@Override
-	public Monitor getPrimaryMonitor () {		
+	public Monitor getPrimaryMonitor () {
 		return new LwjglMonitor(0, 0, "Primary Monitor");
 	}
 
@@ -440,7 +440,7 @@ public class LwjglGraphics implements Graphics {
 		try {
 			org.lwjgl.opengl.DisplayMode targetDisplayMode = null;
 			boolean fullscreen = false;
-			
+
 			if (fullscreen) {
 				org.lwjgl.opengl.DisplayMode[] modes = Display.getAvailableDisplayModes();
 				int freq = 0;
@@ -526,6 +526,25 @@ public class LwjglGraphics implements Graphics {
 		Display.setTitle(title);
 	}
 
+	/**
+	 * Display must be reconfigured via {@link #setWindowedMode(int, int)} for the changes to take
+	 * effect.
+	 */
+	@Override
+	public void setUndecorated (boolean undecorated) {
+		System.setProperty("org.lwjgl.opengl.Window.undecorated", undecorated ? "true" : "false");
+	}
+
+	/**
+	 * Display must be reconfigured via {@link #setWindowedMode(int, int)} for the changes to take
+	 * effect.
+	 */
+	@Override
+	public void setResizable (boolean resizable) {
+		this.config.resizable = resizable;
+		Display.setResizable(resizable);
+	}
+
 	@Override
 	public BufferFormat getBufferFormat () {
 		return bufferFormat;
@@ -594,7 +613,7 @@ public class LwjglGraphics implements Graphics {
 		 *         to create the display a second time */
 		public LwjglApplicationConfiguration onFailure (LwjglApplicationConfiguration initialConfig);
 	}
-	
+
 	@Override
 	public com.badlogic.gdx.graphics.Cursor newCursor (Pixmap pixmap, int xHotspot, int yHotspot) {
 		return new LwjglCursor(pixmap, xHotspot, yHotspot);
@@ -608,7 +627,7 @@ public class LwjglGraphics implements Graphics {
 			throw new GdxRuntimeException("Could not set cursor image.", e);
 		}
 	}
-	
+
 	@Override
 	public void setSystemCursor (SystemCursor systemCursor) {
 		try {
@@ -626,10 +645,10 @@ public class LwjglGraphics implements Graphics {
 			this.mode = mode;
 		}
 	}
-	
+
 	private class LwjglMonitor extends Monitor {
 		protected LwjglMonitor (int virtualX, int virtualY, String name) {
 			super(virtualX, virtualY, name);
 		}
-	}	
+	}
 }

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Graphics.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Graphics.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -368,6 +368,26 @@ public class Lwjgl3Graphics implements Graphics, Disposable {
 			title = "";
 		}
 		GLFW.glfwSetWindowTitle(window.getWindowHandle(), title);
+	}
+
+	/**
+	 * The window must be recreated via {@link #setWindowedMode(int, int)} in order
+	 * for the changes to take effect.
+	 */
+	@Override
+	public void setUndecorated(boolean undecorated) {
+		Lwjgl3ApplicationConfiguration config = getWindow().getConfig();
+		config.setDecorated(!undecorated);
+	}
+
+	/**
+	 * The window must be recreated via {@link #setWindowedMode(int, int)} in order
+	 * for the changes to take effect.
+	 */
+	@Override
+	public void setResizable(boolean resizable) {
+		Lwjgl3ApplicationConfiguration config = getWindow().getConfig();
+		config.setResizable(resizable);
 	}
 
 	@Override

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -118,7 +118,7 @@ public class IOSGraphics extends NSObject implements Graphics, GLKViewDelegate, 
 				app.listener.resize(graphics.width, graphics.height);
 			}
 		}
-		
+
 		@Callback
 		@BindSelector("shouldAutorotateToInterfaceOrientation:")
 		private static boolean shouldAutorotateToInterfaceOrientation (IOSUIViewController self, Selector sel,
@@ -133,7 +133,7 @@ public class IOSGraphics extends NSObject implements Graphics, GLKViewDelegate, 
 			super(frame, context);
 		}
 	}
-	
+
 	IOSApplication app;
 	IOSInput input;
 	GL20 gl20;
@@ -370,7 +370,7 @@ public class IOSGraphics extends NSObject implements Graphics, GLKViewDelegate, 
 	public int getHeight () {
 		return height;
 	}
-	
+
 	@Override
 	public int getBackBufferWidth() {
 		return width;
@@ -446,7 +446,7 @@ public class IOSGraphics extends NSObject implements Graphics, GLKViewDelegate, 
 		return new IOSDisplayMode(getWidth(), getHeight(), config.preferredFramesPerSecond, bufferFormat.r + bufferFormat.g
 			+ bufferFormat.b + bufferFormat.a);
 	}
-	
+
 	@Override
 	public Monitor getPrimaryMonitor() {
 		return new IOSMonitor(0, 0, "Primary Monitor");
@@ -484,6 +484,14 @@ public class IOSGraphics extends NSObject implements Graphics, GLKViewDelegate, 
 
 	@Override
 	public void setTitle (String title) {
+	}
+
+	@Override
+	public void setUndecorated(boolean undecorated) {
+	}
+
+	@Override
+	public void setResizable(boolean resizable) {
 	}
 
 	@Override
@@ -542,7 +550,7 @@ public class IOSGraphics extends NSObject implements Graphics, GLKViewDelegate, 
 	public long getFrameId () {
 		return frameId;
 	}
-	
+
 	@Override
 	public Cursor newCursor (Pixmap pixmap, int xHotspot, int yHotspot) {
 		return null;
@@ -551,17 +559,17 @@ public class IOSGraphics extends NSObject implements Graphics, GLKViewDelegate, 
 	@Override
 	public void setCursor (Cursor cursor) {
 	}
-	
+
 	@Override
 	public void setSystemCursor (SystemCursor systemCursor) {
 	}
-	
+
 	private class IOSDisplayMode extends DisplayMode {
 		protected IOSDisplayMode (int width, int height, int refreshRate, int bitsPerPixel) {
 			super(width, height, refreshRate, bitsPerPixel);
 		}
 	}
-	
+
 	private class IOSMonitor extends Monitor {
 		protected IOSMonitor(int virtualX, int virtualY, String name) {
 			super(virtualX, virtualY, name);

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtGraphics.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtGraphics.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -108,7 +108,7 @@ public class GwtGraphics implements Graphics {
 	public int getHeight () {
 		return canvas.getHeight();
 	}
-	
+
 	@Override
 	public int getBackBufferWidth () {
 		return canvas.getWidth();
@@ -314,13 +314,13 @@ public class GwtGraphics implements Graphics {
 	}
 
 	@Override
-	public boolean setWindowedMode (int width, int height) {		
+	public boolean setWindowedMode (int width, int height) {
 		if (isFullscreenJSNI()) exitFullscreen();
 		canvas.setWidth(width);
 		canvas.setHeight(height);
 		return true;
 	}
-	
+
 
 	@Override
 	public Monitor getPrimaryMonitor () {
@@ -348,7 +348,7 @@ public class GwtGraphics implements Graphics {
 	}
 
 	/** Attempt to lock the orientation. Typically only supported when in full-screen mode.
-	 * 
+	 *
 	 * @param orientation the orientation to attempt locking
 	 * @return did the locking succeed */
 	public boolean lockOrientation (OrientationLockType orientation) {
@@ -356,7 +356,7 @@ public class GwtGraphics implements Graphics {
 	}
 
 	/** Attempt to unlock the orientation.
-	 * 
+	 *
 	 * @return did the unlocking succeed */
 	public boolean unlockOrientation () {
 		return unlockOrientationJSNI();
@@ -365,7 +365,7 @@ public class GwtGraphics implements Graphics {
 	private native boolean lockOrientationJSNI (String orientationEnumValue) /*-{
 		var screen = $wnd.screen;
 
-		// Attempt to find the lockOrientation function 
+		// Attempt to find the lockOrientation function
 		screen.gdxLockOrientation = screen.lockOrientation
 				|| screen.mozLockOrientation || screen.msLockOrientation
 				|| screen.webkitLockOrientation;
@@ -385,7 +385,7 @@ public class GwtGraphics implements Graphics {
 	private native boolean unlockOrientationJSNI () /*-{
 		var screen = $wnd.screen;
 
-		// Attempt to find the lockOrientation function 
+		// Attempt to find the lockOrientation function
 		screen.gdxUnlockOrientation = screen.unlockOrientation
 				|| screen.mozUnlockOrientation || screen.msUnlockOrientation
 				|| screen.webkitUnlockOrientation;
@@ -428,6 +428,14 @@ public class GwtGraphics implements Graphics {
 
 	@Override
 	public void setTitle (String title) {
+	}
+
+	@Override
+	public void setUndecorated (boolean undecorated) {
+	}
+
+	@Override
+	public void setResizable (boolean resizable) {
 	}
 
 	@Override
@@ -481,12 +489,12 @@ public class GwtGraphics implements Graphics {
 	public void setCursor (Cursor cursor) {
 		((GwtApplication)Gdx.app).graphics.canvas.getStyle().setProperty("cursor", ((GwtCursor)cursor).cssCursorProperty);
 	}
-	
+
 	@Override
 	public void setSystemCursor (SystemCursor systemCursor) {
 		((GwtApplication)Gdx.app).graphics.canvas.getStyle().setProperty("cursor", GwtCursor.getNameForSystemCursor(systemCursor));
 	}
-	
+
 	static class GwtMonitor extends Monitor {
 		protected GwtMonitor (int virtualX, int virtualY, String name) {
 			super(virtualX, virtualY, name);

--- a/gdx/src/com/badlogic/gdx/Graphics.java
+++ b/gdx/src/com/badlogic/gdx/Graphics.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -47,14 +47,14 @@ import com.badlogic.gdx.graphics.glutils.VertexBufferObject;
  * @author mzechner */
 public interface Graphics {
 	/** Enumeration describing different types of {@link Graphics} implementations.
-	 * 
+	 *
 	 * @author mzechner */
 	public enum GraphicsType {
 		AndroidGL, LWJGL, Angle, WebGL, iOSGL, JGLFW, Mock, LWJGL3
 	}
 
 	/** Describe a fullscreen display mode
-	 * 
+	 *
 	 * @author mzechner */
 	public class DisplayMode {
 		/** the width in physical pixels **/
@@ -77,16 +77,16 @@ public interface Graphics {
 			return width + "x" + height + ", bpp: " + bitsPerPixel + ", hz: " + refreshRate;
 		}
 	}
-	
+
 	/** Describes a monitor
-	 * 
+	 *
 	 * @author badlogic
 	 */
 	public class Monitor {
 		public final int virtualX;
 		public final int virtualY;
 		public final String name;
-		
+
 		protected Monitor (int virtualX, int virtualY, String name) {
 			this.virtualX = virtualX;
 			this.virtualY = virtualY;
@@ -125,7 +125,7 @@ public interface Graphics {
 	/** Returns whether OpenGL ES 3.0 is available. If it is you can get an instance of {@link GL30} via {@link #getGL30()} to
 	 * access OpenGL ES 3.0 functionality. Note that this functionality will only be available if you instructed the
 	 * {@link Application} instance to use OpenGL ES 3.0!
-	 * 
+	 *
 	 * @return whether OpenGL ES 3.0 is available */
 	public boolean isGL30Available ();
 
@@ -143,7 +143,7 @@ public interface Graphics {
 
 	/** @return the width of the framebuffer in physical pixels */
 	public int getBackBufferWidth ();
-	
+
 	/** @return the height of the framebuffer in physical pixels */
 	public int getBackBufferHeight ();
 
@@ -184,56 +184,81 @@ public interface Graphics {
 	/** This is a scaling factor for the Density Independent Pixel unit, following the same conventions as
 	 * android.util.DisplayMetrics#density, where one DIP is one pixel on an approximately 160 dpi screen. Thus on a 160dpi screen
 	 * this density value will be 1; on a 120 dpi screen it would be .75; etc.
-	 * 
+	 *
 	 * @return the logical density of the Display. */
 	public float getDensity ();
 
 	/** Whether the given backend supports a display mode change via calling {@link Graphics#setFullscreenMode(DisplayMode)}
-	 * 
+	 *
 	 * @return whether display mode changes are supported or not. */
 	public boolean supportsDisplayModeChange ();
-	
+
 	/** @return the primary monitor **/
 	public Monitor getPrimaryMonitor();
-	
+
 	/** @return the monitor the application's window is located on */
 	public Monitor getMonitor();
-	
+
 	/** @return the currently connected {@link Monitor}s */
 	public Monitor[] getMonitors();
 
 	/** @return the supported fullscreen {@link DisplayMode}(s) of the monitor the window is on */
 	public DisplayMode[] getDisplayModes ();
-	
+
 	/** @return the supported fullscreen {@link DisplayMode}s of the given {@link Monitor} */
 	public DisplayMode[] getDisplayModes(Monitor monitor);
 
 	/** @return the current {@link DisplayMode} of the monitor the window is on. */
 	public DisplayMode getDisplayMode ();
-	
+
 	/** @return the current {@link DisplayMode} of the given {@link Monitor} */
 	public DisplayMode getDisplayMode (Monitor monitor);
 
 	/** Sets the window to full-screen mode.
-	 * 
+	 *
 	 * @param displayMode the display mode.
 	 * @return whether the operation succeeded. */
 	public boolean setFullscreenMode (DisplayMode displayMode);
 
 	/** Sets the window to windowed mode.
-	 * 
+	 *
 	 * @param width the width in pixels
 	 * @param height the height in pixels
-	 * @return whether the operation succeeded*/	
+	 * @return whether the operation succeeded*/
 	public boolean setWindowedMode (int width, int height);
 
 	/** Sets the title of the window. Ignored on Android.
-	 * 
+	 *
 	 * @param title the title. */
 	public void setTitle (String title);
 
+	/** Sets the window decoration as enabled or disabled. On Android, this will enable/disable
+	 *  the menu bar.
+	 *
+	 *  Note that immediate behavior of this method may vary depending on the implementation. It
+	 *  may be necessary for the window to be recreated in order for the changes to take effect.
+	 *  Consult the documentation for the backend in use for more information.
+	 *
+	 *  Supported on all GDX desktop backends and on Android (to disable the menu bar).
+	 *
+	 * @param undecorated true if the window border or status bar should be hidden. false otherwise.
+	 */
+	public void setUndecorated (boolean undecorated);
+
+	/** Sets whether or not the window should be resizable. Ignored on Android.
+	 *
+	 *  Note that immediate behavior of this method may vary depending on the implementation. It
+	 *  may be necessary for the window to be recreated in order for the changes to take effect.
+	 *  Consult the documentation for the backend in use for more information.
+	 *
+	 *  Supported on all GDX desktop backends.
+	 *
+	 * @param resizable
+	 */
+	public void setResizable (boolean resizable);
+
 	/** Enable/Disable vsynching. This is a best-effort attempt which might not work on all platforms.
-	 * 
+	 *
 	 * @param vsync vsync enabled or not. */
 	public void setVSync (boolean vsync);
 
@@ -246,16 +271,16 @@ public interface Graphics {
 
 	/** Sets whether to render continuously. In case rendering is performed non-continuously, the following events will trigger a
 	 * redraw:
-	 * 
+	 *
 	 * <ul>
 	 * <li>A call to {@link #requestRendering()}</li>
 	 * <li>Input events from the touch screen/mouse or keyboard</li>
 	 * <li>A {@link Runnable} is posted to the rendering thread via {@link Application#postRunnable(Runnable)}</li>
 	 * </ul>
-	 * 
+	 *
 	 * Life-cycle events will also be reported as usual, see {@link ApplicationListener}. This method can be called from any
 	 * thread.
-	 * 
+	 *
 	 * @param isContinuous whether the rendering should be continuous or not. */
 	public void setContinuousRendering (boolean isContinuous);
 
@@ -272,7 +297,7 @@ public interface Graphics {
 	 * width & height must be powers-of-two greater than zero (not necessarily equal), and alpha transparency must be single-bit
 	 * (i.e., 0x00 or 0xFF only). This function returns a Cursor object that can be set as the system cursor by calling
 	 * {@link #setCursor(Cursor)} .
-	 * 
+	 *
 	 * @param pixmap the mouse cursor image as a {@link com.badlogic.gdx.graphics.Pixmap}
 	 * @param xHotspot the x location of the hotspot pixel within the cursor image (origin top-left corner)
 	 * @param yHotspot the y location of the hotspot pixel within the cursor image (origin top-left corner)
@@ -282,12 +307,12 @@ public interface Graphics {
 	/** Only viable on the lwjgl-backend and on the gwt-backend. Browsers that support cursor:url() and support the png format (the
 	 * pixmap is converted to a data-url of type image/png) should also support custom cursors. Will set the mouse cursor image to
 	 * the image represented by the {@link com.badlogic.gdx.graphics.Cursor}. It is recommended to call this function in the main render thread, and maximum one time per frame.
-	 * 
+	 *
 	 * @param cursor the mouse cursor as a {@link com.badlogic.gdx.graphics.Cursor} */
 	public void setCursor (Cursor cursor);
-	
+
 	/**
 	 * Sets one of the predefined {@link SystemCursor}s
 	 */
-	public void setSystemCursor(SystemCursor systemCursor);	
+	public void setSystemCursor(SystemCursor systemCursor);
 }


### PR DESCRIPTION
Add implemenations for all backends.

Note: most desktop backend implementations require a call to 'setWindowedMode' in order for the changes to take effect.

It is worth noting that this is not necessary with the JogAmp backend. However, as of the time of writing, that backend is not included in LibGDX master.

Fixes #3773