### PR TITLE
Fixed memory leaks on android

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplication.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplication.java
@@ -313,6 +313,12 @@ public class AndroidApplication extends Activity implements AndroidApplicationBa
 	@Override
 	protected void onDestroy () {
 		super.onDestroy();
+		Gdx.app = null;
+		Gdx.input = null;
+		Gdx.audio = null;
+		Gdx.files = null;
+		Gdx.graphics = null;
+		Gdx.net = null;
 	}
 
 	@Override

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidFragmentApplication.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidFragmentApplication.java
@@ -88,6 +88,12 @@ public class AndroidFragmentApplication extends Fragment implements AndroidAppli
 	public void onDetach () {
 		super.onDetach();
 		this.callbacks = null;
+		Gdx.app = null;
+		Gdx.input = null;
+		Gdx.audio = null;
+		Gdx.files = null;
+		Gdx.graphics = null;
+		Gdx.net = null;
 	}
 
 	protected FrameLayout.LayoutParams createLayoutParams () {


### PR DESCRIPTION
I created [this sample project ](https://github.com/SaeedMasoumi/libgdx-android-leak
)to show that how libgdx creates memory leaks on android.

 In [LeakFragment](https://github.com/SaeedMasoumi/libgdx-android-leak/blob/master/android/src/io/saeid/libgdx/androidleak/fragment/LeakFragment.java) and [LeakActivity](https://github.com/SaeedMasoumi/libgdx-android-leak/blob/master/android/src/io/saeid/libgdx/androidleak/activity/LeakActivity.java) classes, i created a method called `whatShouldBeDoneOnSuperMethod` without this method, leak canary will show memory leak.