### PR TITLE
Fixed scrollpane for large heights and exposed some variables

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ScrollPane.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ScrollPane.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -67,6 +67,8 @@ public class ScrollPane extends WidgetGroup {
 	final Vector2 lastPoint = new Vector2();
 	float areaWidth, areaHeight;
 	private boolean fadeScrollBars = true, smoothScrolling = true;
+	float smoothingMaxSpeed = 200, smoothingSpeedFactor = 7;
+	float mouseWheelX, mouseWheelY;
 	float fadeAlpha, fadeAlphaSeconds = 1, fadeDelay, fadeDelaySeconds = 1;
 	boolean cancelTouchFocus = true;
 
@@ -303,22 +305,22 @@ public class ScrollPane extends WidgetGroup {
 		}
 
 		if (smoothScrolling && flingTimer <= 0 && !panning && //
-		// Scroll smoothly when grabbing the scrollbar if one pixel of scrollbar movement is > 20% of the scroll area.
-		((!touchScrollH || (scrollX && maxX / (hScrollBounds.width - hKnobBounds.width) > areaWidth * 0.1f)) //
-			&& (!touchScrollV || (scrollY && maxY / (vScrollBounds.height - vKnobBounds.height) > areaHeight * 0.1f))) //
-		) {
+			// Scroll smoothly when grabbing the scrollbar if one pixel of scrollbar movement is > 20% of the scroll area.
+			((!touchScrollH || (scrollX && maxX / (hScrollBounds.width - hKnobBounds.width) > areaWidth * 0.1f)) //
+				&& (!touchScrollV || (scrollY && maxY / (vScrollBounds.height - vKnobBounds.height) > areaHeight * 0.1f))) //
+			) {
 			if (visualAmountX != amountX) {
 				if (visualAmountX < amountX)
-					visualScrollX(Math.min(amountX, visualAmountX + Math.max(200 * delta, (amountX - visualAmountX) * 7 * delta)));
+					visualScrollX(Math.min(amountX, visualAmountX + Math.max(smoothingMaxSpeed * delta, (amountX - visualAmountX) * smoothingSpeedFactor * delta)));
 				else
-					visualScrollX(Math.max(amountX, visualAmountX - Math.max(200 * delta, (visualAmountX - amountX) * 7 * delta)));
+					visualScrollX(Math.max(amountX, visualAmountX - Math.max(smoothingMaxSpeed * delta, (visualAmountX - amountX) * smoothingSpeedFactor * delta)));
 				animating = true;
 			}
 			if (visualAmountY != amountY) {
 				if (visualAmountY < amountY)
-					visualScrollY(Math.min(amountY, visualAmountY + Math.max(200 * delta, (amountY - visualAmountY) * 7 * delta)));
+					visualScrollY(Math.min(amountY, visualAmountY + Math.max(smoothingMaxSpeed * delta, (amountY - visualAmountY) * smoothingSpeedFactor * delta)));
 				else
-					visualScrollY(Math.max(amountY, visualAmountY - Math.max(200 * delta, (visualAmountY - amountY) * 7 * delta)));
+					visualScrollY(Math.max(amountY, visualAmountY - Math.max(smoothingMaxSpeed * delta, (visualAmountY - amountY) * smoothingSpeedFactor * delta)));
 				animating = true;
 			}
 		} else {
@@ -735,12 +737,12 @@ public class ScrollPane extends WidgetGroup {
 
 	/** Returns the amount to scroll horizontally when the mouse wheel is scrolled. */
 	protected float getMouseWheelX () {
-		return Math.max(areaWidth * 0.9f, maxX * 0.1f) / 4;
+		return mouseWheelX == 0 ? areaWidth : mouseWheelX;
 	}
 
 	/** Returns the amount to scroll vertically when the mouse wheel is scrolled. */
 	protected float getMouseWheelY () {
-		return Math.max(areaHeight * 0.9f, maxY * 0.1f) / 4;
+		return mouseWheelY == 0 ? areaHeight: mouseWheelY;
 	}
 
 	public void setScrollX (float pixels) {


### PR DESCRIPTION
I had some issues with my fork and so this is a re-pull from #3462.

SSCCE: https://gist.github.com/Xtrinity/8b208181fdf05d562ea5

Explanation of issue:
If you scroll in the SSCCE you will see that the scroll overscrolls the areaHeight. I.E the topmost ID is 1 and the greatest ID that's viewable on the screen would be 14. From a UX standpoint I would expect a single scroll down from the mouse to show 15 as the next id instead of jumping to a non-consecutive number like 24.

Explanation of changes:
Exposed existing hard coded values and created two fields for them `smoothingFactor` and `smoothingSpeed`
Created two new fields to define the amount to scroll when the mouse is scrolled, `mouseWheelX` and `mouseWheelY`. If it is not changed by the user then it defaults to scrolling the width or height of the area. If the ScrollPane is not big enough it will automatically not scroll.

Note: I did not test Android or iOS but they shouldn't be affected from the changes committed.