### PR TITLE
Update FileTextureProvider

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g3d/utils/TextureProvider.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/utils/TextureProvider.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,7 +18,6 @@ package com.badlogic.gdx.graphics.g3d.utils;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.assets.AssetManager;
-import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g3d.Model;
 import com.badlogic.gdx.graphics.g3d.model.data.ModelData;
@@ -29,11 +28,30 @@ public interface TextureProvider {
 	public Texture load (String fileName);
 
 	public static class FileTextureProvider implements TextureProvider {
+		private Texture.TextureFilter minFilter, magFilter;
+		private Texture.TextureWrap uWrap, vWrap;
+		private boolean useMipMaps;
+
+		public FileTextureProvider () {
+			minFilter = magFilter = Texture.TextureFilter.Linear;
+			uWrap = vWrap = Texture.TextureWrap.Repeat;
+			useMipMaps = false;
+		}
+
+		public FileTextureProvider (Texture.TextureFilter minFilter, Texture.TextureFilter magFilter, Texture.TextureWrap uWrap,
+			Texture.TextureWrap vWrap, boolean useMipMaps) {
+			this.minFilter = minFilter;
+			this.magFilter = magFilter;
+			this.uWrap = uWrap;
+			this.vWrap = vWrap;
+			this.useMipMaps = useMipMaps;
+		}
+
 		@Override
 		public Texture load (String fileName) {
-			Texture result = new Texture(Gdx.files.internal(fileName));
-			result.setFilter(Texture.TextureFilter.Linear, Texture.TextureFilter.Linear);
-			result.setWrap(Texture.TextureWrap.Repeat, Texture.TextureWrap.Repeat);
+			Texture result = new Texture(Gdx.files.internal(fileName), useMipMaps);
+			result.setFilter(minFilter, magFilter);
+			result.setWrap(uWrap, vWrap);
 			return result;
 		}
 	}


### PR DESCRIPTION
Fix #3845 

When loading model without AssetManager, it's impossible to specify texture attributes.
With this pull request, it's possible.

I didn't remove the `loadModel` like @xoppa asked because it's used in `ObjModelLoader`.