### PR TITLE
LWJGL3: cleanup of per-window / system cursors

### DIFF
--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
@@ -150,6 +150,7 @@ public class Lwjgl3Application implements Application {
 		for (Lwjgl3Window window : windows) {
 			window.dispose();
 		}
+		Lwjgl3Cursor.disposeSystemCursors();
 		if (audio instanceof OpenALAudio) {
 			((OpenALAudio) audio).dispose();
 		}

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Cursor.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Cursor.java
@@ -85,10 +85,16 @@ public class Lwjgl3Cursor implements Cursor {
 		GLFW.glfwDestroyCursor(glfwCursor);
 	}
 
-	static void disposeAll() {
-		while (cursors.size > 0) {
-			cursors.removeIndex(0).dispose();
+	static void dispose(Lwjgl3Window window) {
+		for (int i = cursors.size - 1; i >= 0; i--) {
+			Lwjgl3Cursor cursor = cursors.get(i);
+			if (cursor.window.equals(window)) {
+				cursors.removeIndex(i).dispose();
+			}
 		}
+	}
+
+	static void disposeSystemCursors() {
 		for (long systemCursor : systemCursors.values()) {
 			GLFW.glfwDestroyCursor(systemCursor);
 		}

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Graphics.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Graphics.java
@@ -407,7 +407,6 @@ public class Lwjgl3Graphics implements Graphics, Disposable {
 	@Override
 	public void dispose() {
 		this.resizeCallback.release();
-		Lwjgl3Cursor.disposeAll();
 	}
 
 	public static class Lwjgl3DisplayMode extends DisplayMode {

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Window.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Window.java
@@ -278,7 +278,8 @@ public class Lwjgl3Window implements Disposable {
 	@Override
 	public void dispose() {
 		listener.pause();
-		listener.dispose();		
+		listener.dispose();
+		Lwjgl3Cursor.dispose(this);
 		graphics.dispose();
 		input.dispose();
 		GLFW.glfwSetWindowFocusCallback(windowHandle, null);

--- a/tests/gdx-tests-lwjgl3/src/com/badlogic/gdx/tests/lwjgl3/MultiWindowCursorTest.java
+++ b/tests/gdx-tests-lwjgl3/src/com/badlogic/gdx/tests/lwjgl3/MultiWindowCursorTest.java
@@ -1,0 +1,76 @@
+package com.badlogic.gdx.tests.lwjgl3;
+
+import com.badlogic.gdx.*;
+import com.badlogic.gdx.backends.lwjgl3.*;
+import com.badlogic.gdx.graphics.Cursor;
+import com.badlogic.gdx.graphics.Pixmap;
+import com.badlogic.gdx.math.MathUtils;
+
+public class MultiWindowCursorTest {
+
+	static class WindowWithCursorListener implements ApplicationListener {
+		ApplicationListener listener;
+
+		WindowWithCursorListener(ApplicationListener listener) {
+			this.listener = listener;
+		}
+
+		@Override
+		public void create() {
+			listener.create();
+			if (MathUtils.randomBoolean()) {
+				Cursor.SystemCursor[] systemCursors = Cursor.SystemCursor.values();
+				Cursor.SystemCursor systemCursor = systemCursors[MathUtils.random(systemCursors.length - 1)];
+				Gdx.graphics.setSystemCursor(systemCursor);
+			} else {
+				Pixmap pixmap;
+				if (MathUtils.randomBoolean()) {
+					pixmap = new Pixmap(Gdx.files.internal("data/particle-star.png"));
+				} else {
+					pixmap = new Pixmap(Gdx.files.internal("data/ps-bobargb8888-32x32.png"));
+				}
+				Cursor cursor = Gdx.graphics.newCursor(pixmap, pixmap.getWidth() / 2, pixmap.getHeight() / 2);
+				Gdx.graphics.setCursor(cursor);
+				pixmap.dispose();
+			}
+		}
+
+		@Override
+		public void resize(int width, int height) {
+			listener.resize(width, height);
+		}
+
+		@Override
+		public void render() {
+			listener.render();
+		}
+
+		@Override
+		public void pause() {
+			listener.pause();
+		}
+
+		@Override
+		public void resume() {
+			listener.resume();
+		}
+
+		@Override
+		public void dispose() {
+			listener.dispose();
+		}
+	}
+
+	public static class MainWindow extends MultiWindowTest.MainWindow {
+		@Override
+		public ApplicationListener createChildWindowClass(Class clazz) {
+			return new WindowWithCursorListener(super.createChildWindowClass(clazz));
+		}
+	}
+
+	public static void main(String[] argv) {
+		Lwjgl3ApplicationConfiguration config = new Lwjgl3ApplicationConfiguration();
+		config.setTitle("Multi-window test with cursors");
+		new Lwjgl3Application(new MainWindow(), config);
+	}
+}

--- a/tests/gdx-tests-lwjgl3/src/com/badlogic/gdx/tests/lwjgl3/MultiWindowTest.java
+++ b/tests/gdx-tests-lwjgl3/src/com/badlogic/gdx/tests/lwjgl3/MultiWindowTest.java
@@ -47,16 +47,19 @@ public class MultiWindowTest {
 				config.setWindowPosition(MathUtils.random(0, mode.width - 640), MathUtils.random(0, mode.height - 480));
 				config.setTitle("Child window");
 				Class clazz = childWindowClasses[MathUtils.random(0, childWindowClasses.length - 1)];
-				ApplicationListener listener = null;
-				try {
-					listener = (ApplicationListener)clazz.newInstance();
-				} catch(Throwable t) {
-					new GdxRuntimeException("Couldn't instantiate app listener", t);
-				}
-				Lwjgl3Window window = app.newWindow(listener, config);				
+				ApplicationListener listener = createChildWindowClass(clazz);
+				Lwjgl3Window window = app.newWindow(listener, config);
 			}
 		}
-	}		
+
+		public ApplicationListener createChildWindowClass(Class clazz) {
+			try {
+				return (ApplicationListener) clazz.newInstance();
+			} catch(Throwable t) {
+				throw new GdxRuntimeException("Couldn't instantiate app listener", t);
+			}
+		}
+	}
 	
 	public static void main(String[] argv) {
 		Lwjgl3ApplicationConfiguration config = new Lwjgl3ApplicationConfiguration();


### PR DESCRIPTION
Next try to fix #3880. Each window disposes its own cursors only. System cursors are disposed on application shutdown.