### PR TITLE
Fix selection of non latin characters

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextField.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextField.java
@@ -150,7 +150,7 @@ public class TextField extends Widget implements Disableable {
 	}
 
 	protected boolean isWordCharacter (char c) {
-		return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9');
+		return Character.isLetterOrDigit(c);
 	}
 
 	protected int[] wordUnderCursor (int at) {


### PR DESCRIPTION
This change allows to select non latin letters.
Previously it was impossible to select "éíúóöäü" as a whole word.
You were only able to select one of those characters.
@NathanSweet 