### PR TITLE
Fix #3899

### DIFF
--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglCursor.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglCursor.java
@@ -5,16 +5,20 @@ import java.nio.ByteOrder;
 import java.nio.IntBuffer;
 
 import org.lwjgl.LWJGLException;
-import org.lwjgl.input.Mouse;
 
+import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Cursor;
 import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.utils.GdxRuntimeException;
+import com.badlogic.gdx.utils.SharedLibraryLoader;
 
 public class LwjglCursor implements Cursor {
 	org.lwjgl.input.Cursor lwjglCursor = null;
 
 	public LwjglCursor (Pixmap pixmap, int xHotspot, int yHotspot) {
+		if (((LwjglGraphics)Gdx.graphics).canvas != null && SharedLibraryLoader.isMac) {
+			return;
+		}
 		try {
 			if (pixmap == null) {
 				lwjglCursor = null;

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGraphics.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGraphics.java
@@ -37,6 +37,7 @@ import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.Pixmap.Format;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.GdxRuntimeException;
+import com.badlogic.gdx.utils.SharedLibraryLoader;
 
 /** An implementation of the {@link Graphics} interface based on Lwjgl.
  * @author mzechner */
@@ -620,6 +621,9 @@ public class LwjglGraphics implements Graphics {
 
 	@Override
 	public void setCursor (com.badlogic.gdx.graphics.Cursor cursor) {
+		if (canvas != null && SharedLibraryLoader.isMac) {
+			return;
+		}
 		try {
 			Mouse.setNativeCursor(((LwjglCursor)cursor).lwjglCursor);
 		} catch (LWJGLException e) {
@@ -629,6 +633,9 @@ public class LwjglGraphics implements Graphics {
 	
 	@Override
 	public void setSystemCursor (SystemCursor systemCursor) {
+		if (canvas != null && SharedLibraryLoader.isMac) {
+			return;
+		}
 		try {
 			Mouse.setNativeCursor(null);
 		} catch (LWJGLException e) {


### PR DESCRIPTION
Custom cursors aren't supported on mac when using lwjgl2 and awt, so we simply never change the cursor.
