### PR TITLE
Lwjgl2 backend displayMode tweaks

### DIFF
--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGraphics.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGraphics.java
@@ -402,7 +402,7 @@ public class LwjglGraphics implements Graphics {
 
 	@Override
 	public DisplayMode[] getDisplayModes (Monitor monitor) {
-		return new DisplayMode[] { getDisplayMode() };
+		return getDisplayModes();
 	}
 
 	@Override
@@ -517,7 +517,7 @@ public class LwjglGraphics implements Graphics {
 
 	@Override
 	public DisplayMode getDisplayMode () {
-		org.lwjgl.opengl.DisplayMode mode = Display.getDesktopDisplayMode();
+		org.lwjgl.opengl.DisplayMode mode = Display.getDisplayMode();
 		return new LwjglDisplayMode(mode.getWidth(), mode.getHeight(), mode.getFrequency(), mode.getBitsPerPixel(), mode);
 	}
 


### PR DESCRIPTION
Seems that getDisplayModes(Monitor) only returns the getDisplayMode() result
which in turn getDisplayMode() doesn't return the current mode but the initial one that was the window created with (using getDesktopDisplayMode())