### PR TITLE
FreeTypeFontGenerator-texture-bleeding-#3521-fix 

### DIFF
--- a/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGenerator.java
+++ b/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGenerator.java
@@ -345,6 +345,8 @@ public class FreeTypeFontGenerator implements Disposable {
 			}
 			ownsAtlas = true;
 			packer = new PixmapPacker(size, size, Format.RGBA8888, 1, false, packStrategy);
+			packer.setCurrentTransparentColor(parameter.color);
+			packer.getCurrentTransparentColor().a = 0;
 		}
 
 		if (incremental) data.glyphs = new Array(charactersLength + 32);

--- a/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGenerator.java
+++ b/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGenerator.java
@@ -347,6 +347,10 @@ public class FreeTypeFontGenerator implements Disposable {
 			packer = new PixmapPacker(size, size, Format.RGBA8888, 1, false, packStrategy);
 			packer.setCurrentTransparentColor(parameter.color);
 			packer.getCurrentTransparentColor().a = 0;
+			if (parameter.borderWidth > 0) {
+				packer.setCurrentTransparentColor(parameter.borderColor);
+				packer.getCurrentTransparentColor().a = 0;
+			}
 		}
 
 		if (incremental) data.glyphs = new Array(charactersLength + 32);

--- a/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGenerator.java
+++ b/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGenerator.java
@@ -345,11 +345,11 @@ public class FreeTypeFontGenerator implements Disposable {
 			}
 			ownsAtlas = true;
 			packer = new PixmapPacker(size, size, Format.RGBA8888, 1, false, packStrategy);
-			packer.setCurrentTransparentColor(parameter.color);
-			packer.getCurrentTransparentColor().a = 0;
+			packer.setTransparentColor(parameter.color);
+			packer.getTransparentColor().a = 0;
 			if (parameter.borderWidth > 0) {
-				packer.setCurrentTransparentColor(parameter.borderColor);
-				packer.getCurrentTransparentColor().a = 0;
+				packer.setTransparentColor(parameter.borderColor);
+				packer.getTransparentColor().a = 0;
 			}
 		}
 

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/PixmapPacker.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/PixmapPacker.java
@@ -101,7 +101,7 @@ public class PixmapPacker implements Disposable {
 	Format pageFormat;
 	int padding;
 	boolean duplicateBorder;
-	Color currentTransparentColor = new Color(0f, 0f, 0f, 0f);
+	Color transparentColor = new Color(0f, 0f, 0f, 0f);
 	final Array<Page> pages = new Array();
 	PackStrategy packStrategy;
 
@@ -349,7 +349,7 @@ public class PixmapPacker implements Disposable {
 
 		public Page (PixmapPacker packer) {
 			image = new Pixmap(packer.pageWidth, packer.pageHeight, packer.pageFormat);
-			final Color transparentColor = packer.getCurrentTransparentColor();
+			final Color transparentColor = packer.getTransparentColor();
 			this.image.setColor(transparentColor);
 			this.image.fill();
 		}
@@ -586,12 +586,12 @@ public class PixmapPacker implements Disposable {
 		}
 	}
 
-	public Color getCurrentTransparentColor () {
-		return this.currentTransparentColor;
+	public Color getTransparentColor () {
+		return this.transparentColor;
 	}
 
-	public void setCurrentTransparentColor (Color color) {
-		this.currentTransparentColor.set(color);
+	public void setTransparentColor (Color color) {
+		this.transparentColor.set(color);
 	}
 
 }

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/PixmapPacker.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/PixmapPacker.java
@@ -101,6 +101,7 @@ public class PixmapPacker implements Disposable {
 	Format pageFormat;
 	int padding;
 	boolean duplicateBorder;
+	Color currentTransparentColor = new Color(0f, 0f, 0f, 0f);
 	final Array<Page> pages = new Array();
 	PackStrategy packStrategy;
 
@@ -348,6 +349,9 @@ public class PixmapPacker implements Disposable {
 
 		public Page (PixmapPacker packer) {
 			image = new Pixmap(packer.pageWidth, packer.pageHeight, packer.pageFormat);
+			final Color transparentColor = packer.getCurrentTransparentColor();
+			this.image.setColor(transparentColor);
+			this.image.fill();
 		}
 
 		public Pixmap getPixmap () {
@@ -573,6 +577,7 @@ public class PixmapPacker implements Disposable {
 
 			public SkylinePage (PixmapPacker packer) {
 				super(packer);
+
 			}
 
 			static class Row {
@@ -580,4 +585,13 @@ public class PixmapPacker implements Disposable {
 			}
 		}
 	}
+
+	public Color getCurrentTransparentColor () {
+		return this.currentTransparentColor;
+	}
+
+	public void setCurrentTransparentColor (Color color) {
+		this.currentTransparentColor.set(color);
+	}
+
 }


### PR DESCRIPTION
Fixing https://github.com/libgdx/libgdx/issues/3521
- ```PixmapPacker``` has a new parameter ```Color currentTransparentColor;``` used by ```Page``` constructor to fill transparent pixels.
- ```FreeTypeFontGenerator``` sets packer to use color of the font but with zero alpha for transparent pixels to avoid leaks.