### PR TITLE
fixing #3914

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/glutils/ETC1.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/ETC1.java
@@ -88,7 +88,7 @@ public class ETC1 {
 
 		private void checkNPOT () {
 			if (!MathUtils.isPowerOfTwo(width) || !MathUtils.isPowerOfTwo(height)) {
-				Gdx.app.debug("ETC1Data", "warning: non-power-of-two ETC1 textures may crash the driver of PowerVR GPUs");
+				System.out.println("ETC1Data " + "warning: non-power-of-two ETC1 textures may crash the driver of PowerVR GPUs");
 			}
 		}
 


### PR DESCRIPTION
Fixing ETC1.encodeImagePKM crash due to the null Gdx.app https://github.com/libgdx/libgdx/issues/3914