### PR TITLE
Fixed MapObject x/y properties being scaled twice

### DIFF
--- a/gdx/src/com/badlogic/gdx/maps/tiled/BaseTmxMapLoader.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/BaseTmxMapLoader.java
@@ -242,8 +242,8 @@ public abstract class BaseTmxMapLoader<P extends AssetLoaderParameters<TiledMap>
 			if (id != 0) {
 				object.getProperties().put("id", id);
 			}
-			object.getProperties().put("x", x * scaleX);
-			object.getProperties().put("y", (flipY ? y - height : y) * scaleY);
+			object.getProperties().put("x", x);
+			object.getProperties().put("y", (flipY ? y - height : y));
 			object.getProperties().put("width", width);
 			object.getProperties().put("height", height);
 			object.setVisible(element.getIntAttribute("visible", 1) == 1);


### PR DESCRIPTION
The x and y local variables are already scaled on lines 175 and 176 in the BaseTmxMapLoader, and scaling them again when modifying the properties ObjectMap makes the x and y properties too small (and inconsistent with the coordinates of Rectangle/Ellipse/etc if the MapObject in question is an instance of one of those objects).