### PR TITLE
remove texture artifacts for FreeTypeFontGenerator

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,7 @@
 - Added TextureArray wrapper see https://github.com/libgdx/libgdx/pull/3807
 - Fixed bug in AndroidGL20.cpp which cast a pointer to a 32-bit int. Crash on 64-bit ARM, but only for a specific code path and address...
 - Fixed multiple controllers registering on same index with LWJGL3, see https://github.com/libgdx/libgdx/issues/3774
+- Fixed the FreeTypeFontGenerator texture bleeding, see https://github.com/libgdx/libgdx/issues/3521
 
 [1.9.1]
 - API Change: Override GwtApplication#createApplicationListener() to create your ApplicationListener

--- a/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGenerator.java
+++ b/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGenerator.java
@@ -345,6 +345,12 @@ public class FreeTypeFontGenerator implements Disposable {
 			}
 			ownsAtlas = true;
 			packer = new PixmapPacker(size, size, Format.RGBA8888, 1, false, packStrategy);
+			packer.setTransparentColor(parameter.color);
+			packer.getTransparentColor().a = 0;
+			if (parameter.borderWidth > 0) {
+				packer.setTransparentColor(parameter.borderColor);
+				packer.getTransparentColor().a = 0;
+			}
 		}
 
 		if (incremental) data.glyphs = new Array(charactersLength + 32);

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/PixmapPacker.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/PixmapPacker.java
@@ -101,6 +101,7 @@ public class PixmapPacker implements Disposable {
 	Format pageFormat;
 	int padding;
 	boolean duplicateBorder;
+	Color transparentColor = new Color(0f, 0f, 0f, 0f);
 	final Array<Page> pages = new Array();
 	PackStrategy packStrategy;
 
@@ -348,6 +349,9 @@ public class PixmapPacker implements Disposable {
 
 		public Page (PixmapPacker packer) {
 			image = new Pixmap(packer.pageWidth, packer.pageHeight, packer.pageFormat);
+			final Color transparentColor = packer.getTransparentColor();
+			this.image.setColor(transparentColor);
+			this.image.fill();
 		}
 
 		public Pixmap getPixmap () {
@@ -573,6 +577,7 @@ public class PixmapPacker implements Disposable {
 
 			public SkylinePage (PixmapPacker packer) {
 				super(packer);
+
 			}
 
 			static class Row {
@@ -580,4 +585,13 @@ public class PixmapPacker implements Disposable {
 			}
 		}
 	}
+
+	public Color getTransparentColor () {
+		return this.transparentColor;
+	}
+
+	public void setTransparentColor (Color color) {
+		this.transparentColor.set(color);
+	}
+
 }

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/PixmapPacker.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/PixmapPacker.java
@@ -347,6 +347,7 @@ public class PixmapPacker implements Disposable {
 		final Array<String> addedRects = new Array();
 		boolean dirty;
 
+		/** Creates a new page filled with the color provided by the {@link PixmapPacker#getTransparentColor()} */
 		public Page (PixmapPacker packer) {
 			image = new Pixmap(packer.pageWidth, packer.pageHeight, packer.pageFormat);
 			final Color transparentColor = packer.getTransparentColor();
@@ -586,10 +587,14 @@ public class PixmapPacker implements Disposable {
 		}
 	}
 
+	/** @see PixmapPacker#setTransparentColor(Color color) */
 	public Color getTransparentColor () {
 		return this.transparentColor;
 	}
 
+	/** Sets the default <code>color</code> of the whole {@link PixmapPacker.Page} when a new one created. Helps to avoid texture
+	 * bleeding or to highlight the page for debugging.
+	 * @see Page#Page(PixmapPacker packer) */
 	public void setTransparentColor (Color color) {
 		this.transparentColor.set(color);
 	}


### PR DESCRIPTION
Fixing https://github.com/libgdx/libgdx/issues/3521
- ```PixmapPacker``` has a new parameter ```Color currentTransparentColor;``` used by ```Page``` constructor to fill transparent pixels.
- ```FreeTypeFontGenerator``` sets packer to use color of the font but with zero alpha for transparent pixels to avoid leaks.