### PR TITLE
Modify at VertexAttribute,want more control

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/VertexAttribute.java
+++ b/gdx/src/com/badlogic/gdx/graphics/VertexAttribute.java
@@ -64,11 +64,11 @@ public final class VertexAttribute {
 				usage == Usage.ColorPacked, alias, index);
 	}
 	
-	private VertexAttribute (int usage, int numComponents, int type, boolean normalized, String alias) {
+	public VertexAttribute (int usage, int numComponents, int type, boolean normalized, String alias) {
 		this(usage, numComponents, type, normalized, alias, 0);
 	}
 	
-	private VertexAttribute (int usage, int numComponents, int type, boolean normalized, String alias, int index) {
+	public VertexAttribute (int usage, int numComponents, int type, boolean normalized, String alias, int index) {
 		this.usage = usage;
 		this.numComponents = numComponents;
 		this.type = type;


### PR DESCRIPTION
Change the private constructors to public.Let users  have more control on VertexAttribute,like to set attribute data type ....
I saw the code of `com.badlogic.gdx.graphics.glutils.VertexArray.bind(ShaderProgram, int[])`,It seems supported GL_FLOAT and `GL_UNSIGNED_BYTE`,But when I what to create a `VertexAttribute` with type `GL_UNSIGNED_BYTE`,I found the constructors is private,so I think, it may be public to provide more control on Vertex Attribute?
Or,there has some reason must keep this constructors private?

Sorry for my english.
best regards
