### PR TITLE
LWJGL3 Added the possibility to create windows initially hidden

### DIFF
--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
@@ -320,7 +320,8 @@ public class Lwjgl3Application implements Application {
 		appConfig.setWindowListener(config.windowListener);
 		appConfig.setFullscreenMode(config.fullscreenMode);
 		appConfig.setTitle(config.title);
-		appConfig.setInitialBackgroundColor(config.initialBackgroundColor);		
+		appConfig.setInitialBackgroundColor(config.initialBackgroundColor);
+		appConfig.setInitialVisible(config.initialVisible);
 		Lwjgl3Window window = createWindow(appConfig, listener, windows.get(0).getWindowHandle());
 		windows.add(window);
 		return window;
@@ -329,7 +330,7 @@ public class Lwjgl3Application implements Application {
 	private Lwjgl3Window createWindow(Lwjgl3ApplicationConfiguration config, ApplicationListener listener, long sharedContext) {
 		long windowHandle = createGlfwWindow(config, sharedContext);
 		Lwjgl3Window window = new Lwjgl3Window(windowHandle, listener, config);
-		window.setVisible(true);
+		window.setVisible(config.initialVisible);
 		return window;
 	}
 

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3ApplicationConfiguration.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3ApplicationConfiguration.java
@@ -107,8 +107,7 @@ public class Lwjgl3ApplicationConfiguration {
 	}
 	
 	/**
-	 * @param visibility
-	 * 				whether the window will be visible on creation. (default true)
+	 * @param visibility whether the window will be visible on creation. (default true)
 	 */
 	public void setInitialVisible(boolean visibility) {
 		this.initialVisible = visibility;

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3ApplicationConfiguration.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3ApplicationConfiguration.java
@@ -65,6 +65,7 @@ public class Lwjgl3ApplicationConfiguration {
 	boolean vSyncEnabled = true;
 	String title = "";
 	Color initialBackgroundColor = Color.BLACK;
+	boolean initialVisible = true;
 
 	String preferencesDirectory = ".prefs/";
 	Files.FileType preferencesFileType = FileType.External;
@@ -98,12 +99,20 @@ public class Lwjgl3ApplicationConfiguration {
 		copy.vSyncEnabled = config.vSyncEnabled;
 		copy.title = config.title;
 		copy.initialBackgroundColor = config.initialBackgroundColor;
+		copy.initialVisible = config.initialVisible;
 		copy.preferencesDirectory = config.preferencesDirectory;
 		copy.preferencesFileType = config.preferencesFileType;
 		copy.hdpiMode = config.hdpiMode;
 		return copy;
 	}
 	
+	/**
+	 * @param visibility
+	 * 				whether the window will be visible on creation. (default true)
+	 */
+	public void setInitialVisible(boolean visibility) {
+		this.initialVisible = visibility;
+	}
 
 	/**
 	 * Whether to disable audio or not. If set to false, the returned audio

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3WindowConfiguration.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3WindowConfiguration.java
@@ -31,6 +31,15 @@ public class Lwjgl3WindowConfiguration {
 	Lwjgl3DisplayMode fullscreenMode;
 	String title = "";
 	Color initialBackgroundColor = Color.BLACK;
+	boolean initialVisible = true;
+	
+	/**
+	 * @param visibility
+	 * 				whether the window will be visible on creation. (default true)
+	 */
+	public void setInitialVisible(boolean visibility) {
+		this.initialVisible = visibility;
+	}
 	
 	/**
 	 * Sets the app to use windowed mode.

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3WindowConfiguration.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3WindowConfiguration.java
@@ -34,8 +34,7 @@ public class Lwjgl3WindowConfiguration {
 	boolean initialVisible = true;
 	
 	/**
-	 * @param visibility
-	 * 				whether the window will be visible on creation. (default true)
+	 * @param visibility whether the window will be visible on creation. (default true)
 	 */
 	public void setInitialVisible(boolean visibility) {
 		this.initialVisible = visibility;


### PR DESCRIPTION
Hey folks,

in the moment it is possible to hide windows using Lwjgl3Window#setVisible. This pull requests adds the option to configure windows to be hidden on creation by default. This is handy if the Lwjgl3Application is supposed to only 'spawn' windows using #newWindow. Or (the case why I made the request) if you desire to do offscreen rendering.

While I am not sure if this would be a widely used feature it is a small change and therefor worth considering imho.

-ClaasJG