### PR TITLE
UBJSON reader/writer: fix for writing long/double/char arrays

### DIFF
--- a/gdx/src/com/badlogic/gdx/utils/UBJsonReader.java
+++ b/gdx/src/com/badlogic/gdx/utils/UBJsonReader.java
@@ -96,6 +96,8 @@ public class UBJsonReader implements BaseJsonReader {
 			return new JsonValue(parseString(din, type));
 		else if (type == 'a' || type == 'A')
 			return parseData(din, type);
+		else if (type == 'C')
+			return new JsonValue(din.readChar());
 		else
 			throw new GdxRuntimeException("Unrecognized data type");
 	}

--- a/gdx/src/com/badlogic/gdx/utils/UBJsonWriter.java
+++ b/gdx/src/com/badlogic/gdx/utils/UBJsonWriter.java
@@ -244,7 +244,7 @@ public class UBJsonWriter implements Closeable {
 	public UBJsonWriter value (long[] values) throws IOException {
 		array();
 		out.writeByte('$');
-		out.writeByte('I');
+		out.writeByte('L');
 		out.writeByte('#');
 		value(values.length);
 		for (int i = 0, n = values.length; i < n; i++) {
@@ -277,7 +277,7 @@ public class UBJsonWriter implements Closeable {
 	public UBJsonWriter value (double[] values) throws IOException {
 		array();
 		out.writeByte('$');
-		out.writeByte('d');
+		out.writeByte('D');
 		out.writeByte('#');
 		value(values.length);
 		for (int i = 0, n = values.length; i < n; i++) {
@@ -304,7 +304,7 @@ public class UBJsonWriter implements Closeable {
 	public UBJsonWriter value (char[] values) throws IOException {
 		array();
 		out.writeByte('$');
-		out.writeByte('I');
+		out.writeByte('C');
 		out.writeByte('#');
 		value(values.length);
 		for (int i = 0, n = values.length; i < n; i++) {

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/UBJsonTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/UBJsonTest.java
@@ -44,6 +44,13 @@ public class UBJsonTest extends GdxTest {
 			uw.set("xfloats", new float[] {Float.MIN_VALUE, Float.MAX_VALUE, Float.NaN, Float.NEGATIVE_INFINITY});
 			uw.set("double", 0.000000000000000000001);
 			uw.set("long", Long.MAX_VALUE);
+			uw.set("3bytes", new byte[] {(byte)1, (byte)2, (byte)3});
+			uw.set("3shorts", new short[] {(short)1, (short)2, (short)3});
+			uw.set("3ints", new int[] {1, 2, 3});
+			uw.set("3long", new long[] {1l, 2l, 3l});
+			uw.set("3double", new double[] {1, 2, 3.456789});
+			uw.set("3char", new char[] {'a', 'b', 'c'});
+			uw.set("3strings", new String[] {"", "a", "abc"});
 			uw.array("arr");
 			uw.object().pop();
 			uw.value(true).value(false).value(true);


### PR DESCRIPTION
This is a bug fix for writing and reading long, double and char arrays in UBJSON.

see Issue #3938