### PR TITLE
Fix issue with underscores in method names

### DIFF
--- a/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/NativeCodeGenerator.java
+++ b/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/NativeCodeGenerator.java
@@ -328,8 +328,10 @@ public class NativeCodeGenerator {
 
 	private CMethod findCMethod (JavaMethod javaMethod, ArrayList<CMethod> cMethods) {
 		for (CMethod cMethod : cMethods) {
-			if (cMethod.getHead().endsWith(javaMethod.getClassName() + "_" + javaMethod.getName())
-				|| cMethod.getHead().contains(javaMethod.getClassName() + "_" + javaMethod.getName() + "__")) {
+			String javaMethodName = javaMethod.getName().replace("_", "_1");
+			String javaClassName = javaMethod.getClassName().toString().replace("_", "_1");
+			if (cMethod.getHead().endsWith(javaClassName + "_" + javaMethodName)
+				|| cMethod.getHead().contains(javaClassName + "_" + javaMethodName + "__")) {
 				// FIXME poor man's overloaded method check...
 				// FIXME float test[] won't work, needs to be float[] test.
 				if (cMethod.getArgumentTypes().length - 2 == javaMethod.getArguments().size()) {


### PR DESCRIPTION
Methods with a underscore, e.g. `_foo()` can't be used with jnigen, because they are 
transformed to `__1foo()` according to the rules defined in table 2-1 at 
http://docs.oracle.com/javase/7/docs/technotes/guides/jni/spec/design.html#wp615
They can't be used, because jnigen always looks for "_" + methodName so jnigen looks for a 
function `__foo()` which doesn't exist.