### PR TITLE
Fixes #3509 and adds a simple test program

### DIFF
--- a/extensions/gdx-bullet/jni/swig-src/collision/collision_wrap.cpp
+++ b/extensions/gdx-bullet/jni/swig-src/collision/collision_wrap.cpp
@@ -2368,6 +2368,9 @@ SWIGINTERN bool ContactListener_setEvents(ContactListener *self){
  /*SWIG_JavaArrayArgout##Longlong(jenv, jarr$argnum, (long long *)$1, $input);*/ 
  /*SWIG_JavaArrayArgout##Float(jenv, jarr$argnum, (float *)$1, $input);*/ 
  /*SWIG_JavaArrayArgout##Double(jenv, jarr$argnum, (double *)$1, $input);*/ 
+SWIGINTERN btBroadphasePair *btAlignedObjectArray_Sl_btBroadphasePair_Sg__at(btAlignedObjectArray< btBroadphasePair > *self,int n){
+		return &(self->at(n));
+	}
 SWIGINTERN int btAlignedObjectArray_Sl_btBroadphasePair_Sg__getCollisionObjects(btAlignedObjectArray< btBroadphasePair > *self,int result[],int max,int other){
 		static btManifoldArray marr;
 		const int n = self->size();
@@ -46210,8 +46213,8 @@ SWIGEXPORT jint JNICALL Java_com_badlogic_gdx_physics_bullet_collision_Collision
 }
 
 
-SWIGEXPORT jobject JNICALL Java_com_badlogic_gdx_physics_bullet_collision_CollisionJNI_btBroadphasePairArray_1at(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_, jint jarg2) {
-  jobject jresult = 0 ;
+SWIGEXPORT jlong JNICALL Java_com_badlogic_gdx_physics_bullet_collision_CollisionJNI_btBroadphasePairArray_1at(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_, jint jarg2) {
+  jlong jresult = 0 ;
   btAlignedObjectArray< btBroadphasePair > *arg1 = (btAlignedObjectArray< btBroadphasePair > *) 0 ;
   int arg2 ;
   btBroadphasePair *result = 0 ;
@@ -46221,8 +46224,8 @@ SWIGEXPORT jobject JNICALL Java_com_badlogic_gdx_physics_bullet_collision_Collis
   (void)jarg1_;
   arg1 = *(btAlignedObjectArray< btBroadphasePair > **)&jarg1; 
   arg2 = (int)jarg2; 
-  result = (btBroadphasePair *) &((btAlignedObjectArray< btBroadphasePair > const *)arg1)->at(arg2);
-  jresult = gdx_getTempbtBroadphasePair(jenv, &result, false);
+  result = (btBroadphasePair *)btAlignedObjectArray_Sl_btBroadphasePair_Sg__at(arg1,arg2);
+  *(btBroadphasePair **)&jresult = result; 
   return jresult;
 }
 

--- a/extensions/gdx-bullet/jni/swig-src/collision/com/badlogic/gdx/physics/bullet/collision/CollisionJNI.java
+++ b/extensions/gdx-bullet/jni/swig-src/collision/com/badlogic/gdx/physics/bullet/collision/CollisionJNI.java
@@ -2501,7 +2501,7 @@ public class CollisionJNI {
   public final static native void ContactCache_director_connect(ContactCache obj, long cptr, boolean mem_own, boolean weak_global);
   public final static native void ContactCache_change_ownership(ContactCache obj, long cptr, boolean take_or_release);
   public final static native int btBroadphasePairArray_size(long jarg1, btBroadphasePairArray jarg1_);
-  public final static native btBroadphasePair btBroadphasePairArray_at(long jarg1, btBroadphasePairArray jarg1_, int jarg2);
+  public final static native long btBroadphasePairArray_at(long jarg1, btBroadphasePairArray jarg1_, int jarg2);
   public final static native int btBroadphasePairArray_getCollisionObjects(long jarg1, btBroadphasePairArray jarg1_, int[] jarg2, int jarg3, int jarg4);
   public final static native int btBroadphasePairArray_getCollisionObjectsValue(long jarg1, btBroadphasePairArray jarg1_, int[] jarg2, int jarg3, int jarg4);
   public final static native long new_btBroadphasePairArray();

--- a/extensions/gdx-bullet/jni/swig-src/collision/com/badlogic/gdx/physics/bullet/collision/btBroadphasePairArray.java
+++ b/extensions/gdx-bullet/jni/swig-src/collision/com/badlogic/gdx/physics/bullet/collision/btBroadphasePairArray.java
@@ -84,7 +84,7 @@ public class btBroadphasePairArray extends BulletBase {
   }
 
   public btBroadphasePair at(int n) {
-	return CollisionJNI.btBroadphasePairArray_at(swigCPtr, this, n);
+	return btBroadphasePair.internalTemp(CollisionJNI.btBroadphasePairArray_at(swigCPtr, this, n), false);
 }
 
   public int getCollisionObjects(int[] result, int max, int other) {

--- a/extensions/gdx-bullet/jni/swig/collision/btBroadphasePairArray.i
+++ b/extensions/gdx-bullet/jni/swig/collision/btBroadphasePairArray.i
@@ -30,10 +30,14 @@
 class btAlignedObjectArray<btBroadphasePair> {
 public:
 	SIMD_FORCE_INLINE	int size() const;
-	SIMD_FORCE_INLINE const btBroadphasePair& at(int n) const;
 };
 
 %extend btAlignedObjectArray<btBroadphasePair> {
+
+	btBroadphasePair *at(int n) {
+		return &($self->at(n));
+	}
+
 	int getCollisionObjects(int result[], int max, int other) {
 		static btManifoldArray marr;
 		const int n = $self->size();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/BulletTestCollection.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/BulletTestCollection.java
@@ -40,7 +40,7 @@ public class BulletTestCollection extends GdxTest implements InputProcessor, Ges
 		new RayCastTest(), new RayPickRagdollTest(), new InternalTickTest(), new CollisionWorldTest(), new CollisionTest(),
 		new FrustumCullingTest(), new CollisionDispatcherTest(), new ContactCallbackTest(), new ContactCallbackTest2(),
 		new ContactCacheTest(), new SoftBodyTest(), new SoftMeshTest(), new VehicleTest(), new CharacterTest(), new ImportTest(),
-		new TriangleRaycastTest(), new OcclusionCullingTest()};
+		new TriangleRaycastTest(), new OcclusionCullingTest(), new PairCacheTest()};
 
 	protected int testIndex = 0;
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/PairCacheTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/PairCacheTest.java
@@ -1,0 +1,198 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogic.gdx.tests.bullet;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.PerspectiveCamera;
+import com.badlogic.gdx.graphics.g3d.Model;
+import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
+import com.badlogic.gdx.math.Vector3;
+import com.badlogic.gdx.physics.bullet.collision.*;
+
+/** Based on FrustumCullingTest by Xoppa.
+ * 
+ * @author jsjolund */
+public class PairCacheTest extends BaseBulletTest {
+
+	final static float BOX_X_MIN = -25;
+	final static float BOX_Y_MIN = -25;
+	final static float BOX_Z_MIN = -25;
+
+	final static float BOX_X_MAX = 25;
+	final static float BOX_Y_MAX = 25;
+	final static float BOX_Z_MAX = 25;
+
+	final static float SPEED_X = 360f / 7f;
+	final static float SPEED_Y = 360f / 19f;
+	final static float SPEED_Z = 360f / 13f;
+
+	final static int BOXCOUNT = 100;
+
+	private boolean useFrustumCam = false;
+
+	private btPairCachingGhostObject ghostObject;
+	private BulletEntity ghostEntity;
+	private btPersistentManifoldArray manifoldArray;
+
+	private float angleX, angleY, angleZ;
+
+	private ShapeRenderer shapeRenderer;
+
+	private PerspectiveCamera frustumCam;
+	private PerspectiveCamera overviewCam;
+
+	@Override
+	public void create () {
+		super.create();
+
+		instructions = "Tap to toggle view\nLong press to toggle debug mode\nSwipe for next test\nCtrl+drag to rotate\nScroll to zoom";
+
+		world.addConstructor("collisionBox", new BulletConstructor(world.getConstructor("box").model));
+
+		// Create the entities
+		final float dX = BOX_X_MAX - BOX_X_MIN;
+		final float dY = BOX_Y_MAX - BOX_Y_MIN;
+		final float dZ = BOX_Z_MAX - BOX_Z_MIN;
+		for (int i = 0; i < BOXCOUNT; i++)
+			world.add("collisionBox", BOX_X_MIN + dX * (float)Math.random(), BOX_Y_MIN + dY * (float)Math.random(),
+					BOX_Z_MIN + dZ * (float)Math.random()).setColor(0.25f + 0.5f * (float)Math.random(),
+					0.25f + 0.5f * (float)Math.random(), 0.25f + 0.5f * (float)Math.random(), 1f);
+
+		manifoldArray = new btPersistentManifoldArray();
+		disposables.add(manifoldArray);
+
+		overviewCam = camera;
+		overviewCam.position.set(BOX_X_MAX, BOX_Y_MAX, BOX_Z_MAX);
+		overviewCam.lookAt(Vector3.Zero);
+		overviewCam.far = 150f;
+		overviewCam.update();
+
+		frustumCam = new PerspectiveCamera(camera.fieldOfView, camera.viewportWidth, camera.viewportHeight);
+		frustumCam.far = Vector3.len(BOX_X_MAX, BOX_Y_MAX, BOX_Z_MAX);
+		frustumCam.update();
+
+		final Model ghostModel = FrustumCullingTest.createFrustumModel(frustumCam.frustum.planePoints);
+		disposables.add(ghostModel);
+
+		// The ghost object does not need to be shaped as a camera frustum, it can have any collision shape.
+		ghostObject = FrustumCullingTest.createFrustumObject(frustumCam.frustum.planePoints);
+		disposables.add(ghostObject);
+
+		world.add(ghostEntity = new BulletEntity(ghostModel, ghostObject, 0, 0, 0));
+		disposables.add(ghostEntity);
+
+		shapeRenderer = new ShapeRenderer();
+		disposables.add(shapeRenderer);
+
+	}
+
+	@Override
+	public BulletWorld createWorld () {
+		// No need to use dynamics for this test
+		btDbvtBroadphase broadphase = new btDbvtBroadphase();
+		btDefaultCollisionConfiguration collisionConfig = new btDefaultCollisionConfiguration();
+		btCollisionDispatcher dispatcher = new btCollisionDispatcher(collisionConfig);
+		btCollisionWorld collisionWorld = new btCollisionWorld(dispatcher, broadphase, collisionConfig);
+		return new BulletWorld(collisionConfig, dispatcher, broadphase, null, collisionWorld);
+	}
+
+	@Override
+	public void render () {
+		final float dt = Gdx.graphics.getDeltaTime();
+		ghostEntity.transform.idt();
+		ghostEntity.transform.rotate(Vector3.X, angleX = (angleX + dt * SPEED_X) % 360);
+		ghostEntity.transform.rotate(Vector3.Y, angleY = (angleY + dt * SPEED_Y) % 360);
+		ghostEntity.transform.rotate(Vector3.Z, angleZ = (angleZ + dt * SPEED_Z) % 360);
+
+		// Transform the ghost object
+		ghostEntity.body.setWorldTransform(ghostEntity.transform);
+
+		// Transform the frustum cam
+		frustumCam.direction.set(0, 0, -1);
+		frustumCam.up.set(0, 1, 0);
+		frustumCam.position.set(0, 0, 0);
+		frustumCam.rotate(ghostEntity.transform);
+		frustumCam.update();
+
+		super.render();
+
+		// Find all overlapping pairs which contain the ghost object and draw lines between the collision points.
+		shapeRenderer.setProjectionMatrix(camera.combined);
+		shapeRenderer.begin(ShapeRenderer.ShapeType.Line);
+		shapeRenderer.setColor(Color.WHITE);
+
+		btBroadphasePairArray arr = world.broadphase.getOverlappingPairCache().getOverlappingPairArray();
+		int numPairs = arr.size();
+		for (int i = 0; i < numPairs; ++i) {
+			manifoldArray.clear();
+
+			btBroadphasePair pair = arr.at(i);
+			btBroadphaseProxy proxy0 = btBroadphaseProxy.obtain(pair.getPProxy0().getCPointer(), false);
+			btBroadphaseProxy proxy1 = btBroadphaseProxy.obtain(pair.getPProxy1().getCPointer(), false);
+
+			btBroadphasePair collisionPair = world.collisionWorld.getPairCache().findPair(proxy0, proxy1);
+
+			if (collisionPair == null) continue;
+
+			btCollisionAlgorithm algorithm = collisionPair.getAlgorithm();
+			if (algorithm != null) algorithm.getAllContactManifolds(manifoldArray);
+
+			for (int j = 0; j < manifoldArray.size(); j++) {
+				btPersistentManifold manifold = manifoldArray.at(j);
+
+				boolean isFirstBody = manifold.getBody0() == ghostObject;
+				int otherObjectIndex = isFirstBody ? manifold.getBody1().getUserValue() : manifold.getBody0().getUserValue();
+				Color otherObjectColor = world.entities.get(otherObjectIndex).getColor();
+
+				for (int p = 0; p < manifold.getNumContacts(); ++p) {
+					btManifoldPoint pt = manifold.getContactPoint(p);
+
+					if (pt.getDistance() < 0.f) {
+						if (isFirstBody) {
+							pt.getPositionWorldOnA(tmpV2);
+							pt.getPositionWorldOnB(tmpV1);
+						} else {
+							pt.getPositionWorldOnA(tmpV1);
+							pt.getPositionWorldOnB(tmpV2);
+						}
+						shapeRenderer.line(tmpV1.x, tmpV1.y, tmpV1.z, tmpV2.x, tmpV2.y, tmpV2.z, otherObjectColor, Color.WHITE);
+					}
+				}
+			}
+			btBroadphaseProxy.free(proxy0);
+			btBroadphaseProxy.free(proxy1);
+		}
+		shapeRenderer.end();
+	}
+
+	@Override
+	public boolean tap (float x, float y, int count, int button) {
+		if (useFrustumCam = !useFrustumCam)
+			camera = frustumCam;
+		else
+			camera = overviewCam;
+		return true;
+	}
+
+	@Override
+	public void update () {
+		super.update();
+		// Not using dynamics, so update the collision world manually
+		world.collisionWorld.performDiscreteCollisionDetection();
+	}
+}


### PR DESCRIPTION
Tested on Desktop and Android platforms.

The test program is not very efficient, since the ```btOverlappingPairCache```, ```btCollisionAlgorithm```, ```btPersistentManifold``` and ```btManifoldPoint``` classes do not use pooling.
