### PR TITLE
Fix reference leak in ComparableTimSort

### DIFF
--- a/gdx/src/com/badlogic/gdx/utils/ComparableTimSort.java
+++ b/gdx/src/com/badlogic/gdx/utils/ComparableTimSort.java
@@ -51,6 +51,7 @@ class ComparableTimSort {
 
 	/** Temp storage for merges. */
 	private Object[] tmp;
+	private int tmpCount;
 
 	/** A stack of pending runs yet to be merged. Run i starts at address base[i] and extends for len[i] elements. It's always true
 	 * (so long as the indices are in bounds) that:
@@ -86,6 +87,7 @@ class ComparableTimSort {
 		}
 
 		this.a = a;
+		tmpCount = 0;
 
 		/** March over the array once, left to right, finding natural runs, extending short natural runs to minRun elements, and
 		 * merging runs to maintain stack invariant. */
@@ -114,6 +116,11 @@ class ComparableTimSort {
 		if (DEBUG) assert lo == hi;
 		mergeForceCollapse();
 		if (DEBUG) assert stackSize == 1;
+
+		this.a = null;
+		Object[] tmp = this.tmp;
+		for (int i = 0, n = tmpCount; i < n; i++)
+			tmp[i] = null;
 	}
 
 	/** Creates a TimSort instance to maintain the state of an ongoing sort.
@@ -761,6 +768,7 @@ class ComparableTimSort {
 	 * @param minCapacity the minimum required capacity of the tmp array
 	 * @return tmp, whether or not it grew */
 	private Object[] ensureCapacity (int minCapacity) {
+		tmpCount = Math.max(tmpCount, minCapacity);
 		if (tmp.length < minCapacity) {
 			// Compute smallest power of 2 > minCapacity
 			int newSize = minCapacity;


### PR DESCRIPTION
At the moment ComparableTimSort use a ~~static~~ temp array for performing the sort. The array is not clean up after sorting, therefore maintaining ~~static~~ references to the sorted objects.

This pull request simply mimics what is being done in TimSort which correctly cleanup these references after sorting.