### PR TITLE
Add a getter for the number of managed shaders

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/glutils/ShaderProgram.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/ShaderProgram.java
@@ -783,6 +783,11 @@ public class ShaderProgram implements Disposable {
 		return builder.toString();
 	}
 
+	/** @return the number of managed shader programs currently loaded */
+	public static int getNumManagedShaderPrograms () {
+		return shaders.get(Gdx.app).size;
+	}
+
 	/** Sets the given attribute
 	 * 
 	 * @param name the name of the attribute


### PR DESCRIPTION
This is a very basic addition to allow applications to check in debug build/unit tests the number of managed shaders to detect ressources leaks.

The code is similar to what we have in [Texture.getNumManagedTextures ](https://github.com/libgdx/libgdx/blob/0c00d4b69fb1ab6746484b8cf2486456a5302978/gdx/src/com/badlogic/gdx/graphics/Texture.java) for the same purpose.