### PR TITLE
Add resizable/undecorated lwjgl config options.

### DIFF
--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglApplicationConfiguration.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglApplicationConfiguration.java
@@ -70,6 +70,8 @@ public class LwjglApplicationConfiguration {
 	public boolean forceExit = true;
 	/** whether the window is resizable **/
 	public boolean resizable = true;
+	/** whether the window is undecorated **/
+	public boolean undecorated = false;
 	/** the maximum number of sources that can be played simultaneously */
 	public int audioDeviceSimultaneousSources = 16;
 	/** the audio device buffer size in samples **/

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGraphics.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGraphics.java
@@ -64,6 +64,7 @@ public class LwjglGraphics implements Graphics {
 	BufferFormat bufferFormat = new BufferFormat(8, 8, 8, 8, 16, 8, 0, false);
 	volatile boolean isContinuous = true;
 	volatile boolean requestRendering = false;
+	volatile boolean forceDisplayModeChange = false;
 	boolean softwareMode;
 	boolean usingGL30;
 
@@ -79,7 +80,7 @@ public class LwjglGraphics implements Graphics {
 	}
 
 	LwjglGraphics (Canvas canvas, LwjglApplicationConfiguration config) {
-		this.config = config;
+		this(config);
 		this.canvas = canvas;
 	}
 
@@ -156,6 +157,8 @@ public class LwjglGraphics implements Graphics {
 		if (config.useHDPI) {
 			System.setProperty("org.lwjgl.opengl.Display.enableHighDPI", "true");
 		}
+		
+		setUndecorated(config.undecorated);
 
 		if (canvas != null) {
 			Display.setParent(canvas);
@@ -434,7 +437,8 @@ public class LwjglGraphics implements Graphics {
 	/** Kindly stolen from http://lwjgl.org/wiki/index.php?title=LWJGL_Basics_5_(Fullscreen), not perfect but will do. */
 	@Override
 	public boolean setWindowedMode (int width, int height) {
-		if (getWidth() == width && getHeight() == height && !Display.isFullscreen()) {
+		boolean displaySizeUnchanged = getWidth() == width && getHeight() == height && !Display.isFullscreen();
+		if (displaySizeUnchanged && !forceDisplayModeChange) {
 			return true;
 		}
 
@@ -534,6 +538,8 @@ public class LwjglGraphics implements Graphics {
 	@Override
 	public void setUndecorated (boolean undecorated) {
 		System.setProperty("org.lwjgl.opengl.Window.undecorated", undecorated ? "true" : "false");
+		this.config.undecorated = undecorated;
+		this.forceDisplayModeChange = true;
 	}
 
 	/**


### PR DESCRIPTION
Additional changes:
- Add 'forceDisplayModeChange' flag in LwjglGraphics to force
  'setWindowedMode' to reconfigure the Display after a call to
  'setUndecorated'