### PR TITLE
Add world transform matrix to 3D ParticleController

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g3d/particles/ParticleController.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/particles/ParticleController.java
@@ -54,8 +54,17 @@ public class ParticleController implements Json.Serializable, ResourceData.Confi
 	public ParallelArray particles;
 	public ParticleChannels particleChannels;
 
-	/** Current transform of the controller DO NOT CHANGE MANUALLY */
-	public Matrix4 transform;
+	/** Current transform of the controller. Controls where new particles are generated. DO NOT CHANGE MANUALLY */
+	public final Matrix4 transform;
+
+	/** Optional world transform of the controller, null by default. Translation, rotation and scaling on this matrix will affect
+	 * all particles this controller has generated. */
+	public Matrix4 worldTransform;
+
+	/** If true, the scaling of {@link ParticleController#worldTransform} will affect the size of the particles and the distance
+	 * between them. If false, the scaling will only affect the distance between the particles. Scaling of point sprite particles
+	 * is not supported. */
+	public boolean worldTransformScalesParticles;
 
 	/** Transform flags */
 	public Vector3 scale;
@@ -71,6 +80,7 @@ public class ParticleController implements Json.Serializable, ResourceData.Confi
 		scale = new Vector3(1, 1, 1);
 		influencers = new Array<Influencer>(true, 3, Influencer.class);
 		setTimeStep(DEFAULT_TIME_STEP);
+		worldTransformScalesParticles = false;
 	}
 
 	public ParticleController (String name, Emitter emitter, ParticleControllerRenderer<?, ?> renderer, Influencer... influencers) {
@@ -99,6 +109,16 @@ public class ParticleController implements Json.Serializable, ResourceData.Confi
 	public void setTransform (float x, float y, float z, float qx, float qy, float qz, float qw, float scale) {
 		transform.set(x, y, z, qx, qy, qz, qw, scale, scale, scale);
 		this.scale.set(scale, scale, scale);
+	}
+
+	/** Sets the current world transformation. */
+	public void setWorldTransform (Matrix4 worldTransform) {
+		if (worldTransform == null) {
+			this.worldTransform = null;
+		} else {
+			if (this.worldTransform == null) this.worldTransform = new Matrix4();
+			this.worldTransform.set(worldTransform);
+		}
 	}
 
 	/** Post-multiplies the current transformation with a rotation matrix represented by the given quaternion. */

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/particles/ParticleEffect.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/particles/ParticleEffect.java
@@ -86,10 +86,27 @@ public class ParticleEffect implements Disposable, ResourceData.Configurable {
 		return true;
 	}
 
-	/** Sets the given transform matrix on each controller. */
+	/** Sets the given transform matrix on each controller. {@link ParticleController#transform} affects where new particles are
+	 * generated. */
 	public void setTransform (Matrix4 transform) {
 		for (int i = 0, n = controllers.size; i < n; i++)
 			controllers.get(i).setTransform(transform);
+	}
+
+	/** Sets the given world transform matrix on each controller. {@link ParticleController#worldTransform} affects translation,
+	 * rotation and scale of all particles this effect has generated. If the given matrix is null, the world transforms of the
+	 * particle controllers are also set to null. */
+	public void setWorldTransform (Matrix4 worldTransform) {
+		for (int i = 0, n = controllers.size; i < n; i++)
+			controllers.get(i).setWorldTransform(worldTransform);
+	}
+
+	/** If true, the scaling of {@link ParticleEffect#setWorldTransform(Matrix4)} will affect the size of the particles and the
+	 * distance between them. If false, the scaling will only affect the distance between the particles. Scaling of point sprite
+	 * particles is not supported. */
+	public void setWorldTransformScalesParticles (boolean value) {
+		for (int i = 0, n = controllers.size; i < n; i++)
+			controllers.get(i).worldTransformScalesParticles = value;
 	}
 
 	/** Applies the rotation to the current transformation matrix of each controller. */

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/particles/ParticleSorter.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/particles/ParticleSorter.java
@@ -26,6 +26,7 @@ import com.badlogic.gdx.utils.Array;
  * @author Inferno */
 public abstract class ParticleSorter {
 	static final Vector3 TMP_V1 = new Vector3();
+	static final Vector3 TMP_V2 = new Vector3();
 
 	/** Using this class will not apply sorting */
 	public static class None extends ParticleSorter {
@@ -67,13 +68,15 @@ public abstract class ParticleSorter {
 		@Override
 		public <T extends ParticleControllerRenderData> int[] sort (Array<T> renderData) {
 			float[] val = camera.view.val;
-			float cx = val[Matrix4.M20], cy = val[Matrix4.M21], cz = val[Matrix4.M22];
+			Vector3 cam = TMP_V1.set(val[Matrix4.M20], val[Matrix4.M21], val[Matrix4.M22]);
 			int count = 0, i = 0;
 			for (ParticleControllerRenderData data : renderData) {
 				for (int k = 0, c = i + data.controller.particles.size; i < c; ++i, k += data.positionChannel.strideSize) {
-					distances[i] = cx * data.positionChannel.data[k + ParticleChannels.XOffset] + cy
-						* data.positionChannel.data[k + ParticleChannels.YOffset] + cz
-						* data.positionChannel.data[k + ParticleChannels.ZOffset];
+					Vector3 pos = TMP_V2.set(data.positionChannel.data[k + ParticleChannels.XOffset],
+						data.positionChannel.data[k + ParticleChannels.YOffset],
+						data.positionChannel.data[k + ParticleChannels.ZOffset]);
+					if (data.controller.worldTransform != null) pos.mul(data.controller.worldTransform);
+					distances[i] = cam.dot(pos);
 					particleIndices[i] = i;
 				}
 				count += data.controller.particles.size;

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/particles/batches/PointSpriteParticleBatch.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/particles/batches/PointSpriteParticleBatch.java
@@ -38,6 +38,7 @@ import com.badlogic.gdx.graphics.g3d.particles.ResourceData;
 import com.badlogic.gdx.graphics.g3d.particles.ResourceData.SaveData;
 import com.badlogic.gdx.graphics.g3d.particles.renderers.PointSpriteControllerRenderData;
 import com.badlogic.gdx.graphics.glutils.ShaderProgram;
+import com.badlogic.gdx.math.Matrix4;
 import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.Pool;
@@ -111,6 +112,7 @@ public class PointSpriteParticleBatch extends BufferedParticleBatch<PointSpriteC
 
 	@Override
 	protected void flush (int[] offsets) {
+		Vector3 pos = TMP_V1;
 		int tp = 0;
 		for (PointSpriteControllerRenderData data : renderData) {
 			FloatChannel scaleChannel = data.scaleChannel;
@@ -118,6 +120,7 @@ public class PointSpriteParticleBatch extends BufferedParticleBatch<PointSpriteC
 			FloatChannel positionChannel = data.positionChannel;
 			FloatChannel colorChannel = data.colorChannel;
 			FloatChannel rotationChannel = data.rotationChannel;
+			Matrix4 worldTransform = data.controller.worldTransform;
 
 			for (int p = 0; p < data.controller.particles.size; ++p, ++tp) {
 				int offset = offsets[tp] * CPU_VERTEX_SIZE;
@@ -126,9 +129,14 @@ public class PointSpriteParticleBatch extends BufferedParticleBatch<PointSpriteC
 				int colorOffset = p * colorChannel.strideSize;
 				int rotationOffset = p * rotationChannel.strideSize;
 
-				vertices[offset + CPU_POSITION_OFFSET] = positionChannel.data[positionOffset + ParticleChannels.XOffset];
-				vertices[offset + CPU_POSITION_OFFSET + 1] = positionChannel.data[positionOffset + ParticleChannels.YOffset];
-				vertices[offset + CPU_POSITION_OFFSET + 2] = positionChannel.data[positionOffset + ParticleChannels.ZOffset];
+				pos.x = positionChannel.data[positionOffset + ParticleChannels.XOffset];
+				pos.y = positionChannel.data[positionOffset + ParticleChannels.YOffset];
+				pos.z = positionChannel.data[positionOffset + ParticleChannels.ZOffset];
+				if (worldTransform != null) pos.mul(worldTransform);
+
+				vertices[offset + CPU_POSITION_OFFSET] = pos.x;
+				vertices[offset + CPU_POSITION_OFFSET + 1] = pos.y;
+				vertices[offset + CPU_POSITION_OFFSET + 2] = pos.z;
 				vertices[offset + CPU_COLOR_OFFSET] = colorChannel.data[colorOffset + ParticleChannels.RedOffset];
 				vertices[offset + CPU_COLOR_OFFSET + 1] = colorChannel.data[colorOffset + ParticleChannels.GreenOffset];
 				vertices[offset + CPU_COLOR_OFFSET + 2] = colorChannel.data[colorOffset + ParticleChannels.BlueOffset];

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/ParticleControllerTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/ParticleControllerTest.java
@@ -1,61 +1,89 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
 package com.badlogic.gdx.tests.g3d;
 
 import com.badlogic.gdx.Gdx;
-import com.badlogic.gdx.assets.AssetDescriptor;
-import com.badlogic.gdx.assets.AssetErrorListener;
-import com.badlogic.gdx.assets.loaders.TextureLoader.TextureParameter;
+import com.badlogic.gdx.InputMultiplexer;
 import com.badlogic.gdx.graphics.Color;
-import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Texture;
-import com.badlogic.gdx.graphics.g2d.ParticleEmitter.SpawnEllipseSide;
-import com.badlogic.gdx.graphics.g2d.TextureRegion;
-import com.badlogic.gdx.graphics.g3d.Attribute;
 import com.badlogic.gdx.graphics.g3d.Environment;
-import com.badlogic.gdx.graphics.g3d.Material;
 import com.badlogic.gdx.graphics.g3d.Model;
 import com.badlogic.gdx.graphics.g3d.ModelBatch;
 import com.badlogic.gdx.graphics.g3d.ModelInstance;
-import com.badlogic.gdx.graphics.g3d.attributes.BlendingAttribute;
 import com.badlogic.gdx.graphics.g3d.attributes.ColorAttribute;
+import com.badlogic.gdx.graphics.g3d.attributes.TextureAttribute;
 import com.badlogic.gdx.graphics.g3d.environment.DirectionalLight;
+import com.badlogic.gdx.graphics.g3d.model.Node;
+import com.badlogic.gdx.graphics.g3d.particles.ParticleChannels;
 import com.badlogic.gdx.graphics.g3d.particles.ParticleController;
+import com.badlogic.gdx.graphics.g3d.particles.ParticleEffect;
+import com.badlogic.gdx.graphics.g3d.particles.ParticleShader;
 import com.badlogic.gdx.graphics.g3d.particles.batches.BillboardParticleBatch;
+import com.badlogic.gdx.graphics.g3d.particles.batches.ModelInstanceParticleBatch;
+import com.badlogic.gdx.graphics.g3d.particles.batches.ParticleBatch;
+import com.badlogic.gdx.graphics.g3d.particles.batches.PointSpriteParticleBatch;
 import com.badlogic.gdx.graphics.g3d.particles.emitters.RegularEmitter;
 import com.badlogic.gdx.graphics.g3d.particles.influencers.ColorInfluencer;
 import com.badlogic.gdx.graphics.g3d.particles.influencers.DynamicsInfluencer;
-import com.badlogic.gdx.graphics.g3d.particles.influencers.DynamicsModifier;
 import com.badlogic.gdx.graphics.g3d.particles.influencers.DynamicsModifier.BrownianAcceleration;
+import com.badlogic.gdx.graphics.g3d.particles.influencers.Influencer;
+import com.badlogic.gdx.graphics.g3d.particles.influencers.ModelInfluencer;
 import com.badlogic.gdx.graphics.g3d.particles.influencers.RegionInfluencer;
 import com.badlogic.gdx.graphics.g3d.particles.influencers.ScaleInfluencer;
 import com.badlogic.gdx.graphics.g3d.particles.influencers.SpawnInfluencer;
-import com.badlogic.gdx.graphics.g3d.particles.influencers.ColorInfluencer.Single;
 import com.badlogic.gdx.graphics.g3d.particles.renderers.BillboardRenderer;
+import com.badlogic.gdx.graphics.g3d.particles.renderers.ModelInstanceRenderer;
+import com.badlogic.gdx.graphics.g3d.particles.renderers.PointSpriteRenderer;
 import com.badlogic.gdx.graphics.g3d.particles.values.PointSpawnShapeValue;
+import com.badlogic.gdx.graphics.g3d.utils.CameraInputController;
+import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.math.Matrix4;
 import com.badlogic.gdx.math.Quaternion;
 import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.scenes.scene2d.Action;
+import com.badlogic.gdx.scenes.scene2d.InputEvent;
 import com.badlogic.gdx.scenes.scene2d.Stage;
-import com.badlogic.gdx.scenes.scene2d.actions.Actions;
+import com.badlogic.gdx.scenes.scene2d.ui.ButtonGroup;
+import com.badlogic.gdx.scenes.scene2d.ui.CheckBox;
 import com.badlogic.gdx.scenes.scene2d.ui.Label;
 import com.badlogic.gdx.scenes.scene2d.ui.Skin;
 import com.badlogic.gdx.scenes.scene2d.ui.Table;
+import com.badlogic.gdx.scenes.scene2d.utils.ClickListener;
 import com.badlogic.gdx.utils.Array;
 
-/** @author Inferno */
-public class ParticleControllerTest extends BaseG3dTest{
-	public static final String DEFAULT_PARTICLE = "data/pre_particle.png",
-										DEFAULT_SKIN ="data/uiskin.json";
-	Quaternion tmpQuaternion = new Quaternion();
-	Matrix4 tmpMatrix = new Matrix4(), tmpMatrix4 = new Matrix4();
-	Vector3 tmpVector = new Vector3();
-	
-	private class RotationAction extends Action{
+/** @author Inferno
+ * @author jsjolund */
+public class ParticleControllerTest extends BaseG3dTest {
+	public static final String DEFAULT_PARTICLE = "data/pre_particle.png", DEFAULT_SKIN = "data/uiskin.json",
+		DEFAULT_MODEL = "data/cube.obj";
+	static final Matrix4 TMP_M1 = new Matrix4(), TMP_M2 = new Matrix4();
+	static final Quaternion TMP_Q = new Quaternion();
+	static final Vector3 TMP_V = new Vector3();
+
+	/** Action which changes a {@link ParticleController#transform}. Translates, then continually rotates the transform around an
+	 * axis, which creates a circular movement. This action creates a trail of particles when performed, since it affects where new
+	 * particles are generated. */
+	private class RotationAction extends Action {
 		private ParticleController emitter;
 		Vector3 axis;
 		float angle;
-		
-		public RotationAction (ParticleController emitter, Vector3 axis, float angle) {
+
+		public RotationAction (ParticleController emitter, Vector3 translation, Vector3 axis, float angle) {
+			emitter.setTranslation(translation);
 			this.emitter = emitter;
 			this.axis = axis;
 			this.angle = angle;
@@ -63,99 +91,122 @@ public class ParticleControllerTest extends BaseG3dTest{
 
 		@Override
 		public boolean act (float delta) {
-			emitter.getTransform(tmpMatrix);
-			tmpQuaternion.set(axis, angle*delta).toMatrix(tmpMatrix4.val);
-			tmpMatrix4.mul(tmpMatrix);
-			emitter.setTransform(tmpMatrix4);
+			emitter.getTransform(TMP_M1);
+			TMP_Q.set(axis, angle * delta).toMatrix(TMP_M2.val);
+			TMP_M2.mul(TMP_M1);
+			emitter.setTransform(TMP_M2);
 			return false;
 		}
 	}
-	
-	//Simulation
-	Array<ParticleController> emitters;
-	
-	//Rendering
+
+	/** Action which continually changes a {@link ParticleController#worldTransform}. Translation is performed on the xz-plane in a
+	 * circle around origin. Rotation is performed around the y-axis. Scale is increased and decreased along the y-axis and
+	 * xz-plane in cycles. This action does NOT create a trail of particles when performed, since it does not affect where new
+	 * particles are generated. */
+	private class WorldTransformAction extends Action {
+		private ParticleController emitter;
+
+		final static float DST_FROM_ORIGIN = 10;
+		final static float POS_SPEED = 25;
+		final static float ROT_SPEED = 75;
+		final static float SCL_SPEED = 100;
+
+		float currentPos = 0;
+		float currentRot = 0;
+		float currentScl = 0;
+
+		Vector3 pos = new Vector3();
+		Quaternion rot = new Quaternion();
+		Vector3 scl = new Vector3();
+
+		public WorldTransformAction (ParticleController emitter) {
+			this.emitter = emitter;
+		}
+
+		@Override
+		public boolean act (float delta) {
+			rot.setFromAxis(Vector3.Y, currentRot = (currentRot + delta * ROT_SPEED) % 360);
+
+			float deltaScl = MathUtils.sinDeg(currentScl = (currentScl + delta * SCL_SPEED) % 360);
+			scl.y = deltaScl * 0.5f + 1.5f;
+			scl.x = scl.z = -deltaScl * 0.5f + 1.75f;
+
+			TMP_Q.setFromAxis(Vector3.Y, currentPos = (currentPos + delta * POS_SPEED) % 360)
+				.transform(pos.set(Vector3.Z).scl(DST_FROM_ORIGIN));
+
+			if (emitter.worldTransform != null) emitter.worldTransform.set(pos, rot, scl);
+			return false;
+		}
+	}
+
+	// Simulation
+	ParticleEffect effect;
+
+	// Rendering
 	Environment environment;
+	ParticleBatch particleBatch;
 	BillboardParticleBatch billboardParticleBatch;
-	
-	//UI
+	ModelInstanceParticleBatch modelInstanceParticleBatch;
+	PointSpriteParticleBatch pointSpriteParticleBatch;
+
+	// UI
 	Stage ui;
 	Label fpsLabel;
 	StringBuilder builder;
-	
+
+	private void addController (float x, float y, float z, Vector3 actionAxis, float actionRotation,
+		ParticleController controller) {
+		controller.init();
+		controller.start();
+		effect.getControllers().add(controller);
+		ui.addAction(new RotationAction(controller, new Vector3(x, y, z), actionAxis, actionRotation));
+		ui.addAction(new WorldTransformAction(controller));
+	}
+
 	@Override
 	public void create () {
 		super.create();
-		emitters = new Array<ParticleController>();
-		assets.load(DEFAULT_PARTICLE, Texture.class);
-		assets.load(DEFAULT_SKIN, Skin.class);
-		loading = true;
-		environment = new Environment();
-		environment.set(new ColorAttribute(ColorAttribute.AmbientLight, 0f, 0f, 0.1f, 1f));
-		environment.add(new DirectionalLight().set(1f, 1f, 1f,  0, -0.5f, -1 ));
-		billboardParticleBatch = new BillboardParticleBatch();
-		billboardParticleBatch.setCamera(cam);
+
 		ui = new Stage();
 		builder = new StringBuilder();
-	}
-	
-	@Override
-	public void resize (int width, int height) {
-		super.resize(width, height);
-		ui.getViewport().setWorldSize(width, height);
-		ui.getViewport().update(width, height, true);
-	}
-	
-	@Override
-	protected void onLoaded () {
-		Texture particleTexture = assets.get(DEFAULT_PARTICLE);
-		billboardParticleBatch.setTexture(assets.get(DEFAULT_PARTICLE, Texture.class));
-		
-		//X
-		addEmitter(new float[] {1, 0.12156863f, 0.047058824f}, particleTexture, 
-								tmpVector.set(5,5,0), Vector3.X, 360);
 
-		//Y
-		addEmitter(new float[] {0.12156863f, 1, 0.047058824f}, particleTexture, 
-								tmpVector.set(0,5,-5), Vector3.Y, -360);
-		
-		//Z
-		addEmitter(new float[] {0.12156863f, 0.047058824f, 1}, particleTexture, 
-			tmpVector.set(0,5,5), Vector3.Z, -360);
+		effect = new ParticleEffect();
 
-		setupUI();
-	}
-	
-	private void addEmitter(	float[] colors, Texture particleTexture, 
-														Vector3 translation, 
-														Vector3 actionAxis, float actionRotation){
-		ParticleController controller = createBillboardController(colors, particleTexture);
-		controller.init();
-		controller.start();
-		emitters.add(controller);
-		controller.translate(translation);
-		ui.addAction(new RotationAction(controller, actionAxis, actionRotation));
+		assets.load(DEFAULT_PARTICLE, Texture.class);
+		assets.load(DEFAULT_SKIN, Skin.class);
+		assets.load(DEFAULT_MODEL, Model.class);
+		loading = true;
+
+		environment = new Environment();
+		environment.set(new ColorAttribute(ColorAttribute.AmbientLight, 0f, 0f, 0.1f, 1f));
+		environment.add(new DirectionalLight().set(1f, 1f, 1f, 0, -0.5f, -1));
+
+		modelInstanceParticleBatch = new ModelInstanceParticleBatch();
+
+		pointSpriteParticleBatch = new PointSpriteParticleBatch();
+		pointSpriteParticleBatch.setCamera(cam);
+
+		billboardParticleBatch = new BillboardParticleBatch();
+		billboardParticleBatch.setCamera(cam);
+		billboardParticleBatch.setUseGpu(false);
+		billboardParticleBatch.setAlignMode(ParticleShader.AlignMode.ViewPoint);
+
+		particleBatch = billboardParticleBatch;
+
+		InputMultiplexer multiplexer = new InputMultiplexer();
+		multiplexer.addProcessor(ui);
+		multiplexer.addProcessor(new CameraInputController(cam));
+		Gdx.input.setInputProcessor(multiplexer);
+
+		cam.position.add(TMP_V.set(cam.direction).scl(-20));
+		cam.update();
 	}
 
-	private void setupUI () {
-		Skin skin = assets.get(DEFAULT_SKIN);
-		Table table = new Table();
-		table.setFillParent(true);
-		table.top().left().add(new Label("FPS ", skin)).left();
-		table.add(fpsLabel = new Label("", skin)).left().expandX().row();
-		ui.addActor(table);
-	}
+	private Array<Influencer> createInfluencers (float[] colors) {
+		Array<Influencer> influencers = new Array<Influencer>();
 
-	private ParticleController createBillboardController (float[] colors, Texture particleTexture) {
-		//Emission
-		RegularEmitter emitter = new RegularEmitter();
-		emitter.getDuration().setLow(3000);
-		emitter.getEmission().setHigh(2900);
-		emitter.getLife().setHigh(1000);
-		emitter.setMaxParticleCount(3000);
-
-		//Spawn
-		PointSpawnShapeValue pointSpawnShapeValue = new PointSpawnShapeValue();		
+		// Spawn
+		PointSpawnShapeValue pointSpawnShapeValue = new PointSpawnShapeValue();
 		pointSpawnShapeValue.xOffsetValue.setLow(0, 1f);
 		pointSpawnShapeValue.xOffsetValue.setActive(true);
 		pointSpawnShapeValue.yOffsetValue.setLow(0, 1f);
@@ -163,59 +214,248 @@ public class ParticleControllerTest extends BaseG3dTest{
 		pointSpawnShapeValue.zOffsetValue.setLow(0, 1f);
 		pointSpawnShapeValue.zOffsetValue.setActive(true);
 		SpawnInfluencer spawnSource = new SpawnInfluencer(pointSpawnShapeValue);
+		influencers.add(spawnSource);
 
-		//Scale
+		// Scale
 		ScaleInfluencer scaleInfluencer = new ScaleInfluencer();
-		scaleInfluencer.value.setTimeline(new float[]{0, 1});
-		scaleInfluencer.value.setScaling(new float[]{1, 0});
+		scaleInfluencer.value.setTimeline(new float[] {0, 1});
+		scaleInfluencer.value.setScaling(new float[] {1, 0});
 		scaleInfluencer.value.setLow(0);
 		scaleInfluencer.value.setHigh(1);
+		influencers.add(scaleInfluencer);
 
-		//Color
+		// Color
 		ColorInfluencer.Single colorInfluencer = new ColorInfluencer.Single();
-		colorInfluencer.colorValue.setColors(new float[] {colors[0], colors[1], colors[2], 0,0,0});
+		colorInfluencer.colorValue.setColors(new float[] {colors[0], colors[1], colors[2], 0, 0, 0});
 		colorInfluencer.colorValue.setTimeline(new float[] {0, 1});
 		colorInfluencer.alphaValue.setHigh(1);
 		colorInfluencer.alphaValue.setTimeline(new float[] {0, 0.5f, 0.8f, 1});
 		colorInfluencer.alphaValue.setScaling(new float[] {0, 0.15f, 0.5f, 0});
-		
-		//Dynamics
+		influencers.add(colorInfluencer);
+
+		// Dynamics
 		DynamicsInfluencer dynamicsInfluencer = new DynamicsInfluencer();
 		BrownianAcceleration modifier = new BrownianAcceleration();
-		modifier.strengthValue.setTimeline(new float[]{0,1});
-		modifier.strengthValue.setScaling(new float[]{0,1});
+		modifier.strengthValue.setTimeline(new float[] {0, 1});
+		modifier.strengthValue.setScaling(new float[] {0, 1});
 		modifier.strengthValue.setHigh(80);
 		modifier.strengthValue.setLow(1, 5);
 		dynamicsInfluencer.velocities.add(modifier);
-		
-		return new ParticleController("Billboard Controller", emitter, new BillboardRenderer(billboardParticleBatch),
-			new RegionInfluencer.Single(particleTexture),
-			spawnSource,
-			scaleInfluencer,
-			colorInfluencer,
-			dynamicsInfluencer
-			);
+		influencers.add(dynamicsInfluencer);
+		return influencers;
+	}
+
+	private ParticleController createBillboardController (float[] colors, Texture particleTexture) {
+		RegularEmitter emitter = new RegularEmitter();
+		emitter.getDuration().setLow(3000);
+		emitter.getEmission().setHigh(2900);
+		emitter.getLife().setHigh(1000);
+		emitter.setMaxParticleCount(3000);
+		ParticleController controller = new ParticleController();
+		controller.name = "Billboard Controller";
+		controller.emitter = emitter;
+		controller.renderer = new BillboardRenderer(billboardParticleBatch);
+		controller.particleChannels = new ParticleChannels();
+		controller.influencers = createInfluencers(colors);
+		controller.influencers.add(new RegionInfluencer.Single(particleTexture));
+		return controller;
+	}
+
+	private ParticleController createModelInstanceController (float[] colors, Model model) {
+		RegularEmitter emitter = new RegularEmitter();
+		emitter.getDuration().setLow(3000);
+		emitter.getEmission().setHigh(900);
+		emitter.getLife().setHigh(1000);
+		emitter.setMaxParticleCount(3000);
+		ParticleController controller = new ParticleController();
+		controller.name = "ModelInstance Controller";
+		controller.emitter = emitter;
+		controller.renderer = new ModelInstanceRenderer(modelInstanceParticleBatch);
+		controller.particleChannels = new ParticleChannels();
+		controller.influencers = createInfluencers(colors);
+		controller.influencers.add(new ModelInfluencer.Single(model));
+		return controller;
+	}
+
+	private ParticleController createPointSpriteController (float[] colors) {
+		RegularEmitter emitter = new RegularEmitter();
+		emitter.getDuration().setLow(3000);
+		emitter.getEmission().setHigh(2900);
+		emitter.getLife().setHigh(1000);
+		emitter.setMaxParticleCount(3000);
+		ParticleController controller = new ParticleController();
+		controller.name = "PointSprite Controller";
+		controller.emitter = emitter;
+		controller.renderer = new PointSpriteRenderer(pointSpriteParticleBatch);
+		controller.particleChannels = new ParticleChannels();
+		controller.influencers = createInfluencers(colors);
+		return controller;
+	}
+
+	@Override
+	public void dispose () {
+		super.dispose();
+		ui.dispose();
+		effect.dispose();
+	}
+
+	@Override
+	protected void onLoaded () {
+		pointSpriteParticleBatch.setTexture(assets.get(DEFAULT_PARTICLE, Texture.class));
+
+		final Model particleModel = assets.get(DEFAULT_MODEL, Model.class);
+		for (Node node : particleModel.nodes)
+			node.scale.scl(0.3f);
+		particleModel.materials.first().remove(TextureAttribute.Diffuse);
+		particleModel.materials.first().set(new ColorAttribute(ColorAttribute.AmbientLight, Color.WHITE));
+
+		Texture particleTexture = assets.get(DEFAULT_PARTICLE);
+		billboardParticleBatch.setTexture(assets.get(DEFAULT_PARTICLE, Texture.class));
+
+		float[] colorRed = new float[] {1, 0.12156863f, 0.047058824f};
+		float[] colorGreen = new float[] {0.12156863f, 1, 0.047058824f};
+		float[] colorBlue = new float[] {0.12156863f, 0.047058824f, 1};
+
+		addController(5, 5, 0, Vector3.X, 360, createBillboardController(colorRed, particleTexture));
+		addController(0, 5, -5, Vector3.Y, -360, createBillboardController(colorGreen, particleTexture));
+		addController(0, 5, 5, Vector3.Z, -360, createBillboardController(colorBlue, particleTexture));
+
+		addController(5, 5, 0, Vector3.X, 360, createModelInstanceController(colorRed, particleModel));
+		addController(0, 5, -5, Vector3.Y, -360, createModelInstanceController(colorGreen, particleModel));
+		addController(0, 5, 5, Vector3.Z, -360, createModelInstanceController(colorBlue, particleModel));
+
+		addController(5, 5, 0, Vector3.X, 360, createPointSpriteController(colorRed));
+		addController(0, 5, -5, Vector3.Y, -360, createPointSpriteController(colorGreen));
+		addController(0, 5, 5, Vector3.Z, -360, createPointSpriteController(colorBlue));
+
+		setupUI();
 	}
 
 	@Override
 	protected void render (ModelBatch batch, Array<ModelInstance> instances) {
-		if(emitters.size > 0){
-			//Update
+		if (effect.getControllers().size > 0) {
+			// Update
 			float delta = Gdx.graphics.getDeltaTime();
 			builder.delete(0, builder.length());
 			builder.append(Gdx.graphics.getFramesPerSecond());
 			fpsLabel.setText(builder);
 			ui.act(delta);
 
-			billboardParticleBatch.begin();
-			for (ParticleController controller : emitters){
-				controller.update();
-				controller.draw();
+			particleBatch.begin();
+			for (ParticleController controller : effect.getControllers()) {
+				if (controller.renderer.isCompatible(particleBatch)) {
+					controller.update();
+					controller.draw();
+				}
 			}
-			billboardParticleBatch.end();
-			batch.render(billboardParticleBatch, environment);
+			particleBatch.end();
+			batch.render(particleBatch, environment);
 		}
 		batch.render(instances, environment);
 		ui.draw();
 	}
+
+	@Override
+	public void resize (int width, int height) {
+		super.resize(width, height);
+		ui.getViewport().setWorldSize(width, height);
+		ui.getViewport().update(width, height, true);
+	}
+
+	private void setupUI () {
+		Skin skin = assets.get(DEFAULT_SKIN);
+		Table topTable = new Table();
+		topTable.setFillParent(true);
+		topTable.top().left().add(new Label("FPS ", skin)).left();
+		topTable.add(fpsLabel = new Label("", skin)).left().expandX().row();
+		ui.addActor(topTable);
+
+		Table bottomTable = new Table();
+		bottomTable.setFillParent(true);
+
+		final CheckBox boxUseWorldTransform = new CheckBox("Use world transform matrix", skin);
+		boxUseWorldTransform.addListener(new ClickListener() {
+			boolean useWorldTransform = false;
+
+			@Override
+			public boolean touchDown (InputEvent event, float x, float y, int pointer, int button) {
+				useWorldTransform = !useWorldTransform;
+				effect.setWorldTransform((useWorldTransform) ? new Matrix4() : null);
+				return true;
+			}
+		});
+		final CheckBox boxScaleParticles = new CheckBox("World transform scales particles", skin);
+		boxScaleParticles.addListener(new ClickListener() {
+			boolean scaleParticles = false;
+
+			@Override
+			public boolean touchDown (InputEvent event, float x, float y, int pointer, int button) {
+				scaleParticles = !scaleParticles;
+				for (ParticleController ctrl : effect.getControllers())
+					ctrl.worldTransformScalesParticles = scaleParticles;
+				return true;
+			}
+		});
+		final CheckBox boxBillboardsGPU = new CheckBox("Billboards use GPU", skin);
+		boxBillboardsGPU.addListener(new ClickListener() {
+			@Override
+			public boolean touchDown (InputEvent event, float x, float y, int pointer, int button) {
+				billboardParticleBatch.setUseGpu(!billboardParticleBatch.isUseGPU());
+				return true;
+			}
+		});
+		final CheckBox boxAlignScreen = new CheckBox("Billboards align to screen", skin);
+		boxAlignScreen.addListener(new ClickListener() {
+			@Override
+			public boolean touchDown (InputEvent event, float x, float y, int pointer, int button) {
+				boolean alignScreen = (billboardParticleBatch.getAlignMode() == ParticleShader.AlignMode.Screen);
+				billboardParticleBatch
+					.setAlignMode(alignScreen ? ParticleShader.AlignMode.ViewPoint : ParticleShader.AlignMode.Screen);
+				return true;
+			}
+		});
+		final CheckBox boxBillboardBatch = new CheckBox("BillboardParticleBatch", skin);
+		boxBillboardBatch.addListener(new ClickListener() {
+			@Override
+			public boolean touchDown (InputEvent event, float x, float y, int pointer, int button) {
+				particleBatch = billboardParticleBatch;
+				return true;
+			}
+		});
+		final CheckBox boxModelBatch = new CheckBox("ModelInstanceParticleBatch", skin);
+		boxModelBatch.addListener(new ClickListener() {
+			@Override
+			public boolean touchDown (InputEvent event, float x, float y, int pointer, int button) {
+				particleBatch = modelInstanceParticleBatch;
+				return true;
+			}
+		});
+		final CheckBox boxPointBatch = new CheckBox("PointSpriteParticleBatch", skin);
+		boxPointBatch.addListener(new ClickListener() {
+			@Override
+			public boolean touchDown (InputEvent event, float x, float y, int pointer, int button) {
+				particleBatch = pointSpriteParticleBatch;
+				return true;
+			}
+		});
+		ButtonGroup<CheckBox> batchesBoxes = new ButtonGroup<CheckBox>(boxBillboardBatch, boxModelBatch, boxPointBatch);
+
+		boxBillboardsGPU.setChecked(billboardParticleBatch.isUseGPU());
+		boxAlignScreen.setChecked(billboardParticleBatch.getAlignMode() == ParticleShader.AlignMode.Screen);
+		if (particleBatch == billboardParticleBatch)
+			boxBillboardBatch.setChecked(true);
+		else if (particleBatch == modelInstanceParticleBatch)
+			boxModelBatch.setChecked(true);
+		else if (particleBatch == pointSpriteParticleBatch) boxPointBatch.setChecked(true);
+
+		bottomTable.bottom().left().add(boxUseWorldTransform).left().row();
+		bottomTable.bottom().left().add(boxScaleParticles).left().row();
+		bottomTable.bottom().left().add(boxBillboardsGPU).left().row();
+		bottomTable.bottom().left().add(boxAlignScreen).left().row();
+		for (CheckBox box : batchesBoxes.getButtons())
+			bottomTable.bottom().left().add(box).left().row();
+
+		ui.addActor(bottomTable);
+	}
+
 }


### PR DESCRIPTION
Addresses issue #3264. Adds a ```Matrix4``` to ```ParticleController#worldTransform```, which is used by ```BillboardParticleBatch```, ```PointSpriteParticleBatch``` and ```ModelInstanceRenderer``` when setting the vertices of their ```Renderable```.

In effect, this addition allows entire particle controllers (emitters as well as dynamic influencers) to be translated, rotated and scaled as one would expect. As mentioned in the issue, ```ParticleController#transform``` does not allow this.

A boolean ```ParticleController#worldTransformScalesParticles``` allows the scaling aspect of ```worldTransform``` to be applied to the size of particles.

Another way to implement this would be to let the Batches/Renderers create a separate ```Renderable``` for each ```ParticleController```, then set ```Renderable#worldTransform``` to the one of the controller. However, that would create problems for the billboard particle system, since after ```Renderable#worldTransform``` has been applied, the billboards would not necessarily be aligned correctly to the camera. Another problem is that this would remove the possibility of disabling particle size scaling by ```ParticleController#worldTransform```.

It would be possible to optimize this a bit by letting ```ParticleController#worldTransform = null``` by default and checking for this in the batches/renderers. Then the vertices would only be multiplied by this matrix if it is not null.

The pull request also contains a test program for the transformations, demo at
[http://youtu.be/ApcB0SWciUM](http://youtu.be/ApcB0SWciUM)

Please tell me what you think of these changes.