### PR TITLE
Make Xbox Controller linux friendly

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,7 @@
 - API Change: renamed Lwjgl3WindowListener.windowIsClosing() to closeRequested() to better communicate its intent.
 - Add IndexData.updateIndices method to increase performance when used with IndexBufferObjectSubData. 
 - Added FlushablePool
+- Added Linux mappings to com.badlogic.gdx.controllers.mappings.Xbox
 
 [1.9.2]
 - Added TextureArray wrapper see https://github.com/libgdx/libgdx/pull/3807

--- a/extensions/gdx-controllers/gdx-controllers/src/com/badlogic/gdx/controllers/mappings/Xbox.java
+++ b/extensions/gdx-controllers/gdx-controllers/src/com/badlogic/gdx/controllers/mappings/Xbox.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
- *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,14 +18,15 @@ package com.badlogic.gdx.controllers.mappings;
 
 import com.badlogic.gdx.controllers.Controller;
 import com.badlogic.gdx.utils.SharedLibraryLoader;
+import com.badlogic.jglfw.utils.SharedLibraryLoader;
 
 /** Mappings for the Xbox series of controllers. Works only on desktop so far.
- * 
+ *
  * See <a href="https://upload.wikimedia.org/wikipedia/commons/thumb/2/2c/360_controller.svg/450px-360_controller.svg.png">this
  * image</a> which describes each button and axes.
- * 
+ *
  * All codes are for buttons expect the L_STICK_XXX, R_STICK_XXX, L_BUMPER and R_BUMPER codes, which are axes.
- * 
+ *
  * @author badlogic */
 public class Xbox {
 	// Buttons
@@ -42,11 +43,14 @@ public class Xbox {
 	public static final int DPAD_DOWN;
 	public static final int DPAD_LEFT;
 	public static final int DPAD_RIGHT;
+	public static final int L3;
+	public static final int R3;
+
 
 	// Axes
-	/** left trigger, -1 if not pressed, 1 if pressed **/
+	/** left trigger, -1 if not pressed, 1 if pressed, 0 is initial value **/
 	public static final int L_TRIGGER;
-	/** right trigger, -1 if not pressed, 1 if pressed **/
+	/** right trigger, -1 if not pressed, 1 if pressed, 0 is initial value **/
 	public static final int R_TRIGGER;
 	/** left stick vertical axis, -1 if up, 1 if down **/
 	public static final int L_STICK_VERTICAL_AXIS;
@@ -78,26 +82,30 @@ public class Xbox {
 			L_STICK_HORIZONTAL_AXIS = -1;
 			R_STICK_VERTICAL_AXIS = -1;
 			R_STICK_HORIZONTAL_AXIS = -1;
+			L3 = -1;
+			R3 = -1;
 		} else if (SharedLibraryLoader.isLinux) {
-			A = -1;
-			B = -1;
-			X = -1;
-			Y = -1;
-			GUIDE = -1;
-			L_BUMPER = -1;
-			R_BUMPER = -1;
-			BACK = -1;
-			START = -1;
-			DPAD_UP = -1;
-			DPAD_DOWN = -1;
-			DPAD_LEFT = -1;
-			DPAD_RIGHT = -1;
-			L_TRIGGER = -1;
-			R_TRIGGER = -1;
-			L_STICK_VERTICAL_AXIS = -1;
-			L_STICK_HORIZONTAL_AXIS = -1;
-			R_STICK_VERTICAL_AXIS = -1;
-			R_STICK_HORIZONTAL_AXIS = -1;
+			A = 0;
+			B = 1;
+			X = 2;
+			Y = 3;
+			GUIDE = 8;
+			L_BUMPER = 4;
+			R_BUMPER = 5;
+			BACK = 6;
+			START = 7;
+			DPAD_UP = 0;
+			DPAD_DOWN = 1;
+			DPAD_LEFT = 2;
+			DPAD_RIGHT = 3;
+			L_TRIGGER = 2;
+			R_TRIGGER = 5;
+			L_STICK_VERTICAL_AXIS = 1;
+			L_STICK_HORIZONTAL_AXIS = 0;
+			R_STICK_VERTICAL_AXIS = 4;
+			R_STICK_HORIZONTAL_AXIS = 3;
+			L3 = 9;
+			R3 = 10;
 		} else if (SharedLibraryLoader.isMac) {
 			A = 11;
 			B = 12;
@@ -118,6 +126,8 @@ public class Xbox {
 			L_STICK_HORIZONTAL_AXIS = 2;
 			R_STICK_VERTICAL_AXIS = 5;
 			R_STICK_HORIZONTAL_AXIS = 4;
+			L3 = -1;
+			R3 = -1;
 		} else {
 			A = -1;
 			B = -1;
@@ -138,12 +148,14 @@ public class Xbox {
 			L_STICK_HORIZONTAL_AXIS = -1;
 			R_STICK_VERTICAL_AXIS = -1;
 			R_STICK_HORIZONTAL_AXIS = -1;
+			L3 = -1;
+			R3 = -1;
 		}
 	}
-	
+
 	/** @return whether the {@link Controller} is an Xbox controller
 	 */
 	public static boolean isXboxController(Controller controller) {
-		return controller.getName().contains("Xbox");
+		return controller.getName().matches("(.*)(X-?[Bb]ox|Microsoft PC-joystick)(.*)");
 	}
 }

--- a/gdx/src/com/badlogic/gdx/maps/tiled/BaseTmxMapLoader.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/BaseTmxMapLoader.java
@@ -242,8 +242,8 @@ public abstract class BaseTmxMapLoader<P extends AssetLoaderParameters<TiledMap>
 			if (id != 0) {
 				object.getProperties().put("id", id);
 			}
-			object.getProperties().put("x", x * scaleX);
-			object.getProperties().put("y", (flipY ? y - height : y) * scaleY);
+			object.getProperties().put("x", x);
+			object.getProperties().put("y", (flipY ? y - height : y));
 			object.getProperties().put("width", width);
 			object.getProperties().put("height", height);
 			object.setVisible(element.getIntAttribute("visible", 1) == 1);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/XboxControllerTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/XboxControllerTest.java
@@ -1,0 +1,139 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogic.gdx.tests;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.controllers.Controller;
+import com.badlogic.gdx.controllers.Controllers;
+import com.badlogic.gdx.controllers.PovDirection;
+import com.badlogic.gdx.controllers.mappings.Xbox;
+import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.tests.utils.GdxTest;
+
+public class XboxControllerTest extends GdxTest {
+
+	private static final String LOG_TAG = "Xbox Controller";
+	private Controller controller;
+
+	public void create () {
+		controller = Controllers.getControllers().first();
+		if (controller == null) {
+			Gdx.app.log(LOG_TAG, "No controller connected");
+			Gdx.app.exit();
+			return;
+		}
+
+		Gdx.app.log(LOG_TAG, controller.getName());
+		Gdx.app.log(LOG_TAG, "Is Xbox: " + Xbox.isXboxController(controller));
+	}
+
+	float lastLt = 0.0f;
+	float lastRt = 0.0f;
+	PovDirection lastPov;
+
+	public void render () {
+		Gdx.gl.glClearColor(0.2f, 0.2f, 0.2f, 1);
+		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+
+		if (controller.getButton(Xbox.A)) {
+			Gdx.app.log(LOG_TAG, "Button A was pressed");
+		}
+
+		if (controller.getButton(Xbox.B)) {
+			Gdx.app.log(LOG_TAG, "Button B was pressed");
+		}
+
+		if (controller.getButton(Xbox.X)) {
+			Gdx.app.log(LOG_TAG, "Button X was pressed");
+		}
+
+		if (controller.getButton(Xbox.Y)) {
+			Gdx.app.log(LOG_TAG, "Button Y was pressed");
+		}
+
+		if (controller.getButton(Xbox.BACK)) {
+			Gdx.app.log(LOG_TAG, "Button BACK was pressed");
+		}
+
+		if (controller.getButton(Xbox.GUIDE)) {
+			Gdx.app.log(LOG_TAG, "Button GUIDE was pressed");
+		}
+
+		if (controller.getButton(Xbox.START)) {
+			Gdx.app.log(LOG_TAG, "Button START was pressed");
+		}
+
+		if (controller.getButton(Xbox.L_BUMPER)) {
+			Gdx.app.log(LOG_TAG, "Button LB was pressed");
+		}
+
+		if (controller.getButton(Xbox.R_BUMPER)) {
+			Gdx.app.log(LOG_TAG, "Button RB was pressed");
+		}
+
+		if (controller.getButton(Xbox.L3)) {
+			Gdx.app.log(LOG_TAG, "Button L3 was pressed");
+		}
+
+		if (controller.getButton(Xbox.R3)) {
+			Gdx.app.log(LOG_TAG, "Button R3 was pressed");
+		}
+
+		if (Math.abs(controller.getAxis(Xbox.L_STICK_HORIZONTAL_AXIS)) > 0.2f) {
+			Gdx.app.log(LOG_TAG, "Left stick (horizontal): " + controller.getAxis(Xbox.L_STICK_HORIZONTAL_AXIS));
+		}
+
+		if (Math.abs(controller.getAxis(Xbox.L_STICK_VERTICAL_AXIS)) > 0.2f) {
+			Gdx.app.log(LOG_TAG, "Left stick (vertical): " + controller.getAxis(Xbox.L_STICK_VERTICAL_AXIS));
+		}
+
+		if (Math.abs(controller.getAxis(Xbox.R_STICK_HORIZONTAL_AXIS)) > 0.2f) {
+			Gdx.app.log(LOG_TAG, "Right stick (horizontal): " + controller.getAxis(Xbox.R_STICK_HORIZONTAL_AXIS));
+		}
+
+		if (Math.abs(controller.getAxis(Xbox.R_STICK_VERTICAL_AXIS)) > 0.2f) {
+			Gdx.app.log(LOG_TAG, "Right stick (vertical): " + controller.getAxis(Xbox.R_STICK_VERTICAL_AXIS));
+		}
+
+		if (controller.getAxis(Xbox.L_TRIGGER) != lastLt) {
+			lastLt = controller.getAxis(Xbox.L_TRIGGER);
+			Gdx.app.log(LOG_TAG, "Left trigger: " + lastLt);
+		}
+
+		if (controller.getAxis(Xbox.R_TRIGGER) != lastRt) {
+			lastRt = controller.getAxis(Xbox.R_TRIGGER);
+			Gdx.app.log(LOG_TAG, "Right trigger: " + lastRt);
+		}
+
+		PovDirection pov;
+		if ((pov = controller.getPov(Xbox.DPAD_LEFT)) != lastPov) {
+			lastPov = pov;
+			Gdx.app.log(LOG_TAG, "POV: " + pov);
+		} else if ((pov = controller.getPov(Xbox.DPAD_UP)) != lastPov) {
+			lastPov = pov;
+			Gdx.app.log(LOG_TAG, "POV: " + pov);
+		} else if ((pov = controller.getPov(Xbox.DPAD_RIGHT)) != lastPov) {
+			lastPov = pov;
+			Gdx.app.log(LOG_TAG, "POV: " + pov);
+		} else if ((pov = controller.getPov(Xbox.DPAD_DOWN)) != lastPov) {
+			lastPov = pov;
+			Gdx.app.log(LOG_TAG, "POV: " + pov);
+		}
+
+	}
+
+}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
@@ -260,7 +260,8 @@ public class GdxTests {
 		FreeTypeTest.class,
 		InternationalFontsTest.class,
 		PngTest.class,
-		JsonTest.class
+		JsonTest.class,
+		XboxControllerTest.class
 		// @on
 
 		// SoundTouchTest.class, Mpg123Test.class, WavTest.class, FreeTypeTest.class,


### PR DESCRIPTION
- Added key mappings for linux
- Added 2 new buttons to Xbox: L3 and R3
- Made Xbox#isXboxController() match more variants
- Added test called XboxControllerTest

Wanted to add controller support and working on linux, found out that the Xbox class didn't have the keys mapped for linux. Also improved it at some points.

I tested this on Linux Mint 17.3. 

Few questions:
- Do we need to be a bit more careful, because of the wide variety of linux distros?
- Do I need to add the changes to the `CHANGES` doc?

This fixes a part of https://github.com/libgdx/libgdx/issues/3879