### PR TITLE
[Stage2D] Adjust Stage mouse input

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/Stage.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/Stage.java
@@ -258,8 +258,8 @@ public class Stage extends InputAdapter implements Disposable {
 	/** Applies a touch down event to the stage and returns true if an actor in the scene {@link Event#handle() handled} the event. */
 	public boolean touchDown (int screenX, int screenY, int pointer, int button) {
 		if (screenX < viewport.getScreenX() || screenX >= viewport.getScreenX() + viewport.getScreenWidth()) return false;
-		if (Gdx.graphics.getHeight() - screenY < viewport.getScreenY()
-			|| Gdx.graphics.getHeight() - screenY >= viewport.getScreenY() + viewport.getScreenHeight()) return false;
+		if (viewport.getScreenHeight() - screenY < viewport.getScreenY()
+			|| viewport.getScreenHeight() - screenY >= viewport.getScreenY() + viewport.getScreenHeight()) return false;
 
 		pointerTouched[pointer] = true;
 		pointerScreenX[pointer] = screenX;
@@ -364,8 +364,8 @@ public class Stage extends InputAdapter implements Disposable {
 	 * This event only occurs on the desktop. */
 	public boolean mouseMoved (int screenX, int screenY) {
 		if (screenX < viewport.getScreenX() || screenX >= viewport.getScreenX() + viewport.getScreenWidth()) return false;
-		if (Gdx.graphics.getHeight() - screenY < viewport.getScreenY()
-			|| Gdx.graphics.getHeight() - screenY >= viewport.getScreenY() + viewport.getScreenHeight()) return false;
+		if (viewport.getScreenHeight() - screenY < viewport.getScreenY()
+			|| viewport.getScreenHeight() - screenY >= viewport.getScreenY() + viewport.getScreenHeight()) return false;
 
 		mouseScreenX = screenX;
 		mouseScreenY = screenY;


### PR DESCRIPTION
Adjusts mouse input y-coordinate to be relative to the viewport's height instead of the window's height.  This was a necessary change to my own game where I render a stage to a framebuffer at a constant screen and world size, so as to prevent distortion from texture filtering on individual actors due to my assets being extremely low resolution.  Since there are times when my window might be a larger height than the framebuffer's resolution, and consequently the stage's resolution, the input would be incorrectly positioned and handled if not for this change.