### PR TITLE
Start RelativeTemporalAction at 100% when reversed

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,7 @@
 - API Change: renamed Lwjgl3WindowListener.windowIsClosing() to closeRequested() to better communicate its intent.
 - Add IndexData.updateIndices method to increase performance when used with IndexBufferObjectSubData. 
 - Added FlushablePool
+- Fixed RelativeTemporalAction to start at 100% when reversed
 
 [1.9.2]
 - Added TextureArray wrapper see https://github.com/libgdx/libgdx/pull/3807

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/RelativeTemporalAction.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/RelativeTemporalAction.java
@@ -22,7 +22,7 @@ abstract public class RelativeTemporalAction extends TemporalAction {
 	private float lastPercent;
 
 	protected void begin () {
-		lastPercent = 0;
+		lastPercent = isReverse() ? 1 : 0;
 	}
 
 	protected void update (float percent) {


### PR DESCRIPTION
`TemporalAction` [subtracts the percent from 1][1] on `update` if `reverse` is `true`. In `RelativeTemporalAction`, `update` [subtracts the current percent from the last percent][2]. That means the first update will be ~1, and since `lastPercent` is 0, that value will be passed on to `updateRelative`.

Since we're moving backwards when reversed, I think it makes sense to start 1 here.

[1]: https://github.com/libgdx/libgdx/blob/714d82c829973b4d6cfd205e6a38706c6df897f3/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/TemporalAction.java#L60
[2]: https://github.com/libgdx/libgdx/blob/714d82c829973b4d6cfd205e6a38706c6df897f3/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/RelativeTemporalAction.java#L29