### PR TITLE
Replace all thread-safe StringBuffers with regular StringBuilders

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidInput.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidInput.java
@@ -795,7 +795,7 @@ public class AndroidInput implements Input, OnKeyListener, OnTouchListener {
 			if (realId[i] == pointerId) return i;
 		}
 
-		StringBuffer buf = new StringBuffer();
+		StringBuilder  buf = new StringBuilder ();
 		for (int i = 0; i < len; i++) {
 			buf.append(i + ":" + realId[i] + " ");
 		}

--- a/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/AndroidNdkScriptGenerator.java
+++ b/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/AndroidNdkScriptGenerator.java
@@ -63,7 +63,7 @@ public class AndroidNdkScriptGenerator {
 		String template = new FileDescriptor("com/badlogic/gdx/jnigen/resources/scripts/Android.mk.template", FileType.Classpath)
 			.readString();
 
-		StringBuffer srcFiles = new StringBuffer();
+		StringBuilder  srcFiles = new StringBuilder ();
 		for (int i = 0; i < files.size(); i++) {
 			if (i > 0) srcFiles.append("\t");
 			srcFiles.append(files.get(i).path().replace('\\', '/').replace(config.jniDir.toString() + "/", ""));
@@ -73,7 +73,7 @@ public class AndroidNdkScriptGenerator {
 				srcFiles.append("\n");
 		}
 
-		StringBuffer headerDirs = new StringBuffer();
+		StringBuilder  headerDirs = new StringBuilder ();
 		for (String headerDir : target.headerDirs) {
 			headerDirs.append(headerDir);
 			headerDirs.append(" ");

--- a/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/AntScriptGenerator.java
+++ b/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/AntScriptGenerator.java
@@ -116,9 +116,9 @@ public class AntScriptGenerator {
 		// generate the master build script
 		String template = new FileDescriptor("com/badlogic/gdx/jnigen/resources/scripts/build.xml.template", FileType.Classpath)
 			.readString();
-		StringBuffer clean = new StringBuffer();
-		StringBuffer compile = new StringBuffer();
-		StringBuffer pack = new StringBuffer();
+		StringBuilder  clean = new StringBuilder ();
+		StringBuilder  compile = new StringBuilder ();
+		StringBuilder  pack = new StringBuilder ();
 
 		for (int i = 0; i < buildFiles.size(); i++) {
 			clean.append("\t\t<ant antfile=\"" + buildFiles.get(i) + "\" target=\"clean\"/>\n");
@@ -219,26 +219,26 @@ public class AntScriptGenerator {
 
 		// generate include and exclude fileset Ant description for C/C++
 		// append memcpy_wrap.c to list of files to be build
-		StringBuffer cIncludes = new StringBuffer();
+		StringBuilder  cIncludes = new StringBuilder ();
 		cIncludes.append("\t\t<include name=\"memcpy_wrap.c\"/>\n");
 		for (String cInclude : target.cIncludes) {
 			cIncludes.append("\t\t<include name=\"" + cInclude + "\"/>\n");
 		}
-		StringBuffer cppIncludes = new StringBuffer();
+		StringBuilder  cppIncludes = new StringBuilder ();
 		for (String cppInclude : target.cppIncludes) {
 			cppIncludes.append("\t\t<include name=\"" + cppInclude + "\"/>\n");
 		}
-		StringBuffer cExcludes = new StringBuffer();
+		StringBuilder  cExcludes = new StringBuilder ();
 		for (String cExclude : target.cExcludes) {
 			cExcludes.append("\t\t<exclude name=\"" + cExclude + "\"/>\n");
 		}
-		StringBuffer cppExcludes = new StringBuffer();
+		StringBuilder  cppExcludes = new StringBuilder ();
 		for (String cppExclude : target.cppExcludes) {
 			cppExcludes.append("\t\t<exclude name=\"" + cppExclude + "\"/>\n");
 		}
 
 		// generate C/C++ header directories
-		StringBuffer headerDirs = new StringBuffer();
+		StringBuilder  headerDirs = new StringBuilder ();
 		for (String headerDir : target.headerDirs) {
 			headerDirs.append("\t\t\t<arg value=\"-I" + headerDir + "\"/>\n");
 		}

--- a/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/NativeCodeGenerator.java
+++ b/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/NativeCodeGenerator.java
@@ -294,7 +294,7 @@ public class NativeCodeGenerator {
 		}
 	}
 
-	protected void emitHeaderInclude (StringBuffer buffer, String fileName) {
+	protected void emitHeaderInclude (StringBuilder  buffer, String fileName) {
 		buffer.append("#include <" + fileName + ">\n");
 	}
 
@@ -303,7 +303,7 @@ public class NativeCodeGenerator {
 		String headerFileContent = hFile.readString();
 		ArrayList<CMethod> cMethods = cMethodParser.parse(headerFileContent).getMethods();
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder  buffer = new StringBuilder ();
 		emitHeaderInclude(buffer, hFile.name());
 
 		for (JavaSegment segment : javaSegments) {
@@ -354,23 +354,23 @@ public class NativeCodeGenerator {
 		return null;
 	}
 
-	private void emitLineMarker (StringBuffer buffer, int line) {
+	private void emitLineMarker (StringBuilder  buffer, int line) {
 		buffer.append("\n//@line:");
 		buffer.append(line);
 		buffer.append("\n");
 	}
 
-	private void emitJniSection (StringBuffer buffer, JniSection section) {
+	private void emitJniSection (StringBuilder  buffer, JniSection section) {
 		emitLineMarker(buffer, section.getStartIndex());
 		buffer.append(section.getNativeCode().replace("\r", ""));
 	}
 
-	private void emitJavaMethod (StringBuffer buffer, JavaMethod javaMethod, CMethod cMethod) {
+	private void emitJavaMethod (StringBuilder  buffer, JavaMethod javaMethod, CMethod cMethod) {
 		// get the setup and cleanup code for arrays, buffers and strings
-		StringBuffer jniSetupCode = new StringBuffer();
-		StringBuffer jniCleanupCode = new StringBuffer();
-		StringBuffer additionalArgs = new StringBuffer();
-		StringBuffer wrapperArgs = new StringBuffer();
+		StringBuilder  jniSetupCode = new StringBuilder ();
+		StringBuilder  jniCleanupCode = new StringBuilder ();
+		StringBuilder  additionalArgs = new StringBuilder ();
+		StringBuilder  wrapperArgs = new StringBuilder ();
 		emitJniSetupCode(jniSetupCode, javaMethod, additionalArgs, wrapperArgs);
 		emitJniCleanupCode(jniCleanupCode, javaMethod, cMethod);
 
@@ -429,7 +429,7 @@ public class NativeCodeGenerator {
 
 	}
 
-	protected void emitMethodBody (StringBuffer buffer, JavaMethod javaMethod) {
+	protected void emitMethodBody (StringBuilder  buffer, JavaMethod javaMethod) {
 		// emit a line marker
 		emitLineMarker(buffer, javaMethod.getEndIndex());
 
@@ -438,11 +438,11 @@ public class NativeCodeGenerator {
 		buffer.append("\n");
 	}
 
-	private String emitMethodSignature (StringBuffer buffer, JavaMethod javaMethod, CMethod cMethod, String additionalArguments) {
+	private String emitMethodSignature (StringBuilder  buffer, JavaMethod javaMethod, CMethod cMethod, String additionalArguments) {
 		return emitMethodSignature(buffer, javaMethod, cMethod, additionalArguments, true);
 	}
 
-	private String emitMethodSignature (StringBuffer buffer, JavaMethod javaMethod, CMethod cMethod, String additionalArguments,
+	private String emitMethodSignature (StringBuilder  buffer, JavaMethod javaMethod, CMethod cMethod, String additionalArguments,
 		boolean appendPrefix) {
 		// emit head, consisting of JNIEXPORT,return type and method name
 		// if this is a wrapped method, prefix the method name
@@ -497,8 +497,8 @@ public class NativeCodeGenerator {
 		return wrappedMethodName;
 	}
 
-	private void emitJniSetupCode (StringBuffer buffer, JavaMethod javaMethod, StringBuffer additionalArgs,
-		StringBuffer wrapperArgs) {
+	private void emitJniSetupCode (StringBuilder  buffer, JavaMethod javaMethod, StringBuilder  additionalArgs,
+		StringBuilder  wrapperArgs) {
 		// add environment and class/object as the two first arguments for
 		// wrapped method.
 		if (javaMethod.isStatic()) {
@@ -568,7 +568,7 @@ public class NativeCodeGenerator {
 		buffer.append("\n");
 	}
 
-	private void emitJniCleanupCode (StringBuffer buffer, JavaMethod javaMethod, CMethod cMethod) {
+	private void emitJniCleanupCode (StringBuilder  buffer, JavaMethod javaMethod, CMethod cMethod) {
 		// emit cleanup code for arrays, must come first
 		for (Argument arg : javaMethod.getArguments()) {
 			if (arg.getType().isPrimitiveArray()) {

--- a/gdx/src/com/badlogic/gdx/assets/AssetDescriptor.java
+++ b/gdx/src/com/badlogic/gdx/assets/AssetDescriptor.java
@@ -53,7 +53,7 @@ public class AssetDescriptor<T> {
 
 	@Override
 	public String toString () {
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder  buffer = new StringBuilder ();
 		buffer.append(fileName);
 		buffer.append(", ");
 		buffer.append(type.getName());

--- a/gdx/src/com/badlogic/gdx/assets/AssetManager.java
+++ b/gdx/src/com/badlogic/gdx/assets/AssetManager.java
@@ -691,7 +691,7 @@ public class AssetManager implements Disposable {
 
 	/** @return a string containing ref count and dependency information for all assets. */
 	public synchronized String getDiagnostics () {
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder  buffer = new StringBuilder ();
 		for (String fileName : assetTypes.keys()) {
 			buffer.append(fileName);
 			buffer.append(", ");

--- a/gdx/src/com/badlogic/gdx/net/HttpParametersUtils.java
+++ b/gdx/src/com/badlogic/gdx/net/HttpParametersUtils.java
@@ -36,7 +36,7 @@ public class HttpParametersUtils {
 	 * @return The String with the parameters encoded. */
 	public static String convertHttpParameters (Map<String, String> parameters) {
 		Set<String> keySet = parameters.keySet();
-		StringBuffer convertedParameters = new StringBuffer();
+		StringBuilder  convertedParameters = new StringBuilder ();
 		for (String name : keySet) {
 			convertedParameters.append(encode(name, defaultEncoding));
 			convertedParameters.append(nameValueSeparator);

--- a/gdx/src/com/badlogic/gdx/utils/SerializationException.java
+++ b/gdx/src/com/badlogic/gdx/utils/SerializationException.java
@@ -19,7 +19,7 @@ package com.badlogic.gdx.utils;
 /** Indicates an error during serialization due to misconfiguration or during deserialization due to invalid input data.
  * @author Nathan Sweet */
 public class SerializationException extends RuntimeException {
-	private StringBuffer trace;
+	private StringBuilder  trace;
 
 	public SerializationException () {
 		super();
@@ -51,7 +51,7 @@ public class SerializationException extends RuntimeException {
 
 	public String getMessage () {
 		if (trace == null) return super.getMessage();
-		StringBuffer buffer = new StringBuffer(512);
+		StringBuilder  buffer = new StringBuilder (512);
 		buffer.append(super.getMessage());
 		if (buffer.length() > 0) buffer.append('\n');
 		buffer.append("Serialization trace:");
@@ -63,7 +63,7 @@ public class SerializationException extends RuntimeException {
 	 * can catch {@link SerializationException}, add trace information, and rethrow the exception. */
 	public void addTrace (String info) {
 		if (info == null) throw new IllegalArgumentException("info cannot be null.");
-		if (trace == null) trace = new StringBuffer(512);
+		if (trace == null) trace = new StringBuilder (512);
 		trace.append('\n');
 		trace.append(info);
 	}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/AssetsFileGenerator.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/AssetsFileGenerator.java
@@ -23,14 +23,14 @@ import com.badlogic.gdx.files.FileHandle;
 public class AssetsFileGenerator {
 	public static void main (String[] args) {
 		FileHandle file = new FileHandle(args[0]);
-		StringBuffer list = new StringBuffer();
+		StringBuilder  list = new StringBuilder ();
 		args[0] = args[0].replace("\\", "/");
 		if (!args[0].endsWith("/")) args[0] = args[0] + "/";
 		traverse(file, args[0], list);
 		new FileHandle(args[0] + "/assets.txt").writeString(list.toString(), false);
 	}
 
-	private static final void traverse (FileHandle directory, String base, StringBuffer list) {
+	private static final void traverse (FileHandle directory, String base, StringBuilder  list) {
 		if (directory.name().equals(".svn")) return;
 		String dirName = directory.toString().replace("\\", "/").replace(base, "") + "/";
 		System.out.println(dirName);


### PR DESCRIPTION
> As of release JDK 5, StringBuffers-class has been supplemented with an equivalent class designed for use by a single thread, StringBuilder. The StringBuilder class should generally be used in preference to this one, as it supports all of the same operations but it is faster, as it performs no synchronization. 
https://docs.oracle.com/javase/7/docs/api/java/lang/StringBuffer.html

I called ```ReplaceAll...``` in Eclipse and looks like the changed code is never used publicly so no API affected.

Discussion: https://github.com/libgdx/libgdx/issues/3977