### PR TITLE
Robustify DefaultShader

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/DefaultShader.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/DefaultShader.java
@@ -725,7 +725,6 @@ public class DefaultShader extends BaseShader {
 	}
 
 	private Matrix3 normalMatrix = new Matrix3();
-	private Camera camera;
 	private float time;
 	private boolean lightsSet;
 


### PR DESCRIPTION
Remove camera property of DefaultShader because it already exists in BaseShader.
Here : https://github.com/libgdx/libgdx/blob/1.9.2/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/BaseShader.java#L112