### PR TITLE
Fix MeshBuilder

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g3d/utils/MeshBuilder.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/utils/MeshBuilder.java
@@ -1227,9 +1227,10 @@ public class MeshBuilder implements MeshPartBuilder {
 			for (int iu = 0; iu <= divisionsU; iu++) {
 				angleU = auo + stepU * iu;
 				u = 1f - us * iu;
-				curr1.position.set(MathUtils.cos(angleU) * hw * t, h, MathUtils.sin(angleU) * hd * t).mul(transform);
+				curr1.position.set(MathUtils.cos(angleU) * hw * t, h, MathUtils.sin(angleU) * hd * t);
 				curr1.normal.set(curr1.position).nor();
 				curr1.uv.set(u, v);
+				curr1.position.mul(transform);
 				tmpIndices.set(tempOffset, vertex(curr1));
 				final int o = tempOffset + s;
 				if ((iv > 0) && (iu > 0)) // FIXME don't duplicate lines and points


### PR DESCRIPTION
If a transform matrix is passed to `sphere()` method of MeshBuilder, normal vectors are wrong.

Before this fix : 
![sphere_normal_ko](https://cloud.githubusercontent.com/assets/6367936/14241092/fe314604-fa49-11e5-9669-91bf781d26ac.PNG)

After this fix :
![sphere_normal_ok](https://cloud.githubusercontent.com/assets/6367936/14241105/0ef8dd6c-fa4a-11e5-9d83-5861ed60fcf3.PNG)
