### PR TITLE
GWT Method reflection fix.

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gwtref/client/Method.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gwtref/client/Method.java
@@ -65,12 +65,12 @@ public class Method {
 
 	/** @return the {@link Class} of the enclosing type. */
 	public Class getEnclosingType () {
-		return enclosingType.getClass();
+		return enclosingType.clazz;
 	}
 
 	/** @return the {@link Class} of the return type or null. */
 	public Class getReturnType () {
-		return returnType.getClass();
+		return returnType.clazz;
 	}
 
 	/** @return the list of parameters, can be a zero size array. */


### PR DESCRIPTION
GWT `Method#getEnclosingType()` and `getReturnType()` methods are broken and always return `com.badlogic.gwtref.client.CachedTypeLookup` instead of actual types. This pull request fixes this issue.

I think that originally `getClass()` method was mistaken for `clazz` getter rather than the default Java method that returns the class of the actual object (in this case - `CachedTypeLookup`). Since `clazz` field was already package-private, I didn't add any getters and just accessed the field directly.