### PR TITLE
Headless backend. Remove unused stuff.

### DIFF
--- a/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/HeadlessNet.java
+++ b/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/HeadlessNet.java
@@ -29,7 +29,6 @@ import com.badlogic.gdx.net.ServerSocket;
 import com.badlogic.gdx.net.ServerSocketHints;
 import com.badlogic.gdx.net.Socket;
 import com.badlogic.gdx.net.SocketHints;
-import com.badlogic.gdx.utils.GdxRuntimeException;
 
 /** Headless implementation of the {@link com.badlogic.gdx.Net} API, based on LWJGL implementation
  * @author acoppes

--- a/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/HeadlessPreferences.java
+++ b/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/HeadlessPreferences.java
@@ -33,7 +33,6 @@ import java.util.Map.Entry;
 import java.util.Properties;
 
 public class HeadlessPreferences implements Preferences {
-	private final String name;
 	private final Properties properties = new Properties();
 	private final FileHandle file;
 
@@ -42,7 +41,6 @@ public class HeadlessPreferences implements Preferences {
 	}
 
 	public HeadlessPreferences(FileHandle file) {
-		this.name = file.name();
 		this.file = file;
 		if (!file.exists()) return;
 		InputStream in = null;

--- a/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/mock/input/MockInput.java
+++ b/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/mock/input/MockInput.java
@@ -17,7 +17,6 @@
 package com.badlogic.gdx.backends.headless.mock.input;
 
 import com.badlogic.gdx.Input;
-import com.badlogic.gdx.Input.TextInputListener;
 import com.badlogic.gdx.InputAdapter;
 import com.badlogic.gdx.InputProcessor;
 


### PR DESCRIPTION
To avoid "yellow" warnings.