### PR TITLE
Properly add what PR#3903 tried fixing, also see #3997. Added test

### DIFF
--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGraphics.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGraphics.java
@@ -403,7 +403,7 @@ public class LwjglGraphics implements Graphics {
 
 	@Override
 	public DisplayMode[] getDisplayModes (Monitor monitor) {
-		return new DisplayMode[] { getDisplayMode() };
+		return getDisplayModes();
 	}
 
 	@Override

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/conformance/DisplayModeTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/conformance/DisplayModeTest.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogic.gdx.tests.conformance;
+
+import java.util.Arrays;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Graphics.DisplayMode;
+import com.badlogic.gdx.tests.utils.GdxTest;
+
+public class DisplayModeTest extends GdxTest {
+
+	@Override
+	public void create () {
+		DisplayMode displayMode = Gdx.graphics.getDisplayMode();
+		DisplayMode displayModeForMonitor = Gdx.graphics.getDisplayMode(Gdx.graphics.getMonitor());
+		DisplayMode[] displayModes = Gdx.graphics.getDisplayModes();
+		DisplayMode[] displayModesForMonitor = Gdx.graphics.getDisplayModes(Gdx.graphics.getMonitor());
+
+		Gdx.app.log("DisplayModeTest", "Display mode (using Gdx.graphics.getDisplayMode() ) : " + displayMode);
+		Gdx.app.log("DisplayModeTest",
+			"Display mode (using Gdx.graphics.getDisplayMode(Gdx.graphics.getMonitor()) ) : " + Arrays.toString(displayModes));
+		Gdx.app.log("DisplayModeTest",
+			"Display mode (using Gdx.graphics.getDisplayModes() ) : " + Arrays.toString(displayModesForMonitor));
+		Gdx.app.log("DisplayModeTest",
+			"Display mode (using Gdx.graphics.getDisplayModes(Gdx.graphics.getMonitor()) ): " + displayModeForMonitor);
+		assertDisplayModeEquals(displayMode, displayModeForMonitor);
+		assertDisplayModesEquals(displayModes, displayModesForMonitor);
+	}
+
+	void assertDisplayModesEquals (DisplayMode[] a, DisplayMode[] b) {
+		if (a.length == 0 || b.length == 0) throw new AssertionError("Argument a or b can't be a zero length array");
+		if (a.length != b.length) {
+			throw new AssertionError("Display modes " + Arrays.toString(a) + " aren't equal to display modes " + Arrays.toString(b));
+		}
+		boolean equal = false;
+		for (int i = 0; i < a.length; i++) {
+			equal = isDisplayModeEqual(a[i], b[i]);
+		}
+		if (!equal) {
+			throw new AssertionError("Display modes " + Arrays.toString(a) + " aren't equal to display modes " + Arrays.toString(b));
+		}
+	}
+
+	void assertDisplayModeEquals (DisplayMode a, DisplayMode b) {
+		if (!isDisplayModeEqual(a, b)) {
+			throw new AssertionError(a + " isn't equal to " + b);
+		}
+	}
+
+	boolean isDisplayModeEqual (DisplayMode a, DisplayMode b) {
+		if (a == null || b == null) return false;
+		boolean equal = a.bitsPerPixel == b.bitsPerPixel && a.height == b.height && a.refreshRate == b.refreshRate
+			&& a.width == b.width;
+		return equal;
+	}
+
+}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtTestWrapper.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtTestWrapper.java
@@ -19,13 +19,11 @@ package com.badlogic.gdx.tests.gwt;
 import com.badlogic.gdx.Application;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
-import com.badlogic.gdx.Input.TextInputListener;
 import com.badlogic.gdx.InputAdapter;
 import com.badlogic.gdx.InputMultiplexer;
 import com.badlogic.gdx.InputProcessor;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
-import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.scenes.scene2d.InputEvent;
 import com.badlogic.gdx.scenes.scene2d.Stage;
@@ -39,7 +37,6 @@ import com.badlogic.gdx.scenes.scene2d.utils.ClickListener;
 import com.badlogic.gdx.tests.AccelerometerTest;
 import com.badlogic.gdx.tests.ActionSequenceTest;
 import com.badlogic.gdx.tests.ActionTest;
-import com.badlogic.gdx.tests.AlphaTest;
 import com.badlogic.gdx.tests.AnimationTest;
 import com.badlogic.gdx.tests.AnnotationTest;
 import com.badlogic.gdx.tests.AssetManagerTest;
@@ -104,6 +101,7 @@ import com.badlogic.gdx.tests.TimeUtilsTest;
 import com.badlogic.gdx.tests.UITest;
 import com.badlogic.gdx.tests.VertexBufferObjectShaderTest;
 import com.badlogic.gdx.tests.YDownTest;
+import com.badlogic.gdx.tests.conformance.DisplayModeTest;
 import com.badlogic.gdx.tests.g3d.ModelCacheTest;
 import com.badlogic.gdx.tests.g3d.ShadowMappingTest;
 import com.badlogic.gdx.tests.superkoalio.SuperKoalio;
@@ -521,6 +519,10 @@ public class GwtTestWrapper extends GdxTest {
 	}, new Instancer() {
 		public GdxTest instance () {
 			return new DecalTest();
+		}
+	}, new Instancer() {
+		public GdxTest instance () {
+			return new DisplayModeTest();
 		}
 	}, new Instancer() {
 		public GdxTest instance () {

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
@@ -38,13 +38,14 @@ import java.util.List;
 
 import com.badlogic.gdx.tests.*;
 import com.badlogic.gdx.tests.bench.TiledMapBench;
+import com.badlogic.gdx.tests.conformance.DisplayModeTest;
 import com.badlogic.gdx.tests.examples.MoveSpriteExample;
 import com.badlogic.gdx.tests.extensions.ControllersTest;
 import com.badlogic.gdx.tests.extensions.FreeTypeAtlasTest;
 import com.badlogic.gdx.tests.extensions.FreeTypeDisposeTest;
 import com.badlogic.gdx.tests.extensions.FreeTypeFontLoaderTest;
-import com.badlogic.gdx.tests.extensions.FreeTypeMetricsTest;
 import com.badlogic.gdx.tests.extensions.FreeTypeIncrementalTest;
+import com.badlogic.gdx.tests.extensions.FreeTypeMetricsTest;
 import com.badlogic.gdx.tests.extensions.FreeTypePackTest;
 import com.badlogic.gdx.tests.extensions.FreeTypeTest;
 import com.badlogic.gdx.tests.extensions.InternationalFontsTest;
@@ -122,6 +123,7 @@ public class GdxTests {
 		ETC1Test.class,
 //		EarClippingTriangulatorTest.class,
 		EdgeDetectionTest.class,
+		DisplayModeTest.class,
 		ExitTest.class,
 		ExternalMusicTest.class,
 		FilesTest.class,


### PR DESCRIPTION
Fixes what #3903 tried fixing. 
I've also added a new test that checks that 
`Gdx.graphics.getDisplayMode()` and `Gdx.graphics.getDisplayMode(Gdx.graphics.getMonitor())` return the same display mode.
The test also checks that 
`Gdx.graphics.getDisplayModes()` and 
`Gdx.graphics.getDisplayModes(Gdx.graphics.getMonitor())` are equal.