### PR TITLE
Improve jnigen to generate critical natives

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,7 +9,7 @@
 - Added FlushablePool
 - Added Debug3dRenderer see https://github.com/libgdx/libgdx/pull/3953
 - API Change: moved shape builder logic out of MeshBuilder, see: https://github.com/libgdx/libgdx/pull/3996
-- Jnigen can generate critical natives. Improved performance of Matrix4 on desktop. https://github.com/libgdx/libgdx/pull/4021
+- Jnigen can generate critical natives, see: https://github.com/libgdx/libgdx/pull/4021
 
 [1.9.2]
 - Added TextureArray wrapper see https://github.com/libgdx/libgdx/pull/3807

--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,7 @@
 - Added FlushablePool
 - Added Debug3dRenderer see https://github.com/libgdx/libgdx/pull/3953
 - API Change: moved shape builder logic out of MeshBuilder, see: https://github.com/libgdx/libgdx/pull/3996
+- Jnigen can generate critical natives. Improved performance of Matrix4 on desktop. https://github.com/libgdx/libgdx/pull/4021
 
 [1.9.2]
 - Added TextureArray wrapper see https://github.com/libgdx/libgdx/pull/3807

--- a/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/BuildTarget.java
+++ b/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/BuildTarget.java
@@ -96,39 +96,41 @@ public class BuildTarget {
 		if (type == TargetOs.Windows && !is64Bit) {
 			// Windows 32-Bit
 			return new BuildTarget(TargetOs.Windows, false, new String[] {"**/*.c"}, new String[0], new String[] {"**/*.cpp"},
-				new String[0], new String[0], "i686-w64-mingw32-", "-c -Wall -O2 -mfpmath=sse -msse2 -fmessage-length=0 -m32",
-				"-c -Wall -O2 -mfpmath=sse -msse2 -fmessage-length=0 -m32", 
+				new String[0], new String[0], "i686-w64-mingw32-", "-c -Wall -O2 -mfpmath=sse -msse2 -fmessage-length=0 -m32 -D__DESKTOP__",
+				"-c -Wall -O2 -mfpmath=sse -msse2 -fmessage-length=0 -m32 -D__DESKTOP__", 
 				"-Wl,--kill-at -shared -m32 -static -static-libgcc -static-libstdc++");
 		}
 
 		if (type == TargetOs.Windows && is64Bit) {
 			// Windows 64-Bit
 			return new BuildTarget(TargetOs.Windows, true, new String[] {"**/*.c"}, new String[0], new String[] {"**/*.cpp"},
-				new String[0], new String[0], "x86_64-w64-mingw32-", "-c -Wall -O2 -mfpmath=sse -msse2 -fmessage-length=0 -m64",
-				"-c -Wall -O2 -mfpmath=sse -msse2 -fmessage-length=0 -m64",
+				new String[0], new String[0], "x86_64-w64-mingw32-", "-c -Wall -O2 -mfpmath=sse -msse2 -fmessage-length=0 -m64 -D__DESKTOP__",
+				"-c -Wall -O2 -mfpmath=sse -msse2 -fmessage-length=0 -m64 -D__DESKTOP__",
 				"-Wl,--kill-at -shared -static -static-libgcc -static-libstdc++ -m64");
 		}
 
 		if (type == TargetOs.Linux && !is64Bit) {
 			// Linux 32-Bit
 			return new BuildTarget(TargetOs.Linux, false, new String[] {"**/*.c"}, new String[0], new String[] {"**/*.cpp"},
-				new String[0], new String[0], "", "-c -Wall -O2 -mfpmath=sse -msse -fmessage-length=0 -m32 -fPIC",
-				"-c -Wall -O2 -mfpmath=sse -msse -fmessage-length=0 -m32 -fPIC", "-shared -m32");
+				new String[0], new String[0], "", "-c -Wall -O2 -mfpmath=sse -msse -fmessage-length=0 -m32 -fPIC -D__DESKTOP__",
+				"-c -Wall -O2 -mfpmath=sse -msse -fmessage-length=0 -m32 -fPIC -D__DESKTOP__", 
+				"-shared -m32");
 		}
 
 		if (type == TargetOs.Linux && is64Bit) {
 			// Linux 64-Bit
 			return new BuildTarget(TargetOs.Linux, true, new String[] {"**/*.c"}, new String[0], new String[] {"**/*.cpp"},
-				new String[0], new String[0], "", "-c -Wall -O2 -mfpmath=sse -msse -fmessage-length=0 -m64 -fPIC",
-				"-c -Wall -O2 -mfpmath=sse -msse -fmessage-length=0 -m64 -fPIC", "-shared -m64 -Wl,-wrap,memcpy");
+				new String[0], new String[0], "", "-c -Wall -O2 -mfpmath=sse -msse -fmessage-length=0 -m64 -fPIC -D__DESKTOP__",
+				"-c -Wall -O2 -mfpmath=sse -msse -fmessage-length=0 -m64 -fPIC -D__DESKTOP__", 
+				"-shared -m64 -Wl,-wrap,memcpy");
 		}
 
 		if (type == TargetOs.MacOsX && !is64Bit) {
 			// Mac OS X x86 & x86_64
 			BuildTarget mac = new BuildTarget(TargetOs.MacOsX, false, new String[] {"**/*.c"}, new String[0],
 				new String[] {"**/*.cpp"}, new String[0], new String[0], "",
-				"-c -Wall -O2 -arch i386 -DFIXED_POINT -fmessage-length=0 -fPIC -mmacosx-version-min=10.5",
-				"-c -Wall -O2 -arch i386 -DFIXED_POINT -fmessage-length=0 -fPIC -mmacosx-version-min=10.5",
+				"-c -Wall -O2 -arch i386 -DFIXED_POINT -fmessage-length=0 -fPIC -mmacosx-version-min=10.5 -D__DESKTOP__",
+				"-c -Wall -O2 -arch i386 -DFIXED_POINT -fmessage-length=0 -fPIC -mmacosx-version-min=10.5 -D__DESKTOP__",
 				"-shared -arch i386 -mmacosx-version-min=10.5");
 			return mac;
 		}
@@ -137,8 +139,8 @@ public class BuildTarget {
 			// Mac OS X x86 & x86_64
 			BuildTarget mac = new BuildTarget(TargetOs.MacOsX, true, new String[] {"**/*.c"}, new String[0],
 				new String[] {"**/*.cpp"}, new String[0], new String[0], "",
-				"-c -Wall -O2 -arch x86_64 -DFIXED_POINT -fmessage-length=0 -fPIC -mmacosx-version-min=10.5",
-				"-c -Wall -O2 -arch x86_64 -DFIXED_POINT -fmessage-length=0 -fPIC -mmacosx-version-min=10.5",
+				"-c -Wall -O2 -arch x86_64 -DFIXED_POINT -fmessage-length=0 -fPIC -mmacosx-version-min=10.5 -D__DESKTOP__",
+				"-c -Wall -O2 -arch x86_64 -DFIXED_POINT -fmessage-length=0 -fPIC -mmacosx-version-min=10.5 -D__DESKTOP__",
 				"-shared -arch x86_64 -mmacosx-version-min=10.5");
 			return mac;
 		}

--- a/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/NativeCodeGenerator.java
+++ b/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/NativeCodeGenerator.java
@@ -25,6 +25,7 @@ import com.badlogic.gdx.jnigen.parsing.CMethodParser.CMethod;
 import com.badlogic.gdx.jnigen.parsing.CMethodParser.CMethodParserResult;
 import com.badlogic.gdx.jnigen.parsing.JavaMethodParser;
 import com.badlogic.gdx.jnigen.parsing.JavaMethodParser.Argument;
+import com.badlogic.gdx.jnigen.parsing.JavaMethodParser.ArgumentType;
 import com.badlogic.gdx.jnigen.parsing.JavaMethodParser.JavaMethod;
 import com.badlogic.gdx.jnigen.parsing.JavaMethodParser.JavaSegment;
 import com.badlogic.gdx.jnigen.parsing.JavaMethodParser.JniSection;
@@ -265,7 +266,22 @@ public class NativeCodeGenerator {
 						System.out.print("Generating C/C++ for '" + file + "'...");
 						generateHFile(file);
 						generateCppFile(javaSegments, hFile, cppFile);
-						System.out.println("done");
+						int methodNum = 0, criticalNum = 0;
+						for (JavaSegment segment : javaSegments) {
+							if (segment instanceof JavaMethod) {
+								JavaMethod javaMethod = (JavaMethod)segment;
+								methodNum++;
+								if (javaMethod.isCriticalNative())
+									criticalNum++;
+							}
+						}
+						StringBuilder sb = new StringBuilder("done. ");
+						sb.append(methodNum).append(" native method").append(methodNum>1?"s":"").append(" generated");
+						if (criticalNum>0) {
+							sb.append(" (include ").append(criticalNum).append(" critical Native").append(criticalNum>1?"s)":")");
+						}
+						sb.append(".");
+						System.out.println(sb.toString());
 					}
 				}
 			}
@@ -376,10 +392,15 @@ public class NativeCodeGenerator {
 
 		// check if the user wants to do manual setup of JNI args
 		boolean isManual = javaMethod.isManual();
+		
+		if (javaMethod.isAssertCritical() && !javaMethod.isCriticalNative())
+			throw new RuntimeException("Native method " + javaMethod.getName() + 
+				" had been asserted that it is a critical native, but it dosen't meet the requirements.");
 
-		// if we have disposable arguments (string, buffer, array) and if there is a return
+		// if the native function is critical native,
+		// or if we have disposable arguments (string, buffer, array) and if there is a return
 		// in the native code (conservative, not syntactically checked), emit a wrapper method.
-		if (javaMethod.hasDisposableArgument() && javaMethod.getNativeCode().contains("return")) {
+		if (javaMethod.isCriticalNative() || (javaMethod.hasDisposableArgument() && javaMethod.getNativeCode().contains("return"))) {
 			// if the method is marked as manual, we just emit the signature and let the
 			// user do whatever she wants.
 			if (isManual) {
@@ -414,6 +435,9 @@ public class NativeCodeGenerator {
 					buffer.append("\treturn " + JNI_RETURN_VALUE + ";\n");
 				}
 				buffer.append("}\n\n");
+				
+				if (javaMethod.isCriticalNative())
+					emitCriticalNative(buffer, javaMethod, cMethod, wrappedMethodName);
 			}
 		} else {
 			emitMethodSignature(buffer, javaMethod, cMethod, null);
@@ -432,7 +456,7 @@ public class NativeCodeGenerator {
 	protected void emitMethodBody (StringBuffer buffer, JavaMethod javaMethod) {
 		// emit a line marker
 		emitLineMarker(buffer, javaMethod.getEndIndex());
-
+		
 		// FIXME add tabs cleanup
 		buffer.append(javaMethod.getNativeCode());
 		buffer.append("\n");
@@ -447,7 +471,8 @@ public class NativeCodeGenerator {
 		// emit head, consisting of JNIEXPORT,return type and method name
 		// if this is a wrapped method, prefix the method name
 		String wrappedMethodName = null;
-		if (additionalArguments != null) {
+		boolean isEmittingWrappedMethod = additionalArguments != null;
+		if (isEmittingWrappedMethod) {
 			String[] tokens = cMethod.getHead().replace("\r\n", "").replace("\n", "").split(" ");
 			wrappedMethodName = JNI_WRAPPER_PREFIX + tokens[3];
 			buffer.append("static inline ");
@@ -461,28 +486,48 @@ public class NativeCodeGenerator {
 
 		// construct argument list
 		// Differentiate between static and instance method, then output each argument
-		if (javaMethod.isStatic()) {
+		if (isEmittingWrappedMethod && // only generate special arguments in the wrapped method
+			javaMethod.isCriticalNative()) {
+			buffer.append("(bool _isCriticalNative");
+		} else if (javaMethod.isStatic()) {
 			buffer.append("(JNIEnv* env, jclass clazz");
 		} else {
 			buffer.append("(JNIEnv* env, jobject object");
 		}
 		if (javaMethod.getArguments().size() > 0) buffer.append(", ");
-		for (int i = 0; i < javaMethod.getArguments().size(); i++) {
-			// output the argument type as defined in the header
-			buffer.append(cMethod.getArgumentTypes()[i + 2]);
-			buffer.append(" ");
-			// if this is not a POD or an object, we need to add a prefix
-			// as we will output JNI code to get pointers to strings, arrays
-			// and direct buffers.
-			Argument javaArg = javaMethod.getArguments().get(i);
-			if (!javaArg.getType().isPlainOldDataType() && !javaArg.getType().isObject() && appendPrefix) {
-				buffer.append(JNI_ARG_PREFIX);
+		
+		if (!isEmittingWrappedMethod || !javaMethod.isCriticalNative()) {
+			for (int i = 0; i < javaMethod.getArguments().size(); i++) {
+				// output the argument type as defined in the header
+				buffer.append(cMethod.getArgumentTypes()[i + 2]);
+				buffer.append(" ");
+				// if this is not a POD or an object, we need to add a prefix
+				// as we will output JNI code to get pointers to strings, arrays
+				// and direct buffers.
+				Argument javaArg = javaMethod.getArguments().get(i);
+				if (!javaArg.getType().isPlainOldDataType() && !javaArg.getType().isObject() && appendPrefix) {
+					buffer.append(JNI_ARG_PREFIX);
+				}
+				// output the name of the argument
+				buffer.append(javaArg.getName());
+	
+				// comma, if this is not the last argument
+				if (i < javaMethod.getArguments().size() - 1) buffer.append(", ");
 			}
-			// output the name of the argument
-			buffer.append(javaArg.getName());
-
-			// comma, if this is not the last argument
-			if (i < javaMethod.getArguments().size() - 1) buffer.append(", ");
+		} else {
+			for (int i = 0; i < javaMethod.getArguments().size(); i++) {
+				Argument javaArg = javaMethod.getArguments().get(i);
+				if (javaArg.getType().isPrimitiveArray()) {
+					if (usedArrayLength(javaMethod, javaArg)) {
+						buffer.append("jint ").append(getArrayLengthArgument(javaArg)).append(", ");
+					}
+					buffer.append(javaArg.getType().getArrayJniType());
+				} else {
+					buffer.append(cMethod.getArgumentTypes()[i + 2]);
+				}
+				buffer.append(" ").append(javaArg.getName());
+				if (i < javaMethod.getArguments().size() - 1) buffer.append(", ");
+			}
 		}
 
 		// if this is a wrapper method signature, add the additional arguments
@@ -499,12 +544,40 @@ public class NativeCodeGenerator {
 
 	private void emitJniSetupCode (StringBuffer buffer, JavaMethod javaMethod, StringBuffer additionalArgs,
 		StringBuffer wrapperArgs) {
-		// add environment and class/object as the two first arguments for
-		// wrapped method.
-		if (javaMethod.isStatic()) {
+		if (javaMethod.isCriticalNative()) {
+			wrapperArgs.append("false, ");  // set _isCriticalNative false
+		} else if (javaMethod.isStatic()) {  // add environment and class/object as the two first arguments for wrapped method.
 			wrapperArgs.append("env, clazz, ");
 		} else {
 			wrapperArgs.append("env, object, ");
+		}
+		
+		if (javaMethod.isCriticalNative()) {
+			StringBuilder lengthGetterBuffer = new StringBuilder();
+			for (int i = 0; i < javaMethod.getArguments().size(); i++) {
+				Argument arg = javaMethod.getArguments().get(i);
+				if (arg.getType().isPrimitiveArray()) {
+					String varLength = getArrayLengthArgument(arg);
+					String type = arg.getType().getArrayCType();
+					buffer.append("\t" + type + " " + arg.getName() + " = (" + type + ")env->GetPrimitiveArrayCritical(" 
+										+ JNI_ARG_PREFIX + arg.getName() + ", 0);\n");
+					if (usedArrayLength(javaMethod, arg)) {
+						wrapperArgs.append(varLength);
+						lengthGetterBuffer.append("\tjsize " + varLength + " = env->GetArrayLength(" 
+													+ JNI_ARG_PREFIX + arg.getName() + ");\n");
+						wrapperArgs.append(", ");
+					}
+				}
+				if (arg.getType() == ArgumentType.BooleanArray) // Fix "cannot convert 'bool*' to 'jboolean* {aka unsigned char*}'"
+					wrapperArgs.append("(jboolean*)");
+				if (arg.getType() == ArgumentType.IntegerArray) // Fix "cannot convert 'int*' to 'jint* {aka long int*}'"
+					wrapperArgs.append("(jint*)");
+				wrapperArgs.append(arg.getName());
+				if (i < javaMethod.getArguments().size() - 1) wrapperArgs.append(", ");
+			}
+			buffer.append(lengthGetterBuffer.toString());
+			buffer.append("\n");
+			return;
 		}
 
 		// arguments for wrapper method
@@ -563,7 +636,7 @@ public class NativeCodeGenerator {
 				wrapperArgs.append(arg.getName());
 			}
 		}
-
+		
 		// new line for separation
 		buffer.append("\n");
 	}
@@ -586,5 +659,61 @@ public class NativeCodeGenerator {
 
 		// new line for separation
 		buffer.append("\n");
+	}
+	
+	/**
+	 * Does the native codes used the length of array
+	 */
+	private boolean usedArrayLength(JavaMethod javaMethod, Argument argument) {
+		return javaMethod.getNativeCode().contains(getArrayLengthArgument(argument));
+	}
+	
+	private String getArrayLengthArgument(Argument argument) {
+	// FIXME if someone uses both "array" and "arrayLength" as arguments...
+		return argument.getName() + "Length";
+	}
+	
+	private void emitCriticalNative (StringBuffer buffer, JavaMethod javaMethod, CMethod cMethod, String wrapperName) {
+		if (!javaMethod.isCriticalNative())
+			throw new RuntimeException(javaMethod.getName() + " is not a critical native method");
+		String methodName = cMethod.getHead().replaceFirst("Java_", "JavaCritical_");
+		StringBuilder paramBuffer = new StringBuilder("true"); // set _isCriticalNative true
+		// only generate in desktop
+		// TODO find a better way to differentiate desktop and others. 
+		buffer.append("#if defined(_WIN32) || defined(__linux__) || defined(__APPLE__)\n")
+				.append("\n")
+				.append("extern \"C\" ") // stop name mangling
+				.append(methodName).append("(");
+		boolean firstArgument = true;
+		for (Argument arg : javaMethod.getArguments()) {
+			ArgumentType type = arg.getType();
+			if (firstArgument)
+				firstArgument = false;
+			else
+				buffer.append(",");
+			
+			if (type.isPlainOldDataType()) {
+				String name = arg.getName();
+				buffer.append(" ").append(type.getJniType()).append(" ").append(name);
+				paramBuffer.append(", ").append(name);
+			} else if (type.isPrimitiveArray()) {
+				String name = arg.getName();
+				String varLength = getArrayLengthArgument(arg);
+				buffer.append(" jint ").append(varLength).append(", ")
+						.append(type.getArrayJniType()).append(" ").append(name);
+				if (usedArrayLength(javaMethod, arg)) {
+					paramBuffer.append(", ").append(varLength);
+				}
+				paramBuffer.append(", ").append(name);
+			} else {
+				throw new RuntimeException("Illegal argument in critical native:" + arg.getName() + "(" + type + ")");
+			}
+		}
+		buffer.append(")\n{\n\t");
+		String[] tokens = methodName.split(" ");
+		if (!tokens[1].equals("void"))
+			buffer.append("return ");
+		buffer.append(wrapperName).append("(").append(paramBuffer.toString()).append(");\n}\n\n");
+		buffer.append("#endif\n\n");
 	}
 }

--- a/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/NativeCodeGenerator.java
+++ b/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/NativeCodeGenerator.java
@@ -341,15 +341,7 @@ public class NativeCodeGenerator {
 			}
 		}
 		if (criticalBuffer.length() > 0) {
-			buffer.append("#if defined(_WIN32) || defined(__linux__) \n") // only generate in desktop
-					.append("	#define __DESKTOP__ \n")
-					.append("#elif defined(__APPLE__) \n")
-					.append("	#include <TargetConditionals.h> \n")
-					.append("	#if defined(TARGET_OS_MAC) && !defined(TARGET_OS_IPHONE) \n")
-					.append("		#define __DESKTOP__ \n")
-					.append("	#endif \n")
-					.append("#endif \n")
-					.append("#if defined(__DESKTOP__) \n")
+			buffer.append("#if defined(__DESKTOP__) \n") // Only generate in desktop. Defined in BuildTarget.newDefaultTarget
 					.append(criticalBuffer)
 					.append("#endif \n");
 		}

--- a/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/parsing/RobustJavaMethodParser.java
+++ b/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/parsing/RobustJavaMethodParser.java
@@ -37,6 +37,7 @@ import java.util.Stack;
 
 public class RobustJavaMethodParser implements JavaMethodParser {
 	private static final String JNI_MANUAL = "MANUAL";
+	private static final String JNI_CRITICAL = "CRITICAL";
 	private static final Map<String, ArgumentType> plainOldDataTypes;
 	private static final Map<String, ArgumentType> arrayTypes;
 	private static final Map<String, ArgumentType> bufferTypes;
@@ -107,6 +108,9 @@ public class RobustJavaMethodParser implements JavaMethodParser {
 					if (section.getNativeCode().startsWith(JNI_MANUAL)) {
 						section.setNativeCode(section.getNativeCode().substring(JNI_MANUAL.length()));
 						method.setManual(true);
+					} else if (section.getNativeCode().startsWith(JNI_CRITICAL)) {
+						section.setNativeCode(section.getNativeCode().substring(JNI_CRITICAL.length()));
+						method.assertCritical();
 					}
 					method.setNativeCode(section.getNativeCode());
 					break;
@@ -137,6 +141,7 @@ public class RobustJavaMethodParser implements JavaMethodParser {
 		String className = classStack.peek().getName();
 		String name = method.getName();
 		boolean isStatic = ModifierSet.hasModifier(method.getModifiers(), ModifierSet.STATIC);
+		boolean isSynchronized = ModifierSet.hasModifier(method.getModifiers(), ModifierSet.SYNCHRONIZED);
 		String returnType = method.getType().toString();
 		ArrayList<Argument> arguments = new ArrayList<Argument>();
 
@@ -146,7 +151,7 @@ public class RobustJavaMethodParser implements JavaMethodParser {
 			}
 		}
 
-		return new JavaMethod(className, name, isStatic, returnType, null, arguments, method.getBeginLine(), method.getEndLine());
+		return new JavaMethod(className, name, isStatic, isSynchronized, returnType, null, arguments, method.getBeginLine(), method.getEndLine());
 	}
 
 	private ArgumentType getArgumentType (Parameter parameter) {

--- a/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/parsing/RobustJavaMethodParser.java
+++ b/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/parsing/RobustJavaMethodParser.java
@@ -110,7 +110,7 @@ public class RobustJavaMethodParser implements JavaMethodParser {
 						method.setManual(true);
 					} else if (section.getNativeCode().startsWith(JNI_CRITICAL)) {
 						section.setNativeCode(section.getNativeCode().substring(JNI_CRITICAL.length()));
-						method.assertCritical();
+						method.enableCritical();
 					}
 					method.setNativeCode(section.getNativeCode());
 					break;

--- a/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/test/MyJniClass.java
+++ b/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/test/MyJniClass.java
@@ -31,100 +31,130 @@ public class MyJniClass {
 	public static native void test (boolean boolArg, byte byteArg, char charArg, short shortArg, int intArg, long longArg,
 		float floatArg, double doubleArg, Buffer byteBuffer, boolean[] boolArray, char[] charArray, short[] shortArray,
 		int[] intArray, long[] longArray, float[] floatArray, double[] doubleArray, double[][] multidim, String string); /*
-																																								 * printf(
-																																								 * "boolean: %s\n"
-																																								 * ,
-																																								 * boolArg
-																																								 * ?
-																																								 * "true":
-																																								 * "false"
-																																								 * );
-																																								 * printf(
-																																								 * "byte: %d\n"
-																																								 * ,
-																																								 * byteArg
-																																								 * );
-																																								 * printf(
-																																								 * "char: %c\n"
-																																								 * ,
-																																								 * charArg
-																																								 * );
-																																								 * printf(
-																																								 * "short: %d\n"
-																																								 * ,
-																																								 * shortArg
-																																								 * );
-																																								 * printf(
-																																								 * "int: %d\n"
-																																								 * ,
-																																								 * intArg
-																																								 * );
-																																								 * printf(
-																																								 * "long: %l\n"
-																																								 * ,
-																																								 * longArg
-																																								 * );
-																																								 * printf(
-																																								 * "float: %f\n"
-																																								 * ,
-																																								 * floatArg
-																																								 * );
-																																								 * printf(
-																																								 * "double: %d\n"
-																																								 * ,
-																																								 * doubleArg
-																																								 * );
-																																								 * printf(
-																																								 * "byteBuffer: %d\n"
-																																								 * ,
-																																								 * byteBuffer
-																																								 * [0]);
-																																								 * printf(
-																																								 * "bool[0]: %s\n"
-																																								 * ,
-																																								 * boolArray
-																																								 * [
-																																								 * 0]?"true"
-																																								 * :
-																																								 * "false"
-																																								 * );
-																																								 * printf(
-																																								 * "char[0]: %c\n"
-																																								 * ,
-																																								 * charArray
-																																								 * [0]);
-																																								 * printf(
-																																								 * "short[0]: %d\n"
-																																								 * ,
-																																								 * shortArray
-																																								 * [0]);
-																																								 * printf(
-																																								 * "int[0]: %d\n"
-																																								 * ,
-																																								 * intArray
-																																								 * [0]);
-																																								 * printf(
-																																								 * "long[0]: %ll\n"
-																																								 * ,
-																																								 * longArray
-																																								 * [0]);
-																																								 * printf(
-																																								 * "float[0]: %f\n"
-																																								 * ,
-																																								 * floatArray
-																																								 * [0]);
-																																								 * printf(
-																																								 * "double[0]: %f\n"
-																																								 * ,
-																																								 * doubleArray
-																																								 * [0]);
-																																								 * printf(
-																																								 * "string: %s fuck this nuts\n"
-																																								 * ,
-																																								 * string
-																																								 * );
+																																								  printf(
+																																								  "boolean: %s\n"
+																																								  ,
+																																								  boolArg
+																																								  ?
+																																								  "true":
+																																								  "false"
+																																								  );
+																																								  printf(
+																																								  "byte: %d\n"
+																																								  ,
+																																								  byteArg
+																																								  );
+																																								  printf(
+																																								  "char: %c\n"
+																																								  ,
+																																								  charArg
+																																								  );
+																																								  printf(
+																																								  "short: %d\n"
+																																								  ,
+																																								  shortArg
+																																								  );
+																																								  printf(
+																																								  "int: %d\n"
+																																								  ,
+																																								  intArg
+																																								  );
+																																								  printf(
+																																								  "long: %l\n"
+																																								  ,
+																																								  longArg
+																																								  );
+																																								  printf(
+																																								  "float: %f\n"
+																																								  ,
+																																								  floatArg
+																																								  );
+																																								  printf(
+																																								  "double: %d\n"
+																																								  ,
+																																								  doubleArg
+																																								  );
+																																								  printf(
+																																								  "byteBuffer: %d\n"
+																																								  ,
+																																								  byteBuffer
+																																								  [0]);
+																																								  printf(
+																																								  "bool[0]: %s\n"
+																																								  ,
+																																								  boolArray
+																																								  [
+																																								  0]?"true"
+																																								  :
+																																								  "false"
+																																								  );
+																																								  printf(
+																																								  "char[0]: %c\n"
+																																								  ,
+																																								  charArray
+																																								  [0]);
+																																								  printf(
+																																								  "short[0]: %d\n"
+																																								  ,
+																																								  shortArray
+																																								  [0]);
+																																								  printf(
+																																								  "int[0]: %d\n"
+																																								  ,
+																																								  intArray
+																																								  [0]);
+																																								  printf(
+																																								  "long[0]: %ll\n"
+																																								  ,
+																																								  longArray
+																																								  [0]);
+																																								  printf(
+																																								  "float[0]: %f\n"
+																																								  ,
+																																								  floatArray
+																																								  [0]);
+																																								  printf(
+																																								  "double[0]: %f\n"
+																																								  ,
+																																								  doubleArray
+																																								  [0]);
+																																								  printf(
+																																								  "string: %s fuck this nuts\n"
+																																								  ,
+																																								  string
+																																								  );
 																																								 */
 
+	public static native boolean testCriticalNative(
+		boolean boolArg, byte byteArg, char charArg, short shortArg, int intArg, long longArg, float floatArg, double doubleArg, 
+		boolean[] boolArray, char[] charArray, short[] shortArray, int[] intArray, long[] longArray, float[] floatArray, double[] doubleArray); /*CRITICAL
+	  if(!_isCriticalNative)
+	    return false;
+	  printf("boolean: %s\n", boolArg ? "true": "false");               
+	  printf("byte: %d\n", byteArg);
+	  printf("char: %c\n", charArg);               
+	  printf("short: %d\n", shortArg);               
+	  printf("int: %d\n", intArg);               
+	  printf("long: %l\n", longArg);               
+	  printf("float: %f\n", floatArg);               
+	  printf("double: %f\n", doubleArg);
+	  for(int i=0; i < boolArrayLength; i++)       
+	  	printf("bool[%d]: %s\n", i, boolArray[i]?"true":"false");
+	  for(int i=0; i < charArrayLength; i++)       
+	  	printf("char[%d]: %c\n", i, charArray[i]);
+	  for(int i=0; i < shortArrayLength; i++)
+	  	printf("short[%d]: %c\n", i, shortArray[i]);
+	  for(int i=0; i < intArrayLength; i++)
+	  	printf("int[%d]: %c\n", i, intArray[i]);
+	  for(int i=0; i < longArrayLength; i++)
+	  	printf("long[%d]: %l\n", i, longArray[i]);
+	  for(int i=0; i < floatArrayLength; i++)
+	  	printf("float[%d]: %f\n", i, floatArray[i]);
+	  for(int i=0; i < doubleArrayLength; i++)
+	     printf("float[%d]: %f\n", i, floatArray[i]);  
+	  return true;
+	 */
+	
 	// @off
 	/*JNI
 	#include <stdio.h>


### PR DESCRIPTION
According to [an answer on StackOverflow](http://stackoverflow.com/questions/36298111/is-it-possible-to-use-sun-misc-unsafe-to-call-c-functions-without-jni/36309652#36309652), Hotspot JVM had an undocumented feature: Critical Natives, since Java7. It makes an improvement to reducing overhead of calling native methods (with some limits, anyway). This commit made the Jnigen be able to generate critical natives <del>automatically</del> on all eligible native methods.

What did it change
---
- Made the Jnigen be able to generate critical natives. Only affects desktop version. (Because only desktop has Hotspot, of course. <del>TODO: Is there any better definition to differentiate Linux and Android? I heard that \_\_linux\_\_ is defined in both of them...</del> )
- An new "keyword" for Jnigen: _CRITICAL_. <del>Likes _MANUAL_, but it's used to **assert** that the method is a critical native. If Jnigen can't generate a critical native for that method, it will throw an exception. (Generating critical natives for eligible methods is automatic and enforced.)</del>
UPDATE: Since the second commit, generating critical natives for eligible methods is no longer automatic. The keyword _CRITICAL_ is used for marking out native methods for generaing critical natives.

How does it work
---

- When parser scanning the source and creating JavaMethod, [it will also check if the method meets the condition](https://github.com/libgdx/libgdx/pull/4021/files#diff-ae13bdb9bf9640664a9c06cd8bbbe92eR196) (static & non-synchronized, every arguments must be either primitive or primitive array).
- When parser injecting native codes to the JavaMethod, it will check the codes by a RegExp. If the native function uses _env_ or _clazz_, it will be kicked out, too.
- Time to emit something. [Any JavaMethod which is critical native will always emit a wrapper method](https://github.com/libgdx/libgdx/pull/4021/files#diff-97645e59007ba8ffc5c27196496859f2R417).
- When emitting the wrapper, it won't generate "JNIEnv* env, jclass clazz" since they are disable. Instead, it will generate "bool \_isCriticalNative" as the first arguments. This is used to indicate which one called the wrapper. Should be useful when debug. And then, [it will generate all arguments with critical-native-style](https://github.com/libgdx/libgdx/pull/4021/files#diff-97645e59007ba8ffc5c27196496859f2R513). There is another work need to do when processing arrays. It will check if the codes uses the lengths of array. If not, it will not generate the length of array argument.
- Time to emit standard native function. The codes are pre-generated in [emitJniSetupCode](https://github.com/libgdx/libgdx/pull/4021/files#diff-97645e59007ba8ffc5c27196496859f2R563). Just emit 'em all.
- <del>The last work.</del> [Generate critical native function](https://github.com/libgdx/libgdx/pull/4021/files#diff-97645e59007ba8ffc5c27196496859f2R692). UPDATE: Since the second commit, Jnigen no longer generates critical native after standard native. It will buffer them and emit at the end of generated source at once. 

How to use
---

1. Ensure the native methods satisfy the requirements. (see the post on StackOverflow, or the first item of _How does it work_)
2. Add _CRITICAL_ at the head of block comment. For example: 

```
private static native void hotNative(int imPrimitive, float[] imArray); /*CRITICAL
  someworks(imPrimitive, imArray, imArrayLength);
*/
```

Jnigen will generate that:

```
static inline void wrapped_Java_[package]_[class]_hotNative
    (bool _isCriticalNative, jint imPrimitive, jint imArrayLength, jfloat* imArray)
{
  someworks(imPrimitive, imArray, imArrayLength);
}

JNIEXPORT void JNICALL Java_[package]_[class]_hotNative
    (JNIEnv* env, jclass clazz, jint imPrimitive, jfloatArray obj_imArray)
{
float* imArray = (float*)env->GetPrimitiveArrayCritical(obj_imArray, 0);
jsize imArrayLength= env->GetArrayLength(obj_imArray);
wrapped_Java_[package]_[class]_hotNative(false, imPrimitive, imArrayLength, imArray);
env->ReleasePrimitiveArrayCritical(obj_imArray, imArray , 0);
}

// Some preprocessor to check if it's on desktop.
#if defined(__DESKTOP__)
extern "C" JNIEXPORT void JNICALL JavaCritical_[package]_[class]_hotNative
    (jint imPrimitive, jint imArrayLength, jfloat* imArray)
{
wrapped_Java_[package]_[class]_hotNative(true, imPrimitive, imArrayLength, imArray);
}
#endif 
```
As you see, if you want to get the length of array, you can use _[arrayName]Length_. (On the other side, if you already have an array argument named _XXX_, don't name any other argument as _XXXLength_) If you want to check if the code are called from the critical path, you can use _\_isCriticalNative_. (Don't forget that Hotspot has a _lazy critical entry logic_ for critical natives. The first time calling critical native will always run the normal native function (starts with "Java\_"). After some times (could be hundreds) the Hotspot will replace the normal function with critical one (starts with "JavaCritical\_").)

Pros:
---
- Gives a free performance improving (especially to Matrix4) for desktop. A critical matrix multiplication takes about 35ns when the vanilla one takes about 69ns. A rough SSE+Critical version only takes 24ns (It seems that MinGW can't optimize SSE well? In another native matrix multiplication implementation with MSVC it can takes only 15ns. Whether or not, it should be solved at another time, not now). For comparison, the JOML implementation takes 26ns.

Cons:
---
- Only works on desktop and Hotspot JVM. I don't know if ExcelsiorJET JVM supports this feature.
- Makes the libraries larger! (about 15kb pre library, \*laugh\*)
- Although critical natives is not an new technology, but it's new for using on unofficial projects.

Anyway, it should be treated and tested carefully since it affects all projects which are using Jnigen. I don't know if an engine which focuses on mobile need a desktop-only over-optimization, but it's good for desktop games which depend on heavy matrix operations, and should be enough to quiet the people who complain the performance of matrix of Gdx. 😅