### PR TITLE
Make it possible to use multiple ParticleSystems

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g3d/particles/ParticleSystem.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/particles/ParticleSystem.java
@@ -12,6 +12,9 @@ import com.badlogic.gdx.utils.Pool;
 public final class ParticleSystem implements RenderableProvider{
 	private static ParticleSystem instance;
 	
+	/**
+	 * @deprecated Please directly use the constructor
+	 */
 	public static ParticleSystem get(){
 		if(instance == null)
 			instance = new ParticleSystem();
@@ -21,7 +24,7 @@ public final class ParticleSystem implements RenderableProvider{
 	private Array<ParticleBatch<?>> batches;
 	private Array<ParticleEffect> effects;
 	
-	private ParticleSystem () {
+	public ParticleSystem () {
 		batches = new Array<ParticleBatch<?>>();
 		effects = new Array<ParticleEffect>();
 	}


### PR DESCRIPTION
This makes it possible to use multiple `ParticleSystems`.
There is no reason, for `ParticleSystems` being static.
This could also fix https://github.com/libgdx/libgdx/issues/3018 , although it's unclear whether `ParticleSystem` caused the issue at all.