### PR TITLE
Fixes #4035 and missing "iPad 6,7"

### DIFF
--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSDevice.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSDevice.java
@@ -56,8 +56,11 @@ public enum IOSDevice {
 	IPAD_MINI_AIR_2_WIFI("iPad5,3", 264),
 	IPAD_MINI_AIR_2_WIFI_CELLULAR("iPad5,4", 264),
 	IPAD_PRO_WIFI("iPad6,7", 264),
+	IPAD_PRO("iPad6,7", 264),
 	IPAD_PRO("iPad6,8", 264),
-	
+	IPAD_PRO("iPad6,3", 264),
+	IPAD_PRO("iPad6,4", 264),
+
 	SIMULATOR_32("i386", 264),
 	SIMULATOR_64("x86_64", 264);
 	

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSDevice.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSDevice.java
@@ -56,10 +56,9 @@ public enum IOSDevice {
 	IPAD_MINI_AIR_2_WIFI("iPad5,3", 264),
 	IPAD_MINI_AIR_2_WIFI_CELLULAR("iPad5,4", 264),
 	IPAD_PRO_WIFI("iPad6,7", 264),
-	IPAD_PRO("iPad6,7", 264),
 	IPAD_PRO("iPad6,8", 264),
-	IPAD_PRO("iPad6,3", 264),
-	IPAD_PRO("iPad6,4", 264),
+	IPAD_PRO_97_WIFI("iPad6,3", 264),
+	IPAD_PRO_97("iPad6,4", 264),
 
 	SIMULATOR_32("i386", 264),
 	SIMULATOR_64("x86_64", 264);


### PR DESCRIPTION
I cross checked against https://www.theiphonewiki.com/wiki/Models and found that "iPad6,7" was also missing, so I added it too.