### PR TITLE
Emulate ScreenUtils for GWT

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/graphics/Pixmap.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/graphics/Pixmap.java
@@ -102,6 +102,10 @@ public class Pixmap implements Disposable {
 		context.drawImage(img, 0, 0);
 		context.setGlobalCompositeOperation(getComposite());
 	}
+	
+	public Context2d getContext() {
+		return context;
+	}
 
 	private static Composite getComposite () {
 		return Composite.SOURCE_OVER;

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/utils/ScreenUtils.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/utils/ScreenUtils.java
@@ -1,0 +1,138 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogic.gdx.utils;
+
+import java.nio.ByteBuffer;
+import java.nio.HasArrayBufferView;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.Pixmap;
+import com.badlogic.gdx.graphics.Pixmap.Format;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.TextureRegion;
+import com.badlogic.gdx.math.MathUtils;
+import com.google.gwt.canvas.dom.client.Context2d;
+import com.google.gwt.typedarrays.shared.ArrayBufferView;
+
+/** Class with static helper methods that provide access to the default OpenGL FrameBuffer. These methods can be used to get the
+ * entire screen content or a portion thereof.
+ * 
+ * @author espitz */
+public final class ScreenUtils {
+
+	/** Returns the default framebuffer contents as a {@link TextureRegion} with a width and height equal to the current screen
+	 * size. The base {@link Texture} always has {@link MathUtils#nextPowerOfTwo} dimensions and RGBA8888 {@link Format}. It can be
+	 * accessed via {@link TextureRegion#getTexture}. The texture is not managed and has to be reloaded manually on a context loss.
+	 * The returned TextureRegion is flipped along the Y axis by default. */
+	public static TextureRegion getFrameBufferTexture () {
+		final int w = Gdx.graphics.getBackBufferWidth();
+		final int h = Gdx.graphics.getBackBufferHeight();
+		return getFrameBufferTexture(0, 0, w, h);
+	}
+
+	/** Returns a portion of the default framebuffer contents specified by x, y, width and height as a {@link TextureRegion} with
+	 * the same dimensions. The base {@link Texture} always has {@link MathUtils#nextPowerOfTwo} dimensions and RGBA8888
+	 * {@link Format}. It can be accessed via {@link TextureRegion#getTexture}. This texture is not managed and has to be reloaded
+	 * manually on a context loss. If the width and height specified are larger than the framebuffer dimensions, the Texture will
+	 * be padded accordingly. Pixels that fall outside of the current screen will have RGBA values of 0.
+	 * 
+	 * @param x the x position of the framebuffer contents to capture
+	 * @param y the y position of the framebuffer contents to capture
+	 * @param w the width of the framebuffer contents to capture
+	 * @param h the height of the framebuffer contents to capture */
+	public static TextureRegion getFrameBufferTexture (int x, int y, int w, int h) {
+		final int potW = MathUtils.nextPowerOfTwo(w);
+		final int potH = MathUtils.nextPowerOfTwo(h);
+
+		final Pixmap pixmap = getFrameBufferPixmap(x, y, w, h);
+		final Pixmap potPixmap = new Pixmap(potW, potH, Format.RGBA8888);
+		potPixmap.drawPixmap(pixmap, 0, 0);
+		Texture texture = new Texture(potPixmap);
+		TextureRegion textureRegion = new TextureRegion(texture, 0, h, w, -h);
+		potPixmap.dispose();
+		pixmap.dispose();
+
+		return textureRegion;
+	}
+
+	public static Pixmap getFrameBufferPixmap (int x, int y, int w, int h) {
+		Gdx.gl.glPixelStorei(GL20.GL_PACK_ALIGNMENT, 1);
+
+		final Pixmap pixmap = new Pixmap(w, h, Format.RGBA8888);
+		ByteBuffer pixels = BufferUtils.newByteBuffer(h * w * 4);
+		Gdx.gl.glReadPixels(x, y, w, h, GL20.GL_RGBA, GL20.GL_UNSIGNED_BYTE, pixels);
+		putPixelsBack(pixmap, pixels);
+		return pixmap;
+	}
+
+	public static void putPixelsBack (Pixmap pixmap, ByteBuffer pixels) {
+		if (pixmap.getWidth() == 0 || pixmap.getHeight() == 0) return;
+		putPixelsBack(((HasArrayBufferView)pixels).getTypedArray(), pixmap.getWidth(), pixmap.getHeight(), pixmap.getContext());
+
+	}
+
+	private native static void putPixelsBack (ArrayBufferView pixels, int width, int height, Context2d ctx)/*-{
+		var imgData = ctx.createImageData(width, height);
+		var data = imgData.data;
+
+		for (var i = 0, len = width * height * 4; i < len; i++) {
+			data[i] = pixels[i] & 0xff;
+		}
+		ctx.putImageData(imgData, 0, 0);
+	}-*/;
+
+	/** Returns the default framebuffer contents as a byte[] array with a length equal to screen width * height * 4. The byte[]
+	 * will always contain RGBA8888 data. Because of differences in screen and image origins the framebuffer contents should be
+	 * flipped along the Y axis if you intend save them to disk as a bitmap. Flipping is not a cheap operation, so use this
+	 * functionality wisely.
+	 * 
+	 * @param flipY whether to flip pixels along Y axis */
+	public static byte[] getFrameBufferPixels (boolean flipY) {
+		final int w = Gdx.graphics.getBackBufferWidth();
+		final int h = Gdx.graphics.getBackBufferHeight();
+		return getFrameBufferPixels(0, 0, w, h, flipY);
+	}
+
+	/** Returns a portion of the default framebuffer contents specified by x, y, width and height, as a byte[] array with a length
+	 * equal to the specified width * height * 4. The byte[] will always contain RGBA8888 data. If the width and height specified
+	 * are larger than the framebuffer dimensions, the Texture will be padded accordingly. Pixels that fall outside of the current
+	 * screen will have RGBA values of 0. Because of differences in screen and image origins the framebuffer contents should be
+	 * flipped along the Y axis if you intend save them to disk as a bitmap. Flipping is not a cheap operation, so use this
+	 * functionality wisely.
+	 * 
+	 * @param flipY whether to flip pixels along Y axis */
+	public static byte[] getFrameBufferPixels (int x, int y, int w, int h, boolean flipY) {
+		Gdx.gl.glPixelStorei(GL20.GL_PACK_ALIGNMENT, 1);
+		final ByteBuffer pixels = BufferUtils.newByteBuffer(w * h * 4);
+		Gdx.gl.glReadPixels(x, y, w, h, GL20.GL_RGBA, GL20.GL_UNSIGNED_BYTE, pixels);
+		final int numBytes = w * h * 4;
+		byte[] lines = new byte[numBytes];
+		if (flipY) {
+			final int numBytesPerLine = w * 4;
+			for (int i = 0; i < h; i++) {
+				pixels.position((h - i - 1) * numBytesPerLine);
+				pixels.get(lines, i * numBytesPerLine, numBytesPerLine);
+			}
+		} else {
+			pixels.clear();
+			pixels.get(lines);
+		}
+		return lines;
+
+	}
+}

--- a/gdx/src/com/badlogic/gdx.gwt.xml
+++ b/gdx/src/com/badlogic/gdx.gwt.xml
@@ -438,7 +438,7 @@
 		<include name="utils/QuickSelect.java"/>
 		<include name="utils/ReflectionPool.java"/>
 		<include name="utils/Scaling.java"/>
-		<exclude name="utils/ScreenUtils.java"/> <!-- Reason: Type mismatch Buffer->ByteBuffer -->
+		<include name="utils/ScreenUtils.java"/>
 		<include name="utils/Select.java"/>
 		<include name="utils/SerializationException.java"/> <!-- Emulated: Reflection -->
 		<exclude name="utils/SharedLibraryLoader.java"/> <!-- Reason: Natives -->

--- a/tests/gdx-tests/src/com/badlogic/gdx/GdxTests.gwt.xml
+++ b/tests/gdx-tests/src/com/badlogic/gdx/GdxTests.gwt.xml
@@ -2,7 +2,6 @@
 <!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit trunk//EN" "http://google-web-toolkit.googlecode.com/svn/trunk/distro-source/core/src/gwt-module.dtd">
 <module>
 	<source path="tests">
-		<exclude name="**/AlphaTest.java"/> <!-- ScreenUtils -->
 		<exclude name="**/AudioDeviceTest.java"/> <!-- audio missing -->
 		<exclude name="**/AudioRecorderTest.java"/> <!-- audio missing -->
 		<exclude name="**/BobTest.java"/> <!-- GL ES 1.0 -->
@@ -12,7 +11,6 @@
 		<exclude name="**/KTXTest.java"/> <!-- use ECT1 which is native -->
 		<exclude name="**/ETC1Test.java"/> <!-- native -->
 		<exclude name="**/FFTTest.java"/> <!-- native -->
-		<exclude name="**/FramebufferToTextureTest.java"/> <!-- ScreenUtils missing -->
 		<exclude name="**/FreeType*.java"/> <!-- native  -->
 		<exclude name="**/Gdx2DTest.java"/> <!-- native -->
 		<exclude name="**/HeightField.java"/> <!-- Incompatible type due to emulation -->
@@ -23,8 +21,6 @@
 		<exclude name="**/Mpg123Test.java"/> <!-- native -->
 		<exclude name="**/PngTest.java"/> <!-- Not compatible -->
 		<exclude name="**/RemoteTest.java"/> <!-- networking -->
-		<exclude name="**/ScreenCaptureTest.java"/> <!-- ScreenUtils -->
-		<exclude name="**/ScreenshotTest.java"/> <!-- ScreenUtils -->
 		<exclude name="**/SelectTest.java"/> <!-- String.format -->
 		<exclude name="**/SoundTouchTest.java"/> <!-- native -->
 		<exclude name="**/StbTrueTypeTest.java"/> <!-- native -->

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/FramebufferToTextureTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/FramebufferToTextureTest.java
@@ -70,7 +70,6 @@ public class FramebufferToTextureTest extends GdxTest {
 		Gdx.gl.glClearColor(clearColor.g, clearColor.g, clearColor.b, clearColor.a);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
 		Gdx.gl.glEnable(GL20.GL_DEPTH_TEST);
-		Gdx.gl.glEnable(GL20.GL_TEXTURE_2D);
 
 		cam.update();
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtTestWrapper.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtTestWrapper.java
@@ -60,6 +60,7 @@ import com.badlogic.gdx.tests.DecalTest;
 import com.badlogic.gdx.tests.EdgeDetectionTest;
 import com.badlogic.gdx.tests.FilterPerformanceTest;
 import com.badlogic.gdx.tests.FrameBufferTest;
+import com.badlogic.gdx.tests.FramebufferToTextureTest;
 import com.badlogic.gdx.tests.GLProfilerErrorTest;
 import com.badlogic.gdx.tests.GestureDetectorTest;
 import com.badlogic.gdx.tests.GroupCullingTest;
@@ -456,6 +457,10 @@ public class GwtTestWrapper extends GdxTest {
 		}
 	}, new Instancer() {
 		public GdxTest instance () {
+			return new AlphaTest();
+		}
+	}, new Instancer() {
+		public GdxTest instance () {
 			return new AnimationTest();
 		}
 	}, new Instancer() {
@@ -539,6 +544,10 @@ public class GwtTestWrapper extends GdxTest {
 		new Instancer() {
 			public GdxTest instance () {
 				return new FrameBufferTest();
+			}
+		}, new Instancer() {
+			public GdxTest instance () {
+				return new FramebufferToTextureTest();
 			}
 		}, new Instancer() {
 			public GdxTest instance () {


### PR DESCRIPTION
Add FramebufferToTextureTest and AlphaTest to GWT, remove obsolete 
tests.