### PR TITLE
Improve performance of glReadPixels() and ScreenUtils on GWT

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -11,6 +11,12 @@
 - API Change: moved shape builder logic out of MeshBuilder, see: https://github.com/libgdx/libgdx/pull/3996
 - API Change: Table reset now calls clearChildren, not clear.
 - Fixed crashes in AndroidMusic.java when isPlaying is called. Errors are now logged only rather than crashing the app.
+- Added emulation of ScreenUtils for GWT
+- Improved performance of glReadPixels() on GWT. New method is 20-30 times faster
+- Fixed crash on Mac when using LWJGL2, custom cursors and embedding the game in an AWT window
+- Fixed getDisplayModes(Monitor monitor) returning wrong data on LWJGL2 backend
+- Fixed Gdx.input.getCurrentEventTime() not being set on LWJGL3, fixes GestureDetector and flick scroll not working
+- Fixed not being able to select non-latin characters in TextFields
 
 [1.9.2]
 - Added TextureArray wrapper see https://github.com/libgdx/libgdx/pull/3807

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -175,3 +175,4 @@ kotcrab https://github.com/kotcrab
 ClaudiuBele https://github.com/ClaudiuBele
 realitix https://github.com/realitix
 vmilea https://github.com/vmilea
+intrigus https://github.com/intrigus

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtGL20.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtGL20.java
@@ -71,7 +71,6 @@ public class GwtGL20 implements GL20 {
 	final WebGLRenderingContext gl;
 
 	protected GwtGL20 (WebGLRenderingContext gl) {
-		;
 		this.gl = gl;
 		this.gl.pixelStorei(WebGLRenderingContext.UNPACK_PREMULTIPLY_ALPHA_WEBGL, 0);
 	}
@@ -414,7 +413,8 @@ public class GwtGL20 implements GL20 {
 	public void glReadPixels (int x, int y, int width, int height, int format, int type, Buffer pixels) {
 		// verify request
 		if ((format != WebGLRenderingContext.RGBA) || (type != WebGLRenderingContext.UNSIGNED_BYTE)) {
-			throw new GdxRuntimeException("Only format RGBA and type UNSIGNED_BYTE are currently supported for glReadPixels(...).");
+			throw new GdxRuntimeException(
+				"Only format RGBA and type UNSIGNED_BYTE are currently supported for glReadPixels(...). Create an issue when you need other formats.");
 		}
 		if (!(pixels instanceof ByteBuffer)) {
 			throw new GdxRuntimeException("Inputed pixels buffer needs to be of type ByteBuffer for glReadPixels(...).");
@@ -422,16 +422,10 @@ public class GwtGL20 implements GL20 {
 
 		// create new ArrayBufferView (4 bytes per pixel)
 		int size = 4 * width * height;
-		Uint8Array buffer = Uint8ArrayNative.create(size);
+		Uint8Array buffer = TypedArrays.createUint8Array(((HasArrayBufferView)pixels).getTypedArray().buffer(), 0, size);
 
 		// read bytes to ArrayBufferView
 		gl.readPixels(x, y, width, height, format, type, buffer);
-
-		// copy ArrayBufferView to our pixels array
-		ByteBuffer pixelsByte = (ByteBuffer)pixels;
-		for (int i = 0; i < size; i++) {
-			pixelsByte.put((byte)(buffer.get(i) & 0x000000ff));
-		}
 	}
 
 	@Override

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/utils/ScreenUtils.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/utils/ScreenUtils.java
@@ -90,8 +90,11 @@ public final class ScreenUtils {
 		var imgData = ctx.createImageData(width, height);
 		var data = imgData.data;
 
-		for (var i = 0, len = width * height * 4; i < len; i++) {
+		for (var i = 0, len = width * height; i < len; i++) {
 			data[i] = pixels[i] & 0xff;
+			data[i+1] = pixels[i+1] & 0xff;
+			data[i+2] = pixels[i+2] & 0xff;
+			data[i+3] = pixels[i+3] & 0xff;
 		}
 		ctx.putImageData(imgData, 0, 0);
 	}-*/;


### PR DESCRIPTION
glReadPixels() is about 20 times faster now, ScreenUtils is about 15% 
faster

I also added the CHANGES from my other PRs.