### PR TITLE
Sort GWT tests, remove "optimization" in ScreenUtils

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/utils/ScreenUtils.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/utils/ScreenUtils.java
@@ -90,11 +90,8 @@ public final class ScreenUtils {
 		var imgData = ctx.createImageData(width, height);
 		var data = imgData.data;
 
-		for (var i = 0, len = width * height; i < len; i++) {
+		for (var i = 0, len = width * height * 4; i < len; i++) {
 			data[i] = pixels[i] & 0xff;
-			data[i+1] = pixels[i+1] & 0xff;
-			data[i+2] = pixels[i+2] & 0xff;
-			data[i+3] = pixels[i+3] & 0xff;
 		}
 		ctx.putImageData(imgData, 0, 0);
 	}-*/;

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtTestWrapper.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtTestWrapper.java
@@ -16,6 +16,9 @@
 
 package com.badlogic.gdx.tests.gwt;
 
+import java.util.Arrays;
+import java.util.Comparator;
+
 import com.badlogic.gdx.Application;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
@@ -37,6 +40,7 @@ import com.badlogic.gdx.scenes.scene2d.utils.ClickListener;
 import com.badlogic.gdx.tests.AccelerometerTest;
 import com.badlogic.gdx.tests.ActionSequenceTest;
 import com.badlogic.gdx.tests.ActionTest;
+import com.badlogic.gdx.tests.AlphaTest;
 import com.badlogic.gdx.tests.AnimationTest;
 import com.badlogic.gdx.tests.AnnotationTest;
 import com.badlogic.gdx.tests.AssetManagerTest;
@@ -131,6 +135,12 @@ public class GwtTestWrapper extends GdxTest {
 		ScrollPane scroll = new ScrollPane(table);
 		container.add(scroll).expand().fill();
 		table.pad(10).defaults().expandX().space(4);
+		Arrays.sort(tests, new Comparator<Instancer>() {
+			@Override
+			public int compare (Instancer o1, Instancer o2) {
+				return o1.instance().getClass().getName().compareTo(o2.instance().getClass().getName());
+			}
+		});
 		for (final Instancer instancer : tests) {
 			table.row();
 			TextButton button = new TextButton(instancer.instance().getClass().getName(), skin);


### PR DESCRIPTION
Turns out that javascript engines are jiting as much as java vms, which means that micro benchmarks are pretty useless. (E.g. the speed is dependent on which function is called first) :(
Since there is no benchmarking tool for javascript that is as good as [JHM](http://openjdk.java.net/projects/code-tools/jmh/) is for java, I removed the "optimizations".