### PR TITLE
Classpath fonts can now be referenced in skin JSON

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Skin.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Skin.java
@@ -469,6 +469,7 @@ public class Skin implements Disposable {
 
 				FileHandle fontFile = skinFile.parent().child(path);
 				if (!fontFile.exists()) fontFile = Gdx.files.internal(path);
+				if (!fontFile.exists()) fontFile = Gdx.files.classpath(path);
 				if (!fontFile.exists()) throw new SerializationException("Font file not found: " + fontFile);
 
 				// Use a region with the same name as the font, else use a PNG file in the same directory as the FNT file.


### PR DESCRIPTION
Currently, this is properly parsed by Desktop and GWT, which basically use the same mechanism for internal and classpath files:
```
  com.badlogic.gdx.graphics.g2d.BitmapFont: { 
    default: { file: { com/badlogic/gdx/utils/arial-15.fnt }
  }
```

However, this fails on Android. It would be nice if you could reference fonts located at classpath (for example - provided by external libraries), so you wouldn't have to include your own font files. Very useful for prototyping.