### PR TITLE
Make addAsset public to avoid inheritance just to access this method

### DIFF
--- a/gdx/src/com/badlogic/gdx/assets/AssetManager.java
+++ b/gdx/src/com/badlogic/gdx/assets/AssetManager.java
@@ -475,7 +475,7 @@ public class AssetManager implements Disposable {
 	}
 
 	/** Adds an asset to this AssetManager */
-	protected <T> void addAsset (final String fileName, Class<T> type, T asset) {
+	public <T> void addAsset (final String fileName, Class<T> type, T asset) {
 		// add the asset to the filename lookup
 		assetTypes.put(fileName, type);
 


### PR DESCRIPTION
Don't know what to say more, this is a simple change to make this method more easy to use.