### PR TITLE
Fix typo in RandomXS128.java

### DIFF
--- a/gdx/src/com/badlogic/gdx/math/RandomXS128.java
+++ b/gdx/src/com/badlogic/gdx/math/RandomXS128.java
@@ -177,7 +177,7 @@ public class RandomXS128 extends Random {
 	
 	/**
 	 * Returns the internal seeds to allow state saving.
-	 * @param seed muse be 0 or 1, designating which of the 2 long seeds to return
+	 * @param seed must be 0 or 1, designating which of the 2 long seeds to return
 	 * @return the internal seed that can be used in setState
 	 */
 	public long getState(int seed) {


### PR DESCRIPTION
getState(int) javadoc contains "seed **muse** be 0 or 1"