### PR TITLE
Updated third party extension versions

### DIFF
--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/data/extensions.xml
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/data/extensions.xml
@@ -164,8 +164,8 @@
 		<name>gdx-kiwi</name>
 		<description>Guava-inspired utilities for LibGDX.</description>
 		<package>com.github.czyzby.kiwi</package>
-		<version>1.6.1.9.2</version>
-		<compatibility>1.9.2</compatibility>
+		<version>1.6.1.9.3</version>
+		<compatibility>1.9.3</compatibility>
 		<website>https://github.com/czyzby/gdx-lml/tree/master/kiwi</website>
 		<gwtInherits>
 			<inherit>com.github.czyzby.kiwi.GdxKiwi</inherit>
@@ -186,8 +186,8 @@
 		<name>gdx-lml</name>
 		<description>Parser of HTML-like templates into Scene2D actors.</description>
 		<package>com.github.czyzby.lml</package>
-		<version>1.6.1.9.2</version>
-		<compatibility>1.9.2</compatibility>
+		<version>1.6.1.9.3</version>
+		<compatibility>1.9.3</compatibility>
 		<website>https://github.com/czyzby/gdx-lml/tree/master/lml</website>
 		<gwtInherits>
 			<inherit>com.github.czyzby.lml.GdxLml</inherit>
@@ -209,8 +209,8 @@
 		<name>gdx-lml-vis</name>
 		<description>Parser of HTML-like templates into VisUI actors.</description>
 		<package>com.github.czyzby.lml.vis</package>
-		<version>1.6.1.9.2</version>
-		<compatibility>1.9.2</compatibility>
+		<version>1.6.1.9.3</version>
+		<compatibility>1.9.3</compatibility>
 		<website>https://github.com/czyzby/gdx-lml/tree/master/lml-vis</website>
 		<gwtInherits>
 			<inherit>com.github.czyzby.lml.vis.GdxLmlVis</inherit>


### PR DESCRIPTION
Updated `gdx-kiwi`, `gdx-lml` and `gdx-lml-vis`.