### PR TITLE
Allow tap count reset on ClickListener

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/ClickListener.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/ClickListener.java
@@ -174,6 +174,11 @@ public class ClickListener extends InputListener {
 	public int getTapCount () {
 		return tapCount;
 	}
+	
+	/** Sets the tap count back to zero. */
+	public void resetTapCount () {
+		tapCount = 0;
+	}
 
 	public float getTouchDownX () {
 		return touchDownX;


### PR DESCRIPTION
I was having a hard time working around this missing method. There are cases where I have a widget that does something different with a drag than with a double click. But if I quickly drag and then click soon after the drag, it still counts as a double click. By double click, I mean checking `if (getTapCount() == 2)` in the `click` method.