### PR TITLE
Add critical natives for some hot methods

### DIFF
--- a/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/parsing/RobustJavaMethodParser.java
+++ b/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/parsing/RobustJavaMethodParser.java
@@ -137,6 +137,7 @@ public class RobustJavaMethodParser implements JavaMethodParser {
 		String className = classStack.peek().getName();
 		String name = method.getName();
 		boolean isStatic = ModifierSet.hasModifier(method.getModifiers(), ModifierSet.STATIC);
+		boolean isSynchronized = ModifierSet.hasModifier(method.getModifiers(), ModifierSet.SYNCHRONIZED);
 		String returnType = method.getType().toString();
 		ArrayList<Argument> arguments = new ArrayList<Argument>();
 
@@ -146,7 +147,7 @@ public class RobustJavaMethodParser implements JavaMethodParser {
 			}
 		}
 
-		return new JavaMethod(className, name, isStatic, returnType, null, arguments, method.getBeginLine(), method.getEndLine());
+		return new JavaMethod(className, name, isStatic, isSynchronized, returnType, null, arguments, method.getBeginLine(), method.getEndLine());
 	}
 
 	private ArgumentType getArgumentType (Parameter parameter) {

--- a/gdx/jni/com.badlogic.gdx.math.Matrix4.cpp
+++ b/gdx/jni/com.badlogic.gdx.math.Matrix4.cpp
@@ -1,4 +1,13 @@
 #include <com.badlogic.gdx.math.Matrix4.h>
+#if (defined(_WIN32) || defined(__linux__) || defined(__unix)) && !defined(__ANDROID__)
+#define __LIBGDX__DESKTOP__ 1
+#endif
+#if defined(__APPLE__)
+#include "TargetConditionals.h"
+#if TARGET_OS_MAC && !TARGET_OS_IPHONE
+#define __LIBGDX__DESKTOP__ 1
+#endif
+#endif
 
 //@line:1157
 
@@ -154,12 +163,21 @@
 
 }
 
+#if __LIBGDX__DESKTOP__
+ extern "C" JNIEXPORT void JNICALL JavaCritical_com_badlogic_gdx_math_Matrix4_mul(jint mataLength, jfloat* mata, jint matbLength, jfloat* matb) {
+
+//@line:1307
+
+	matrix4_mul(mata, matb);
+	
+}
+#endif
 JNIEXPORT void JNICALL Java_com_badlogic_gdx_math_Matrix4_mulVec___3F_3F(JNIEnv* env, jclass clazz, jfloatArray obj_mat, jfloatArray obj_vec) {
 	float* mat = (float*)env->GetPrimitiveArrayCritical(obj_mat, 0);
 	float* vec = (float*)env->GetPrimitiveArrayCritical(obj_vec, 0);
 
 
-//@line:1313
+//@line:1317
 
 		matrix4_mulVec(mat, vec);
 	
@@ -168,12 +186,21 @@ JNIEXPORT void JNICALL Java_com_badlogic_gdx_math_Matrix4_mulVec___3F_3F(JNIEnv*
 
 }
 
+#if __LIBGDX__DESKTOP__
+ extern "C" JNIEXPORT void JNICALL JavaCritical_com_badlogic_gdx_math_Matrix4_mulVec___3F_3F(jint matLength, jfloat* mat, jint vecLength, jfloat* vec) {
+
+//@line:1321
+
+		matrix4_mulVec(mat, vec);
+	
+}
+#endif
 JNIEXPORT void JNICALL Java_com_badlogic_gdx_math_Matrix4_mulVec___3F_3FIII(JNIEnv* env, jclass clazz, jfloatArray obj_mat, jfloatArray obj_vecs, jint offset, jint numVecs, jint stride) {
 	float* mat = (float*)env->GetPrimitiveArrayCritical(obj_mat, 0);
 	float* vecs = (float*)env->GetPrimitiveArrayCritical(obj_vecs, 0);
 
 
-//@line:1328
+//@line:1336
 
 		float* vecPtr = vecs + offset;
 		for(int i = 0; i < numVecs; i++) {
@@ -186,12 +213,25 @@ JNIEXPORT void JNICALL Java_com_badlogic_gdx_math_Matrix4_mulVec___3F_3FIII(JNIE
 
 }
 
+#if __LIBGDX__DESKTOP__
+ extern "C" JNIEXPORT void JNICALL JavaCritical_com_badlogic_gdx_math_Matrix4_mulVec___3F_3FIII(jint matLength, jfloat* mat, jint vecsLength, jfloat* vecs, jint offset, jint numVecs, jint stride) {
+
+//@line:1344
+
+	float* vecPtr = vecs + offset;
+	for(int i = 0; i < numVecs; i++) {
+		matrix4_mulVec(mat, vecPtr);
+		vecPtr += stride;
+	}
+	
+}
+#endif
 JNIEXPORT void JNICALL Java_com_badlogic_gdx_math_Matrix4_prj___3F_3F(JNIEnv* env, jclass clazz, jfloatArray obj_mat, jfloatArray obj_vec) {
 	float* mat = (float*)env->GetPrimitiveArrayCritical(obj_mat, 0);
 	float* vec = (float*)env->GetPrimitiveArrayCritical(obj_vec, 0);
 
 
-//@line:1342
+//@line:1358
 
 		matrix4_proj(mat, vec);
 	
@@ -200,12 +240,21 @@ JNIEXPORT void JNICALL Java_com_badlogic_gdx_math_Matrix4_prj___3F_3F(JNIEnv* en
 
 }
 
+#if __LIBGDX__DESKTOP__
+ extern "C" JNIEXPORT void JNICALL JavaCritical_com_badlogic_gdx_math_Matrix4_prj___3F_3F(jint matLength, jfloat* mat, jint vecLength, jfloat* vec) {
+
+//@line:1362
+
+	matrix4_proj(mat, vec);
+	
+}
+#endif
 JNIEXPORT void JNICALL Java_com_badlogic_gdx_math_Matrix4_prj___3F_3FIII(JNIEnv* env, jclass clazz, jfloatArray obj_mat, jfloatArray obj_vecs, jint offset, jint numVecs, jint stride) {
 	float* mat = (float*)env->GetPrimitiveArrayCritical(obj_mat, 0);
 	float* vecs = (float*)env->GetPrimitiveArrayCritical(obj_vecs, 0);
 
 
-//@line:1357
+//@line:1377
 
 		float* vecPtr = vecs + offset;
 		for(int i = 0; i < numVecs; i++) {
@@ -218,12 +267,25 @@ JNIEXPORT void JNICALL Java_com_badlogic_gdx_math_Matrix4_prj___3F_3FIII(JNIEnv*
 
 }
 
+#if __LIBGDX__DESKTOP__
+ extern "C" JNIEXPORT void JNICALL JavaCritical_com_badlogic_gdx_math_Matrix4_prj___3F_3FIII(jint matLength, jfloat* mat, jint vecsLength, jfloat* vecs, jint offset, jint numVecs, jint stride) {
+
+//@line:1385
+
+	float* vecPtr = vecs + offset;
+	for(int i = 0; i < numVecs; i++) {
+		matrix4_proj(mat, vecPtr);
+		vecPtr += stride;
+	}
+	
+}
+#endif
 JNIEXPORT void JNICALL Java_com_badlogic_gdx_math_Matrix4_rot___3F_3F(JNIEnv* env, jclass clazz, jfloatArray obj_mat, jfloatArray obj_vec) {
 	float* mat = (float*)env->GetPrimitiveArrayCritical(obj_mat, 0);
 	float* vec = (float*)env->GetPrimitiveArrayCritical(obj_vec, 0);
 
 
-//@line:1371
+//@line:1399
 
 		matrix4_rot(mat, vec);
 	
@@ -232,12 +294,21 @@ JNIEXPORT void JNICALL Java_com_badlogic_gdx_math_Matrix4_rot___3F_3F(JNIEnv* en
 
 }
 
+#if __LIBGDX__DESKTOP__
+ extern "C" JNIEXPORT void JNICALL JavaCritical_com_badlogic_gdx_math_Matrix4_rot___3F_3F(jint matLength, jfloat* mat, jint vecLength, jfloat* vec) {
+
+//@line:1403
+
+	matrix4_rot(mat, vec);
+	
+}
+#endif
 JNIEXPORT void JNICALL Java_com_badlogic_gdx_math_Matrix4_rot___3F_3FIII(JNIEnv* env, jclass clazz, jfloatArray obj_mat, jfloatArray obj_vecs, jint offset, jint numVecs, jint stride) {
 	float* mat = (float*)env->GetPrimitiveArrayCritical(obj_mat, 0);
 	float* vecs = (float*)env->GetPrimitiveArrayCritical(obj_vecs, 0);
 
 
-//@line:1386
+//@line:1418
 
 		float* vecPtr = vecs + offset;
 		for(int i = 0; i < numVecs; i++) {
@@ -250,10 +321,23 @@ JNIEXPORT void JNICALL Java_com_badlogic_gdx_math_Matrix4_rot___3F_3FIII(JNIEnv*
 
 }
 
+#if __LIBGDX__DESKTOP__
+ extern "C" JNIEXPORT void JNICALL JavaCritical_com_badlogic_gdx_math_Matrix4_rot___3F_3FIII(jint matLength, jfloat* mat, jint vecsLength, jfloat* vecs, jint offset, jint numVecs, jint stride) {
+
+//@line:1426
+
+	float* vecPtr = vecs + offset;
+	for(int i = 0; i < numVecs; i++) {
+		matrix4_rot(mat, vecPtr);
+		vecPtr += stride;
+	}
+	
+}
+#endif
 static inline jboolean wrapped_Java_com_badlogic_gdx_math_Matrix4_inv
 (JNIEnv* env, jclass clazz, jfloatArray obj_values, float* values) {
 
-//@line:1398
+//@line:1438
 
 		return matrix4_inv(values);
 	
@@ -269,10 +353,19 @@ JNIEXPORT jboolean JNICALL Java_com_badlogic_gdx_math_Matrix4_inv(JNIEnv* env, j
 	return JNI_returnValue;
 }
 
+#if __LIBGDX__DESKTOP__
+ extern "C" JNIEXPORT jboolean JNICALL JavaCritical_com_badlogic_gdx_math_Matrix4_inv(jint valuesLength, jfloat* values) {
+
+//@line:1442
+
+		return matrix4_inv(values);
+	
+}
+#endif
 static inline jfloat wrapped_Java_com_badlogic_gdx_math_Matrix4_det
 (JNIEnv* env, jclass clazz, jfloatArray obj_values, float* values) {
 
-//@line:1406
+//@line:1450
 
 		return matrix4_det(values);
 	
@@ -288,3 +381,12 @@ JNIEXPORT jfloat JNICALL Java_com_badlogic_gdx_math_Matrix4_det(JNIEnv* env, jcl
 	return JNI_returnValue;
 }
 
+#if __LIBGDX__DESKTOP__
+ extern "C" JNIEXPORT jfloat JNICALL JavaCritical_com_badlogic_gdx_math_Matrix4_det(jint valuesLength, jfloat* values) {
+
+//@line:1454
+
+		return matrix4_det(values);
+	
+}
+#endif

--- a/gdx/jni/com.badlogic.gdx.utils.BufferUtils.cpp
+++ b/gdx/jni/com.badlogic.gdx.utils.BufferUtils.cpp
@@ -1,4 +1,13 @@
 #include <com.badlogic.gdx.utils.BufferUtils.h>
+#if (defined(_WIN32) || defined(__linux__) || defined(__unix)) && !defined(__ANDROID__)
+#define __LIBGDX__DESKTOP__ 1
+#endif
+#if defined(__APPLE__)
+#include "TargetConditionals.h"
+#if TARGET_OS_MAC && !TARGET_OS_IPHONE
+#define __LIBGDX__DESKTOP__ 1
+#endif
+#endif
 
 //@line:497
  
@@ -293,12 +302,21 @@ JNIEXPORT void JNICALL Java_com_badlogic_gdx_utils_BufferUtils_transformV4M4Jni_
 
 }
 
+#if __LIBGDX__DESKTOP__
+ extern "C" JNIEXPORT void JNICALL JavaCritical_com_badlogic_gdx_utils_BufferUtils_transformV4M4Jni___3FII_3FI(jint dataLength, jfloat* data, jint strideInBytes, jint count, jint matrixLength, jfloat* matrix, jint offsetInBytes) {
+
+//@line:715
+
+		transform<4, 4>((float*)data, strideInBytes / 4, count, (float*)matrix, offsetInBytes / 4);  
+	
+}
+#endif
 JNIEXPORT void JNICALL Java_com_badlogic_gdx_utils_BufferUtils_transformV3M4Jni__Ljava_nio_Buffer_2II_3FI(JNIEnv* env, jclass clazz, jobject obj_data, jint strideInBytes, jint count, jfloatArray obj_matrix, jint offsetInBytes) {
 	unsigned char* data = (unsigned char*)(obj_data?env->GetDirectBufferAddress(obj_data):0);
 	float* matrix = (float*)env->GetPrimitiveArrayCritical(obj_matrix, 0);
 
 
-//@line:715
+//@line:719
 
 		transform<3, 4>((float*)data, strideInBytes / 4, count, (float*)matrix, offsetInBytes / 4);
 	
@@ -311,7 +329,7 @@ JNIEXPORT void JNICALL Java_com_badlogic_gdx_utils_BufferUtils_transformV3M4Jni_
 	float* matrix = (float*)env->GetPrimitiveArrayCritical(obj_matrix, 0);
 
 
-//@line:719
+//@line:723
 
 		transform<3, 4>((float*)data, strideInBytes / 4, count, (float*)matrix, offsetInBytes / 4);
 	
@@ -320,12 +338,21 @@ JNIEXPORT void JNICALL Java_com_badlogic_gdx_utils_BufferUtils_transformV3M4Jni_
 
 }
 
+#if __LIBGDX__DESKTOP__
+ extern "C" JNIEXPORT void JNICALL JavaCritical_com_badlogic_gdx_utils_BufferUtils_transformV3M4Jni___3FII_3FI(jint dataLength, jfloat* data, jint strideInBytes, jint count, jint matrixLength, jfloat* matrix, jint offsetInBytes) {
+
+//@line:727
+
+		transform<3, 4>((float*)data, strideInBytes / 4, count, (float*)matrix, offsetInBytes / 4);
+	
+}
+#endif
 JNIEXPORT void JNICALL Java_com_badlogic_gdx_utils_BufferUtils_transformV2M4Jni__Ljava_nio_Buffer_2II_3FI(JNIEnv* env, jclass clazz, jobject obj_data, jint strideInBytes, jint count, jfloatArray obj_matrix, jint offsetInBytes) {
 	unsigned char* data = (unsigned char*)(obj_data?env->GetDirectBufferAddress(obj_data):0);
 	float* matrix = (float*)env->GetPrimitiveArrayCritical(obj_matrix, 0);
 
 
-//@line:723
+//@line:731
 
 		transform<2, 4>((float*)data, strideInBytes / 4, count, (float*)matrix, offsetInBytes / 4);
 	
@@ -338,7 +365,7 @@ JNIEXPORT void JNICALL Java_com_badlogic_gdx_utils_BufferUtils_transformV2M4Jni_
 	float* matrix = (float*)env->GetPrimitiveArrayCritical(obj_matrix, 0);
 
 
-//@line:727
+//@line:735
 
 		transform<2, 4>((float*)data, strideInBytes / 4, count, (float*)matrix, offsetInBytes / 4);
 	
@@ -347,12 +374,21 @@ JNIEXPORT void JNICALL Java_com_badlogic_gdx_utils_BufferUtils_transformV2M4Jni_
 
 }
 
+#if __LIBGDX__DESKTOP__
+ extern "C" JNIEXPORT void JNICALL JavaCritical_com_badlogic_gdx_utils_BufferUtils_transformV2M4Jni___3FII_3FI(jint dataLength, jfloat* data, jint strideInBytes, jint count, jint matrixLength, jfloat* matrix, jint offsetInBytes) {
+
+//@line:739
+
+		transform<2, 4>((float*)data, strideInBytes / 4, count, (float*)matrix, offsetInBytes / 4);
+	
+}
+#endif
 JNIEXPORT void JNICALL Java_com_badlogic_gdx_utils_BufferUtils_transformV3M3Jni__Ljava_nio_Buffer_2II_3FI(JNIEnv* env, jclass clazz, jobject obj_data, jint strideInBytes, jint count, jfloatArray obj_matrix, jint offsetInBytes) {
 	unsigned char* data = (unsigned char*)(obj_data?env->GetDirectBufferAddress(obj_data):0);
 	float* matrix = (float*)env->GetPrimitiveArrayCritical(obj_matrix, 0);
 
 
-//@line:731
+//@line:743
 
 		transform<3, 3>((float*)data, strideInBytes / 4, count, (float*)matrix, offsetInBytes / 4);
 	
@@ -365,7 +401,7 @@ JNIEXPORT void JNICALL Java_com_badlogic_gdx_utils_BufferUtils_transformV3M3Jni_
 	float* matrix = (float*)env->GetPrimitiveArrayCritical(obj_matrix, 0);
 
 
-//@line:735
+//@line:747
 
 		transform<3, 3>((float*)data, strideInBytes / 4, count, (float*)matrix, offsetInBytes / 4);
 	
@@ -374,12 +410,21 @@ JNIEXPORT void JNICALL Java_com_badlogic_gdx_utils_BufferUtils_transformV3M3Jni_
 
 }
 
+#if __LIBGDX__DESKTOP__
+ extern "C" JNIEXPORT void JNICALL JavaCritical_com_badlogic_gdx_utils_BufferUtils_transformV3M3Jni___3FII_3FI(jint dataLength, jfloat* data, jint strideInBytes, jint count, jint matrixLength, jfloat* matrix, jint offsetInBytes) {
+
+//@line:751
+
+		transform<3, 3>((float*)data, strideInBytes / 4, count, (float*)matrix, offsetInBytes / 4);
+	
+}
+#endif
 JNIEXPORT void JNICALL Java_com_badlogic_gdx_utils_BufferUtils_transformV2M3Jni__Ljava_nio_Buffer_2II_3FI(JNIEnv* env, jclass clazz, jobject obj_data, jint strideInBytes, jint count, jfloatArray obj_matrix, jint offsetInBytes) {
 	unsigned char* data = (unsigned char*)(obj_data?env->GetDirectBufferAddress(obj_data):0);
 	float* matrix = (float*)env->GetPrimitiveArrayCritical(obj_matrix, 0);
 
 
-//@line:739
+//@line:755
 
 		transform<2, 3>((float*)data, strideInBytes / 4, count, (float*)matrix, offsetInBytes / 4);
 	
@@ -392,7 +437,7 @@ JNIEXPORT void JNICALL Java_com_badlogic_gdx_utils_BufferUtils_transformV2M3Jni_
 	float* matrix = (float*)env->GetPrimitiveArrayCritical(obj_matrix, 0);
 
 
-//@line:743
+//@line:759
 
 		transform<2, 3>((float*)data, strideInBytes / 4, count, (float*)matrix, offsetInBytes / 4);
 	
@@ -401,10 +446,19 @@ JNIEXPORT void JNICALL Java_com_badlogic_gdx_utils_BufferUtils_transformV2M3Jni_
 
 }
 
+#if __LIBGDX__DESKTOP__
+ extern "C" JNIEXPORT void JNICALL JavaCritical_com_badlogic_gdx_utils_BufferUtils_transformV2M3Jni___3FII_3FI(jint dataLength, jfloat* data, jint strideInBytes, jint count, jint matrixLength, jfloat* matrix, jint offsetInBytes) {
+
+//@line:763
+
+		transform<2, 3>((float*)data, strideInBytes / 4, count, (float*)matrix, offsetInBytes / 4);
+	
+}
+#endif
 static inline jlong wrapped_Java_com_badlogic_gdx_utils_BufferUtils_find__Ljava_nio_Buffer_2IILjava_nio_Buffer_2II
 (JNIEnv* env, jclass clazz, jobject obj_vertex, jint vertexOffsetInBytes, jint strideInBytes, jobject obj_vertices, jint verticesOffsetInBytes, jint numVertices, unsigned char* vertex, unsigned char* vertices) {
 
-//@line:747
+//@line:767
 
 		return find((float *)&vertex[vertexOffsetInBytes / 4], (unsigned int)(strideInBytes / 4), (float*)&vertices[verticesOffsetInBytes / 4], (unsigned int)numVertices);
 	
@@ -423,7 +477,7 @@ JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_utils_BufferUtils_find__Ljava_nio_
 static inline jlong wrapped_Java_com_badlogic_gdx_utils_BufferUtils_find___3FIILjava_nio_Buffer_2II
 (JNIEnv* env, jclass clazz, jfloatArray obj_vertex, jint vertexOffsetInBytes, jint strideInBytes, jobject obj_vertices, jint verticesOffsetInBytes, jint numVertices, unsigned char* vertices, float* vertex) {
 
-//@line:751
+//@line:771
 
 		return find((float *)&vertex[vertexOffsetInBytes / 4], (unsigned int)(strideInBytes / 4), (float*)&vertices[verticesOffsetInBytes / 4], (unsigned int)numVertices);
 	
@@ -443,7 +497,7 @@ JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_utils_BufferUtils_find___3FIILjava
 static inline jlong wrapped_Java_com_badlogic_gdx_utils_BufferUtils_find__Ljava_nio_Buffer_2II_3FII
 (JNIEnv* env, jclass clazz, jobject obj_vertex, jint vertexOffsetInBytes, jint strideInBytes, jfloatArray obj_vertices, jint verticesOffsetInBytes, jint numVertices, unsigned char* vertex, float* vertices) {
 
-//@line:755
+//@line:775
 
 		return find((float *)&vertex[vertexOffsetInBytes / 4], (unsigned int)(strideInBytes / 4), (float*)&vertices[verticesOffsetInBytes / 4], (unsigned int)numVertices);
 	
@@ -463,7 +517,7 @@ JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_utils_BufferUtils_find__Ljava_nio_
 static inline jlong wrapped_Java_com_badlogic_gdx_utils_BufferUtils_find___3FII_3FII
 (JNIEnv* env, jclass clazz, jfloatArray obj_vertex, jint vertexOffsetInBytes, jint strideInBytes, jfloatArray obj_vertices, jint verticesOffsetInBytes, jint numVertices, float* vertex, float* vertices) {
 
-//@line:759
+//@line:779
 
 		return find((float *)&vertex[vertexOffsetInBytes / 4], (unsigned int)(strideInBytes / 4), (float*)&vertices[verticesOffsetInBytes / 4], (unsigned int)numVertices);
 	
@@ -481,10 +535,19 @@ JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_utils_BufferUtils_find___3FII_3FII
 	return JNI_returnValue;
 }
 
+#if __LIBGDX__DESKTOP__
+ extern "C" JNIEXPORT jlong JNICALL JavaCritical_com_badlogic_gdx_utils_BufferUtils_find___3FII_3FII(jint vertexLength, jfloat* vertex, jint vertexOffsetInBytes, jint strideInBytes, jint verticesLength, jfloat* vertices, jint verticesOffsetInBytes, jint numVertices) {
+
+//@line:783
+
+	return find((float *)&vertex[vertexOffsetInBytes / 4], (unsigned int)(strideInBytes / 4), (float*)&vertices[verticesOffsetInBytes / 4], (unsigned int)numVertices);
+	
+}
+#endif
 static inline jlong wrapped_Java_com_badlogic_gdx_utils_BufferUtils_find__Ljava_nio_Buffer_2IILjava_nio_Buffer_2IIF
 (JNIEnv* env, jclass clazz, jobject obj_vertex, jint vertexOffsetInBytes, jint strideInBytes, jobject obj_vertices, jint verticesOffsetInBytes, jint numVertices, jfloat epsilon, unsigned char* vertex, unsigned char* vertices) {
 
-//@line:763
+//@line:787
 
 		return find((float *)&vertex[vertexOffsetInBytes / 4], (unsigned int)(strideInBytes / 4), (float*)&vertices[verticesOffsetInBytes / 4], (unsigned int)numVertices, epsilon);
 	
@@ -503,7 +566,7 @@ JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_utils_BufferUtils_find__Ljava_nio_
 static inline jlong wrapped_Java_com_badlogic_gdx_utils_BufferUtils_find___3FIILjava_nio_Buffer_2IIF
 (JNIEnv* env, jclass clazz, jfloatArray obj_vertex, jint vertexOffsetInBytes, jint strideInBytes, jobject obj_vertices, jint verticesOffsetInBytes, jint numVertices, jfloat epsilon, unsigned char* vertices, float* vertex) {
 
-//@line:767
+//@line:791
 
 		return find((float *)&vertex[vertexOffsetInBytes / 4], (unsigned int)(strideInBytes / 4), (float*)&vertices[verticesOffsetInBytes / 4], (unsigned int)numVertices, epsilon);
 	
@@ -523,7 +586,7 @@ JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_utils_BufferUtils_find___3FIILjava
 static inline jlong wrapped_Java_com_badlogic_gdx_utils_BufferUtils_find__Ljava_nio_Buffer_2II_3FIIF
 (JNIEnv* env, jclass clazz, jobject obj_vertex, jint vertexOffsetInBytes, jint strideInBytes, jfloatArray obj_vertices, jint verticesOffsetInBytes, jint numVertices, jfloat epsilon, unsigned char* vertex, float* vertices) {
 
-//@line:771
+//@line:795
 
 		return find((float *)&vertex[vertexOffsetInBytes / 4], (unsigned int)(strideInBytes / 4), (float*)&vertices[verticesOffsetInBytes / 4], (unsigned int)numVertices, epsilon);
 	
@@ -543,7 +606,7 @@ JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_utils_BufferUtils_find__Ljava_nio_
 static inline jlong wrapped_Java_com_badlogic_gdx_utils_BufferUtils_find___3FII_3FIIF
 (JNIEnv* env, jclass clazz, jfloatArray obj_vertex, jint vertexOffsetInBytes, jint strideInBytes, jfloatArray obj_vertices, jint verticesOffsetInBytes, jint numVertices, jfloat epsilon, float* vertex, float* vertices) {
 
-//@line:775
+//@line:799
 
 		return find((float *)&vertex[vertexOffsetInBytes / 4], (unsigned int)(strideInBytes / 4), (float*)&vertices[verticesOffsetInBytes / 4], (unsigned int)numVertices, epsilon);
 	
@@ -561,3 +624,12 @@ JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_utils_BufferUtils_find___3FII_3FII
 	return JNI_returnValue;
 }
 
+#if __LIBGDX__DESKTOP__
+ extern "C" JNIEXPORT jlong JNICALL JavaCritical_com_badlogic_gdx_utils_BufferUtils_find___3FII_3FIIF(jint vertexLength, jfloat* vertex, jint vertexOffsetInBytes, jint strideInBytes, jint verticesLength, jfloat* vertices, jint verticesOffsetInBytes, jint numVertices, jfloat epsilon) {
+
+//@line:803
+
+	return find((float *)&vertex[vertexOffsetInBytes / 4], (unsigned int)(strideInBytes / 4), (float*)&vertices[verticesOffsetInBytes / 4], (unsigned int)numVertices, epsilon);
+
+}
+#endif

--- a/gdx/src/com/badlogic/gdx/math/Matrix4.java
+++ b/gdx/src/com/badlogic/gdx/math/Matrix4.java
@@ -1300,8 +1300,12 @@ public class Matrix4 implements Serializable {
 	 *
 	 * @param mata the first matrix.
 	 * @param matb the second matrix. */
-	public static native void mul (float[] mata, float[] matb) /*-{ }-*/; /*
+	public static native void mul (float[] mata, float[] matb);/*
 		matrix4_mul(mata, matb);
+	*/
+	
+	private static native void mul_JNICritical (int mataLength, float[] mata, int matbLength, float[] matb);/*
+	matrix4_mul(mata, matb);
 	*/
 
 	/** Multiplies the vector with the given matrix. The matrix array is assumed to hold a 4x4 column major matrix as you can get
@@ -1310,7 +1314,11 @@ public class Matrix4 implements Serializable {
 	 * {@link Vector3#mul(Matrix4)}.
 	 * @param mat the matrix
 	 * @param vec the vector. */
-	public static native void mulVec (float[] mat, float[] vec) /*-{ }-*/; /*
+	public static native void mulVec (float[] mat, float[] vec);/*
+		matrix4_mulVec(mat, vec);
+	*/
+	
+	private static native void mulVec_JNICritical (int matLength, float[] mat, int vecLength, float[] vec);/*
 		matrix4_mulVec(mat, vec);
 	*/
 
@@ -1325,12 +1333,20 @@ public class Matrix4 implements Serializable {
 	 * @param offset the offset into the vectors array
 	 * @param numVecs the number of vectors
 	 * @param stride the stride between vectors in floats */
-	public static native void mulVec (float[] mat, float[] vecs, int offset, int numVecs, int stride) /*-{ }-*/; /*
+	public static native void mulVec (float[] mat, float[] vecs, int offset, int numVecs, int stride);/*
 		float* vecPtr = vecs + offset;
 		for(int i = 0; i < numVecs; i++) {
 			matrix4_mulVec(mat, vecPtr);
 			vecPtr += stride;
 		}
+	*/
+	
+	private static native void mulVec_JNICritical (int matLength, float[] mat, int vecsLength, float[] vecs, int offset, int numVecs, int stride);/*
+	float* vecPtr = vecs + offset;
+	for(int i = 0; i < numVecs; i++) {
+		matrix4_mulVec(mat, vecPtr);
+		vecPtr += stride;
+	}
 	*/
 
 	/** Multiplies the vector with the given matrix, performing a division by w. The matrix array is assumed to hold a 4x4 column
@@ -1339,8 +1355,12 @@ public class Matrix4 implements Serializable {
 	 * same as {@link Vector3#prj(Matrix4)}.
 	 * @param mat the matrix
 	 * @param vec the vector. */
-	public static native void prj (float[] mat, float[] vec) /*-{ }-*/; /*
+	public static native void prj (float[] mat, float[] vec);/*
 		matrix4_proj(mat, vec);
+	*/
+	
+	private static native void prj_JNICritical (int matLength, float[] mat, int vecLength, float[] vec);/*
+	matrix4_proj(mat, vec);
 	*/
 
 	/** Multiplies the vectors with the given matrix, , performing a division by w. The matrix array is assumed to hold a 4x4 column
@@ -1354,12 +1374,20 @@ public class Matrix4 implements Serializable {
 	 * @param offset the offset into the vectors array
 	 * @param numVecs the number of vectors
 	 * @param stride the stride between vectors in floats */
-	public static native void prj (float[] mat, float[] vecs, int offset, int numVecs, int stride) /*-{ }-*/; /*
+	public static native void prj (float[] mat, float[] vecs, int offset, int numVecs, int stride);/*
 		float* vecPtr = vecs + offset;
 		for(int i = 0; i < numVecs; i++) {
 			matrix4_proj(mat, vecPtr);
 			vecPtr += stride;
 		}
+	*/
+	
+	private static native void prj_JNICritical (int matLength, float[] mat, int vecsLength, float[] vecs, int offset, int numVecs, int stride);/*
+	float* vecPtr = vecs + offset;
+	for(int i = 0; i < numVecs; i++) {
+		matrix4_proj(mat, vecPtr);
+		vecPtr += stride;
+	}
 	*/
 
 	/** Multiplies the vector with the top most 3x3 sub-matrix of the given matrix. The matrix array is assumed to hold a 4x4 column
@@ -1368,8 +1396,12 @@ public class Matrix4 implements Serializable {
 	 * same as {@link Vector3#rot(Matrix4)}.
 	 * @param mat the matrix
 	 * @param vec the vector. */
-	public static native void rot (float[] mat, float[] vec) /*-{ }-*/; /*
+	public static native void rot (float[] mat, float[] vec);/*
 		matrix4_rot(mat, vec);
+	*/
+	
+	private static native void rot_JNICritical (int matLength, float[] mat, int vecLength, float[] vec);/*
+	matrix4_rot(mat, vec);
 	*/
 
 	/** Multiplies the vectors with the top most 3x3 sub-matrix of the given matrix. The matrix array is assumed to hold a 4x4
@@ -1383,19 +1415,31 @@ public class Matrix4 implements Serializable {
 	 * @param offset the offset into the vectors array
 	 * @param numVecs the number of vectors
 	 * @param stride the stride between vectors in floats */
-	public static native void rot (float[] mat, float[] vecs, int offset, int numVecs, int stride) /*-{ }-*/; /*
+	public static native void rot (float[] mat, float[] vecs, int offset, int numVecs, int stride) ;/*
 		float* vecPtr = vecs + offset;
 		for(int i = 0; i < numVecs; i++) {
 			matrix4_rot(mat, vecPtr);
 			vecPtr += stride;
 		}
 	*/
+	
+	private static native void rot_JNICritical (int matLength, float[] mat, int vecsLength, float[] vecs, int offset, int numVecs, int stride) ;/*
+	float* vecPtr = vecs + offset;
+	for(int i = 0; i < numVecs; i++) {
+		matrix4_rot(mat, vecPtr);
+		vecPtr += stride;
+	}
+	*/
 
 	/** Computes the inverse of the given matrix. The matrix array is assumed to hold a 4x4 column major matrix as you can get from
 	 * {@link Matrix4#val}.
 	 * @param values the matrix values.
 	 * @return false in case the inverse could not be calculated, true otherwise. */
-	public static native boolean inv (float[] values) /*-{ }-*/; /*
+	public static native boolean inv (float[] values);/*
+		return matrix4_inv(values);
+	*/
+	
+	private static native boolean inv_JNICritical (int valuesLength, float[] values);/*
 		return matrix4_inv(values);
 	*/
 
@@ -1403,7 +1447,11 @@ public class Matrix4 implements Serializable {
 	 * from {@link Matrix4#val}.
 	 * @param values the matrix values.
 	 * @return the determinante. */
-	public static native float det (float[] values) /*-{ }-*/; /*
+	public static native float det (float[] values);/*
+		return matrix4_det(values);
+	*/
+	
+	private static native float det_JNICritical (int valuesLength, float[] values);/*
 		return matrix4_det(values);
 	*/
 

--- a/gdx/src/com/badlogic/gdx/utils/BufferUtils.java
+++ b/gdx/src/com/badlogic/gdx/utils/BufferUtils.java
@@ -712,6 +712,10 @@ public final class BufferUtils {
 		transform<4, 4>((float*)data, strideInBytes / 4, count, (float*)matrix, offsetInBytes / 4);  
 	*/
 	
+	private native static void transformV4M4Jni_JNICritical (int dataLength, float[] data, int strideInBytes, int count, int matrixLength, float[] matrix, int offsetInBytes); /*
+		transform<4, 4>((float*)data, strideInBytes / 4, count, (float*)matrix, offsetInBytes / 4);  
+	*/
+	
 	private native static void transformV3M4Jni (Buffer data, int strideInBytes, int count, float[] matrix, int offsetInBytes); /*
 		transform<3, 4>((float*)data, strideInBytes / 4, count, (float*)matrix, offsetInBytes / 4);
 	*/
@@ -720,11 +724,19 @@ public final class BufferUtils {
 		transform<3, 4>((float*)data, strideInBytes / 4, count, (float*)matrix, offsetInBytes / 4);
 	*/
 	
+	private native static void transformV3M4Jni_JNICritical (int dataLength, float[] data, int strideInBytes, int count, int matrixLength, float[] matrix, int offsetInBytes); /*
+		transform<3, 4>((float*)data, strideInBytes / 4, count, (float*)matrix, offsetInBytes / 4);
+	*/
+	
 	private native static void transformV2M4Jni (Buffer data, int strideInBytes, int count, float[] matrix, int offsetInBytes); /*
 		transform<2, 4>((float*)data, strideInBytes / 4, count, (float*)matrix, offsetInBytes / 4);
 	*/
 	
 	private native static void transformV2M4Jni (float[] data, int strideInBytes, int count, float[] matrix, int offsetInBytes); /*
+		transform<2, 4>((float*)data, strideInBytes / 4, count, (float*)matrix, offsetInBytes / 4);
+	*/
+	
+	private native static void transformV2M4Jni_JNICritical (int dataLength, float[] data, int strideInBytes, int count, int matrixLength, float[] matrix, int offsetInBytes); /*
 		transform<2, 4>((float*)data, strideInBytes / 4, count, (float*)matrix, offsetInBytes / 4);
 	*/
 
@@ -736,11 +748,19 @@ public final class BufferUtils {
 		transform<3, 3>((float*)data, strideInBytes / 4, count, (float*)matrix, offsetInBytes / 4);
 	*/
 	
+	private native static void transformV3M3Jni_JNICritical (int dataLength, float[] data, int strideInBytes, int count, int matrixLength, float[] matrix, int offsetInBytes); /*
+		transform<3, 3>((float*)data, strideInBytes / 4, count, (float*)matrix, offsetInBytes / 4);
+	*/
+	
 	private native static void transformV2M3Jni (Buffer data, int strideInBytes, int count, float[] matrix, int offsetInBytes); /*
 		transform<2, 3>((float*)data, strideInBytes / 4, count, (float*)matrix, offsetInBytes / 4);
 	*/
 	
 	private native static void transformV2M3Jni (float[] data, int strideInBytes, int count, float[] matrix, int offsetInBytes); /*
+		transform<2, 3>((float*)data, strideInBytes / 4, count, (float*)matrix, offsetInBytes / 4);
+	*/
+	
+	private native static void transformV2M3Jni_JNICritical (int dataLength, float[] data, int strideInBytes, int count, int matrixLength, float[] matrix, int offsetInBytes); /*
 		transform<2, 3>((float*)data, strideInBytes / 4, count, (float*)matrix, offsetInBytes / 4);
 	*/
 	
@@ -760,6 +780,10 @@ public final class BufferUtils {
 		return find((float *)&vertex[vertexOffsetInBytes / 4], (unsigned int)(strideInBytes / 4), (float*)&vertices[verticesOffsetInBytes / 4], (unsigned int)numVertices);
 	*/
 	
+	private native static long find_JNICritical(int vertexLength, float[] vertex, int vertexOffsetInBytes, int strideInBytes, int verticesLength, float[] vertices, int verticesOffsetInBytes, int numVertices); /*
+	return find((float *)&vertex[vertexOffsetInBytes / 4], (unsigned int)(strideInBytes / 4), (float*)&vertices[verticesOffsetInBytes / 4], (unsigned int)numVertices);
+	*/
+	
 	private native static long find(Buffer vertex, int vertexOffsetInBytes, int strideInBytes, Buffer vertices, int verticesOffsetInBytes, int numVertices, float epsilon); /*
 		return find((float *)&vertex[vertexOffsetInBytes / 4], (unsigned int)(strideInBytes / 4), (float*)&vertices[verticesOffsetInBytes / 4], (unsigned int)numVertices, epsilon);
 	*/
@@ -775,4 +799,8 @@ public final class BufferUtils {
 	private native static long find(float[] vertex, int vertexOffsetInBytes, int strideInBytes, float[] vertices, int verticesOffsetInBytes, int numVertices, float epsilon); /*
 		return find((float *)&vertex[vertexOffsetInBytes / 4], (unsigned int)(strideInBytes / 4), (float*)&vertices[verticesOffsetInBytes / 4], (unsigned int)numVertices, epsilon);
 	*/
+	
+	private native static long find_JNICritical(int vertexLength, float[] vertex, int vertexOffsetInBytes, int strideInBytes, int verticesLength, float[] vertices, int verticesOffsetInBytes, int numVertices, float epsilon); /*
+	return find((float *)&vertex[vertexOffsetInBytes / 4], (unsigned int)(strideInBytes / 4), (float*)&vertices[verticesOffsetInBytes / 4], (unsigned int)numVertices, epsilon);
+*/
 }


### PR DESCRIPTION
Similar to https://github.com/libgdx/libgdx/pull/4021 but more explicit.

Adds support for critical natives, which reduces the overhead of jni-calls.
Critical natives are supported on Hotspot JVMs since Java7. See also [this answer on stackoverflow](http://stackoverflow.com/questions/36298111/is-it-possible-to-use-sun-misc-unsafe-to-call-c-functions-without-jni/36309652#36309652).

This PR shouldn't break any code.
Critical natives have been tested on Mac OS X 64bit, Linux 32 and 64bit, Windows 32 and 64bit.
# How to use
1. Ensure that your method can be used as a critical native. This means that it is **static**, **non-synchronized** and only has **primitives** or **primitives arrays** as arguments.
2. The method also can not use the normal `JNIEnv*` or  `jclass` arguments

Support for critical natives has to be _explicitly_ added.
So for example, if we have this method:

``` java
private static native void foo(int anInt, float[] anArray); /*
  foo(anInt, anArray);
*/
```

jnigen would create this:

``` c
JNIEXPORT void JNICALL Java_[package]_[class]_foo(JNIEnv* env, jclass clazz, jint anInt, jfloatArray obj_anArray)
{
  float* anArray = (float*)env->GetPrimitiveArrayCritical(obj_anArray, 0);
  foo(anInt, anArray);
  env->ReleasePrimitiveArrayCritical(obj_anArray, anArray, 0);
}
```
## **That's is the way it currently works.**

This PR adds support for generating critical natives.
To do so, we have to add a new (java) method:

``` java
private static native void foo_JNICritical(int anInt, int anArrayLength, float[] anArray); /*
  foo(anInt, anArray);
*/
```

this method is then used for generating a critical native, so it becomes this:

``` c
JNIEXPORT void JNICALL JavaCritical_[package]_[class]_foo(jint anInt, jint anArrayLength, jfloatArray anArray)
{
  foo(anInt, anArray);
}
```
## **What changed compared to the non critical version:**

Compare:
Normal version:

``` java
private static native void foo(int anInt, float[] anArray);
```

vs.
Critical version

``` java
private static native void foo_JNICritical(int anInt, int anArrayLength, float[] anArray);
```
1. A critical version has the same name plus `_JNICritical` to identify it as a critical native.
2. You **have to** add a new parameter of type `int` before every primitive array.
   The parameter contains the length of the primitive array. 
   **If you don't do this your critical native will probably _not_ be called!**
# Which functions benefits from it

Functions that do relatively little work in the native code benefit from it, since the jni overhead is greatly reduced.
That's why the various methods of `Matrix4` (`mul`, `rot`, ...),which all need to pass primitive arrays, are about 2 times faster.
Some methods of `BufferUtils` also gained support for critical natives, but I didn't benchmark how much they're faster and as is the case with `Matrix4` only methods that pass primitive arrays gained support.
