### PR TITLE
[WIP] Make scene2d groups generic

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/WidgetGroup.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/WidgetGroup.java
@@ -34,7 +34,7 @@ import com.badlogic.gdx.utils.SnapshotArray;
  * {@link #invalidate()} or {@link #invalidateHierarchy()} as needed. By default, invalidateHierarchy is called when child widgets
  * are added and removed.
  * @author Nathan Sweet */
-public class WidgetGroup extends Group implements Layout {
+public class WidgetGroup extends Group<Actor> implements Layout {
 	private boolean needsLayout = true;
 	private boolean fillParent;
 	private boolean layoutEnabled = true;


### PR DESCRIPTION
I wanted to subclass a `Group` that could only contain a certain kind of `Actor`. This would result in an unnecessary amount of casting from an Actor to a subclass. 

I thought about making my own implementation of group but that stops quite a few of the group parts of the API from working (e.g. I can no longer set `actor.parent`).

The logical conclusion of this is to make Groups generic.

Any implementation I can think of will lead to breaking BC in some way. At first I tried creating a `class GenericGroup<T extends Actor>` and then re-implemented Group to simply be:

```java
public class Group extends GenericGroup<Actor> { }
```

But that broke things in spectacular ways.

Changing `Group` to `Group<T extends Actor>` is far more stable and if things do break it's a little more obvious, so that's what this PR contains.

I'm still not sure that this is the best way to move forward or even if something like this is required. I wanted to see what other people thought about this.

## Reverse for Actors

The complement to this is to make an `ActorContainer` interface. The generic `Group` would implement this and then all types of Group can be replaced with this. This would allow for people to create the lighter implementations of groups and successfully set actor's parents.

This may be overkill, though.