### PR TITLE
Implements properties types for tiled map loader

### DIFF
--- a/gdx/src/com/badlogic/gdx/maps/tiled/BaseTmxMapLoader.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/BaseTmxMapLoader.java
@@ -1,14 +1,6 @@
 
 package com.badlogic.gdx.maps.tiled;
 
-import java.io.BufferedInputStream;
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.StringTokenizer;
-import java.util.zip.GZIPInputStream;
-import java.util.zip.InflaterInputStream;
-
 import com.badlogic.gdx.assets.AssetLoaderParameters;
 import com.badlogic.gdx.assets.loaders.AsynchronousAssetLoader;
 import com.badlogic.gdx.assets.loaders.FileHandleResolver;
@@ -32,6 +24,14 @@ import com.badlogic.gdx.utils.GdxRuntimeException;
 import com.badlogic.gdx.utils.StreamUtils;
 import com.badlogic.gdx.utils.XmlReader;
 import com.badlogic.gdx.utils.XmlReader.Element;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.StringTokenizer;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.InflaterInputStream;
 
 public abstract class BaseTmxMapLoader<P extends AssetLoaderParameters<TiledMap>> extends AsynchronousAssetLoader<TiledMap, P> {
 
@@ -266,11 +266,28 @@ public abstract class BaseTmxMapLoader<P extends AssetLoaderParameters<TiledMap>
 			for (Element property : element.getChildrenByName("property")) {
 				String name = property.getAttribute("name", null);
 				String value = property.getAttribute("value", null);
+				String type = property.getAttribute("type", null);
 				if (value == null) {
 					value = property.getText();
 				}
-				properties.put(name, value);
+				Object castValue = castProperty(name, value, type);
+				properties.put(name, castValue);
 			}
+		}
+	}
+
+	private Object castProperty (String name, String value, String type) {
+		if (type == null) {
+			return value;
+		} else if (type.equals("int")) {
+			return Integer.valueOf(value);
+		} else if (type.equals("float")) {
+			return Float.valueOf(value);
+		} else if (type.equals("bool")) {
+			return Boolean.valueOf(value);
+		} else {
+			throw new GdxRuntimeException("Wrong type given for property " + name + ", given : " + type
+				+ ", supported : string, bool, int, float");
 		}
 	}
 

--- a/tests/gdx-tests-android/assets/data/maps/tiled/isometric_grass_and_water.tmx
+++ b/tests/gdx-tests-android/assets/data/maps/tiled/isometric_grass_and_water.tmx
@@ -1,13 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="isometric" width="25" height="25" tilewidth="64" tileheight="32">
- <tileset firstgid="1" name="isometric_grass_and_water" tilewidth="64" tileheight="64">
+<map version="1.0" orientation="isometric" renderorder="right-down" width="25" height="25" tilewidth="64" tileheight="32" nextobjectid="1">
+ <properties>
+  <property name="boolCustomProperty" type="bool" value="true"/>
+  <property name="floatCustomProperty" type="float" value="1.5600000000000001"/>
+  <property name="intCustomProperty" type="int" value="5"/>
+  <property name="mapCustomProperty" value="mapCustomValue"/>
+ </properties>
+ <tileset firstgid="1" name="isometric_grass_and_water" tilewidth="64" tileheight="64" tilecount="24" columns="4">
   <tileoffset x="0" y="16"/>
+  <properties>
+   <property name="tilesetCustomProperty" value="tilesetCustomValue"/>
+  </properties>
   <image source="isometric_grass_and_water.png" width="256" height="384"/>
   <terraintypes>
    <terrain name="Grass" tile="0"/>
    <terrain name="Water" tile="22"/>
   </terraintypes>
-  <tile id="0" terrain="0,0,0,0"/>
+  <tile id="0" terrain="0,0,0,0">
+   <properties>
+    <property name="tileCustomProperty" value="tileCustomValue"/>
+   </properties>
+  </tile>
   <tile id="1" terrain="0,0,0,0"/>
   <tile id="2" terrain="0,0,0,0"/>
   <tile id="3" terrain="0,0,0,0"/>
@@ -33,6 +46,9 @@
   <tile id="23" terrain="1,1,1,1"/>
  </tileset>
  <layer name="Tile Layer 1" width="25" height="25">
+  <properties>
+   <property name="layerCustomProperty" value="layerCustomValue"/>
+  </properties>
   <data encoding="base64" compression="zlib">
    eJx1lttywjAMROVgyqVtAoFC/v9L68xoh5PFPGhIYktrrVYyS0QszZ7Nvpvd0n7y24L1Q7MhrTSreN/le821HZ7lv9qYa6sdE0cYs/kX7PXYwtfaevYp7WDrd+SnHByjYr/npP1zZ4/elcuM71rjeckdc5KNHX75fMwc9s2uzb6AsYstJzwrv5/Tz89SLIZy8v203llV8xl7yMU+462/v81OqA114/UhrzUxRqwprnh6ZGzp2PNQfPqRu/X9hnMV8F/xLg1L42erDf2oaa2RI2qPtbgbhmw2H69nMUxx/gVccXdC3AW/o/HV60vW59Lhu8arDxmfGIPFUV1qbLVQEIs4PlOeHQxqVjmzr5mLYsmf+5Qj5yM1r3Ne4p1D5VcMh3qWZibLx2fYkBhPYOv81I9wbrGd45zFU7zrndpwDjkHXXfej9zHc3EG+D3AWcCZMJif7hTnVxr6i9edtoBDz8N7kxqbY6sN9gJnsnqIOqCme7Un76579sIV8dccHvHqZefH76BP9wjzkVapM2rL+5/8cR6QS9eh8p2AT12y5oO9+7yh5hzLZypnHX29/pzB9PE7bOg8Mza5KvGu4R7mp/89zqvr7x+TnxEn
   </data>

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapAssetManagerTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapAssetManagerTest.java
@@ -23,14 +23,35 @@ import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.maps.MapLayer;
 import com.badlogic.gdx.maps.tiled.TiledMap;
 import com.badlogic.gdx.maps.tiled.TiledMapRenderer;
+import com.badlogic.gdx.maps.tiled.TiledMapTile;
+import com.badlogic.gdx.maps.tiled.TiledMapTileSet;
 import com.badlogic.gdx.maps.tiled.TmxMapLoader;
 import com.badlogic.gdx.maps.tiled.renderers.IsometricTiledMapRenderer;
 import com.badlogic.gdx.tests.utils.GdxTest;
 import com.badlogic.gdx.tests.utils.OrthoCamController;
 
 public class TiledMapAssetManagerTest extends GdxTest {
+
+	private static final String MAP_PROPERTY_NAME = "mapCustomProperty";
+	private static final String BOOL_PROPERTY_NAME = "boolCustomProperty";
+	private static final String INT_PROPERTY_NAME = "intCustomProperty";
+	private static final String FLOAT_PROPERTY_NAME = "floatCustomProperty";
+
+	private static final String TILESET_PROPERTY_NAME = "tilesetCustomProperty";
+	private static final String TILE_PROPERTY_NAME = "tileCustomProperty";
+	private static final String LAYER_PROPERTY_NAME = "layerCustomProperty";
+
+	private static final String MAP_PROPERTY_VALUE = "mapCustomValue";
+	private static final boolean BOOL_PROPERTY_VALUE = true;
+	private static final int INT_PROPERTY_VALUE = 5;
+	private static final float FLOAT_PROPERTY_VALUE = 1.56f;
+
+	private static final String TILESET_PROPERTY_VALUE = "tilesetCustomValue";
+	private static final String TILE_PROPERTY_VALUE = "tileCustomValue";
+	private static final String LAYER_PROPERTY_VALUE = "layerCustomValue";
 
 	private TiledMap map;
 	private TiledMapRenderer renderer;
@@ -62,6 +83,48 @@ public class TiledMapAssetManagerTest extends GdxTest {
 		assetManager.finishLoading();
 		map = assetManager.get("data/maps/tiled/isometric_grass_and_water.tmx");
 		renderer = new IsometricTiledMapRenderer(map, 1f / 64f);
+
+		String mapCustomValue = map.getProperties().get(MAP_PROPERTY_NAME, String.class);
+		Gdx.app.log("TiledMapAssetManagerTest", "Property : " + MAP_PROPERTY_NAME + ", Value : " + mapCustomValue);
+		if (!MAP_PROPERTY_VALUE.equals(mapCustomValue)) {
+			throw new RuntimeException("Failed to get map properties");
+		}
+
+		boolean boolCustomValue = map.getProperties().get(BOOL_PROPERTY_NAME, Boolean.class);
+		Gdx.app.log("TiledMapAssetManagerTest", "Property : " + BOOL_PROPERTY_NAME + ", Value : " + boolCustomValue);
+		if (boolCustomValue != BOOL_PROPERTY_VALUE) {
+			throw new RuntimeException("Failed to get boolean map properties");
+		}
+
+		int intCustomValue = map.getProperties().get(INT_PROPERTY_NAME, Integer.class);
+		Gdx.app.log("TiledMapAssetManagerTest", "Property : " + INT_PROPERTY_NAME + ", Value : " + intCustomValue);
+		if (intCustomValue != INT_PROPERTY_VALUE) {
+			throw new RuntimeException("Failed to get int map properties");
+		}
+
+		float floatCustomValue = map.getProperties().get(FLOAT_PROPERTY_NAME, Float.class);
+		Gdx.app.log("TiledMapAssetManagerTest", "Property : " + FLOAT_PROPERTY_NAME + ", Value : " + floatCustomValue);
+		if (floatCustomValue != FLOAT_PROPERTY_VALUE) {
+			throw new RuntimeException("Failed to get float map properties");
+		}
+
+		TiledMapTileSet tileset = map.getTileSets().getTileSet(0);
+		String tilesetCustomValue = tileset.getProperties().get(TILESET_PROPERTY_NAME, String.class);
+		if (!TILESET_PROPERTY_VALUE.equals(tilesetCustomValue)) {
+			throw new RuntimeException("Failed to get tileset properties");
+		}
+
+		TiledMapTile tile = tileset.getTile(1);
+		String tileCustomValue = tile.getProperties().get(TILE_PROPERTY_NAME, String.class);
+		if (!TILE_PROPERTY_VALUE.equals(tileCustomValue)) {
+			throw new RuntimeException("Failed to get tile properties");
+		}
+
+		MapLayer layer = map.getLayers().get(0);
+		String layerCustomValue = layer.getProperties().get(LAYER_PROPERTY_NAME, String.class);
+		if (!LAYER_PROPERTY_VALUE.equals(layerCustomValue)) {
+			throw new RuntimeException("Failed to get layer properties");
+		}
 	}
 
 	@Override


### PR DESCRIPTION
Added property cast for new tiled maps.
You can now use the methods :

- get (String key, Class<T> clazz)
- get (String key, T defaultValue, Class<T> clazz)

of the MapProperties class.
Support String, Boolean, Integer and Float types.