### PR TITLE
Add support for HTTP PATCH

### DIFF
--- a/gdx/src/com/badlogic/gdx/Net.java
+++ b/gdx/src/com/badlogic/gdx/Net.java
@@ -97,6 +97,7 @@ public interface Net {
 	 * <li>POST</li>
 	 * <li>PUT</li>
 	 * <li>DELETE</li>
+   * <li>PATCH</li>
 	 * </ul> */
 	public static interface HttpMethods {
 
@@ -104,6 +105,7 @@ public interface Net {
 		public static final String POST = "POST";
 		public static final String PUT = "PUT";
 		public static final String DELETE = "DELETE";
+		public static final String PATCH = "PATCH";
 
 	}
 

--- a/gdx/src/com/badlogic/gdx/net/NetJavaImpl.java
+++ b/gdx/src/com/badlogic/gdx/net/NetJavaImpl.java
@@ -150,7 +150,7 @@ public class NetJavaImpl {
 
 			final HttpURLConnection connection = (HttpURLConnection)url.openConnection();
 			// should be enabled to upload data.
-			final boolean doingOutPut = method.equalsIgnoreCase(HttpMethods.POST) || method.equalsIgnoreCase(HttpMethods.PUT);
+			final boolean doingOutPut = method.equalsIgnoreCase(HttpMethods.POST) || method.equalsIgnoreCase(HttpMethods.PUT) || method.equalsIgnoreCase(HttpMethods.PATCH);
 			connection.setDoOutput(doingOutPut);
 			connection.setDoInput(true);
 			connection.setRequestMethod(method);


### PR DESCRIPTION
Setting the method to "PATCH" on a request causes it to be sent without a body but still with the PATCH verb.

This PR makes PATCH a proper HTTP verb in libgdx. The alternative would be to make the HTTP classes throw an exception when unsupported verbs are used instead of failing silently like it does now.
