### PR TITLE
Added the setInputProcessor.

### DIFF
--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/box2d/ApplyForce.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/box2d/ApplyForce.java
@@ -28,6 +28,7 @@
 
 package com.badlogic.gdx.tests.box2d;
 
+import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input.Keys;
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.physics.box2d.Body;
@@ -160,6 +161,7 @@ public class ApplyForce extends Box2DTest {
 
 			shape.dispose();
 		}
+		Gdx.input.setInputProcessor(this);
 	}
 
 	private final Vector2 tmp = new Vector2();


### PR DESCRIPTION
Added the setInputProcessor. 
In the current class and the parent class, was not set neither in the input processor.

I do not know if the ApplyForce class is extended in some other example and that other example there is the set for inputprocessor. If ApplyForce really is a complete example then missed this set.