### PR TITLE
Added support to window icon on LWJGL3 backend

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,7 @@
 - Moved snapping from ProgressBar to Slider to prevent snapping when setting the value programmatically.
 - Bullet: added btSoftBody#getLinkCount() and btSoftBody#getLink(int), see https://github.com/libgdx/libgdx/issues/4152
 - API Change: Wrapping for scene2d's HorizontalGroup and VerticalGroup.
+- Added addIcon() to Lwjgl3ApplicationConfiguration to support window icon on LWJGL3 backend
 
 [1.9.3]
 - Switched to MobiDevelop's RoboVM fork (http://robovm.mobidevelop.com)

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3ApplicationConfiguration.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3ApplicationConfiguration.java
@@ -39,6 +39,7 @@ import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Graphics.Lwjgl3Monitor;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.glutils.HdpiUtils;
+import com.badlogic.gdx.utils.Array;
 
 public class Lwjgl3ApplicationConfiguration {
 	boolean disableAudio = false;
@@ -115,6 +116,19 @@ public class Lwjgl3ApplicationConfiguration {
 		copy.debug = config.debug;
 		copy.debugStream = config.debugStream;
 		return copy;
+	}
+
+	Array<String> iconPaths = new Array();
+	Array<FileType> iconFileTypes = new Array();
+
+	/**
+	 * Adds a window icon. Those of (or closest to) the sizes desired by the system are selected.
+	 * The icon is rescaled if needed. Typically three icons should be provided: 128x128 (for Mac),
+	 * 32x32 (for Windows and Linux), and 16x16 (for Windows).
+	 */
+	public void addIcon (String path, FileType fileType) {
+		iconPaths.add(path);
+		iconFileTypes.add(fileType);
 	}
 	
 	/**


### PR DESCRIPTION
Now that GLFW has the glfwSetWindowIcon() method, I added support to window icon on LWJGL3 backend.
I tried to be as close as possible to LWJGL backend implementation.
I've tested with icons on png, jpg and bmp formats. But only on Windows.
I am not sure if the best place to put the GLFW.glfwSetWindowIcon() call is in the Lwjgl3Graphics constructor. Any suggestion?