### PR TITLE
Allow custom window icons in Lwjgl3

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,7 @@
 - Moved snapping from ProgressBar to Slider to prevent snapping when setting the value programmatically.
 - Bullet: added btSoftBody#getLinkCount() and btSoftBody#getLink(int), see https://github.com/libgdx/libgdx/issues/4152
 - API Change: Wrapping for scene2d's HorizontalGroup and VerticalGroup.
+- Allow window icons to be set in Lwjgl3ApplicationConfiguration or LwjglWindowConfiguration.
 
 [1.9.3]
 - Switched to MobiDevelop's RoboVM fork (http://robovm.mobidevelop.com)

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
@@ -20,9 +20,11 @@ import java.io.File;
 import java.io.PrintStream;
 import java.nio.IntBuffer;
 
+import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.glutils.GLVersion;
 import org.lwjgl.glfw.GLFW;
 import org.lwjgl.glfw.GLFWErrorCallback;
+import org.lwjgl.glfw.GLFWImage;
 import org.lwjgl.glfw.GLFWVidMode;
 import org.lwjgl.opengl.AMDDebugOutput;
 import org.lwjgl.opengl.ARBDebugOutput;
@@ -352,6 +354,7 @@ public class Lwjgl3Application implements Application {
 		appConfig.setWindowedMode(config.windowWidth, config.windowHeight);
 		appConfig.setWindowPosition(config.windowX, config.windowY);
 		appConfig.setWindowSizeLimits(config.windowMinWidth, config.windowMinHeight, config.windowMaxWidth, config.windowMaxHeight);
+		appConfig.setWindowIcon(config.windowIconFileType, config.windowIconPaths);
 		appConfig.setResizable(config.windowResizable);
 		appConfig.setDecorated(config.windowDecorated);
 		appConfig.setWindowListener(config.windowListener);
@@ -430,6 +433,33 @@ public class Lwjgl3Application implements Application {
 			} else {
 				GLFW.glfwSetWindowPos(windowHandle, config.windowX, config.windowY);
 			}
+		}
+		if (config.windowIconPaths != null){
+			GLFWImage.Buffer buffer = GLFWImage.malloc(config.windowIconPaths.length);
+			Pixmap[] tmpPixmaps = new Pixmap[config.windowIconPaths.length];
+			Pixmap.Blending previousBlending = Pixmap.getBlending();
+			Pixmap.setBlending(Pixmap.Blending.None);
+			for (int i = 0; i < config.windowIconPaths.length; i++) {
+				Pixmap pixmap = new Pixmap(Gdx.files.getFileHandle(config.windowIconPaths[i], config.windowIconFileType));
+				if (pixmap.getFormat() != Pixmap.Format.RGBA8888) {
+					Pixmap rgba = new Pixmap(pixmap.getWidth(), pixmap.getHeight(), Pixmap.Format.RGBA8888);
+					rgba.drawPixmap(pixmap, 0, 0);
+					pixmap.dispose();
+					pixmap = rgba;
+				}
+				tmpPixmaps[i] = pixmap;
+
+				GLFWImage icon = GLFWImage.malloc();
+				icon.set(pixmap.getWidth(), pixmap.getHeight(), pixmap.getPixels());
+				buffer.put(icon);
+
+				icon.free();
+			}
+			Pixmap.setBlending(previousBlending); //just in case, avoid surprises
+			buffer.position(0);
+			GLFW.glfwSetWindowIcon(windowHandle, buffer);
+			buffer.free();
+			for (Pixmap pixmap : tmpPixmaps) pixmap.dispose();
 		}
 		GLFW.glfwMakeContextCurrent(windowHandle);
 		GLFW.glfwSwapInterval(config.vSyncEnabled ? 1 : 0);

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3ApplicationConfiguration.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3ApplicationConfiguration.java
@@ -18,6 +18,7 @@ package com.badlogic.gdx.backends.lwjgl3;
 
 import java.io.PrintStream;
 import java.nio.IntBuffer;
+import java.util.Arrays;
 
 import org.lwjgl.BufferUtils;
 import org.lwjgl.PointerBuffer;
@@ -61,6 +62,8 @@ public class Lwjgl3ApplicationConfiguration {
 	int windowMinWidth = -1, windowMinHeight = -1, windowMaxWidth = -1, windowMaxHeight = -1;
 	boolean windowResizable = true;
 	boolean windowDecorated = true;
+	FileType windowIconFileType;
+	String[] windowIconPaths;
 	Lwjgl3WindowListener windowListener;
 	Lwjgl3DisplayMode fullscreenMode;
 
@@ -103,6 +106,9 @@ public class Lwjgl3ApplicationConfiguration {
 		copy.windowMaxHeight = config.windowMaxHeight;
 		copy.windowResizable = config.windowResizable;
 		copy.windowDecorated = config.windowDecorated;
+		copy.windowIconFileType = config.windowIconFileType;
+		if (config.windowIconPaths != null) 
+			copy.windowIconPaths = Arrays.copyOf(config.windowIconPaths, config.windowIconPaths.length);
 		copy.windowListener = config.windowListener;
 		copy.fullscreenMode = config.fullscreenMode;
 		copy.vSyncEnabled = config.vSyncEnabled;
@@ -252,8 +258,19 @@ public class Lwjgl3ApplicationConfiguration {
 	}
 	
 	/**
+	 * Sets the icon that will be used in the window's title bar. Has no effect in macOS, which doesn't use window icons.
+	 * @param icon One or more image paths, relative to the given FileType. Must be JPEG, PNG, or BMP format. The one 
+	 * closest to the system's desired size will be scaled. Good sizes include 16x16, 32x32 and 48x48. The provided
+	 * file paths must point to valid images for as long new windows might be created.
+	 */
+	public void setWindowIcon (FileType fileType, String... filePaths){
+		windowIconFileType = fileType;
+		windowIconPaths = filePaths;
+	}
+	
+	/**
 	 * Sets the {@link Lwjgl3WindowListener} which will be informed about
-	 * iconficiation, focus loss and window close events.
+	 * iconification, focus loss and window close events.
 	 */
 	public void setWindowListener(Lwjgl3WindowListener windowListener) {
 		this.windowListener = windowListener;

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3WindowConfiguration.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3WindowConfiguration.java
@@ -16,6 +16,7 @@
 
 package com.badlogic.gdx.backends.lwjgl3;
 
+import com.badlogic.gdx.Files.FileType;
 import com.badlogic.gdx.Graphics.DisplayMode;
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Graphics.Lwjgl3DisplayMode;
 import com.badlogic.gdx.graphics.Color;
@@ -28,6 +29,8 @@ public class Lwjgl3WindowConfiguration {
 	int windowMinWidth = -1, windowMinHeight = -1, windowMaxWidth = -1, windowMaxHeight = -1;
 	boolean windowResizable = true;
 	boolean windowDecorated = true;
+	FileType windowIconFileType;
+	String[] windowIconPaths;
 	Lwjgl3WindowListener windowListener;
 	Lwjgl3DisplayMode fullscreenMode;
 	String title = "";
@@ -86,6 +89,16 @@ public class Lwjgl3WindowConfiguration {
 		windowMinHeight = minHeight;
 		windowMaxWidth = maxWidth;
 		windowMaxHeight = maxHeight;
+	}
+	
+	/**
+	 * Sets the icon that will be used in the window's title bar. Has no effect in macOS, which doesn't use window icons.
+	 * @param icon One or more image paths, relative to the given FileType. Must be JPEG, PNG, or BMP format. The one 
+	 * closest to the system's desired size will be scaled. Good sizes include 16x16, 32x32 and 48x48.
+	 */
+	public void setWindowIcon (FileType fileType, String... filePaths){
+		windowIconFileType = fileType;
+		windowIconPaths = filePaths;
 	}
 	
 	/**

--- a/tests/gdx-tests-lwjgl3/src/com/badlogic/gdx/tests/lwjgl3/MultiWindowTest.java
+++ b/tests/gdx-tests-lwjgl3/src/com/badlogic/gdx/tests/lwjgl3/MultiWindowTest.java
@@ -3,6 +3,7 @@ package com.badlogic.gdx.tests.lwjgl3;
 import com.badlogic.gdx.ApplicationAdapter;
 import com.badlogic.gdx.ApplicationListener;
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Files.FileType;
 import com.badlogic.gdx.Graphics.DisplayMode;
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application;
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3ApplicationConfiguration;
@@ -46,6 +47,7 @@ public class MultiWindowTest {
 				DisplayMode mode = Gdx.graphics.getDisplayMode();
 				config.setWindowPosition(MathUtils.random(0, mode.width - 640), MathUtils.random(0, mode.height - 480));
 				config.setTitle("Child window");
+				config.setWindowIcon(FileType.Internal, "data/testdot.png");
 				Class clazz = childWindowClasses[MathUtils.random(0, childWindowClasses.length - 1)];
 				ApplicationListener listener = createChildWindowClass(clazz);
 				Lwjgl3Window window = app.newWindow(listener, config);


### PR DESCRIPTION
This is an alternate to #4177.  I fixed some bugs it had, simplified usage, and added the ability to set icons in the window configuration, so different windows can have different icons.