### PR TITLE
LwjglCanvas disposes listener before OpenGL context get killed

### DIFF
--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglCanvas.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglCanvas.java
@@ -295,11 +295,6 @@ public class LwjglCanvas implements Application {
 			public void run () {
 				if (!running) return;
 				running = false;
-				try {
-					Display.destroy();
-					if (audio != null) audio.dispose();
-				} catch (Throwable ignored) {
-				}
 				Array<LifecycleListener> listeners = lifecycleListeners;
 				synchronized (listeners) {
 					for (LifecycleListener listener : listeners) {
@@ -309,6 +304,11 @@ public class LwjglCanvas implements Application {
 				}
 				listener.pause();
 				listener.dispose();
+				try {
+					Display.destroy();
+					if (audio != null) audio.dispose();
+				} catch (Throwable ignored) {
+				}
 			}
 		});
 	}


### PR DESCRIPTION
This commit fixes libgdx/libgdx#4203

Please, check ```LwjglCanvasTest.java``` with ```setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE)``` and see that it's now working correct.