### PR TITLE
Always respect explicit row() calls (fixes #4183)

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Table.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Table.java
@@ -341,6 +341,7 @@ public class Table extends WidgetGroup {
 	/** Indicates that subsequent cells should be added to a new row and returns the cell values that will be used as the defaults
 	 * for all cells in the new row. */
 	public Cell row () {
+		implicitEndRow = false;
 		if (cells.size > 0) {
 			endRow();
 			invalidate();


### PR DESCRIPTION
If the user calls `row()` it can be assumed the user definitely wants a new row. #4183 describes a case where this is needed.