### PR TITLE
Small fix to error message generated by XmlReader.Element.getAttribute(String name)

### DIFF
--- a/gdx/src/com/badlogic/gdx/utils/XmlReader.java
+++ b/gdx/src/com/badlogic/gdx/utils/XmlReader.java
@@ -470,9 +470,9 @@ public class XmlReader {
 
 		/** @throws GdxRuntimeException if the attribute was not found. */
 		public String getAttribute (String name) {
-			if (attributes == null) throw new GdxRuntimeException("Element " + name + " doesn't have attribute: " + name);
+			if (attributes == null) throw new GdxRuntimeException("Element " + this.name + " doesn't have attribute: " + name);
 			String value = attributes.get(name);
-			if (value == null) throw new GdxRuntimeException("Element " + name + " doesn't have attribute: " + name);
+			if (value == null) throw new GdxRuntimeException("Element " + this.name + " doesn't have attribute: " + name);
 			return value;
 		}
 

--- a/gdx/src/com/badlogic/gdx/utils/XmlReader.rl
+++ b/gdx/src/com/badlogic/gdx/utils/XmlReader.rl
@@ -265,9 +265,9 @@ public class XmlReader {
 
 		/** @throws GdxRuntimeException if the attribute was not found. */
 		public String getAttribute (String name) {
-			if (attributes == null) throw new GdxRuntimeException("Element " + name + " doesn't have attribute: " + name);
+			if (attributes == null) throw new GdxRuntimeException("Element " + this.name + " doesn't have attribute: " + name);
 			String value = attributes.get(name);
-			if (value == null) throw new GdxRuntimeException("Element " + name + " doesn't have attribute: " + name);
+			if (value == null) throw new GdxRuntimeException("Element " + this.name + " doesn't have attribute: " + name);
 			return value;
 		}
 


### PR DESCRIPTION
The error message generated by this function when the attribute did not exist was was of the form
"Element $attribute doesn't have attribute: $attribute"
instead of
"Element $element doesn't have attribute: $attribute"