### PR TITLE
Fix #4202

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,7 @@
 - Moved snapping from ProgressBar to Slider to prevent snapping when setting the value programmatically.
 - Bullet: added btSoftBody#getLinkCount() and btSoftBody#getLink(int), see https://github.com/libgdx/libgdx/issues/4152
 - API Change: Wrapping for scene2d's HorizontalGroup and VerticalGroup.
+- Fix hiero problem with certain unicode characters. See https://github.com/libgdx/libgdx/issues/4202
 
 [1.9.3]
 - Switched to MobiDevelop's RoboVM fork (http://robovm.mobidevelop.com)

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/hiero/BMFontUtil.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/hiero/BMFontUtil.java
@@ -196,7 +196,7 @@ public class BMFontUtil {
 	}
 
 	void writeGlyph (PrintStream out, int pageWidth, int pageHeight, int pageIndex, Glyph glyph) {
-		out.println("char id=" + String.format("%-6s", glyph.getCodePoint()) //
+		out.println("char id=" + String.format("%-7s ", glyph.getCodePoint()) //
 			+ "x=" + String.format("%-5s", (int)(glyph.getU() * pageWidth)) //
 			+ "y=" + String.format("%-5s", (int)(glyph.getV() * pageHeight)) //
 			+ "width=" + String.format("%-5s", glyph.getWidth()) //


### PR DESCRIPTION
The largest code point is 1,114,111, that's why I changed the format. (See http://unicode.org/faq/utf_bom.html#gen6  )
Previously only 6 digits were printed now 7 digits are printed and to be on the safe side I also included a space.   
So 
````
id=128512x
````

becomes 
````
id=128512  x
```