### PR TITLE
Add HitMode to Group to allow choosing the hit detection strategy

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,7 @@
 - Moved snapping from ProgressBar to Slider to prevent snapping when setting the value programmatically.
 - Bullet: added btSoftBody#getLinkCount() and btSoftBody#getLink(int), see https://github.com/libgdx/libgdx/issues/4152
 - API Change: Wrapping for scene2d's HorizontalGroup and VerticalGroup.
+- API Addition: Group#setHitMode allows to change the strategy for detecting the actor that has been hit in a group
 
 [1.9.3]
 - Switched to MobiDevelop's RoboVM fork (http://robovm.mobidevelop.com)


### PR DESCRIPTION
When multiple actors are added to a group, the one that gets returned by the hit method is the first one in the children hierarchy.

I have a use case where the actor that should be returned when the screen is touched is the one nearest to the hit coordinates (when two actors are partially superimposed, the current logic where the topmost actor is always returned feels unnatural when playing the game).

This pull request adds a HitMode option on the the Group class, that defaults to the current implementation and can be changed to a "nearest actor" mode.