### PR TITLE
TexturePacker.Settings copy ctor extracted to dedicated method

### DIFF
--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/texturepacker/TexturePacker.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/texturepacker/TexturePacker.java
@@ -562,8 +562,15 @@ public class TexturePacker {
 
 		public Settings () {
 		}
+	
 
+		/** @see #set(Settings)  */
 		public Settings (Settings settings) {
+			set(settings);
+		}
+
+		/** Copies values from another instance to the current one */
+		public void set(Settings settings) {
 			fast = settings.fast;
 			rotation = settings.rotation;
 			pot = settings.pot;


### PR DESCRIPTION
```TexturePacker.Settings``` has constructor with another ```Settings``` as param to make a copy instance. Much flexible to have this code in separate method (```Settings#set(Settings)```), to be able to copy fields from another instance anytime.