### PR TITLE
Add freetype error codes to exceptions

### DIFF
--- a/extensions/gdx-freetype/jni/com.badlogic.gdx.graphics.g2d.freetype.FreeType.cpp
+++ b/extensions/gdx-freetype/jni/com.badlogic.gdx.graphics.g2d.freetype.FreeType.cpp
@@ -1,14 +1,26 @@
 #include <com.badlogic.gdx.graphics.g2d.freetype.FreeType.h>
 
-//@line:35
+//@line:36
 
 	#include <ft2build.h>
 	#include FT_FREETYPE_H
 	#include FT_STROKER_H
-	 JNIEXPORT void JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Library_doneFreeType(JNIEnv* env, jclass clazz, jlong library) {
+	
+	static jint lastError = 0;	
+	 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_getLastErrorCode(JNIEnv* env, jclass clazz) {
 
 
-//@line:64
+//@line:44
+
+		return lastError;
+	
+
+}
+
+JNIEXPORT void JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Library_doneFreeType(JNIEnv* env, jclass clazz, jlong library) {
+
+
+//@line:71
 
 			FT_Done_FreeType((FT_Library)library);
 		
@@ -18,11 +30,14 @@
 static inline jlong wrapped_Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Library_newMemoryFace
 (JNIEnv* env, jclass clazz, jlong library, jobject obj_data, jint dataSize, jint faceIndex, char* data) {
 
-//@line:91
+//@line:99
 
 			FT_Face face = 0;
 			FT_Error error = FT_New_Memory_Face((FT_Library)library, (const FT_Byte*)data, dataSize, faceIndex, &face);
-			if(error) return 0;
+			if(error) {
+				lastError = error;
+				return 0;
+			}
 			else return (jlong)face;
 		
 }
@@ -39,11 +54,14 @@ JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_000
 JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Library_strokerNew(JNIEnv* env, jclass clazz, jlong library) {
 
 
-//@line:104
+//@line:115
 
 			FT_Stroker stroker;
 			FT_Error error = FT_Stroker_New((FT_Library)library, &stroker);
-			if(error) return 0;
+			if(error) {
+				lastError = error;
+				return 0;
+			}
 			else return (jlong)stroker;
 		
 
@@ -52,7 +70,7 @@ JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_000
 JNIEXPORT void JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_doneFace(JNIEnv* env, jclass clazz, jlong face) {
 
 
-//@line:130
+//@line:144
 
 			FT_Done_Face((FT_Face)face);
 		
@@ -62,7 +80,7 @@ JNIEXPORT void JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getFaceFlags(JNIEnv* env, jclass clazz, jlong face) {
 
 
-//@line:138
+//@line:152
 
 			return ((FT_Face)face)->face_flags;
 		
@@ -72,7 +90,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getStyleFlags(JNIEnv* env, jclass clazz, jlong face) {
 
 
-//@line:146
+//@line:160
 
 			return ((FT_Face)face)->style_flags;
 		
@@ -82,7 +100,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getNumGlyphs(JNIEnv* env, jclass clazz, jlong face) {
 
 
-//@line:154
+//@line:168
 
 			return ((FT_Face)face)->num_glyphs;
 		
@@ -92,7 +110,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getAscender(JNIEnv* env, jclass clazz, jlong face) {
 
 
-//@line:162
+//@line:176
 
 			return ((FT_Face)face)->ascender;
 		
@@ -102,7 +120,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getDescender(JNIEnv* env, jclass clazz, jlong face) {
 
 
-//@line:170
+//@line:184
 
 			return ((FT_Face)face)->descender;
 		
@@ -112,7 +130,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getHeight(JNIEnv* env, jclass clazz, jlong face) {
 
 
-//@line:178
+//@line:192
 
 			return ((FT_Face)face)->height;
 		
@@ -122,7 +140,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getMaxAdvanceWidth(JNIEnv* env, jclass clazz, jlong face) {
 
 
-//@line:186
+//@line:200
 
 			return ((FT_Face)face)->max_advance_width;
 		
@@ -132,7 +150,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getMaxAdvanceHeight(JNIEnv* env, jclass clazz, jlong face) {
 
 
-//@line:194
+//@line:208
 
 			return ((FT_Face)face)->max_advance_height;
 		
@@ -142,7 +160,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getUnderlinePosition(JNIEnv* env, jclass clazz, jlong face) {
 
 
-//@line:202
+//@line:216
 
 			return ((FT_Face)face)->underline_position;
 		
@@ -152,7 +170,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getUnderlineThickness(JNIEnv* env, jclass clazz, jlong face) {
 
 
-//@line:210
+//@line:224
 
 			return ((FT_Face)face)->underline_thickness;
 		
@@ -162,7 +180,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jboolean JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_selectSize(JNIEnv* env, jclass clazz, jlong face, jint strike_index) {
 
 
-//@line:218
+//@line:232
 
 			return !FT_Select_Size((FT_Face)face, strike_index);
 		
@@ -172,7 +190,7 @@ JNIEXPORT jboolean JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_
 JNIEXPORT jboolean JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_setCharSize(JNIEnv* env, jclass clazz, jlong face, jint charWidth, jint charHeight, jint horzResolution, jint vertResolution) {
 
 
-//@line:226
+//@line:240
 
 			return !FT_Set_Char_Size((FT_Face)face, charWidth, charHeight, horzResolution, vertResolution);
 		
@@ -182,7 +200,7 @@ JNIEXPORT jboolean JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_
 JNIEXPORT jboolean JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_setPixelSizes(JNIEnv* env, jclass clazz, jlong face, jint pixelWidth, jint pixelHeight) {
 
 
-//@line:234
+//@line:248
 
 			return !FT_Set_Pixel_Sizes((FT_Face)face, pixelWidth, pixelHeight);
 		
@@ -192,7 +210,7 @@ JNIEXPORT jboolean JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_
 JNIEXPORT jboolean JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_loadGlyph(JNIEnv* env, jclass clazz, jlong face, jint glyphIndex, jint loadFlags) {
 
 
-//@line:242
+//@line:256
 
 			return !FT_Load_Glyph((FT_Face)face, glyphIndex, loadFlags);
 		
@@ -202,7 +220,7 @@ JNIEXPORT jboolean JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_
 JNIEXPORT jboolean JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_loadChar(JNIEnv* env, jclass clazz, jlong face, jint charCode, jint loadFlags) {
 
 
-//@line:250
+//@line:264
 
 			return !FT_Load_Char((FT_Face)face, charCode, loadFlags);
 		
@@ -212,7 +230,7 @@ JNIEXPORT jboolean JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_
 JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getGlyph(JNIEnv* env, jclass clazz, jlong face) {
 
 
-//@line:258
+//@line:272
 
 			return (jlong)((FT_Face)face)->glyph;
 		
@@ -222,7 +240,7 @@ JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_000
 JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getSize(JNIEnv* env, jclass clazz, jlong face) {
 
 
-//@line:266
+//@line:280
 
 			return (jlong)((FT_Face)face)->size;
 		
@@ -232,7 +250,7 @@ JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_000
 JNIEXPORT jboolean JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_hasKerning(JNIEnv* env, jclass clazz, jlong face) {
 
 
-//@line:274
+//@line:288
 
 			return FT_HAS_KERNING(((FT_Face)face));
 		
@@ -242,7 +260,7 @@ JNIEXPORT jboolean JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getKerning(JNIEnv* env, jclass clazz, jlong face, jint leftGlyph, jint rightGlyph, jint kernMode) {
 
 
-//@line:282
+//@line:296
 
 			FT_Vector kerning;
 			FT_Error error = FT_Get_Kerning((FT_Face)face, leftGlyph, rightGlyph, kernMode, &kerning);
@@ -255,7 +273,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Face_getCharIndex(JNIEnv* env, jclass clazz, jlong face, jint charCode) {
 
 
-//@line:293
+//@line:307
 
 			return FT_Get_Char_Index((FT_Face)face, charCode);
 		
@@ -265,7 +283,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Size_getMetrics(JNIEnv* env, jclass clazz, jlong address) {
 
 
-//@line:308
+//@line:322
 
 			return (jlong)&((FT_Size)address)->metrics;
 		
@@ -275,7 +293,7 @@ JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_000
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024SizeMetrics_getXppem(JNIEnv* env, jclass clazz, jlong metrics) {
 
 
-//@line:322
+//@line:336
 
 			return ((FT_Size_Metrics*)metrics)->x_ppem;
 		
@@ -285,7 +303,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024SizeMetrics_getYppem(JNIEnv* env, jclass clazz, jlong metrics) {
 
 
-//@line:330
+//@line:344
 
 			return ((FT_Size_Metrics*)metrics)->y_ppem;
 		
@@ -295,7 +313,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024SizeMetrics_getXscale(JNIEnv* env, jclass clazz, jlong metrics) {
 
 
-//@line:338
+//@line:352
 
 			return ((FT_Size_Metrics*)metrics)->x_scale;
 		
@@ -305,7 +323,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024SizeMetrics_getYscale(JNIEnv* env, jclass clazz, jlong metrics) {
 
 
-//@line:346
+//@line:360
 
 			return ((FT_Size_Metrics*)metrics)->x_scale;
 		
@@ -315,7 +333,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024SizeMetrics_getAscender(JNIEnv* env, jclass clazz, jlong metrics) {
 
 
-//@line:354
+//@line:368
 
 			return ((FT_Size_Metrics*)metrics)->ascender;
 		
@@ -325,7 +343,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024SizeMetrics_getDescender(JNIEnv* env, jclass clazz, jlong metrics) {
 
 
-//@line:362
+//@line:376
 
 			return ((FT_Size_Metrics*)metrics)->descender;
 		
@@ -335,7 +353,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024SizeMetrics_getHeight(JNIEnv* env, jclass clazz, jlong metrics) {
 
 
-//@line:370
+//@line:384
 
 			return ((FT_Size_Metrics*)metrics)->height;
 		
@@ -345,7 +363,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024SizeMetrics_getMaxAdvance(JNIEnv* env, jclass clazz, jlong metrics) {
 
 
-//@line:378
+//@line:392
 
 			return ((FT_Size_Metrics*)metrics)->max_advance;
 		
@@ -355,7 +373,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphSlot_getMetrics(JNIEnv* env, jclass clazz, jlong slot) {
 
 
-//@line:392
+//@line:406
 
 			return (jlong)&((FT_GlyphSlot)slot)->metrics;
 		
@@ -365,7 +383,7 @@ JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_000
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphSlot_getLinearHoriAdvance(JNIEnv* env, jclass clazz, jlong slot) {
 
 
-//@line:400
+//@line:414
 
 			return ((FT_GlyphSlot)slot)->linearHoriAdvance;
 		
@@ -375,7 +393,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphSlot_getLinearVertAdvance(JNIEnv* env, jclass clazz, jlong slot) {
 
 
-//@line:408
+//@line:422
 
 			return ((FT_GlyphSlot)slot)->linearVertAdvance;
 		
@@ -385,7 +403,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphSlot_getAdvanceX(JNIEnv* env, jclass clazz, jlong slot) {
 
 
-//@line:416
+//@line:430
 
 			return ((FT_GlyphSlot)slot)->advance.x;
 		
@@ -395,7 +413,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphSlot_getAdvanceY(JNIEnv* env, jclass clazz, jlong slot) {
 
 
-//@line:424
+//@line:438
 
 			return ((FT_GlyphSlot)slot)->advance.y;
 		
@@ -405,7 +423,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphSlot_getFormat(JNIEnv* env, jclass clazz, jlong slot) {
 
 
-//@line:432
+//@line:446
 
 			return ((FT_GlyphSlot)slot)->format;
 		
@@ -415,7 +433,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphSlot_getBitmap(JNIEnv* env, jclass clazz, jlong slot) {
 
 
-//@line:440
+//@line:454
 
 			FT_GlyphSlot glyph = ((FT_GlyphSlot)slot);
 			return (jlong)&(glyph->bitmap);
@@ -426,7 +444,7 @@ JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_000
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphSlot_getBitmapLeft(JNIEnv* env, jclass clazz, jlong slot) {
 
 
-//@line:449
+//@line:463
 
 			return ((FT_GlyphSlot)slot)->bitmap_left;
 		
@@ -436,7 +454,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphSlot_getBitmapTop(JNIEnv* env, jclass clazz, jlong slot) {
 
 
-//@line:457
+//@line:471
 
 			return ((FT_GlyphSlot)slot)->bitmap_top;
 		
@@ -446,7 +464,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jboolean JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphSlot_renderGlyph(JNIEnv* env, jclass clazz, jlong slot, jint renderMode) {
 
 
-//@line:465
+//@line:479
 
 			return !FT_Render_Glyph((FT_GlyphSlot)slot, (FT_Render_Mode)renderMode);
 		
@@ -456,11 +474,14 @@ JNIEXPORT jboolean JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_
 JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphSlot_getGlyph(JNIEnv* env, jclass clazz, jlong glyphSlot) {
 
 
-//@line:475
+//@line:489
 
 			FT_Glyph glyph;
 			FT_Error error = FT_Get_Glyph((FT_GlyphSlot)glyphSlot, &glyph);
-			if(error) return 0;
+			if(error) {
+				lastError = error;
+				return 0;
+			}
 			else return (jlong)glyph;
 		
 
@@ -469,7 +490,7 @@ JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_000
 JNIEXPORT void JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Glyph_done(JNIEnv* env, jclass clazz, jlong glyph) {
 
 
-//@line:495
+//@line:512
 
 			FT_Done_Glyph((FT_Glyph)glyph);
 		
@@ -479,7 +500,7 @@ JNIEXPORT void JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Glyph_strokeBorder(JNIEnv* env, jclass clazz, jlong glyph, jlong stroker, jboolean inside) {
 
 
-//@line:503
+//@line:520
 
 			FT_Glyph border_glyph = (FT_Glyph)glyph;
 			FT_Glyph_StrokeBorder(&border_glyph, (FT_Stroker)stroker, inside, 1);
@@ -491,11 +512,14 @@ JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_000
 JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Glyph_toBitmap(JNIEnv* env, jclass clazz, jlong glyph, jint renderMode) {
 
 
-//@line:516
+//@line:533
 
 			FT_Glyph bitmap = (FT_Glyph)glyph;
 			FT_Error error = FT_Glyph_To_Bitmap(&bitmap, (FT_Render_Mode)renderMode, NULL, 1);
-			if(error) return 0;
+			if(error) {
+				lastError = error;
+				return 0;
+			}
 			return (jlong)bitmap;
 		
 
@@ -504,7 +528,7 @@ JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_000
 JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Glyph_getBitmap(JNIEnv* env, jclass clazz, jlong glyph) {
 
 
-//@line:530
+//@line:550
 
 			FT_BitmapGlyph glyph_bitmap = ((FT_BitmapGlyph)glyph);
 			return (jlong)&(glyph_bitmap->bitmap);
@@ -515,7 +539,7 @@ JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_000
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Glyph_getLeft(JNIEnv* env, jclass clazz, jlong glyph) {
 
 
-//@line:542
+//@line:562
 
 			FT_BitmapGlyph glyph_bitmap = ((FT_BitmapGlyph)glyph);
 			return glyph_bitmap->left;
@@ -526,7 +550,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Glyph_getTop(JNIEnv* env, jclass clazz, jlong glyph) {
 
 
-//@line:554
+//@line:574
 
 			FT_BitmapGlyph glyph_bitmap = ((FT_BitmapGlyph)glyph);
 			return glyph_bitmap->top;
@@ -537,7 +561,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Bitmap_getRows(JNIEnv* env, jclass clazz, jlong bitmap) {
 
 
-//@line:570
+//@line:590
 
 			return ((FT_Bitmap*)bitmap)->rows;
 		
@@ -547,7 +571,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Bitmap_getWidth(JNIEnv* env, jclass clazz, jlong bitmap) {
 
 
-//@line:578
+//@line:598
 
 			return ((FT_Bitmap*)bitmap)->width;
 		
@@ -557,7 +581,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Bitmap_getPitch(JNIEnv* env, jclass clazz, jlong bitmap) {
 
 
-//@line:586
+//@line:606
 
 			return ((FT_Bitmap*)bitmap)->pitch;
 		
@@ -567,7 +591,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jobject JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Bitmap_getBuffer(JNIEnv* env, jclass clazz, jlong bitmap) {
 
 
-//@line:601
+//@line:621
 
 			FT_Bitmap* bmp = (FT_Bitmap*)bitmap;
 			return env->NewDirectByteBuffer((void*)bmp->buffer, bmp->rows * abs(bmp->pitch) * bmp->width);
@@ -578,7 +602,7 @@ JNIEXPORT jobject JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Bitmap_getNumGray(JNIEnv* env, jclass clazz, jlong bitmap) {
 
 
-//@line:670
+//@line:690
 
 			return ((FT_Bitmap*)bitmap)->num_grays;
 		
@@ -588,7 +612,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Bitmap_getPixelMode(JNIEnv* env, jclass clazz, jlong bitmap) {
 
 
-//@line:678
+//@line:698
 
 			return ((FT_Bitmap*)bitmap)->pixel_mode;
 		
@@ -598,7 +622,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphMetrics_getWidth(JNIEnv* env, jclass clazz, jlong metrics) {
 
 
-//@line:692
+//@line:712
 
 			return ((FT_Glyph_Metrics*)metrics)->width;
 		
@@ -608,7 +632,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphMetrics_getHeight(JNIEnv* env, jclass clazz, jlong metrics) {
 
 
-//@line:700
+//@line:720
 
 			return ((FT_Glyph_Metrics*)metrics)->height;
 		
@@ -618,7 +642,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphMetrics_getHoriBearingX(JNIEnv* env, jclass clazz, jlong metrics) {
 
 
-//@line:708
+//@line:728
 
 			return ((FT_Glyph_Metrics*)metrics)->horiBearingX;
 		
@@ -628,7 +652,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphMetrics_getHoriBearingY(JNIEnv* env, jclass clazz, jlong metrics) {
 
 
-//@line:716
+//@line:736
 
 			return ((FT_Glyph_Metrics*)metrics)->horiBearingY;
 		
@@ -638,7 +662,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphMetrics_getHoriAdvance(JNIEnv* env, jclass clazz, jlong metrics) {
 
 
-//@line:724
+//@line:744
 
 			return ((FT_Glyph_Metrics*)metrics)->horiAdvance;
 		
@@ -648,7 +672,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphMetrics_getVertBearingX(JNIEnv* env, jclass clazz, jlong metrics) {
 
 
-//@line:732
+//@line:752
 
 			return ((FT_Glyph_Metrics*)metrics)->vertBearingX;
 		
@@ -658,7 +682,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphMetrics_getVertBearingY(JNIEnv* env, jclass clazz, jlong metrics) {
 
 
-//@line:740
+//@line:760
 
 			return ((FT_Glyph_Metrics*)metrics)->vertBearingY;
 		 
@@ -668,7 +692,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024GlyphMetrics_getVertAdvance(JNIEnv* env, jclass clazz, jlong metrics) {
 
 
-//@line:748
+//@line:768
 
 			return ((FT_Glyph_Metrics*)metrics)->vertAdvance;
 		
@@ -678,7 +702,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT void JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Stroker_set(JNIEnv* env, jclass clazz, jlong stroker, jint radius, jint lineCap, jint lineJoin, jint miterLimit) {
 
 
-//@line:762
+//@line:782
 
 			FT_Stroker_Set((FT_Stroker)stroker, radius, (FT_Stroker_LineCap)lineCap, (FT_Stroker_LineJoin)lineJoin, miterLimit);
 		
@@ -688,7 +712,7 @@ JNIEXPORT void JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT void JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_00024Stroker_done(JNIEnv* env, jclass clazz, jlong stroker) {
 
 
-//@line:771
+//@line:791
 
 			FT_Stroker_Done((FT_Stroker)stroker);
 		
@@ -698,11 +722,14 @@ JNIEXPORT void JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_0002
 JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_initFreeTypeJni(JNIEnv* env, jclass clazz) {
 
 
-//@line:871
+//@line:891
 
 		FT_Library library = 0;
 		FT_Error error = FT_Init_FreeType(&library);
-		if(error) return 0;
+		if(error) {
+			lastError = error;
+			return 0;
+		}
 		else return (jlong)library;
 	
 

--- a/extensions/gdx-freetype/jni/com.badlogic.gdx.graphics.g2d.freetype.FreeType.h
+++ b/extensions/gdx-freetype/jni/com.badlogic.gdx.graphics.g2d.freetype.FreeType.h
@@ -9,6 +9,14 @@ extern "C" {
 #endif
 /*
  * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType
+ * Method:    getLastErrorCode
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_com_badlogic_gdx_graphics_g2d_freetype_FreeType_getLastErrorCode
+  (JNIEnv *, jclass);
+
+/*
+ * Class:     com_badlogic_gdx_graphics_g2d_freetype_FreeType
  * Method:    initFreeTypeJni
  * Signature: ()J
  */

--- a/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeType.java
+++ b/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeType.java
@@ -36,8 +36,18 @@ public class FreeType {
 	#include <ft2build.h>
 	#include FT_FREETYPE_H
 	#include FT_STROKER_H
+	
+	static jint lastError = 0;	
 	 */
-
+	
+	/**
+	 * 
+	 * @return returns the last error code FreeType reported
+	 */
+	static native int getLastErrorCode(); /*
+		return lastError;
+	*/
+	
 	private static class Pointer {
 		long address;
 		
@@ -80,7 +90,7 @@ public class FreeType {
 			long face = newMemoryFace(address, buffer, buffer.remaining(), faceIndex);
 			if(face == 0) {
 				BufferUtils.disposeUnsafeByteBuffer(buffer);
-				throw new GdxRuntimeException("Couldn't load font");
+				throw new GdxRuntimeException("Couldn't load font, FreeType error code: " + getLastErrorCode());
 			}
 			else {
 				fontData.put(face, buffer);
@@ -91,20 +101,26 @@ public class FreeType {
 		private static native long newMemoryFace(long library, ByteBuffer data, int dataSize, int faceIndex); /*
 			FT_Face face = 0;
 			FT_Error error = FT_New_Memory_Face((FT_Library)library, (const FT_Byte*)data, dataSize, faceIndex, &face);
-			if(error) return 0;
+			if(error) {
+				lastError = error;
+				return 0;
+			}
 			else return (jlong)face;
 		*/
 
 		public Stroker createStroker() {
 			long stroker = strokerNew(address);
-			if(stroker == 0) throw new GdxRuntimeException("Couldn't create FreeType stroker");
+			if(stroker == 0) throw new GdxRuntimeException("Couldn't create FreeType stroker, FreeType error code: " + getLastErrorCode());
 			return new Stroker(stroker);
 		}
 
 		private static native long strokerNew(long library); /*
 			FT_Stroker stroker;
 			FT_Error error = FT_Stroker_New((FT_Library)library, &stroker);
-			if(error) return 0;
+			if(error) {
+				lastError = error;
+				return 0;
+			}
 			else return (jlong)stroker;
 		*/
 	}
@@ -468,14 +484,17 @@ public class FreeType {
 
 		public Glyph getGlyph() {
 			long glyph = getGlyph(address);
-			if(glyph == 0) throw new GdxRuntimeException("Couldn't get glyph");
+			if(glyph == 0) throw new GdxRuntimeException("Couldn't get glyph, FreeType error code: " + getLastErrorCode());
 			return new Glyph(glyph);
 		}
 
 		private static native long getGlyph(long glyphSlot); /*
 			FT_Glyph glyph;
 			FT_Error error = FT_Get_Glyph((FT_GlyphSlot)glyphSlot, &glyph);
-			if(error) return 0;
+			if(error) {
+				lastError = error;
+				return 0;
+			}
 			else return (jlong)glyph;
 		*/
 	}
@@ -508,7 +527,7 @@ public class FreeType {
 
 		public void toBitmap(int renderMode) {
 			long bitmap = toBitmap(address, renderMode);
-			if (bitmap == 0) throw new GdxRuntimeException("Couldn't render glyph");
+			if (bitmap == 0) throw new GdxRuntimeException("Couldn't render glyph, FreeType error code: " + getLastErrorCode());
 			address = bitmap;
 			rendered = true;
 		}
@@ -516,7 +535,10 @@ public class FreeType {
 		private static native long toBitmap(long glyph, int renderMode); /*
 			FT_Glyph bitmap = (FT_Glyph)glyph;
 			FT_Error error = FT_Glyph_To_Bitmap(&bitmap, (FT_Render_Mode)renderMode, NULL, 1);
-			if(error) return 0;
+			if(error) {
+				lastError = error;
+				return 0;
+			}
 			return (jlong)bitmap;
 		*/
 
@@ -784,7 +806,7 @@ public class FreeType {
 	private static int encode (char a, char b, char c, char d) {
 		return (a << 24) | (b << 16) | (c << 8) | d;
 	}
-   
+
 	public static int FT_ENCODING_NONE = 0;
 	public static int FT_ENCODING_MS_SYMBOL = encode('s', 'y', 'm', 'b');
 	public static int FT_ENCODING_UNICODE = encode('u', 'n', 'i', 'c');
@@ -861,17 +883,20 @@ public class FreeType {
 	public static int FT_STROKER_LINEJOIN_MITER          = FT_STROKER_LINEJOIN_MITER_VARIABLE;
 	public static int FT_STROKER_LINEJOIN_MITER_FIXED    = 3;
 
-   public static Library initFreeType() {
+   public static Library initFreeType() {   	
    	new SharedLibraryLoader().load("gdx-freetype");
    	long address = initFreeTypeJni();
-   	if(address == 0) throw new GdxRuntimeException("Couldn't initialize FreeType library");
+   	if(address == 0) throw new GdxRuntimeException("Couldn't initialize FreeType library, FreeType error code: " + getLastErrorCode());
    	else return new Library(address);
    }
    
 	private static native long initFreeTypeJni(); /*
 		FT_Library library = 0;
 		FT_Error error = FT_Init_FreeType(&library);
-		if(error) return 0;
+		if(error) {
+			lastError = error;
+			return 0;
+		}
 		else return (jlong)library;
 	*/
 


### PR DESCRIPTION
# What does this PR do?
This PR adds a way to get the error code most free type functions return.
There is currently no way to get the error code since `if(error) return 0;` hides the error code.
It's possible to know _that_ an error occurred  but not _what_ error exactly occurred.

We could create a wrapper class which contains an error code (if there is one) and the result of the function, but this would be too inefficient.
That's why I came up with this solution.

When a function returns `0` you can now check the error code via `getLastErrorCode()`.
All functions that throw an exception now include the error code.

The PR would allow easier fixing of this issue:
https://github.com/libgdx/libgdx/issues/3692