### PR TITLE
Fixes loading external Tiled tilesets with relative images

### DIFF
--- a/gdx/src/com/badlogic/gdx/maps/tiled/TmxMapLoader.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/TmxMapLoader.java
@@ -404,7 +404,12 @@ public class TmxMapLoader extends BaseTmxMapLoader<TmxMapLoader.Parameters> {
 						imageSource = imageElement.getAttribute("source");
 						imageWidth = imageElement.getIntAttribute("width", 0);
 						imageHeight = imageElement.getIntAttribute("height", 0);
-						image = getRelativeFileHandle(tmxFile, imageSource);
+
+						if (source != null) {
+							image = getRelativeFileHandle(getRelativeFileHandle(tmxFile, source), imageSource);
+						} else {
+							image = getRelativeFileHandle(tmxFile, imageSource);
+						}
 					}
 					TextureRegion texture = imageResolver.getImage(image.path());
 					TiledMapTile tile = new StaticTiledMapTile(texture);


### PR DESCRIPTION
This commit fixes a bug when loading external tilesets with external images.

Consider the following directory structure:

```
root/
    tilemap.tmx [refers to tileset as "tiles/tileset.tsx"]
    tiles/
        tileset.tsx [refers to images as "tile#.png"]
        tile1.png
        tile2.png
```

Previously, it would try to load the images using the tilemap's location as a base, so it would look for images in root/tile#.png. Now, it will load from root/tiles/tile#.png as expected.
