### PR TITLE
Fix for issue #3994.

### DIFF
--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/bmfont/BitmapFontWriter.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/bmfont/BitmapFontWriter.java
@@ -181,8 +181,8 @@ public class BitmapFontWriter {
 			.append(quote(info.italic ? 1 : 0)).append(" charset=\"").append(info.charset == null ? "" : info.charset)
 			.append("\" unicode=").append(quote(info.unicode ? 1 : 0)).append(" stretchH=").append(quote(info.stretchH))
 			.append(" smooth=").append(quote(info.smooth ? 1 : 0)).append(" aa=").append(quote(info.aa)).append(" padding=")
-			.append(xmlQuote).append(info.padding.up).append(",").append(info.padding.down).append(",").append(info.padding.left)
-			.append(",").append(info.padding.right).append(xmlQuote).append(" spacing=").append(xmlQuote)
+			.append(xmlQuote).append(info.padding.up).append(",").append(info.padding.right).append(",").append(info.padding.down)
+			.append(",").append(info.padding.left).append(xmlQuote).append(" spacing=").append(xmlQuote)
 			.append(info.spacing.horizontal).append(",").append(info.spacing.vertical).append(xmlQuote).append(xmlCloseSelf)
 			.append("\n");
 

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/hiero/BMFontUtil.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/hiero/BMFontUtil.java
@@ -69,8 +69,8 @@ public class BMFontUtil {
 		int pageHeight = unicodeFont.getGlyphPageHeight();
 		out.println("info face=\"" + font.getFontName() + "\" size=" + font.getSize() + " bold=" + (font.isBold() ? 1 : 0)
 			+ " italic=" + (font.isItalic() ? 1 : 0) + " charset=\"\" unicode=0 stretchH=100 smooth=1 aa=1 padding="
-			+ unicodeFont.getPaddingTop() + "," + unicodeFont.getPaddingLeft() + "," + unicodeFont.getPaddingBottom() + ","
-			+ unicodeFont.getPaddingRight() + " spacing=" + unicodeFont.getPaddingAdvanceX() + ","
+			+ unicodeFont.getPaddingTop() + "," + unicodeFont.getPaddingRight() + "," + unicodeFont.getPaddingBottom() + ","
+			+ unicodeFont.getPaddingLeft() + " spacing=" + unicodeFont.getPaddingAdvanceX() + ","
 			+ unicodeFont.getPaddingAdvanceY());
 		out.println("common lineHeight=" + unicodeFont.getLineHeight() + " base=" + unicodeFont.getAscent() + " scaleW=" + pageWidth
 			+ " scaleH=" + pageHeight + " pages=" + unicodeFont.getGlyphPages().size() + " packed=0");

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/hiero/unicodefont/Glyph.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/hiero/unicodefont/Glyph.java
@@ -80,8 +80,8 @@ public class Glyph {
 			char[] chars = Character.toChars(codePoint);
 			GlyphVector charVector = unicodeFont.getFont().layoutGlyphVector(GlyphPage.renderContext, chars, 0, chars.length,
 				Font.LAYOUT_LEFT_TO_RIGHT);
-			GlyphMetrics charMetrics = vector.getGlyphMetrics(0);
-			xOffset = vector.getGlyphPixelBounds(0, GlyphPage.renderContext, 0, 0).x - unicodeFont.getPaddingLeft();
+			GlyphMetrics charMetrics = charVector.getGlyphMetrics(0);
+			xOffset = charVector.getGlyphPixelBounds(0, GlyphPage.renderContext, 0, 0).x - unicodeFont.getPaddingLeft();
 			xAdvance = (int)(metrics.getAdvanceX() + unicodeFont.getPaddingAdvanceX() + unicodeFont.getPaddingLeft()
 				+ unicodeFont.getPaddingRight());
 

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFont.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFont.java
@@ -487,9 +487,9 @@ public class BitmapFont implements Disposable {
 				String[] padding = line.substring(0, line.indexOf(' ')).split(",", 4);
 				if (padding.length != 4) throw new GdxRuntimeException("Invalid padding.");
 				padTop = Integer.parseInt(padding[0]);
-				padLeft = Integer.parseInt(padding[1]);
+				padRight = Integer.parseInt(padding[1]);
 				padBottom = Integer.parseInt(padding[2]);
-				padRight = Integer.parseInt(padding[3]);
+				padLeft = Integer.parseInt(padding[3]);
 				float padY = padTop + padBottom;
 
 				line = reader.readLine();


### PR DESCRIPTION
Fixes issue #3994 where the Java renderer does not correctly set the BMFont xoffset because `charVector` was not being used.

I was experiencing this issue as well because I want to use the Java renderer in Hiero.  It looks like a simple bug; I compiled Hiero with this change and the fix corrects `xoffset`.  To test, I'm saving Arial using Java Rendering, the Extended character set, and setting 1 page of size 1024x512.  Attached are `.fnt` files before and after the fix (renamed to `.txt` for Github upload).  Notice `xoffset=2` for every character in the "before" file.  The "after" file with this fix renders correctly for me.
[arial-after-fix.txt](https://github.com/libgdx/libgdx/files/446252/arial-after-fix.txt)
[arial-before-fix.txt](https://github.com/libgdx/libgdx/files/446251/arial-before-fix.txt)
