### PR TITLE
Add cascading style support to Skin

### DIFF
--- a/gdx/src/com/badlogic/gdx/utils/Json.java
+++ b/gdx/src/com/badlogic/gdx/utils/Json.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 
 import com.badlogic.gdx.files.FileHandle;
@@ -76,6 +77,10 @@ public class Json {
 		this.ignoreUnknownFields = ignoreUnknownFields;
 	}
 
+	public boolean isIgnoreUnknownFields () {
+		return ignoreUnknownFields;
+	}
+
 	/** When true, fields with the {@link Deprecated} annotation will not be serialized. */
 	public void setIgnoreDeprecated (boolean ignoreDeprecated) {
 		this.ignoreDeprecated = ignoreDeprecated;
@@ -119,6 +124,10 @@ public class Json {
 	public void setTypeName (String typeName) {
 		this.typeName = typeName;
 	}
+	
+	public String getTypeName () {
+		return typeName;
+	}
 
 	/** Sets the serializer to use when the type being deserialized is not known (null).
 	 * @param defaultSerializer May be null. */
@@ -150,7 +159,7 @@ public class Json {
 		metadata.elementType = elementType;
 	}
 
-	private OrderedMap<String, FieldMetadata> getFields (Class type) {
+	protected final OrderedMap<String, FieldMetadata> getFields (Class type) {
 		OrderedMap<String, FieldMetadata> fields = typeToFields.get(type);
 		if (fields != null) return fields;
 
@@ -790,7 +799,7 @@ public class Json {
 			FieldMetadata metadata = fields.get(child.name);
 			if (metadata == null) {
 				if (child.name.equals(typeName)) continue;
-				if (ignoreUnknownFields) {
+				if (ignoreUnknownFields || isNonexistantFieldKnown(type, child.name)) {
 					if (debug) System.out.println("Ignoring unknown field: " + child.name + " (" + type.getName() + ")");
 					continue;
 				} else {
@@ -815,6 +824,16 @@ public class Json {
 				throw ex;
 			}
 		}
+	}
+
+	/** Override to allow subclasses to use fake field names for other purposes in {@link #readFields(Object, JsonValue)} without
+	 * triggering an exception for unknown fields.
+	 * @param type The object type being read.
+	 * @param fieldName A field name encountered in the Json map for which there is no actual field.
+	 * @return Whether the field name should be treated as known, i.e., not throw an exception when encountered in
+	 *         {@code readFields()}. */
+	protected boolean isNonexistantFieldKnown (Class type, String fieldName) {
+		return false;
 	}
 
 	/** @param type May be null if the type is unknown.
@@ -1092,8 +1111,8 @@ public class Json {
 		return new JsonReader().parse(json).prettyPrint(settings);
 	}
 
-	static private class FieldMetadata {
-		Field field;
+	static protected class FieldMetadata {
+		public final Field field;
 		Class elementType;
 
 		public FieldMetadata (Field field) {

--- a/tests/gdx-tests-android/assets/data/uiskin.json
+++ b/tests/gdx-tests-android/assets/data/uiskin.json
@@ -11,11 +11,11 @@ com.badlogic.gdx.scenes.scene2d.ui.Skin$TintedDrawable: {
 },
 com.badlogic.gdx.scenes.scene2d.ui.Button$ButtonStyle: {
 	default: { down: default-round-down, up: default-round },
-	toggle: { down: default-round-down, checked: default-round-down, up: default-round }
+	toggle: { parent: default, checked: default-round-down }
 },
 com.badlogic.gdx.scenes.scene2d.ui.TextButton$TextButtonStyle: {
 	default: { down: default-round-down, up: default-round, font: default-font, fontColor: white },
-	toggle: { down: default-round-down, up: default-round, checked: default-round-down, font: default-font, fontColor: white, downFontColor: red }
+	toggle: { parent: default, checked: default-round-down, downFontColor: red }
 },
 com.badlogic.gdx.scenes.scene2d.ui.ScrollPane$ScrollPaneStyle: {
 	default: { vScroll: default-scroll, hScrollKnob: default-round-large, background: default-rect, hScroll: default-scroll, vScrollKnob: default-round-large }
@@ -33,7 +33,7 @@ com.badlogic.gdx.scenes.scene2d.ui.SplitPane$SplitPaneStyle: {
 },
 com.badlogic.gdx.scenes.scene2d.ui.Window$WindowStyle: {
 	default: { titleFont: default-font, background: default-window, titleFontColor: white },
-	dialog: { titleFont: default-font, background: default-window, titleFontColor: white, stageBackground: dialogDim }
+	dialog: { parent: default, stageBackground: dialogDim }
 },
 com.badlogic.gdx.scenes.scene2d.ui.ProgressBar$ProgressBarStyle: {
 	default-horizontal: { background: default-slider, knob: default-slider-knob },


### PR DESCRIPTION
This will help clean up skin json files considerably. A prime use case is ImageButtonStyle (or ImageTextButtonStyle)--I find it is common to have many ImageButtonStyles in my skin with all the same values except for the Image. But I also have many other types of Button subclass styles where I am using some of the same values over and over. It becomes error prone to make tweaks to these parameters and keep the visual look of all the buttons the same.

Usage: For any style definition, you can specify a `parent` in the Json that names another style to use for default values. The parent can be a superclass style, so a TextButtonStyle could use a ButtonStyle as a parent, for example. You then only need to specify parameters that have different values than those of the parent.
