### PR TITLE
Can use Skin subclasses with SkinLoader

### DIFF
--- a/gdx/src/com/badlogic/gdx/assets/loaders/SkinLoader.java
+++ b/gdx/src/com/badlogic/gdx/assets/loaders/SkinLoader.java
@@ -66,7 +66,7 @@ public class SkinLoader extends AsynchronousAssetLoader<Skin, SkinLoader.SkinPar
 			}
 		}
 		TextureAtlas atlas = manager.get(textureAtlasPath, TextureAtlas.class);
-		Skin skin = new Skin(atlas);
+		Skin skin = generateSkin(atlas);
 		if (resources != null) {
 			for (Entry<String, Object> entry : resources.entries()) {
 				skin.add(entry.key, entry.value);
@@ -74,6 +74,13 @@ public class SkinLoader extends AsynchronousAssetLoader<Skin, SkinLoader.SkinPar
 		}
 		skin.load(file);
 		return skin;
+	}
+	
+	/** Override to allow subclasses of Skin to be loaded.
+	 * @param atlas The TextureAtlas that the skin will use. 
+	 * @return A new Skin (or subclass of Skin) instance based on the provided TextureAtlas. */
+	protected Skin generateSkin (TextureAtlas atlas){
+		return new Skin(atlas);
 	}
 
 	static public class SkinParameter extends AssetLoaderParameters<Skin> {


### PR DESCRIPTION
Skin's Json-loading behavior can be highly customized by overriding `getJsonLoader`, but then the subclass needs a custom Loader class for use with AssetManager. So I exposed a method for instantiating the skin.

Usage:

```
manager.setLoader(Skin.class, new SkinLoader(manager.getFileHandleResolver()){
        public Skin generateSkin (TextureAtlas atlas) { 
            return new MySkinSubclass(atlas); 
        }
    });
```