### PR TITLE
Fix column align in VerticalGroup

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/VerticalGroup.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/VerticalGroup.java
@@ -174,9 +174,9 @@ public class VerticalGroup extends WidgetGroup {
 			}
 
 			float x = padLeft;
-			if ((align & Align.top) != 0)
+			if ((align & Align.right) != 0)
 				x += columnWidth - width;
-			else if ((align & Align.bottom) == 0) // center
+			else if ((align & Align.left) == 0) // center
 				x += (columnWidth - width) / 2;
 
 			y -= height + space;


### PR DESCRIPTION
Fix not to compare X align with Align.top and Align.bottom
