### PR TITLE
Texture packer now correctly overrides old file if extension is not .atlas

### DIFF
--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/texturepacker/TexturePackerFileProcessor.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/texturepacker/TexturePackerFileProcessor.java
@@ -116,6 +116,9 @@ public class TexturePackerFileProcessor extends FileProcessor {
 				merge(rootSettings, settingsFile);
 			}
 
+			String atlasExtension = rootSettings.atlasExtension == null ? "" : rootSettings.atlasExtension;
+			atlasExtension = Pattern.quote(atlasExtension);
+
 			for (int i = 0, n = rootSettings.scale.length; i < n; i++) {
 				FileProcessor deleteProcessor = new FileProcessor() {
 					protected void processFile (Entry inputFile) throws Exception {
@@ -131,7 +134,7 @@ public class TexturePackerFileProcessor extends FileProcessor {
 				int dotIndex = prefix.lastIndexOf('.');
 				if (dotIndex != -1) prefix = prefix.substring(0, dotIndex);
 				deleteProcessor.addInputRegex("(?i)" + prefix + "\\d*\\.(png|jpg|jpeg)");
-				deleteProcessor.addInputRegex("(?i)" + prefix + "\\.atlas");
+				deleteProcessor.addInputRegex("(?i)" + prefix + atlasExtension);
 
 				String dir = packFile.getParent();
 				if (dir == null)


### PR DESCRIPTION
`TexturePackerFileProcessor#process(File[], File)` was hardcoded to delete old pack files only with `.atlas` extension. And in case where `Settings#atlasExtension` has set to custom value it crashes on pack. For example if I use `.pack` extension:
```
Exception in thread "main" java.lang.RuntimeException: Error packing images.
	at com.badlogic.gdx.tools.texturepacker.TexturePacker.process(TexturePacker.java:649)
	at com.badlogic.gdx.tools.texturepacker.Test.main(Test.java:7)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at com.intellij.rt.execution.application.AppMain.main(AppMain.java:147)
Caused by: java.lang.Exception: Error processing directory: D:\Temp\pack_test\input
	at com.badlogic.gdx.tools.FileProcessor.process(FileProcessor.java:157)
	at com.badlogic.gdx.tools.texturepacker.TexturePackerFileProcessor.process(TexturePackerFileProcessor.java:145)
	at com.badlogic.gdx.tools.FileProcessor.process(FileProcessor.java:121)
	at com.badlogic.gdx.tools.texturepacker.TexturePackerFileProcessor.process(TexturePackerFileProcessor.java:96)
	at com.badlogic.gdx.tools.texturepacker.TexturePacker.process(TexturePacker.java:647)
	... 6 more
Caused by: com.badlogic.gdx.utils.GdxRuntimeException: A region with the name "test-patch" has already been packed: test-patch
	at com.badlogic.gdx.tools.texturepacker.TexturePacker.writePackFile(TexturePacker.java:297)
	at com.badlogic.gdx.tools.texturepacker.TexturePacker.pack(TexturePacker.java:114)
	at com.badlogic.gdx.tools.texturepacker.TexturePackerFileProcessor.processDir(TexturePackerFileProcessor.java:222)
	at com.badlogic.gdx.tools.FileProcessor.process(FileProcessor.java:155)
	... 10 more
```
 Now it extracts extension from `Settings#atlasExtension` and removes old files correctly.