### PR TITLE
Add support for saving/loading the rendering type in Hiero

### DIFF
--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/hiero/Hiero.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/hiero/Hiero.java
@@ -354,6 +354,12 @@ public class Hiero extends JFrame {
 		settings.setGlyphPageWidth(((Number)glyphPageWidthCombo.getSelectedItem()).intValue());
 		settings.setGlyphPageHeight(((Number)glyphPageHeightCombo.getSelectedItem()).intValue());
 		settings.setGlyphText(sampleTextPane.getText());
+		if (nativeRadio.isSelected())
+			settings.setRenderType(RenderType.Native.ordinal());
+		else if (freeTypeRadio.isSelected())
+			settings.setRenderType(RenderType.FreeType.ordinal());
+		else
+			settings.setRenderType(RenderType.Java.ordinal());
 		for (Iterator iter = effectPanels.iterator(); iter.hasNext();) {
 			EffectPanel panel = (EffectPanel)iter.next();
 			settings.getEffects().add(panel.getEffect());
@@ -381,6 +387,12 @@ public class Hiero extends JFrame {
 		padAdvanceYSpinner.setValue(new Integer(settings.getPaddingAdvanceY()));
 		glyphPageWidthCombo.setSelectedItem(new Integer(settings.getGlyphPageWidth()));
 		glyphPageHeightCombo.setSelectedItem(new Integer(settings.getGlyphPageHeight()));
+		if (settings.getRenderType() == RenderType.Native.ordinal())
+			nativeRadio.setSelected(true);
+		else if (settings.getRenderType() == RenderType.FreeType.ordinal())
+			freeTypeRadio.setSelected(true);
+		else if (settings.getRenderType() == RenderType.Java.ordinal()) 
+			javaRadio.setSelected(true);
 		String gt = settings.getGlyphText();
 		if (gt.length() > 0) {
 			sampleTextPane.setText(settings.getGlyphText());

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/hiero/HieroSettings.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/hiero/HieroSettings.java
@@ -28,6 +28,7 @@ import java.util.List;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.tools.hiero.unicodefont.UnicodeFont;
+import com.badlogic.gdx.tools.hiero.unicodefont.UnicodeFont.RenderType;
 import com.badlogic.gdx.tools.hiero.unicodefont.effects.ConfigurableEffect;
 import com.badlogic.gdx.tools.hiero.unicodefont.effects.ConfigurableEffect.Value;
 import com.badlogic.gdx.utils.GdxRuntimeException;
@@ -35,6 +36,7 @@ import com.badlogic.gdx.utils.GdxRuntimeException;
 /** Holds the settings needed to configure a UnicodeFont.
  * @author Nathan Sweet */
 public class HieroSettings {
+	private static final String RENDER_TYPE = "render_type";
 	private String fontName = "Arial";
 	private int fontSize = 12;
 	private boolean bold, italic, mono;
@@ -46,6 +48,7 @@ public class HieroSettings {
 	private boolean nativeRendering;
 	private boolean font2Active = false;
 	private String font2File = "";
+	private int renderType = RenderType.FreeType.ordinal();
 
 	public HieroSettings () {
 	}
@@ -100,6 +103,8 @@ public class HieroSettings {
 					nativeRendering = Boolean.parseBoolean(value);
 				} else if (name.equals("glyph.text")) {
 					glyphText = value;
+				} else if (name.equals(RENDER_TYPE)) {
+					renderType = Integer.parseInt(value);
 				} else if (name.equals("effect.class")) {
 					try {
 						effects.add(Class.forName(value).newInstance());
@@ -334,6 +339,8 @@ public class HieroSettings {
 		out.println("glyph.page.height=" + glyphPageHeight);
 		out.println("glyph.text=" + glyphText);
 		out.println();
+		out.println(RENDER_TYPE + "=" + renderType);
+		out.println();
 		for (Iterator iter = effects.iterator(); iter.hasNext();) {
 			ConfigurableEffect effect = (ConfigurableEffect)iter.next();
 			out.println("effect.class=" + effect.getClass().getName());
@@ -344,5 +351,13 @@ public class HieroSettings {
 			out.println();
 		}
 		out.close();
+	}
+
+	public void setRenderType (int renderType) {
+		this.renderType = renderType;
+	}
+
+	public int getRenderType () {
+		return renderType;
 	}
 }


### PR DESCRIPTION
Using the command line batch support in Hiero was hampered by Hiero not saving/loading the rendering mode. Since it defaults to FreeType rendering, no effects would get exported by the batch mode since that requires the Java rendering mode.