### PR TITLE
DefaultRenderableSorter accounts for center of Renderable mesh

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,6 @@
 [1.9.5]
 - API Addition: ApplicationLogger interface, allowing easier access to custom logging
+- DefaultRenderableSorter accounts for center of Renderable mesh, see https://github.com/libgdx/libgdx/pull/4319
 
 [1.9.4]
 - Moved snapping from ProgressBar to Slider to prevent snapping when setting the value programmatically.

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/utils/DefaultRenderableSorter.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/utils/DefaultRenderableSorter.java
@@ -21,7 +21,7 @@ import java.util.Comparator;
 import com.badlogic.gdx.graphics.Camera;
 import com.badlogic.gdx.graphics.g3d.Renderable;
 import com.badlogic.gdx.graphics.g3d.attributes.BlendingAttribute;
-import com.badlogic.gdx.math.MathUtils;
+import com.badlogic.gdx.math.Matrix4;
 import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.utils.Array;
 
@@ -36,6 +36,16 @@ public class DefaultRenderableSorter implements RenderableSorter, Comparator<Ren
 		renderables.sort(this);
 	}
 
+	private Vector3 getTranslation (Matrix4 worldTransform, Vector3 center, Vector3 output) {
+		if (center.isZero())
+			worldTransform.getTranslation(output);
+		else if (!worldTransform.hasRotationOrScaling())
+			worldTransform.getTranslation(output).add(center);
+		else
+			output.set(center).mul(worldTransform);
+		return output;
+	}
+
 	@Override
 	public int compare (final Renderable o1, final Renderable o2) {
 		final boolean b1 = o1.material.has(BlendingAttribute.Type) && ((BlendingAttribute)o1.material.get(BlendingAttribute.Type)).blended;
@@ -44,8 +54,8 @@ public class DefaultRenderableSorter implements RenderableSorter, Comparator<Ren
 		// FIXME implement better sorting algorithm
 		// final boolean same = o1.shader == o2.shader && o1.mesh == o2.mesh && (o1.lights == null) == (o2.lights == null) &&
 		// o1.material.equals(o2.material);
-		o1.worldTransform.getTranslation(tmpV1);
-		o2.worldTransform.getTranslation(tmpV2);
+		getTranslation(o1.worldTransform, o1.meshPart.center, tmpV1);
+		getTranslation(o2.worldTransform, o2.meshPart.center, tmpV2);
 		final float dst = (int)(1000f * camera.position.dst2(tmpV1)) - (int)(1000f * camera.position.dst2(tmpV2));
 		final int result = dst < 0 ? -1 : (dst > 0 ? 1 : 0);
 		return b1 ? -result : result;

--- a/gdx/src/com/badlogic/gdx/math/Matrix4.java
+++ b/gdx/src/com/badlogic/gdx/math/Matrix4.java
@@ -1557,4 +1557,11 @@ public class Matrix4 implements Serializable {
 		dst[10] = val[M13];
 		dst[11] = val[M23];
 	}
+
+	/** @return True if this matrix has any rotation or scaling, false otherwise */
+	public boolean hasRotationOrScaling () {
+		return !(MathUtils.isEqual(val[M00], 1) && MathUtils.isEqual(val[M11], 1) && MathUtils.isEqual(val[M22], 1)
+			&& MathUtils.isZero(val[M01]) && MathUtils.isZero(val[M02]) && MathUtils.isZero(val[M10]) && MathUtils.isZero(val[M12])
+			&& MathUtils.isZero(val[M20]) && MathUtils.isZero(val[M21]));
+	}
 }


### PR DESCRIPTION
Useful for cases when ```Renderable``` translation cannot be stored in ```Renderable#worldTransform``` but must be stored in ```Renderable#MeshPart#center```, for example in 3D ```ParticleSystem```. The performance penalty of this change can be tested in e.g. ```Basic3DTest```, but I had a hard time seeing any change. It seems to be insignificant compared to the time it takes to render the models.