### PR TITLE
#4267 Fixing a deadlock problem in AndroidGraphics and AndroidGraphicsLiveWallpaper

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphics.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphics.java
@@ -356,7 +356,7 @@ public class AndroidGraphics implements Graphics, Renderer {
 			pause = true;
 			while (pause) {
 				try {
-                    synchSem.acquire();
+					synchSem.acquire();
 					if (pause) {
 						// pause will never go false if onDrawFrame is never called by the GLThread
 						// when entering this method, we MUST enforce continuous rendering

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphics.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphics.java
@@ -340,7 +340,7 @@ public class AndroidGraphics implements Graphics, Renderer {
 	}
 
 	Object synch = new Object();
-    Semaphore synchSem = new Semaphore(0);
+	Semaphore synchSem = new Semaphore(0);
 
 	void resume () {
 		synchronized (synch) {
@@ -377,7 +377,7 @@ public class AndroidGraphics implements Graphics, Renderer {
 
 			while (destroy) {
 				try {
-                    synchSem.acquire();
+					synchSem.acquire();
 				} catch (InterruptedException ex) {
 					Gdx.app.log(LOG_TAG, "waiting for destroy synchronization failed!");
 				}
@@ -415,12 +415,12 @@ public class AndroidGraphics implements Graphics, Renderer {
 
 			if (pause) {
 				pause = false;
-                synchSem.release();
+				synchSem.release();
 			}
 
 			if (destroy) {
 				destroy = false;
-                synchSem.release();
+				synchSem.release();
 			}
 		}
 

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphicsLiveWallpaper.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphicsLiveWallpaper.java
@@ -135,7 +135,7 @@ public final class AndroidGraphicsLiveWallpaper extends AndroidGraphics {
 
 			while (resume) {
 				try {
-                    synchSem.acquire();
+					synchSem.acquire();
 				} catch (InterruptedException ignored) {
 					Gdx.app.log("AndroidGraphics", "waiting for resume synchronization failed!");
 				}
@@ -169,17 +169,17 @@ public final class AndroidGraphicsLiveWallpaper extends AndroidGraphics {
 
 			if (resume) {
 				resume = false;
-                synchSem.release();
+				synchSem.release();
 			}
 
 			if (pause) {
 				pause = false;
-                synchSem.release();
+				synchSem.release();
 			}
 
 			if (destroy) {
 				destroy = false;
-                synchSem.release();
+				synchSem.release();
 			}
 		}
 

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphicsLiveWallpaper.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphicsLiveWallpaper.java
@@ -135,7 +135,7 @@ public final class AndroidGraphicsLiveWallpaper extends AndroidGraphics {
 
 			while (resume) {
 				try {
-					synch.wait();
+                    synchSem.acquire();
 				} catch (InterruptedException ignored) {
 					Gdx.app.log("AndroidGraphics", "waiting for resume synchronization failed!");
 				}
@@ -169,17 +169,17 @@ public final class AndroidGraphicsLiveWallpaper extends AndroidGraphics {
 
 			if (resume) {
 				resume = false;
-				synch.notifyAll();
+                synchSem.release();
 			}
 
 			if (pause) {
 				pause = false;
-				synch.notifyAll();
+                synchSem.release();
 			}
 
 			if (destroy) {
 				destroy = false;
-				synch.notifyAll();
+                synchSem.release();
 			}
 		}
 


### PR DESCRIPTION
There was a problem with a possible deadlock occurrence in AndroidGraphics and AndroidGraphicsLiveWallpaper classes.
The issue is that a running thread can execute _notify_ before another thread executes _wait_ on the synch object, resulting in a deadlock.
The solution I propose is using semaphores for synchronization instead of mutexes.
Benefit of semaphores is that they internally remember number of permits allowed, 
and thus thread that _signals_ (releases) a semaphore will allow a thread that later arrives to the semaphore to use that permit,
unlike mutexes where waiting thread will be unblocked only by future notifications.