### PR TITLE
Add Matrix4::hasRotationOrScaling to GWT backend

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/math/Matrix4.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/math/Matrix4.java
@@ -1612,4 +1612,11 @@ public class Matrix4 implements Serializable {
 		dst[10] = val[M13];
 		dst[11] = val[M23];
 	}
+
+	/** @return True if this matrix has any rotation or scaling, false otherwise */
+	public boolean hasRotationOrScaling () {
+		return !(MathUtils.isEqual(val[M00], 1) && MathUtils.isEqual(val[M11], 1) && MathUtils.isEqual(val[M22], 1)
+				&& MathUtils.isZero(val[M01]) && MathUtils.isZero(val[M02]) && MathUtils.isZero(val[M10]) && MathUtils.isZero(val[M12])
+				&& MathUtils.isZero(val[M20]) && MathUtils.isZero(val[M21]));
+	}
 }


### PR DESCRIPTION
Following #4319, a ``hasRotationOrScaling`` method was added to ``Matrix4``.

However, the method had not been replicated in the GWT backend, causing it to stop compiling properly.