### PR TITLE
Fix Gradle build problems cause by the retooling

### DIFF
--- a/extensions/gdx-controllers/gdx-controllers-android/build.gradle
+++ b/extensions/gdx-controllers/gdx-controllers-android/build.gradle
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+dependencies {
+    compileOnly project(":extensions:gdx-controllers:gdx-controllers");
+    compileOnly project(":backends:gdx-backend-android");
+}

--- a/extensions/gdx-controllers/gdx-controllers-desktop/build.gradle
+++ b/extensions/gdx-controllers/gdx-controllers-desktop/build.gradle
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+dependencies {
+    compileOnly project(":extensions:gdx-controllers:gdx-controllers")
+    compileOnly project(":backends:gdx-backend-lwjgl");
+    compileOnly project(":extensions:gdx-jnigen")
+}

--- a/tests/gdx-tests-android/AndroidManifest.xml
+++ b/tests/gdx-tests-android/AndroidManifest.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+      xmlns:tools="http://schemas.android.com/tools"
       package="com.badlogic.gdx.tests.android"
       android:versionCode="1"
       android:versionName="1.0"
       android:installLocation="preferExternal">
-	<uses-sdk android:minSdkVersion="8" android:targetSdkVersion="19"/>
+	<uses-sdk android:minSdkVersion="8" android:targetSdkVersion="19"
+		tools:overrideLibrary="android.support.v4, android.support.compat, android.support.mediacompat, android.support.coreutils, android.support.coreui, android.support.fragment" />
 	<uses-permission android:name="android.permission.RECORD_AUDIO"/>
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.VIBRATE"/>

--- a/tests/gdx-tests-android/build.gradle
+++ b/tests/gdx-tests-android/build.gradle
@@ -48,5 +48,8 @@ android {
 			jniLibs.srcDirs = ['libs']
 		}		
 	}
+	lintOptions {
+		disable "ResourceType"
+	}
 }
 

--- a/tests/gdx-tests-gwt/build.gradle
+++ b/tests/gdx-tests-gwt/build.gradle
@@ -71,6 +71,7 @@ task addSource << {
     sourceSets.main.compileClasspath += files(project(':tests:gdx-tests').sourceSets.main.allJava.srcDirs)
     sourceSets.main.compileClasspath += files(project(':backends:gdx-backends-gwt').sourceSets.main.allJava.srcDirs)
     sourceSets.main.compileClasspath += files(project(':extensions:gdx-box2d:gdx-box2d-gwt').sourceSets.main.allJava.srcDirs)
+    sourceSets.main.compileClasspath += files(project(':extensions:gdx-controllers:gdx-controllers').sourceSets.main.allJava.srcDirs)
     sourceSets.main.compileClasspath += files(project(':extensions:gdx-controllers:gdx-controllers-gwt').sourceSets.main.allJava.srcDirs)
     sourceSets.main.compileClasspath += files(project(':gdx').sourceSets.main.allJava.srcDirs)
 }


### PR DESCRIPTION
Since the Gradle retooling, the source won't build under Gradle anymore.

This is the minimum changeset required to get the command-line Gradle build working again. It's not enough to Sync the project or run the demos under Android Studio but it's a step in the right direction, bringing back command-line tools.