### PR TITLE
Fixes #4495 (wrong Label pref height)

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Label.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Label.java
@@ -230,7 +230,11 @@ public class Label extends Widget {
 
 	public float getPrefHeight () {
 		if (prefSizeInvalid) scaleAndComputePrefSize();
-		float height = prefSize.y - style.font.getDescent() * fontScaleY * 2;
+		float descentScaleCorrection = 1;
+		if (fontScaleChanged) {
+			descentScaleCorrection = fontScaleY / style.font.getScaleY();
+		}
+		float height = prefSize.y - style.font.getDescent() * descentScaleCorrection * 2;
 		Drawable background = style.background;
 		if (background != null) height += background.getTopHeight() + background.getBottomHeight();
 		return height;

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Label.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Label.java
@@ -231,9 +231,7 @@ public class Label extends Widget {
 	public float getPrefHeight () {
 		if (prefSizeInvalid) scaleAndComputePrefSize();
 		float descentScaleCorrection = 1;
-		if (fontScaleChanged) {
-			descentScaleCorrection = fontScaleY / style.font.getScaleY();
-		}
+		if (fontScaleChanged) descentScaleCorrection = fontScaleY / style.font.getScaleY();
 		float height = prefSize.y - style.font.getDescent() * descentScaleCorrection * 2;
 		Drawable background = style.background;
 		if (background != null) height += background.getTopHeight() + background.getBottomHeight();


### PR DESCRIPTION
Pref height is not correctly calculated if BitmapFont scale Y is different to 1.

Label only takes into account fontScaleY correction for the descent value assuming the underlying Bitmap y font scale is 1. The correction should be the relation between the BitmapFont and Label scales.

Find SSCCE test attached that illustrates the issue

http://pastebin.com/EB7mv2AU

Before the fix

![java 2016-10-30 14-24-51-818](https://cloud.githubusercontent.com/assets/1794492/19836838/d28cff7c-9eac-11e6-8f78-d9334ddc8097.png)

After the fix

![java 2016-10-30 14-23-17-652](https://cloud.githubusercontent.com/assets/1794492/19836843/e2d22826-9eac-11e6-9e57-e782ad46f036.png)
