### PR TITLE
Restore ParticleEffect scale when returning to pool (Fixes #2893)

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g2d/ParticleEffect.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/ParticleEffect.java
@@ -38,6 +38,7 @@ public class ParticleEffect implements Disposable {
 	private final Array<ParticleEmitter> emitters;
 	private BoundingBox bounds;
 	private boolean ownsTexture;
+	protected float sizeScale = 1f, motionScale = 1f;
 
 	public ParticleEffect () {
 		emitters = new Array(8);
@@ -54,9 +55,22 @@ public class ParticleEffect implements Disposable {
 			emitters.get(i).start();
 	}
 
+	/** Resets the effect so it can be started again like a new effect. Any changes to 
+	 * scale are reverted. See {@link #reset(boolean)}.*/
 	public void reset () {
+		reset(true);
+	}
+	
+	/** Resets the effect so it can be started again like a new effect.
+	 * @param resetScaling Whether to restore the original size and motion parameters if they were scaled. Repeated scaling
+	 * and resetting may introduce error. */
+	public void reset (boolean resetScaling){
 		for (int i = 0, n = emitters.size; i < n; i++)
 			emitters.get(i).reset();
+		if (resetScaling && (sizeScale != 1f || motionScale != 1f)){
+			scaleEffect(1f / sizeScale, 1f / motionScale);
+			sizeScale = motionScale = 1f;
+		}
 	}
 
 	public void update (float delta) {
@@ -234,43 +248,20 @@ public class ParticleEffect implements Disposable {
 		return bounds;
 	}
 
+	/** Permanently scales all the size and motion parameters of all the emitters in this effect. If this effect originated from a
+	 * {@link ParticleEffectPool}, the scale will be reset when it is returned to the pool. */
 	public void scaleEffect (float scaleFactor) {
+		scaleEffect(scaleFactor, scaleFactor);
+	}
+
+	/** Permanently scales all the size and motion parameters of all the emitters in this effect. If this effect originated from a
+	 * {@link ParticleEffectPool}, the scale will be reset when it is returned to the pool. */
+	public void scaleEffect (float sizeScaleFactor, float motionScaleFactor) {
+		sizeScale *= sizeScaleFactor;
+		motionScale *= motionScaleFactor;
 		for (ParticleEmitter particleEmitter : emitters) {
-			particleEmitter.getScale().setHigh(particleEmitter.getScale().getHighMin() * scaleFactor,
-				particleEmitter.getScale().getHighMax() * scaleFactor);
-			particleEmitter.getScale().setLow(particleEmitter.getScale().getLowMin() * scaleFactor,
-				particleEmitter.getScale().getLowMax() * scaleFactor);
-
-			particleEmitter.getVelocity().setHigh(particleEmitter.getVelocity().getHighMin() * scaleFactor,
-				particleEmitter.getVelocity().getHighMax() * scaleFactor);
-			particleEmitter.getVelocity().setLow(particleEmitter.getVelocity().getLowMin() * scaleFactor,
-				particleEmitter.getVelocity().getLowMax() * scaleFactor);
-
-			particleEmitter.getGravity().setHigh(particleEmitter.getGravity().getHighMin() * scaleFactor,
-				particleEmitter.getGravity().getHighMax() * scaleFactor);
-			particleEmitter.getGravity().setLow(particleEmitter.getGravity().getLowMin() * scaleFactor,
-				particleEmitter.getGravity().getLowMax() * scaleFactor);
-
-			particleEmitter.getWind().setHigh(particleEmitter.getWind().getHighMin() * scaleFactor,
-				particleEmitter.getWind().getHighMax() * scaleFactor);
-			particleEmitter.getWind().setLow(particleEmitter.getWind().getLowMin() * scaleFactor,
-				particleEmitter.getWind().getLowMax() * scaleFactor);
-
-			particleEmitter.getSpawnWidth().setHigh(particleEmitter.getSpawnWidth().getHighMin() * scaleFactor,
-				particleEmitter.getSpawnWidth().getHighMax() * scaleFactor);
-			particleEmitter.getSpawnWidth().setLow(particleEmitter.getSpawnWidth().getLowMin() * scaleFactor,
-				particleEmitter.getSpawnWidth().getLowMax() * scaleFactor);
-
-			particleEmitter.getSpawnHeight().setHigh(particleEmitter.getSpawnHeight().getHighMin() * scaleFactor,
-				particleEmitter.getSpawnHeight().getHighMax() * scaleFactor);
-			particleEmitter.getSpawnHeight().setLow(particleEmitter.getSpawnHeight().getLowMin() * scaleFactor,
-				particleEmitter.getSpawnHeight().getLowMax() * scaleFactor);
-
-			particleEmitter.getXOffsetValue().setLow(particleEmitter.getXOffsetValue().getLowMin() * scaleFactor,
-				particleEmitter.getXOffsetValue().getLowMax() * scaleFactor);
-
-			particleEmitter.getYOffsetValue().setLow(particleEmitter.getYOffsetValue().getLowMin() * scaleFactor,
-				particleEmitter.getYOffsetValue().getLowMax() * scaleFactor);
+			particleEmitter.scaleSize(sizeScaleFactor);
+			particleEmitter.scaleMotion(motionScaleFactor);
 		}
 	}
 

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/ParticleEffectPool.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/ParticleEffectPool.java
@@ -17,6 +17,7 @@
 package com.badlogic.gdx.graphics.g2d;
 
 import com.badlogic.gdx.graphics.g2d.ParticleEffectPool.PooledEffect;
+import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.Pool;
 
 public class ParticleEffectPool extends Pool<PooledEffect> {
@@ -30,21 +31,28 @@ public class ParticleEffectPool extends Pool<PooledEffect> {
 	protected PooledEffect newObject () {
 		return new PooledEffect(effect);
 	}
-
-	public PooledEffect obtain () {
-		PooledEffect effect = super.obtain();
-		effect.reset();
-		return effect;
+	
+	public void free (PooledEffect effect) {
+		super.free(effect);
+		
+		effect.reset(false); // copy parameters exactly to avoid introducing error
+		if (effect.sizeScale != this.effect.sizeScale || effect.motionScale != this.effect.motionScale){
+			Array<ParticleEmitter> emitters = effect.getEmitters();
+			Array<ParticleEmitter> templateEmitters = this.effect.getEmitters();
+			for (int i=0; i<emitters.size; i++){
+				ParticleEmitter emitter = emitters.get(i);
+				ParticleEmitter templateEmitter = templateEmitters.get(i);
+				emitter.matchSize(templateEmitter);
+				emitter.matchMotion(templateEmitter);
+			}
+			effect.sizeScale = this.effect.sizeScale;
+			effect.motionScale = this.effect.motionScale;
+		}
 	}
 
 	public class PooledEffect extends ParticleEffect {
 		PooledEffect (ParticleEffect effect) {
 			super(effect);
-		}
-
-		@Override
-		public void reset () {
-			super.reset();
 		}
 
 		public void free () {

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/ParticleEmitter.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/ParticleEmitter.java
@@ -19,6 +19,7 @@ package com.badlogic.gdx.graphics.g2d;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.Writer;
+import java.util.Arrays;
 
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Texture;
@@ -53,6 +54,8 @@ public class ParticleEmitter {
 	private ScaledNumericValue spawnWidthValue = new ScaledNumericValue();
 	private ScaledNumericValue spawnHeightValue = new ScaledNumericValue();
 	private SpawnShapeValue spawnShapeValue = new SpawnShapeValue();
+	
+	private RangedNumericValue[] sizeValues, motionValues; // lazy
 
 	private float accumulator;
 	private Sprite sprite;
@@ -856,6 +859,58 @@ public class ParticleEmitter {
 
 		return bounds;
 	}
+	
+	protected RangedNumericValue[] getSizeValues (){
+		if (sizeValues == null){
+			sizeValues = new RangedNumericValue[5];
+			sizeValues[0] = scaleValue;
+			sizeValues[1] = spawnWidthValue;
+			sizeValues[2] = spawnHeightValue;
+			sizeValues[3] = xOffsetValue;
+			sizeValues[4] = yOffsetValue;
+		}
+		return sizeValues;
+	}
+	
+	protected RangedNumericValue[] getMotionValues (){
+		if (motionValues == null){
+			motionValues = new RangedNumericValue[3];
+			motionValues[0] = velocityValue;
+			motionValues[1] = windValue;
+			motionValues[2] = gravityValue;
+		}
+		return motionValues;
+	}
+	
+	/** Permanently scales the size of the emitter by scaling all its ranged values related to size. */
+	public void scaleSize (float scale){
+		if (scale == 1f) return;
+		for (RangedNumericValue value : getSizeValues()) value.scale(scale);
+	}
+	
+	/** Permanently scales the speed of the emitter by scaling all its ranged values related to motion. */
+	public void scaleMotion (float scale){
+		if (scale == 1f) return;
+		for (RangedNumericValue value : getMotionValues()) value.scale(scale);
+	}
+	
+	/** Sets all size-related ranged values to match those of the template emitter. */
+	public void matchSize (ParticleEmitter template){
+		RangedNumericValue[] values = getSizeValues();
+		RangedNumericValue[] templateValues = template.getSizeValues();
+		for (int i=0; i<values.length; i++){
+			values[i].set(templateValues[i]);
+		}
+	}
+	
+	/** Sets all motion-related ranged values to match those of the template emitter. */
+	public void matchMotion (ParticleEmitter template){
+		RangedNumericValue[] values = getMotionValues();
+		RangedNumericValue[] templateValues = template.getMotionValues();
+		for (int i=0; i<values.length; i++){
+			values[i].set(templateValues[i]);
+		}
+	}
 
 	public void save (Writer output) throws IOException {
 		output.write(name + "\n");
@@ -1115,6 +1170,17 @@ public class ParticleEmitter {
 		public void setLowMax (float lowMax) {
 			this.lowMax = lowMax;
 		}
+		
+		/** permanently scales the range by a scalar. */
+		public void scale (float scale){
+			lowMin *= scale;
+			lowMax *= scale;
+		}
+		
+		public void set (RangedNumericValue value){
+			this.lowMin = value.lowMin;
+			this.lowMax = value.lowMax;
+		}
 
 		public void save (Writer output) throws IOException {
 			super.save(output);
@@ -1171,6 +1237,34 @@ public class ParticleEmitter {
 
 		public void setHighMax (float highMax) {
 			this.highMax = highMax;
+		}
+		
+		public void scale (float scale){
+			super.scale(scale);
+			highMin *= scale;
+			highMax *= scale;
+		}
+		
+		public void set (RangedNumericValue value){
+			if (value instanceof ScaledNumericValue)
+				set((ScaledNumericValue)value);
+			else
+				super.set(value);
+		}
+		
+		public void set (ScaledNumericValue value){
+			super.set(value);
+			this.highMin = value.highMin;
+			this.highMax = value.highMax;
+			if (scaling.length != value.scaling.length)
+				scaling = Arrays.copyOf(value.scaling, value.scaling.length);
+			else
+				System.arraycopy(value.scaling, 0, scaling, 0, scaling.length);
+			if (timeline.length != value.timeline.length)
+				timeline = Arrays.copyOf(value.timeline, value.timeline.length);
+			else
+				System.arraycopy(value.timeline, 0, timeline, 0, timeline.length);
+			this.relative = value.relative;
 		}
 
 		public float[] getScaling () {

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ParticleEmittersTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ParticleEmittersTest.java
@@ -52,7 +52,7 @@ public class ParticleEmittersTest extends GdxTest {
 	float fpsCounter;
 	Stage ui;
 	CheckBox skipCleanup;
-	Button clearEmitters;
+	Button clearEmitters, scaleEffects;
 	Label logLabel;
 
 	@Override
@@ -130,20 +130,21 @@ public class ParticleEmittersTest extends GdxTest {
 		ui = new Stage(new ExtendViewport(640, 480));
 		Skin skin = new Skin(Gdx.files.internal("data/uiskin.json"));
 		skipCleanup = new CheckBox("Skip blend function clean-up", skin);
-		skipCleanup.setTransform(false);
 		skipCleanup.addListener(listener);
 		logLabel = new Label("", skin.get(LabelStyle.class));
 		clearEmitters = new TextButton("Clear screen", skin);
-		clearEmitters.setTransform(false);
 		clearEmitters.addListener(listener);
+		scaleEffects = new TextButton("Scale existing effects", skin);
+		scaleEffects.addListener(listener);
 		Table table = new Table();
 		table.setTransform(false);
 		table.setFillParent(true);
 		table.defaults().padTop(5).left();
 		table.top().left().padLeft(5);
-		table.add(skipCleanup).row();
-		table.add(clearEmitters).row();
-		table.add(logLabel);
+		table.add(skipCleanup).colspan(2).row();
+		table.add(clearEmitters).spaceRight(10);
+		table.add(scaleEffects).row();
+		table.add(logLabel).colspan(2);
 		ui.addActor(table);
 	}
 
@@ -164,6 +165,10 @@ public class ParticleEmittersTest extends GdxTest {
 				for (PooledEffect e : effects)
 					e.free();
 				effects.clear();
+			} else if (actor == scaleEffects) {
+				for (ParticleEffect eff : effects) {
+					eff.scaleEffect(1.5f);
+				}
 			}
 		}
 	};


### PR DESCRIPTION
Fixes #2893.

The scaleEffect() method is not easily reversible in the ParticleEffect class, unfortunately. But the PooledEffect class has easy access to the original parameters in the prototype effect in the pool, which is the common way ParticleEffects are used anyway.

Since the ParticleEffect super class is unchanged, this fix won't break code that was relying on `reset()` not affecting scale.
