### PR TITLE
Buttons keep skin reference

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Button.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Button.java
@@ -63,6 +63,7 @@ public class Button extends Table implements Disableable {
 
 	public Button (Actor child, Skin skin, String styleName) {
 		this(child, skin.get(styleName, ButtonStyle.class));
+		setSkin(skin);
 	}
 
 	public Button (Actor child, ButtonStyle style) {

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ImageButton.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ImageButton.java
@@ -31,10 +31,12 @@ public class ImageButton extends Button {
 
 	public ImageButton (Skin skin) {
 		this(skin.get(ImageButtonStyle.class));
+		setSkin(skin);
 	}
 
 	public ImageButton (Skin skin, String styleName) {
 		this(skin.get(styleName, ImageButtonStyle.class));
+		setSkin(skin);
 	}
 
 	public ImageButton (ImageButtonStyle style) {


### PR DESCRIPTION
Fixes #4387 

These few constructors (out of all the Button and Button subclass constructors) were missing this pass-through of the Skin reference, causing `getSkin()` to return null when it shouldn't (that is, when a skin was passed to the constructor).