### PR TITLE
Clean up VertexAttribute and expose expert constructors

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,11 +1,10 @@
 [LATEST]
+- VertexAttribute expert constructors exposed. Short types can now be used for attributes.
 
 [1.9.5]
 - Fix NPE swallowing "video driver unsupported" error on LWJGL 2 backend.
 - Allow window icons to be set in Lwjgl3ApplicationConfiguration or Lwjgl3WindowConfiguration.
 - Allow window icon and title to be changed in Lwjgl3Window
-[1.9.5]
-- VertexAttribute expert constructors exposed.
 - API Addition: ApplicationLogger interface, allowing easier access to custom logging
 - DefaultRenderableSorter accounts for center of Renderable mesh, see https://github.com/libgdx/libgdx/pull/4319
 - Bullet: added FilterableVehicleRaycaster, see https://github.com/libgdx/libgdx/pull/4361

--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,8 @@
 - Fix NPE swallowing "video driver unsupported" error on LWJGL 2 backend.
 - Allow window icons to be set in Lwjgl3ApplicationConfiguration or Lwjgl3WindowConfiguration.
 - Allow window icon and title to be changed in Lwjgl3Window
+[1.9.5]
+- VertexAttribute expert constructors exposed.
 - API Addition: ApplicationLogger interface, allowing easier access to custom logging
 - DefaultRenderableSorter accounts for center of Renderable mesh, see https://github.com/libgdx/libgdx/pull/4319
 - Bullet: added FilterableVehicleRaycaster, see https://github.com/libgdx/libgdx/pull/4361

--- a/gdx/src/com/badlogic/gdx/graphics/Mesh.java
+++ b/gdx/src/com/badlogic/gdx/graphics/Mesh.java
@@ -1027,7 +1027,7 @@ public class Mesh implements Disposable {
 					if (a == null) continue;
 					for (int j = 0; j < a.numComponents; j++)
 						checks[++idx] = (short)(a.offset + j);
-					attrs[++ai] = new VertexAttribute(a.usage, a.numComponents, a.alias);
+					attrs[++ai] = new VertexAttribute(a.usage, a.numComponents, a.type, a.normalized, a.alias, a.unit);
 					newVertexSize += a.numComponents;
 				}
 			}

--- a/gdx/src/com/badlogic/gdx/graphics/Mesh.java
+++ b/gdx/src/com/badlogic/gdx/graphics/Mesh.java
@@ -1027,7 +1027,7 @@ public class Mesh implements Disposable {
 					if (a == null) continue;
 					for (int j = 0; j < a.numComponents; j++)
 						checks[++idx] = (short)(a.offset + j);
-					attrs[++ai] = new VertexAttribute(a.usage, a.numComponents, a.type, a.normalized, a.alias, a.unit);
+					attrs[++ai] = a.copy();
 					newVertexSize += a.numComponents;
 				}
 			}

--- a/gdx/src/com/badlogic/gdx/graphics/VertexAttribute.java
+++ b/gdx/src/com/badlogic/gdx/graphics/VertexAttribute.java
@@ -23,18 +23,18 @@ import com.badlogic.gdx.graphics.VertexAttributes.Usage;
 import com.badlogic.gdx.graphics.glutils.ShaderProgram;
 import com.badlogic.gdx.graphics.glutils.VertexArray;
 
-/** A single vertex attribute defined by its {@link Usage}, its number of components and its shader alias. The Usage is needed for
- * the fixed function pipeline of OpenGL ES 1.x. Generic attributes are not supported in the fixed function pipeline. The number
- * of components defines how many components the attribute has. The alias defines to which shader attribute this attribute should
- * bind. The alias is used by a {@link Mesh} when drawing with a {@link ShaderProgram}. The alias can be changed at any time.
+/** A single vertex attribute defined by its {@link Usage}, its number of components and its shader alias. The Usage is used
+ * for uniquely identifying the vertex attribute from among its {@linkplain VertexAttributes} siblings. The number of components 
+ * defines how many components the attribute has. The alias defines to which shader attribute this attribute should bind. The alias 
+ * is used by a {@link Mesh} when drawing with a {@link ShaderProgram}. The alias can be changed at any time.
  * 
  * @author mzechner */
 public final class VertexAttribute {
-	/** the attribute {@link Usage} **/
+	/** The attribute {@link Usage}, used for identification. **/
 	public final int usage;
 	/** the number of components this attribute has **/
 	public final int numComponents;
-	/** whether the values are normalized to either -1f and +1f (signed) or 0f and +1f (unsigned) */
+	/** For fixed types, whether the values are normalized to either -1f and +1f (signed) or 0f and +1f (unsigned) */
 	public final boolean normalized;
 	/** the OpenGL type of each component, e.g. {@link GL20#GL_FLOAT} or {@link GL20#GL_UNSIGNED_BYTE}  */
 	public final int type;
@@ -46,91 +46,53 @@ public final class VertexAttribute {
 	public int unit;
 	private final int usageIndex;
 
-	/** Constructs a new VertexAttribute.
+	/** Constructs a new VertexAttribute. The GL data type is automatically selected based on the usage.
 	 * 
-	 * @param usage the usage, used for the fixed function pipeline. Generic attributes are not supported in the fixed function
-	 *           pipeline.
+	 * @param usage The attribute {@link Usage}, used to select the {@link #type} and for identification.
 	 * @param numComponents the number of components of this attribute, must be between 1 and 4.
 	 * @param alias the alias used in a shader for this attribute. Can be changed after construction. */
 	public VertexAttribute (int usage, int numComponents, String alias) {
 		this(usage, numComponents, alias, 0);
 	}
 
+	/** Constructs a new VertexAttribute. The GL data type is automatically selected based on the usage.
+	 * 
+	 * @param usage The attribute {@link Usage}, used to select the {@link #type} and for identification.
+	 * @param numComponents the number of components of this attribute, must be between 1 and 4.
+	 * @param alias the alias used in a shader for this attribute. Can be changed after construction.
+	 * @param unit Optional unit/index specifier, used for texture coordinates and bone weights */
+	public VertexAttribute (int usage, int numComponents, String alias, int unit) {
+		this(usage, numComponents, usage == Usage.ColorPacked ? GL20.GL_UNSIGNED_BYTE : GL20.GL_FLOAT, 
+				usage == Usage.ColorPacked, alias, unit);
+	}
+
 	/** Constructs a new VertexAttribute.
 	 * 
-	 * @param usage the usage, used for the fixed function pipeline. Generic attributes are not supported in the fixed function
-	 *           pipeline.
+	 * @param usage The attribute {@link Usage}, used for identification.
 	 * @param numComponents the number of components of this attribute, must be between 1 and 4.
-	 * @param alias the alias used in a shader for this attribute. Can be changed after construction.
-	 * @param index unit/index of the attribute, used for boneweights and texture coordinates. */
-	public VertexAttribute (int usage, int numComponents, String alias, int index) {
-		this(usage, numComponents, usage == Usage.ColorPacked ? GL20.GL_UNSIGNED_BYTE : GL20.GL_FLOAT, 
-				usage == Usage.ColorPacked, alias, index);
-	}
-	/** Constructs a new VertexAttribute.<br>
-	 * <b>
-	 * <font color=#ff0000>
-	 * Warning:this protected constructor provide a way to extends vertex attribute for some special use.
-	 * if you use this constructor,must careful with vertices buffers.
-	 * <li>
-	 * Mesh represents vertices data as {@link FloatBuffer} by {@link Mesh#getVerticesBuffer()},
-	 * it means you had better keep vertex size equals n*4( n is a integer,4 means 4 bytes per float).In other words,if you don't that,
-	 * it will be difficult to update vertices data.
-	 * </li>
-	 * <li>
-	 * 	with {@link VertexArray},{@link VertexArray#bind(ShaderProgram)} already says something like: if you don't keep  a float vertex attribute'offset  equals n*4( n is a integer,4 means 4 bytes per float), GL will get wrong offset. 
-	 * 	<pre>	buffer.position(attribute.offset / 4);</pre>
-	 * 	the above code miss decimal part when attribute'offset not  equals n*4
-	 * </li>
-	 * 	<br>
-	 * 	Maybe there has more note points,just be careful with it.
-	 * </font>
-	 * </b>
-	 * @param usage the usage, used for the fixed function pipeline. Generic attributes are not supported in the fixed function
-	 *           pipeline.
-	 * @param numComponents the number of components of this attribute, must be between 1 and 4.
-	 * @param type the OpenGL type of each component, e.g. {@link GL20#GL_FLOAT} or {@link GL20#GL_UNSIGNED_BYTE} 
-	 * @param normalized  whether the values are normalized to either -1f and +1f (signed) or 0f and +1f (unsigned) 
-	 * @param alias the alias used in a shader for this attribute. Can be changed after construction.
-	 **/
-	protected VertexAttribute (int usage, int numComponents, int type, boolean normalized, String alias) {
+	 * @param type the OpenGL type of each component, e.g. {@link GL20#GL_FLOAT} or {@link GL20#GL_UNSIGNED_BYTE}
+	 * @param normalized For fixed types, whether the values are normalized to either -1f and +1f (signed) or 0f and +1f (unsigned) 
+	 * @param alias The alias used in a shader for this attribute. Can be changed after construction. */
+	public VertexAttribute (int usage, int numComponents, int type, boolean normalized, String alias) {
 		this(usage, numComponents, type, normalized, alias, 0);
 	}
-	/** Constructs a new VertexAttribute.<br>
-	 * <b>
-	 * <font color=#ff0000>
-	 * Warning:this protected constructor provide a way to extends vertex attribute for some special use.
-	 * if you use this constructor,must careful with vertices buffers.
-	 * <li>
-	 * Mesh represents vertices data as {@link FloatBuffer} by {@link Mesh#getVerticesBuffer()},
-	 * it means you had better keep vertex size equals n*4( n is a integer,4 means 4 bytes per float).In other words,if you don't that,
-	 * it will be difficult to update vertices data.
-	 * </li>
-	 * <li>
-	 * 	with {@link VertexArray},{@link VertexArray#bind(ShaderProgram)} already says something like: if you don't keep  a float vertex attribute'offset  equals n*4( n is a integer,4 means 4 bytes per float), GL will get wrong offset. 
-	 * 	<pre>	buffer.position(attribute.offset / 4);</pre>
-	 * 	the above code miss decimal part when attribute'offset not  equals n*4
-	 * </li>
-	 * 	<br>
-	 * 	Maybe there has more note points,just be careful with it.
-	 * </font>
-	 * </b>
-	 * @param usage the usage, used for the fixed function pipeline. Generic attributes are not supported in the fixed function
-	 *           pipeline.
+	
+	/** Constructs a new VertexAttribute.
+	 * 
+	 * @param usage The attribute {@link Usage}, used for identification.
 	 * @param numComponents the number of components of this attribute, must be between 1 and 4.
-	 * @param type the OpenGL type of each component, e.g. {@link GL20#GL_FLOAT} or {@link GL20#GL_UNSIGNED_BYTE} 
-	 * @param normalized  whether the values are normalized to either -1f and +1f (signed) or 0f and +1f (unsigned) 
-	 * @param alias the alias used in a shader for this attribute. Can be changed after construction.
-	 * @param index unit/index of the attribute, used for boneweights and texture coordinates.
-	 **/
-	protected VertexAttribute (int usage, int numComponents, int type, boolean normalized, String alias, int index) {
+	 * @param type the OpenGL type of each component, e.g. {@link GL20#GL_FLOAT} or {@link GL20#GL_UNSIGNED_BYTE}
+	 * @param normalized For fixed types, whether the values are normalized to either -1f and +1f (signed) or 0f and +1f (unsigned) 
+	 * @param alias The alias used in a shader for this attribute. Can be changed after construction.
+	 * @param unit Optional unit/index specifier, used for texture coordinates and bone weights */
+	public VertexAttribute (int usage, int numComponents, int type, boolean normalized, String alias, int unit) {
 		this.usage = usage;
 		this.numComponents = numComponents;
 		this.type = type;
 		this.normalized = normalized;
 		this.alias = alias;
-		this.unit = index;
-		this.usageIndex = Integer.numberOfTrailingZeros(usage);	
+		this.unit = unit;
+		this.usageIndex = Integer.numberOfTrailingZeros(usage);
 	}
 
 	public static VertexAttribute Position () {
@@ -162,7 +124,7 @@ public final class VertexAttribute {
 	}
 
 	public static VertexAttribute BoneWeight (int unit) {
-		return new VertexAttribute(Usage.BoneWeight, 2, "a_boneWeight" + unit, unit);
+		return new VertexAttribute(Usage.BoneWeight, 2, ShaderProgram.BONEWEIGHT_ATTRIBUTE + unit, unit);
 	}
 
 	/** Tests to determine if the passed object was created with the same parameters */
@@ -175,7 +137,8 @@ public final class VertexAttribute {
 	}
 
 	public boolean equals (final VertexAttribute other) {
-		return other != null && usage == other.usage && numComponents == other.numComponents && alias.equals(other.alias)
+		return other != null && usage == other.usage && numComponents == other.numComponents 
+			&& type == other.type && normalized == other.normalized && alias.equals(other.alias)
 			&& unit == other.unit;
 	}
 
@@ -184,11 +147,27 @@ public final class VertexAttribute {
 		return (usageIndex << 8) + (unit & 0xFF);
 	}
 	
+	/** @return How many bytes this attribute uses. */
+	public int getNumBytes () {
+		switch (type) {
+		case GL20.GL_FLOAT:
+		case GL20.GL_FIXED:
+			return 4 * numComponents;
+		case GL20.GL_UNSIGNED_BYTE:
+		case GL20.GL_BYTE:
+			return numComponents;
+		case GL20.GL_UNSIGNED_SHORT:
+		case GL20.GL_SHORT:
+			return 2 * numComponents;
+		}
+		return 0;
+	}
+
 	@Override
 	public int hashCode () {
 		int result = getKey();
 		result = 541 * result + numComponents;
 		result = 541 * result + alias.hashCode();
-		return result; 
+		return result;
 	}
 }

--- a/gdx/src/com/badlogic/gdx/graphics/VertexAttribute.java
+++ b/gdx/src/com/badlogic/gdx/graphics/VertexAttribute.java
@@ -70,7 +70,9 @@ public final class VertexAttribute {
 	 * 
 	 * @param usage The attribute {@link Usage}, used for identification.
 	 * @param numComponents the number of components of this attribute, must be between 1 and 4.
-	 * @param type the OpenGL type of each component, e.g. {@link GL20#GL_FLOAT} or {@link GL20#GL_UNSIGNED_BYTE}
+	 * @param type the OpenGL type of each component, e.g. {@link GL20#GL_FLOAT} or {@link GL20#GL_UNSIGNED_BYTE}. Since {@link Mesh}
+	 * stores vertex data in 32bit floats, the total size of this attribute (type size times number of components) must be a 
+	 * multiple of four.
 	 * @param normalized For fixed types, whether the values are normalized to either -1f and +1f (signed) or 0f and +1f (unsigned) 
 	 * @param alias The alias used in a shader for this attribute. Can be changed after construction. */
 	public VertexAttribute (int usage, int numComponents, int type, boolean normalized, String alias) {
@@ -81,7 +83,9 @@ public final class VertexAttribute {
 	 * 
 	 * @param usage The attribute {@link Usage}, used for identification.
 	 * @param numComponents the number of components of this attribute, must be between 1 and 4.
-	 * @param type the OpenGL type of each component, e.g. {@link GL20#GL_FLOAT} or {@link GL20#GL_UNSIGNED_BYTE}
+	 * @param type the OpenGL type of each component, e.g. {@link GL20#GL_FLOAT} or {@link GL20#GL_UNSIGNED_BYTE}. Since {@link Mesh}
+	 * stores vertex data in 32bit floats, the total size of this attribute (type size times number of components) must be a 
+	 * multiple of four bytes.
 	 * @param normalized For fixed types, whether the values are normalized to either -1f and +1f (signed) or 0f and +1f (unsigned) 
 	 * @param alias The alias used in a shader for this attribute. Can be changed after construction.
 	 * @param unit Optional unit/index specifier, used for texture coordinates and bone weights */

--- a/gdx/src/com/badlogic/gdx/graphics/VertexAttribute.java
+++ b/gdx/src/com/badlogic/gdx/graphics/VertexAttribute.java
@@ -94,6 +94,12 @@ public final class VertexAttribute {
 		this.unit = unit;
 		this.usageIndex = Integer.numberOfTrailingZeros(usage);
 	}
+	
+	/** @return A copy of this VertexAttribute with the same parameters. The {@link #offset} is not copied and must
+	 * be recalculated, as is typically done by the {@linkplain VertexAttributes} that owns the VertexAttribute. */
+	public VertexAttribute copy (){
+		return new VertexAttribute(usage, numComponents, type, normalized, alias, unit);
+	}
 
 	public static VertexAttribute Position () {
 		return new VertexAttribute(Usage.Position, 3, ShaderProgram.POSITION_ATTRIBUTE);
@@ -148,7 +154,7 @@ public final class VertexAttribute {
 	}
 	
 	/** @return How many bytes this attribute uses. */
-	public int getNumBytes () {
+	public int getSizeInBytes () {
 		switch (type) {
 		case GL20.GL_FLOAT:
 		case GL20.GL_FIXED:

--- a/gdx/src/com/badlogic/gdx/graphics/VertexAttributes.java
+++ b/gdx/src/com/badlogic/gdx/graphics/VertexAttributes.java
@@ -92,10 +92,7 @@ public final class VertexAttributes implements Iterable<VertexAttribute>, Compar
 		for (int i = 0; i < attributes.length; i++) {
 			VertexAttribute attribute = attributes[i];
 			attribute.offset = count;
-			if (attribute.usage == VertexAttributes.Usage.ColorPacked)
-				count += 4;
-			else
-				count += 4 * attribute.numComponents;
+			count += attribute.getNumBytes();
 		}
 
 		return count;

--- a/gdx/src/com/badlogic/gdx/graphics/VertexAttributes.java
+++ b/gdx/src/com/badlogic/gdx/graphics/VertexAttributes.java
@@ -92,7 +92,7 @@ public final class VertexAttributes implements Iterable<VertexAttribute>, Compar
 		for (int i = 0; i < attributes.length; i++) {
 			VertexAttribute attribute = attributes[i];
 			attribute.offset = count;
-			count += attribute.getNumBytes();
+			count += attribute.getSizeInBytes();
 		}
 
 		return count;

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/ShaderProgram.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/ShaderProgram.java
@@ -79,6 +79,8 @@ public class ShaderProgram implements Disposable {
 	public static final String TANGENT_ATTRIBUTE = "a_tangent";
 	/** default name for binormal attribute **/
 	public static final String BINORMAL_ATTRIBUTE = "a_binormal";
+	/** default name for boneweight attribute **/
+	public static final String BONEWEIGHT_ATTRIBUTE = "a_boneWeight";
 
 	/** flag indicating whether attributes & uniforms must be present at all times **/
 	public static boolean pedantic = true;

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/VertexArray.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/VertexArray.java
@@ -110,15 +110,9 @@ public class VertexArray implements VertexData {
 				if (location < 0) continue;
 				shader.enableVertexAttribute(location);
 
-				if (attribute.type == GL20.GL_FLOAT) {
-					buffer.position(attribute.offset / 4);
-					shader.setVertexAttribute(location, attribute.numComponents, attribute.type, attribute.normalized, attributes.vertexSize,
-							buffer);
-				} else {
-					byteBuffer.position(attribute.offset);
-					shader.setVertexAttribute(location, attribute.numComponents, attribute.type, attribute.normalized, attributes.vertexSize,
-						byteBuffer);
-				}
+				byteBuffer.position(attribute.offset);
+				shader.setVertexAttribute(location, attribute.numComponents, attribute.type, attribute.normalized, attributes.vertexSize,
+					byteBuffer);
 			}
 		} else {
 			for (int i = 0; i < numAttributes; i++) {
@@ -127,15 +121,9 @@ public class VertexArray implements VertexData {
 				if (location < 0) continue;
 				shader.enableVertexAttribute(location);
 
-				if (attribute.type == GL20.GL_FLOAT) {
-					buffer.position(attribute.offset / 4);
-					shader.setVertexAttribute(location, attribute.numComponents, attribute.type, attribute.normalized, attributes.vertexSize,
-							buffer);
-				} else {
-					byteBuffer.position(attribute.offset);
-					shader.setVertexAttribute(location, attribute.numComponents, attribute.type, attribute.normalized, attributes.vertexSize,
-						byteBuffer);
-				}
+				byteBuffer.position(attribute.offset);
+				shader.setVertexAttribute(location, attribute.numComponents, attribute.type, attribute.normalized, attributes.vertexSize,
+					byteBuffer);
 			}
 		}
 		isBound = true;

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/VertexBufferObject.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/VertexBufferObject.java
@@ -29,25 +29,13 @@ import com.badlogic.gdx.utils.GdxRuntimeException;
 
 /** <p>
  * A {@link VertexData} implementation based on OpenGL vertex buffer objects.
- * </p>
- * 
  * <p>
- * If the OpenGL ES context was lost you can call {@link #invalidate()} to recreate a new OpenGL vertex buffer object. This class
- * can be used seamlessly with OpenGL ES 1.x and 2.0.
- * </p>
- * 
+ * If the OpenGL ES context was lost you can call {@link #invalidate()} to recreate a new OpenGL vertex buffer object.
  * <p>
- * In case OpenGL ES 2.0 is used in the application the data is bound via glVertexAttribPointer() according to the attribute
- * aliases specified via {@link VertexAttributes} in the constructor.
- * </p>
- * 
- * <p>
- * Uses indirect Buffers on Android 1.5/1.6 to fix GC invocation due to leaking PlatformAddress instances.
- * </p>
- * 
+ * The data is bound via glVertexAttribPointer() according to the attribute aliases specified via {@link VertexAttributes} 
+ * in the constructor.
  * <p>
  * VertexBufferObjects must be disposed via the {@link #dispose()} method when no longer needed
- * </p>
  * 
  * @author mzechner, Dave Clayton <contact@redskyforge.com> */
 public class VertexBufferObject implements VertexData {

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/VertexBufferObjectSubData.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/VertexBufferObjectSubData.java
@@ -28,25 +28,13 @@ import com.badlogic.gdx.utils.GdxRuntimeException;
 
 /** <p>
  * A {@link VertexData} implementation based on OpenGL vertex buffer objects.
- * </p>
- * 
  * <p>
- * If the OpenGL ES context was lost you can call {@link #invalidate()} to recreate a new OpenGL vertex buffer object. This class
- * can be used seamlessly with OpenGL ES 1.x and 2.0.
- * </p>
- * 
+ * If the OpenGL ES context was lost you can call {@link #invalidate()} to recreate a new OpenGL vertex buffer object.
  * <p>
- * In case OpenGL ES 2.0 is used in the application the data is bound via glVertexAttribPointer() according to the attribute
- * aliases specified via {@link VertexAttributes} in the constructor.
- * </p>
- * 
- * <p>
- * Uses indirect Buffers on Android 1.5/1.6 to fix GC invocation due to leaking PlatformAddress instances.
- * </p>
- * 
+ * The data is bound via glVertexAttribPointer() according to the attribute aliases specified via {@link VertexAttributes} 
+ * in the constructor.
  * <p>
  * VertexBufferObjects must be disposed via the {@link #dispose()} method when no longer needed
- * </p>
  * 
  * @author mzechner */
 public class VertexBufferObjectSubData implements VertexData {

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/MeshShaderTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/MeshShaderTest.java
@@ -17,20 +17,25 @@
 package com.badlogic.gdx.tests;
 
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Mesh;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.VertexAttribute;
+import com.badlogic.gdx.graphics.VertexAttributes.Usage;
 import com.badlogic.gdx.graphics.glutils.ShaderProgram;
 import com.badlogic.gdx.math.Matrix4;
 import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.tests.utils.GdxTest;
+import com.badlogic.gdx.utils.NumberUtils;
 
 public class MeshShaderTest extends GdxTest {
 	ShaderProgram shader;
-	Mesh mesh;
+	Mesh mesh, meshCustomVA;
 	Texture texture;
 	Matrix4 matrix = new Matrix4();
+	
+	private static final float FLOAT_WHITE = Color.WHITE.toFloatBits();
 
 	@Override
 	public void create () {
@@ -54,7 +59,24 @@ public class MeshShaderTest extends GdxTest {
 		mesh.setVertices(new float[] {-0.5f, -0.5f, 0, 1, 1, 1, 1, 0, 1, 0.5f, -0.5f, 0, 1, 1, 1, 1, 1, 1, 0.5f, 0.5f, 0, 1, 1, 1,
 			1, 1, 0, -0.5f, 0.5f, 0, 1, 1, 1, 1, 0, 0});
 		mesh.setIndices(new short[] {0, 1, 2, 2, 3, 0});
+		
+		//Mesh with texCoords wearing a pair of shorts. :)
+		meshCustomVA = new Mesh(true, 4, 6, VertexAttribute.Position(), VertexAttribute.ColorPacked(), 
+			new VertexAttribute(Usage.TextureCoordinates, 2, GL20.GL_UNSIGNED_SHORT, true, ShaderProgram.TEXCOORD_ATTRIBUTE + "0", 0));
+		meshCustomVA.setVertices(new float[] {
+			-0.5f, -0.5f, 0, FLOAT_WHITE, toSingleFloat(0, 1), 
+			0.5f, -0.5f, 0, FLOAT_WHITE, toSingleFloat(1, 1), 
+			0.5f, 0.5f, 0, FLOAT_WHITE, toSingleFloat(1, 0), 
+			-0.5f, 0.5f, 0, FLOAT_WHITE, toSingleFloat(0, 0)
+			});
+		meshCustomVA.setIndices(new short[] {0, 1, 2, 2, 3, 0});
+		
 		texture = new Texture(Gdx.files.internal("data/bobrgb888-32x32.png"));
+	}
+	
+	private static float toSingleFloat (float u, float v){
+		int vu = ((int)(v * 0xffff) << 16) | (int)(u * 0xffff);
+		return NumberUtils.intToFloatColor(vu); //v will lose some precision due to masking
 	}
 
 	Vector3 axis = new Vector3(0, 0, 1);
@@ -64,6 +86,8 @@ public class MeshShaderTest extends GdxTest {
 	public void render () {
 		angle += Gdx.graphics.getDeltaTime() * 45;
 		matrix.setToRotation(axis, angle);
+		
+		Mesh meshToDraw = Gdx.input.isButtonPressed(0) ? meshCustomVA : mesh;
 
 		Gdx.gl20.glViewport(0, 0, Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight());
 		Gdx.gl20.glClearColor(0.2f, 0.2f, 0.2f, 1);
@@ -75,7 +99,7 @@ public class MeshShaderTest extends GdxTest {
 		shader.begin();
 		shader.setUniformMatrix("u_worldView", matrix);
 		shader.setUniformi("u_texture", 0);
-		mesh.render(shader, GL20.GL_TRIANGLES);
+		meshToDraw.render(shader, GL20.GL_TRIANGLES);
 		shader.end();
 	}
 


### PR DESCRIPTION
This builds off of #3936. The expert constructors can be made public with a bit of clean-up to avoid potential pitfalls and clarify the docs. Users will still need to understand the parameters that go into `glVertexAttribPointer`, but I don't think people will try to use any of the constructors unless they know what they're for.

@xoppa 
I think MeshBuilder might be incompatible with customized VertexAttributes, based on a quick look at its `begin()` method. I'm not very familiar with MeshBuilder, but you might want to add a doc clarifying that it only supports the built-in VertexAttributes. I didn't test it, but maybe it would be compatible so long as one of the built-in Usages is used.

Most people will never need these features, but they might open up some ways to optimize mesh vertex sizes. I've tried doing that before and this would have helped.
