### PR TITLE
Fix #4264

### DIFF
--- a/gdx/src/com/badlogic/gdx/utils/OrderedMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/OrderedMap.java
@@ -207,6 +207,7 @@ public class OrderedMap<K, V> extends ObjectMap<K, V> {
 		public void remove () {
 			if (currentIndex < 0) throw new IllegalStateException("next must be called before remove.");
 			map.remove(keys.get(nextIndex - 1));
+			nextIndex--;
 		}
 	}
 
@@ -235,6 +236,7 @@ public class OrderedMap<K, V> extends ObjectMap<K, V> {
 		public void remove () {
 			if (currentIndex < 0) throw new IllegalStateException("next must be called before remove.");
 			map.remove(keys.get(nextIndex - 1));
+			nextIndex--;
 		}
 	}
 }


### PR DESCRIPTION
This PR fixes #4264 
The fix that has been applied to the `OrderedMapEntries`'s `remove()` method in https://github.com/libgdx/libgdx/commit/ff6f7ca68a92c286ba22fdcb6f0fe444aff91f66#diff-de7b99a30e1c60ad7d53b49223a4fc2bL180
has also been applied to the `remove()` methods of `OrderedMapValues` and `OrderedMapKeys`.