### PR TITLE
Fix #4330

### DIFF
--- a/extensions/gdx-box2d/gdx-box2d/jni/com.badlogic.gdx.physics.box2d.joints.WeldJoint.cpp
+++ b/extensions/gdx-box2d/gdx-box2d/jni/com.badlogic.gdx.physics.box2d.joints.WeldJoint.cpp
@@ -31,10 +31,21 @@ JNIEXPORT void JNICALL Java_com_badlogic_gdx_physics_box2d_joints_WeldJoint_jniG
 
 }
 
-JNIEXPORT jfloat JNICALL Java_com_badlogic_gdx_physics_box2d_joints_WeldJoint_jniGetFrequency(JNIEnv* env, jobject object, jlong addr) {
+JNIEXPORT jfloat JNICALL Java_com_badlogic_gdx_physics_box2d_joints_WeldJoint_jniGetReferenceAngle(JNIEnv* env, jobject object, jlong addr) {
 
 
 //@line:67
+
+		b2WeldJoint* joint = (b2WeldJoint*)addr;
+		return joint->GetReferenceAngle();
+	
+
+}
+
+JNIEXPORT jfloat JNICALL Java_com_badlogic_gdx_physics_box2d_joints_WeldJoint_jniGetFrequency(JNIEnv* env, jobject object, jlong addr) {
+
+
+//@line:76
 
 		b2WeldJoint* joint = (b2WeldJoint*)addr;
 		return joint->GetFrequency();
@@ -45,7 +56,7 @@ JNIEXPORT jfloat JNICALL Java_com_badlogic_gdx_physics_box2d_joints_WeldJoint_jn
 JNIEXPORT void JNICALL Java_com_badlogic_gdx_physics_box2d_joints_WeldJoint_jniSetFrequency(JNIEnv* env, jobject object, jlong addr, jfloat hz) {
 
 
-//@line:76
+//@line:85
 
 		b2WeldJoint* joint = (b2WeldJoint*)addr;
 		joint->SetFrequency(hz);
@@ -56,7 +67,7 @@ JNIEXPORT void JNICALL Java_com_badlogic_gdx_physics_box2d_joints_WeldJoint_jniS
 JNIEXPORT jfloat JNICALL Java_com_badlogic_gdx_physics_box2d_joints_WeldJoint_jniGetDampingRatio(JNIEnv* env, jobject object, jlong addr) {
 
 
-//@line:85
+//@line:94
 
 		b2WeldJoint* joint = (b2WeldJoint*)addr;
 		return joint->GetDampingRatio();
@@ -67,7 +78,7 @@ JNIEXPORT jfloat JNICALL Java_com_badlogic_gdx_physics_box2d_joints_WeldJoint_jn
 JNIEXPORT void JNICALL Java_com_badlogic_gdx_physics_box2d_joints_WeldJoint_jniSetDampingRatio(JNIEnv* env, jobject object, jlong addr, jfloat ratio) {
 
 
-//@line:94
+//@line:103
 
 		b2WeldJoint* joint = (b2WeldJoint*)addr;
 		joint->SetDampingRatio(ratio);

--- a/extensions/gdx-box2d/gdx-box2d/jni/com.badlogic.gdx.physics.box2d.joints.WeldJoint.h
+++ b/extensions/gdx-box2d/gdx-box2d/jni/com.badlogic.gdx.physics.box2d.joints.WeldJoint.h
@@ -25,6 +25,14 @@ JNIEXPORT void JNICALL Java_com_badlogic_gdx_physics_box2d_joints_WeldJoint_jniG
 
 /*
  * Class:     com_badlogic_gdx_physics_box2d_joints_WeldJoint
+ * Method:    jniGetReferenceAngle
+ * Signature: (J)F
+ */
+JNIEXPORT jfloat JNICALL Java_com_badlogic_gdx_physics_box2d_joints_WeldJoint_jniGetReferenceAngle
+  (JNIEnv *, jobject, jlong);
+
+/*
+ * Class:     com_badlogic_gdx_physics_box2d_joints_WeldJoint
  * Method:    jniGetFrequency
  * Signature: (J)F
  */

--- a/extensions/gdx-box2d/gdx-box2d/src/com/badlogic/gdx/physics/box2d/joints/WeldJoint.java
+++ b/extensions/gdx-box2d/gdx-box2d/src/com/badlogic/gdx/physics/box2d/joints/WeldJoint.java
@@ -59,6 +59,15 @@ public class WeldJoint extends Joint {
 		anchor[0] = joint->GetLocalAnchorB().x;
 		anchor[1] = joint->GetLocalAnchorB().y;
 	*/
+	
+	public float getReferenceAngle () {
+		return jniGetReferenceAngle(addr);
+	}
+
+	private native float jniGetReferenceAngle (long addr); /*
+		b2WeldJoint* joint = (b2WeldJoint*)addr;
+		return joint->GetReferenceAngle();
+	*/
 
 	public float getFrequency () {
 		return jniGetFrequency(addr);


### PR DESCRIPTION
This PR adds the missing method `getReferenceAngle()` to `WeldJoint.java`.