### PR TITLE
Clean up redundant code in Lwjgl3 backend

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,5 @@
 [1.9.5]
-- Allow window icons to be set in Lwjgl3ApplicationConfiguration or LwjglWindowConfiguration.
+- Allow window icons to be set in Lwjgl3ApplicationConfiguration or Lwjgl3WindowConfiguration.
 - Allow window icon and title to be changed in Lwjgl3Window
 - API Addition: ApplicationLogger interface, allowing easier access to custom logging
 - DefaultRenderableSorter accounts for center of Renderable mesh, see https://github.com/libgdx/libgdx/pull/4319

--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,6 @@
 [1.9.5]
+- Allow window icons to be set in Lwjgl3ApplicationConfiguration or LwjglWindowConfiguration.
+- Allow window icon and title to be changed in Lwjgl3Window
 - API Addition: ApplicationLogger interface, allowing easier access to custom logging
 - DefaultRenderableSorter accounts for center of Renderable mesh, see https://github.com/libgdx/libgdx/pull/4319
 - Bullet: added FilterableVehicleRaycaster, see https://github.com/libgdx/libgdx/pull/4361

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
@@ -20,11 +20,9 @@ import java.io.File;
 import java.io.PrintStream;
 import java.nio.IntBuffer;
 import com.badlogic.gdx.ApplicationLogger;
-import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.glutils.GLVersion;
 import org.lwjgl.glfw.GLFW;
 import org.lwjgl.glfw.GLFWErrorCallback;
-import org.lwjgl.glfw.GLFWImage;
 import org.lwjgl.glfw.GLFWVidMode;
 import org.lwjgl.opengl.AMDDebugOutput;
 import org.lwjgl.opengl.ARBDebugOutput;
@@ -431,32 +429,8 @@ public class Lwjgl3Application implements Application {
 				GLFW.glfwSetWindowPos(windowHandle, config.windowX, config.windowY);
 			}
 		}
-		if (config.windowIconPaths != null && !SharedLibraryLoader.isMac){
-			GLFWImage.Buffer buffer = GLFWImage.malloc(config.windowIconPaths.length);
-			Pixmap[] tmpPixmaps = new Pixmap[config.windowIconPaths.length];
-			Pixmap.Blending previousBlending = Pixmap.getBlending();
-			Pixmap.setBlending(Pixmap.Blending.None);
-			for (int i = 0; i < config.windowIconPaths.length; i++) {
-				Pixmap pixmap = new Pixmap(Gdx.files.getFileHandle(config.windowIconPaths[i], config.windowIconFileType));
-				if (pixmap.getFormat() != Pixmap.Format.RGBA8888) {
-					Pixmap rgba = new Pixmap(pixmap.getWidth(), pixmap.getHeight(), Pixmap.Format.RGBA8888);
-					rgba.drawPixmap(pixmap, 0, 0);
-					pixmap.dispose();
-					pixmap = rgba;
-				}
-				tmpPixmaps[i] = pixmap;
-
-				GLFWImage icon = GLFWImage.malloc();
-				icon.set(pixmap.getWidth(), pixmap.getHeight(), pixmap.getPixels());
-				buffer.put(icon);
-
-				icon.free();
-			}
-			Pixmap.setBlending(previousBlending); //just in case, avoid surprises
-			buffer.position(0);
-			GLFW.glfwSetWindowIcon(windowHandle, buffer);
-			buffer.free();
-			for (Pixmap pixmap : tmpPixmaps) pixmap.dispose();
+		if (config.windowIconPaths != null) {
+			Lwjgl3Window.setIcon(windowHandle, config.windowIconPaths, config.windowIconFileType);
 		}
 		GLFW.glfwMakeContextCurrent(windowHandle);
 		GLFW.glfwSwapInterval(config.vSyncEnabled ? 1 : 0);

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
@@ -412,11 +412,11 @@ public class Lwjgl3Application implements Application {
 		if (windowHandle == 0) {
 			throw new GdxRuntimeException("Couldn't create window");
 		}
-		GLFW.glfwSetWindowSizeLimits(windowHandle, //avoiding GLFW_DONT_CARE due to GLFW bug (https://github.com/glfw/glfw/pull/805)
+		GLFW.glfwSetWindowSizeLimits(windowHandle, // avoiding GLFW_DONT_CARE due to GLFW bug (https://github.com/glfw/glfw/pull/805)
 			config.windowMinWidth > -1 ? config.windowMinWidth : 0, 
 				config.windowMinHeight > -1 ? config.windowMinHeight : 0, 
 					config.windowMaxWidth > -1 ? config.windowMaxWidth : 0xffff,
-						config.windowMaxHeight> -1 ? config.windowMaxHeight : 0xffff);
+						config.windowMaxHeight > -1 ? config.windowMaxHeight : 0xffff);
 		if (config.fullscreenMode == null) {
 			if (config.windowX == -1 && config.windowY == -1) {
 				int windowWidth = Math.max(config.windowWidth, config.windowMinWidth);

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
@@ -346,17 +346,7 @@ public class Lwjgl3Application implements Application {
 	 */
 	public Lwjgl3Window newWindow(ApplicationListener listener, Lwjgl3WindowConfiguration config) {
 		Lwjgl3ApplicationConfiguration appConfig = Lwjgl3ApplicationConfiguration.copy(this.config);
-		appConfig.setWindowedMode(config.windowWidth, config.windowHeight);
-		appConfig.setWindowPosition(config.windowX, config.windowY);
-		appConfig.setWindowSizeLimits(config.windowMinWidth, config.windowMinHeight, config.windowMaxWidth, config.windowMaxHeight);
-		appConfig.setWindowIcon(config.windowIconFileType, config.windowIconPaths);
-		appConfig.setResizable(config.windowResizable);
-		appConfig.setDecorated(config.windowDecorated);
-		appConfig.setWindowListener(config.windowListener);
-		appConfig.setFullscreenMode(config.fullscreenMode);
-		appConfig.setTitle(config.title);
-		appConfig.setInitialBackgroundColor(config.initialBackgroundColor);
-		appConfig.setInitialVisible(config.initialVisible);
+		appConfig.setWindowConfiguration(config);
 		Lwjgl3Window window = createWindow(appConfig, listener, windows.get(0).getWindowHandle());
 		windows.add(window);
 		return window;
@@ -412,11 +402,7 @@ public class Lwjgl3Application implements Application {
 		if (windowHandle == 0) {
 			throw new GdxRuntimeException("Couldn't create window");
 		}
-		GLFW.glfwSetWindowSizeLimits(windowHandle,
-			config.windowMinWidth > -1 ? config.windowMinWidth : GLFW.GLFW_DONT_CARE, 
-				config.windowMinHeight > -1 ? config.windowMinHeight : GLFW.GLFW_DONT_CARE, 
-					config.windowMaxWidth > -1 ? config.windowMaxWidth : GLFW.GLFW_DONT_CARE,
-						config.windowMaxHeight > -1 ? config.windowMaxHeight : GLFW.GLFW_DONT_CARE);
+		Lwjgl3Window.setSizeLimits(windowHandle, config.windowMinWidth, config.windowMinHeight, config.windowMaxWidth, config.windowMaxWidth);
 		if (config.fullscreenMode == null) {
 			if (config.windowX == -1 && config.windowY == -1) {
 				int windowWidth = Math.max(config.windowWidth, config.windowMinWidth);

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
@@ -412,11 +412,11 @@ public class Lwjgl3Application implements Application {
 		if (windowHandle == 0) {
 			throw new GdxRuntimeException("Couldn't create window");
 		}
-		GLFW.glfwSetWindowSizeLimits(windowHandle, // avoiding GLFW_DONT_CARE due to GLFW bug (https://github.com/glfw/glfw/pull/805)
-			config.windowMinWidth > -1 ? config.windowMinWidth : 0, 
-				config.windowMinHeight > -1 ? config.windowMinHeight : 0, 
-					config.windowMaxWidth > -1 ? config.windowMaxWidth : 0xffff,
-						config.windowMaxHeight > -1 ? config.windowMaxHeight : 0xffff);
+		GLFW.glfwSetWindowSizeLimits(windowHandle,
+			config.windowMinWidth > -1 ? config.windowMinWidth : GLFW.GLFW_DONT_CARE, 
+				config.windowMinHeight > -1 ? config.windowMinHeight : GLFW.GLFW_DONT_CARE, 
+					config.windowMaxWidth > -1 ? config.windowMaxWidth : GLFW.GLFW_DONT_CARE,
+						config.windowMaxHeight > -1 ? config.windowMaxHeight : GLFW.GLFW_DONT_CARE);
 		if (config.fullscreenMode == null) {
 			if (config.windowX == -1 && config.windowY == -1) {
 				int windowWidth = Math.max(config.windowWidth, config.windowMinWidth);

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3ApplicationConfiguration.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3ApplicationConfiguration.java
@@ -18,6 +18,7 @@ package com.badlogic.gdx.backends.lwjgl3;
 
 import java.io.PrintStream;
 import java.nio.IntBuffer;
+import java.util.Arrays;
 
 import org.lwjgl.BufferUtils;
 import org.lwjgl.PointerBuffer;
@@ -61,6 +62,8 @@ public class Lwjgl3ApplicationConfiguration {
 	int windowMinWidth = -1, windowMinHeight = -1, windowMaxWidth = -1, windowMaxHeight = -1;
 	boolean windowResizable = true;
 	boolean windowDecorated = true;
+	FileType windowIconFileType;
+	String[] windowIconPaths;
 	Lwjgl3WindowListener windowListener;
 	Lwjgl3DisplayMode fullscreenMode;
 
@@ -103,6 +106,9 @@ public class Lwjgl3ApplicationConfiguration {
 		copy.windowMaxHeight = config.windowMaxHeight;
 		copy.windowResizable = config.windowResizable;
 		copy.windowDecorated = config.windowDecorated;
+		copy.windowIconFileType = config.windowIconFileType;
+		if (config.windowIconPaths != null) 
+			copy.windowIconPaths = Arrays.copyOf(config.windowIconPaths, config.windowIconPaths.length);
 		copy.windowListener = config.windowListener;
 		copy.fullscreenMode = config.fullscreenMode;
 		copy.vSyncEnabled = config.vSyncEnabled;
@@ -252,8 +258,19 @@ public class Lwjgl3ApplicationConfiguration {
 	}
 	
 	/**
+	 * Sets the icon that will be used in the window's title bar. Has no effect in macOS, which doesn't use window icons.
+	 * @param icon One or more image paths, relative to the given FileType. Must be JPEG, PNG, or BMP format. The one 
+	 * closest to the system's desired size will be scaled. Good sizes include 16x16, 32x32 and 48x48. The provided
+	 * file paths must point to valid images for as long new windows might be created.
+	 */
+	public void setWindowIcon (FileType fileType, String... filePaths){
+		windowIconFileType = fileType;
+		windowIconPaths = filePaths;
+	}
+	
+	/**
 	 * Sets the {@link Lwjgl3WindowListener} which will be informed about
-	 * iconficiation, focus loss and window close events.
+	 * iconification, focus loss and window close events.
 	 */
 	public void setWindowListener(Lwjgl3WindowListener windowListener) {
 		this.windowListener = windowListener;

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3ApplicationConfiguration.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3ApplicationConfiguration.java
@@ -18,7 +18,6 @@ package com.badlogic.gdx.backends.lwjgl3;
 
 import java.io.PrintStream;
 import java.nio.IntBuffer;
-import java.util.Arrays;
 
 import org.lwjgl.BufferUtils;
 import org.lwjgl.PointerBuffer;
@@ -35,13 +34,11 @@ import com.badlogic.gdx.Graphics.DisplayMode;
 import com.badlogic.gdx.Graphics.Monitor;
 import com.badlogic.gdx.Preferences;
 import com.badlogic.gdx.audio.Music;
-import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Graphics.Lwjgl3DisplayMode;
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Graphics.Lwjgl3Monitor;
-import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.glutils.HdpiUtils;
 
-public class Lwjgl3ApplicationConfiguration {
+public class Lwjgl3ApplicationConfiguration extends Lwjgl3WindowConfiguration {
 	boolean disableAudio = false;
 	int audioDeviceSimultaneousSources = 16;
 	int audioDeviceBufferSize = 512;
@@ -55,22 +52,7 @@ public class Lwjgl3ApplicationConfiguration {
 	int depth = 16, stencil = 0;
 	int samples = 0;
 
-	int windowX = -1;
-	int windowY = -1;
-	int windowWidth = 640;
-	int windowHeight = 480;
-	int windowMinWidth = -1, windowMinHeight = -1, windowMaxWidth = -1, windowMaxHeight = -1;
-	boolean windowResizable = true;
-	boolean windowDecorated = true;
-	FileType windowIconFileType;
-	String[] windowIconPaths;
-	Lwjgl3WindowListener windowListener;
-	Lwjgl3DisplayMode fullscreenMode;
-
 	boolean vSyncEnabled = true;
-	String title = "";
-	Color initialBackgroundColor = Color.BLACK;
-	boolean initialVisible = true;
 
 	String preferencesDirectory = ".prefs/";
 	Files.FileType preferencesFileType = FileType.External;
@@ -82,45 +64,32 @@ public class Lwjgl3ApplicationConfiguration {
 	
 	static Lwjgl3ApplicationConfiguration copy(Lwjgl3ApplicationConfiguration config) {
 		Lwjgl3ApplicationConfiguration copy = new Lwjgl3ApplicationConfiguration();
-		copy.disableAudio = config.disableAudio;
-		copy.audioDeviceSimultaneousSources = config.audioDeviceSimultaneousSources;
-		copy.audioDeviceBufferSize = config.audioDeviceBufferSize;
-		copy.audioDeviceBufferCount = config.audioDeviceBufferCount;
-		copy.useGL30 = config.useGL30;
-		copy.gles30ContextMajorVersion = config.gles30ContextMajorVersion;
-		copy.gles30ContextMinorVersion = config.gles30ContextMinorVersion;
-		copy.r = config.r;
-		copy.g = config.g;
-		copy.b = config.b;
-		copy.a = config.a;
-		copy.depth = config.depth;
-		copy.stencil = config.stencil;
-		copy.samples = config.samples;
-		copy.windowX = config.windowX;
-		copy.windowY = config.windowY;
-		copy.windowWidth = config.windowWidth;
-		copy.windowHeight = config.windowHeight;
-		copy.windowMinWidth = config.windowMinWidth;
-		copy.windowMinHeight = config.windowMinHeight;
-		copy.windowMaxWidth = config.windowMaxWidth;
-		copy.windowMaxHeight = config.windowMaxHeight;
-		copy.windowResizable = config.windowResizable;
-		copy.windowDecorated = config.windowDecorated;
-		copy.windowIconFileType = config.windowIconFileType;
-		if (config.windowIconPaths != null) 
-			copy.windowIconPaths = Arrays.copyOf(config.windowIconPaths, config.windowIconPaths.length);
-		copy.windowListener = config.windowListener;
-		copy.fullscreenMode = config.fullscreenMode;
-		copy.vSyncEnabled = config.vSyncEnabled;
-		copy.title = config.title;
-		copy.initialBackgroundColor = config.initialBackgroundColor;
-		copy.initialVisible = config.initialVisible;
-		copy.preferencesDirectory = config.preferencesDirectory;
-		copy.preferencesFileType = config.preferencesFileType;
-		copy.hdpiMode = config.hdpiMode;
-		copy.debug = config.debug;
-		copy.debugStream = config.debugStream;
+		copy.set(config);
 		return copy;
+	}
+	
+	void set (Lwjgl3ApplicationConfiguration config){
+		super.setWindowConfiguration(config);
+		disableAudio = config.disableAudio;
+		audioDeviceSimultaneousSources = config.audioDeviceSimultaneousSources;
+		audioDeviceBufferSize = config.audioDeviceBufferSize;
+		audioDeviceBufferCount = config.audioDeviceBufferCount;
+		useGL30 = config.useGL30;
+		gles30ContextMajorVersion = config.gles30ContextMajorVersion;
+		gles30ContextMinorVersion = config.gles30ContextMinorVersion;
+		r = config.r;
+		g = config.g;
+		b = config.b;
+		a = config.a;
+		depth = config.depth;
+		stencil = config.stencil;
+		samples = config.samples;
+		vSyncEnabled = config.vSyncEnabled;
+		preferencesDirectory = config.preferencesDirectory;
+		preferencesFileType = config.preferencesFileType;
+		hdpiMode = config.hdpiMode;
+		debug = config.debug;
+		debugStream = config.debugStream;
 	}
 	
 	/**
@@ -211,100 +180,11 @@ public class Lwjgl3ApplicationConfiguration {
 	}
 
 	/**
-	 * Sets the app to use windowed mode.
-	 * 
-	 * @param width
-	 *            the width of the window (default 640)
-	 * @param height
-	 *            the height of the window (default 480)
-	 */
-	public void setWindowedMode(int width, int height) {
-		this.windowWidth = width;
-		this.windowHeight = height;		
-	}
-	
-	/** 
-	 * @param resizable whether the windowed mode window is resizable (default true)
-	 */
-	public void setResizable(boolean resizable) {
-		this.windowResizable = resizable;
-	}
-	
-	/**
-	 * @param decorated whether the windowed mode window is decorated, i.e. displaying the title bars (default true)
-	 */
-	public void setDecorated(boolean decorated) {
-		this.windowDecorated = decorated;
-	}
-	
-	/**
-	 * Sets the position of the window in windowed mode on the
-	 * primary monitor. Default -1 for booth coordinates for centered.
-	 */
-	public void setWindowPosition(int x, int y) {
-		windowX = x;
-		windowY = y;
-	}
-	
-	/**
-	 * Sets minimum and maximum size limits for the window. If the window is full screen or not resizable, these 
-	 * limits are ignored. The default for all four parameters is -1, which means unrestricted.
-	 */
-	public void setWindowSizeLimits(int minWidth, int minHeight, int maxWidth, int maxHeight) {
-		windowMinWidth = minWidth;
-		windowMinHeight = minHeight;
-		windowMaxWidth = maxWidth;
-		windowMaxHeight = maxHeight;
-	}
-	
-	/**
-	 * Sets the icon that will be used in the window's title bar. Has no effect in macOS, which doesn't use window icons.
-	 * @param icon One or more image paths, relative to the given FileType. Must be JPEG, PNG, or BMP format. The one 
-	 * closest to the system's desired size will be scaled. Good sizes include 16x16, 32x32 and 48x48. The provided
-	 * file paths must point to valid images for as long new windows might be created.
-	 */
-	public void setWindowIcon (FileType fileType, String... filePaths){
-		windowIconFileType = fileType;
-		windowIconPaths = filePaths;
-	}
-	
-	/**
-	 * Sets the {@link Lwjgl3WindowListener} which will be informed about
-	 * iconification, focus loss and window close events.
-	 */
-	public void setWindowListener(Lwjgl3WindowListener windowListener) {
-		this.windowListener = windowListener;
-	}
-
-	/**
-	 * Sets the app to use fullscreen mode. Use the static methods like
-	 * {@link #getDisplayMode()} on this class to enumerate connected monitors
-	 * and their fullscreen display modes.
-	 */
-	public void setFullscreenMode(DisplayMode mode) {
-		this.fullscreenMode = (Lwjgl3DisplayMode)mode;
-	}
-
-	/**
 	 * Sets whether to use vsync. This setting can be changed anytime at runtime
 	 * via {@link Graphics#setVSync(boolean)}.
 	 */
 	public void useVsync(boolean vsync) {
 		this.vSyncEnabled = vsync;
-	}
-
-	/**
-	 * Sets the window title. Defaults to empty string.
-	 */
-	public void setTitle(String title) {
-		this.title = title;
-	}
-
-	/**
-	 * Sets the initial background color. Defaults to black.
-	 */
-	public void setInitialBackgroundColor(Color color) {
-		initialBackgroundColor = color;
 	}
 
 	/**

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Window.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Window.java
@@ -294,6 +294,20 @@ public class Lwjgl3Window implements Disposable {
 		GLFW.glfwSetWindowTitle(windowHandle, title);
 	}
 
+	/** Sets minimum and maximum size limits for the window. If the window is full screen or not resizable, these limits are
+	 * ignored. Use -1 to indicate an unrestricted dimension. */
+	public void setSizeLimits (int minWidth, int minHeight, int maxWidth, int maxHeight) {
+		setSizeLimits(windowHandle, minWidth, minHeight, maxWidth, maxHeight);
+	}
+	
+	static void setSizeLimits (long windowHandle, int minWidth, int minHeight, int maxWidth, int maxHeight) {
+		GLFW.glfwSetWindowSizeLimits(windowHandle, 
+			minWidth > -1 ? minWidth: GLFW.GLFW_DONT_CARE, 
+			minHeight > -1 ? minHeight : GLFW.GLFW_DONT_CARE, 
+				maxWidth > -1 ? maxWidth : GLFW.GLFW_DONT_CARE,
+					maxHeight > -1 ? maxHeight : GLFW.GLFW_DONT_CARE);
+	}
+
 	Lwjgl3Graphics getGraphics() {
 		return graphics;
 	}

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3WindowConfiguration.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3WindowConfiguration.java
@@ -16,6 +16,7 @@
 
 package com.badlogic.gdx.backends.lwjgl3;
 
+import com.badlogic.gdx.Files.FileType;
 import com.badlogic.gdx.Graphics.DisplayMode;
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Graphics.Lwjgl3DisplayMode;
 import com.badlogic.gdx.graphics.Color;
@@ -28,6 +29,8 @@ public class Lwjgl3WindowConfiguration {
 	int windowMinWidth = -1, windowMinHeight = -1, windowMaxWidth = -1, windowMaxHeight = -1;
 	boolean windowResizable = true;
 	boolean windowDecorated = true;
+	FileType windowIconFileType;
+	String[] windowIconPaths;
 	Lwjgl3WindowListener windowListener;
 	Lwjgl3DisplayMode fullscreenMode;
 	String title = "";
@@ -86,6 +89,16 @@ public class Lwjgl3WindowConfiguration {
 		windowMinHeight = minHeight;
 		windowMaxWidth = maxWidth;
 		windowMaxHeight = maxHeight;
+	}
+	
+	/**
+	 * Sets the icon that will be used in the window's title bar. Has no effect in macOS, which doesn't use window icons.
+	 * @param icon One or more image paths, relative to the given FileType. Must be JPEG, PNG, or BMP format. The one 
+	 * closest to the system's desired size will be scaled. Good sizes include 16x16, 32x32 and 48x48.
+	 */
+	public void setWindowIcon (FileType fileType, String... filePaths){
+		windowIconFileType = fileType;
+		windowIconPaths = filePaths;
 	}
 	
 	/**

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3WindowConfiguration.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3WindowConfiguration.java
@@ -93,10 +93,20 @@ public class Lwjgl3WindowConfiguration {
 	
 	/**
 	 * Sets the icon that will be used in the window's title bar. Has no effect in macOS, which doesn't use window icons.
-	 * @param icon One or more image paths, relative to the given FileType. Must be JPEG, PNG, or BMP format. The one 
-	 * closest to the system's desired size will be scaled. Good sizes include 16x16, 32x32 and 48x48.
+	 * @param filePaths One or more {@linkplain FileType#Internal internal} image paths. Must be JPEG, PNG, or BMP format.
+	 * The one closest to the system's desired size will be scaled. Good sizes include 16x16, 32x32 and 48x48.
 	 */
-	public void setWindowIcon (FileType fileType, String... filePaths){
+	public void setWindowIcon (String... filePaths) {
+		setWindowIcon(FileType.Internal, filePaths);
+	}
+	
+	/**
+	 * Sets the icon that will be used in the window's title bar. Has no effect in macOS, which doesn't use window icons.
+	 * @param fileType The type of file handle the paths are relative to.
+	 * @param filePaths One or more image paths, relative to the given {@linkplain FileType}. Must be JPEG, PNG, or BMP format. 
+	 * The one closest to the system's desired size will be scaled. Good sizes include 16x16, 32x32 and 48x48.
+	 */
+	public void setWindowIcon (FileType fileType, String... filePaths) {
 		windowIconFileType = fileType;
 		windowIconPaths = filePaths;
 	}

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3WindowConfiguration.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3WindowConfiguration.java
@@ -16,6 +16,8 @@
 
 package com.badlogic.gdx.backends.lwjgl3;
 
+import java.util.Arrays;
+
 import com.badlogic.gdx.Files.FileType;
 import com.badlogic.gdx.Graphics.DisplayMode;
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Graphics.Lwjgl3DisplayMode;
@@ -36,6 +38,27 @@ public class Lwjgl3WindowConfiguration {
 	String title = "";
 	Color initialBackgroundColor = Color.BLACK;
 	boolean initialVisible = true;
+	
+	void setWindowConfiguration (Lwjgl3WindowConfiguration config){
+		windowX = config.windowX;
+		windowY = config.windowY;
+		windowWidth = config.windowWidth;
+		windowHeight = config.windowHeight;
+		windowMinWidth = config.windowMinWidth;
+		windowMinHeight = config.windowMinHeight;
+		windowMaxWidth = config.windowMaxWidth;
+		windowMaxHeight = config.windowMaxHeight;
+		windowResizable = config.windowResizable;
+		windowDecorated = config.windowDecorated;
+		windowIconFileType = config.windowIconFileType;
+		if (config.windowIconPaths != null) 
+			windowIconPaths = Arrays.copyOf(config.windowIconPaths, config.windowIconPaths.length);
+		windowListener = config.windowListener;
+		fullscreenMode = config.fullscreenMode;
+		title = config.title;
+		initialBackgroundColor = config.initialBackgroundColor;
+		initialVisible = config.initialVisible;
+	}
 	
 	/**
 	 * @param visibility whether the window will be visible on creation. (default true)

--- a/tests/gdx-tests-lwjgl3/src/com/badlogic/gdx/tests/lwjgl3/MultiWindowTest.java
+++ b/tests/gdx-tests-lwjgl3/src/com/badlogic/gdx/tests/lwjgl3/MultiWindowTest.java
@@ -3,13 +3,18 @@ package com.badlogic.gdx.tests.lwjgl3;
 import com.badlogic.gdx.ApplicationAdapter;
 import com.badlogic.gdx.ApplicationListener;
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Input;
+import com.badlogic.gdx.Files.FileType;
 import com.badlogic.gdx.Graphics.DisplayMode;
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application;
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3ApplicationConfiguration;
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Window;
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3WindowConfiguration;
+import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.Pixmap.Blending;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.tests.BulletTestCollection;
@@ -24,6 +29,7 @@ public class MultiWindowTest {
 	
 	public static class MainWindow extends ApplicationAdapter {
 		Class[] childWindowClasses = { ShaderCollectionTest.class, BulletTestCollection.class, UITest.class, Basic3DSceneTest.class };
+		private Lwjgl3Window latestWindow;
 		
 		@Override
 		public void create () {
@@ -41,14 +47,30 @@ public class MultiWindowTest {
 			sharedSpriteBatch.end();
 			
 			if(Gdx.input.justTouched()) {
-				Lwjgl3Application app = (Lwjgl3Application)Gdx.app;
-				Lwjgl3WindowConfiguration config = new Lwjgl3WindowConfiguration();
-				DisplayMode mode = Gdx.graphics.getDisplayMode();
-				config.setWindowPosition(MathUtils.random(0, mode.width - 640), MathUtils.random(0, mode.height - 480));
-				config.setTitle("Child window");
-				Class clazz = childWindowClasses[MathUtils.random(0, childWindowClasses.length - 1)];
-				ApplicationListener listener = createChildWindowClass(clazz);
-				Lwjgl3Window window = app.newWindow(listener, config);
+				if (Gdx.input.isButtonPressed(Input.Buttons.RIGHT) && latestWindow != null){
+					latestWindow.setTitle("Retitled window");
+					int size = 48;
+					Pixmap.setBlending(Blending.None);
+					Pixmap icon = new Pixmap(size, size, Pixmap.Format.RGBA8888);
+					icon.setColor(Color.BLUE);
+					icon.fill();
+					icon.setColor(Color.CLEAR);
+					for (int i = 0; i < size; i += 3)
+						for (int j = 0; j < size; j += 3)
+							icon.drawPixel(i, j);
+					latestWindow.setIcon(icon);
+					icon.dispose();
+				} else {
+					Lwjgl3Application app = (Lwjgl3Application)Gdx.app;
+					Lwjgl3WindowConfiguration config = new Lwjgl3WindowConfiguration();
+					DisplayMode mode = Gdx.graphics.getDisplayMode();
+					config.setWindowPosition(MathUtils.random(0, mode.width - 640), MathUtils.random(0, mode.height - 480));
+					config.setTitle("Child window");
+					config.setWindowIcon(FileType.Internal, "data/testdot.png");
+					Class clazz = childWindowClasses[MathUtils.random(0, childWindowClasses.length - 1)];
+					ApplicationListener listener = createChildWindowClass(clazz);
+					latestWindow = app.newWindow(listener, config);
+				}
 			}
 		}
 


### PR DESCRIPTION
I broke this out of #4261 to avoid changing too much at once. This cleans up redundant code by having the app config extend the window config and adding some copy methods to make these easier to maintain without introducing bugs.

I also added the ability to change the window size limits of an existing window.

@code-disaster I can rebase and squash this after you merge #4261 so it isn't so messy.