### PR TITLE
Fix potential multi-window resize bug

### DIFF
--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
@@ -129,13 +129,7 @@ public class Lwjgl3Application implements Application {
 
 			closedWindows.clear();
 			for (Lwjgl3Window window : windows) {
-				Gdx.graphics = window.getGraphics();
-				Gdx.gl30 = window.getGraphics().getGL30();
-				Gdx.gl20 = Gdx.gl30 != null ? Gdx.gl30 : window.getGraphics().getGL20();
-				Gdx.gl = Gdx.gl30 != null ? Gdx.gl30 : Gdx.gl20;
-				Gdx.input = window.getInput();
-
-				GLFW.glfwMakeContextCurrent(window.getWindowHandle());
+				window.makeCurrent();
 				currentWindow = window;
 				synchronized (lifecycleListeners) {
 					window.update();

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Graphics.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Graphics.java
@@ -65,7 +65,7 @@ public class Lwjgl3Graphics implements Graphics, Disposable {
 			if (!window.isListenerInitialized()) {
 				return;
 			}
-			GLFW.glfwMakeContextCurrent(windowHandle);
+			window.makeCurrent();
 			gl20.glViewport(0, 0, width, height);
 			window.getListener().resize(getWidth(), getHeight());
 			window.getListener().render();

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Window.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Window.java
@@ -26,7 +26,7 @@ import org.lwjgl.glfw.GLFWWindowFocusCallback;
 import org.lwjgl.glfw.GLFWWindowIconifyCallback;
 
 import com.badlogic.gdx.ApplicationListener;
-import com.badlogic.gdx.LifecycleListener;
+import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.Disposable;
 
@@ -277,7 +277,17 @@ public class Lwjgl3Window implements Disposable {
 			listenerInitialized = true;		
 		}
 	}
-	
+
+	void makeCurrent() {
+		Gdx.graphics = graphics;
+		Gdx.gl30 = graphics.getGL30();
+		Gdx.gl20 = Gdx.gl30 != null ? Gdx.gl30 : graphics.getGL20();
+		Gdx.gl = Gdx.gl30 != null ? Gdx.gl30 : Gdx.gl20;
+		Gdx.input = input;
+
+		GLFW.glfwMakeContextCurrent(windowHandle);
+	}
+
 	@Override
 	public void dispose() {
 		listener.pause();


### PR DESCRIPTION
A resize triggers a call to render(). Need to be sure Gdx.graphics, Gdx.input, etc. are correct for the window that's getting rendered.