### PR TITLE
Fix for #4409 - 

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/glutils/GLFrameBuffer.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/GLFrameBuffer.java
@@ -202,10 +202,11 @@ public abstract class GLFrameBuffer<T extends GLTexture> implements Disposable {
 
 			gl.glFramebufferRenderbuffer(GL20.GL_FRAMEBUFFER, GL20.GL_DEPTH_ATTACHMENT, GL20.GL_RENDERBUFFER, depthStencilPackedBufferHandle);
 			gl.glFramebufferRenderbuffer(GL20.GL_FRAMEBUFFER, GL20.GL_STENCIL_ATTACHMENT, GL20.GL_RENDERBUFFER, depthStencilPackedBufferHandle);
-			result = gl.glCheckFramebufferStatus(GL20.GL_FRAMEBUFFER);
 		}
 
 		gl.glBindFramebuffer(GL20.GL_FRAMEBUFFER, defaultFramebufferHandle);
+
+		result = gl.glCheckFramebufferStatus(GL20.GL_FRAMEBUFFER);
 
 		if (result != GL20.GL_FRAMEBUFFER_COMPLETE) {
 			disposeColorTexture(colorTexture);


### PR DESCRIPTION
See also: https://github.com/libgdx/libgdx/issues/4409 and https://github.com/libgdx/libgdx/issues/3227.

Deferred frame buffer status query 'til after frame buffer bind. This prevents a FRAMEBUFFER_INCOMPLETE_DRAW_BUFFER_EXT error on some systems.