### PR TITLE
Add Lwjgl3 maximized window features

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -10,6 +10,9 @@
 - Updated LWJGL3 backend to LWJGL 3.1.0, see https://blog.lwjgl.org/lwjgl-3-1-0-released/
 - LWJGL3 backend now supports non-continuous rendering, see https://github.com/libgdx/libgdx/pull/3772
 - API Change: Lwjgl3WindowListener.refreshRequested() is called when the windowing system (GLFW) reports contents of a window are dirty and need to be redrawn.
+- API Change: Lwjgl3WindowListener.maximized() and .demaximized() are called when a window enters and exits a maximized state.
+- API Change: Lwjgl3Window.deiconify() renamed to .restore() since it can also be used to demaximize a window.
+- Lwjgl3Window now has a maximize() method, and windows can be started maximized using the window or app configuration's setMaximized() method.
 
 [1.9.4]
 - Moved snapping from ProgressBar to Slider to prevent snapping when setting the value programmatically.

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
@@ -379,6 +379,7 @@ public class Lwjgl3Application implements Application {
 		GLFW.glfwDefaultWindowHints();
 		GLFW.glfwWindowHint(GLFW.GLFW_VISIBLE, GLFW.GLFW_FALSE);
 		GLFW.glfwWindowHint(GLFW.GLFW_RESIZABLE, config.windowResizable ? GLFW.GLFW_TRUE : GLFW.GLFW_FALSE);
+		GLFW.glfwWindowHint(GLFW.GLFW_MAXIMIZED, config.windowMaximized ? GLFW.GLFW_TRUE : GLFW.GLFW_FALSE);
 		
 		if(sharedContextWindow == 0) {
 			GLFW.glfwWindowHint(GLFW.GLFW_RED_BITS, config.r);
@@ -419,7 +420,7 @@ public class Lwjgl3Application implements Application {
 			throw new GdxRuntimeException("Couldn't create window");
 		}
 		Lwjgl3Window.setSizeLimits(windowHandle, config.windowMinWidth, config.windowMinHeight, config.windowMaxWidth, config.windowMaxHeight);
-		if (config.fullscreenMode == null) {
+		if (config.fullscreenMode == null && !config.windowMaximized) {
 			if (config.windowX == -1 && config.windowY == -1) {
 				int windowWidth = Math.max(config.windowWidth, config.windowMinWidth);
 				int windowHeight = Math.max(config.windowHeight, config.windowMinHeight);

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Window.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Window.java
@@ -25,6 +25,7 @@ import org.lwjgl.glfw.GLFWImage;
 import org.lwjgl.glfw.GLFWWindowCloseCallback;
 import org.lwjgl.glfw.GLFWWindowFocusCallback;
 import org.lwjgl.glfw.GLFWWindowIconifyCallback;
+import org.lwjgl.glfw.GLFWWindowMaximizeCallback;
 import org.lwjgl.glfw.GLFWWindowRefreshCallback;
 
 import com.badlogic.gdx.ApplicationListener;
@@ -92,6 +93,25 @@ public class Lwjgl3Window implements Disposable {
 		}
 	};
 	
+	private final GLFWWindowMaximizeCallback maximizeCallback = new GLFWWindowMaximizeCallback() {
+		@Override
+		public void invoke (long windowHandle, final boolean maximized) {
+			postRunnable(new Runnable() {
+				@Override
+				public void run() {
+					if(windowListener != null) {
+						if(maximized) {
+							windowListener.maximized();
+						} else {
+							windowListener.demaximized();
+						}
+					}
+				}
+			});
+		}
+		
+	};
+	
 	private final GLFWWindowCloseCallback closeCallback = new GLFWWindowCloseCallback() {
 		@Override
 		public void invoke(final long windowHandle) {
@@ -153,6 +173,7 @@ public class Lwjgl3Window implements Disposable {
 		
 		GLFW.glfwSetWindowFocusCallback(windowHandle, focusCallback);
 		GLFW.glfwSetWindowIconifyCallback(windowHandle, iconifyCallback);
+		GLFW.glfwSetWindowMaximizeCallback(windowHandle, maximizeCallback);
 		GLFW.glfwSetWindowCloseCallback(windowHandle, closeCallback);
 		GLFW.glfwSetDropCallback(windowHandle, dropCallback);
 		GLFW.glfwSetWindowRefreshCallback(windowHandle, refreshCallback);
@@ -227,18 +248,25 @@ public class Lwjgl3Window implements Disposable {
 	}
 	
 	/**
-	 * Minimizes (iconfies) the window. Iconified windows do not call
-	 * their {@link ApplicationListener} until the window is deiconified.
+	 * Minimizes (iconifies) the window. Iconified windows do not call
+	 * their {@link ApplicationListener} until the window is restored.
 	 */
 	public void iconifyWindow() {
 		GLFW.glfwIconifyWindow(windowHandle);
 	}
 	
 	/**
-	 * De-minimizes the window.
+	 * De-minimizes (de-iconifies) and de-maximizes the window.
 	 */
-	public void deiconifyWindow() {
+	public void restoreWindow() {
 		GLFW.glfwRestoreWindow(windowHandle);
+	}
+	
+	/**
+	 * Maximizes the window.
+	 */
+	public void maximizeWindow() {
+		GLFW.glfwMaximizeWindow(windowHandle);
 	}
 	
 	/**

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3WindowAdapter.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3WindowAdapter.java
@@ -14,6 +14,14 @@ public class Lwjgl3WindowAdapter implements Lwjgl3WindowListener {
 	@Override
 	public void deiconified() {
 	}
+	
+	@Override
+	public void maximized() {
+	}
+	
+	@Override
+	public void demaximized() {
+	}
 
 	@Override
 	public void focusLost() {

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3WindowConfiguration.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3WindowConfiguration.java
@@ -31,6 +31,7 @@ public class Lwjgl3WindowConfiguration {
 	int windowMinWidth = -1, windowMinHeight = -1, windowMaxWidth = -1, windowMaxHeight = -1;
 	boolean windowResizable = true;
 	boolean windowDecorated = true;
+	boolean windowMaximized = false;
 	FileType windowIconFileType;
 	String[] windowIconPaths;
 	Lwjgl3WindowListener windowListener;
@@ -50,6 +51,7 @@ public class Lwjgl3WindowConfiguration {
 		windowMaxHeight = config.windowMaxHeight;
 		windowResizable = config.windowResizable;
 		windowDecorated = config.windowDecorated;
+		windowMaximized = config.windowMaximized;
 		windowIconFileType = config.windowIconFileType;
 		if (config.windowIconPaths != null) 
 			windowIconPaths = Arrays.copyOf(config.windowIconPaths, config.windowIconPaths.length);
@@ -81,7 +83,7 @@ public class Lwjgl3WindowConfiguration {
 	}
 	
 	/** 
-	 * @param resizable whether the windowed mode window is resizable
+	 * @param resizable whether the windowed mode window is resizable (default true)
 	 */
 	public void setResizable(boolean resizable) {
 		this.windowResizable = resizable;
@@ -92,6 +94,13 @@ public class Lwjgl3WindowConfiguration {
 	 */
 	public void setDecorated(boolean decorated) {
 		this.windowDecorated = decorated;
+	}
+	
+	/**
+	 * @param maximized whether the window starts maximized. Ignored if the window is full screen. (default false)
+	 */
+	public void setMaximized(boolean maximized) {
+		this.windowMaximized = maximized;
 	}
 	
 	/**

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3WindowListener.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3WindowListener.java
@@ -44,6 +44,16 @@ public interface Lwjgl3WindowListener {
 	void deiconified();
 	
 	/**
+	 * Called when the window is maximized.
+	 */
+	void maximized();
+	
+	/**
+	 * Called when the window is demaximized.
+	 */
+	void demaximized();
+	
+	/**
 	 * Called when the window lost focus to another window. The
 	 * window's {@link ApplicationListener} will continue to be
 	 * called.

--- a/tests/gdx-tests-lwjgl3/src/com/badlogic/gdx/tests/lwjgl3/Lwjgl3DebugStarter.java
+++ b/tests/gdx-tests-lwjgl3/src/com/badlogic/gdx/tests/lwjgl3/Lwjgl3DebugStarter.java
@@ -110,25 +110,24 @@ public class Lwjgl3DebugStarter {
 						if(character == 'c') {
 							Gdx.input.setCursorCatched(!Gdx.input.isCursorCatched());
 						}
+						Lwjgl3Window window = ((Lwjgl3Graphics)Gdx.graphics).getWindow();
 						if(character == 'v') {
-							Lwjgl3Window window = ((Lwjgl3Graphics)Gdx.graphics).getWindow();
 							window.setVisible(false);
 						}
 						if(character == 's') {
-							Lwjgl3Window window = ((Lwjgl3Graphics)Gdx.graphics).getWindow();
 							window.setVisible(true);
 						}
 						if(character == 'q') {
-							Lwjgl3Window window = ((Lwjgl3Graphics)Gdx.graphics).getWindow();
 							window.closeWindow();
 						}
 						if(character == 'i') {
-							Lwjgl3Window window = ((Lwjgl3Graphics)Gdx.graphics).getWindow();
 							window.iconifyWindow();
 						}
+						if(character == 'm') {
+							window.maximizeWindow();
+						}
 						if(character == 'r') {
-							Lwjgl3Window window = ((Lwjgl3Graphics)Gdx.graphics).getWindow();
-							window.deiconifyWindow();
+							window.restoreWindow();
 						}
 						if(character == 'u') {
 							Gdx.net.openURI("https://google.com");
@@ -188,6 +187,16 @@ public class Lwjgl3DebugStarter {
 			@Override
 			public void deiconified () {
 				Gdx.app.log("Window", "deiconified");				
+			}
+			
+			@Override
+			public void maximized () {
+				Gdx.app.log("Window", "maximized");		
+			}
+
+			@Override
+			public void demaximized () {
+				Gdx.app.log("Window", "demaximized");				
 			}
 
 			@Override


### PR DESCRIPTION
I put in a callback for maximized state, and options to maximize a window at will or start it maximized.

I renamed `window.deiconify()` to `window.restore()` to reflect that it can be used for two different purposes. Better to rename it now when the backend is young than to make it a quirk forever.

Addresses #4298. I didn't add a `isMaximized()` method to keep it clean, as we don't have `isFullScreen` or `isIconified` window methods, and the callback should be sufficient.