### PR TITLE
Lwjgl3WindowListener.deiconified() removed

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -11,6 +11,7 @@
 - LWJGL3 backend now supports non-continuous rendering, see https://github.com/libgdx/libgdx/pull/3772
 - API Change: Lwjgl3WindowListener.refreshRequested() is called when the windowing system (GLFW) reports contents of a window are dirty and need to be redrawn.
 - API Change: Lwjgl3WindowListener.maximized() is called when a window enters or exits a maximized state.
+- API Change: Lwjgl3WindowListener.deiconified() removed, combined with .iconified().
 - API Change: Lwjgl3Window.deiconify() renamed to .restore() since it can also be used to de-maximize a window.
 - Lwjgl3Window now has a maximize() method, and windows can be started maximized using the window or app configuration's setMaximized() method.
 

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Window.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Window.java
@@ -76,11 +76,7 @@ public class Lwjgl3Window implements Disposable {
 				@Override
 				public void run() {
 					if(windowListener != null) {
-						if(iconified) {
-							windowListener.iconified();
-						} else {
-							windowListener.deiconified();
-						}
+						windowListener.iconified(iconified);
 					}
 					Lwjgl3Window.this.iconified = iconified;
 					if(iconified) {

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3WindowAdapter.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3WindowAdapter.java
@@ -8,13 +8,9 @@ package com.badlogic.gdx.backends.lwjgl3;
  */
 public class Lwjgl3WindowAdapter implements Lwjgl3WindowListener {
 	@Override
-	public void iconified() {
+	public void iconified(boolean isIconified) {
 	}
 
-	@Override
-	public void deiconified() {
-	}
-	
 	@Override
 	public void maximized(boolean isMaximized) {
 	}

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3WindowListener.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3WindowListener.java
@@ -20,28 +20,23 @@ package com.badlogic.gdx.backends.lwjgl3;
 import com.badlogic.gdx.ApplicationListener;
 
 /**
- * Receives notifications of various window events, such as iconficiation,
+ * Receives notifications of various window events, such as iconification,
  * focus loss and gain, and window close events. Can be set per window
  * via {@link Lwjgl3ApplicationConfiguration} and {@link Lwjgl3WindowConfiguration}.
  * Close events can be canceled by returning false.
  * 
  * @author badlogic
- *
  */
 public interface Lwjgl3WindowListener {
 	/**
-	 * Called when the window is iconified, i.e. its minimize button
-	 * was clicked. The window's {@link ApplicationListener} will
-	 * be paused
+	 * Called when the window is iconified (i.e. its minimize button
+	 * was clicked), or when restored from the iconified state. When a window becomes
+	 * iconified, its {@link ApplicationListener} will be paused, and when restored
+	 * it will be resumed.
+	 * 
+	 * @param isIconified True if window is iconified, false if it leaves the iconified state
 	 */
-	void iconified();
-	
-	/**
-	 * Called when the window is deiconified, i.e. its task bar
-	 * icon was clicked. The window's {@link ApplicationListener}
-	 * will be resumed.
-	 */
-	void deiconified();
+	void iconified(boolean isIconified);
 	
 	/**
 	 * Called when the window is maximized, or restored from the maximized state.

--- a/tests/gdx-tests-lwjgl3/src/com/badlogic/gdx/tests/lwjgl3/Lwjgl3DebugStarter.java
+++ b/tests/gdx-tests-lwjgl3/src/com/badlogic/gdx/tests/lwjgl3/Lwjgl3DebugStarter.java
@@ -180,13 +180,8 @@ public class Lwjgl3DebugStarter {
 		config.setWindowListener(new Lwjgl3WindowListener() {
 
 			@Override
-			public void iconified () {
-				Gdx.app.log("Window", "iconified");
-			}
-
-			@Override
-			public void deiconified () {
-				Gdx.app.log("Window", "deiconified");				
+			public void iconified (boolean isIconified) {
+				Gdx.app.log("Window", "iconified: "+ (isIconified ? "true" : "false"));
 			}
 			
 			@Override
@@ -211,11 +206,15 @@ public class Lwjgl3DebugStarter {
 			}
 
 			@Override
-			public void filesDropped (String[] files) {				
+			public void filesDropped (String[] files) {	
+				for (String file : files){
+					Gdx.app.log("Window", "File dropped: " + file);
+				}
 			}
 
 			@Override
 			public void refreshRequested() {
+				Gdx.app.log("Window", "refreshRequested");
 			}
 		});
 		for(DisplayMode mode: Lwjgl3ApplicationConfiguration.getDisplayModes()) {


### PR DESCRIPTION
Tidying Lwjgl3WindowListener up a bit, since we already modified it.