### PR TITLE
Added ShaderProgramLoader for AssetManager

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -19,6 +19,7 @@
 - NinePatch can now be drawn rotated or scaled.
 - NinepatchDrawable is now a TransformDrawable.
 - API Change: g2d.Animation is now generic so it can support Drawables, PolygonRegions, NinePatches, etc. To fix existing code, specify the TextureRegion type in animation declarations (and instantiations in Java 6), i.e. Animation<TextureRegion> myAnimation = new Animation<TextureRegion>(...);
+- Added ShaderProgramLoader for AssetManager.
 
 [1.9.4]
 - Moved snapping from ProgressBar to Slider to prevent snapping when setting the value programmatically.

--- a/gdx/src/com/badlogic/gdx.gwt.xml
+++ b/gdx/src/com/badlogic/gdx.gwt.xml
@@ -43,6 +43,7 @@
 		<include name="assets/loaders/MusicLoader.java"/>
 		<include name="assets/loaders/ParticleEffectLoader.java"/>
 		<include name="assets/loaders/PixmapLoader.java"/>
+		<include name="assets/loaders/ShaderProgramLoader.java"/>
 		<include name="assets/loaders/SkinLoader.java"/>
 		<include name="assets/loaders/SoundLoader.java"/>
 		<include name="assets/loaders/SynchronousAssetLoader.java"/>

--- a/gdx/src/com/badlogic/gdx/assets/AssetManager.java
+++ b/gdx/src/com/badlogic/gdx/assets/AssetManager.java
@@ -26,6 +26,7 @@ import com.badlogic.gdx.assets.loaders.I18NBundleLoader;
 import com.badlogic.gdx.assets.loaders.MusicLoader;
 import com.badlogic.gdx.assets.loaders.ParticleEffectLoader;
 import com.badlogic.gdx.assets.loaders.PixmapLoader;
+import com.badlogic.gdx.assets.loaders.ShaderProgramLoader;
 import com.badlogic.gdx.assets.loaders.SkinLoader;
 import com.badlogic.gdx.assets.loaders.SoundLoader;
 import com.badlogic.gdx.assets.loaders.TextureAtlasLoader;
@@ -43,6 +44,7 @@ import com.badlogic.gdx.graphics.g2d.TextureAtlas;
 import com.badlogic.gdx.graphics.g3d.Model;
 import com.badlogic.gdx.graphics.g3d.loader.G3dModelLoader;
 import com.badlogic.gdx.graphics.g3d.loader.ObjLoader;
+import com.badlogic.gdx.graphics.glutils.ShaderProgram;
 import com.badlogic.gdx.scenes.scene2d.ui.Skin;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.Disposable;
@@ -112,6 +114,7 @@ public class AssetManager implements Disposable {
 			setLoader(Model.class, ".g3dj", new G3dModelLoader(new JsonReader(), resolver));
 			setLoader(Model.class, ".g3db", new G3dModelLoader(new UBJsonReader(), resolver));
 			setLoader(Model.class, ".obj", new ObjLoader(resolver));
+			setLoader(ShaderProgram.class, new ShaderProgramLoader(resolver));
 		}
 		executor = new AsyncExecutor(1);
 	}

--- a/gdx/src/com/badlogic/gdx/assets/loaders/ShaderProgramLoader.java
+++ b/gdx/src/com/badlogic/gdx/assets/loaders/ShaderProgramLoader.java
@@ -1,0 +1,92 @@
+
+package com.badlogic.gdx.assets.loaders;
+
+import com.badlogic.gdx.assets.AssetDescriptor;
+import com.badlogic.gdx.assets.AssetLoaderParameters;
+import com.badlogic.gdx.assets.AssetManager;
+import com.badlogic.gdx.files.FileHandle;
+import com.badlogic.gdx.graphics.glutils.ShaderProgram;
+import com.badlogic.gdx.utils.Array;
+import com.badlogic.gdx.utils.GdxRuntimeException;
+
+/** {@link AssetLoader} for {@link ShaderProgram} instances loaded from text files. If the file suffix is ".vert", it is assumed
+ * to be a vertex shader, and a fragment shader is found using the same file name with a ".frag" suffix. And vice versa if the
+ * file suffix is ".frag". These default suffixes can be changed in the ShaderProgramLoader constructor.
+ * <p>
+ * For all other file suffixes, the same file is used for both (and therefore should internally distinguish between the programs
+ * using preprocessor directives and {@link ShaderProgram#prependVertexCode} and {@link ShaderProgram#prependFragmentCode}).
+ * <p>
+ * The above default behavior for finding the files can be overridden by explicitly setting the file names in a
+ * {@link ShaderProgramParameter}. The parameter can also be used to prepend code to the programs.
+ * @author cypherdare */
+public class ShaderProgramLoader extends AsynchronousAssetLoader<ShaderProgram, ShaderProgramLoader.ShaderProgramParameter> {
+
+	private String vertexFileSuffix = ".vert";
+	private String fragmentFileSuffix = ".frag";
+
+	public ShaderProgramLoader (FileHandleResolver resolver) {
+		super(resolver);
+	}
+
+	public ShaderProgramLoader (FileHandleResolver resolver, String vertexFileSuffix, String fragmentFileSuffix) {
+		super(resolver);
+		this.vertexFileSuffix = vertexFileSuffix;
+		this.fragmentFileSuffix = fragmentFileSuffix;
+	}
+
+	@Override
+	public Array<AssetDescriptor> getDependencies (String fileName, FileHandle file, ShaderProgramParameter parameter) {
+		return null;
+	}
+
+	@Override
+	public void loadAsync (AssetManager manager, String fileName, FileHandle file, ShaderProgramParameter parameter) {
+	}
+
+	@Override
+	public ShaderProgram loadSync (AssetManager manager, String fileName, FileHandle file, ShaderProgramParameter parameter) {
+		String vertFileName = null, fragFileName = null;
+		if (parameter != null) {
+			if (parameter.vertexFile != null) vertFileName = parameter.vertexFile;
+			if (parameter.fragmentFile != null) fragFileName = parameter.fragmentFile;
+		}
+		if (vertFileName == null && fileName.endsWith(fragmentFileSuffix)) {
+			vertFileName = fileName.substring(0, fileName.length() - fragmentFileSuffix.length()) + vertexFileSuffix;
+		}
+		if (fragFileName == null && fileName.endsWith(vertexFileSuffix)) {
+			fragFileName = fileName.substring(0, fileName.length() - vertexFileSuffix.length()) + fragmentFileSuffix;
+		}
+		FileHandle vertexFile = vertFileName == null ? file : resolve(vertFileName);
+		FileHandle fragmentFile = fragFileName == null ? file : resolve(fragFileName);
+		String vertexCode = vertexFile.readString();
+		String fragmentCode = vertexFile.equals(fragmentFile) ? vertexCode : fragmentFile.readString();
+		if (parameter != null) {
+			if (parameter.prependVertexCode != null) vertexCode = parameter.prependVertexCode + vertexCode;
+			if (parameter.prependFragmentCode != null) fragmentCode = parameter.prependFragmentCode + fragmentCode;
+		}
+
+		ShaderProgram shaderProgram = new ShaderProgram(vertexCode, fragmentCode);
+		if ((parameter == null || parameter.logOnCompileFailure) && !shaderProgram.isCompiled()) {
+			manager.getLogger().error("ShaderProgram " + fileName + " failed to compile:\n" + shaderProgram.getLog());
+		}
+
+		return shaderProgram;
+	}
+
+	static public class ShaderProgramParameter extends AssetLoaderParameters<ShaderProgram> {
+		/** File name to be used for the vertex program instead of the default determined by the file name used to submit this asset
+		 * to AssetManager. */
+		public String vertexFile;
+		/** File name to be used for the fragment program instead of the default determined by the file name used to submit this
+		 * asset to AssetManager. */
+		public String fragmentFile;
+		/** Whether to log (at the error level) the shader's log if it fails to compile. Default true. */
+		public boolean logOnCompileFailure = true;
+		/** Code that is always added to the vertex shader code. This is added as-is, and you should include a newline (`\n`) if
+		 * needed. {@linkplain ShaderProgram#prependVertexCode} is placed before this code. */
+		public String prependVertexCode;
+		/** Code that is always added to the fragment shader code. This is added as-is, and you should include a newline (`\n`) if
+		 * needed. {@linkplain ShaderProgram#prependFragmentCode} is placed before this code. */
+		public String prependFragmentCode;
+	}
+}

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/ShaderProgram.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/ShaderProgram.java
@@ -39,7 +39,7 @@ import com.badlogic.gdx.utils.ObjectIntMap;
 import com.badlogic.gdx.utils.ObjectMap;
 
 /** <p>
- * A shader program encapsulates a vertex and fragment shader pair linked to form a shader program useable with OpenGL ES 2.0.
+ * A shader program encapsulates a vertex and fragment shader pair linked to form a shader program.
  * </p>
  * 
  * <p>

--- a/tests/gdx-tests-android/assets/data/g2d/batchCommon.vert
+++ b/tests/gdx-tests-android/assets/data/g2d/batchCommon.vert
@@ -1,0 +1,16 @@
+attribute vec4 a_position;
+attribute vec4 a_color;
+attribute vec2 a_texCoord0;
+
+varying vec2 v_texCoords;
+varying vec4 v_color;
+
+uniform mat4 u_projTrans;
+
+void main()
+{
+	v_texCoords = a_texCoord0;
+	v_color = a_color;
+	v_color.a = v_color.a * (255.0/254.0);
+	gl_Position =  u_projTrans * a_position;
+}

--- a/tests/gdx-tests-android/assets/data/g2d/monochrome.frag
+++ b/tests/gdx-tests-android/assets/data/g2d/monochrome.frag
@@ -1,0 +1,18 @@
+#ifdef GL_ES
+#define LOWP lowp
+	precision mediump float;
+#else
+#define LOWP 
+#endif
+
+varying LOWP vec4 v_color;
+varying vec2 v_texCoords;
+
+uniform sampler2D u_texture;
+     
+void main()
+{
+	vec4 texture = texture2D(u_texture, v_texCoords);
+	float lum = dot(vec3(0.3, 0.59, 0.11), texture.rgb);
+	gl_FragColor = v_color * vec4(vec3(lum), texture.a);
+}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/AssetManagerTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/AssetManagerTest.java
@@ -25,6 +25,7 @@ import com.badlogic.gdx.assets.AssetDescriptor;
 import com.badlogic.gdx.assets.AssetErrorListener;
 import com.badlogic.gdx.assets.AssetManager;
 import com.badlogic.gdx.assets.loaders.I18NBundleLoader;
+import com.badlogic.gdx.assets.loaders.ShaderProgramLoader;
 import com.badlogic.gdx.assets.loaders.TextureLoader;
 import com.badlogic.gdx.assets.loaders.resolvers.InternalFileHandleResolver;
 import com.badlogic.gdx.assets.loaders.resolvers.ResolutionFileResolver;
@@ -34,9 +35,11 @@ import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.graphics.g2d.TextureAtlas;
+import com.badlogic.gdx.graphics.glutils.ShaderProgram;
 import com.badlogic.gdx.tests.utils.GdxTest;
 import com.badlogic.gdx.utils.BufferUtils;
 import com.badlogic.gdx.utils.I18NBundle;
+import com.badlogic.gdx.utils.Logger;
 import com.badlogic.gdx.utils.TimeUtils;
 
 public class AssetManagerTest extends GdxTest implements AssetErrorListener {
@@ -72,6 +75,7 @@ public class AssetManagerTest extends GdxTest implements AssetErrorListener {
 	private BitmapFont multiPageFont;
 	private TextureAtlas tex2;
 	private Texture tex1;
+	private ShaderProgram shader;
 
 	private void load () {
 // Gdx.app.setLogLevel(Logger.DEBUG);
@@ -83,6 +87,7 @@ public class AssetManagerTest extends GdxTest implements AssetErrorListener {
 // map = TiledLoader.createMap(Gdx.files.internal("data/tiledmap/tilemap csv.tmx"));
 // atlas = new TileAtlas(map, Gdx.files.internal("data/tiledmap/"));
 // renderer = new TileMapRenderer(map, atlas, 8, 8);
+		shader = new ShaderProgram(Gdx.files.internal("data/g2d/batchCommon.vert").readString(), Gdx.files.internal("data/g2d/monochrome.frag").readString());
 		System.out.println("plain took: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
 
 		start = TimeUtils.nanoTime();
@@ -97,6 +102,12 @@ public class AssetManagerTest extends GdxTest implements AssetErrorListener {
 // manager.load("data/tiledmap/tilemap csv.tmx", TileMapRenderer.class, new
 // TileMapRendererLoader.TileMapParameter("data/tiledmap/", 8, 8));
 		manager.load("data/i18n/message2", I18NBundle.class, new I18NBundleLoader.I18NBundleParameter(reloads % 2 == 0 ? Locale.ITALIAN : Locale.ENGLISH));
+		manager.load("data/g2d/monochrome.frag", ShaderProgram.class, new ShaderProgramLoader.ShaderProgramParameter(){
+			{
+				vertexFile = "data/g2d/batchCommon.vert";
+			}
+		});
+		
 	}
 
 	private void unload () {
@@ -106,6 +117,7 @@ public class AssetManagerTest extends GdxTest implements AssetErrorListener {
 // tex3.dispose();
 // atlas.dispose();
 // renderer.dispose();
+		shader.dispose();
 
 		manager.unload("data/animation.png");
 // manager.unload("data/pack1.png");
@@ -117,6 +129,7 @@ public class AssetManagerTest extends GdxTest implements AssetErrorListener {
 // manager.unload("data/test.etc1");
 // manager.unload("data/tiledmap/tilemap csv.tmx");
 		manager.unload("data/i18n/message2");
+		manager.unload("data/g2d/monochrome.frag");
 	}
 
 	private void invalidateTexture (Texture texture) {
@@ -146,6 +159,9 @@ public class AssetManagerTest extends GdxTest implements AssetErrorListener {
 		}
 		frame++;
 
+		if (manager.isLoaded("data/g2d/monochrome.frag")) batch.setShader(manager.get("data/g2d/monochrome.frag", ShaderProgram.class));
+		else batch.setShader(null);
+		
 		batch.begin();
 		if (manager.isLoaded("data/animation.png")) batch.draw(manager.get("data/animation.png", Texture.class), 100, 100);
 		if (manager.isLoaded("data/verdana39.png")) batch.draw(manager.get("data/verdana39.png", Texture.class), 300, 100);


### PR DESCRIPTION
It always bothers me that ShaderPrograms can't be managed along with the rest of the assets. And since they're a synchronously loaded type of asset, it would be nice for animated loading screens if they could also be included in step-by-step loading via AssetManager.

Since typically two files are used, it provides various ways to specify the second file. The easiest (zero configuration) way would be to use .vert and .frag file name suffixes, and queue them to AssetManager.load() using either of the file names.

I derived from AsynchronousAssetLoader for future flexibility. I saw that some other synchronous loaders do the same.