### PR TITLE
Fix LWJGL2 NPE when GPU driver is unsupported.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,5 @@
 [1.9.5]
+- Fix NPE swallowing "video driver unsupported" error on LWJGL 2 backend.
 - Allow window icons to be set in Lwjgl3ApplicationConfiguration or Lwjgl3WindowConfiguration.
 - Allow window icon and title to be changed in Lwjgl3Window
 - API Addition: ApplicationLogger interface, allowing easier access to custom logging

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGraphics.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGraphics.java
@@ -319,7 +319,7 @@ public class LwjglGraphics implements Graphics {
 						createDisplayPixelFormat(useGL30, gles30ContextMajor, gles30ContextMinor);
 						return;
 					}
-					throw new GdxRuntimeException("OpenGL is not supported by the video driver: " + glVersion.getDebugVersionString(), ex3);
+					throw new GdxRuntimeException("OpenGL is not supported by this video driver.", ex3);
 				}
 				if (getDisplayMode().bitsPerPixel == 16) {
 					bufferFormat = new BufferFormat(5, 6, 5, 0, 8, 0, 0, false);


### PR DESCRIPTION
Problem:

- In LwjglGraphics, glVersion is not initialized until after
  #createDisplayPixelFormat is called, yet when all else fails when
  creating an OpenGL context in this method, throwing a
  GdxRuntimeException, it attempts to call
  glVersion#getDebugVersionString, which always results in a
  NullPointerException, because glVersion is always null here.

- This NPE swallows the original, useful error message ("OpenGL is not
  supported by the video driver: "), as well as the original exception,
  which most likely is an LwjglException with the message "pixel format
  not accelerated.", which is also useful.

Solution:

- Do not attempt to get the non-existent OpenGL debug string when
  re-throwing an exception from #createDisplayPixelFormat.

- Reword the error message to exclude the debug string.

Other:

- Update CHANGES file with fix.

Related to #4356.