### PR TITLE
fixes libgdx/libgdx#2252 reduce CPU usage in OpenALAudioDevice

### DIFF
--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/audio/OpenALAudioDevice.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/audio/OpenALAudioDevice.java
@@ -145,7 +145,7 @@ public class OpenALAudioDevice implements AudioDevice {
 			}
 			// Wait for buffer to be free.
 			try {
-				Thread.sleep((long)(1000 * secondsPerBuffer / bufferCount));
+				Thread.sleep((long)(1000 * secondsPerBuffer));
 			} catch (InterruptedException ignored) {
 			}
 		}

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALAudioDevice.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALAudioDevice.java
@@ -145,7 +145,7 @@ public class OpenALAudioDevice implements AudioDevice {
 			}
 			// Wait for buffer to be free.
 			try {
-				Thread.sleep((long)(1000 * secondsPerBuffer / bufferCount));
+				Thread.sleep((long)(1000 * secondsPerBuffer));
 			} catch (InterruptedException ignored) {
 			}
 		}


### PR DESCRIPTION
I had the same problem as in libgdx/libgdx#2252. When writing to audio device, Thread is not sleeping because of a wrong time calculation which result to zero (no sleep at all) with sample rate of 44100 Hz or above.