### PR TITLE
Generic Animation class

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -18,6 +18,7 @@
 - Lwjgl3Window now has a maximize() method, and windows can be started maximized using the window or app configuration's setMaximized() method.
 - NinePatch can now be drawn rotated or scaled.
 - NinepatchDrawable is now a TransformDrawable.
+- API Change: g2d.Animation is now generic so it can support Drawables, PolygonRegions, NinePatches, etc. To fix existing code, specify the TextureRegion type in animation declarations (and instantiations in Java 6), i.e. Animation<TextureRegion> myAnimation = new Animation<TextureRegion>(...);
 
 [1.9.4]
 - Moved snapping from ProgressBar to Slider to prevent snapping when setting the value programmatically.

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/Animation.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/Animation.java
@@ -20,13 +20,16 @@ import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.utils.Array;
 
 /** <p>
- * An Animation stores a list of {@link TextureRegion}s representing an animated sequence, e.g. for running or jumping. Each
- * region of an Animation is called a key frame, multiple key frames make up the animation.
- * </p>
+ * An Animation stores a list of objects representing an animated sequence, e.g. for running or jumping. Each
+ * object in the Animation is called a key frame, and multiple key frames make up the animation.
+ * <p>
+ * The animation's type is the class representing a frame of animation. For example, a typical 2D animation could be made
+ * up of {@link com.badlogic.gdx.graphics.g2d.TextureRegion TextureRegions} and would be specified as:
+ * <p><code>Animation&lt;TextureRegion&gt; myAnimation = new Animation&lt;TextureRegion&gt;(...);</code>
  * 
  * @author mzechner */
-public class Animation {
-
+public class Animation<T> {
+	
 	/** Defines possible playback modes for an {@link Animation}. */
 	public enum PlayMode {
 		NORMAL,
@@ -36,8 +39,9 @@ public class Animation {
 		LOOP_PINGPONG,
 		LOOP_RANDOM,
 	}
-
-	final TextureRegion[] keyFrames;
+	
+	/** Length must not be modified without updating {@link #animationDuration}. See {@link #setKeyFrames(T[])}. */
+	T[] keyFrames;
 	private float frameDuration;
 	private float animationDuration;
 	private int lastFrameNumber;
@@ -48,54 +52,42 @@ public class Animation {
 	/** Constructor, storing the frame duration and key frames.
 	 * 
 	 * @param frameDuration the time between frames in seconds.
-	 * @param keyFrames the {@link TextureRegion}s representing the frames. */
-	public Animation (float frameDuration, Array<? extends TextureRegion> keyFrames) {
+	 * @param keyFrames the objects representing the frames. */
+	public Animation (float frameDuration, Array<? extends T> keyFrames) {
 		this.frameDuration = frameDuration;
-		this.animationDuration = keyFrames.size * frameDuration;
-		this.keyFrames = new TextureRegion[keyFrames.size];
+		T[] frames = (T[]) new Object[keyFrames.size];
 		for (int i = 0, n = keyFrames.size; i < n; i++) {
-			this.keyFrames[i] = keyFrames.get(i);
+			frames[i] = keyFrames.get(i);
 		}
-
-		this.playMode = PlayMode.NORMAL;
-	}
-
-	/** Constructor, storing the frame duration, key frames and play type.
-	 * 
-	 * @param frameDuration the time between frames in seconds.
-	 * @param keyFrames the {@link TextureRegion}s representing the frames.
-	 * @param playMode the animation playback mode. */
-	public Animation (float frameDuration, Array<? extends TextureRegion> keyFrames, PlayMode playMode) {
-
-		this.frameDuration = frameDuration;
-		this.animationDuration = keyFrames.size * frameDuration;
-		this.keyFrames = new TextureRegion[keyFrames.size];
-		for (int i = 0, n = keyFrames.size; i < n; i++) {
-			this.keyFrames[i] = keyFrames.get(i);
-		}
-
-		this.playMode = playMode;
+		setKeyFrames(frames);
 	}
 
 	/** Constructor, storing the frame duration and key frames.
 	 * 
 	 * @param frameDuration the time between frames in seconds.
-	 * @param keyFrames the {@link TextureRegion}s representing the frames. */
-	public Animation (float frameDuration, TextureRegion... keyFrames) {
-		this.frameDuration = frameDuration;
-		this.animationDuration = keyFrames.length * frameDuration;
-		this.keyFrames = keyFrames;
-		this.playMode = PlayMode.NORMAL;
+	 * @param keyFrames the objects representing the frames. */
+	public Animation (float frameDuration, Array<? extends T> keyFrames, PlayMode playMode) {
+		this(frameDuration, keyFrames);
+		setPlayMode(playMode);
 	}
 
-	/** Returns a {@link TextureRegion} based on the so called state time. This is the amount of seconds an object has spent in the
+	/** Constructor, storing the frame duration and key frames.
+	 * 
+	 * @param frameDuration the time between frames in seconds.
+	 * @param keyFrames the objects representing the frames. */
+	public Animation (float frameDuration, T... keyFrames) {
+		this.frameDuration = frameDuration;
+		setKeyFrames(keyFrames);
+	}
+
+	/** Returns a frame based on the so called state time. This is the amount of seconds an object has spent in the
 	 * state this Animation instance represents, e.g. running, jumping and so on. The mode specifies whether the animation is
 	 * looping or not.
 	 * 
 	 * @param stateTime the time spent in the state represented by this animation.
 	 * @param looping whether the animation is looping or not.
-	 * @return the TextureRegion representing the frame of animation for the given state time. */
-	public TextureRegion getKeyFrame (float stateTime, boolean looping) {
+	 * @return the frame of animation for the given state time. */
+	public T getKeyFrame (float stateTime, boolean looping) {
 		// we set the play mode by overriding the previous mode based on looping
 		// parameter value
 		PlayMode oldPlayMode = playMode;
@@ -111,18 +103,18 @@ public class Animation {
 				playMode = PlayMode.LOOP;
 		}
 
-		TextureRegion frame = getKeyFrame(stateTime);
+		T frame = getKeyFrame(stateTime);
 		playMode = oldPlayMode;
 		return frame;
 	}
 
-	/** Returns a {@link TextureRegion} based on the so called state time. This is the amount of seconds an object has spent in the
+	/** Returns a frame based on the so called state time. This is the amount of seconds an object has spent in the
 	 * state this Animation instance represents, e.g. running, jumping and so on using the mode specified by
 	 * {@link #setPlayMode(PlayMode)} method.
 	 * 
 	 * @param stateTime
-	 * @return the TextureRegion representing the frame of animation for the given state time. */
-	public TextureRegion getKeyFrame (float stateTime) {
+	 * @return the frame of animation for the given state time. */
+	public T getKeyFrame (float stateTime) {
 		int frameNumber = getKeyFrameIndex(stateTime);
 		return keyFrames[frameNumber];
 	}
@@ -168,10 +160,15 @@ public class Animation {
 		return frameNumber;
 	}
 
-	/** Returns the keyFrames[] array where all the TextureRegions of the animation are stored.
-	 * @return keyFrames[] field */
-	public TextureRegion[] getKeyFrames () {
+	/** Returns the keyframes[] array where all the frames of the animation are stored.
+	 * @return The keyframes[] field. */
+	public T[] getKeyFrames () {
 		return keyFrames;
+	}
+	
+	protected void setKeyFrames (T... keyFrames) {
+		this.keyFrames = keyFrames;
+		this.animationDuration = keyFrames.length * frameDuration;
 	}
 
 	/** Returns the animation play mode. */

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/AnimationTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/AnimationTest.java
@@ -48,8 +48,8 @@ public class AnimationTest extends GdxTest {
 		}
 	}
 
-	Animation leftWalk;
-	Animation rightWalk;
+	Animation<TextureRegion> leftWalk;
+	Animation<TextureRegion> rightWalk;
 	Caveman[] cavemen;
 	Texture texture;
 	SpriteBatch batch;
@@ -65,8 +65,8 @@ public class AnimationTest extends GdxTest {
 			frame.flip(true, false);
 			rightWalkFrames[i] = frame;
 		}
-		leftWalk = new Animation(0.25f, leftWalkFrames);
-		rightWalk = new Animation(0.25f, rightWalkFrames);
+		leftWalk = new Animation<TextureRegion>(0.25f, leftWalkFrames);
+		rightWalk = new Animation<TextureRegion>(0.25f, rightWalkFrames);
 
 		cavemen = new Caveman[100];
 		for (int i = 0; i < 100; i++) {

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/SimpleAnimationTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/SimpleAnimationTest.java
@@ -26,16 +26,16 @@ import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.tests.utils.GdxTest;
 
 public class SimpleAnimationTest extends GdxTest {
-	private Animation currentWalk;
+	private Animation<TextureRegion> currentWalk;
 	private float currentFrameTime;
 	private Vector2 position;
 
 	private Texture texture;
 
-	private Animation downWalk;
-	private Animation leftWalk;
-	private Animation rightWalk;
-	private Animation upWalk;
+	private Animation<TextureRegion> downWalk;
+	private Animation<TextureRegion> leftWalk;
+	private Animation<TextureRegion> rightWalk;
+	private Animation<TextureRegion> upWalk;
 
 	private SpriteBatch spriteBatch;
 
@@ -50,10 +50,10 @@ public class SimpleAnimationTest extends GdxTest {
 		TextureRegion[] leftWalkReg = regions[1];
 		TextureRegion[] rightWalkReg = regions[2];
 		TextureRegion[] upWalkReg = regions[3];
-		downWalk = new Animation(ANIMATION_SPEED, downWalkReg);
-		leftWalk = new Animation(ANIMATION_SPEED, leftWalkReg);
-		rightWalk = new Animation(ANIMATION_SPEED, rightWalkReg);
-		upWalk = new Animation(ANIMATION_SPEED, upWalkReg);
+		downWalk = new Animation<TextureRegion>(ANIMATION_SPEED, downWalkReg);
+		leftWalk = new Animation<TextureRegion>(ANIMATION_SPEED, leftWalkReg);
+		rightWalk = new Animation<TextureRegion>(ANIMATION_SPEED, rightWalkReg);
+		upWalk = new Animation<TextureRegion>(ANIMATION_SPEED, upWalkReg);
 
 		currentWalk = leftWalk;
 		currentFrameTime = 0.0f;

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/superkoalio/SuperKoalio.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/superkoalio/SuperKoalio.java
@@ -69,9 +69,9 @@ public class SuperKoalio extends GdxTest {
 	private OrthogonalTiledMapRenderer renderer;
 	private OrthographicCamera camera;
 	private Texture koalaTexture;
-	private Animation stand;
-	private Animation walk;
-	private Animation jump;
+	private Animation<TextureRegion> stand;
+	private Animation<TextureRegion> walk;
+	private Animation<TextureRegion> jump;
 	private Koala koala;
 	private Pool<Rectangle> rectPool = new Pool<Rectangle>() {
 		@Override


### PR DESCRIPTION
I have found myself copy-pasting the Animation class a few times to support NinePatches or certain types of Drawables. I think PolygonRegions would be another common need. I'm also playing around with multi-texturing for normal-mapped sprites, so an animation made up of TextureRegionPairs would be useful. So it makes sense for the frame type to be generic.

This is one way to do it that shouldn't affect existing code, unless someone is serializing Animations for some reason (although I doubt anyone is trying to serialize TextureRegions, nor does it make sense to serialize assets). I created a new Animation class in the `utils` package (since this theoretically could be used for more than just 2D animation frames, think decals or some sort of state manager). The existing Animation class extends from it and has a pass-through PlayMode class to prevent code breakage, and having to fully qualify PlayMode if the g2d.Animation class has been imported.

Here are some alternative ways to do this. Any opinions?

1. Do it like this PR, except that the existing g2d.Animation class is untouched. Zero chance of code breakage, but now we'd have two classes with a bunch of duplicate code.
2. Do it like this PR, but give the utils.Animation class a different name to avoid confusion. Maybe could also remove the g2d.Animation.PlayMode pass-through class, although that would force people to fix up some code by importing the new class.
3. Keep this PR as is, deprecate the old g2d.Animation class, with a Javadoc explaining the change, and remove it in a year or two. In the long term this may be the cleanest.
4. Rip off the Band-Aid by deleting the g2d.Animation class now.
5. Forget the new class. Just make g2d.Animation generic, and force people to update code to specify &lt;TextureRegion&gt;. This is a nice middle-ground. Code will be broken, but is easy to fix, and it avoids adding a new class.