### PR TITLE
Fix RenderContext Javadoc

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g3d/utils/RenderContext.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/utils/RenderContext.java
@@ -39,15 +39,7 @@ public class RenderContext {
 		this.textureBinder = textures;
 	}
 
-	/** Sets up the render context, must be matched with a call to {@link #end()}. Resets the following OpenGL states to their
-	 * defaults:
-	 * <ul>
-	 * <li>Depth buffer writing (depth mask) is enabled.
-	 * <li>Depth testing is disabled.
-	 * <li>Face culling is disabled.
-	 * <li>Blending is disabled.
-	 * </ul>
-	 */
+	/** Sets up the render context, must be matched with a call to {@link #end()}. */
 	public void begin () {
 		Gdx.gl.glDisable(GL20.GL_DEPTH_TEST);
 		depthFunc = 0;

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/utils/RenderContext.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/utils/RenderContext.java
@@ -39,7 +39,7 @@ public class RenderContext {
 		this.textureBinder = textures;
 	}
 
-	/** Sets up the render context, must be matched with a call to {@link #end()}. Assumes that the OpenGL states are in their
+	/** Sets up the render context, must be matched with a call to {@link #end()}. Resets the OpenGL states to their
 	 * defaults. */
 	public void begin () {
 		Gdx.gl.glDisable(GL20.GL_DEPTH_TEST);

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/utils/RenderContext.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/utils/RenderContext.java
@@ -39,8 +39,15 @@ public class RenderContext {
 		this.textureBinder = textures;
 	}
 
-	/** Sets up the render context, must be matched with a call to {@link #end()}. Resets the OpenGL states to their
-	 * defaults. */
+	/** Sets up the render context, must be matched with a call to {@link #end()}. Resets the following OpenGL states to their
+	 * defaults:
+	 * <ul>
+	 * <li>Depth buffer writing (depth mask) is enabled.
+	 * <li>Depth testing is disabled.
+	 * <li>Face culling is disabled.
+	 * <li>Blending is disabled.
+	 * </ul>
+	 */
 	public void begin () {
 		Gdx.gl.glDisable(GL20.GL_DEPTH_TEST);
 		depthFunc = 0;


### PR DESCRIPTION
The begin() method states that it assumes default OpenGL states, but actually it enforces them, regardless of what the state was before calling begin().