### PR TITLE
Removed usage of Pattern and Matcher in BitmapFont

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFont.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFont.java
@@ -25,8 +25,6 @@ package com.badlogic.gdx.graphics.g2d;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.util.StringTokenizer;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.files.FileHandle;
@@ -528,25 +526,18 @@ public class BitmapFont implements Disposable {
 					if (line == null) throw new GdxRuntimeException("Missing additional page definitions.");
 
 					// Expect ID to mean "index".
-					Matcher matcher = Pattern.compile(".*id=(\\d+)").matcher(line);
-					if (matcher.matches()) {
-						String id = matcher.group(1);
-						try {
-							int pageID = Integer.parseInt(id.substring(3));
-							if (pageID != p) throw new GdxRuntimeException("Page IDs must be indices starting at 0: " + id.substring(3));
+					String id = line.substring(line.indexOf("id="), line.indexOf("id=")+4);
+					try {
+						int pageID = Integer.parseInt(id.substring(3));
+						if (pageID != p)
+                        				throw new GdxRuntimeException("Page IDs must be indices starting at 0: " + id.substring(3));
 						} catch (NumberFormatException ex) {
 							throw new GdxRuntimeException("Invalid page id: " + id.substring(3), ex);
 						}
+						String fileName = line.substring(line.indexOf("file=")+5);
+						imagePaths[p] = fontFile.parent().child(fileName).path().replaceAll("\\\\", "/");
 					}
-
-					matcher = Pattern.compile(".*file=\"?([^\"]*+)\"?").matcher(line);
-					if (!matcher.matches()) throw new GdxRuntimeException("Missing: file");
-					String fileName = matcher.group(1);
-
-					imagePaths[p] = fontFile.parent().child(fileName).path().replaceAll("\\\\", "/");
-				}
 				descent = 0;
-
 				while (true) {
 					line = reader.readLine();
 					if (line == null) break; // EOF

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFont.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFont.java
@@ -525,14 +525,15 @@ public class BitmapFont implements Disposable {
 					line = reader.readLine();
 					if (line == null) throw new GdxRuntimeException("Missing additional page definitions.");
 					// Expect ID to mean "index".
-					if(!line.contains("id=")) throw new GdxRuntimeException("Missing: id");
-					String id = line.substring(line.indexOf("id="), line.indexOf(" ", line.indexOf("id=")));
-					try {
-						int pageID = Integer.parseInt(id.substring(3));
-						if (pageID != p)
-                        				throw new GdxRuntimeException("Page IDs must be indices starting at 0: " + id.substring(3));
-					} catch (NumberFormatException ex) {
-						throw new GdxRuntimeException("Invalid page id: " + id.substring(3), ex);
+					if(line.contains("id=")){
+						String id = line.substring(line.indexOf("id="), line.indexOf(" ", line.indexOf("id=")));
+						try {
+							int pageID = Integer.parseInt(id.substring(3));
+							if (pageID != p)
+                        					throw new GdxRuntimeException("Page IDs must be indices starting at 0: " + id.substring(3));
+						} catch (NumberFormatException ex) {
+							throw new GdxRuntimeException("Invalid page id: " + id.substring(3), ex);
+						}
 					}
 					if(!line.contains("file=")) throw new GdxRuntimeException("Missing: file");
 					String fileName = line.substring(line.indexOf("file=")+5);

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFont.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFont.java
@@ -526,7 +526,7 @@ public class BitmapFont implements Disposable {
 					if (line == null) throw new GdxRuntimeException("Missing additional page definitions.");
 
 					// Expect ID to mean "index".
-					String id = line.substring(line.indexOf("id="), line.indexOf("id=")+4);
+					String id = line.substring(line.indexOf("id="), line.indexOf(" ", line.indexOf("id=")));
 					try {
 						int pageID = Integer.parseInt(id.substring(3));
 						if (pageID != p)

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFont.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFont.java
@@ -524,19 +524,20 @@ public class BitmapFont implements Disposable {
 					// Read each "page" info line.
 					line = reader.readLine();
 					if (line == null) throw new GdxRuntimeException("Missing additional page definitions.");
-
 					// Expect ID to mean "index".
+					if(!line.contains("id=")) throw new GdxRuntimeException("Missing: id");
 					String id = line.substring(line.indexOf("id="), line.indexOf(" ", line.indexOf("id=")));
 					try {
 						int pageID = Integer.parseInt(id.substring(3));
 						if (pageID != p)
                         				throw new GdxRuntimeException("Page IDs must be indices starting at 0: " + id.substring(3));
-						} catch (NumberFormatException ex) {
-							throw new GdxRuntimeException("Invalid page id: " + id.substring(3), ex);
-						}
-						String fileName = line.substring(line.indexOf("file=")+5);
-						imagePaths[p] = fontFile.parent().child(fileName).path().replaceAll("\\\\", "/");
+					} catch (NumberFormatException ex) {
+						throw new GdxRuntimeException("Invalid page id: " + id.substring(3), ex);
 					}
+					if(!line.contains("file=")) throw new GdxRuntimeException("Missing: file");
+					String fileName = line.substring(line.indexOf("file=")+5);
+					imagePaths[p] = fontFile.parent().child(fileName).path().replaceAll("\\\\", "/");
+				}
 				descent = 0;
 				while (true) {
 					line = reader.readLine();


### PR DESCRIPTION
These wouldn't function properly in GWT 2.8.0 so I changed it to simply use substring.