### PR TITLE
Fix #4471 start LWJGL3 on the first thread on Mac

### DIFF
--- a/tests/gdx-tests-lwjgl3/build.gradle
+++ b/tests/gdx-tests-lwjgl3/build.gradle
@@ -34,6 +34,11 @@ task launchTestsLwjgl3 (dependsOn: classes, type: JavaExec) {
     standardInput = System.in
     workingDir = new File("../gdx-tests-android/assets")
     ignoreExitValue = true
+    
+    if (System.getProperty("os.name").toLowerCase().contains("mac")) {
+        // Required to run lwjgl java apps on Mac OSX
+        jvmArgs = ["-XstartOnFirstThread"]
+    }
 }
 configure (launchTestsLwjgl3) {
     group "LibGDX"


### PR DESCRIPTION
LWJGL3 needs to be started on the first thread on Mac, because
only the first thread can process input and user events.