### PR TITLE
Fix BitmapFont parsing

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFont.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFont.java
@@ -528,8 +528,8 @@ public class BitmapFont implements Disposable {
 					if (line == null) throw new GdxRuntimeException("Missing additional page definitions.");
 
 					// Expect ID to mean "index".
-					Matcher matcher = Pattern.compile(".*id=(\\d+).*").matcher(line);
-					if (matcher.matches()) {
+					Matcher matcher = Pattern.compile(".*id=(\\d+)").matcher(line);
+					if (matcher.find()) {
 						String id = matcher.group(1);
 						try {
 							int pageID = Integer.parseInt(id);
@@ -539,8 +539,8 @@ public class BitmapFont implements Disposable {
 						}
 					}
 
-					matcher = Pattern.compile(".*file=\"?([^\"]+)\"?.*").matcher(line);
-					if (!matcher.matches()) throw new GdxRuntimeException("Missing: file");
+					matcher = Pattern.compile(".*file=\"?([^\"]+)\"?").matcher(line);
+					if (!matcher.find()) throw new GdxRuntimeException("Missing: file");
 					String fileName = matcher.group(1);
 
 					imagePaths[p] = fontFile.parent().child(fileName).path().replaceAll("\\\\", "/");

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFont.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFont.java
@@ -528,18 +528,18 @@ public class BitmapFont implements Disposable {
 					if (line == null) throw new GdxRuntimeException("Missing additional page definitions.");
 
 					// Expect ID to mean "index".
-					Matcher matcher = Pattern.compile(".*id=(\\d+)").matcher(line);
+					Matcher matcher = Pattern.compile(".*id=(\\d+).*").matcher(line);
 					if (matcher.matches()) {
 						String id = matcher.group(1);
 						try {
-							int pageID = Integer.parseInt(id.substring(3));
-							if (pageID != p) throw new GdxRuntimeException("Page IDs must be indices starting at 0: " + id.substring(3));
+							int pageID = Integer.parseInt(id);
+							if (pageID != p) throw new GdxRuntimeException("Page IDs must be indices starting at 0: " + id);
 						} catch (NumberFormatException ex) {
-							throw new GdxRuntimeException("Invalid page id: " + id.substring(3), ex);
+							throw new GdxRuntimeException("Invalid page id: " + id, ex);
 						}
 					}
 
-					matcher = Pattern.compile(".*file=\"?([^\"]*+)\"?").matcher(line);
+					matcher = Pattern.compile(".*file=\"?([^\"]+)\"?.*").matcher(line);
 					if (!matcher.matches()) throw new GdxRuntimeException("Missing: file");
 					String fileName = matcher.group(1);
 


### PR DESCRIPTION
#### Issue details
A recent commit https://github.com/libgdx/libgdx/commit/7420bd0f5111b73e2f1b9c5393640adfbc4aadbb changed a few regular expressions on the BMFont parser, which are now giving problems on GWT.

Desktop jvm expects to match the whole string when matching the expression to find the "id=", while GWT matches part of the string. With the current expression desktop fails to match the string (incorrectly) but gwt seems to find a match, leading to the problem when going through "id.substring(3)" when the id already contains the match group with the expected number and returns an empty string.

Desktop jvm also seems to be more forgiving when matching the expression used to find the "file=", but GWT throws an exception when it encounters "*+".

#### Reproduction steps/code
Just load a font in GWT.

#### Version of LibGDX and/or relevant dependencies
1.9.5

#### Please select the affected platforms
- [ ] Android
- [ ] iOS (robovm)
- [ ] iOS (MOE)
- [x] HTML/GWT
- [ ] Windows
- [ ] Linux
- [ ] MacOS