### PR TITLE
Lwjgl3Input delegates to InputEventQueue for event timestamps.

### DIFF
--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Input.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Input.java
@@ -41,20 +41,14 @@ public class Lwjgl3Input implements Input, Disposable {
 	private int pressedKeys;
 	private boolean keyJustPressed;
 	private boolean[] justPressedKeys = new boolean[256];
-	private long currentEventTime;	
 	private char lastCharacter;
-	
-	private void updateCurrentEventTime () {
-		currentEventTime = System.nanoTime();
-	}
-	
+		
 	private GLFWKeyCallback keyCallback = new GLFWKeyCallback() {		
 		@Override
 		public void invoke(long window, int key, int scancode, int action, int mods) {
 			switch (action) {
 			case GLFW.GLFW_PRESS:
 				key = getGdxKeyCode(key);
-				updateCurrentEventTime();
 				eventQueue.keyDown(key);								
 				pressedKeys++;
 				keyJustPressed = true;
@@ -67,14 +61,12 @@ public class Lwjgl3Input implements Input, Disposable {
 			case GLFW.GLFW_RELEASE:
 				pressedKeys--;
 				Lwjgl3Input.this.window.getGraphics().requestRendering();
-				updateCurrentEventTime();
 				eventQueue.keyUp(getGdxKeyCode(key));
 				break;
 
 			case GLFW.GLFW_REPEAT:
 				if (lastCharacter != 0) {
 					Lwjgl3Input.this.window.getGraphics().requestRendering();
-					updateCurrentEventTime();
 					eventQueue.keyTyped(lastCharacter);
 				}
 				break;
@@ -88,7 +80,6 @@ public class Lwjgl3Input implements Input, Disposable {
 			if ((codepoint & 0xff00) == 0xf700) return;
 			lastCharacter = (char)codepoint;
 			Lwjgl3Input.this.window.getGraphics().requestRendering();
-			updateCurrentEventTime();
 			eventQueue.keyTyped((char)codepoint);
 		}
 	};
@@ -97,7 +88,6 @@ public class Lwjgl3Input implements Input, Disposable {
 		@Override
 		public void invoke(long window, double scrollX, double scrollY) {
 			Lwjgl3Input.this.window.getGraphics().requestRendering();
-			updateCurrentEventTime();
 			eventQueue.scrolled((int)-Math.signum(scrollY));
 		}
 	};
@@ -123,7 +113,6 @@ public class Lwjgl3Input implements Input, Disposable {
 			}
 			
 			Lwjgl3Input.this.window.getGraphics().requestRendering();
-			updateCurrentEventTime();
 			if (mousePressed > 0) {								
 				eventQueue.touchDragged(mouseX, mouseY, 0);
 			} else {								
@@ -137,7 +126,6 @@ public class Lwjgl3Input implements Input, Disposable {
 		public void invoke(long window, int button, int action, int mods) {
 			int gdxButton = toGdxButton(button);
 			if (button != -1 && gdxButton == -1) return;
-			updateCurrentEventTime(); 
 
 			if (action == GLFW.GLFW_PRESS) {
 				mousePressed++;
@@ -296,7 +284,8 @@ public class Lwjgl3Input implements Input, Disposable {
 
 	@Override
 	public long getCurrentEventTime() {
-		return currentEventTime;
+		// queue sets its event time for each event dequeued/processed
+		return eventQueue.getCurrentEventTime();
 	}	
 
 	@Override


### PR DESCRIPTION
Would close #4512.

Suggest that `Lwjgl3Input` should delegate to its `InputEventQueue` for event timestamp reporting, instead of keeping its own `currentEventTime` field.