### PR TITLE
gdx-dialogs extension version is now 1.2.0 and supports GWT

### DIFF
--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/data/extensions.xml
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/data/extensions.xml
@@ -149,8 +149,8 @@
 	   <name>gdx-dialogs</name>
 	   <description>Provides cross-platform support for native dialogs</description>
 	   <package>de.tomgrill.gdxdialogs</package>
-	   <version>1.1.0</version>
-	   <compatibility>1.9.3</compatibility>
+	   <version>1.2.0</version>
+	   <compatibility>1.9.5</compatibility>
 	   <website>https://github.com/TomGrill/gdx-dialogs</website>
 	   <gwtInherits></gwtInherits>
 	   <projects>
@@ -169,7 +169,11 @@
 			<ios-moe>
 				<dependency>de.tomgrill.gdxdialogs:gdx-dialogs-ios-moe</dependency>
 			</ios-moe>
-			<html>null</html>
+			<html>
+		   		<dependency>de.tomgrill.gdxdialogs:gdx-dialogs-html</dependency>
+				<dependency>de.tomgrill.gdxdialogs:gdx-dialogs-html:sources</dependency>
+				<dependency>de.tomgrill.gdxdialogs:gdx-dialogs-core:sources</dependency>
+		   	</html>
 		</projects>
 	</extension>
 	<extension>


### PR DESCRIPTION
gdx-dialogs extension version is now 1.2.0 and supports GWT