### PR TITLE
Add Mesh constructor for VertexAttributes

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/Mesh.java
+++ b/gdx/src/com/badlogic/gdx/graphics/Mesh.java
@@ -150,6 +150,17 @@ public class Mesh implements Disposable {
 	 * @param attributes the {@link VertexAttribute}s. Each vertex attribute defines one property of a vertex such as position,
 	 *           normal or texture coordinate */
 	public Mesh (VertexDataType type, boolean isStatic, int maxVertices, int maxIndices, VertexAttribute... attributes) {
+		this(type, isStatic, maxVertices, maxIndices, new VertexAttributes(attributes));
+	}
+	
+	/** Creates a new Mesh with the given attributes. This is an expert method with no error checking. Use at your own risk.
+	 * 
+	 * @param type the {@link VertexDataType} to be used, VBO or VA.
+	 * @param isStatic whether this mesh is static or not. Allows for internal optimizations.
+	 * @param maxVertices the maximum number of vertices this mesh can hold
+	 * @param maxIndices the maximum number of indices this mesh can hold
+	 * @param attributes the {@link VertexAttributes}. */
+	public Mesh (VertexDataType type, boolean isStatic, int maxVertices, int maxIndices, VertexAttributes attributes) {
 		switch (type) {
 		case VertexBufferObject:
 			vertices = new VertexBufferObject(isStatic, maxVertices, attributes);

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/VertexBufferObjectSubData.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/VertexBufferObjectSubData.java
@@ -47,15 +47,24 @@ public class VertexBufferObjectSubData implements VertexData {
 	final int usage;
 	boolean isDirty = false;
 	boolean isBound = false;
+	
+	/** Constructs a new interleaved VertexBufferObject.
+	 * 
+	 * @param isStatic whether the vertex data is static.
+	 * @param numVertices the maximum number of vertices
+	 * @param attributes the {@link VertexAttributes}. */
+	public VertexBufferObjectSubData (boolean isStatic, int numVertices, VertexAttribute... attributes) {
+		this(isStatic, numVertices, new VertexAttributes(attributes));
+	}
 
 	/** Constructs a new interleaved VertexBufferObject.
 	 * 
 	 * @param isStatic whether the vertex data is static.
 	 * @param numVertices the maximum number of vertices
 	 * @param attributes the {@link VertexAttribute}s. */
-	public VertexBufferObjectSubData (boolean isStatic, int numVertices, VertexAttribute... attributes) {
+	public VertexBufferObjectSubData (boolean isStatic, int numVertices, VertexAttributes attributes) {
 		this.isStatic = isStatic;
-		this.attributes = new VertexAttributes(attributes);
+		this.attributes = attributes;
 		byteBuffer = BufferUtils.newByteBuffer(this.attributes.vertexSize * numVertices);
 		isDirect = true;
 


### PR DESCRIPTION
I was finding it kind of hacky to work around this missing constructor. I wanted to work with a VertexAttributes object to calculate some stuff before instantiating the Mesh, so I ended up creating one and throwing it away before passing the same individual VertexAttribute objects to Mesh for it to generate another VertexAttributes.

Also, I could see someone possibly wanting to subclass VertexAttributes.