### PR TITLE
Vastly improve performance of DefaultShader#canRender(..)

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/DefaultShader.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/DefaultShader.java
@@ -637,6 +637,13 @@ public class DefaultShader extends BaseShader {
 		return tmpAttributes;
 	}
 
+	private static final long combineAttributeMasks (final Renderable renderable) {
+		long mask = 0;
+		if (renderable.environment != null) mask |= renderable.environment.getMask();
+		if (renderable.material != null) mask |= renderable.material.getMask();
+		return mask;
+	}
+
 	public static String createPrefix (final Renderable renderable, final Config config) {
 		final Attributes attributes = combineAttributes(renderable);
 		String prefix = "";
@@ -712,8 +719,8 @@ public class DefaultShader extends BaseShader {
 
 	@Override
 	public boolean canRender (final Renderable renderable) {
-		final Attributes attributes = combineAttributes(renderable);
-		return (attributesMask == (attributes.getMask() | optionalAttributes))
+		final long renderableMask = combineAttributeMasks(renderable);
+		return (attributesMask == (renderableMask | optionalAttributes))
 			&& (vertexMask == renderable.meshPart.mesh.getVertexAttributes().getMask()) && (renderable.environment != null) == lighting;
 	}
 


### PR DESCRIPTION
Explanation:
`DefaultShader#canRender(..)` used to call `combineAttributes(..)` on the renderable, and then only use the mask.  `combineAttributes(..)` is very expensive (around O(n<sup>2</sup>log(n)) where n is the number of unique attributes, because it sorts after adding each attribute).  But all the function really needs is the combined mask, and since we keep the masks for both Attributes objects around anyway we can get it with just a bitwise or.

Our game uses a large number of ModelInstances with about 15 shaders, which meant every time it added a renderable to the batch (several times per ModelInstance) it would have to iterate ~7 shaders on average and combineAttributes(..) for each one, which was a major hit to pre-render time.  Implementing this change brought the frame render time on our min spec phone from 40ms to 30ms, a major performance gain that made the game playable.