### PR TITLE
#4532 AL_DIRECT_CHANNELS_SOFT fixes narrow stereo channel problem wit…

### DIFF
--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALMusic.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALMusic.java
@@ -28,6 +28,7 @@ import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.utils.GdxRuntimeException;
 
 import static org.lwjgl.openal.AL10.*;
+import static org.lwjgl.openal.SOFTDirectChannels.AL_DIRECT_CHANNELS_SOFT;
 
 /** @author Nathan Sweet */
 public abstract class OpenALMusic implements Music {
@@ -77,6 +78,8 @@ public abstract class OpenALMusic implements Music {
 				int errorCode = alGetError();
 				if (errorCode != AL_NO_ERROR) throw new GdxRuntimeException("Unable to allocate audio buffers. AL Error: " + errorCode);
 			}
+
+			alSourcei(sourceID, AL_DIRECT_CHANNELS_SOFT, AL_TRUE);
 			alSourcei(sourceID, AL_LOOPING, AL_FALSE);
 			setPan(pan, volume);
 


### PR DESCRIPTION
Fix to this:
- https://github.com/libgdx/libgdx/issues/4532

It is not really possible to test this without listening to the difference. The difference is that without this fix, the left and right channels won't be cleanly separated and the audio sounds muffled. With this fix, there should be cleaner separation between left and right channels.