### PR TITLE
Fix #4536: HexagonalTiledMapRenderer staggering bug

### DIFF
--- a/gdx/src/com/badlogic/gdx/maps/tiled/renderers/HexagonalTiledMapRenderer.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/renderers/HexagonalTiledMapRenderer.java
@@ -155,9 +155,9 @@ public class HexagonalTiledMapRenderer extends BatchTiledMapRenderer {
 			for (int row = row2 - 1; row >= row1; row--) {
 				// depending on the stagger index either shift for even or uneven indexes
 				if ((row % 2 == 0) == staggerIndexEven)
-					shiftX = 0;
-				else
 					shiftX = layerTileWidth50;
+				else
+					shiftX = 0;
 				for (int col = col1; col < col2; col++) {
 					renderCell(layer.getCell(col, row), layerTileWidth * col + shiftX, tileHeightUpperCorner * row, color);
 				}


### PR DESCRIPTION
Fixed staggering on even indexes for HexagonalTiledMapRenderer (now the map has the same staggering as it appears in Tiled Editor)