### PR TITLE
Reset renderable.userData in RenderablePool

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g3d/ModelBatch.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/ModelBatch.java
@@ -55,6 +55,7 @@ public class ModelBatch implements Disposable {
 			renderable.material = null;
 			renderable.meshPart.set("", null, 0, 0, 0);
 			renderable.shader = null;
+			renderable.userData = null;
 			return renderable;
 		}
 	}

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/utils/shapebuilders/RenderableShapeBuilder.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/utils/shapebuilders/RenderableShapeBuilder.java
@@ -46,6 +46,7 @@ public class RenderableShapeBuilder extends BaseShapeBuilder {
 			renderable.material = null;
 			renderable.meshPart.set("", null, 0, 0, 0);
 			renderable.shader = null;
+			renderable.userData = null;
 			return renderable;
 		}
 	}


### PR DESCRIPTION
This pull request changes ModelBatch.RenderablePool.obtain() and RenderableShapeBuilder.RenderablePool.obtain() to reset renderable.userData as currently it is not reset.

[Forum post](http://badlogicgames.com/forum/viewtopic.php?f=11&t=25563)