### PR TITLE
TexturePacker, allow user to set the amount of bleed iterations.

### DIFF
--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/texturepacker/TexturePacker.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/texturepacker/TexturePacker.java
@@ -223,7 +223,7 @@ public class TexturePacker {
 
 			if (settings.bleed && !settings.premultiplyAlpha
 				&& !(settings.outputFormat.equalsIgnoreCase("jpg") || settings.outputFormat.equalsIgnoreCase("jpeg"))) {
-				canvas = new ColorBleedEffect().processImage(canvas, 2);
+				canvas = new ColorBleedEffect().processImage(canvas, settings.bleedIterations);
 				g = (Graphics2D)canvas.getGraphics();
 			}
 
@@ -553,6 +553,7 @@ public class TexturePacker {
 		public boolean premultiplyAlpha;
 		public boolean useIndexes = true;
 		public boolean bleed = true;
+		public int bleedIterations = 2;
 		public boolean limitMemory = true;
 		public boolean grid;
 		public float[] scale = {1};
@@ -601,6 +602,7 @@ public class TexturePacker {
 			square = settings.square;
 			useIndexes = settings.useIndexes;
 			bleed = settings.bleed;
+			bleedIterations = settings.bleedIterations;
 			limitMemory = settings.limitMemory;
 			grid = settings.grid;
 			scale = settings.scale;


### PR DESCRIPTION
Currently TextureAtlas performs 2 iterations to bleed colored pixels to transparent ones, but this is not enough when a MipMapLinearLinear filtering is used, leaving white artifacts in the final result.

This PR exposes the amount of iterations to the user, so they can perform 2, 4, or even 8 iterations if they want to, while keeping the default value unchanged.