### PR TITLE
Fixed KTXProcessor in gdx-tools never exiting.

### DIFF
--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/ktx/KTXProcessor.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/ktx/KTXProcessor.java
@@ -337,9 +337,12 @@ public class KTXProcessor {
 				}
 
 				out.close();
+				System.out.println("Finished");
 			} catch (Exception e) {
 				Gdx.app.error("KTXProcessor", "Error writing to file: " + output.getName(), e);
 			}
+
+			Gdx.app.exit();
 		}
 	}
 


### PR DESCRIPTION
When running KTXProcessor, the process would never exit, eventhough the conversion went fine. This PR fixes this issue.