### PR TITLE
improve gitignore template fix libgdx/libgdx#4560

### DIFF
--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/gitignore
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/gitignore
@@ -6,64 +6,108 @@
 hs_err_pid*
 
 ## Robovm
-robovm-build/
+/ios/robovm-build/
 
 ## GWT
-war/
-html/war/gwt_bree/
-html/gwt-unitCache/
+/html/war/
+/html/gwt-unitCache/
 .apt_generated/
-html/war/WEB-INF/deploy/
-html/war/WEB-INF/classes/
 .gwt/
 gwt-unitCache/
 www-test/
 .gwt-tmp/
 
 ## Android Studio and Intellij and Android in general
-android/libs/armeabi/
-android/libs/armeabi-v7a/
-android/libs/arm64-v8a/
-android/libs/x86/
-android/libs/x86_64/
-android/gen/
+/android/libs/armeabi/
+/android/libs/armeabi-v7a/
+/android/libs/arm64-v8a/
+/android/libs/x86/
+/android/libs/x86_64/
+/android/gen/
 .idea/
 *.ipr
 *.iws
 *.iml
-out/
+/android/out/
 com_crashlytics_export_strings.xml
 
 ## Eclipse
+
 .classpath
 .project
-.metadata
-**/bin/
-tmp/
+.metadata/
+/android/bin/
+/core/bin/
+/desktop/bin/
+/html/bin/
+/ios/bin/
+/ios-moe/bin/
 *.tmp
 *.bak
 *.swp
 *~.nib
-local.properties
 .settings/
 .loadpath
 .externalToolBuilders/
 *.launch
 
 ## NetBeans
-**/nbproject/private/
-build/
-nbbuild/
-dist/
-nbdist/
+
+/nbproject/private/
+/android/nbproject/private/
+/core/nbproject/private/
+/desktop/nbproject/private/
+/html/nbproject/private/
+/ios/nbproject/private/
+/ios-moe/nbproject/private/
+
+/build/
+/android/build/
+/core/build/
+/desktop/build/
+/html/build/
+/ios/build/
+/ios-moe/build/
+
+/nbbuild/
+/android/nbbuild/
+/core/nbbuild/
+/desktop/nbbuild/
+/html/nbbuild/
+/ios/nbbuild/
+/ios-moe/nbbuild/
+
+/dist/
+/android/dist/
+/core/dist/
+/desktop/dist/
+/html/dist/
+/ios/dist/
+/ios-moe/dist/
+
+/nbdist/
+/android/nbdist/
+/core/nbdist/
+/desktop/nbdist/
+/html/nbdist/
+/ios/nbdist/
+/ios-moe/nbdist/
+
 nbactions.xml
 nb-configuration.xml
 
 ## Gradle
 
-.gradle
+/local.properties
+.gradle/
 gradle-app.setting
-build/
+/build/
+/android/build/
+/core/build/
+/desktop/build/
+/html/build/
+/ios/build/
+/ios-moe/build/
 
 ## OS Specific
 .DS_Store


### PR DESCRIPTION
as discussed in #4560, here is the fix (maybe not the final fix).

I'm not really confident with these modifications because I'm not using all OS/IDE/Targets. I'm using eclipse on linux and mostly target desktop and android so I think this fix should be validated by more contributors.

Has you can see, what I've done so far is : 
* add leading slashes and full path to avoid unwanted ignore.
* removed some duplicates : for instance html/war/WEB-INF/deploy/ is useless with /html/war
* removed some IMO useless : tmp/
* move local.properties to gradle section

Note that I could use single wildcard instead of path for every sub project (for instance /*/dist/) but it could conflicts with some project specific folder structure.

@Tom-Ski : I don't really understand why you want to keep just one big file instead of dispatching some parts in related sub projects. It would be cleaner way for many reasons : 
* make gitignore files more readable.
* avoid useless ignore when not targeting all platforms.
* easily manage sub folder renaming / moving.

Thanks to point me in the right direction in order to improve these changes.