### PR TITLE
Update libgdx-utils 3rd party extension

### DIFF
--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/data/extensions.xml
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/data/extensions.xml
@@ -74,8 +74,8 @@
 		<name>libgdx-utils</name>
 		<description>Various utilities and features</description>
 		<package>net.dermetfan.gdx</package>
-		<version>0.13.3</version>
-		<compatibility>1.9.2</compatibility>
+		<version>0.13.4</version>
+		<compatibility>1.9.5</compatibility>
 		<website>http://dermetfan.net/libgdx-utils.php</website>
 		<gwtInherits>
 			<inherit>libgdx-utils</inherit>
@@ -97,8 +97,8 @@
 		<name>libgdx-utils-box2d</name>
 		<description>Various utilities and features for the Box2D extension</description>
 		<package>net.dermetfan.gdx</package>
-		<version>0.13.3</version>
-		<compatibility>1.9.2</compatibility>
+		<version>0.13.4</version>
+		<compatibility>1.9.5</compatibility>
 		<website>http://dermetfan.net/libgdx-utils.php</website>
 		<gwtInherits>
 			<inherit>libgdx-utils-box2d</inherit>


### PR DESCRIPTION
new release to fix [incompatibility](https://bitbucket.org/dermetfan/libgdx-utils/issues/18/not-compatible-with-gwt-html5-on-libgdx#comment-32858945) with libGDX 1.9.5