### PR TITLE
LwjglAWTCanvas: Fix for flickering cursor during swing/javafx drag & drop

### DIFF
--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglAWTCanvas.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglAWTCanvas.java
@@ -76,7 +76,6 @@ public class LwjglAWTCanvas implements Application {
 	int logLevel = LOG_INFO;
 	ApplicationLogger applicationLogger;
 	final String logTag = "LwjglAWTCanvas";
-	Cursor cursor;
 
 	public LwjglAWTCanvas (ApplicationListener listener) {
 		this(listener, null, null);
@@ -251,7 +250,6 @@ public class LwjglAWTCanvas implements Application {
 		if (!running) return;
 
 		setGlobals();
-		canvas.setCursor(cursor);
 
 		int width = Math.max(1, graphics.getWidth());
 		int height = Math.max(1, graphics.getHeight());
@@ -481,7 +479,7 @@ public class LwjglAWTCanvas implements Application {
 
 	/** @param cursor May be null. */
 	public void setCursor (Cursor cursor) {
-		this.cursor = cursor;
+		canvas.setCursor(cursor);
 	}
 
 	@Override

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglCanvas.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglCanvas.java
@@ -63,7 +63,6 @@ public class LwjglCanvas implements Application {
 	boolean running = true;
 	int logLevel = LOG_INFO;
 	ApplicationLogger applicationLogger;
-	Cursor cursor;
 
 	public LwjglCanvas (ApplicationListener listener) {
 		LwjglApplicationConfiguration config = new LwjglApplicationConfiguration();
@@ -213,7 +212,6 @@ public class LwjglCanvas implements Application {
 				}
 				try {
 					Display.processMessages();
-					if (cursor != null || !isWindows) canvas.setCursor(cursor);
 
 					boolean shouldRender = false;
 
@@ -416,7 +414,7 @@ public class LwjglCanvas implements Application {
 
 	/** @param cursor May be null. */
 	public void setCursor (Cursor cursor) {
-		this.cursor = cursor;
+		canvas.setCursor(cursor);
 	}
 
 	@Override


### PR DESCRIPTION
Every render frame, canvas.setCursor(cursor); would be called:
https://github.com/libgdx/libgdx/blob/master/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglAWTCanvas.java#L254

When you have an application using swing or javafx drag & drop features, the above will cause the mouse-cursor to flicker during dnd.

LwjglCanvas suffers from the same issue:
https://github.com/libgdx/libgdx/blob/9b8f20b2d0e96e53f0f2b98dc8f6131c810aae71/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglCanvas.java#L216

I'm honestly not sure why this was done every frame..
@NathanSweet could you please give some insight?