### PR TITLE
MeshBuilder error using Short.MAX_VALUE vertices

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g3d/utils/MeshBuilder.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/utils/MeshBuilder.java
@@ -72,7 +72,7 @@ public class MeshBuilder implements MeshPartBuilder {
 	/** The size (in number of floats) of each vertex */
 	private int stride;
 	/** The current vertex index, used for indexing */
-	private short vindex;
+	private int vindex;
 	/** The offset in the indices array when begin() was called, used to define a meshpart. */
 	private int istart;
 	/** The offset within an vertex to position */
@@ -536,7 +536,7 @@ public class MeshBuilder implements MeshPartBuilder {
 
 	@Override
 	public short vertex (Vector3 pos, Vector3 nor, Color col, Vector2 uv) {
-		if (vindex >= Short.MAX_VALUE) throw new GdxRuntimeException("Too many vertices used");
+		if (vindex > Short.MAX_VALUE) throw new GdxRuntimeException("Too many vertices used");
 
 		vertex[posOffset] = pos.x;
 		if (posSize > 1) vertex[posOffset + 1] = pos.y;


### PR DESCRIPTION
MeshBuilder will give an error when trying to use Short.MAX_VALUE vertices in a mesh.  This means meshes created using MeshBuilder can only use (Short.MAX_VALUE - 1) total vertices.

A use case requiring the change would be a mesh pooling implementation using MeshBuilder currently needs to check against the size of (Short.MAX_VALUE - 1) instead of the actual number of vertices allocated in the mesh.