### PR TITLE
Prevent potential crashes in IOSApplication due to audio being unavailable

### DIFF
--- a/backends/gdx-backend-moe/src/com/badlogic/gdx/backends/iosmoe/IOSApplication.java
+++ b/backends/gdx-backend-moe/src/com/badlogic/gdx/backends/iosmoe/IOSApplication.java
@@ -256,9 +256,15 @@ public class IOSApplication implements Application {
 		Gdx.app.debug("IOSApplication", "resumed");
 		// workaround for ObjectAL crash problem
 		// see: https://groups.google.com/forum/?fromgroups=#!topic/objectal-for-iphone/ubRWltp_i1Q
-		OALAudioSession.sharedInstance().forceEndInterruption();
+		OALAudioSession audioSession = OALAudioSession.sharedInstance();
+		if (audioSession != null) {
+			audioSession.forceEndInterruption();
+		}
 		if (config.allowIpod) {
-			OALSimpleAudio.sharedInstance().setUseHardwareIfAvailable(false);
+			OALSimpleAudio audio = OALSimpleAudio.sharedInstance();
+			if (audio != null) {
+				audio.setUseHardwareIfAvailable(false);
+			}
 		}
 		graphics.makeCurrent();
 		graphics.resume();
@@ -267,7 +273,10 @@ public class IOSApplication implements Application {
 	final void willEnterForeground (UIApplication uiApp) {
 		// workaround for ObjectAL crash problem
 		// see: https://groups.google.com/forum/?fromgroups=#!topic/objectal-for-iphone/ubRWltp_i1Q
-		OALAudioSession.sharedInstance().forceEndInterruption();
+		OALAudioSession audioSession = OALAudioSession.sharedInstance();
+		if (audioSession != null) {
+			audioSession.forceEndInterruption();
+		}
 	}
 
 	final void willResignActive (UIApplication uiApp) {

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSApplication.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSApplication.java
@@ -247,9 +247,15 @@ public class IOSApplication implements Application {
 		Gdx.app.debug("IOSApplication", "resumed");
 		// workaround for ObjectAL crash problem
 		// see: https://groups.google.com/forum/?fromgroups=#!topic/objectal-for-iphone/ubRWltp_i1Q
-		OALAudioSession.sharedInstance().forceEndInterruption();
+		OALAudioSession audioSession = OALAudioSession.sharedInstance();
+		if (audioSession != null) {
+			audioSession.forceEndInterruption();
+		}
 		if (config.allowIpod) {
-			OALSimpleAudio.sharedInstance().setUseHardwareIfAvailable(false);
+			OALSimpleAudio audio = OALSimpleAudio.sharedInstance();
+			if (audio != null) {
+				audio.setUseHardwareIfAvailable(false);
+			}
 		}
 		graphics.makeCurrent();
 		graphics.resume();
@@ -258,7 +264,10 @@ public class IOSApplication implements Application {
 	final void willEnterForeground (UIApplication uiApp) {
 		// workaround for ObjectAL crash problem
 		// see: https://groups.google.com/forum/?fromgroups=#!topic/objectal-for-iphone/ubRWltp_i1Q
-		OALAudioSession.sharedInstance().forceEndInterruption();
+		OALAudioSession audioSession = OALAudioSession.sharedInstance();
+		if (audioSession != null) {
+			audioSession.forceEndInterruption();
+		}
 	}
 
 	final void willResignActive (UIApplication uiApp) {

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSNet.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSNet.java
@@ -20,7 +20,6 @@ import org.robovm.apple.foundation.NSURL;
 import org.robovm.apple.uikit.UIApplication;
 
 import com.badlogic.gdx.Net;
-import com.badlogic.gdx.Net.Protocol;
 import com.badlogic.gdx.net.NetJavaImpl;
 import com.badlogic.gdx.net.NetJavaServerSocketImpl;
 import com.badlogic.gdx.net.NetJavaSocketImpl;
@@ -65,6 +64,11 @@ public class IOSNet implements Net {
 
 	@Override
 	public boolean openURI (String URI) {
-		return uiApp.openURL(new NSURL(URI));
+		NSURL url = new NSURL(URI);
+		if (uiApp.canOpenURL(url)) {
+			uiApp.openURL(url);
+			return true;
+		}
+		return false;
 	}
 }


### PR DESCRIPTION
I am seeing several `EXC_BAD_ACCESS KERN_INVALID_ADDRESS` crash logs happening when `OALSimpleAudio.sharedInstance().setUseHardwareIfAvailable(false);` is called. 

The issue seems to be that the shared instance of `OALSimpleAudio` is sometimes not available and returns `null`. There is already a null-check in https://github.com/libgdx/libgdx/blob/14d89225ae26afc1cc7f52e986e566bf19425275/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSAudio.java#L34 for the very same reason.

This PR adds the same checks to `didBecomeActive` and `willEnterForeground` for the `OALAudioSession` and `OALSimpleAudio` instances. 
I also made a very small change to robovm `IOSNet` to accompany the latest changes to moe `IOSNet`.