### PR TITLE
Avoid type-unaware Animation (fixes #4476)

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g2d/Animation.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/Animation.java
@@ -18,6 +18,7 @@ package com.badlogic.gdx.graphics.g2d;
 
 import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.utils.Array;
+import com.badlogic.gdx.utils.reflect.ArrayReflection;
 
 /** <p>
  * An Animation stores a list of objects representing an animated sequence, e.g. for running or jumping. Each
@@ -52,10 +53,12 @@ public class Animation<T> {
 	/** Constructor, storing the frame duration and key frames.
 	 * 
 	 * @param frameDuration the time between frames in seconds.
-	 * @param keyFrames the objects representing the frames. */
+	 * @param keyFrames the objects representing the frames. If this Array is type-aware, {@link #getKeyFrames()} can return the
+	 *           correct type of array. Otherwise, it returns an Object[]. */
 	public Animation (float frameDuration, Array<? extends T> keyFrames) {
 		this.frameDuration = frameDuration;
-		T[] frames = (T[]) new Object[keyFrames.size];
+		Class arrayType = keyFrames.items.getClass().getComponentType();
+		T[] frames = (T[])ArrayReflection.newInstance(arrayType, keyFrames.size);
 		for (int i = 0, n = keyFrames.size; i < n; i++) {
 			frames[i] = keyFrames.get(i);
 		}
@@ -65,7 +68,8 @@ public class Animation<T> {
 	/** Constructor, storing the frame duration and key frames.
 	 * 
 	 * @param frameDuration the time between frames in seconds.
-	 * @param keyFrames the objects representing the frames. */
+	 * @param keyFrames the objects representing the frames. If this Array is type-aware, {@link #getKeyFrames()} can
+	 * return the correct type of array. Otherwise, it returns an Object[].*/
 	public Animation (float frameDuration, Array<? extends T> keyFrames, PlayMode playMode) {
 		this(frameDuration, keyFrames);
 		setPlayMode(playMode);
@@ -161,7 +165,8 @@ public class Animation<T> {
 	}
 
 	/** Returns the keyframes[] array where all the frames of the animation are stored.
-	 * @return The keyframes[] field. */
+	 * @return The keyframes[] field. This array is an Object[] if the animation was instantiated with an Array that was not
+	 *         type-aware. */
 	public T[] getKeyFrames () {
 		return keyFrames;
 	}

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/TextureAtlas.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/TextureAtlas.java
@@ -320,7 +320,7 @@ public class TextureAtlas implements Disposable {
 	/** Returns all regions with the specified name, ordered by smallest to largest {@link AtlasRegion#index index}. This method
 	 * uses string comparison to find the regions, so the result should be cached rather than calling this method multiple times. */
 	public Array<AtlasRegion> findRegions (String name) {
-		Array<AtlasRegion> matched = new Array();
+		Array<AtlasRegion> matched = new Array(AtlasRegion.class);
 		for (int i = 0, n = regions.size; i < n; i++) {
 			AtlasRegion region = regions.get(i);
 			if (region.name.equals(name)) matched.add(new AtlasRegion(region));
@@ -332,7 +332,7 @@ public class TextureAtlas implements Disposable {
 	 * stored rather than calling this method multiple times.
 	 * @see #createSprite(String) */
 	public Array<Sprite> createSprites () {
-		Array sprites = new Array(regions.size);
+		Array sprites = new Array(true, regions.size, Sprite.class);
 		for (int i = 0, n = regions.size; i < n; i++)
 			sprites.add(newSprite(regions.get(i)));
 		return sprites;
@@ -367,7 +367,7 @@ public class TextureAtlas implements Disposable {
 	 * calling this method multiple times.
 	 * @see #createSprite(String) */
 	public Array<Sprite> createSprites (String name) {
-		Array<Sprite> matched = new Array();
+		Array<Sprite> matched = new Array(Sprite.class);
 		for (int i = 0, n = regions.size; i < n; i++) {
 			AtlasRegion region = regions.get(i);
 			if (region.name.equals(name)) matched.add(newSprite(region));

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/AnimationTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/AnimationTest.java
@@ -25,6 +25,7 @@ import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.tests.utils.GdxTest;
+import com.badlogic.gdx.utils.Array;
 
 public class AnimationTest extends GdxTest {
 
@@ -59,14 +60,19 @@ public class AnimationTest extends GdxTest {
 	public void create () {
 		texture = new Texture(Gdx.files.internal("data/walkanim.png"));
 		TextureRegion[] leftWalkFrames = TextureRegion.split(texture, 64, 64)[0];
-		TextureRegion[] rightWalkFrames = new TextureRegion[leftWalkFrames.length];
-		for (int i = 0; i < rightWalkFrames.length; i++) {
+		Array<TextureRegion> rightWalkFrames = new Array(TextureRegion.class);
+		for (int i = 0; i < leftWalkFrames.length; i++) {
 			TextureRegion frame = new TextureRegion(leftWalkFrames[i]);
 			frame.flip(true, false);
-			rightWalkFrames[i] = frame;
+			rightWalkFrames.add(frame);
 		}
 		leftWalk = new Animation<TextureRegion>(0.25f, leftWalkFrames);
 		rightWalk = new Animation<TextureRegion>(0.25f, rightWalkFrames);
+		
+		TextureRegion[] rightRegions = rightWalk.getKeyFrames(); // testing backing array type
+		TextureRegion firstRightRegion = rightRegions[0];
+		Gdx.app.log("AnimationTest", String.format("First right walk region is %s x %s", 
+			firstRightRegion.getRegionWidth(), firstRightRegion.getRegionHeight()));
 
 		cavemen = new Caveman[100];
 		for (int i = 0; i < 100; i++) {
@@ -79,6 +85,7 @@ public class AnimationTest extends GdxTest {
 
 	@Override
 	public void render () {
+		Gdx.gl.glClearColor(0.1f, 0f, 0.25f, 1f);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		batch.begin();
 		for (int i = 0; i < cavemen.length; i++) {

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TextureAtlasTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TextureAtlasTest.java
@@ -26,6 +26,7 @@ import com.badlogic.gdx.graphics.g2d.Sprite;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.graphics.g2d.TextureAtlas;
 import com.badlogic.gdx.graphics.g2d.TextureAtlas.AtlasRegion;
+import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer.ShapeType;
 import com.badlogic.gdx.tests.utils.GdxTest;
@@ -35,7 +36,7 @@ public class TextureAtlasTest extends GdxTest {
 	Sprite badlogic, badlogicSmall, star;
 	TextureAtlas atlas;
 	TextureAtlas jumpAtlas;
-	Animation jumpAnimation;
+	Animation<TextureRegion> jumpAnimation;
 	BitmapFont font;
 	float time = 0;
 	ShapeRenderer renderer;
@@ -47,7 +48,7 @@ public class TextureAtlasTest extends GdxTest {
 		atlas = new TextureAtlas(Gdx.files.internal("data/pack"));
 		jumpAtlas = new TextureAtlas(Gdx.files.internal("data/jump.txt"));
 
-		jumpAnimation = new Animation(0.25f, jumpAtlas.findRegions("ALIEN_JUMP_"));
+		jumpAnimation = new Animation<TextureRegion>(0.25f, jumpAtlas.findRegions("ALIEN_JUMP_"));
 
 		badlogic = atlas.createSprite("badlogicslice");
 		badlogic.setPosition(50, 50);


### PR DESCRIPTION
Fixes #4476.

An animation instantiated with an Array was using a backing Object array instead of the correct array type, causing possible CCE when calling `getKeyFrames()` and assigning it to its expected type.

Now it uses the same backing type as the Array that's passed in, so as long as the Array was instantiated with a type parameter, you're good to go. I updated TextureAtlas to return type-aware arrays in `findRegions()` since this is a common source of animation frames.