### PR TITLE
Fixed crash in Particle3D system.

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g3d/particles/particles.fragment.glsl
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/particles/particles.fragment.glsl
@@ -23,7 +23,7 @@ void main() {
 
 //Point particles
 varying vec4 v_color;
-varying mat2 v_rotation;
+varying vec4 v_rotation;
 varying MED vec4 v_region;
 varying vec2 v_uvRegionCenter;
 
@@ -32,7 +32,7 @@ uniform vec2 u_regionSize;
 
 void main() {
 	vec2 uv = v_region.xy + gl_PointCoord*v_region.zw - v_uvRegionCenter;
-	vec2 texCoord = v_rotation * uv  +v_uvRegionCenter;
+	vec2 texCoord = mat2(v_rotation) * uv  +v_uvRegionCenter;
 	gl_FragColor = texture2D(u_diffuseTexture, texCoord)* v_color;
 }
 

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/particles/particles.vertex.glsl
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/particles/particles.vertex.glsl
@@ -82,7 +82,7 @@ attribute vec4 a_region;
 
 //out
 varying vec4 v_color;
-varying mat2 v_rotation;
+varying vec4 v_rotation;
 varying MED vec4 v_region;
 varying vec2 v_uvRegionCenter;
 
@@ -100,7 +100,7 @@ void main(){
 	vec4 projCorner = u_projTrans * vec4(halfSize, halfSize, eyePos.z, eyePos.w);
 	gl_PointSize = u_screenWidth * projCorner.x / projCorner.w;
 	gl_Position = u_projTrans * eyePos;
-	v_rotation = mat2(a_sizeAndRotation.y, a_sizeAndRotation.z, -a_sizeAndRotation.z, a_sizeAndRotation.y);
+	v_rotation = vec4(a_sizeAndRotation.y, a_sizeAndRotation.z, -a_sizeAndRotation.z, a_sizeAndRotation.y);
 	v_color = a_color;
 	v_region.xy = a_region.xy;
 	v_region.zw = a_region.zw -a_region.xy;	


### PR DESCRIPTION
I have tested the Particle3D system on three smartphones so far and two of them crashed on the:
`varying mat2 v_rotation;` part. One of them is the Nexus 7 2012 and the other is a Sony (not sure model, not mine).

I can only speculate because I have searched the web and did not find anything. So my hypothesis is that some GPUs does not support matrices sent as varying. I've tried the code in the pull request and it compiles fine on all three devices. 