### PR TITLE
InputProcessor Default methods

### DIFF
--- a/gdx/src/com/badlogic/gdx/InputAdapter.java
+++ b/gdx/src/com/badlogic/gdx/InputAdapter.java
@@ -15,9 +15,10 @@
  ******************************************************************************/
 
 package com.badlogic.gdx;
+import com.badlogic.gdx.InputProcessor;
 
 /** An adapter class for {@link InputProcessor}. You can derive from this and only override what you are interested in.
- * 
+ * @deprecated override methods in {@link InputProcessor} instead
  * @author mzechner */
 public class InputAdapter implements InputProcessor {
 	public boolean keyDown (int keycode) {

--- a/gdx/src/com/badlogic/gdx/InputProcessor.java
+++ b/gdx/src/com/badlogic/gdx/InputProcessor.java
@@ -21,7 +21,7 @@ import com.badlogic.gdx.Input.Buttons;
 /** An InputProcessor is used to receive input events from the keyboard and the touch screen (mouse on the desktop). For this it
  * has to be registered with the {@link Input#setInputProcessor(InputProcessor)} method. It will be called each frame before the
  * call to {@link ApplicationListener#render()}. Each method returns a boolean in case you want to use this with the
- * {@link InputMultiplexer} to chain input processors.
+ * {@link InputMultiplexer} to chain input processors. Override what you need.
  * 
  * @author mzechner */
 public interface InputProcessor {
@@ -29,19 +29,25 @@ public interface InputProcessor {
 	 * 
 	 * @param keycode one of the constants in {@link Input.Keys}
 	 * @return whether the input was processed */
-	public boolean keyDown (int keycode);
+	public default boolean keyDown (int keycode){
+		return false;
+	}
 
 	/** Called when a key was released
 	 * 
 	 * @param keycode one of the constants in {@link Input.Keys}
 	 * @return whether the input was processed */
-	public boolean keyUp (int keycode);
+	public default boolean keyUp (int keycode){
+		return false;
+	}
 
 	/** Called when a key was typed
 	 * 
 	 * @param character The character
 	 * @return whether the input was processed */
-	public boolean keyTyped (char character);
+	public default boolean keyTyped (char character){
+		return false;
+	}
 
 	/** Called when the screen was touched or a mouse button was pressed. The button parameter will be {@link Buttons#LEFT} on iOS.
 	 * @param screenX The x coordinate, origin is in the upper left corner
@@ -49,25 +55,35 @@ public interface InputProcessor {
 	 * @param pointer the pointer for the event.
 	 * @param button the button
 	 * @return whether the input was processed */
-	public boolean touchDown (int screenX, int screenY, int pointer, int button);
+	public default boolean touchDown (int screenX, int screenY, int pointer, int button){
+		return false;
+	}
 
 	/** Called when a finger was lifted or a mouse button was released. The button parameter will be {@link Buttons#LEFT} on iOS.
 	 * @param pointer the pointer for the event.
 	 * @param button the button
 	 * @return whether the input was processed */
-	public boolean touchUp (int screenX, int screenY, int pointer, int button);
+	public default boolean touchUp (int screenX, int screenY, int pointer, int button){
+		return false;
+	}
 
 	/** Called when a finger or the mouse was dragged.
 	 * @param pointer the pointer for the event.
 	 * @return whether the input was processed */
-	public boolean touchDragged (int screenX, int screenY, int pointer);
+	public default boolean touchDragged (int screenX, int screenY, int pointer){
+		return false;
+	}
 
 	/** Called when the mouse was moved without any buttons being pressed. Will not be called on iOS.
 	 * @return whether the input was processed */
-	public boolean mouseMoved (int screenX, int screenY);
+	public default boolean mouseMoved (int screenX, int screenY){
+		return false;
+	}
 
 	/** Called when the mouse wheel was scrolled. Will not be called on iOS.
 	 * @param amount the scroll amount, -1 or 1 depending on the direction the wheel was scrolled.
 	 * @return whether the input was processed. */
-	public boolean scrolled (int amount);
+	public default boolean scrolled (int amount){
+		return false;
+	}
 }


### PR DESCRIPTION
It annoyed me that there was no interface with default methods for the input processor. I didn't want to give up extending my classes to an InputAdapter or have a mess of methods I will not use. So I added default methods to the InputProcessor and depreciated the meaningless InputAdapter. 

You can rework this to your liking, but just get the general idea, use default methods for the InputProcessor and future interfaces of the same category. 