### PR TITLE
Improved support for OpenGL ES 3.0 and added support for OpenGL ES 3.1

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,9 @@
+[gles31]
+- Improved OpenGL ES 3.0 Support (somo missing functions)
+- Added OpenGL ES 3.1 Support (for LWJGL3 and Android)
+- API addition: added Lwjgl3ApplicationConfiguration.useOpenGL31() for OpenGL ES 3.1 
+- API addition: added Graphics.isGL31Available() and Graphics.getGL31() for OpenGL ES 3.1
+
 [1.9.6]
 - API addition: Configurable TexturePacker bleed iterations
 - Updated IOS Multi-OS Engine backend to 1.3.0-beta-2

--- a/backends/gdx-backend-android/libs/android-5.0.0_r1.txt
+++ b/backends/gdx-backend-android/libs/android-5.0.0_r1.txt
@@ -1,0 +1,3 @@
+This file was downloaded from here
+http://grepcode.com/snapshot/repository.grepcode.com/java/ext/com.google.android/android/5.0.0_r1
+License is Apache 2.0

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGL30.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGL30.java
@@ -243,10 +243,10 @@ public class AndroidGL30 extends AndroidGL20 implements GL30 {
 		GLES30.glFramebufferTextureLayer(target, attachment, texture, level, layer);
 	}
 
-// @Override
-// public java.nio.Buffer glMapBufferRange(int target, int offset, int length, int access) {
-// return GLES30.glMapBufferRange(target, offset, length, access);
-// }
+	@Override
+	public java.nio.Buffer glMapBufferRange(int target, int offset, int length, int access) {
+		return GLES30.glMapBufferRange(target, offset, length, access);
+	}
 
 	@Override
 	public void glFlushMappedBufferRange (int target, int offset, int length) {
@@ -411,26 +411,26 @@ public class AndroidGL30 extends AndroidGL20 implements GL30 {
 		return GLES30.glGetFragDataLocation(program, name);
 	}
 
-// @Override
-// public void glUniform1ui(int location, int v0) {
-// GLES30.glUniform1ui(location, v0);
-// }
-//
-// @Override
-// public void glUniform2ui(int location, int v0, int v1) {
-// GLES30.glUniform2ui(location, v0, v1);
-// }
-//
-// @Override
-// public void glUniform3ui(int location, int v0, int v1, int v2) {
-// GLES30.glUniform3ui(location, v0, v1, v2);
-// }
+	@Override
+	public void glUniform1ui(int location, int v0) {
+		GLES30.glUniform1ui(location, v0);
+	}
 
-// @Override
-// public void glUniform4ui(int location, int v0, int v1, int v2, int v3) {
-// GLES30.glUniform4ui(location, v0, v1, v2, v3);
-// }
-//
+	@Override
+	public void glUniform2ui(int location, int v0, int v1) {
+		GLES30.glUniform2ui(location, v0, v1);
+	}
+
+	@Override
+	public void glUniform3ui(int location, int v0, int v1, int v2) {
+		GLES30.glUniform3ui(location, v0, v1, v2);
+	}
+
+	@Override
+	public void glUniform4ui(int location, int v0, int v1, int v2, int v3) {
+		GLES30.glUniform4ui(location, v0, v1, v2, v3);
+	}
+
 // @Override
 // public void glUniform1uiv(int location, int count, int[] value, int offset) {
 // GLES30.glUniform1uiv(location, count, value, offset);
@@ -595,30 +595,30 @@ public class AndroidGL30 extends AndroidGL20 implements GL30 {
 		GLES30.glDrawElementsInstanced(mode, count, type, indicesOffset, instanceCount);
 	}
 
-// @Override
-// public long glFenceSync(int condition, int flags) {
-// return GLES30.glFenceSync(condition, flags);
-// }
+	@Override
+	public long glFenceSync(int condition, int flags) {
+		return GLES30.glFenceSync(condition, flags);
+	}
 //
 // @Override
 // public boolean glIsSync(long sync) {
 // return GLES30.glIsSync(sync);
 // }
 //
-// @Override
-// public void glDeleteSync(long sync) {
-// GLES30.glDeleteSync(sync);
-// }
+	@Override
+	public void glDeleteSync(long sync) {
+		GLES30.glDeleteSync(sync);
+	}
 //
 // @Override
 // public int glClientWaitSync(long sync, int flags, long timeout) {
 // return GLES30.glClientWaitSync(sync, flags, timeout);
 // }
 
-// @Override
-// public void glWaitSync(long sync, int flags, long timeout) {
-// GLES30.glWaitSync(sync, flags, timeout);
-// }
+	@Override
+	public void glWaitSync(long sync, int flags, long timeout) {
+		GLES30.glWaitSync(sync, flags, timeout);
+	}
 //
 // @Override
 // public void glGetInteger64v(int pname, long[] params, int offset) {

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGL31.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGL31.java
@@ -1,0 +1,313 @@
+/*******************************************************************************
+* Copyright 2017 See AUTHORS file.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+******************************************************************************/
+
+package com.badlogic.gdx.backends.android;
+
+import java.nio.FloatBuffer;
+import java.nio.IntBuffer;
+
+import android.opengl.GLES31;
+
+import com.badlogic.gdx.graphics.GL31;
+
+public class AndroidGL31 extends AndroidGL30 implements GL31 {
+
+	@Override
+	public void glActiveShaderProgram (int pipeline, int program) {
+		GLES31.glActiveShaderProgram(pipeline, program);
+	}
+
+	@Override
+	public void glBindImageTexture (int unit, int texture, int level, boolean layered, int layer, int access, int format) {
+		GLES31.glBindImageTexture(unit, texture, level, layered, layer, access, format);
+	}
+
+	@Override
+	public void glBindProgramPipeline (int pipeline) {
+		GLES31.glBindProgramPipeline(pipeline);
+	}
+
+	@Override
+	public void glBindVertexBuffer (int bindingindex, int buffer, long offset, int stride) {
+		GLES31.glBindVertexBuffer(bindingindex, buffer, offset, stride);
+	}
+
+	@Override
+	public int glCreateShaderProgramv (int type, String[] strings) {
+		return glCreateShaderProgramv(type, strings);
+	}
+
+	@Override
+	public void glDeleteProgramPipelines (int n, IntBuffer pipelines) {
+		GLES31.glDeleteProgramPipelines(n, pipelines);
+	}	
+
+	@Override
+	public void glDispatchCompute (int num_groups_x, int num_groups_y, int num_groups_z) {
+		GLES31.glDispatchCompute(num_groups_x, num_groups_y, num_groups_z);
+	}
+
+	@Override
+	public void glDispatchComputeIndirect (long indirect) {
+		GLES31.glDispatchComputeIndirect(indirect);
+	}
+
+	@Override
+	public void glDrawArraysIndirect (int mode, long indirect) {	
+		GLES31.glDrawArraysIndirect(mode, indirect);
+	}
+
+	@Override
+	public void glDrawElementsIndirect (int mode, int type, long indirect) {
+		GLES31.glDrawElementsIndirect (mode, type, indirect);
+	}
+
+	@Override
+	public void glFramebufferParameteri (int target, int pname, int param) {
+		GLES31.glFramebufferParameteri (target, pname, param);
+	}
+
+	@Override
+	public void glGenProgramPipelines (int n, IntBuffer pipelines) {
+		GLES31.glGenProgramPipelines(n, pipelines);
+	}
+
+	@Override
+	public void glGetBooleani_v (int target, int index, IntBuffer data) {
+		GLES31.glGetBooleani_v(target, index, data);
+	}
+
+	@Override
+	public void glGetFramebufferParameteriv (int target, int pname, IntBuffer params) {
+		GLES31.glGetFramebufferParameteriv(target, pname, params);
+	}	
+
+	@Override
+ 	public void glGetMultisamplefv (int pname, int index, FloatBuffer val) {
+ 		GLES31.glGetMultisamplefv(pname, index, val);
+ 	}	
+
+ 	@Override
+ 	public void glGetProgramInterfaceiv (int program, int programInterface, int pname, IntBuffer params) {
+ 		GLES31.glGetProgramInterfaceiv(program, programInterface, pname, params);
+ 	}
+ 	
+	@Override 
+	public String glGetProgramPipelineInfoLog (int program) {
+		return GLES31.glGetProgramPipelineInfoLog(program);
+	}
+
+ 	@Override
+	public void glGetProgramPipelineiv (int pipeline, int pname, IntBuffer params) {
+		GLES31.glGetProgramPipelineiv(pipeline, pname, params);
+	}
+
+	@Override
+	public int glGetProgramResourceIndex (int program, int programInterface, String name) {
+		return GLES31.glGetProgramResourceIndex(program, programInterface, name);		
+	}
+
+	@Override
+	public int glGetProgramResourceLocation (int program, int programInterface, String name) {
+		return GLES31.glGetProgramResourceLocation (program, programInterface, name);		
+	}		
+
+	@Override
+	public String glGetProgramResourceName(int program, int programInterface, int index) {
+		return GLES31.glGetProgramResourceName(program, programInterface, index);
+	}	
+	
+	@Override
+	public void glGetProgramResourceiv (int program, int programInterface, int index, int propCount, IntBuffer props, int bufSize, IntBuffer length, IntBuffer params) {
+		GLES31.glGetProgramResourceiv(program, programInterface, index, propCount, props, bufSize, length, params);
+	}
+
+	@Override
+ 	public void glGetTexLevelParameterfv (int target, int level, int pname, FloatBuffer params) {
+ 		GLES31.glGetTexLevelParameterfv (target, level, pname, params);
+ 	}
+ 
+ 	@Override
+	public void glGetTexLevelParameteriv (int target, int level, int pname, IntBuffer params) {
+		GLES31.glGetTexLevelParameteriv (target, level, pname, params);
+	}
+
+	@Override
+	public boolean glIsProgramPipeline (int pipeline) {
+		return GLES31.glIsProgramPipeline(pipeline);
+	}
+
+	@Override
+	public void glMemoryBarrier (int barriers) {
+		GLES31.glMemoryBarrier(barriers);
+	}
+
+	@Override
+	public void glMemoryBarrierByRegion (int barriers) {		
+		GLES31.glMemoryBarrierByRegion(barriers);
+	}
+
+	@Override
+	public void glProgramUniform1f (int program, int location, float v0) {
+		GLES31.glProgramUniform1f(program, location, v0); 
+	}
+
+	@Override
+	public void glProgramUniform1i (int program, int location, int v0) {
+		GLES31.glProgramUniform1i(program, location, v0);
+	}
+
+	@Override
+	public void glProgramUniform1ui (int program, int location, int v0) {
+		GLES31.glProgramUniform1ui(program, location, v0);
+	}
+
+	@Override
+	public void glProgramUniform2f (int program, int location, float v0, float v1) {
+		GLES31.glProgramUniform2f(program, location, v0, v1); 
+	}
+
+	@Override
+	public void glProgramUniform2i (int program, int location, int v0, int v1) {
+		GLES31.glProgramUniform2i(program, location, v0, v1);
+	}
+
+	@Override
+	public void glProgramUniform2ui (int program, int location, int v0, int v1) {
+		GLES31.glProgramUniform2ui(program, location, v0, v1);
+	}
+
+	@Override
+	public void glProgramUniform3f (int program, int location, float v0, float v1, float v2) {
+		GLES31.glProgramUniform3f(program, location, v0, v1, v2); 
+	}
+
+	@Override
+	public void glProgramUniform3i (int program, int location, int v0, int v1, int v2) {
+		GLES31.glProgramUniform3i(program, location, v0, v1, v2);
+	}
+
+	@Override
+	public void glProgramUniform3ui (int program, int location, int v0, int v1, int v2) {
+		GLES31.glProgramUniform3ui(program, location, v0, v1, v2);
+	}
+
+	@Override
+	public void glProgramUniform4f (int program, int location, float v0, float v1, float v2, float v3) {
+		GLES31.glProgramUniform4f(program, location, v0, v1, v2, v3); 
+	}
+
+	@Override
+	public void glProgramUniform4i (int program, int location, int v0, int v1, int v2, int v3) {
+		GLES31.glProgramUniform4i(program, location, v0, v1, v2, v3);
+	}
+
+	@Override
+	public void glProgramUniform4ui (int program, int location, int v0, int v1, int v2, int v3) {
+		GLES31.glProgramUniform4ui(program, location, v0, v1, v2, v3);
+	}
+
+	@Override
+	public void glProgramUniform4uiv (int program, int location, int count, IntBuffer value) {
+		GLES31.glProgramUniform4uiv(program, location, count, value);
+	}
+
+	@Override
+	public void glProgramUniformMatrix2fv (int program, int location, int count, boolean transpose, FloatBuffer value) {
+		GLES31.glProgramUniformMatrix2fv(program, location, count, transpose, value);
+	}
+
+	@Override
+	public void glProgramUniformMatrix2x3fv (int program, int location, int count, boolean transpose, FloatBuffer value) {
+		GLES31.glProgramUniformMatrix2x3fv(program, location, count, transpose, value);
+	}
+
+	@Override
+	public void glProgramUniformMatrix2x4fv (int program, int location, int count, boolean transpose, FloatBuffer value) {
+		GLES31.glProgramUniformMatrix2x4fv(program, location, count, transpose, value);
+	}		
+
+	@Override
+	public void glProgramUniformMatrix3fv (int program, int location, int count, boolean transpose, FloatBuffer value) {
+		GLES31.glProgramUniformMatrix3fv(program, location, count, transpose, value);
+	}
+
+	@Override
+	public void glProgramUniformMatrix3x2fv (int program, int location, int count, boolean transpose, FloatBuffer value) {
+		GLES31.glProgramUniformMatrix3x2fv(program, location, count, transpose, value);
+	}
+
+	@Override
+	public void glProgramUniformMatrix3x4fv (int program, int location, int count, boolean transpose, FloatBuffer value) {
+		GLES31.glProgramUniformMatrix3x4fv(program, location, count, transpose, value);
+	}
+
+	@Override
+	public void glProgramUniformMatrix4fv (int program, int location, int count, boolean transpose, FloatBuffer value) {
+		GLES31.glProgramUniformMatrix4fv(program, location, count, transpose, value);
+	}
+
+	@Override
+	public void glProgramUniformMatrix4x2fv (int program, int location, int count, boolean transpose, FloatBuffer value) {
+		GLES31.glProgramUniformMatrix4x2fv(program, location, count, transpose, value);
+	}
+
+	@Override
+	public void glProgramUniformMatrix4x3fv (int program, int location, int count, boolean transpose, FloatBuffer value) {
+		GLES31.glProgramUniformMatrix4x3fv(program, location, count, transpose, value);
+	}	
+
+	@Override
+	public void glSampleMaski (int maskNumber, int mask) {
+		GLES31.glSampleMaski(maskNumber, mask);
+	}
+
+	@Override
+	public void glTexStorage2DMultisample (int target, int samples, int internalformat, int width, int height, boolean fixedsamplelocations) {
+		GLES31.glTexStorage2DMultisample(target, samples, internalformat, width, height, fixedsamplelocations);
+	}
+
+	@Override
+	public void glUseProgramStages (int pipeline, int stages, int program) {
+		GLES31.glUseProgramStages(pipeline, stages, program);
+	}
+
+	@Override
+	public void glValidateProgramPipeline (int pipeline) {
+		GLES31.glValidateProgramPipeline(pipeline);
+	}
+
+	@Override
+	public void glVertexAttribBinding (int attribindex, int bindingindex) {
+		GLES31.glVertexAttribBinding(attribindex, bindingindex);
+	}
+
+	@Override
+	public void glVertexAttribFormat (int attribindex, int size, int type, boolean normalized, int relativeoffset) {
+		GLES31.glVertexAttribFormat(attribindex, size, type, normalized, relativeoffset);
+	}
+
+	@Override
+	public void glVertexAttribIFormat (int attribindex, int size, int type, int relativeoffset) {
+		GLES31.glVertexAttribIFormat(attribindex, size, type, relativeoffset);
+	}
+
+	@Override
+	public void glVertexBindingDivisor (int bindingindex, int divisor) {
+		GLES31.glVertexBindingDivisor(bindingindex, divisor);
+	}
+
+}

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphics.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphics.java
@@ -47,6 +47,7 @@ import com.badlogic.gdx.graphics.Cursor;
 import com.badlogic.gdx.graphics.Cursor.SystemCursor;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.GL30;
+import com.badlogic.gdx.graphics.GL31;
 import com.badlogic.gdx.graphics.Mesh;
 import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.Texture;
@@ -79,6 +80,7 @@ public class AndroidGraphics implements Graphics, Renderer {
 	AndroidApplicationBase app;
 	GL20 gl20;
 	GL30 gl30;
+	GL31 gl31;
 	EGLContext eglContext;
 	GLVersion glVersion;
 	String extensions;
@@ -149,6 +151,7 @@ public class AndroidGraphics implements Graphics, Renderer {
 			view.setRenderer(this);
 			return view;
 		} else {
+			/* no changes needed here for opengles3.1 since 3.0 and 3.1 both use the same context */
 			GLSurfaceView20 view = new GLSurfaceView20(application.getContext(), resolutionStrategy, config.useGL30 ? 3 : 2);
 			if (configChooser != null)
 				view.setEGLConfigChooser(configChooser);
@@ -244,19 +247,30 @@ public class AndroidGraphics implements Graphics, Renderer {
 		String vendorString = gl.glGetString(GL10.GL_VENDOR);
 		String rendererString = gl.glGetString(GL10.GL_RENDERER);
 		glVersion = new GLVersion(Application.ApplicationType.Android, versionString, vendorString, rendererString);
-		if (config.useGL30 && glVersion.getMajorVersion() > 2) {
-			if (gl30 != null) return;
-			gl20 = gl30 = new AndroidGL30();
 
-			Gdx.gl = gl30;
-			Gdx.gl20 = gl30;
-			Gdx.gl30 = gl30;
+		if ((glVersion.getMajorVersion() > 3) || (glVersion.getMajorVersion() == 3 && glVersion.getMinorVersion() > 0)) {
+			if (gl31 != null) return;
+			gl20 = gl30 = gl31 = new AndroidGL31();
+
+			Gdx.gl = gl31;
+			Gdx.gl20 = gl31;
+			Gdx.gl30 = gl31;
+			Gdx.gl31 = gl31;
 		} else {
-			if (gl20 != null) return;
-			gl20 = new AndroidGL20();
+			if (config.useGL30 && glVersion.getMajorVersion() > 2) {
+				if (gl30 != null) return;
+				gl20 = gl30 = new AndroidGL30();
 
-			Gdx.gl = gl20;
-			Gdx.gl20 = gl20;
+				Gdx.gl = gl30;
+				Gdx.gl20 = gl30;
+				Gdx.gl30 = gl30;
+			} else {
+				if (gl20 != null) return;
+				gl20 = new AndroidGL20();
+
+				Gdx.gl = gl20;
+				Gdx.gl20 = gl20;
+			}
 		}
 
 		Gdx.app.log(LOG_TAG, "OGL renderer: " + gl.glGetString(GL10.GL_RENDERER));
@@ -692,8 +706,18 @@ public class AndroidGraphics implements Graphics, Renderer {
 	}
 
 	@Override
+	public boolean isGL31Available () {
+		return gl31 != null;
+	}
+
+	@Override
 	public GL30 getGL30 () {
 		return gl30;
+	}
+
+	@Override
+	public GL31 getGL31 () {
+		return gl31;
 	}
 
 	@Override

--- a/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/mock/graphics/MockGraphics.java
+++ b/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/mock/graphics/MockGraphics.java
@@ -21,6 +21,7 @@ import com.badlogic.gdx.Graphics;
 import com.badlogic.gdx.graphics.Cursor;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.GL30;
+import com.badlogic.gdx.graphics.GL31;
 import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.Cursor.SystemCursor;
 import com.badlogic.gdx.graphics.glutils.GLVersion;
@@ -42,12 +43,22 @@ public class MockGraphics implements Graphics {
 	}
 
 	@Override
+	public boolean isGL31Available() {
+		return false;
+	}
+
+	@Override
 	public GL20 getGL20() {
 		return null;
 	}
 
 	@Override
 	public GL30 getGL30() {
+		return null;
+	}
+
+	@Override
+	public GL31 getGL31() {
 		return null;
 	}
 

--- a/backends/gdx-backend-jglfw/src/com/badlogic/gdx/backends/jglfw/JglfwGraphics.java
+++ b/backends/gdx-backend-jglfw/src/com/badlogic/gdx/backends/jglfw/JglfwGraphics.java
@@ -29,6 +29,7 @@ import com.badlogic.gdx.graphics.Cursor;
 import com.badlogic.gdx.graphics.Cursor.SystemCursor;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.GL30;
+import com.badlogic.gdx.graphics.GL31;
 import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.glutils.GLVersion;
 import com.badlogic.gdx.utils.Array;
@@ -459,7 +460,17 @@ public class JglfwGraphics implements Graphics {
 	}
 
 	@Override
+	public boolean isGL31Available () {
+		return false;
+	}
+
+	@Override
 	public GL30 getGL30 () {
+		return null;
+	}
+
+	@Override
+	public GL31 getGL31 () {
 		return null;
 	}
 

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGL30.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGL30.java
@@ -36,6 +36,7 @@ import org.lwjgl.opengl.GL33;
 import org.lwjgl.opengl.GL40;
 import org.lwjgl.opengl.GL41;
 import org.lwjgl.opengl.GL43;
+import org.lwjgl.opengl.GLSync; 
 
 import com.badlogic.gdx.utils.GdxRuntimeException;
 
@@ -648,4 +649,46 @@ class LwjglGL30 extends LwjglGL20 implements com.badlogic.gdx.graphics.GL30 {
 		int height) {
 		GL43.glInvalidateSubFramebuffer(target, attachments, x, y, width, height);
 	}
+
+	@Override
+	public long glFenceSync(int condition, int flags) {
+		GLSync s = GL32.glFenceSync(condition, flags);
+		return s.getPointer();
+	}
+	
+	@Override
+	public void glDeleteSync(long sync) {
+		throw new UnsupportedOperationException("Not implemented, please use LWJGL3 instead.");
+	}
+	
+	@Override
+	public void glWaitSync(long sync, int flags, long timeout) {
+		throw new UnsupportedOperationException("Not implemented, please use LWJGL3 instead.");	
+	}	
+
+	@Override	
+	public java.nio.Buffer glMapBufferRange(int target, int offset, int length, int access) {
+		throw new UnsupportedOperationException("Not implemented, please use LWJGL3 instead.");	
+	}
+
+	@Override
+	public void glUniform1ui(int location, int v0) {
+		GL30.glUniform1ui(location, v0);
+	}
+
+	@Override
+	public void glUniform2ui(int location, int v0, int v1) {
+		GL30.glUniform2ui(location, v0, v1);
+	}
+
+	@Override
+	public void glUniform3ui(int location, int v0, int v1, int v2) {
+		GL30.glUniform3ui(location, v0, v1, v2);
+	}
+
+	@Override
+	public void glUniform4ui(int location, int v0, int v1, int v2, int v3) {
+		GL30.glUniform4ui(location, v0, v1, v2, v3);
+	}		
+
 }

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGraphics.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGraphics.java
@@ -35,6 +35,7 @@ import com.badlogic.gdx.graphics.Cursor;
 import com.badlogic.gdx.graphics.Cursor.SystemCursor;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.GL30;
+import com.badlogic.gdx.graphics.GL31;
 import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.Pixmap.Format;
 import com.badlogic.gdx.utils.Array;
@@ -603,8 +604,18 @@ public class LwjglGraphics implements Graphics {
 	}
 
 	@Override
+	public boolean isGL31Available () {
+		return false;
+	}
+
+	@Override
 	public GL30 getGL30 () {
 		return gl30;
+	}
+
+	@Override
+	public GL31 getGL31 () {
+		return null;
 	}
 
 	/** A callback used by LwjglApplication when trying to create the display */

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
@@ -399,7 +399,7 @@ public class Lwjgl3Application implements Application {
 			GLFW.glfwWindowHint(GLFW.GLFW_SAMPLES, config.samples);
 		}
 
-		if (config.useGL30) {
+		if ((config.useGL30) || (config.useGL31)) {
 			GLFW.glfwWindowHint(GLFW.GLFW_CONTEXT_VERSION_MAJOR, config.gles30ContextMajorVersion);
 			GLFW.glfwWindowHint(GLFW.GLFW_CONTEXT_VERSION_MINOR, config.gles30ContextMinorVersion);
 			if (SharedLibraryLoader.isMac) {

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3ApplicationConfiguration.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3ApplicationConfiguration.java
@@ -45,6 +45,7 @@ public class Lwjgl3ApplicationConfiguration extends Lwjgl3WindowConfiguration {
 	int audioDeviceBufferCount = 9;
 
 	boolean useGL30 = false;
+	boolean useGL31 = false;	
 	int gles30ContextMajorVersion = 3;
 	int gles30ContextMinorVersion = 2;
 
@@ -76,6 +77,7 @@ public class Lwjgl3ApplicationConfiguration extends Lwjgl3WindowConfiguration {
 		audioDeviceBufferSize = config.audioDeviceBufferSize;
 		audioDeviceBufferCount = config.audioDeviceBufferCount;
 		useGL30 = config.useGL30;
+		useGL31 = config.useGL31;		
 		gles30ContextMajorVersion = config.gles30ContextMajorVersion;
 		gles30ContextMinorVersion = config.gles30ContextMinorVersion;
 		r = config.r;
@@ -150,6 +152,26 @@ public class Lwjgl3ApplicationConfiguration extends Lwjgl3WindowConfiguration {
 		this.gles30ContextMajorVersion = gles3MajorVersion;
 		this.gles30ContextMinorVersion = gles3MinorVersion;
 	}
+
+	/**
+	 * Sets whether to use OpenGL ES 3.1 emulation. If the given major/minor
+	 * version is not supported, the backend falls back to OpenGL ES 2.0
+	 * emulation. The default parameters for major and minor should be 4 and 5 for full support,
+	 * but 4 and 3 can be used for almost full support (only glGetTextureLevelParameter and
+	 * glMemoryBarrierByRegion will fail).
+	 *
+	 * @param useGL31
+	 *            whether to use OpenGL ES 3.1
+	 * @param gles3MajorVersion
+	 *            OpenGL ES major version, use 3 as default
+	 * @param gles3MinorVersion
+	 *            OpenGL ES minor version, use 2 as default	 
+	 */
+	public void useOpenGL31(boolean useGL31, int gles3MajorVersion, int gles3MinorVersion) {
+		this.useGL31 = useGL31;
+		this.gles30ContextMajorVersion = gles3MajorVersion;
+		this.gles30ContextMinorVersion = gles3MinorVersion;
+	}	
 
 	/**
 	 * Sets the bit depth of the color, depth and stencil buffer as well as

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3GL30.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3GL30.java
@@ -649,4 +649,44 @@ class Lwjgl3GL30 extends Lwjgl3GL20 implements com.badlogic.gdx.graphics.GL30 {
 		int height) {
 		GL43.glInvalidateSubFramebuffer(target, attachments, x, y, width, height);
 	}
+	
+	@Override
+	public long glFenceSync(int condition, int flags) {
+		return GL32.glFenceSync(condition, flags);
+	}
+	
+	@Override
+	public void glDeleteSync(long sync) {
+		GL32.glDeleteSync(sync);
+	}
+	
+	@Override
+	public void glWaitSync(long sync, int flags, long timeout) {
+		GL32.glWaitSync(sync, flags, timeout);
+	}
+
+	@Override
+	public java.nio.Buffer glMapBufferRange(int target, int offset, int length, int access) {
+		return GL30.glMapBufferRange(target, offset, length, access);
+	}	
+
+	@Override
+	public void glUniform1ui(int location, int v0) {
+		GL30.glUniform1ui(location, v0);
+	}
+
+	@Override
+	public void glUniform2ui(int location, int v0, int v1) {
+		GL30.glUniform2ui(location, v0, v1);
+	}
+
+	@Override
+	public void glUniform3ui(int location, int v0, int v1, int v2) {
+		GL30.glUniform3ui(location, v0, v1, v2);
+	}
+
+	@Override
+	public void glUniform4ui(int location, int v0, int v1, int v2, int v3) {
+		GL30.glUniform4ui(location, v0, v1, v2, v3);
+	}	
 }

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3GL31.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3GL31.java
@@ -1,0 +1,333 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogic.gdx.backends.lwjgl3;
+
+import java.nio.Buffer;
+import java.nio.ByteBuffer;
+import java.nio.DoubleBuffer;
+import java.nio.FloatBuffer;
+import java.nio.IntBuffer;
+import java.nio.LongBuffer;
+import java.nio.ShortBuffer;
+
+import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL12;
+import org.lwjgl.opengl.GL15;
+import org.lwjgl.opengl.GL20;
+import org.lwjgl.opengl.GL21;
+import org.lwjgl.opengl.GL30;
+import org.lwjgl.opengl.GL31;
+import org.lwjgl.opengl.GL32;
+import org.lwjgl.opengl.GL33;
+import org.lwjgl.opengl.GL40;
+import org.lwjgl.opengl.GL41;
+import org.lwjgl.opengl.GL42;
+import org.lwjgl.opengl.GL43;
+import org.lwjgl.opengl.GL45;
+
+import static org.lwjgl.system.MemoryUtil.*; 
+
+import com.badlogic.gdx.utils.GdxRuntimeException;
+
+class Lwjgl3GL31 extends Lwjgl3GL30 implements com.badlogic.gdx.graphics.GL31 {
+ 
+	@Override
+	public void glActiveShaderProgram (int pipeline, int program) {
+		GL41.glActiveShaderProgram(pipeline, program);
+	}
+
+	@Override
+	public void glBindImageTexture (int unit, int texture, int level, boolean layered, int layer, int access, int format) {
+		GL42.glBindImageTexture(unit, texture, level, layered, layer, access, format);
+	}
+
+	@Override
+	public void glBindProgramPipeline (int pipeline) {
+		GL41.glBindProgramPipeline(pipeline);
+	}
+
+	@Override
+	public void glBindVertexBuffer (int bindingindex, int buffer, long offset, int stride) {
+		GL43.glBindVertexBuffer(bindingindex, buffer, offset, stride);
+	}
+
+	@Override
+	public int glCreateShaderProgramv (int type, String[] strings) {
+		return GL41.glCreateShaderProgramv(type, strings);
+	}
+
+	@Override
+	public void glDeleteProgramPipelines (int n, IntBuffer pipelines) {
+		GL41.glDeleteProgramPipelines(pipelines);
+	}
+
+	@Override
+	public void glDispatchCompute (int num_groups_x, int num_groups_y, int num_groups_z) {
+		GL43.glDispatchCompute(num_groups_x, num_groups_y, num_groups_z);
+	}
+ 
+	@Override
+	public void glDispatchComputeIndirect (long indirect) {
+		GL43.glDispatchComputeIndirect(indirect);
+	}
+
+	@Override
+	public void glDrawArraysIndirect (int mode, long indirect) {	
+		GL40.glDrawArraysIndirect(mode, indirect);
+	}
+
+	@Override
+	public void glDrawElementsIndirect (int mode, int type, long indirect) {
+		GL40.glDrawElementsIndirect (mode, type, indirect);
+	}
+
+	@Override
+	public void glFramebufferParameteri (int target, int pname, int param) {
+		GL43.glFramebufferParameteri(target, pname, param);
+	}
+
+	@Override
+	public void glGenProgramPipelines (int n, IntBuffer pipelines) {
+		GL41.glGenProgramPipelines(pipelines);
+	}
+
+	@Override
+	public void glGetBooleani_v (int target, int index, IntBuffer data) {
+		GL30.nglGetBooleani_v(target, index, memAddress(data));
+	}
+
+	@Override
+	public void glGetFramebufferParameteriv (int target, int pname, IntBuffer params) {
+		GL43.glGetFramebufferParameteriv(target, pname, params);
+	}
+
+	@Override
+ 	public void glGetMultisamplefv (int pname, int index, FloatBuffer val) {
+ 		GL32.glGetMultisamplefv(pname, index, val);
+ 	}
+
+ 	@Override
+ 	public void glGetProgramInterfaceiv (int program, int programInterface, int pname, IntBuffer params) {
+ 		GL43.glGetProgramInterfaceiv(program, programInterface, pname, params);
+ 	}
+ 	
+	@Override 
+	public String glGetProgramPipelineInfoLog (int program) {
+		return GL41.glGetProgramPipelineInfoLog(program);
+	}
+
+ 	@Override
+	public void glGetProgramPipelineiv (int pipeline, int pname, IntBuffer params) {
+		GL41.glGetProgramPipelineiv(pipeline, pname, params);
+	}
+
+	@Override
+	public int glGetProgramResourceIndex (int program, int programInterface, String name) {
+		return GL43.glGetProgramResourceIndex(program, programInterface, name);
+	}
+
+	@Override
+	public int glGetProgramResourceLocation (int program, int programInterface, String name) {
+		return GL43.glGetProgramResourceLocation (program, programInterface, name);
+	}
+
+	@Override
+	public String glGetProgramResourceName(int program, int programInterface, int index) {
+		return GL43.glGetProgramResourceName(program, programInterface, index, 1024);
+	}
+	
+	@Override
+	public void glGetProgramResourceiv (int program, int programInterface, int index, int propCount, IntBuffer props, int bufSize, IntBuffer length, IntBuffer params) {
+		GL43.glGetProgramResourceiv(program, programInterface, index, props, length, params);
+	}
+
+	@Override
+ 	public void glGetTexLevelParameterfv (int target, int level, int pname, FloatBuffer params) {
+ 		GL45.glGetTextureLevelParameterfv(target, level, pname, params);
+ 	}
+ 
+ 	@Override
+	public void glGetTexLevelParameteriv (int target, int level, int pname, IntBuffer params) {
+		GL45.glGetTextureLevelParameteriv(target, level, pname, params);
+	}
+
+	@Override
+	public boolean glIsProgramPipeline (int pipeline) {
+		return GL41.glIsProgramPipeline(pipeline);
+	}
+
+	@Override
+	public void glMemoryBarrier (int barriers) {
+		GL42.glMemoryBarrier(barriers);
+	}
+
+	@Override
+	public void glMemoryBarrierByRegion (int barriers) {		
+		GL45.glMemoryBarrierByRegion(barriers);
+	}
+
+	@Override
+	public void glProgramUniform1f (int program, int location, float v0) {
+		GL41.glProgramUniform1f(program, location, v0); 
+	}
+
+	@Override
+	public void glProgramUniform1i (int program, int location, int v0) {
+		GL41.glProgramUniform1i(program, location, v0);
+	}
+
+	@Override
+	public void glProgramUniform1ui (int program, int location, int v0) {
+		GL41.glProgramUniform1ui(program, location, v0);
+	}
+
+	@Override
+	public void glProgramUniform2f (int program, int location, float v0, float v1) {
+		GL41.glProgramUniform2f(program, location, v0, v1); 
+	}
+
+	@Override
+	public void glProgramUniform2i (int program, int location, int v0, int v1) {
+		GL41.glProgramUniform2i(program, location, v0, v1);
+	}
+
+	@Override
+	public void glProgramUniform2ui (int program, int location, int v0, int v1) {
+		GL41.glProgramUniform2ui(program, location, v0, v1);
+	}
+
+	@Override
+	public void glProgramUniform3f (int program, int location, float v0, float v1, float v2) {
+		GL41.glProgramUniform3f(program, location, v0, v1, v2); 
+	}
+
+	@Override
+	public void glProgramUniform3i (int program, int location, int v0, int v1, int v2) {
+		GL41.glProgramUniform3i(program, location, v0, v1, v2);
+	}
+
+	@Override
+	public void glProgramUniform3ui (int program, int location, int v0, int v1, int v2) {
+		GL41.glProgramUniform3ui(program, location, v0, v1, v2);
+	}
+
+	@Override
+	public void glProgramUniform4f (int program, int location, float v0, float v1, float v2, float v3) {
+		GL41.glProgramUniform4f(program, location, v0, v1, v2, v3); 
+	}
+
+	@Override
+	public void glProgramUniform4i (int program, int location, int v0, int v1, int v2, int v3) {
+		GL41.glProgramUniform4i(program, location, v0, v1, v2, v3);
+	}
+
+	@Override
+	public void glProgramUniform4ui (int program, int location, int v0, int v1, int v2, int v3) {
+		GL41.glProgramUniform4ui(program, location, v0, v1, v2, v3);
+	}
+
+	@Override
+	public void glProgramUniform4uiv (int program, int location, int count, IntBuffer value) {
+		GL41.glProgramUniform4uiv(program, location, value);
+	}
+
+	@Override
+	public void glProgramUniformMatrix2fv (int program, int location, int count, boolean transpose, FloatBuffer value) {
+		GL41.glProgramUniformMatrix2fv(program, location, transpose, value);
+	}
+
+	@Override
+	public void glProgramUniformMatrix2x3fv (int program, int location, int count, boolean transpose, FloatBuffer value) {
+		GL41.glProgramUniformMatrix2x3fv(program, location, transpose, value);
+	}
+
+	@Override
+	public void glProgramUniformMatrix2x4fv (int program, int location, int count, boolean transpose, FloatBuffer value) {
+		GL41.glProgramUniformMatrix2x4fv(program, location, transpose, value);
+	}		
+
+	@Override
+	public void glProgramUniformMatrix3fv (int program, int location, int count, boolean transpose, FloatBuffer value) {
+		GL41.glProgramUniformMatrix3fv(program, location, transpose, value);
+	}
+
+	@Override
+	public void glProgramUniformMatrix3x2fv (int program, int location, int count, boolean transpose, FloatBuffer value) {
+		GL41.glProgramUniformMatrix3x2fv(program, location, transpose, value);
+	}
+
+	@Override
+	public void glProgramUniformMatrix3x4fv (int program, int location, int count, boolean transpose, FloatBuffer value) {
+		GL41.glProgramUniformMatrix3x4fv(program, location, transpose, value);
+	}
+
+	@Override
+	public void glProgramUniformMatrix4fv (int program, int location, int count, boolean transpose, FloatBuffer value) {
+		GL41.glProgramUniformMatrix4fv(program, location, transpose, value);
+	}
+
+	@Override
+	public void glProgramUniformMatrix4x2fv (int program, int location, int count, boolean transpose, FloatBuffer value) {
+		GL41.glProgramUniformMatrix4x2fv(program, location, transpose, value);
+	}
+
+	@Override
+	public void glProgramUniformMatrix4x3fv (int program, int location, int count, boolean transpose, FloatBuffer value) {
+		GL41.glProgramUniformMatrix4x3fv(program, location, transpose, value);
+	}	
+
+	@Override
+	public void glSampleMaski (int maskNumber, int mask) {
+		GL32.glSampleMaski(maskNumber, mask);
+	}
+
+	@Override
+	public void glTexStorage2DMultisample (int target, int samples, int internalformat, int width, int height, boolean fixedsamplelocations) {
+		GL43.glTexStorage2DMultisample(target, samples, internalformat, width, height, fixedsamplelocations);
+	}
+
+	@Override
+	public void glUseProgramStages (int pipeline, int stages, int program) {
+		GL41.glUseProgramStages(pipeline, stages, program);
+	}
+
+	@Override
+	public void glValidateProgramPipeline (int pipeline) {
+		GL41.glValidateProgramPipeline(pipeline);
+	}
+
+	@Override
+	public void glVertexAttribBinding (int attribindex, int bindingindex) {
+		GL43.glVertexAttribBinding(attribindex, bindingindex);
+	}
+
+	@Override
+	public void glVertexAttribFormat (int attribindex, int size, int type, boolean normalized, int relativeoffset) {
+		GL43.glVertexAttribFormat(attribindex, size, type, normalized, relativeoffset);
+	}
+
+	@Override
+	public void glVertexAttribIFormat (int attribindex, int size, int type, int relativeoffset) {
+		GL43.glVertexAttribIFormat(attribindex, size, type, relativeoffset);
+	}
+
+	@Override
+	public void glVertexBindingDivisor (int bindingindex, int divisor) {
+		GL43.glVertexBindingDivisor(bindingindex, divisor);
+	}
+	
+}

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Graphics.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Graphics.java
@@ -31,6 +31,7 @@ import com.badlogic.gdx.graphics.Cursor;
 import com.badlogic.gdx.graphics.Cursor.SystemCursor;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.GL30;
+import com.badlogic.gdx.graphics.GL31;
 import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.utils.Disposable;
 import org.lwjgl.opengl.GL11;
@@ -39,6 +40,7 @@ public class Lwjgl3Graphics implements Graphics, Disposable {
 	private final Lwjgl3Window window;
 	private final GL20 gl20;
 	private final GL30 gl30;
+	private final GL31 gl31;	
 	private GLVersion glVersion;
 	private volatile int backBufferWidth;
 	private volatile int backBufferHeight;
@@ -76,12 +78,20 @@ public class Lwjgl3Graphics implements Graphics, Disposable {
 
 	public Lwjgl3Graphics(Lwjgl3Window window) {
 		this.window = window;
-		if (window.getConfig().useGL30) {
-			this.gl30 = new Lwjgl3GL30();
-			this.gl20 = this.gl30;
+		if (window.getConfig().useGL31) {
+			this.gl31 = new Lwjgl3GL31();
+			this.gl30 = this.gl31;
+			this.gl20 = this.gl31;
 		} else {
-			this.gl20 = new Lwjgl3GL20();
-			this.gl30 = null;
+			if (window.getConfig().useGL30) {
+				this.gl30 = new Lwjgl3GL30();
+				this.gl20 = this.gl30;
+				this.gl31 = null;
+			} else {
+				this.gl20 = new Lwjgl3GL20();
+				this.gl30 = null;
+				this.gl31 = null;
+			}			
 		}
 		updateFramebufferInfo();
 		initiateGL();
@@ -133,6 +143,11 @@ public class Lwjgl3Graphics implements Graphics, Disposable {
 	}
 
 	@Override
+	public boolean isGL31Available() {
+		return gl31 != null;
+	}
+
+	@Override
 	public GL20 getGL20() {
 		return gl20;
 	}
@@ -142,6 +157,11 @@ public class Lwjgl3Graphics implements Graphics, Disposable {
 		return gl30;
 	}
 
+	@Override
+	public GL31 getGL31() {
+		return gl31;
+	}
+	
 	@Override
 	public int getWidth() {
 		if (window.getConfig().hdpiMode == HdpiMode.Pixels) {

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Window.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Window.java
@@ -421,11 +421,11 @@ public class Lwjgl3Window implements Disposable {
 
 	void makeCurrent() {
 		Gdx.graphics = graphics;
+		Gdx.gl31 = graphics.getGL31();
 		Gdx.gl30 = graphics.getGL30();
-		Gdx.gl20 = Gdx.gl30 != null ? Gdx.gl30 : graphics.getGL20();
-		Gdx.gl = Gdx.gl30 != null ? Gdx.gl30 : Gdx.gl20;
+		Gdx.gl20 = Gdx.gl31 != null ? Gdx.gl31 : Gdx.gl30 != null ? Gdx.gl30 : graphics.getGL20();
+		Gdx.gl = Gdx.gl31 != null ? Gdx.gl31 : Gdx.gl30 != null ? Gdx.gl30 : Gdx.gl20;
 		Gdx.input = input;
-
 		GLFW.glfwMakeContextCurrent(windowHandle);
 	}
 

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGLES30.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGLES30.java
@@ -198,4 +198,20 @@ public class IOSGLES30 extends IOSGLES20 implements GL30 {
     public native void glInvalidateFramebuffer(int target, int numAttachments, IntBuffer attachments);
 
     public native void glInvalidateSubFramebuffer(int target, int numAttachments, IntBuffer attachments, int x, int y, int width, int height);
+
+    public native long glFenceSync(int condition, int flags);
+
+    public native void glDeleteSync(long sync);
+
+    public native void glWaitSync(long sync, int flags, long timeout);
+
+    public native java.nio.Buffer glMapBufferRange(int target, int offset, int length, int access);
+
+    public native void glUniform1ui(int location, int v0);
+
+    public native void glUniform2ui(int location, int v0, int v1);
+
+    public native void glUniform3ui(int location, int v0, int v1, int v2);
+
+    public native void glUniform4ui(int location, int v0, int v1, int v2, int v3);
 }

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
@@ -46,6 +46,7 @@ import com.badlogic.gdx.backends.iosrobovm.custom.HWMachine;
 import com.badlogic.gdx.graphics.Cursor;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.GL30;
+import com.badlogic.gdx.graphics.GL31;
 import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.Cursor.SystemCursor;
 import com.badlogic.gdx.utils.Array;
@@ -540,10 +541,20 @@ public class IOSGraphics extends NSObject implements Graphics, GLKViewDelegate, 
 	@Override
 	public boolean isGL30Available () {
 		return false;
+	}	
+
+	@Override
+	public boolean isGL31Available () {
+		return false;
 	}
 
 	@Override
 	public GL30 getGL30 () {
+		return null;
+	}
+
+	@Override
+	public GL31 getGL31 () {
 		return null;
 	}
 

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtGraphics.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtGraphics.java
@@ -24,6 +24,7 @@ import com.badlogic.gdx.graphics.Cursor;
 import com.badlogic.gdx.graphics.Cursor.SystemCursor;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.GL30;
+import com.badlogic.gdx.graphics.GL31;
 import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.glutils.GLVersion;
 import com.badlogic.gdx.utils.GdxRuntimeException;
@@ -479,10 +480,20 @@ public class GwtGraphics implements Graphics {
 	}
 
 	@Override
+	public boolean isGL31Available () {
+		return false;
+	}
+
+	@Override
 	public GL30 getGL30 () {
 		return null;
 	}
 
+	@Override
+	public GL31 getGL31 () {
+		return null;
+	}
+	
 	@Override
 	public Cursor newCursor (Pixmap pixmap, int xHotspot, int yHotspot) {
 		return new GwtCursor(pixmap, xHotspot, yHotspot);

--- a/gdx/src/com/badlogic/gdx/Gdx.java
+++ b/gdx/src/com/badlogic/gdx/Gdx.java
@@ -18,6 +18,7 @@ package com.badlogic.gdx;
 
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.GL30;
+import com.badlogic.gdx.graphics.GL31;
 
 /** Environment class holding references to the {@link Application}, {@link Graphics}, {@link Audio}, {@link Files} and
  * {@link Input} instances. The references are held in public static fields which allows static access to all sub systems. Do not
@@ -36,4 +37,5 @@ public class Gdx {
 	public static GL20 gl;
 	public static GL20 gl20;
 	public static GL30 gl30;
+	public static GL31 gl31;	
 }

--- a/gdx/src/com/badlogic/gdx/Graphics.java
+++ b/gdx/src/com/badlogic/gdx/Graphics.java
@@ -20,6 +20,7 @@ import com.badlogic.gdx.graphics.Cursor;
 import com.badlogic.gdx.graphics.Cursor.SystemCursor;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.GL30;
+import com.badlogic.gdx.graphics.GL31;
 import com.badlogic.gdx.graphics.Mesh;
 import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.g2d.Batch;
@@ -129,11 +130,17 @@ public interface Graphics {
 	 * @return whether OpenGL ES 3.0 is available */
 	public boolean isGL30Available ();
 
+	/** @return whether OpenGL ES 3.1 is available */
+	public boolean isGL31Available ();		
+
 	/** @return the {@link GL20} instance */
 	public GL20 getGL20 ();
 
 	/** @return the {@link GL30} instance or null if not supported */
 	public GL30 getGL30 ();
+
+	/** @return the {@link GL31} instance or null if not supported */
+	public GL31 getGL31 ();
 
 	/** @return the width of the client area in logical pixels. */
 	public int getWidth ();

--- a/gdx/src/com/badlogic/gdx/graphics/GL30.java
+++ b/gdx/src/com/badlogic/gdx/graphics/GL30.java
@@ -611,14 +611,8 @@ public interface GL30 extends GL20 {
 
 	public void glFramebufferTextureLayer (int target, int attachment, int texture, int level, int layer);
 
-// // C function GLvoid * glMapBufferRange ( GLenum target, GLintptr offset, GLsizeiptr length, GLbitfield access )
-//
-// public java.nio.Buffer glMapBufferRange(
-// int target,
-// int offset,
-// int length,
-// int access
-// );
+	// C function GLvoid * glMapBufferRange ( GLenum target, GLintptr offset, GLsizeiptr length, GLbitfield access )
+	public java.nio.Buffer glMapBufferRange(int target, int offset, int length, int access);
 
 	// C function void glFlushMappedBufferRange ( GLenum target, GLintptr offset, GLsizeiptr length )
 
@@ -823,40 +817,22 @@ public interface GL30 extends GL20 {
 
 	public int glGetFragDataLocation (int program, String name);
 
-// // C function void glUniform1ui ( GLint location, GLuint v0 )
-//
-// public void glUniform1ui(
-// int location,
-// int v0
-// );
-//
-// // C function void glUniform2ui ( GLint location, GLuint v0, GLuint v1 )
-//
-// public void glUniform2ui(
-// int location,
-// int v0,
-// int v1
-// );
-//
-// // C function void glUniform3ui ( GLint location, GLuint v0, GLuint v1, GLuint v2 )
-//
-// public void glUniform3ui(
-// int location,
-// int v0,
-// int v1,
-// int v2
-// );
-//
-// // C function void glUniform4ui ( GLint location, GLuint v0, GLuint v1, GLuint v2, GLuint v3 )
-//
-// public void glUniform4ui(
-// int location,
-// int v0,
-// int v1,
-// int v2,
-// int v3
-// );
-//
+	// C function void glUniform1ui ( GLint location, GLuint v0 )
+
+	public void glUniform1ui (int location, int v0);
+
+	// C function void glUniform2ui ( GLint location, GLuint v0, GLuint v1 )
+
+	public void glUniform2ui (int location, int v0, int v1);
+
+	// C function void glUniform3ui ( GLint location, GLuint v0, GLuint v1, GLuint v2 )
+
+ 	public void glUniform3ui (int location, int v0, int v1, int v2);
+
+	// C function void glUniform4ui ( GLint location, GLuint v0, GLuint v1, GLuint v2, GLuint v3 )
+
+	public void glUniform4ui (int location, int v0, int v1, int v2, int v3);
+
 // // C function void glUniform1uiv ( GLint location, GLsizei count, const GLuint *value )
 //
 // public void glUniform1uiv(
@@ -1065,13 +1041,13 @@ public interface GL30 extends GL20 {
 
 	public void glDrawElementsInstanced (int mode, int count, int type, int indicesOffset, int instanceCount);
 
-// // C function GLsync glFenceSync ( GLenum condition, GLbitfield flags )
-//
-// public long glFenceSync(
-// int condition,
-// int flags
-// );
-//
+ // C function GLsync glFenceSync ( GLenum condition, GLbitfield flags )
+
+ public long glFenceSync(
+ int condition,
+ int flags
+ );
+
 // // C function GLboolean glIsSync ( GLsync sync )
 //
 // public boolean glIsSync(
@@ -1079,11 +1055,11 @@ public interface GL30 extends GL20 {
 // );
 //
 // // C function void glDeleteSync ( GLsync sync )
-//
-// public void glDeleteSync(
-// long sync
-// );
-//
+
+ public void glDeleteSync(
+ long sync
+ );
+
 // // C function GLenum glClientWaitSync ( GLsync sync, GLbitfield flags, GLuint64 timeout )
 //
 // public int glClientWaitSync(
@@ -1093,12 +1069,12 @@ public interface GL30 extends GL20 {
 // );
 //
 // // C function void glWaitSync ( GLsync sync, GLbitfield flags, GLuint64 timeout )
-//
-// public void glWaitSync(
-// long sync,
-// int flags,
-// long timeout
-// );
+
+ public void glWaitSync(
+ long sync,
+ int flags,
+ long timeout
+ );
 
 // // C function void glGetInteger64v ( GLenum pname, GLint64 *params )
 //

--- a/gdx/src/com/badlogic/gdx/graphics/GL31.java
+++ b/gdx/src/com/badlogic/gdx/graphics/GL31.java
@@ -1,0 +1,355 @@
+/*
+ **
+ ** Copyright, The Android Open Source Project
+ **
+ ** Licensed under the Apache License, Version 2.0 (the "License");
+ ** you may not use this file except in compliance with the License.
+ ** You may obtain a copy of the License at
+ **
+ **     http://www.apache.org/licenses/LICENSE-2.0
+ **
+ ** Unless required by applicable law or agreed to in writing, software
+ ** distributed under the License is distributed on an "AS IS" BASIS,
+ ** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ** See the License for the specific language governing permissions and
+ ** limitations under the License.
+ */
+
+package com.badlogic.gdx.graphics;
+
+import java.nio.Buffer;
+import java.nio.FloatBuffer;
+import java.nio.IntBuffer;
+
+/** OpenGL ES 3.1 */
+public interface GL31 extends GL30 {
+	public final int GL_COMPUTE_SHADER                             = 0x91B9;
+	public final int GL_MAX_COMPUTE_UNIFORM_BLOCKS                 = 0x91BB;
+	public final int GL_MAX_COMPUTE_TEXTURE_IMAGE_UNITS            = 0x91BC;
+	public final int GL_MAX_COMPUTE_IMAGE_UNIFORMS                 = 0x91BD;
+	public final int GL_MAX_COMPUTE_SHARED_MEMORY_SIZE             = 0x8262;
+	public final int GL_MAX_COMPUTE_UNIFORM_COMPONENTS             = 0x8263;
+	public final int GL_MAX_COMPUTE_ATOMIC_COUNTER_BUFFERS         = 0x8264;
+	public final int GL_MAX_COMPUTE_ATOMIC_COUNTERS                = 0x8265;
+	public final int GL_MAX_COMBINED_COMPUTE_UNIFORM_COMPONENTS    = 0x8266;
+	public final int GL_MAX_COMPUTE_WORK_GROUP_INVOCATIONS         = 0x90EB;
+	public final int GL_MAX_COMPUTE_WORK_GROUP_COUNT               = 0x91BE;
+	public final int GL_MAX_COMPUTE_WORK_GROUP_SIZE                = 0x91BF;
+	public final int GL_COMPUTE_WORK_GROUP_SIZE                    = 0x8267;
+	public final int GL_DISPATCH_INDIRECT_BUFFER                   = 0x90EE;
+	public final int GL_DISPATCH_INDIRECT_BUFFER_BINDING           = 0x90EF;
+	public final int GL_COMPUTE_SHADER_BIT                         = 0x20;
+	public final int GL_DRAW_INDIRECT_BUFFER                       = 0x8F3F;
+	public final int GL_DRAW_INDIRECT_BUFFER_BINDING               = 0x8F43;
+	public final int GL_MAX_UNIFORM_LOCATIONS                      = 0x826E;
+	public final int GL_FRAMEBUFFER_DEFAULT_WIDTH                  = 0x9310;
+	public final int GL_FRAMEBUFFER_DEFAULT_HEIGHT                 = 0x9311;
+	public final int GL_FRAMEBUFFER_DEFAULT_SAMPLES                = 0x9313;
+	public final int GL_FRAMEBUFFER_DEFAULT_FIXED_SAMPLE_LOCATIONS = 0x9314;
+	public final int GL_MAX_FRAMEBUFFER_WIDTH                      = 0x9315;
+	public final int GL_MAX_FRAMEBUFFER_HEIGHT                     = 0x9316;
+	public final int GL_MAX_FRAMEBUFFER_SAMPLES                    = 0x9318;
+	public final int GL_UNIFORM                                    = 0x92E1;
+	public final int GL_UNIFORM_BLOCK                              = 0x92E2;
+	public final int GL_PROGRAM_INPUT                              = 0x92E3;
+	public final int GL_PROGRAM_OUTPUT                             = 0x92E4;
+	public final int GL_BUFFER_VARIABLE                            = 0x92E5;
+	public final int GL_SHADER_STORAGE_BLOCK                       = 0x92E6;
+	public final int GL_ATOMIC_COUNTER_BUFFER                      = 0x92C0;
+	public final int GL_TRANSFORM_FEEDBACK_VARYING                 = 0x92F4;
+	public final int GL_ACTIVE_RESOURCES                           = 0x92F5;
+	public final int GL_MAX_NAME_LENGTH                            = 0x92F6;
+	public final int GL_MAX_NUM_ACTIVE_VARIABLES                   = 0x92F7;
+	public final int GL_NAME_LENGTH                                = 0x92F9;
+	public final int GL_TYPE                                       = 0x92FA;
+	public final int GL_ARRAY_SIZE                                 = 0x92FB;
+	public final int GL_OFFSET                                     = 0x92FC;
+	public final int GL_BLOCK_INDEX                                = 0x92FD;
+	public final int GL_ARRAY_STRIDE                               = 0x92FE;
+	public final int GL_MATRIX_STRIDE                              = 0x92FF;
+	public final int GL_IS_ROW_MAJOR                               = 0x9300;
+	public final int GL_ATOMIC_COUNTER_BUFFER_INDEX                = 0x9301;
+	public final int GL_BUFFER_BINDING                             = 0x9302;
+	public final int GL_BUFFER_DATA_SIZE                           = 0x9303;
+	public final int GL_NUM_ACTIVE_VARIABLES                       = 0x9304;
+	public final int GL_ACTIVE_VARIABLES                           = 0x9305;
+	public final int GL_REFERENCED_BY_VERTEX_SHADER                = 0x9306;
+	public final int GL_REFERENCED_BY_FRAGMENT_SHADER              = 0x930A;
+	public final int GL_REFERENCED_BY_COMPUTE_SHADER               = 0x930B;
+	public final int GL_TOP_LEVEL_ARRAY_SIZE                       = 0x930C;
+	public final int GL_TOP_LEVEL_ARRAY_STRIDE                     = 0x930D;
+	public final int GL_LOCATION                                   = 0x930E;
+	public final int GL_VERTEX_SHADER_BIT                          = 0x1;
+	public final int GL_FRAGMENT_SHADER_BIT                        = 0x2;
+	public final int GL_ALL_SHADER_BITS                            = 0xFFFFFFFF;
+	public final int GL_PROGRAM_SEPARABLE                          = 0x8258;
+	public final int GL_ACTIVE_PROGRAM                             = 0x8259;
+	public final int GL_PROGRAM_PIPELINE_BINDING                   = 0x825A;
+	public final int GL_ATOMIC_COUNTER_BUFFER_BINDING              = 0x92C1;
+	public final int GL_ATOMIC_COUNTER_BUFFER_START                = 0x92C2;
+	public final int GL_ATOMIC_COUNTER_BUFFER_SIZE                 = 0x92C3;
+	public final int GL_MAX_VERTEX_ATOMIC_COUNTER_BUFFERS          = 0x92CC;
+	public final int GL_MAX_FRAGMENT_ATOMIC_COUNTER_BUFFERS        = 0x92D0;
+	public final int GL_MAX_COMBINED_ATOMIC_COUNTER_BUFFERS        = 0x92D1;
+	public final int GL_MAX_VERTEX_ATOMIC_COUNTERS                 = 0x92D2;
+	public final int GL_MAX_FRAGMENT_ATOMIC_COUNTERS               = 0x92D6;
+	public final int GL_MAX_COMBINED_ATOMIC_COUNTERS               = 0x92D7;
+	public final int GL_MAX_ATOMIC_COUNTER_BUFFER_SIZE             = 0x92D8;
+	public final int GL_MAX_ATOMIC_COUNTER_BUFFER_BINDINGS         = 0x92DC;
+	public final int GL_ACTIVE_ATOMIC_COUNTER_BUFFERS              = 0x92D9;
+	public final int GL_UNSIGNED_INT_ATOMIC_COUNTER                = 0x92DB;
+	public final int GL_MAX_IMAGE_UNITS                            = 0x8F38;
+	public final int GL_MAX_VERTEX_IMAGE_UNIFORMS                  = 0x90CA;
+	public final int GL_MAX_FRAGMENT_IMAGE_UNIFORMS                = 0x90CE;
+	public final int GL_MAX_COMBINED_IMAGE_UNIFORMS                = 0x90CF;
+	public final int GL_IMAGE_BINDING_NAME                         = 0x8F3A;
+	public final int GL_IMAGE_BINDING_LEVEL                        = 0x8F3B;
+	public final int GL_IMAGE_BINDING_LAYERED                      = 0x8F3C;
+	public final int GL_IMAGE_BINDING_LAYER                        = 0x8F3D;
+	public final int GL_IMAGE_BINDING_ACCESS                       = 0x8F3E;
+	public final int GL_IMAGE_BINDING_FORMAT                       = 0x906E;
+	public final int GL_VERTEX_ATTRIB_ARRAY_BARRIER_BIT            = 0x1;
+	public final int GL_ELEMENT_ARRAY_BARRIER_BIT                  = 0x2;
+	public final int GL_UNIFORM_BARRIER_BIT                        = 0x4;
+	public final int GL_TEXTURE_FETCH_BARRIER_BIT                  = 0x8;
+	public final int GL_SHADER_IMAGE_ACCESS_BARRIER_BIT            = 0x20;
+	public final int GL_COMMAND_BARRIER_BIT                        = 0x40;
+	public final int GL_PIXEL_BUFFER_BARRIER_BIT                   = 0x80;
+	public final int GL_TEXTURE_UPDATE_BARRIER_BIT                 = 0x100;
+	public final int GL_BUFFER_UPDATE_BARRIER_BIT                  = 0x200;
+	public final int GL_FRAMEBUFFER_BARRIER_BIT                    = 0x400;
+	public final int GL_TRANSFORM_FEEDBACK_BARRIER_BIT             = 0x800;
+	public final int GL_ATOMIC_COUNTER_BARRIER_BIT                 = 0x1000;
+	public final int GL_ALL_BARRIER_BITS                           = 0xFFFFFFFF;
+	public final int GL_IMAGE_2D                                   = 0x904D;
+	public final int GL_IMAGE_3D                                   = 0x904E;
+	public final int GL_IMAGE_CUBE                                 = 0x9050;
+	public final int GL_IMAGE_2D_ARRAY                             = 0x9053;
+	public final int GL_INT_IMAGE_2D                               = 0x9058;
+	public final int GL_INT_IMAGE_3D                               = 0x9059;
+	public final int GL_INT_IMAGE_CUBE                             = 0x905B;
+	public final int GL_INT_IMAGE_2D_ARRAY                         = 0x905E;
+	public final int GL_UNSIGNED_INT_IMAGE_2D                      = 0x9063;
+	public final int GL_UNSIGNED_INT_IMAGE_3D                      = 0x9064;
+	public final int GL_UNSIGNED_INT_IMAGE_CUBE                    = 0x9066;
+	public final int GL_UNSIGNED_INT_IMAGE_2D_ARRAY                = 0x9069;
+	public final int GL_IMAGE_FORMAT_COMPATIBILITY_TYPE            = 0x90C7;
+	public final int GL_IMAGE_FORMAT_COMPATIBILITY_BY_SIZE         = 0x90C8;
+	public final int GL_IMAGE_FORMAT_COMPATIBILITY_BY_CLASS        = 0x90C9;
+	public final int GL_READ_ONLY                                  = 0x88B8;
+	public final int GL_WRITE_ONLY                                 = 0x88B9;
+	public final int GL_READ_WRITE                                 = 0x88BA;
+	public final int GL_SHADER_STORAGE_BUFFER                      = 0x90D2;
+	public final int GL_SHADER_STORAGE_BUFFER_BINDING              = 0x90D3;
+	public final int GL_SHADER_STORAGE_BUFFER_START                = 0x90D4;
+	public final int GL_SHADER_STORAGE_BUFFER_SIZE                 = 0x90D5;
+	public final int GL_MAX_VERTEX_SHADER_STORAGE_BLOCKS           = 0x90D6;
+	public final int GL_MAX_FRAGMENT_SHADER_STORAGE_BLOCKS         = 0x90DA;
+	public final int GL_MAX_COMPUTE_SHADER_STORAGE_BLOCKS          = 0x90DB;
+	public final int GL_MAX_COMBINED_SHADER_STORAGE_BLOCKS         = 0x90DC;
+	public final int GL_MAX_SHADER_STORAGE_BUFFER_BINDINGS         = 0x90DD;
+	public final int GL_MAX_SHADER_STORAGE_BLOCK_SIZE              = 0x90DE;
+	public final int GL_SHADER_STORAGE_BUFFER_OFFSET_ALIGNMENT     = 0x90DF;
+	public final int GL_SHADER_STORAGE_BARRIER_BIT                 = 0x2000;
+	public final int GL_MAX_COMBINED_SHADER_OUTPUT_RESOURCES       = 0x8F39;
+	public final int GL_DEPTH_STENCIL_TEXTURE_MODE                 = 0x90EA;
+	public final int GL_STENCIL_INDEX                              = 0x1901;
+	public final int GL_MIN_PROGRAM_TEXTURE_GATHER_OFFSET          = 0x8E5E;
+	public final int GL_MAX_PROGRAM_TEXTURE_GATHER_OFFSET          = 0x8E5F;
+	public final int GL_SAMPLE_POSITION                            = 0x8E50;
+	public final int GL_SAMPLE_MASK                                = 0x8E51;
+	public final int GL_SAMPLE_MASK_VALUE                          = 0x8E52;
+	public final int GL_TEXTURE_2D_MULTISAMPLE                     = 0x9100;
+	public final int GL_MAX_SAMPLE_MASK_WORDS                      = 0x8E59;
+	public final int GL_MAX_COLOR_TEXTURE_SAMPLES                  = 0x910E;
+	public final int GL_MAX_DEPTH_TEXTURE_SAMPLES                  = 0x910F;
+	public final int GL_MAX_INTEGER_SAMPLES                        = 0x9110;
+	public final int GL_TEXTURE_BINDING_2D_MULTISAMPLE             = 0x9104;
+	public final int GL_TEXTURE_SAMPLES                            = 0x9106;
+	public final int GL_TEXTURE_FIXED_SAMPLE_LOCATIONS             = 0x9107;
+	public final int GL_TEXTURE_WIDTH                              = 0x1000;
+	public final int GL_TEXTURE_HEIGHT                             = 0x1001;
+	public final int GL_TEXTURE_DEPTH                              = 0x8071;
+	public final int GL_TEXTURE_INTERNAL_FORMAT                    = 0x1003;
+	public final int GL_TEXTURE_RED_SIZE                           = 0x805C;
+	public final int GL_TEXTURE_GREEN_SIZE                         = 0x805D;
+	public final int GL_TEXTURE_BLUE_SIZE                          = 0x805E;
+	public final int GL_TEXTURE_ALPHA_SIZE                         = 0x805F;
+	public final int GL_TEXTURE_DEPTH_SIZE                         = 0x884A;
+	public final int GL_TEXTURE_STENCIL_SIZE                       = 0x88F1;
+	public final int GL_TEXTURE_SHARED_SIZE                        = 0x8C3F;
+	public final int GL_TEXTURE_RED_TYPE                           = 0x8C10;
+	public final int GL_TEXTURE_GREEN_TYPE                         = 0x8C11;
+	public final int GL_TEXTURE_BLUE_TYPE                          = 0x8C12;
+	public final int GL_TEXTURE_ALPHA_TYPE                         = 0x8C13;
+	public final int GL_TEXTURE_DEPTH_TYPE                         = 0x8C16;
+	public final int GL_TEXTURE_COMPRESSED                         = 0x86A1;
+	public final int GL_SAMPLER_2D_MULTISAMPLE                     = 0x9108;
+	public final int GL_INT_SAMPLER_2D_MULTISAMPLE                 = 0x9109;
+	public final int GL_UNSIGNED_INT_SAMPLER_2D_MULTISAMPLE        = 0x910A;
+	public final int GL_VERTEX_ATTRIB_BINDING                      = 0x82D4;
+	public final int GL_VERTEX_ATTRIB_RELATIVE_OFFSET              = 0x82D5;
+	public final int GL_VERTEX_BINDING_DIVISOR                     = 0x82D6;
+	public final int GL_VERTEX_BINDING_OFFSET                      = 0x82D7;
+	public final int GL_VERTEX_BINDING_STRIDE                      = 0x82D8;
+	public final int GL_VERTEX_BINDING_BUFFER                      = 0x8F4F;
+	public final int GL_MAX_VERTEX_ATTRIB_RELATIVE_OFFSET          = 0x82D9;
+	public final int GL_MAX_VERTEX_ATTRIB_BINDINGS                 = 0x82DA;
+	public final int GL_MAX_VERTEX_ATTRIB_STRIDE                   = 0x82E5; 	
+
+	public void glActiveShaderProgram (int pipeline, int program);
+
+	public void glBindImageTexture (int unit, int texture, int level, boolean layered, int layer, int access, int format);
+
+	public void glBindProgramPipeline (int pipeline);
+
+	public void glBindVertexBuffer (int bindingindex, int buffer, long offset, int stride);
+
+	public int glCreateShaderProgramv (int type, String[] strings);
+
+	// void glDeleteProgramPipelines(int n, int[] pipelines, int offset)
+	public void glDeleteProgramPipelines (int n, IntBuffer pipelines);
+
+	public void glDispatchCompute (int num_groups_x, int num_groups_y, int num_groups_z);
+
+ 	public void glDispatchComputeIndirect (long indirect);
+
+ 	public void glDrawArraysIndirect (int mode, long indirect);
+
+ 	public void glDrawElementsIndirect (int mode, int type, long indirect);
+ 	
+ 	public void glFramebufferParameteri (int target, int pname, int param);
+
+	// void glGenProgramPipelines(int n, int[] pipelines, int offset)
+ 	public void glGenProgramPipelines (int n, IntBuffer pipelines);
+
+	// void	glGetBooleani_v(int target, int index, boolean[] data, int offset)
+	public void glGetBooleani_v (int target, int index, IntBuffer data);
+
+	// void	glGetFramebufferParameteriv(int target, int pname, int[] params, int offset)
+	public void glGetFramebufferParameteriv (int target, int pname, IntBuffer params);
+
+ 	// void	glGetMultisamplefv(int pname, int index, float[] val, int offset)
+ 	public void glGetMultisamplefv (int pname, int index, FloatBuffer val);
+
+	// void	glGetProgramInterfaceiv(int program, int programInterface, int pname, int[] params, int offset)
+	public void glGetProgramInterfaceiv (int program, int programInterface, int pname, IntBuffer params);
+
+	public String glGetProgramPipelineInfoLog (int program);
+
+	// void	glGetProgramPipelineiv(int pipeline, int pname, int[] params, int offset)
+	public void glGetProgramPipelineiv (int pipeline, int pname, IntBuffer params);
+
+	public int glGetProgramResourceIndex (int program, int programInterface, String name);
+
+	public int glGetProgramResourceLocation (int program, int programInterface, String name);
+
+	public String glGetProgramResourceName(int program, int programInterface, int index);
+
+ 	// void	glGetProgramResourceiv(int program, int programInterface, int index, int propCount, int[] props, int propsOffset, int bufSize, int[] length, int lengthOffset, int[] params, int paramsOffset)	
+	public void glGetProgramResourceiv (int program, int programInterface, int index, int propCount, IntBuffer props, int bufSize, IntBuffer length, IntBuffer params);
+
+	// void	glGetTexLevelParameterfv(int target, int level, int pname, float[] params, int offset)
+ 	public void glGetTexLevelParameterfv (int target, int level, int pname, FloatBuffer params);
+ 
+	// void	glGetTexLevelParameteriv(int target, int level, int pname, int[] params, int offset)
+	public void glGetTexLevelParameteriv (int target, int level, int pname, IntBuffer params);
+
+ 	public boolean glIsProgramPipeline (int pipeline);
+
+	public void glMemoryBarrier (int barriers);
+
+	public void glMemoryBarrierByRegion (int barriers);
+
+	public void glProgramUniform1f (int program, int location, float v0);
+
+	// void glProgramUniform1fv(int program, int location, int count, FloatBuffer value)
+	// void glProgramUniform1fv(int program, int location, int count, float[] value, int offset)
+	public void glProgramUniform1i (int program, int location, int v0);
+
+	// void glProgramUniform1iv(int program, int location, int count, int[] value, int offset)
+	// void glProgramUniform1iv(int program, int location, int count, IntBuffer value)
+	public void glProgramUniform1ui (int program, int location, int v0);
+
+	// void glProgramUniform1uiv(int program, int location, int count, int[] value, int offset)
+	// void glProgramUniform1uiv(int program, int location, int count, IntBuffer value)
+	public void glProgramUniform2f (int program, int location, float v0, float v1);
+
+	// void glProgramUniform2fv(int program, int location, int count, FloatBuffer value)
+	// void glProgramUniform2fv(int program, int location, int count, float[] value, int offset)
+	public void glProgramUniform2i (int program, int location, int v0, int v1);
+
+	// void glProgramUniform2iv(int program, int location, int count, IntBuffer value)
+	// void glProgramUniform2iv(int program, int location, int count, int[] value, int offset)
+	public void glProgramUniform2ui (int program, int location, int v0, int v1);
+
+	// void glProgramUniform2uiv(int program, int location, int count, IntBuffer value)
+	// void glProgramUniform2uiv(int program, int location, int count, int[] value, int offset)
+	public void glProgramUniform3f (int program, int location, float v0, float v1, float v2);
+
+	// void glProgramUniform3fv(int program, int location, int count, FloatBuffer value)
+	// void glProgramUniform3fv(int program, int location, int count, float[] value, int offset)
+	public void glProgramUniform3i (int program, int location, int v0, int v1, int v2);
+
+	// void glProgramUniform3iv(int program, int location, int count, int[] value, int offset)
+	// void glProgramUniform3iv(int program, int location, int count, IntBuffer value)
+	public void glProgramUniform3ui (int program, int location, int v0, int v1, int v2);
+
+	// void glProgramUniform3uiv(int program, int location, int count, IntBuffer value)
+	// void glProgramUniform3uiv(int program, int location, int count, int[] value, int offset)
+	public void glProgramUniform4f (int program, int location, float v0, float v1, float v2, float v3);
+
+	// void glProgramUniform4fv(int program, int location, int count, FloatBuffer value)
+	// void glProgramUniform4fv(int program, int location, int count, float[] value, int offset)
+	public void glProgramUniform4i (int program, int location, int v0, int v1, int v2, int v3);
+
+	// void glProgramUniform4iv(int program, int location, int count, int[] value, int offset)
+	// void glProgramUniform4iv(int program, int location, int count, IntBuffer value)
+	public void glProgramUniform4ui (int program, int location, int v0, int v1, int v2, int v3);
+
+	// void glProgramUniform4uiv(int program, int location, int count, int[] value, int offset)
+	public void glProgramUniform4uiv (int program, int location, int count, IntBuffer value);
+
+	// void glProgramUniformMatrix2fv(int program, int location, int count, boolean transpose, float[] value, int offset)
+	public void glProgramUniformMatrix2fv (int program, int location, int count, boolean transpose, FloatBuffer value);
+
+	// void glProgramUniformMatrix2x3fv(int program, int location, int count, boolean transpose, float[] value, int offset)
+	public void glProgramUniformMatrix2x3fv (int program, int location, int count, boolean transpose, FloatBuffer value);
+
+	// void glProgramUniformMatrix2x4fv(int program, int location, int count, boolean transpose, float[] value, int offset)
+	public void glProgramUniformMatrix2x4fv (int program, int location, int count, boolean transpose, FloatBuffer value);
+
+	// void glProgramUniformMatrix3fv(int program, int location, int count, boolean transpose, float[] value, int offset)
+	public void glProgramUniformMatrix3fv (int program, int location, int count, boolean transpose, FloatBuffer value);
+
+	// void glProgramUniformMatrix3x2fv(int program, int location, int count, boolean transpose, float[] value, int offset)
+	public void glProgramUniformMatrix3x2fv (int program, int location, int count, boolean transpose, FloatBuffer value);
+
+	// void glProgramUniformMatrix3x4fv(int program, int location, int count, boolean transpose, float[] value, int offset)
+	public void glProgramUniformMatrix3x4fv (int program, int location, int count, boolean transpose, FloatBuffer value);
+
+	// void glProgramUniformMatrix4fv(int program, int location, int count, boolean transpose, float[] value, int offset)
+	public void glProgramUniformMatrix4fv (int program, int location, int count, boolean transpose, FloatBuffer value);
+
+	// void glProgramUniformMatrix4x2fv(int program, int location, int count, boolean transpose, float[] value, int offset)
+	public void glProgramUniformMatrix4x2fv (int program, int location, int count, boolean transpose, FloatBuffer value);
+
+	// void glProgramUniformMatrix4x3fv(int program, int location, int count, boolean transpose, float[] value, int offset)
+	public void glProgramUniformMatrix4x3fv (int program, int location, int count, boolean transpose, FloatBuffer value);
+
+	public void glSampleMaski (int maskNumber, int mask);
+
+	public void glTexStorage2DMultisample (int target, int samples, int internalformat, int width, int height, boolean fixedsamplelocations);
+
+	public void glUseProgramStages (int pipeline, int stages, int program);
+
+	public void glValidateProgramPipeline (int pipeline);
+
+	public void glVertexAttribBinding (int attribindex, int bindingindex);
+
+	public void glVertexAttribFormat (int attribindex, int size, int type, boolean normalized, int relativeoffset);
+
+	public void glVertexAttribIFormat (int attribindex, int size, int type, int relativeoffset);	
+
+	public void glVertexBindingDivisor(int bindingindex, int divisor);
+}

--- a/gdx/src/com/badlogic/gdx/graphics/profiling/GL30Profiler.java
+++ b/gdx/src/com/badlogic/gdx/graphics/profiling/GL30Profiler.java
@@ -1880,4 +1880,64 @@ public class GL30Profiler extends GLProfiler implements GL30 {
 		gl30.glInvalidateSubFramebuffer(target, numAttachments, attachments, x, y, width, height);
 		check();
 	}
+	
+	@Override
+	public long glFenceSync(int condition, int flags) {
+		calls++;
+		long result = gl30.glFenceSync(condition, flags);
+		check();
+		return result;		
+	}
+	
+	@Override
+	public void glDeleteSync(long sync) {
+		calls++;
+		gl30.glDeleteSync(sync);
+		check();
+	}
+	
+	@Override
+	public void glWaitSync(long sync, int flags, long timeout) {
+		calls++;
+		gl30.glWaitSync(sync, flags, timeout);
+		check();
+	}
+
+	@Override
+	public java.nio.Buffer glMapBufferRange(int target, int offset, int length, int access) {
+		calls++;
+		java.nio.Buffer result = gl30.glMapBufferRange(target, offset, length, access);
+		check();	
+		return result;
+	}	
+
+	@Override
+	public void glUniform1ui (int location, int v0) {
+		calls++;
+		gl30.glUniform1ui(location, v0);
+		check();
+	}
+	
+	@Override
+	public void glUniform2ui (int location, int v0, int v1) {
+		calls++;
+		gl30.glUniform2ui(location, v0, v1);
+		check();
+	}
+
+	@Override
+	public void glUniform3ui (int location, int v0, int v1, int v2) {
+		calls++;
+		gl30.glUniform3ui(location, v0, v1, v2);
+		check();
+	}
+
+	@Override
+	public void glUniform4ui (int location, int v0, int v1, int v2, int v3) {
+		calls++;
+		gl30.glUniform4ui(location, v0, v1, v2, v3);
+		check();
+	}
+
+	
 }


### PR DESCRIPTION
- Improved OpenGL ES 3.0 Support (some missing functions)
- Added OpenGL ES 3.1 Support (for LWJGL3 and Android)
- API addition: added Lwjgl3ApplicationConfiguration.useOpenGL31() for OpenGL ES 3.1 
- API addition: added Graphics.isGL31Available() and Graphics.getGL31() for OpenGL ES 3.1

More details here:
http://www.badlogicgames.com/forum/viewtopic.php?f=17&t=25868
