### PR TITLE
Add map() function to MathUtils

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -23,6 +23,7 @@
 - API Change: removed JGLFW backend
 - Fixed mixed up use of TexturePacker.Settings.stripWhitespaceX|Y.
 - Added joystick POV support to LWJGL3 controller backend.
+- Add map() function to MathUtils, ported from Processing
 
 [1.9.6]
 - Fix performance regression in LWJGL3 backend, use java.nio instead of BufferUtils. Those are intrinsics and quite a bit faster than BufferUtils on HotSpot.

--- a/CHANGES
+++ b/CHANGES
@@ -23,7 +23,7 @@
 - API Change: removed JGLFW backend
 - Fixed mixed up use of TexturePacker.Settings.stripWhitespaceX|Y.
 - Added joystick POV support to LWJGL3 controller backend.
-- Add map() function to MathUtils, ported from Processing
+- API addition: Added map() method to MathUtils
 
 [1.9.6]
 - Fix performance regression in LWJGL3 backend, use java.nio instead of BufferUtils. Those are intrinsics and quite a bit faster than BufferUtils on HotSpot.

--- a/gdx/src/com/badlogic/gdx/math/MathUtils.java
+++ b/gdx/src/com/badlogic/gdx/math/MathUtils.java
@@ -316,17 +316,14 @@ public final class MathUtils {
 		return (int)(value + 0.5f);
 	}
 
-	/** Returns a re-mapped float value from one range to another. Examples:
-	 * 2 in [ 0, 10] ->  6 in [ 5, 10].
-	 * 0 in [-5,  5] -> 20 in [10, 30].
-	 * 9 in [ 0, 10] ->  1 in [10,  0].
-	 * value in [istart, iend] -> re-mapped in [ostart, stop] */
-	static public final float map(float value, float istart, float istop, float ostart, float ostop) {
-		return ostart + (ostop - ostart) * ((value - istart) / (istop - istart));
+	/** Returns a re-mapped float value from inRange to outRange. */
+	static public float map (float value, float inRangeStart, float inRangeEnd, float outRangeStart, float outRangeEnd) {
+		return outRangeStart + (outRangeEnd - outRangeStart) * ((value - inRangeStart) / (inRangeEnd - inRangeStart));
 	}
 
-	static public final double map(double value, double istart, double istop, double ostart, double ostop) {
-		return ostart + (ostop - ostart) * ((value - istart) / (istop - istart));
+	/** Returns a re-mapped double value from inRange to outRange. */
+	static public double map (double value, double inRangeStart, double inRangeEnd, double outRangeStart, double outRangeEnd) {
+		return outRangeStart + (outRangeEnd - outRangeStart) * ((value - inRangeStart) / (inRangeEnd - inRangeStart));
 	}
 
 	/** Returns true if the value is zero (using the default tolerance as upper bound) */

--- a/gdx/src/com/badlogic/gdx/math/MathUtils.java
+++ b/gdx/src/com/badlogic/gdx/math/MathUtils.java
@@ -316,6 +316,19 @@ public final class MathUtils {
 		return (int)(value + 0.5f);
 	}
 
+	/** Returns a re-mapped float value from one range to another. Examples:
+	 * 2 in [ 0, 10] ->  6 in [ 5, 10].
+	 * 0 in [-5,  5] -> 20 in [10, 30].
+	 * 9 in [ 0, 10] ->  1 in [10,  0].
+	 * value in [istart, iend] -> re-mapped in [ostart, stop] */
+	static public final float map(float value, float istart, float istop, float ostart, float ostop) {
+		return ostart + (ostop - ostart) * ((value - istart) / (istop - istart));
+	}
+
+	static public final double map(double value, double istart, double istop, double ostart, double ostop) {
+		return ostart + (ostop - ostart) * ((value - istart) / (istop - istart));
+	}
+
 	/** Returns true if the value is zero (using the default tolerance as upper bound) */
 	static public boolean isZero (float value) {
 		return Math.abs(value) <= FLOAT_ROUNDING_ERROR;


### PR DESCRIPTION
Hey! First, I love `libGDX`. Amazing work :)

There's a function which I've been missing and I find *really* useful, `map()`. It takes an input value and two ranges, start range and end range. It then maps the value from the start to the end range. Pretty useful. I ported it from [Processing](https://github.com/processing/processing/blob/db4f1449e4097e08683a276c64db392f906362b4/core/src/processing/core/PApplet.java#L4369-L4373) because I would love to see it integrated into `libGDX` too.

There is another implementation for [JavaScript](http://stackoverflow.com/a/23202637/4759433), but I took the one from the Processing team (the algorithm to calculate the mapped value is not mine, but it's not something private anyway since it's also available for JavaScript in a different way etc.)