### PR TITLE
Sprite.setTextureFit() added.

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g2d/Sprite.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/Sprite.java
@@ -128,6 +128,7 @@ public class Sprite extends TextureRegion {
 
 	/** Sets the texture and resizes the sprite to the size of that texture. */
 	public void setTextureFit (Texture texture) {
+		this.texture = texture;
 		setSize (texture.getWidth(), texture.getHeight());
 		setRegion (0, 0, texture.getWidth(), texture.getHeight());
 	}

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/Sprite.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/Sprite.java
@@ -126,6 +126,12 @@ public class Sprite extends TextureRegion {
 		dirty = sprite.dirty;
 	}
 
+	/** Sets the texture and resizes the sprite to the size of that texture. */
+	public setTextureFit (Texture texture) {
+		setSize (texture.getWidth(), texture.getHeight());
+		setRegion (0, 0, texture.getWidth(), texture.getHeight());
+	}
+
 	/** Sets the position and size of the sprite when drawn, before scaling and rotation are applied. If origin, rotation, or scale
 	 * are changed, it is slightly more efficient to set the bounds after those operations. */
 	public void setBounds (float x, float y, float width, float height) {

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/Sprite.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/Sprite.java
@@ -127,7 +127,7 @@ public class Sprite extends TextureRegion {
 	}
 
 	/** Sets the texture and resizes the sprite to the size of that texture. */
-	public setTextureFit (Texture texture) {
+	public void setTextureFit (Texture texture) {
 		setSize (texture.getWidth(), texture.getHeight());
 		setRegion (0, 0, texture.getWidth(), texture.getHeight());
 	}


### PR DESCRIPTION
Most 24fps animations consist of too many frames and they can't fit in a 4096x4096 sprite sheet. In that case, every frame has to reside in a separate file. setTextureFit (Texture tex) resizes the sprite when a texture with different dimensions from the current one is set. I've chosen that name because it will pop up on the auto-completion menu when someone decides to call setTexture().