### PR TITLE
added getParticles protected method

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g2d/ParticleEmitter.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/ParticleEmitter.java
@@ -378,6 +378,10 @@ public class ParticleEmitter {
 		return new Particle(sprite);
 	}
 
+	protected Particle[] getParticles () {
+		return particles;
+	}
+
 	private void activateParticle (int index) {
 		Particle particle = particles[index];
 		if (particle == null) {


### PR DESCRIPTION
This make it possible for subclass to access `particles` array without using reflection.