### PR TITLE
Update to LWJGL 3.1.1

### DIFF
--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Graphics.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Graphics.java
@@ -370,24 +370,18 @@ public class Lwjgl3Graphics implements Graphics, Disposable {
 		GLFW.glfwSetWindowTitle(window.getWindowHandle(), title);
 	}
 
-	/**
-	 * The window must be recreated via {@link #setWindowedMode(int, int)} in order
-	 * for the changes to take effect.
-	 */
 	@Override
 	public void setUndecorated(boolean undecorated) {
 		Lwjgl3ApplicationConfiguration config = getWindow().getConfig();
 		config.setDecorated(!undecorated);
+		GLFW.glfwSetWindowAttrib(window.getWindowHandle(), GLFW.GLFW_DECORATED, undecorated ? GLFW.GLFW_FALSE : GLFW.GLFW_TRUE);
 	}
 
-	/**
-	 * The window must be recreated via {@link #setWindowedMode(int, int)} in order
-	 * for the changes to take effect.
-	 */
 	@Override
 	public void setResizable(boolean resizable) {
 		Lwjgl3ApplicationConfiguration config = getWindow().getConfig();
 		config.setResizable(resizable);
+		GLFW.glfwSetWindowAttrib(window.getWindowHandle(), GLFW.GLFW_RESIZABLE, resizable ? GLFW.GLFW_TRUE : GLFW.GLFW_FALSE);
 	}
 
 	@Override

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -62,7 +62,7 @@ libraries.lwjgl3 = [
         "org.lwjgl:lwjgl-openal:${versions.lwjgl3}:natives-macos",
         "org.lwjgl:lwjgl-openal:${versions.lwjgl3}:natives-windows",
         "org.lwjgl:lwjgl-opengl:${versions.lwjgl3}",
-		"org.lwjgl:lwjgl-opengl:${versions.lwjgl3}:natives-linux",
+        "org.lwjgl:lwjgl-opengl:${versions.lwjgl3}:natives-linux",
         "org.lwjgl:lwjgl-opengl:${versions.lwjgl3}:natives-macos",
         "org.lwjgl:lwjgl-opengl:${versions.lwjgl3}:natives-windows",
         "org.lwjgl:lwjgl-stb:${versions.lwjgl3}",

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -26,7 +26,7 @@ versions.gwt = "2.8.0"
 versions.gwtPlugin = "0.6"
 versions.jglwf = "1.1"
 versions.lwjgl = "2.9.2"
-versions.lwjgl3 = "3.1.0"
+versions.lwjgl3 = "3.1.1"
 versions.jlayer = "1.0.1-gdx"
 versions.jorbis = "0.0.17"
 versions.junit = "4.11"
@@ -62,6 +62,9 @@ libraries.lwjgl3 = [
         "org.lwjgl:lwjgl-openal:${versions.lwjgl3}:natives-macos",
         "org.lwjgl:lwjgl-openal:${versions.lwjgl3}:natives-windows",
         "org.lwjgl:lwjgl-opengl:${versions.lwjgl3}",
+		"org.lwjgl:lwjgl-opengl:${versions.lwjgl3}:natives-linux",
+        "org.lwjgl:lwjgl-opengl:${versions.lwjgl3}:natives-macos",
+        "org.lwjgl:lwjgl-opengl:${versions.lwjgl3}:natives-windows",
         "org.lwjgl:lwjgl-stb:${versions.lwjgl3}",
         "org.lwjgl:lwjgl-stb:${versions.lwjgl3}:natives-linux",
         "org.lwjgl:lwjgl-stb:${versions.lwjgl3}:natives-macos",

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <android.version>4.4</android.version>
     <gwt.version>2.8.0</gwt.version>
     <lwjgl.version>2.9.2</lwjgl.version>
-    <lwjgl3.version>3.1.0</lwjgl3.version>
+    <lwjgl3.version>3.1.1</lwjgl3.version>
     <jglfw.version>1.1</jglfw.version>
     <robovm.version>2.3.0</robovm.version>
     <moe.version>1.3.0-beta-2</moe.version>


### PR DESCRIPTION
Updated the LWJGL3 backend's `setUndecorated` and `setResizable` methods (in
Lwjgl3Graphics.java), so they work with `glfwSetWindowAttrib` (added on
LWJGL 3.1.1)