### PR TITLE
Invalidating addActorBefore()/addActorAfter() with Table as they do not work (Fixes #4602)

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Table.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Table.java
@@ -31,6 +31,7 @@ import com.badlogic.gdx.utils.Align;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.Pool;
 import com.badlogic.gdx.utils.Pools;
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 /** A group that sizes and positions children using table constraints. By default, {@link #getTouchable()} is
  * {@link Touchable#childrenOnly}.
@@ -1272,4 +1273,27 @@ public class Table extends WidgetGroup {
 			return background == null ? 0 : background.getRightWidth();
 		}
 	};
+
+
+	/** From the <a href="https://github.com/libgdx/libgdx/wiki/Table#inserting-cells">documentation</a>
+	 * <p><i>Table currently does not allow cells to be inserted in the middle or removed.
+	 * To do that, the Table needs to be rebuilt: call clearChildren to remove all children and cells,
+	 * then add them all to the Table again.
+	 * If inserting or removing cells is needed, {@link VerticalGroup} or {@link HorizontalGroup} can be used.</i></p>
+	 * @author Cedric Martens */
+	@Override
+	public void addActorBefore(Actor actorBefore, Actor actor) {
+		throw new NotImplementedException();
+	}
+
+	/** From the <a href="https://github.com/libgdx/libgdx/wiki/Table#inserting-cells">documentation</a>
+	 * <p><i>Table currently does not allow cells to be inserted in the middle or removed.
+	 * To do that, the Table needs to be rebuilt: call clearChildren to remove all children and cells,
+	 * then add them all to the Table again.
+	 * If inserting or removing cells is needed, {@link VerticalGroup} or {@link HorizontalGroup} can be used.</i></p>
+	 * @author Cedric Martens */
+	@Override
+	public void addActorAfter(Actor actorAfter, Actor actor) {
+		throw new NotImplementedException();
+	}
 }

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Table.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Table.java
@@ -31,7 +31,6 @@ import com.badlogic.gdx.utils.Align;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.Pool;
 import com.badlogic.gdx.utils.Pools;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 /** A group that sizes and positions children using table constraints. By default, {@link #getTouchable()} is
  * {@link Touchable#childrenOnly}.
@@ -1283,7 +1282,7 @@ public class Table extends WidgetGroup {
 	 * @author Cedric Martens */
 	@Override
 	public void addActorBefore(Actor actorBefore, Actor actor) {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 
 	/** From the <a href="https://github.com/libgdx/libgdx/wiki/Table#inserting-cells">documentation</a>
@@ -1294,6 +1293,6 @@ public class Table extends WidgetGroup {
 	 * @author Cedric Martens */
 	@Override
 	public void addActorAfter(Actor actorAfter, Actor actor) {
-		throw new NotImplementedException();
+		throw new UnsupportedOperationException();
 	}
 }


### PR DESCRIPTION
I did the suggestion 2. (throw an exception) as suggested in the bottom of Issue #4602

I added documentation to the methods and quoted the documentation [here](https://github.com/libgdx/libgdx/wiki/Table#inserting-cells) which explains that these are not supported and suggests an alternative way to accomplish the desired result.