### PR TITLE
Stage: allow to access/read debugAll Variable

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/Stage.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/Stage.java
@@ -785,6 +785,10 @@ public class Stage extends InputAdapter implements Disposable {
 		else
 			root.setDebug(false, true);
 	}
+	
+	public boolean isDebugAll () {
+		return debugAll;
+	}
 
 	/** If true, debug is enabled only for the actor under the mouse. Can be combined with {@link #setDebugAll(boolean)}. */
 	public void setDebugUnderMouse (boolean debugUnderMouse) {


### PR DESCRIPTION
its already allowed to change the debugAll variable in Stage.class, why not allow to access/read it as well ?
(its really inconvenient to access it in other ways)