### PR TITLE
Add POV support to Android controller backend

### DIFF
--- a/extensions/gdx-controllers/gdx-controllers-android/src/com/badlogic/gdx/controllers/android/AndroidController.java
+++ b/extensions/gdx-controllers/gdx-controllers-android/src/com/badlogic/gdx/controllers/android/AndroidController.java
@@ -18,15 +18,13 @@ package com.badlogic.gdx.controllers.android;
 
 import android.view.InputDevice;
 import android.view.InputDevice.MotionRange;
+import android.view.MotionEvent;
 
-import com.badlogic.gdx.controllers.ControlType;
 import com.badlogic.gdx.controllers.Controller;
 import com.badlogic.gdx.controllers.ControllerListener;
 import com.badlogic.gdx.controllers.PovDirection;
 import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.utils.Array;
-import com.badlogic.gdx.utils.GdxRuntimeException;
-import com.badlogic.gdx.utils.IntFloatMap;
 import com.badlogic.gdx.utils.IntIntMap;
 
 public class AndroidController implements Controller {
@@ -36,6 +34,8 @@ public class AndroidController implements Controller {
 	protected final IntIntMap buttons = new IntIntMap();
 	protected final float[] axes;
 	protected final int[] axesIds;
+	protected int pov = 0;
+	private boolean povAxis;
 	private final Array<ControllerListener> listeners = new Array<ControllerListener>();
 	
 	public AndroidController(int deviceId, String name) {
@@ -46,7 +46,11 @@ public class AndroidController implements Controller {
 		int numAxes = 0;
 		for (MotionRange range : device.getMotionRanges()) {
 			if ((range.getSource() & InputDevice.SOURCE_CLASS_JOYSTICK) != 0) {
-				numAxes += 1;
+				if (range.getAxis() != MotionEvent.AXIS_HAT_X && range.getAxis() != MotionEvent.AXIS_HAT_Y) {
+					numAxes += 1;
+				} else {
+					povAxis = true;
+				}
 			}
 		}
 
@@ -55,13 +59,19 @@ public class AndroidController implements Controller {
 		int i = 0;
 		for (MotionRange range : device.getMotionRanges()) {
 			if ((range.getSource() & InputDevice.SOURCE_CLASS_JOYSTICK) != 0) {
-				axesIds[i++] = range.getAxis();
+				if (range.getAxis() != MotionEvent.AXIS_HAT_X && range.getAxis() != MotionEvent.AXIS_HAT_Y) {
+					axesIds[i++] = range.getAxis();
+				}
 			}
 		}
 	}
 
 	public boolean isAttached () {
 		return attached;
+	}
+
+	public boolean hasPovAxis() {
+		return povAxis;
 	}
 
 	public void setAttached (boolean attached) {
@@ -118,7 +128,29 @@ public class AndroidController implements Controller {
 
 	@Override
 	public PovDirection getPov (int povIndex) {
-		return PovDirection.center;
+		if (povIndex != 0) return PovDirection.center;
+		switch (pov) {
+			case 0x00000000:
+				return PovDirection.center;
+			case 0x00000001:
+				return PovDirection.north;
+			case 0x00000010:
+				return PovDirection.south;
+			case 0x00000100:
+				return PovDirection.east;
+			case 0x00001000:
+				return PovDirection.west;
+			case 0x00000101:
+				return PovDirection.northEast;
+			case 0x00000110:
+				return PovDirection.southEast;
+			case 0x00001001:
+				return PovDirection.northWest;
+			case 0x00001010:
+				return PovDirection.southWest;
+			default:
+				throw new RuntimeException("Unexpected POV value : " + pov);
+		}
 	}
 
 	@Override

--- a/extensions/gdx-controllers/gdx-controllers-android/src/com/badlogic/gdx/controllers/android/AndroidControllers.java
+++ b/extensions/gdx-controllers/gdx-controllers-android/src/com/badlogic/gdx/controllers/android/AndroidControllers.java
@@ -30,6 +30,7 @@ import com.badlogic.gdx.backends.android.AndroidInputThreePlus;
 import com.badlogic.gdx.controllers.Controller;
 import com.badlogic.gdx.controllers.ControllerListener;
 import com.badlogic.gdx.controllers.ControllerManager;
+import com.badlogic.gdx.controllers.PovDirection;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.IntMap;
 import com.badlogic.gdx.utils.IntMap.Entry;
@@ -116,6 +117,14 @@ public class AndroidControllers implements LifecycleListener, ControllerManager,
 									if(listener.axisMoved(event.controller, event.code, event.axisValue)) break;
 								}
 								break;
+							case AndroidControllerEvent.POV:
+								for (ControllerListener listener : listeners) {
+									if (listener.povMoved(event.controller, 0, event.povDirection)) break;
+								}
+								for (ControllerListener listener : event.controller.getListeners()) {
+									if (listener.povMoved(event.controller, 0, event.povDirection)) break;
+								}
+								break;
 							default:
 						}
 					}
@@ -134,21 +143,46 @@ public class AndroidControllers implements LifecycleListener, ControllerManager,
 		if(controller != null) {
 			synchronized(eventQueue) {
 				final int historySize = motionEvent.getHistorySize();
+
+				if (controller.hasPovAxis()) {
+					int direction = 0;
+					float povX = motionEvent.getAxisValue(MotionEvent.AXIS_HAT_X);
+					float povY = motionEvent.getAxisValue(MotionEvent.AXIS_HAT_Y);
+					if (Float.compare(povY, -1.0f) == 0) {
+						direction |= 0x00000001;
+					} else if (Float.compare(povY, 1.0f) == 0) {
+						direction |= 0x00000010;
+					}
+					if (Float.compare(povX, 1.0f) == 0) {
+						direction |= 0x00000100;
+					} else if (Float.compare(povX, -1.0f) == 0) {
+						direction |= 0x00001000;
+					}
+					if (direction != controller.pov) {
+						controller.pov = direction;
+						AndroidControllerEvent event = eventPool.obtain();
+						event.type = AndroidControllerEvent.POV;
+						event.controller = controller;
+						event.povDirection = controller.getPov(0);
+						eventQueue.add(event);
+					}
+				}
+
 				int axisIndex = 0;
-            for (int axisId: controller.axesIds) {
-            	float axisValue = motionEvent.getAxisValue(axisId);
-            	if(controller.getAxis(axisIndex) == axisValue) {
-            		axisIndex++;
-            		continue;
-            	}
-            	AndroidControllerEvent event = eventPool.obtain();
-   				event.type = AndroidControllerEvent.AXIS;
-   				event.controller = controller;
-   				event.code = axisIndex;
-   				event.axisValue = axisValue;
-   				eventQueue.add(event);
-   				axisIndex++;
-            }
+            	for (int axisId: controller.axesIds) {
+					float axisValue = motionEvent.getAxisValue(axisId);
+					if(controller.getAxis(axisIndex) == axisValue) {
+						axisIndex++;
+						continue;
+					}
+					AndroidControllerEvent event = eventPool.obtain();
+					event.type = AndroidControllerEvent.AXIS;
+					event.controller = controller;
+					event.code = axisIndex;
+					event.axisValue = axisValue;
+					eventQueue.add(event);
+					axisIndex++;
+				}
 			}
 			return true;
 		}
@@ -166,11 +200,48 @@ public class AndroidControllers implements LifecycleListener, ControllerManager,
 				AndroidControllerEvent event = eventPool.obtain();
 				event.controller = controller;
 				if(keyEvent.getAction() == KeyEvent.ACTION_DOWN) {
-					event.type = AndroidControllerEvent.BUTTON_DOWN;
+					if (keyCode == KeyEvent.KEYCODE_DPAD_UP) {
+						event.type = AndroidControllerEvent.POV;
+						controller.pov |= 0x00000001;
+						event.povDirection = controller.getPov(0);
+					} else if (keyCode == KeyEvent.KEYCODE_DPAD_DOWN) {
+						event.type = AndroidControllerEvent.POV;
+						controller.pov |= 0x00000010;
+						event.povDirection = controller.getPov(0);
+					} else if (keyCode == KeyEvent.KEYCODE_DPAD_RIGHT) {
+						event.type = AndroidControllerEvent.POV;
+						controller.pov |= 0x00000100;
+						event.povDirection = controller.getPov(0);
+					} else if (keyCode == KeyEvent.KEYCODE_DPAD_LEFT) {
+						event.type = AndroidControllerEvent.POV;
+						controller.pov |= 0x00001000;
+						event.povDirection = controller.getPov(0);
+					} else {
+						event.type = AndroidControllerEvent.BUTTON_DOWN;
+						event.code = keyCode;
+					}
 				} else {
-					event.type = AndroidControllerEvent.BUTTON_UP;
+					if (keyCode == KeyEvent.KEYCODE_DPAD_UP) {
+						event.type = AndroidControllerEvent.POV;
+						controller.pov &= 0x00001110;
+						event.povDirection = controller.getPov(0);
+					} else if (keyCode == KeyEvent.KEYCODE_DPAD_DOWN) {
+						event.type = AndroidControllerEvent.POV;
+						controller.pov &= 0x00001101;
+						event.povDirection = controller.getPov(0);
+					} else if (keyCode == KeyEvent.KEYCODE_DPAD_RIGHT) {
+						event.type = AndroidControllerEvent.POV;
+						controller.pov &= 0x00001011;
+						event.povDirection = controller.getPov(0);
+					} else if (keyCode == KeyEvent.KEYCODE_DPAD_LEFT) {
+						event.type = AndroidControllerEvent.POV;
+						controller.pov &= 0x00000111;
+						event.povDirection = controller.getPov(0);
+					} else {
+						event.type = AndroidControllerEvent.BUTTON_UP;
+						event.code = keyCode;
+					}
 				}
-				event.code = keyCode;
 				eventQueue.add(event);
 			}
 			if (keyCode == KeyEvent.KEYCODE_BACK && !Gdx.input.isCatchBackKey()) {

--- a/tests/gdx-tests-android/build.gradle
+++ b/tests/gdx-tests-android/build.gradle
@@ -28,7 +28,7 @@ dependencies {
 	compile project(":gdx")
 	compile project(":extensions:gdx-box2d:gdx-box2d")
 	compile project(":extensions:gdx-bullet")
-	compile project(":extensions:gdx-controllers:gdx-controllers")
+	compile project(":extensions:gdx-controllers:gdx-controllers-android")
 	compile project(":extensions:gdx-freetype")
 	compile project(":backends:gdx-backend-android")
 	compile libraries.android

--- a/tests/gdx-tests-lwjgl/build.gradle
+++ b/tests/gdx-tests-lwjgl/build.gradle
@@ -21,6 +21,7 @@ ext {
 dependencies {
     compile project(":tests:gdx-tests")
     compile project(":backends:gdx-backend-lwjgl")
+    compile project(":extensions:gdx-controllers:gdx-controllers-desktop")
     compile testnatives.desktop
 }
 


### PR DESCRIPTION
POV was reported as axes or buttons (depending on the controller) and not properly translated into `PovDirection`

Tested on Galaxy S6, Asus TF700, Nexus Player and Ouya with the following controllers:

- MOGA Pro Power
- Wireless Bluetooth Gamepad w/ Keyboard
- Nexus Player Gamepad
- Ouya Controller
- Logitech F510
- Thrustmaster Dual Trigger 3-in-1
- Thrustmaster T-Flight Stick X