### PR TITLE
Updated Vis extensions

### DIFF
--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/data/extensions.xml
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/data/extensions.xml
@@ -23,8 +23,8 @@
 		<name>VisUI</name>
 		<description>Flat design skin for scene2d.ui and UI toolkit</description>
 		<package>com.kotcrab.vis.ui</package>
-		<version>1.2.4</version>
-		<compatibility>1.9.4</compatibility>
+		<version>1.3.0</version>
+		<compatibility>1.9.6</compatibility>
 		<website>https://github.com/kotcrab/VisEditor/wiki/VisUI</website>
 		<gwtInherits>
 			<inherit>com.kotcrab.vis.vis-ui</inherit>
@@ -39,34 +39,6 @@
 			<ios-moe></ios-moe>
 			<html>
 				<dependency>com.kotcrab.vis:vis-ui:sources</dependency>
-			</html>
-		</projects>
-	</extension>
-		<extension>
-		<name>VisRuntime</name>
-		<description>Runtime for VisEditor</description>
-		<package>com.kotcrab.vis.runtime</package>
-		<version>0.3.2</version>
-		<compatibility>1.9.3</compatibility>
-		<website>http://vis.kotcrab.com</website>
-		<gwtInherits>
-			<inherit>com.kotcrab.vis.vis-runtime</inherit>
-		</gwtInherits>
-		<projects>
-			<core>
-				<dependency>com.kotcrab.vis:vis-runtime</dependency>
-			</core>
-			<desktop></desktop>
-			<android></android>
-			<ios></ios>
-			<ios-moe></ios-moe>
-			<html>
-				<dependency external="true">net.onedaybeard.artemis:artemis-odb-gwt:1.3.1</dependency>
-				<dependency external="true">net.onedaybeard.artemis:artemis-odb-gwt:1.3.1:sources</dependency>
-				<dependency external="true">net.onedaybeard.artemis:artemis-odb:1.3.1:sources</dependency>
-				<dependency>com.kotcrab.vis:vis-runtime-gwt</dependency>
-				<dependency>com.kotcrab.vis:vis-runtime-gwt:sources</dependency>
-				<dependency>com.kotcrab.vis:vis-runtime:sources</dependency>
 			</html>
 		</projects>
 	</extension>


### PR DESCRIPTION
Updating VisUI to 1.3.0 and removing VisRuntime, no longer maintained.