### PR TITLE
Fix GWT-Pixmap. Add missing format.

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/graphics/Pixmap.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/graphics/Pixmap.java
@@ -123,6 +123,7 @@ public class Pixmap implements Disposable {
 		this.imageElement = imageElement;
 		this.width = imageElement != null ? imageElement.getWidth() : width;
 		this.height = imageElement != null ? imageElement.getHeight() : height;
+		this.format = Format.RGBA8888;
 
 		buffer = BufferUtils.newIntBuffer(1);
 		id = nextId++;


### PR DESCRIPTION
Pixmap's `format` is null, because #4234 incorrectly removed it.
See https://github.com/libgdx/libgdx/pull/4234/files#diff-193f92909143c2ad5b478ee1618ce414L126