### PR TITLE
Fix blending being incorrectly used for gwt-pixmap

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/graphics/Pixmap.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/graphics/Pixmap.java
@@ -147,11 +147,8 @@ public class Pixmap implements Disposable {
 	 * @param blending the blending type */
 	public void setBlending (Blending blending) {
 		this.blending = blending;
-		Composite composite = getComposite();
-		for (Pixmap pixmap : pixmaps.values()) {
-			pixmap.ensureCanvasExists();
-			pixmap.context.setGlobalCompositeOperation(composite);
-		}
+		this.ensureCanvasExists();
+		this.context.setGlobalCompositeOperation(getComposite());
 	}
 
 	/** @return the currently set {@link Blending} */


### PR DESCRIPTION
Pixmap blending has been global state, but it recently became per pixmap-state.
So setting the blending should only change it for the current pixmap and not for
all pixmaps.
This works fine on desktop, but is broken on GWT.