### PR TITLE
Make updateImage() protected

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ImageButton.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ImageButton.java
@@ -71,7 +71,8 @@ public class ImageButton extends Button {
 		return style;
 	}
 
-	private void updateImage () {
+	/** Updates the Image with the appropriate Drawable from the style before it is drawn. */
+	protected void updateImage () {
 		Drawable drawable = null;
 		if (isDisabled() && style.imageDisabled != null)
 			drawable = style.imageDisabled;

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ImageTextButton.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ImageTextButton.java
@@ -83,7 +83,8 @@ public class ImageTextButton extends Button {
 		return style;
 	}
 
-	private void updateImage () {
+	/** Updates the Image with the appropriate Drawable from the style before it is drawn. */
+	protected void updateImage () {
 		Drawable drawable = null;
 		if (isDisabled() && style.imageDisabled != null)
 			drawable = style.imageDisabled;


### PR DESCRIPTION
It would be nice to be able to explicitly set the Drawable used by ImageButton and ImageTextButton at will so I'm not locked into the states defined in the style,, but `updateImage()` overrides that change in `draw()`. I know I can subclass Button directly, but this would make the whole process less of a hassle. 