### PR TITLE
Can set null region on TextureRegionDrawable

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/TextureRegionDrawable.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/TextureRegionDrawable.java
@@ -52,8 +52,10 @@ public class TextureRegionDrawable extends BaseDrawable implements TransformDraw
 
 	public void setRegion (TextureRegion region) {
 		this.region = region;
-		setMinWidth(region.getRegionWidth());
-		setMinHeight(region.getRegionHeight());
+		if (region != null) {
+			setMinWidth(region.getRegionWidth());
+			setMinHeight(region.getRegionHeight());
+		}
 	}
 
 	public TextureRegion getRegion () {


### PR DESCRIPTION
The reason for this is so the TextureRegionDrawable itself, or any WidgetGroup that references it, can be used in a Pool. If you have a widget that is poolable and references any TextureRegion (indirectly through a TextureRegionDrawable), there needs to be a way to null out the TextureRegion reference for returning it to the pool. 

This moves the NPE from `setRegion` to `draw`, but presumably `draw` won't be called on it if it's been sent to a pool.

My use case is that I have a large panel of custom image buttons, and the number of buttons and the images vary each time the panel is brought up, so I wanted to pool the buttons to make it a bit more snappy.