### PR TITLE
Update GWT controller extension and add POV support

### DIFF
--- a/extensions/gdx-controllers/gdx-controllers-gwt/src/com/badlogic/gdx/controllers/gwt/GwtController.java
+++ b/extensions/gdx-controllers/gdx-controllers-gwt/src/com/badlogic/gdx/controllers/gwt/GwtController.java
@@ -29,11 +29,15 @@ public class GwtController implements Controller {
 	private int index;
 	
 	private String name;
-	
+
+	private boolean standardMapping;
+
 	protected final float[] axes;
 	
 	protected final IntFloatMap buttons = new IntFloatMap();
-	
+
+	protected int pov = 0;
+
 	private final Array<ControllerListener> listeners = new Array<ControllerListener>();
 	
 	public GwtController(int index, String name) {
@@ -42,12 +46,15 @@ public class GwtController implements Controller {
 		
 		Gamepad gamepad = Gamepad.getGamepad(index);
 		axes = new float[gamepad.getAxes().length()];
+		standardMapping = gamepad.getMapping().equals("standard");
 	}
 	
 	public int getIndex() {
 		return index;
 	}
-	
+
+	public boolean isStandardMapping() {return standardMapping; }
+
 	@Override
 	public String getName() {
 		return name;
@@ -69,8 +76,28 @@ public class GwtController implements Controller {
 	}
 
 	@Override
-	public PovDirection getPov(int povCode) {
-		return PovDirection.center;
+	public PovDirection getPov(int povIndex) {
+		if (povIndex != 0) return PovDirection.center;
+		switch (pov) {
+			case 0x00000001:
+				return PovDirection.north;
+			case 0x00000010:
+				return PovDirection.south;
+			case 0x00000100:
+				return PovDirection.east;
+			case 0x00001000:
+				return PovDirection.west;
+			case 0x00000101:
+				return PovDirection.northEast;
+			case 0x00000110:
+				return PovDirection.southEast;
+			case 0x00001001:
+				return PovDirection.northWest;
+			case 0x00001010:
+				return PovDirection.southWest;
+			default:
+				return PovDirection.center;
+		}
 	}
 
 	@Override

--- a/extensions/gdx-controllers/gdx-controllers-gwt/src/com/badlogic/gdx/controllers/gwt/GwtControllers.java
+++ b/extensions/gdx-controllers/gdx-controllers-gwt/src/com/badlogic/gdx/controllers/gwt/GwtControllers.java
@@ -21,14 +21,21 @@ import com.badlogic.gdx.controllers.Controller;
 import com.badlogic.gdx.controllers.ControllerListener;
 import com.badlogic.gdx.controllers.ControllerManager;
 import com.badlogic.gdx.controllers.gwt.support.Gamepad;
+import com.badlogic.gdx.controllers.gwt.support.GamepadButton;
 import com.badlogic.gdx.controllers.gwt.support.GamepadSupport;
 import com.badlogic.gdx.controllers.gwt.support.GamepadSupportListener;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.IntMap;
 import com.badlogic.gdx.utils.Pool;
+import com.google.gwt.core.client.JsArray;
 import com.google.gwt.core.client.JsArrayNumber;
 
 public class GwtControllers implements ControllerManager, GamepadSupportListener {
+
+	private static final int STANDARD_CONTROLLER_DPAD_UP = 12;
+	private static final int STANDARD_CONTROLLER_DPAD_DOWN = 13;
+	private static final int STANDARD_CONTROLLER_DPAD_LEFT = 14;
+	private static final int STANDARD_CONTROLLER_DPAD_RIGHT = 15;
 
 	private final IntMap<GwtController> controllerMap = new IntMap<GwtController>();
 	private final Array<Controller> controllers = new Array<Controller>();
@@ -40,63 +47,71 @@ public class GwtControllers implements ControllerManager, GamepadSupportListener
 			return new GwtControllerEvent();
 		}
 	};
-	
-	public GwtControllers() {
+
+	public GwtControllers () {
 		GamepadSupport.init(this);
 		setupEventQueue();
 	}
-	
-	public void setupEventQueue() {
+
+	public void setupEventQueue () {
 		new Runnable() {
 			@SuppressWarnings("synthetic-access")
 			@Override
 			public void run () {
-				synchronized(eventQueue) {
-					for(GwtControllerEvent event: eventQueue) {
-						switch(event.type) {
-							case GwtControllerEvent.CONNECTED:
-								controllers.add(event.controller);
-								for(ControllerListener listener: listeners) {
-									listener.connected(event.controller);
-								}
-								break;
-							case GwtControllerEvent.DISCONNECTED:
-								controllers.removeValue(event.controller, true);
-								for(ControllerListener listener: listeners) {
-									listener.disconnected(event.controller);
-								}
-								for(ControllerListener listener: event.controller.getListeners()) {
-									listener.disconnected(event.controller);
-								}
-								break;
-							case GwtControllerEvent.BUTTON_DOWN:
-								event.controller.buttons.put(event.code, event.amount);
-								for(ControllerListener listener: listeners) {
-									if(listener.buttonDown(event.controller, event.code)) break;
-								}
-								for(ControllerListener listener: event.controller.getListeners()) {
-									if(listener.buttonDown(event.controller, event.code)) break;
-								}
-								break;
-							case GwtControllerEvent.BUTTON_UP:
-								event.controller.buttons.remove(event.code, event.amount);
-								for(ControllerListener listener: listeners) {
-									if(listener.buttonUp(event.controller, event.code)) break;
-								}
-								for(ControllerListener listener: event.controller.getListeners()) {
-									if(listener.buttonUp(event.controller, event.code)) break;
-								}
-								break;
-							case GwtControllerEvent.AXIS:
-								event.controller.axes[event.code] = event.amount;
-								for(ControllerListener listener: listeners) {
-									if(listener.axisMoved(event.controller, event.code, event.amount)) break;
-								}
-								for(ControllerListener listener: event.controller.getListeners()) {
-									if(listener.axisMoved(event.controller, event.code, event.amount)) break;
-								}
-								break;
-							default:
+				synchronized (eventQueue) {
+					for (GwtControllerEvent event : eventQueue) {
+						switch (event.type) {
+						case GwtControllerEvent.CONNECTED:
+							controllers.add(event.controller);
+							for (ControllerListener listener : listeners) {
+								listener.connected(event.controller);
+							}
+							break;
+						case GwtControllerEvent.DISCONNECTED:
+							controllers.removeValue(event.controller, true);
+							for (ControllerListener listener : listeners) {
+								listener.disconnected(event.controller);
+							}
+							for (ControllerListener listener : event.controller.getListeners()) {
+								listener.disconnected(event.controller);
+							}
+							break;
+						case GwtControllerEvent.BUTTON_DOWN:
+							event.controller.buttons.put(event.code, event.amount);
+							for (ControllerListener listener : listeners) {
+								if (listener.buttonDown(event.controller, event.code)) break;
+							}
+							for (ControllerListener listener : event.controller.getListeners()) {
+								if (listener.buttonDown(event.controller, event.code)) break;
+							}
+							break;
+						case GwtControllerEvent.BUTTON_UP:
+							event.controller.buttons.remove(event.code, event.amount);
+							for (ControllerListener listener : listeners) {
+								if (listener.buttonUp(event.controller, event.code)) break;
+							}
+							for (ControllerListener listener : event.controller.getListeners()) {
+								if (listener.buttonUp(event.controller, event.code)) break;
+							}
+							break;
+						case GwtControllerEvent.AXIS:
+							event.controller.axes[event.code] = event.amount;
+							for (ControllerListener listener : listeners) {
+								if (listener.axisMoved(event.controller, event.code, event.amount)) break;
+							}
+							for (ControllerListener listener : event.controller.getListeners()) {
+								if (listener.axisMoved(event.controller, event.code, event.amount)) break;
+							}
+							break;
+						case GwtControllerEvent.POV:
+							for (ControllerListener listener : listeners) {
+								if (listener.povMoved(event.controller, 0, event.povDirection)) break;
+							}
+							for (ControllerListener listener : event.controller.getListeners()) {
+								if (listener.povMoved(event.controller, 0, event.povDirection)) break;
+							}
+							break;
+						default:
 						}
 					}
 					eventPool.freeAll(eventQueue);
@@ -106,32 +121,32 @@ public class GwtControllers implements ControllerManager, GamepadSupportListener
 			}
 		}.run();
 	}
-	
+
 	@Override
-	public Array<Controller> getControllers() {
+	public Array<Controller> getControllers () {
 		return controllers;
 	}
 
 	@Override
-	public void addListener(ControllerListener listener) {
-		synchronized(eventQueue) {
+	public void addListener (ControllerListener listener) {
+		synchronized (eventQueue) {
 			listeners.add(listener);
 		}
 	}
 
 	@Override
-	public void removeListener(ControllerListener listener) {
-		synchronized(eventQueue) {
+	public void removeListener (ControllerListener listener) {
+		synchronized (eventQueue) {
 			listeners.removeValue(listener, true);
 		}
 	}
 
 	@Override
-	public void onGamepadConnected(int index) {
+	public void onGamepadConnected (int index) {
 		Gamepad gamepad = Gamepad.getGamepad(index);
 		GwtController controller = new GwtController(gamepad.getIndex(), gamepad.getId());
 		controllerMap.put(index, controller);
-		synchronized(eventQueue) {
+		synchronized (eventQueue) {
 			GwtControllerEvent event = eventPool.obtain();
 			event.type = GwtControllerEvent.CONNECTED;
 			event.controller = controller;
@@ -140,10 +155,10 @@ public class GwtControllers implements ControllerManager, GamepadSupportListener
 	}
 
 	@Override
-	public void onGamepadDisconnected(int index) {
+	public void onGamepadDisconnected (int index) {
 		GwtController controller = controllerMap.remove(index);
-		if(controller != null) {
-			synchronized(eventQueue) {
+		if (controller != null) {
+			synchronized (eventQueue) {
 				GwtControllerEvent event = eventPool.obtain();
 				event.type = GwtControllerEvent.DISCONNECTED;
 				event.controller = controller;
@@ -151,45 +166,81 @@ public class GwtControllers implements ControllerManager, GamepadSupportListener
 			}
 		}
 	}
-	
+
 	@Override
-	public void onGamepadUpdated(int index) {
+	public void onGamepadUpdated (int index) {
 		Gamepad gamepad = Gamepad.getGamepad(index);
 		GwtController controller = controllerMap.get(index);
 		if (gamepad != null && controller != null) {
 			// Determine what changed
 			JsArrayNumber axes = gamepad.getAxes();
-			JsArrayNumber buttons = gamepad.getButtons();
-			synchronized(eventQueue) {
+			JsArray<GamepadButton> buttons = gamepad.getButtons();
+			synchronized (eventQueue) {
 				for (int i = 0, j = axes.length(); i < j; i++) {
 					float oldAxis = controller.getAxis(i);
-					float newAxis = (float) axes.get(i);
+					float newAxis = (float)axes.get(i);
 					if (oldAxis != newAxis) {
 						GwtControllerEvent event = eventPool.obtain();
 						event.type = GwtControllerEvent.AXIS;
 						event.controller = controller;
-						event.code = i;						
+						event.code = i;
 						event.amount = newAxis;
 						eventQueue.add(event);
 					}
-				}			
+				}
 				for (int i = 0, j = buttons.length(); i < j; i++) {
-					float oldButton = controller.getButtonAmount(i);
-					float newButton = (float) buttons.get(i);
-					if (oldButton != newButton) {
-						if ((oldButton < 0.5f && newButton < 0.5f) || (oldButton >= 0.5f && newButton >= 0.5f)) {
-							controller.buttons.put(i, newButton);
-							continue;
+					float newButton = (float)buttons.get(i).getValue();
+					if (controller.isStandardMapping() && i >= STANDARD_CONTROLLER_DPAD_UP && i <= STANDARD_CONTROLLER_DPAD_RIGHT) {
+						int direction = controller.pov;
+						if (newButton < 0.5f) {
+							if (i == STANDARD_CONTROLLER_DPAD_UP)
+								direction &= 0x00001110;
+							else if (i == STANDARD_CONTROLLER_DPAD_DOWN)
+								direction &= 0x00001101;
+							else if (i == STANDARD_CONTROLLER_DPAD_LEFT)
+								direction &= 0x00000111;
+							else if (i == STANDARD_CONTROLLER_DPAD_RIGHT)
+								direction &= 0x00001011;
+						} else {
+							if (i == STANDARD_CONTROLLER_DPAD_UP) {
+								direction |= 0x00000001;
+								direction &= 0x00001101;
+							} else if (i == STANDARD_CONTROLLER_DPAD_DOWN) {
+								direction |= 0x00000010;
+								direction &= 0x00001110;
+							} else if (i == STANDARD_CONTROLLER_DPAD_LEFT) {
+								direction |= 0x00001000;
+								direction &= 0x00001011;
+							} else if (i == STANDARD_CONTROLLER_DPAD_RIGHT) {
+								direction |= 0x00000100;
+								direction &= 0x00000111;
+							}
 						}
+						if (direction != controller.pov) {
+							controller.pov = direction;
+							GwtControllerEvent event = eventPool.obtain();
+							event.type = GwtControllerEvent.POV;
+							event.controller = controller;
+							event.povDirection = controller.getPov(0);
+							eventQueue.add(event);
+						}
+					} else {
+						float oldButton = controller.getButtonAmount(i);
+						if (oldButton != newButton) {
+							if ((oldButton < 0.5f && newButton < 0.5f) || (oldButton >= 0.5f && newButton >= 0.5f)) {
+								controller.buttons.put(i, newButton);
+								continue;
+							}
 
-						GwtControllerEvent event = eventPool.obtain();
-						event.type = newButton >= 0.5f ? GwtControllerEvent.BUTTON_DOWN : GwtControllerEvent.BUTTON_UP;
-						event.controller = controller;
-						event.code = i;						
-						event.amount = newButton;
-						eventQueue.add(event);
-					}					
-				}				
+							GwtControllerEvent event = eventPool.obtain();
+							event.type = newButton >= 0.5f ? GwtControllerEvent.BUTTON_DOWN : GwtControllerEvent.BUTTON_UP;
+							event.controller = controller;
+							event.code = i;
+							event.amount = newButton;
+							eventQueue.add(event);
+						}
+					}
+				}
 			}
 		}
 	}
@@ -198,7 +249,7 @@ public class GwtControllers implements ControllerManager, GamepadSupportListener
 	public void clearListeners () {
 		listeners.clear();
 	}
-	
+
 	@Override
 	public Array<ControllerListener> getListeners () {
 		return listeners;

--- a/extensions/gdx-controllers/gdx-controllers-gwt/src/com/badlogic/gdx/controllers/gwt/support/Gamepad.java
+++ b/extensions/gdx-controllers/gdx-controllers-gwt/src/com/badlogic/gdx/controllers/gwt/support/Gamepad.java
@@ -17,6 +17,7 @@
 package com.badlogic.gdx.controllers.gwt.support;
 
 import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.core.client.JsArray;
 import com.google.gwt.core.client.JsArrayNumber;
 
 public final class Gamepad extends JavaScriptObject {
@@ -28,31 +29,39 @@ public final class Gamepad extends JavaScriptObject {
 	public native String getId() /*-{
 		return this.id; 
 	}-*/;
-	
+
 	public native int getIndex() /*-{
 		return this.index;
 	}-*/;
-	
+
+	public native boolean getConnected() /*-{
+		return this.conected;
+	}-*/;
+
 	public native double getTimestamp() /*-{
 		return this.timestamp; 
 	}-*/;
-	
+
+	public native String getMapping() /*-{
+		return this.mapping;
+	}-*/;
+
 	public native JsArrayNumber getAxes() /*-{
 		return this.axes;
 	}-*/;
 	
-	public native JsArrayNumber getButtons() /*-{
+	public native JsArray<GamepadButton> getButtons() /*-{
 		return this.buttons;
 	}-*/;
 
 	public native double getPreviousTimestamp() /*-{
 		return this.previousTimestamp;
 	}-*/;
-	
+
 	public native void setPreviousTimestamp(double previousTimestamp) /*-{
 		this.previousTimestamp = previousTimestamp;
 	}-*/;
-	
+
 	public static Gamepad getGamepad(int index) {
 		return GamepadSupport.getGamepad(index);		
 	}

--- a/extensions/gdx-controllers/gdx-controllers-gwt/src/com/badlogic/gdx/controllers/gwt/support/GamepadButton.java
+++ b/extensions/gdx-controllers/gdx-controllers-gwt/src/com/badlogic/gdx/controllers/gwt/support/GamepadButton.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogic.gdx.controllers.gwt.support;
+
+import com.google.gwt.core.client.JavaScriptObject;
+
+public final class GamepadButton extends JavaScriptObject {
+
+    protected GamepadButton() {
+        // Required by GWT
+    }
+
+    public native boolean getPressed() /*-{
+		return this.pressed;
+	}-*/;
+
+    public native double getTouched() /*-{
+		return this.touched;
+	}-*/;
+
+    public native double getValue() /*-{
+		return this.value;
+	}-*/;
+
+}

--- a/extensions/gdx-controllers/gdx-controllers-gwt/src/com/badlogic/gdx/controllers/gwt/support/GamepadSupport.java
+++ b/extensions/gdx-controllers/gdx-controllers-gwt/src/com/badlogic/gdx/controllers/gwt/support/GamepadSupport.java
@@ -115,18 +115,18 @@ public class GamepadSupport {
 	}
 	
 	private static native void nativeInit() /*-{
-        var gamepadSupportAvailable = !! navigator.getGamepads || !! navigator.webkitGetGamepads || !! navigator.webkitGamepads || (navigator.userAgent.indexOf('Firefox/') != -1);
+        var gamepadSupportAvailable = !! navigator.getGamepads;
         if (gamepadSupportAvailable) {
-            $wnd.addEventListener('MozGamepadConnected', @com.badlogic.gdx.controllers.gwt.support.GamepadSupport::handleGamepadConnect(Lcom/badlogic/gdx/controllers/gwt/support/GamepadSupport$GamepadEvent;), false);
-            $wnd.addEventListener('MozGamepadDisconnected', @com.badlogic.gdx.controllers.gwt.support.GamepadSupport::handleGamepadDisconnect(Lcom/badlogic/gdx/controllers/gwt/support/GamepadSupport$GamepadEvent;), false);
-            if ( !! navigator.getGamepads || !! navigator.webkitGamepads || !! navigator.webkitGetGamepads) {
+            $wnd.addEventListener('gamepadconnected', @com.badlogic.gdx.controllers.gwt.support.GamepadSupport::handleGamepadConnect(Lcom/badlogic/gdx/controllers/gwt/support/GamepadSupport$GamepadEvent;), false);
+            $wnd.addEventListener('gamepaddisconnected', @com.badlogic.gdx.controllers.gwt.support.GamepadSupport::handleGamepadDisconnect(Lcom/badlogic/gdx/controllers/gwt/support/GamepadSupport$GamepadEvent;), false);
+            if ( !! navigator.getGamepads) {
                 @com.badlogic.gdx.controllers.gwt.support.GamepadSupport::startPolling()();
             }
         }
 	}-*/;
 	
 	private static native JsArray<Gamepad> nativePollGamepads() /*-{
-		return rawGamepads = (navigator.webkitGetGamepads && navigator.webkitGetGamepads()) || navigator.webkitGamepads;
+		return navigator.getGamepads();
 	}-*/;
 	
 	public static native void consoleLog(String message) /*-{

--- a/tests/gdx-tests-gwt/build.gradle
+++ b/tests/gdx-tests-gwt/build.gradle
@@ -43,7 +43,6 @@ gwt {
 
     compiler {
         strict = true;
-        enableClosureCompiler = true;
         disableCastChecking = true;
     }
 }

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtTestWrapper.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtTestWrapper.java
@@ -110,6 +110,7 @@ import com.badlogic.gdx.tests.UITest;
 import com.badlogic.gdx.tests.VertexBufferObjectShaderTest;
 import com.badlogic.gdx.tests.YDownTest;
 import com.badlogic.gdx.tests.conformance.DisplayModeTest;
+import com.badlogic.gdx.tests.extensions.ControllersTest;
 import com.badlogic.gdx.tests.g3d.ModelCacheTest;
 import com.badlogic.gdx.tests.g3d.ShadowMappingTest;
 import com.badlogic.gdx.tests.superkoalio.SuperKoalio;
@@ -529,6 +530,10 @@ public class GwtTestWrapper extends GdxTest {
 	}, new Instancer() {
 		public GdxTest instance () {
 			return new ComplexActionTest();
+		}
+	}, new Instancer() {
+		public GdxTest instance () {
+			return new ControllersTest();
 		}
 	}, new Instancer() {
 		public GdxTest instance () {


### PR DESCRIPTION
Due to changes in the way browsers handle controllers since the extension was written, the GWT controllers extension wasn't working anymore. Fortunately, all major browsers now pretty much conforms to the W3C working draft so the extension shouldn't break too much in the future.

This updates the extension to use the currently supported controller api. I've also added proper POV support for gamepads reporting a "standard" mapping. In my tests, only XInput gamepads reported as "standard" and everyting else had different ways of reporting their pov, which also differed between browsers.

This was tested as working on Chrome, Firefox and Opera. 