### PR TITLE
Add getFilter and fix GWT getBlending

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/graphics/Pixmap.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/graphics/Pixmap.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import com.badlogic.gdx.backends.gwt.GwtApplication;
 import com.badlogic.gdx.backends.gwt.GwtFileHandle;
 import com.badlogic.gdx.files.FileHandle;
+import com.badlogic.gdx.graphics.Pixmap.Filter;
 import com.badlogic.gdx.utils.BufferUtils;
 import com.badlogic.gdx.utils.Disposable;
 import com.badlogic.gdx.utils.GdxRuntimeException;
@@ -93,7 +94,8 @@ public class Pixmap implements Disposable {
 	float a;
 	String color = make(r, g, b, a);
 	static String clearColor = make(255, 255, 255, 1.0f);
-	Blending blending;
+	Blending blending = Blending.SourceOver;
+	Filter filter = Filter.BiLinear;
 	CanvasPixelArray pixels;
 	private ImageElement imageElement;
 
@@ -160,6 +162,12 @@ public class Pixmap implements Disposable {
 	 * {@link Pixmap#drawPixmap(Pixmap, int, int, int, int, int, int, int, int)}.
 	 * @param filter the filter. */
 	public void setFilter (Filter filter) {
+		this.filter = filter;
+	}
+
+	/** @return the currently set {@link Filter} */
+	public Filter getFilter () {
+		return filter;
 	}
 
 	public Format getFormat () {

--- a/gdx/src/com/badlogic/gdx/graphics/Pixmap.java
+++ b/gdx/src/com/badlogic/gdx/graphics/Pixmap.java
@@ -93,6 +93,7 @@ public class Pixmap implements Disposable {
 	}
 
 	private Blending blending = Blending.SourceOver;
+	private Filter filter = Filter.BiLinear;
 
 	final Gdx2DPixmap pixmap;
 	int color = 0;
@@ -110,6 +111,7 @@ public class Pixmap implements Disposable {
 	 * {@link Pixmap#drawPixmap(Pixmap, int, int, int, int, int, int, int, int)}.
 	 * @param filter the filter. */
 	public void setFilter (Filter filter) {
+		this.filter = filter;
 		pixmap.setScale(filter == Filter.NearestNeighbour ? Gdx2DPixmap.GDX2D_SCALE_NEAREST : Gdx2DPixmap.GDX2D_SCALE_LINEAR);
 	}
 
@@ -372,5 +374,10 @@ public class Pixmap implements Disposable {
 	/** @return the currently set {@link Blending} */
 	public Blending getBlending () {
 		return blending;
+	}
+	
+	/** @return the currently set {@link Filter} */
+	public Filter getFilter (){
+		return filter;
 	}
 }


### PR DESCRIPTION
Pixmap needs a `getFilter()` method so it can be copied or serialized.

**Also:** GWT's Pixmap had initial state of null for `getBlending()`. It should have an initial state so the getter method will have the same results across platforms. That's why I also added a `filter` parameter, even though it goes unused.