### PR TITLE
Mesh needs to check index array, resolves #4697

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/Mesh.java
+++ b/gdx/src/com/badlogic/gdx/graphics/Mesh.java
@@ -503,10 +503,16 @@ public class Mesh implements Disposable {
 				Gdx.gl20.glDrawArrays(primitiveType, offset, count);
 			}
 		} else {
-			if (indices.getNumIndices() > 0)
+			if (indices.getNumIndices() > 0) {
+				if (count + offset > indices.getNumMaxIndices()) {
+					throw new GdxRuntimeException("Mesh attempting to access memory outside of the index buffer (count: "
+						+ count + ", offset: " + offset + ", max: " + indices.getNumMaxIndices() + ")");
+				}
+				
 				Gdx.gl20.glDrawElements(primitiveType, count, GL20.GL_UNSIGNED_SHORT, offset * 2);
-			else
+			} else {
 				Gdx.gl20.glDrawArrays(primitiveType, offset, count);
+			}
 		}
 
 		if (autoBind) unbind(shader);


### PR DESCRIPTION
This is a pull request to throw an exception if a Mesh tries to render with indices outside of the index array. Created because of #4697 