### PR TITLE
Fix WindowedMean bug

### DIFF
--- a/gdx/src/com/badlogic/gdx/math/WindowedMean.java
+++ b/gdx/src/com/badlogic/gdx/math/WindowedMean.java
@@ -81,7 +81,7 @@ public final class WindowedMean {
 
 	/** @return the oldest value in the window */
 	public float getOldest () {
-		return last_value == values.length - 1 ? values[0] : values[last_value + 1];
+		return last_value == values.length - 1 ? values[0] : values[last_value];
 	}
 
 	/** @return the value last added */
@@ -104,5 +104,19 @@ public final class WindowedMean {
 	
 	public int getWindowSize () {
 		return values.length;
+	}
+
+	/** @return A new <code>float[]</code> containing all values currently in the window of the stream, in order from oldest to
+	 *         latest. The length of the array is smaller than the window size if not enough data has been added. */
+	public float[] getWindowValues () {
+		float[] windowValues = new float[added_values];
+		if (hasEnoughData()) {
+			for (int i = 0; i < windowValues.length; i++) {
+				windowValues[i] = values[(i + last_value) % values.length];
+			}
+		} else {
+			System.arraycopy(values, 0, windowValues, 0, added_values);
+		}
+		return windowValues;
 	}
 }


### PR DESCRIPTION
`WindowedMean.getOldest()` usually returns the second oldest value.

Also added a method for getting the final part of the stream in order, to enable easy serialization/copying.