### PR TITLE
Fix issue with ambient cubemap out of bounds

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g3d/environment/AmbientCubemap.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/environment/AmbientCubemap.java
@@ -21,6 +21,8 @@ import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.utils.GdxRuntimeException;
 
 public class AmbientCubemap {
+	private static final int NUM_VALUES = 6 * 3;
+
 	private final static float clamp (final float v) {
 		return v < 0f ? 0f : (v > 1f ? 1f : v);
 	}
@@ -28,11 +30,11 @@ public class AmbientCubemap {
 	public final float data[];
 
 	public AmbientCubemap () {
-		data = new float[6 * 3];
+		data = new float[NUM_VALUES];
 	}
 
 	public AmbientCubemap (final float copyFrom[]) {
-		if (copyFrom.length != (6 * 3)) throw new GdxRuntimeException("Incorrect array size");
+		if (copyFrom.length != (NUM_VALUES)) throw new GdxRuntimeException("Incorrect array size");
 		data = new float[copyFrom.length];
 		System.arraycopy(copyFrom, 0, data, 0, data.length);
 	}
@@ -56,10 +58,11 @@ public class AmbientCubemap {
 	}
 
 	public AmbientCubemap set (float r, float g, float b) {
-		for (int idx = 0; idx < data.length;) {
-			data[idx++] = r;
-			data[idx++] = g;
-			data[idx++] = b;
+		for (int idx = 0; idx < NUM_VALUES;) {
+			data[idx] = r;
+			data[idx+1] = g;
+			data[idx+2] = b;
+			idx += 3;
 		}
 		return this;
 	}


### PR DESCRIPTION
I was running into an issue where sometimes on some versions of android (6.0) there was a crash with the ambient cube map. This issue has been mentioned by the community and looks like it might be an issue with pro guarding the file `AmbientCubemap.java`. I have patched the file and it looks like the crashes have gone away for me.

Since the cube map needs to always be sized with 18 elements anyways, I made a constant for the size as well.

No changes have been made to the actual functionality of the CubeMaps.

Libgdx forum [discussion](http://www.badlogicgames.com/forum/viewtopic.php?t=23411)

Sample Stack Trace:
`java.lang.ArrayIndexOutOfBoundsException: length=18; index=18 at com.badlogic.gdx.graphics.g3d.environment.AmbientCubemap.set(AmbientCubemap.java:60) at com.badlogic.gdx.graphics.g3d.environment.AmbientCubemap.set(AmbientCubemap.java:55) at com.badlogic.gdx.graphics.g3d.shaders.DefaultShader$Setters$ACubemap.set(DefaultShader.java:357) at com.badlogic.gdx.graphics.g3d.shaders.BaseShader.render(BaseShader.java:237) at com.badlogic.gdx.graphics.g3d.shaders.DefaultShader.render(DefaultShader.java:761) at com.badlogic.gdx.graphics.g3d.shaders.BaseShader.render(BaseShader.java:232) at com.perblue.voxelgo.g3d.VGOShader3D.render(VGOShader3D.java:130) at com.badlogic.gdx.graphics.g3d.ModelBatch.flush(ModelBatch.java:206) at com.badlogic.gdx.graphics.g3d.ModelBatch.end(ModelBatch.java:217) at com.perblue.voxelgo.g3d.RepresentationManager.render(RepresentationManager.java:341) at com.perblue.voxelgo.go_ui.screens.BaseSceneScreen.render(BaseSceneScreen.java:65)`
