### PR TITLE
Fix WindowedMean, part 2

### DIFF
--- a/gdx/src/com/badlogic/gdx/math/WindowedMean.java
+++ b/gdx/src/com/badlogic/gdx/math/WindowedMean.java
@@ -81,7 +81,7 @@ public final class WindowedMean {
 
 	/** @return the oldest value in the window */
 	public float getOldest () {
-		return last_value == values.length - 1 ? values[0] : values[last_value];
+		return added_values < values.length ? values[0] : values[last_value];
 	}
 
 	/** @return the value last added */


### PR DESCRIPTION
Oops, `WindowedMean.getOldest()` is still wrong in some cases. I blame the field name for confusion. :) This fixes it for all cases.

Simple test to prove it:
>     WindowedMean wm = new WindowedMean(5);
>     for (int i=0; i<50; i++){
>         float newValue = MathUtils.random();
>         wm.addValue(newValue);
>         System.out.println(String.format("Added new value %f. Oldest: %f. Latest: %f.",
>                newValue, wm.getOldest(), wm.getLatest()));
>     }