### PR TITLE
Fix bug with recreate window in lwjgl3 integration

### DIFF
--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
@@ -208,8 +208,10 @@ public class Lwjgl3Application implements Application {
 			((OpenALAudio) audio).dispose();
 		}
 		errorCallback.free();
+		errorCallback = null;
 		if (glDebugCallback != null) {
 			glDebugCallback.free();
+			glDebugCallback = null;
 		}
 		GLFW.glfwTerminate();
 	}


### PR DESCRIPTION
I noticed a fatal error during recreate window (second `Lwjgl3Application` instantiation in the same process). 

Bug reproduction:
```java
Scanner reader = new Scanner(System.in);
Lwjgl3ApplicationConfiguration conf = new Lwjgl3ApplicationConfiguration();
Thread t = new Thread(() -> new Lwjgl3Application(new AppListener(),  conf));
t.start();
reader.nextLine();  // press enter
Gdx.app.exit();
t.join();
reader.nextLine(); // press enter
t = new Thread(() -> new Lwjgl3Application(new AppListener(),  conf));
t.start();
reader.nextLine(); // press enter
Gdx.app.exit();
```

Error description:
```
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  EXCEPTION_ACCESS_VIOLATION (0xc0000005) at pc=0x000000001ca50000, pid=18440, tid=0x00000000000076b4
#
# JRE version: Java(TM) SE Runtime Environment (8.0_111-b14) (build 1.8.0_111-b14)
# Java VM: Java HotSpot(TM) 64-Bit Server VM (25.111-b14 mixed mode windows-amd64 compressed oops)
# Problematic frame:
# C  0x000000001ca50000
#
# Failed to write core dump. Minidumps are not enabled by default on client versions of Windows
#
# An error report file with more information is saved as:
# C:\Development\karaf\hs_err_pid18440.log
Compiled method (nm)  194567 7362     n 0       org.lwjgl.system.JNI::invokeV (native)
 total in heap  [0x0000000002c99510,0x0000000002c99870] = 864
 relocation     [0x0000000002c99630,0x0000000002c99678] = 72
 main code      [0x0000000002c99680,0x0000000002c99868] = 488
 oops           [0x0000000002c99868,0x0000000002c99870] = 8
#
# If you would like to submit a bug report, please visit:
#   http://bugreport.java.com/bugreport/crash.jsp
# The crash happened outside the Java Virtual Machine in native code.
# See problematic frame for where to report the bug.
#
AL lib: (EE) alc_cleanup: 1 device not closed
```

Cause:
There are static fields in the `Lwjgl3Application` class that are not set to null when it is disposing.  Therefore, during second instationation, the static method `GLFW.glfwInit()` is not called (the `GLFW` libraray is not loaded).