### PR TITLE
Removed unnecessary clamp in Interpolation.smoother

### DIFF
--- a/gdx/src/com/badlogic/gdx/math/Interpolation.java
+++ b/gdx/src/com/badlogic/gdx/math/Interpolation.java
@@ -53,7 +53,7 @@ public abstract class Interpolation {
 	/** By Ken Perlin. */
 	static public final Interpolation smoother = new Interpolation() {
 		public float apply (float a) {
-			return MathUtils.clamp(a * a * a * (a * (a * 6 - 15) + 10), 0, 1);
+			return a * a * a * (a * (a * 6 - 15) + 10);
 		}
 	};
 	static public final Interpolation fade = smoother;


### PR DESCRIPTION
The `clamp` isn't required here, because `a` is expected to be in `[0, 1]` for all `Interpolation` objects anyway. For example, `Interpolation.linear.apply(3)` would return `3` not `1`.

Ken Perlin [clamped only a version](https://en.wikipedia.org/wiki/Smoothstep#Variations) where you interpolate between an `edge0` and `edge1` argument