### PR TITLE
Better ignore un-needed files for iOS platform - gdx-setup

### DIFF
--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/gitignore
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/gitignore
@@ -112,3 +112,14 @@ gradle-app.setting
 ## OS Specific
 .DS_Store
 Thumbs.db
+
+## iOS
+/ios/xcode/*.xcodeproj/*
+!/ios/xcode/*.xcodeproj/xcshareddata
+!/ios/xcode/*.xcodeproj/project.pbxproj
+/ios/xcode/native/
+
+/ios-moe/xcode/*.xcodeproj/*
+!/ios-moe/xcode/*.xcodeproj/xcshareddata
+!/ios-moe/xcode/*.xcodeproj/project.pbxproj
+/ios-moe/xcode/native/


### PR DESCRIPTION
This will improve `.gitignore` file generated by `gdx-setup.jar` tool.

In detail, inside `.xcodeproj` there are also unnecessary files which are
not needed to be included into git source tree. Those files include
local user's data (unique for each local user opening Xcode), but
particular folders are still need i.e. `xcshareddata` (for shared scheme
in case for more complex build process of executing build command
against shared scheme for project from external tool), and of course
`project.pbxproj` project file itself.

Also ignored artifacts as they are built dynamically in `native/` folder
of `ios/xcode/` and `ios-moe/xcode/`. Each built file (`.a`) has a several MBs in
size, and would be much better to exclude it. In tested, for project
that includes only Box2d, `native/` directory alone would be ~13MB in
size. This will make git user smoothly and effectively clone the
project without much waiting, and also no need to put it back in as it's
ignored.