### PR TITLE
Recognize X-Box 360 controller as Xbox controller

### DIFF
--- a/extensions/gdx-controllers/gdx-controllers/src/com/badlogic/gdx/controllers/mappings/Xbox.java
+++ b/extensions/gdx-controllers/gdx-controllers/src/com/badlogic/gdx/controllers/mappings/Xbox.java
@@ -154,6 +154,6 @@ public class Xbox {
 	/** @return whether the {@link Controller} is an Xbox controller
 	 */
 	public static boolean isXboxController(Controller controller) {
-		return controller.getName().contains("Xbox");
+		return controller.getName().contains("Xbox") || controller.getName().contains("X-Box");
 	}
 }


### PR DESCRIPTION
On Linux I get `Microsoft X-Box 360 pad` as `controller.getName()`, so currently `isXboxController()` returns `false` for me.

cc @WilliamHayward