### PR TITLE
Controllers not working in GWT backend

### DIFF
--- a/extensions/gdx-controllers/gdx-controllers-gwt/src/com/badlogic/gdx/controllers/gwt/GwtControllers.java
+++ b/extensions/gdx-controllers/gdx-controllers-gwt/src/com/badlogic/gdx/controllers/gwt/GwtControllers.java
@@ -175,7 +175,7 @@ public class GwtControllers implements ControllerManager, GamepadSupportListener
 				}			
 				for (int i = 0, j = buttons.length(); i < j; i++) {
 					float oldButton = controller.getButtonAmount(i);
-					float newButton = (float) buttons.get(i);
+					float newButton = gamepad.getButton(i);
 					if (oldButton != newButton) {
 						if ((oldButton < 0.5f && newButton < 0.5f) || (oldButton >= 0.5f && newButton >= 0.5f)) {
 							controller.buttons.put(i, newButton);

--- a/extensions/gdx-controllers/gdx-controllers-gwt/src/com/badlogic/gdx/controllers/gwt/support/Gamepad.java
+++ b/extensions/gdx-controllers/gdx-controllers-gwt/src/com/badlogic/gdx/controllers/gwt/support/Gamepad.java
@@ -41,6 +41,14 @@ public final class Gamepad extends JavaScriptObject {
 		return this.axes;
 	}-*/;
 	
+	public native float getButton(int i) /*-{
+	    var b = this.buttons[i];
+        if (typeof(b) == "object") {
+          return b.value;
+        }
+		return b;
+	}-*/;
+
 	public native JsArrayNumber getButtons() /*-{
 		return this.buttons;
 	}-*/;

--- a/extensions/gdx-controllers/gdx-controllers-gwt/src/com/badlogic/gdx/controllers/gwt/support/GamepadSupport.java
+++ b/extensions/gdx-controllers/gdx-controllers-gwt/src/com/badlogic/gdx/controllers/gwt/support/GamepadSupport.java
@@ -117,8 +117,8 @@ public class GamepadSupport {
 	private static native void nativeInit() /*-{
         var gamepadSupportAvailable = !! navigator.getGamepads || !! navigator.webkitGetGamepads || !! navigator.webkitGamepads || (navigator.userAgent.indexOf('Firefox/') != -1);
         if (gamepadSupportAvailable) {
-            $wnd.addEventListener('MozGamepadConnected', @com.badlogic.gdx.controllers.gwt.support.GamepadSupport::handleGamepadConnect(Lcom/badlogic/gdx/controllers/gwt/support/GamepadSupport$GamepadEvent;), false);
-            $wnd.addEventListener('MozGamepadDisconnected', @com.badlogic.gdx.controllers.gwt.support.GamepadSupport::handleGamepadDisconnect(Lcom/badlogic/gdx/controllers/gwt/support/GamepadSupport$GamepadEvent;), false);
+            $wnd.addEventListener('gamepadconnected', @com.badlogic.gdx.controllers.gwt.support.GamepadSupport::handleGamepadConnect(Lcom/badlogic/gdx/controllers/gwt/support/GamepadSupport$GamepadEvent;), false);
+            $wnd.addEventListener('gamepaddisconnected', @com.badlogic.gdx.controllers.gwt.support.GamepadSupport::handleGamepadDisconnect(Lcom/badlogic/gdx/controllers/gwt/support/GamepadSupport$GamepadEvent;), false);
             if ( !! navigator.getGamepads || !! navigator.webkitGamepads || !! navigator.webkitGetGamepads) {
                 @com.badlogic.gdx.controllers.gwt.support.GamepadSupport::startPolling()();
             }
@@ -126,7 +126,8 @@ public class GamepadSupport {
 	}-*/;
 	
 	private static native JsArray<Gamepad> nativePollGamepads() /*-{
-		return rawGamepads = (navigator.webkitGetGamepads && navigator.webkitGetGamepads()) || navigator.webkitGamepads;
+		return rawGamepads =
+           navigator.getGamepads ? navigator.getGamepads() : ((navigator.webkitGetGamepads && navigator.webkitGetGamepads()) || navigator.webkitGamepads);
 	}-*/;
 	
 	public static native void consoleLog(String message) /*-{


### PR DESCRIPTION
fixes libgdx/libgdx#4768

The four year old Javascript Webkit function calls aren't working in Chrome and Firefox any more. This commit adds the current function calls according to Mozilla's documentation with a fall-back to the old calls.