### PR TITLE
Added "Use Kotlin" option for setup tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ libgdx-*.zip.MD5
 /extensions/gdx-freetype/libs/
 /extensions/gdx-image/libs/
 /extensions/gdx-setup/gdx-setup.jar
+/extensions/gdx-setup/test/
 
 #the LWJGL3 libs are pulled via fetch.xml
 /backends/gdx-backend-lwjgl3/libs/lwjgl*.jar

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/BuildScriptHelper.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/BuildScriptHelper.java
@@ -27,8 +27,9 @@ public class BuildScriptHelper {
 
 	private static int indent = 0;
 
-	public static void addBuildScript(List<ProjectType> projects, BufferedWriter wr) throws IOException {
+	public static void addBuildScript(Language language, List<ProjectType> projects, BufferedWriter wr) throws IOException {
 		write(wr, "buildscript {");
+		write(wr, language.buildScript + "\n");
 		//repos
 		write(wr, "repositories {");
 		write(wr, DependencyBank.mavenLocal);
@@ -50,6 +51,7 @@ public class BuildScriptHelper {
 		if (projects.contains(ProjectType.IOSMOE)) {
 			write(wr, "classpath '" + DependencyBank.moePluginImport + "'");
 		}
+		write(wr, language.buildScriptDependencies + "\n");
 		write(wr, "}");
 		write(wr, "}");
 		space(wr);
@@ -79,20 +81,20 @@ public class BuildScriptHelper {
 		write(wr, "}");
 	}
 
-	public static void addProject(ProjectType project, List<Dependency> dependencies, BufferedWriter wr) throws IOException {
+	public static void addProject(Language language, ProjectType project, List<Dependency> dependencies, BufferedWriter wr) throws IOException {
 		space(wr);
 		write(wr, "project(\":" + project.getName() + "\") {");
-		for (String plugin : project.getPlugins()) {
+		for (String plugin : project.getPlugins(language)) {
 			write(wr, "apply plugin: \"" + plugin + "\"");
 		}
 		space(wr);
 		addConfigurations(project, wr);
 		space(wr);
-		addDependencies(project, dependencies, wr);
+		addDependencies(language, project, dependencies, wr);
 		write(wr, "}");
 	}
 
-	private static void addDependencies(ProjectType project, List<Dependency> dependencyList, BufferedWriter wr) throws IOException {
+	private static void addDependencies(Language language, ProjectType project, List<Dependency> dependencyList, BufferedWriter wr) throws IOException {
 		write(wr, "dependencies {");
 		if (!project.equals(ProjectType.CORE)) {
 			write(wr, "compile project(\":" + ProjectType.CORE.getName() + "\")");
@@ -108,6 +110,7 @@ public class BuildScriptHelper {
 				}
 			}
 		}
+		write(wr, language.dependencies);
 		write(wr, "}");
 	}
 

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/DependencyBank.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/DependencyBank.java
@@ -229,27 +229,25 @@ public class DependencyBank {
 
 
 	public enum ProjectType {
-		CORE("core", new String[]{"java"}),
-		DESKTOP("desktop", new String[]{"java"}),
-		ANDROID("android", new String[]{"android"}),
-		IOS("ios", new String[]{"java", "robovm"}),
-		IOSMOE("ios-moe", new String[] {"moe"}),
-		HTML("html", new String[]{"gwt", "war"});
+		CORE("core"),
+		DESKTOP("desktop"),
+		ANDROID("android"),
+		IOS("ios"),
+		IOSMOE("ios-moe"),
+		HTML("html");
 
 		private final String name;
-		private final String[] plugins;
 
-		ProjectType(String name, String plugins[]) {
+		ProjectType(String name) {
 			this.name = name;
-			this.plugins = plugins;
 		}
 
 		public String getName() {
 			return name;
 		}
 
-		public String[] getPlugins() {
-			return plugins;
+		public String[] getPlugins(Language sourceLanguage) {
+			return sourceLanguage.values[ordinal()];
 		}
 	}
 

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/DependencyBank.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/DependencyBank.java
@@ -247,7 +247,7 @@ public class DependencyBank {
 		}
 
 		public String[] getPlugins(Language sourceLanguage) {
-			return sourceLanguage.values[ordinal()];
+			return sourceLanguage.platformPlugins[ordinal()];
 		}
 	}
 

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetup.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetup.java
@@ -233,7 +233,7 @@ public class GdxSetup {
 	}
 
 	public void build (ProjectBuilder builder, String outputDir, String appName, String packageName, String mainClass,
-		String sdkLocation, CharCallback callback, List<String> gradleArgs) {
+			String language, String sdkLocation, CharCallback callback, List<String> gradleArgs) {
 		Project project = new Project();
 
 		String packageDir = packageName.replace('.', '/');
@@ -349,6 +349,7 @@ public class GdxSetup {
 		Map<String, String> values = new HashMap<String, String>();
 		values.put("%APP_NAME%", appName);
 		values.put("%APP_NAME_ESCAPED%", appName.replace("'", "\\'"));
+		values.put("%LANG%", language);
 		values.put("%PACKAGE%", packageName);
 		values.put("%PACKAGE_DIR%", packageDir);
 		values.put("%MAIN_CLASS%", mainClass);
@@ -653,9 +654,16 @@ public class GdxSetup {
 				 dependencies.add(bank.getDependency(ProjectDependency.GDX));
 			}
 
+			String language = params.containsKey("language") ? params.get("language") : "java";
+			Language languageEnum = Language.JAVA;
+			for(Language l: Language.values()) {
+				if(l.name.equals(language)) {
+					languageEnum = l;
+				}
+			}
 			builder.buildProject(projects, dependencies);
-			builder.build();
-			new GdxSetup().build(builder, params.get("dir"), params.get("name"), params.get("package"), params.get("mainClass"),
+			builder.build(languageEnum);
+			new GdxSetup().build(builder, params.get("dir"), params.get("name"), params.get("package"), params.get("mainClass"), language,
 				sdkLocation, new CharCallback() {
 					@Override
 					public void character (char c) {

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetup.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetup.java
@@ -233,7 +233,7 @@ public class GdxSetup {
 	}
 
 	public void build (ProjectBuilder builder, String outputDir, String appName, String packageName, String mainClass,
-			String language, String sdkLocation, CharCallback callback, List<String> gradleArgs) {
+			Language language, String sdkLocation, CharCallback callback, List<String> gradleArgs) {
 		Project project = new Project();
 
 		String packageDir = packageName.replace('.', '/');
@@ -256,7 +256,7 @@ public class GdxSetup {
 		// core project
 		project.files.add(new ProjectFile("core/build.gradle"));
 		project.files.add(new ProjectFile("core/src/MainClass", "core/src/" + packageDir + "/" + mainClass + ".java", true));
-		if (builder.modules.contains(ProjectType.HTML)) {
+		if (builder.modules.contains(ProjectType.HTML) && language.gwtSupported) {
 			project.files.add(new ProjectFile("core/CoreGdxDefinition", "core/src/" + mainClass + ".gwt.xml", true));
 		}
 
@@ -349,7 +349,7 @@ public class GdxSetup {
 		Map<String, String> values = new HashMap<String, String>();
 		values.put("%APP_NAME%", appName);
 		values.put("%APP_NAME_ESCAPED%", appName.replace("'", "\\'"));
-		values.put("%LANG%", language);
+		values.put("%LANG%", language.name);
 		values.put("%PACKAGE%", packageName);
 		values.put("%PACKAGE_DIR%", packageDir);
 		values.put("%MAIN_CLASS%", mainClass);
@@ -663,7 +663,7 @@ public class GdxSetup {
 			}
 			builder.buildProject(projects, dependencies);
 			builder.build(languageEnum);
-			new GdxSetup().build(builder, params.get("dir"), params.get("name"), params.get("package"), params.get("mainClass"), language,
+			new GdxSetup().build(builder, params.get("dir"), params.get("name"), params.get("package"), params.get("mainClass"), languageEnum,
 				sdkLocation, new CharCallback() {
 					@Override
 					public void character (char c) {

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetupUI.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetupUI.java
@@ -154,6 +154,8 @@ public class GdxSetupUI extends JFrame {
 			JOptionPane.showMessageDialog(this, "Please enter a game class name.");
 			return;
 		}
+		
+		final Language languageEnum = ui.settings.kotlinBox.isSelected() ? Language.KOTLIN : Language.JAVA;
 
 		final String destination = ui.form.destinationText.getText().trim();
 		if (destination.length() == 0) {
@@ -201,7 +203,7 @@ public class GdxSetupUI extends JFrame {
 		List<String> incompatList = builder.buildProject(modules, dependencies);
 		if (incompatList.size() == 0) {
 			try {
-				builder.build();
+				builder.build(languageEnum);
 			} catch (IOException e) {
 				e.printStackTrace();
 			}
@@ -242,7 +244,7 @@ public class GdxSetupUI extends JFrame {
 				return;
 			} else {
 				try {
-					builder.build();
+					builder.build(languageEnum);
 				} catch (IOException e) {
 					e.printStackTrace();
 				}
@@ -253,7 +255,7 @@ public class GdxSetupUI extends JFrame {
 		new Thread() {
 			public void run () {
 				log("Generating app in " + destination);
-				new GdxSetup().build(builder, destination, name, pack, clazz, sdkLocation, new CharCallback() {
+				new GdxSetup().build(builder, destination, name, pack, clazz, languageEnum.name, sdkLocation, new CharCallback() {
 					@Override
 					public void character (char c) {
 						log(c);

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetupUI.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetupUI.java
@@ -255,7 +255,7 @@ public class GdxSetupUI extends JFrame {
 		new Thread() {
 			public void run () {
 				log("Generating app in " + destination);
-				new GdxSetup().build(builder, destination, name, pack, clazz, languageEnum.name, sdkLocation, new CharCallback() {
+				new GdxSetup().build(builder, destination, name, pack, clazz, languageEnum, sdkLocation, new CharCallback() {
 					@Override
 					public void character (char c) {
 						log(c);
@@ -300,7 +300,7 @@ public class GdxSetupUI extends JFrame {
 
 	class UI extends JPanel {
 		Form form = new Form();
-		SettingsDialog settings = new SettingsDialog();
+		SettingsDialog settings;
 		SetupButton generateButton = new SetupButton("Generate");
 		SetupButton advancedButton = new SetupButton("Advanced");
 		JPanel buttonPanel = new JPanel();
@@ -380,7 +380,8 @@ public class GdxSetupUI extends JFrame {
 			textArea.setEditable(false);
 			textArea.setLineWrap(true);
 			uiLayout();
-			uiEvents();
+			uiEvents(); 
+			settings = new SettingsDialog(form.gwtCheckBox);
 			titleEvents(minimize, exit);
 		}
 
@@ -424,7 +425,7 @@ public class GdxSetupUI extends JFrame {
 		private void uiEvents () {
 			advancedButton.addActionListener(new ActionListener() {
 				public void actionPerformed (ActionEvent e) {
-					settings.showDialog();
+					settings.showDialog(form.gwtCheckBox);
 				}
 			});
 			generateButton.addActionListener(new ActionListener() {
@@ -459,6 +460,7 @@ public class GdxSetupUI extends JFrame {
 		JLabel extensionsLabel = new JLabel("Extensions");
 		List<JPanel> extensionsPanels = new ArrayList<JPanel>();
 		SetupButton showMoreExtensionsButton = new SetupButton("Show Third Party Extensions");
+		SetupCheckBox gwtCheckBox;
 
 		{
 			uiLayout();
@@ -524,6 +526,10 @@ public class GdxSetupUI extends JFrame {
 					continue;
 				}				
 				SetupCheckBox checkBox = new SetupCheckBox(projectType.getName().substring(0, 1).toUpperCase() + projectType.getName().substring(1, projectType.getName().length()));
+				if (projectType == ProjectType.HTML) {
+					gwtCheckBox = checkBox;
+				} 
+				
 				if (projectType != ProjectType.IOSMOE) {
 					modules.add(projectType);
 					checkBox.setSelected(true);

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetupUI.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetupUI.java
@@ -174,6 +174,12 @@ public class GdxSetupUI extends JFrame {
 							"Your Android SDK path doesn't contain an SDK! Please install the Android SDK, including all platforms and build tools!");
 			return;
 		}
+		
+		if (modules.contains(ProjectType.HTML) && !languageEnum.gwtSupported) {
+			JOptionPane.showMessageDialog(this, "HTML sub-projects are not supported by the selected programming language.");
+			ui.form.gwtCheckBox.setSelected(false);
+			modules.remove(ProjectType.HTML);
+		}
 
 		if (modules.contains(ProjectType.ANDROID)) {
 			if (!GdxSetup.isSdkUpToDate(sdkLocation)) {

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/Language.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/Language.java
@@ -1,27 +1,27 @@
 package com.badlogic.gdx.setup;
 
 public enum Language {
-	JAVA ("java", "", "", "", "java;java;android;java,robovm;moe;gwt,war") ,
-	KOTLIN ("kotlin", "ext.kotlinVersion = '1.0.0'", 
+	JAVA ("java", "", "", "", "java;java;android;java,robovm;moe;gwt,war", true) ,
+	KOTLIN ("kotlin", "ext.kotlinVersion = '1.1.1'", 
 			"classpath \"org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion\"", 
 			"compile \"org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion\"",
-			"kotlin;kotlin;android,kotlin-android;kotlin,robovm;moe;gwt,war");
+			"kotlin;kotlin;android,kotlin-android;kotlin,robovm;moe; ",
+			false);
 	
 	public final String[] corePlugins, desktopPlugins, androidPlugins, iosPlugins, iosmoePlugins, htmlPlugins;
-	private final String source;
-	public final String[][] values;
+	public final String[][] platformPlugins;
 	public final String name, buildScript, buildScriptDependencies, dependencies;
+	public final boolean gwtSupported;
 	
-	private Language(String name, String buildScript, String buildScriptDependencies, String dependencies, String src) {
+	private Language(String name, String buildScript, String buildScriptDependencies, String dependencies, String src, boolean gwtSupported) {
 		this.name = name;
 		this.buildScript = buildScript;
 		this.buildScriptDependencies = buildScriptDependencies;
 		this.dependencies = dependencies;
-		source = src;
 		String[] parts = src.split(";");
-		values = new String[parts.length][];
-		for(int i = 0; i < values.length; i++) {
-			values[i] = parts[i].split(",");
+		platformPlugins = new String[parts.length][];
+		for(int i = 0; i < platformPlugins.length; i++) {
+			platformPlugins[i] = parts[i].split(",");
 		}
 		this.corePlugins = parts[0].split(",");
 		this.desktopPlugins = parts[1].split(",");
@@ -29,6 +29,6 @@ public enum Language {
 		this.iosPlugins = parts[3].split(",");
 		this.iosmoePlugins = parts[4].split(",");
 		this.htmlPlugins = parts[5].split(",");
+		this.gwtSupported = gwtSupported;
 	}
-	
 }

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/Language.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/Language.java
@@ -1,0 +1,34 @@
+package com.badlogic.gdx.setup;
+
+public enum Language {
+	JAVA ("java", "", "", "", "java;java;android;java,robovm;moe;gwt,war") ,
+	KOTLIN ("kotlin", "ext.kotlinVersion = '1.0.0'", 
+			"classpath \"org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion\"", 
+			"compile \"org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion\"",
+			"kotlin;kotlin;android,kotlin-android;kotlin,robovm;moe;gwt,war");
+	
+	public final String[] corePlugins, desktopPlugins, androidPlugins, iosPlugins, iosmoePlugins, htmlPlugins;
+	private final String source;
+	public final String[][] values;
+	public final String name, buildScript, buildScriptDependencies, dependencies;
+	
+	private Language(String name, String buildScript, String buildScriptDependencies, String dependencies, String src) {
+		this.name = name;
+		this.buildScript = buildScript;
+		this.buildScriptDependencies = buildScriptDependencies;
+		this.dependencies = dependencies;
+		source = src;
+		String[] parts = src.split(";");
+		values = new String[parts.length][];
+		for(int i = 0; i < values.length; i++) {
+			values[i] = parts[i].split(",");
+		}
+		this.corePlugins = parts[0].split(",");
+		this.desktopPlugins = parts[1].split(",");
+		this.androidPlugins = parts[2].split(",");
+		this.iosPlugins = parts[3].split(",");
+		this.iosmoePlugins = parts[4].split(",");
+		this.htmlPlugins = parts[5].split(",");
+	}
+	
+}

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/ProjectBuilder.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/ProjectBuilder.java
@@ -50,7 +50,7 @@ public class ProjectBuilder {
 		return incompatibilities;
 	}
 
-	public boolean build() throws IOException {
+	public boolean build(Language language) throws IOException {
 		settingsFile = File.createTempFile("libgdx-setup-settings", ".gradle");
 		buildFile = File.createTempFile("libgdx-setup-build", ".gradle");
 		if (!settingsFile.exists()) {
@@ -78,10 +78,10 @@ public class ProjectBuilder {
 			FileWriter buildWriter = new FileWriter(buildFile.getAbsoluteFile());
 			BufferedWriter buildBw = new BufferedWriter(buildWriter);
 
-			BuildScriptHelper.addBuildScript(modules, buildBw);
+			BuildScriptHelper.addBuildScript(language, modules, buildBw);
 			BuildScriptHelper.addAllProjects(buildBw);
 			for (ProjectType module : modules) {
-				BuildScriptHelper.addProject(module, dependencies, buildBw);
+				BuildScriptHelper.addProject(language, module, dependencies, buildBw);
 			}
 
 			//Add task here for now

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/SettingsDialog.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/SettingsDialog.java
@@ -76,7 +76,7 @@ public class SettingsDialog extends JDialog {
 	private boolean offlineSnapshot;
 	private boolean kotlinSnapshot;
 
-	public SettingsDialog (SetupCheckBox gwtCheckBox) {
+	public SettingsDialog (final SetupCheckBox gwtCheckBox) {
 		contentPane = new JPanel(new GridBagLayout());
 		setContentPane(contentPane);
 		setModal(true);
@@ -129,7 +129,7 @@ public class SettingsDialog extends JDialog {
 		setLocationRelativeTo(null);
 	}
 
-	private void uiLayout (SetupCheckBox gwtCheckBox) {
+	private void uiLayout (final SetupCheckBox gwtCheckBox) {
 		content = new JPanel(new GridBagLayout());
 		content.setBorder(BorderFactory.createEmptyBorder(20, 20, 20, 20));
 

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/SettingsDialog.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/SettingsDialog.java
@@ -74,14 +74,15 @@ public class SettingsDialog extends JDialog {
 	private boolean ideaSnapshot;
 	private boolean eclipseSnapshot;
 	private boolean offlineSnapshot;
+	private boolean kotlinSnapshot;
 
-	public SettingsDialog () {
+	public SettingsDialog (SetupCheckBox gwtCheckBox) {
 		contentPane = new JPanel(new GridBagLayout());
 		setContentPane(contentPane);
 		setModal(true);
 		getRootPane().setDefaultButton(buttonOK);
 
-		uiLayout();
+		uiLayout(gwtCheckBox);
 		uiStyle();
 
 		buttonOK.addActionListener(new ActionListener() {
@@ -128,7 +129,7 @@ public class SettingsDialog extends JDialog {
 		setLocationRelativeTo(null);
 	}
 
-	private void uiLayout () {
+	private void uiLayout (SetupCheckBox gwtCheckBox) {
 		content = new JPanel(new GridBagLayout());
 		content.setBorder(BorderFactory.createEmptyBorder(20, 20, 20, 20));
 
@@ -182,6 +183,19 @@ public class SettingsDialog extends JDialog {
 		offlineDesc.setForeground(new Color(170, 170, 170));
 		offlineBox.setBackground(new Color(36, 36, 36));
 		kotlinBox = new SetupCheckBox();
+		kotlinBox.addActionListener(new ActionListener() {
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				final String message = "Using Kotlin with the HTML backend is not supported. Do you want to disable the HTML backend?";
+				if(kotlinBox.isSelected() && gwtCheckBox.isSelected() &&
+						JOptionPane.showConfirmDialog(kotlinBox, message, "Warning!", 
+						JOptionPane.YES_NO_OPTION) == 0) {
+					gwtCheckBox.setSelected(false);
+				} else if(gwtCheckBox.isSelected()) {
+					kotlinBox.setSelected(false);
+				}
+			}
+		});
 		offlineBox.setBackground(new Color(36, 36, 36));
 		kotlinLabel.setForeground(new Color(170, 170, 170));
 		kotlinDesc.setForeground(new Color(170, 170, 170));
@@ -242,9 +256,10 @@ public class SettingsDialog extends JDialog {
 		mavenTextField.setForeground(new Color(255, 255, 255));
 	}
 
-	public void showDialog () {
+	public void showDialog (SetupCheckBox gwtCheckBox) {
 		takeSnapshot();
 		setVisible(true);
+		kotlinBox.setSelected(!gwtCheckBox.isSelected());
 	}
 
 	public List<String> getGradleArgs () {
@@ -282,6 +297,7 @@ public class SettingsDialog extends JDialog {
 		ideaSnapshot = ideaBox.isSelected();
 		eclipseSnapshot = eclipseBox.isSelected();
 		offlineSnapshot = offlineBox.isSelected();
+		kotlinSnapshot = kotlinBox.isSelected();
 	}
 
 	private void restore () {
@@ -289,6 +305,6 @@ public class SettingsDialog extends JDialog {
 		ideaBox.setSelected(ideaSnapshot);
 		eclipseBox.setSelected(eclipseSnapshot);
 		offlineBox.setSelected(offlineSnapshot);
+		kotlinBox.setSelected(kotlinSnapshot);
 	}
-
 }

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/SettingsDialog.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/SettingsDialog.java
@@ -69,6 +69,7 @@ public class SettingsDialog extends JDialog {
 	private SetupCheckBox ideaBox;
 	private SetupCheckBox eclipseBox;
 	SetupCheckBox offlineBox;
+	SetupCheckBox kotlinBox;
 	private String mavenSnapshot;
 	private boolean ideaSnapshot;
 	private boolean eclipseSnapshot;
@@ -174,10 +175,16 @@ public class SettingsDialog extends JDialog {
 		eclipseBox.setBackground(new Color(36, 36, 36));
 		JLabel offlineLabel = new JLabel("Offline Mode");
 		JLabel offlineDesc = new JLabel("Don't force download dependencies");
+		JLabel kotlinLabel = new JLabel("Use Kotlin");
+		JLabel kotlinDesc = new JLabel("Use Kotlin as the main language.");
 		offlineBox = new SetupCheckBox();
 		offlineLabel.setForeground(new Color(170, 170, 170));
 		offlineDesc.setForeground(new Color(170, 170, 170));
 		offlineBox.setBackground(new Color(36, 36, 36));
+		kotlinBox = new SetupCheckBox();
+		offlineBox.setBackground(new Color(36, 36, 36));
+		kotlinLabel.setForeground(new Color(170, 170, 170));
+		kotlinDesc.setForeground(new Color(170, 170, 170));
 
 		JSeparator separator = new JSeparator();
 		separator.setForeground(new Color(85, 85, 85));
@@ -200,6 +207,10 @@ public class SettingsDialog extends JDialog {
 		content.add(offlineLabel, new GridBagConstraints(0, 5, 1, 1, 1, 1, NORTH, HORIZONTAL, new Insets(0, 0, 0, 0), 0, 0));
 		content.add(offlineBox, new GridBagConstraints(1, 5, 2, 1, 1, 1, NORTH, HORIZONTAL, new Insets(0, 15, 0, 0), 0, 0));
 		content.add(offlineDesc, new GridBagConstraints(3, 5, 1, 1, 1, 1, NORTH, HORIZONTAL, new Insets(0, 15, 0, 0), 0, 0));
+		
+		content.add(kotlinLabel, new GridBagConstraints(0, 6, 1, 1, 1, 1, NORTH, HORIZONTAL, new Insets(0, 0, 0, 0), 0, 0));
+		content.add(kotlinBox, new GridBagConstraints(1, 6, 2, 1, 1, 1, NORTH, HORIZONTAL, new Insets(0, 15, 0, 0), 0, 0));
+		content.add(kotlinDesc, new GridBagConstraints(3, 6, 1, 1, 1, 1, NORTH, HORIZONTAL, new Insets(0, 15, 0, 0), 0, 0));
 
 
 		String text = "<p style=\"font-size:10\">Click for more info on using Gradle without IDE integration</p>";

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/core/build.gradle
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/core/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: "java"
+apply plugin: "%LANG%"
 
 sourceCompatibility = 1.6
 [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/desktop/build.gradle
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/desktop/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: "java"
+apply plugin: "%LANG%"
 
 sourceCompatibility = 1.6
 sourceSets.main.java.srcDirs = [ "src/" ]


### PR DESCRIPTION
Supporting the new languages was primarily implemented through using a new Language enum containing the language-specific Gradle-related strings for the two supported languages (Java and Kotlin). Could be extended in the future to include other languages like Scala or Clojure.

I also edited the project build.gradle templates to be agnostic as to what language plugin they use.

This is feature that I personally felt I wanted to have, as tweaking new projects to compile Kotlin properly took a lot of time.