### PR TITLE
Update build.gradle

### DIFF
--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/ios-moe/build.gradle
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/ios-moe/build.gradle
@@ -51,6 +51,7 @@ moeMainDebugIphonesimulatorXcodeBuild.dependsOn copyNatives
 eclipse {
     // Set Multi-OS Engine nature
     project {
+        name = appName + "-ios-moe"
         natures 'org.multi-os-engine.project'
     }
 }


### PR DESCRIPTION
ios moe eclipse project will now be named appName+'ios-moe" instead of just "ios-moe". Otherwise, ios-moe eclipse projects do not match other platforms' project naming conventions