### PR TITLE
Add resetScale method to BitmapFont

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFont.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFont.java
@@ -246,6 +246,13 @@ public class BitmapFont implements Disposable {
 		cache.getColor().set(r, g, b, a);
 	}
 
+	/** Reset the font to the original size */
+	public void resetScale () {
+		data.setScale(1 / data.scaleX, 1 / data.scaleY);
+		data.scaleX = 1;
+		data.scaleY = 1;
+	}
+
 	public float getScaleX () {
 		return data.scaleX;
 	}


### PR DESCRIPTION
I am using this method to reset the font to the original scale. I thought it might be useful.

When I call setScale(2) the scale is applied to the font and it gets bigger, then if I call setScale(1) the font font keeps the same size (2).

I just needed a method to get the original size back. Please let me know if there is a method to do this already, I couldn't find it.