### PR TITLE
Add icon dropped callback to live wallpaper listener

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidWallpaperListener.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidWallpaperListener.java
@@ -17,14 +17,9 @@ package com.badlogic.gdx.backends.android;
 import com.badlogic.gdx.ApplicationListener;
 
 /** Implement this listener in your libGDX application additionally to {@link ApplicationListener} if you want receive live
- * wallpaper specific events, ex: MyApplication implements ApplicationListener, AndroidWallpaperListener
- * 
- * Notice! This callbacks will work only if app is running as android live wallpaper: you have to link application with
- * AndroidLiveWallpaperService from in gdx-android-backend
- * 
- * Notice libGDX developers! If you do not like android specific classes in gdx backend, you can rename this class to for example:
- * com.badlogic.gdx.WallpaperListener so it will be 'generic' and not 'android specific', but besides of point of view the fact is
- * that live wallpapers are available only on android devices so far.
+ * wallpaper specific events, ex: MyApplication implements ApplicationListener, AndroidWallpaperListener. The callbacks
+ * will only be called if the ApplicationListener is running from an AndroidLiveWallpaperService.
+ * <p>
  * 
  * @author Jaroslaw Wisniewski <j.wisniewski@appsisle.com> */
 public interface AndroidWallpaperListener {
@@ -36,11 +31,15 @@ public interface AndroidWallpaperListener {
 	 * @param yOffsetStep
 	 * @param xPixelOffset
 	 * @param yPixelOffset */
-	abstract void offsetChange (float xOffset, float yOffset, float xOffsetStep, float yOffsetStep, int xPixelOffset,
+	void offsetChange (float xOffset, float yOffset, float xOffsetStep, float yOffsetStep, int xPixelOffset,
 		int yPixelOffset);
 
 	/** Called after 'isPreview' state had changed. First time called just after application initialization.
 	 * @param isPreview current status, save this value and update always when this method is called if you want track live
 	 *           wallpaper isPreview status. */
-	abstract void previewStateChange (boolean isPreview);
+	void previewStateChange (boolean isPreview);
+	
+	/** Called in response to an icon dropping on the home screen. Not all Android launcher apps are guaranteed to support this. */
+	void iconDropped (int x, int y);
+	
 }

--- a/tests/gdx-tests-android/src/com/badlogic/gdx/tests/android/LiveWallpaper.java
+++ b/tests/gdx-tests-android/src/com/badlogic/gdx/tests/android/LiveWallpaper.java
@@ -49,5 +49,12 @@ public class LiveWallpaper extends AndroidLiveWallpaperService {
 		public void previewStateChange (boolean isPreview) {
 			Log.i("LiveWallpaper test", "previewStateChange(isPreview:"+isPreview+")");
 		}
+
+		@Override
+		public void iconDropped (int x, int y) {
+			Log.i("LiveWallpaper test", "iconDropped (" + x + ", " + y + ")");
+		}
+		
+		
 	}
 }


### PR DESCRIPTION
This adds one more callback for the LiveWallpaperListener, for an icon dropped event, which tells you when and where an icon was dropped on the home screen. I don't think the Android specifications enforce this feature, but it worked in a couple of launchers that I tested.