### PR TITLE
Remove obsolete code

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/glutils/FileTextureData.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/FileTextureData.java
@@ -26,7 +26,6 @@ import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.utils.GdxRuntimeException;
 
 public class FileTextureData implements TextureData {
-	static public boolean copyToPOT;
 
 	final FileHandle file;
 	int width = 0;
@@ -42,7 +41,6 @@ public class FileTextureData implements TextureData {
 		this.format = format;
 		this.useMipMaps = useMipMaps;
 		if (pixmap != null) {
-			pixmap = ensurePot(pixmap);
 			width = pixmap.getWidth();
 			height = pixmap.getHeight();
 			if (format == null) this.format = pixmap.getFormat();
@@ -61,28 +59,12 @@ public class FileTextureData implements TextureData {
 			if (file.extension().equals("cim"))
 				pixmap = PixmapIO.readCIM(file);
 			else
-				pixmap = ensurePot(new Pixmap(file));
+				pixmap = new Pixmap(file);
 			width = pixmap.getWidth();
 			height = pixmap.getHeight();
 			if (format == null) format = pixmap.getFormat();
 		}
 		isPrepared = true;
-	}
-
-	private Pixmap ensurePot (Pixmap pixmap) {
-		if (Gdx.gl20 == null && copyToPOT) {
-			int pixmapWidth = pixmap.getWidth();
-			int pixmapHeight = pixmap.getHeight();
-			int potWidth = MathUtils.nextPowerOfTwo(pixmapWidth);
-			int potHeight = MathUtils.nextPowerOfTwo(pixmapHeight);
-			if (pixmapWidth != potWidth || pixmapHeight != potHeight) {
-				Pixmap tmp = new Pixmap(potWidth, potHeight, pixmap.getFormat());
-				tmp.drawPixmap(pixmap, 0, 0, 0, 0, pixmapWidth, pixmapHeight);
-				pixmap.dispose();
-				return tmp;
-			}
-		}
-		return pixmap;
 	}
 
 	@Override


### PR DESCRIPTION
I think this method is left over from when GL 1 support was removed. `gl20` is never null.