### PR TITLE
Fix jvm crash introduced by changes to the particles shader (#4621)

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g3d/particles/particles.fragment.glsl
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/particles/particles.fragment.glsl
@@ -32,7 +32,7 @@ uniform vec2 u_regionSize;
 
 void main() {
 	vec2 uv = v_region.xy + gl_PointCoord*v_region.zw - v_uvRegionCenter;
-	vec2 texCoord = mat2(v_rotation) * uv  +v_uvRegionCenter;
+	vec2 texCoord = mat2(v_rotation.x, v_rotation.y, v_rotation.z, v_rotation.w) * uv  +v_uvRegionCenter;
 	gl_FragColor = texture2D(u_diffuseTexture, texCoord)* v_color;
 }
 


### PR DESCRIPTION
The changes introduced by #4621 cause the JVM to crash on desktop (just run the FlameEditor and it will crash). It seems like the constructor `mat2(vec4)` causes the crash. Passing the 4 components separately fixes it.

Note that I can only test on desktop.