### PR TITLE
Edited a comment

### DIFF
--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/extensions/FreeTypeFontLoaderTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/extensions/FreeTypeFontLoaderTest.java
@@ -30,7 +30,7 @@ public class FreeTypeFontLoaderTest extends GdxTest {
 		// load to fonts via the generator (implicitely done by the FreetypeFontLoader).
 		// Note: you MUST specify a FreetypeFontGenerator defining the ttf font file name and the size
 		// of the font to be generated. The names of the fonts are arbitrary and are not pointing
-		// to a file on disk!
+		// to a file on disk (BUT MUST END WITH THE FONT FILE FORMAT '.ttf')!
 		FreeTypeFontLoaderParameter size1Params = new FreeTypeFontLoaderParameter();
 		size1Params.fontFileName = "data/arial.ttf";
 		size1Params.fontParameters.size = 10;

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/extensions/FreeTypeFontLoaderTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/extensions/FreeTypeFontLoaderTest.java
@@ -30,7 +30,7 @@ public class FreeTypeFontLoaderTest extends GdxTest {
 		// load to fonts via the generator (implicitely done by the FreetypeFontLoader).
 		// Note: you MUST specify a FreetypeFontGenerator defining the ttf font file name and the size
 		// of the font to be generated. The names of the fonts are arbitrary and are not pointing
-		// to a file on disk (BUT MUST END WITH THE FONT FILE FORMAT '.ttf')!
+		// to a file on disk (but must end with the font's file format '.ttf')!
 		FreeTypeFontLoaderParameter size1Params = new FreeTypeFontLoaderParameter();
 		size1Params.fontFileName = "data/arial.ttf";
 		size1Params.fontParameters.size = 10;


### PR DESCRIPTION
After spending few hours to understand why I get the "Couldn't load dependencies of asset" when tried loading same font with different parameters, I've found out that the name cannot be fully arbitrary as it says in the comment - It must have the suffix of file format.