### PR TITLE
Updated the setup tool for the HTML backend

### DIFF
--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/DependencyBank.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/DependencyBank.java
@@ -39,7 +39,7 @@ public class DependencyBank {
 	static String libGDXReleaseUrl = "https://oss.sonatype.org/content/repositories/releases/";
 
 	//Project plugins
-	static String gwtPluginImport = "de.richsource.gradle.plugins:gwt-gradle-plugin:0.6";
+	static String gwtPluginImport = "org.wisepersist:gwt-gradle-plugin:1.0.1";
 	static String androidPluginImport = "com.android.tools.build:gradle:2.2.0";
 	static String roboVMPluginImport = "com.mobidevelop.robovm:robovm-gradle-plugin:" + roboVMVersion;
 	static String moePluginImport = "org.multi-os-engine:moe-gradle:" + moeVersion;

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/gradle/wrapper/gradle-wrapper.properties
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/html/GdxDefinitionSuperdev
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/html/GdxDefinitionSuperdev
@@ -1,12 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit trunk//EN" "http://google-web-toolkit.googlecode.com/svn/trunk/distro-source/core/src/gwt-module.dtd">
 <module rename-to="html">
-%GWT_INHERITS%
     <inherits name='%PACKAGE%.GdxDefinition' />
-    
     <collapse-all-properties />
-    
-	<add-linker name="xsiframe"/>	
-	<set-configuration-property name="devModeRedirectEnabled" value="true"/>
-	<set-configuration-property name='xsiframe.failIfScriptTag' value='FALSE'/>	
+
+    <set-configuration-property name="user.home" value="" />
 </module>

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/html/build.gradle
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/html/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: "java"
-apply plugin: "jetty"
+
+import org.wisepersist.gradle.plugins.gwt.GwtSuperDev
+
+def HttpFileServer server = null
+def httpfilePort = 9090
 
 gwt {
     gwtVersion='%GWT_VERSION%' // Should match the gwt version used for building the gwt backend
@@ -9,7 +13,6 @@ gwt {
     src = files(file("src/")) // Needs to be in front of "modules" below.
     modules '%PACKAGE%.GdxDefinition'
     devModules '%PACKAGE%.GdxDefinitionSuperdev'
-    project.webAppDirName = 'webapp'
 
     compiler {
         strict = true;
@@ -17,17 +20,32 @@ gwt {
     }
 }
 
-task draftRun(type: JettyRunWar) {
-    dependsOn draftWar
-    dependsOn.remove('war')
-    webApp=draftWar.archivePath
-    daemon=true
+task startHttpServer() {
+    dependsOn draftCompileGwt
+
+    String output = project.buildDir.path + "/gwt/draftOut";
+
+    doLast {
+        copy {
+            from "webapp"
+            into output
+        }
+
+        copy {
+            from "war"
+            into output
+        }
+
+        server = new SimpleHttpFileServerFactory().start(new File(output), httpfilePort)
+
+        println "Server started in directory " + server.getContentRoot() + ", port " + server.getPort()
+    }
 }
 
-task superDev(type: de.richsource.gradle.plugins.gwt.GwtSuperDev) {
-    dependsOn draftRun
+task superDev(type: GwtSuperDev) {
+    dependsOn startHttpServer
     doFirst {
-    	gwt.modules = gwt.devModules
+        gwt.modules = gwt.devModules
     }
 }
 
@@ -49,13 +67,12 @@ task dist(dependsOn: [clean, compileGwt]) {
     }
 }
 
-draftWar {
-   from "war"
+task addSource {
+    doLast {
+        sourceSets.main.compileClasspath += files(project(':core').sourceSets.main.allJava.srcDirs)
+    }
 }
 
-task addSource << {
-	sourceSets.main.compileClasspath += files(project(':core').sourceSets.main.allJava.srcDirs)
-}
 
 tasks.compileGwt.dependsOn(addSource)
 tasks.draftCompileGwt.dependsOn(addSource)


### PR DESCRIPTION
Updated the setup tool to handle the deprecation of the Jetty plugin from the Gradle distribution (4+)
Moved over to using a simple file server to serve the content whilst the SuperDev mode is handled by GWT and it's internal Jetty
Changed the GWT plugin to a newer one, it's fork of what was there before but this is actively maintained.

This is what I use for my HTML5 based projects now - Thought I should give back to the community :)