### PR TITLE
cache cubemap sides to reduce memory consumption

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/glutils/FrameBufferCubemap.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/FrameBufferCubemap.java
@@ -65,7 +65,7 @@ public class FrameBufferCubemap extends GLFrameBuffer<Cubemap> {
 	private int currentSide;
 
 	/** cubemap sides cache */
-	private Cubemap.CubemapSide[] cubemapSides = Cubemap.CubemapSide.values();
+	private static final Cubemap.CubemapSide[] cubemapSides = Cubemap.CubemapSide.values();
 
 	/** Creates a new FrameBuffer having the given dimensions and potentially a depth buffer attached.
 	 *

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/FrameBufferCubemap.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/FrameBufferCubemap.java
@@ -64,6 +64,9 @@ public class FrameBufferCubemap extends GLFrameBuffer<Cubemap> {
 	/** the zero-based index of the active side **/
 	private int currentSide;
 
+	/** cubemap sides cache */
+	private Cubemap.CubemapSide[] cubemapSides = Cubemap.CubemapSide.values();
+
 	/** Creates a new FrameBuffer having the given dimensions and potentially a depth buffer attached.
 	 *
 	 * @param format
@@ -145,6 +148,6 @@ public class FrameBufferCubemap extends GLFrameBuffer<Cubemap> {
 
 	/** Get the currently bound side. */
 	public Cubemap.CubemapSide getSide () {
-		return currentSide < 0 ? null : Cubemap.CubemapSide.values()[currentSide];
+		return currentSide < 0 ? null : cubemapSides [currentSide];
 	}
 }


### PR DESCRIPTION
Easy to reproduce by running FrameBufferCubemapTest with visualVM.