### PR TITLE
avoid unnecessary FloatBuffer allocation

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/glutils/VertexArray.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/VertexArray.java
@@ -110,9 +110,15 @@ public class VertexArray implements VertexData {
 				if (location < 0) continue;
 				shader.enableVertexAttribute(location);
 
-				byteBuffer.position(attribute.offset);
-				shader.setVertexAttribute(location, attribute.numComponents, attribute.type, attribute.normalized, attributes.vertexSize,
-					byteBuffer);
+				if (attribute.type == GL20.GL_FLOAT) {
+					buffer.position(attribute.offset / 4);
+					shader.setVertexAttribute(location, attribute.numComponents, attribute.type, attribute.normalized,
+						attributes.vertexSize, buffer);
+				} else {
+					byteBuffer.position(attribute.offset);
+					shader.setVertexAttribute(location, attribute.numComponents, attribute.type, attribute.normalized,
+						attributes.vertexSize, byteBuffer);
+				}
 			}
 		} else {
 			for (int i = 0; i < numAttributes; i++) {
@@ -121,9 +127,15 @@ public class VertexArray implements VertexData {
 				if (location < 0) continue;
 				shader.enableVertexAttribute(location);
 
-				byteBuffer.position(attribute.offset);
-				shader.setVertexAttribute(location, attribute.numComponents, attribute.type, attribute.normalized, attributes.vertexSize,
-					byteBuffer);
+				if (attribute.type == GL20.GL_FLOAT) {
+					buffer.position(attribute.offset / 4);
+					shader.setVertexAttribute(location, attribute.numComponents, attribute.type, attribute.normalized,
+						attributes.vertexSize, buffer);
+				} else {
+					byteBuffer.position(attribute.offset);
+					shader.setVertexAttribute(location, attribute.numComponents, attribute.type, attribute.normalized,
+						attributes.vertexSize, byteBuffer);
+				}
 			}
 		}
 		isBound = true;


### PR DESCRIPTION
Easy to reproduce by running Scene2dTest with visualVM : a new DirectFloatBufferU was created for each attribute binding causes a lot of garbage in memory.

Since vertex array already maintains a FloatBuffer view of its bytes it is possible to pass the float buffer for float type and then avoid unnecessary conversion.