### PR TITLE
Add support for 2d particle independant scale X and Y

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -25,6 +25,8 @@
 - API Change: removed JGLFW backend
 - Fixed mixed up use of TexturePacker.Settings.stripWhitespaceX|Y.
 - Added joystick POV support to LWJGL3 controller backend.
+- Added support for 2d particles independant scale X and Y.
+- API Change: ParticleEmitter getScale, matchSize are now getScaleX/getScaleY, matchSizeX/matchSizeY. Added scaleSize(float scaleX, float scaleY)
 
 [1.9.6]
 - Fix performance regression in LWJGL3 backend, use java.nio instead of BufferUtils. Those are intrinsics and quite a bit faster than BufferUtils on HotSpot.

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/EffectPanel.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/EffectPanel.java
@@ -55,7 +55,7 @@ class EffectPanel extends JPanel {
 		emitter.getDuration().setLow(1000);
 		emitter.getEmission().setHigh(50);
 		emitter.getLife().setHigh(500);
-		emitter.getScale().setHigh(32, 32);
+		emitter.getXScale().setHigh(32, 32);
 
 		emitter.getTint().setColors(new float[] {1, 0.12156863f, 0.047058824f});
 		emitter.getTransparency().setHigh(1);
@@ -78,7 +78,7 @@ class EffectPanel extends JPanel {
 		emitter.getLife().setTimeline(new float[] {0, 0.66f, 1});
 		emitter.getLife().setScaling(new float[] {1, 1, 0.3f});
 
-		emitter.getScale().setHigh(32, 32);
+		emitter.getXScale().setHigh(32, 32);
 
 		emitter.getRotation().setLow(1, 360);
 		emitter.getRotation().setHigh(180, 180);

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/ParticleEditor.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/ParticleEditor.java
@@ -123,7 +123,8 @@ public class ParticleEditor extends JFrame {
 					"Width of the spawn shape, in world units."));
 				addRow(new ScaledNumericPanel(emitter.getSpawnHeight(), "Duration", "Spawn Height",
 					"Height of the spawn shape, in world units."));
-				addRow(new ScaledNumericPanel(emitter.getScale(), "Life", "Size", "Particle size, in world units."));
+				addRow(new ScaledNumericPanel(emitter.getXScale(), "Life", "X Size", "Particle x size, in world units. If Y Size is not active, this also controls the y size"));
+				addRow(new ScaledNumericPanel(emitter.getYScale(), "Life", "Y Size", "Particle y size, in world units."));
 				addRow(new ScaledNumericPanel(emitter.getVelocity(), "Life", "Velocity", "Particle speed, in world units per second."));
 				addRow(new ScaledNumericPanel(emitter.getAngle(), "Life", "Angle", "Particle emission angle, in degrees."));
 				addRow(new ScaledNumericPanel(emitter.getRotation(), "Life", "Rotation", "Particle rotation, in degrees."));

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/ParticleEffect.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/ParticleEffect.java
@@ -38,7 +38,9 @@ public class ParticleEffect implements Disposable {
 	private final Array<ParticleEmitter> emitters;
 	private BoundingBox bounds;
 	private boolean ownsTexture;
-	protected float sizeScale = 1f, motionScale = 1f;
+	protected float xSizeScale = 1f;
+	protected float ySizeScale = 1f;
+	protected float motionScale = 1f;
 
 	public ParticleEffect () {
 		emitters = new Array(8);
@@ -67,9 +69,9 @@ public class ParticleEffect implements Disposable {
 	public void reset (boolean resetScaling){
 		for (int i = 0, n = emitters.size; i < n; i++)
 			emitters.get(i).reset();
-		if (resetScaling && (sizeScale != 1f || motionScale != 1f)){
-			scaleEffect(1f / sizeScale, 1f / motionScale);
-			sizeScale = motionScale = 1f;
+		if (resetScaling && (xSizeScale != 1f || ySizeScale != 1f || motionScale != 1f)){
+			scaleEffect(1f / xSizeScale, 1f / ySizeScale, 1f / motionScale);
+			xSizeScale = ySizeScale = motionScale = 1f;
 		}
 	}
 
@@ -251,16 +253,23 @@ public class ParticleEffect implements Disposable {
 	/** Permanently scales all the size and motion parameters of all the emitters in this effect. If this effect originated from a
 	 * {@link ParticleEffectPool}, the scale will be reset when it is returned to the pool. */
 	public void scaleEffect (float scaleFactor) {
-		scaleEffect(scaleFactor, scaleFactor);
+		scaleEffect(scaleFactor, scaleFactor, scaleFactor);
+	}
+	
+	/** Permanently scales all the size and motion parameters of all the emitters in this effect. If this effect originated from a
+	 * {@link ParticleEffectPool}, the scale will be reset when it is returned to the pool. */
+	public void scaleEffect (float scaleFactor, float motionScaleFactor) {
+		scaleEffect(scaleFactor, scaleFactor, motionScaleFactor);
 	}
 
 	/** Permanently scales all the size and motion parameters of all the emitters in this effect. If this effect originated from a
 	 * {@link ParticleEffectPool}, the scale will be reset when it is returned to the pool. */
-	public void scaleEffect (float sizeScaleFactor, float motionScaleFactor) {
-		sizeScale *= sizeScaleFactor;
+	public void scaleEffect (float xSizeScaleFactor, float ySizeScaleFactor, float motionScaleFactor) {
+		xSizeScale *= xSizeScaleFactor;
+		ySizeScale *= ySizeScaleFactor;
 		motionScale *= motionScaleFactor;
 		for (ParticleEmitter particleEmitter : emitters) {
-			particleEmitter.scaleSize(sizeScaleFactor);
+			particleEmitter.scaleSize(xSizeScaleFactor, ySizeScaleFactor);
 			particleEmitter.scaleMotion(motionScaleFactor);
 		}
 	}

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/ParticleEffectPool.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/ParticleEffectPool.java
@@ -36,7 +36,7 @@ public class ParticleEffectPool extends Pool<PooledEffect> {
 		super.free(effect);
 		
 		effect.reset(false); // copy parameters exactly to avoid introducing error
-		if (effect.sizeScale != this.effect.sizeScale || effect.motionScale != this.effect.motionScale){
+		if (effect.xSizeScale != this.effect.xSizeScale || effect.ySizeScale != this.effect.ySizeScale || effect.motionScale != this.effect.motionScale){
 			Array<ParticleEmitter> emitters = effect.getEmitters();
 			Array<ParticleEmitter> templateEmitters = this.effect.getEmitters();
 			for (int i=0; i<emitters.size; i++){
@@ -45,7 +45,8 @@ public class ParticleEffectPool extends Pool<PooledEffect> {
 				emitter.matchSize(templateEmitter);
 				emitter.matchMotion(templateEmitter);
 			}
-			effect.sizeScale = this.effect.sizeScale;
+			effect.xSizeScale = this.effect.xSizeScale;
+			effect.ySizeScale = this.effect.ySizeScale;
 			effect.motionScale = this.effect.motionScale;
 		}
 	}


### PR DESCRIPTION
This makes it possible to set scale X and Y independently. When scaleY is not active, scaleX is used for both X and Y.

The editor has been updated accordingly. The loader is backward compatible with the previous file format.

This PR is mergeable with my other PR "animated particles"