### PR TITLE
Allow List#setItems() with the original items

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/List.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/List.java
@@ -251,13 +251,16 @@ public class List<T> extends Widget implements Cullable {
 	}
 
 	/** Sets the items visible in the list, clearing the selection if it is no longer valid. If a selection is
-	 * {@link ArraySelection#getRequired()}, the first item is selected. */
+	 * {@link ArraySelection#getRequired()}, the first item is selected. This can safely be called with a
+	 * (modified) array returned from {@link #getItems()}. */
 	public void setItems (Array newItems) {
 		if (newItems == null) throw new IllegalArgumentException("newItems cannot be null.");
 		float oldPrefWidth = getPrefWidth(), oldPrefHeight = getPrefHeight();
 
-		items.clear();
-		items.addAll(newItems);
+		if (newItems != items) {
+			items.clear();
+			items.addAll(newItems);
+		}
 		selection.validate();
 
 		invalidate();


### PR DESCRIPTION
This allows uses like the following, without the need for copying the
entire array:

    Array<String> items = list.getItems();
    items.add("hello world");
    list.setItems(items);

Issue #2834 suggests that this should work, but it doesn't; it clears
the items instead.

It seems unlikely that anyone would use that on purpose (as
`List#clearItems()` already exists), so this change is unlikely to break
anyone.