### PR TITLE
Made it possible to let the IOSApplication use IOSInput subclasses.

### DIFF
--- a/backends/gdx-backend-moe/src/com/badlogic/gdx/backends/iosmoe/IOSApplication.java
+++ b/backends/gdx-backend-moe/src/com/badlogic/gdx/backends/iosmoe/IOSApplication.java
@@ -172,7 +172,7 @@ public class IOSApplication implements Application {
 		}
 
 		// setup libgdx
-		this.input = new IOSInput(this);
+		this.input = createInput();
 		createGraphics(scale);
 		Gdx.gl = Gdx.gl20 = graphics.gl20;
 		Gdx.gl30 = graphics.gl30;
@@ -192,6 +192,15 @@ public class IOSApplication implements Application {
 	protected void createGraphics (float scale) {
 		this.graphics = IOSGraphics.alloc().init(scale, this, config, input, config.useGL30);
 	}
+
+	 /**
+	  * With this method you can simply extend IOSApplication and override this method to load your custom class that extends IOSInput.
+	  *
+	  * @return an IOSInput instance that handles the input of the application.
+	  */
+	 protected IOSInput createInput() {
+		  return new IOSInput(this);
+	 }
 
 	private int getIosVersion () {
 		String systemVersion = UIDevice.currentDevice().systemVersion();

--- a/backends/gdx-backend-moe/src/com/badlogic/gdx/backends/iosmoe/IOSInput.java
+++ b/backends/gdx-backend-moe/src/com/badlogic/gdx/backends/iosmoe/IOSInput.java
@@ -305,30 +305,6 @@ public class IOSInput implements Input {
 		buildUIAlertView(listener, title, text, hint).show();
 	}
 
-	// hack for software keyboard support
-	// uses a hidden textfield to capture input
-	// see: http://www.badlogicgames.com/forum/viewtopic.php?f=17&t=11788
-
-	private class HiddenTextField extends UITextField {
-		public HiddenTextField (CGRect frame) {
-			super(frame.getPeer());
-
-			setKeyboardType(UIKeyboardType.Default);
-			setReturnKeyType(UIReturnKeyType.Done);
-			setAutocapitalizationType(UITextAutocapitalizationType.None);
-			setAutocorrectionType(UITextAutocorrectionType.No);
-			setSpellCheckingType(UITextSpellCheckingType.No);
-			setHidden(true);
-		}
-
-		@Override
-		public void deleteBackward () {
-			app.input.inputProcessor.keyTyped((char)8);
-			super.deleteBackward();
-			Gdx.graphics.requestRendering();
-		}
-	}
-
 	private UITextField textfield = null;
 	private final UITextFieldDelegate textDelegate = new UITextFieldDelegate() {
 		@Override


### PR DESCRIPTION
See my forum topic for my original issue.
http://www.badlogicgames.com/forum/viewtopic.php?f=11&t=26824

I'd love to make stuff like the CMMotionManager protected too so it's behavior can be adjusted from subclasses, but as it's a multi os engine binding that might make it easy for people who have no experience with MOE to introduce bugs so I thought I'd check if you guys accept this change first.

About the removal of "HiddenTextField", I am pretty sure that it is not being used. My app works fine without it. I have looked in the forum topic mentioned in the comment (http://www.badlogicgames.com/forum/viewtopic.php?f=17&t=11788) and that seems to be about RoboVM rather than MOE.

If something needs work let me know in the comments or on the forum topic.