### PR TITLE
Make desktop input dialog modal

### DIFF
--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglInput.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglInput.java
@@ -192,6 +192,8 @@ final public class LwjglInput implements Input {
 					}
 				});
 
+				dialog.setModal(true);
+				dialog.setAlwaysOnTop(true);
 				dialog.setVisible(true);
 				dialog.dispose();
 


### PR DESCRIPTION
Make desktop input dialog for Gdx.input.getTextInput modal and set it to be always on top, because currently when executing getTextInput on the desktop sometimes the input dialog gets under the game window, so it's invisible.