### PR TITLE
2d particle effect rotation and better scaling

### DIFF
--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/EffectPanel.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/EffectPanel.java
@@ -34,6 +34,7 @@ import javax.swing.table.DefaultTableModel;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.g2d.ParticleEffect;
 import com.badlogic.gdx.graphics.g2d.ParticleEmitter;
+import com.badlogic.gdx.tools.particleeditor.ParticleEditor.TransformMode;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.StreamUtils;
 
@@ -115,6 +116,8 @@ class EffectPanel extends JPanel {
 		else {
 			ParticleEmitter p = emitters.get(0);
 			emitter.setPosition(p.getX(), p.getY());
+			emitter.setEmitterScale(p.getEmitterScaleX(), p.getEmitterScaleY());
+			emitter.setEmitterRotation(p.getEmitterRotation());
 		}
 		emitters.add(emitter);
 
@@ -256,6 +259,16 @@ class EffectPanel extends JPanel {
 		editor.effect.start();
 	}
 
+	void changeTransformMode (TransformMode transformMode) {
+		editor.transformMode = transformMode;
+	}
+
+	void resetTransform() {
+		editor.effect.setPosition(editor.worldCamera.viewportWidth / 2, editor.worldCamera.viewportHeight / 2);
+		editor.effect.setScale(1, 1);
+		editor.effect.setRotation(0);
+	}
+
 	private void initializeComponents () {
 		setLayout(new GridBagLayout());
 		{
@@ -327,8 +340,12 @@ class EffectPanel extends JPanel {
 				});
 			}
 			{
+				sideButtons.add(new JSeparator(JSeparator.HORIZONTAL), new GridBagConstraints(0, -1, 1, 1, 0, 0,
+					GridBagConstraints.CENTER, GridBagConstraints.HORIZONTAL, new Insets(0, 0, 6, 0), 0, 0));
+			}
+			{
 				JButton upButton = new JButton("Up");
-				sideButtons.add(upButton, new GridBagConstraints(0, -1, 1, 1, 0, 1, GridBagConstraints.SOUTH,
+				sideButtons.add(upButton, new GridBagConstraints(0, -1, 1, 1, 0, 0, GridBagConstraints.CENTER,
 					GridBagConstraints.HORIZONTAL, new Insets(0, 0, 6, 0), 0, 0));
 				upButton.addActionListener(new ActionListener() {
 					public void actionPerformed (ActionEvent event) {
@@ -339,10 +356,76 @@ class EffectPanel extends JPanel {
 			{
 				JButton downButton = new JButton("Down");
 				sideButtons.add(downButton, new GridBagConstraints(0, -1, 1, 1, 0, 0, GridBagConstraints.CENTER,
-					GridBagConstraints.HORIZONTAL, new Insets(0, 0, 0, 0), 0, 0));
+					GridBagConstraints.HORIZONTAL, new Insets(0, 0, 6, 0), 0, 0));
 				downButton.addActionListener(new ActionListener() {
 					public void actionPerformed (ActionEvent event) {
 						move(1);
+					}
+				});
+			}
+			{
+				sideButtons.add(new JSeparator(JSeparator.HORIZONTAL), new GridBagConstraints(0, -1, 1, 1, 0, 0,
+					GridBagConstraints.CENTER, GridBagConstraints.HORIZONTAL, new Insets(0, 0, 6, 0), 0, 0));
+			}
+			{
+				ButtonGroup checkboxGroup = new ButtonGroup();
+				JToggleButton translateButton = new JToggleButton("Translate", editor.transformMode == TransformMode.translate);
+				sideButtons.add(translateButton, new GridBagConstraints(0, -1, 1, 1, 0, 0, GridBagConstraints.CENTER,
+					GridBagConstraints.HORIZONTAL, new Insets(0, 0, 6, 0), 0, 0));
+				checkboxGroup.add(translateButton);
+				translateButton.addActionListener(new ActionListener() {
+					public void actionPerformed (ActionEvent event) {
+						changeTransformMode(TransformMode.translate);
+					}
+				});
+				JToggleButton scaleButton = new JToggleButton("Scale", editor.transformMode == TransformMode.scale);
+				sideButtons.add(scaleButton, new GridBagConstraints(0, -1, 1, 1, 0, 0, GridBagConstraints.CENTER,
+					GridBagConstraints.HORIZONTAL, new Insets(0, 0, 6, 0), 0, 0));
+				checkboxGroup.add(scaleButton);
+				scaleButton.addActionListener(new ActionListener() {
+					public void actionPerformed (ActionEvent event) {
+						changeTransformMode(TransformMode.scale);
+					}
+				});
+				JToggleButton scaleXButton = new JToggleButton("Scale X", editor.transformMode == TransformMode.scaleX);
+				sideButtons.add(scaleXButton, new GridBagConstraints(0, -1, 1, 1, 0, 0, GridBagConstraints.CENTER,
+					GridBagConstraints.HORIZONTAL, new Insets(0, 0, 6, 0), 0, 0));
+				checkboxGroup.add(scaleXButton);
+				scaleXButton.addActionListener(new ActionListener() {
+					public void actionPerformed (ActionEvent event) {
+						changeTransformMode(TransformMode.scaleX);
+					}
+				});
+				JToggleButton scaleYButton = new JToggleButton("Scale Y", editor.transformMode == TransformMode.scaleY);
+				sideButtons.add(scaleYButton, new GridBagConstraints(0, -1, 1, 1, 0, 0, GridBagConstraints.CENTER,
+					GridBagConstraints.HORIZONTAL, new Insets(0, 0, 6, 0), 0, 0));
+				checkboxGroup.add(scaleYButton);
+				scaleYButton.addActionListener(new ActionListener() {
+					public void actionPerformed (ActionEvent event) {
+						changeTransformMode(TransformMode.scaleY);
+					}
+				});
+				JToggleButton rotateButton = new JToggleButton("Rotate", editor.transformMode == TransformMode.rotate);
+				sideButtons.add(rotateButton, new GridBagConstraints(0, -1, 1, 1, 0, 0, GridBagConstraints.CENTER,
+					GridBagConstraints.HORIZONTAL, new Insets(0, 0, 6, 0), 0, 0));
+				checkboxGroup.add(rotateButton);
+				rotateButton.addActionListener(new ActionListener() {
+					public void actionPerformed (ActionEvent event) {
+						changeTransformMode(TransformMode.rotate);
+					}
+				});
+			}
+			{
+				sideButtons.add(new JSeparator(JSeparator.HORIZONTAL), new GridBagConstraints(0, -1, 1, 1, 0, 0,
+					GridBagConstraints.CENTER, GridBagConstraints.HORIZONTAL, new Insets(0, 0, 6, 0), 0, 0));
+			}
+			{
+				JButton resetButton = new JButton("Reset");
+				sideButtons.add(resetButton, new GridBagConstraints(0, -1, 1, 1, 0, 0, GridBagConstraints.CENTER,
+					GridBagConstraints.HORIZONTAL, new Insets(0, 0, 6, 0), 0, 0));
+				resetButton.addActionListener(new ActionListener() {
+					public void actionPerformed (ActionEvent event) {
+						resetTransform();
 					}
 				});
 			}

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/ParticleEffect.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/ParticleEffect.java
@@ -117,6 +117,16 @@ public class ParticleEffect implements Disposable {
 			emitters.get(i).setPosition(x, y);
 	}
 
+	public void setScale (float scaleX, float scaleY) {
+		for (int i = 0, n = emitters.size; i < n; i++)
+			emitters.get(i).setEmitterScale(scaleX, scaleY);
+	}
+
+	public void setRotation (float rotation) {
+		for (int i = 0, n = emitters.size; i < n; i++)
+			emitters.get(i).setEmitterRotation(rotation);
+	}
+
 	public void setFlip (boolean flipX, boolean flipY) {
 		for (int i = 0, n = emitters.size; i < n; i++)
 			emitters.get(i).setFlip(flipX, flipY);


### PR DESCRIPTION
Particle emitters can now be rotated. To achieve this, I made particles use a local transform (position, scale, rotation). The sprite's transform is then set to the world transform of the particle, using the transform of the parent (the emitter).  Here is a [small demo](https://imgur.com/a/z9bL0).

The editor has been updated to allow for rotation and scaling of the effect.

I originally planned to add rotation only, but since I was using a `Matrix3` for the parent transform, adding scale was easy. In fact, I believe this way of scaling is much simpler and works better than the current `scaleEffect` API which scales every parameter related to position/movement, and always felt more like a workaround.

I know that this is a significant change, so I would understand if it can't be merged. 

If it can however, please let me know if I should also push [that other commit](https://github.com/FredGithub/libgdx/commit/bc8a26fd76f1ed852349b041940c3b732782ab44), which reduces code complexity quite a bit by removing everything related to the current `scaleEffect`. Removing various public APIs (and the work of other people) is not the best though, but having 2 APIs for scaling is also not ideal. Not sure what to do at that point.