### PR TITLE
make TangentialAcceleration and PolarAcceleration respect global flag

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g3d/particles/influencers/DynamicsModifier.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/particles/influencers/DynamicsModifier.java
@@ -371,6 +371,12 @@ public abstract class DynamicsModifier extends Influencer {
 				float cosTheta = MathUtils.cosDeg(theta), sinTheta = MathUtils.sinDeg(theta), cosPhi = MathUtils.cosDeg(phi), sinPhi = MathUtils
 					.sinDeg(phi);
 				TMP_V3.set(cosTheta * sinPhi, cosPhi, sinTheta * sinPhi).nor().scl(strength);
+
+				if (!isGlobal) {
+					controller.transform.getRotation(TMP_Q, true);
+					TMP_V3.mul(TMP_Q);
+				}
+
 				directionalVelocityChannel.data[i + ParticleChannels.XOffset] += TMP_V3.x;
 				directionalVelocityChannel.data[i + ParticleChannels.YOffset] += TMP_V3.y;
 				directionalVelocityChannel.data[i + ParticleChannels.ZOffset] += TMP_V3.z;
@@ -415,11 +421,17 @@ public abstract class DynamicsModifier extends Influencer {
 
 				float cosTheta = MathUtils.cosDeg(theta), sinTheta = MathUtils.sinDeg(theta), cosPhi = MathUtils.cosDeg(phi), sinPhi = MathUtils
 					.sinDeg(phi);
-				TMP_V3
-					.set(cosTheta * sinPhi, cosPhi, sinTheta * sinPhi)
-					.crs(positionChannel.data[positionOffset + ParticleChannels.XOffset],
-						positionChannel.data[positionOffset + ParticleChannels.YOffset],
-						positionChannel.data[positionOffset + ParticleChannels.ZOffset]).nor().scl(strength);
+				TMP_V3.set(cosTheta * sinPhi, cosPhi, sinTheta * sinPhi);
+				TMP_V1.set(positionChannel.data[positionOffset + ParticleChannels.XOffset],
+					positionChannel.data[positionOffset + ParticleChannels.YOffset],
+					positionChannel.data[positionOffset + ParticleChannels.ZOffset]);
+				if (!isGlobal) {
+					controller.transform.getTranslation(TMP_V2);
+					TMP_V1.sub(TMP_V2);
+					controller.transform.getRotation(TMP_Q, true);
+					TMP_V3.mul(TMP_Q);
+				}
+				TMP_V3.crs(TMP_V1).nor().scl(strength);
 				directionalVelocityChannel.data[i + ParticleChannels.XOffset] += TMP_V3.x;
 				directionalVelocityChannel.data[i + ParticleChannels.YOffset] += TMP_V3.y;
 				directionalVelocityChannel.data[i + ParticleChannels.ZOffset] += TMP_V3.z;

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/particles/influencers/SpawnInfluencer.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/particles/influencers/SpawnInfluencer.java
@@ -31,6 +31,7 @@ public class SpawnInfluencer extends Influencer {
 
 	public SpawnShapeValue spawnShapeValue;
 	FloatChannel positionChannel;
+	FloatChannel rotationChannel;
 
 	public SpawnInfluencer () {
 		spawnShapeValue = new PointSpawnShapeValue();
@@ -52,6 +53,7 @@ public class SpawnInfluencer extends Influencer {
 	@Override
 	public void allocateChannels () {
 		positionChannel = controller.particles.addChannel(ParticleChannels.Position);
+		rotationChannel = controller.particles.addChannel(ParticleChannels.Rotation3D);
 	}
 
 	@Override
@@ -67,6 +69,13 @@ public class SpawnInfluencer extends Influencer {
 			positionChannel.data[i + ParticleChannels.XOffset] = TMP_V1.x;
 			positionChannel.data[i + ParticleChannels.YOffset] = TMP_V1.y;
 			positionChannel.data[i + ParticleChannels.ZOffset] = TMP_V1.z;
+		}
+		for (int i = startIndex * rotationChannel.strideSize, c = i + count * rotationChannel.strideSize; i < c; i += rotationChannel.strideSize) {
+			controller.transform.getRotation(TMP_Q, true);
+			rotationChannel.data[i + ParticleChannels.XOffset] = TMP_Q.x;
+			rotationChannel.data[i + ParticleChannels.YOffset] = TMP_Q.y;
+			rotationChannel.data[i + ParticleChannels.ZOffset] = TMP_Q.z;
+			rotationChannel.data[i + ParticleChannels.WOffset] = TMP_Q.w;
 		}
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/ParticleControllerInfluencerSingleTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/ParticleControllerInfluencerSingleTest.java
@@ -1,0 +1,175 @@
+
+package com.badlogic.gdx.tests.g3d;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g3d.Environment;
+import com.badlogic.gdx.graphics.g3d.ModelBatch;
+import com.badlogic.gdx.graphics.g3d.ModelInstance;
+import com.badlogic.gdx.graphics.g3d.particles.ParticleController;
+import com.badlogic.gdx.graphics.g3d.particles.batches.BillboardParticleBatch;
+import com.badlogic.gdx.graphics.g3d.particles.emitters.RegularEmitter;
+import com.badlogic.gdx.graphics.g3d.particles.influencers.DynamicsInfluencer;
+import com.badlogic.gdx.graphics.g3d.particles.influencers.DynamicsModifier.TangentialAcceleration;
+import com.badlogic.gdx.graphics.g3d.particles.influencers.Influencer;
+import com.badlogic.gdx.graphics.g3d.particles.influencers.ParticleControllerFinalizerInfluencer;
+import com.badlogic.gdx.graphics.g3d.particles.influencers.ParticleControllerInfluencer;
+import com.badlogic.gdx.graphics.g3d.particles.influencers.RegionInfluencer;
+import com.badlogic.gdx.graphics.g3d.particles.influencers.SpawnInfluencer;
+import com.badlogic.gdx.graphics.g3d.particles.renderers.BillboardRenderer;
+import com.badlogic.gdx.graphics.g3d.particles.renderers.ParticleControllerControllerRenderer;
+import com.badlogic.gdx.graphics.g3d.particles.values.CylinderSpawnShapeValue;
+import com.badlogic.gdx.graphics.g3d.particles.values.PointSpawnShapeValue;
+import com.badlogic.gdx.math.Matrix4;
+import com.badlogic.gdx.math.Quaternion;
+import com.badlogic.gdx.math.Vector3;
+import com.badlogic.gdx.scenes.scene2d.Stage;
+import com.badlogic.gdx.scenes.scene2d.ui.Label;
+import com.badlogic.gdx.scenes.scene2d.ui.Skin;
+import com.badlogic.gdx.scenes.scene2d.ui.Table;
+import com.badlogic.gdx.utils.Array;
+
+/** @author ryanastout */
+public class ParticleControllerInfluencerSingleTest extends BaseG3dTest {
+	public static final String DEFAULT_PARTICLE = "data/pre_particle.png", DEFAULT_SKIN = "data/uiskin.json";
+	Quaternion tmpQuaternion = new Quaternion();
+	Matrix4 tmpMatrix = new Matrix4(), tmpMatrix4 = new Matrix4();
+	Vector3 tmpVector = new Vector3();
+
+	// Simulation
+	Array<ParticleController> emitters;
+
+	// Rendering
+	Environment environment;
+	BillboardParticleBatch billboardParticleBatch;
+
+	// UI
+	Stage ui;
+	Label fpsLabel;
+	StringBuilder builder;
+
+	@Override
+	public void create () {
+		super.create();
+		emitters = new Array<ParticleController>();
+		assets.load(DEFAULT_PARTICLE, Texture.class);
+		assets.load(DEFAULT_SKIN, Skin.class);
+		loading = true;
+		environment = new Environment();
+		billboardParticleBatch = new BillboardParticleBatch();
+		billboardParticleBatch.setCamera(cam);
+
+		ui = new Stage();
+		builder = new StringBuilder();
+	}
+
+	@Override
+	public void resize (int width, int height) {
+		super.resize(width, height);
+		ui.getViewport().setWorldSize(width, height);
+		ui.getViewport().update(width, height, true);
+	}
+
+	@Override
+	protected void onLoaded () {
+		Texture particleTexture = assets.get(DEFAULT_PARTICLE);
+		billboardParticleBatch.setTexture(assets.get(DEFAULT_PARTICLE, Texture.class));
+
+		addEmitter(particleTexture);
+
+		setupUI();
+	}
+
+	private void addEmitter (Texture particleTexture) {
+		ParticleController controller = createBillboardController(particleTexture);
+		controller.init();
+		controller.start();
+		emitters.add(controller);
+
+		controller.translate(new Vector3(5, 0, 5));
+		controller.rotate(Vector3.X, 90);
+	}
+
+	private void setupUI () {
+		Skin skin = assets.get(DEFAULT_SKIN);
+		Table table = new Table();
+		table.setFillParent(true);
+		table.top().left().add(new Label("FPS ", skin)).left();
+		table.add(fpsLabel = new Label("", skin)).left().expandX().row();
+		ui.addActor(table);
+	}
+
+	private ParticleController createBillboardController (Texture particleTexture) {
+		// Emission
+		RegularEmitter emitter = new RegularEmitter();
+		emitter.getDuration().setLow(1000);
+		emitter.getEmission().setHigh(300);
+		emitter.getLife().setHigh(4000);
+		emitter.setMaxParticleCount(20);
+
+		// Spawn
+
+		CylinderSpawnShapeValue cylinderSpawnShapeValue = new CylinderSpawnShapeValue();
+		cylinderSpawnShapeValue.spawnWidthValue.setHigh(5);// x
+		cylinderSpawnShapeValue.spawnHeightValue.setHigh(10);// y
+		cylinderSpawnShapeValue.spawnDepthValue.setHigh(5);// z
+		cylinderSpawnShapeValue.setEdges(true);
+
+		SpawnInfluencer spawnSource = new SpawnInfluencer(cylinderSpawnShapeValue);
+		// Dynamics
+		DynamicsInfluencer dynamicsInfluencer = new DynamicsInfluencer();
+
+		TangentialAcceleration tangentialAcceleration = new TangentialAcceleration();
+		tangentialAcceleration.thetaValue.setActive(true);
+		tangentialAcceleration.thetaValue.setTimeline(new float[] {0});
+		tangentialAcceleration.thetaValue.setScaling(new float[] {1});
+		tangentialAcceleration.thetaValue.setHigh(90);
+		tangentialAcceleration.phiValue.setActive(true);
+		tangentialAcceleration.phiValue.setTimeline(new float[] {0});
+		tangentialAcceleration.phiValue.setScaling(new float[] {1});
+		tangentialAcceleration.phiValue.setHigh(0);
+		tangentialAcceleration.strengthValue.setActive(true);
+		tangentialAcceleration.strengthValue.setHigh(10);
+		tangentialAcceleration.strengthValue.setTimeline(new float[] {0});
+		tangentialAcceleration.strengthValue.setScaling(new float[] {1});
+		tangentialAcceleration.isGlobal = false;
+		dynamicsInfluencer.velocities.add(tangentialAcceleration);
+
+		ParticleController ret = new ParticleController("Billboard Controller", emitter, new BillboardRenderer(
+			billboardParticleBatch), new RegionInfluencer.Single(particleTexture), spawnSource, dynamicsInfluencer);
+
+		ParticleControllerInfluencer pci = new ParticleControllerInfluencer.Single(ret);
+		SpawnInfluencer si = new SpawnInfluencer(new PointSpawnShapeValue());
+		Influencer pcfi = new ParticleControllerFinalizerInfluencer();
+		RegularEmitter emitter2 = new RegularEmitter();
+		emitter2.getDuration().setLow(3000);
+		emitter2.getEmission().setHigh(300);
+		emitter2.getLife().setHigh(4000);
+		emitter2.setMaxParticleCount(30);
+		ParticleController ret2 = new ParticleController("Bigger", emitter2, new ParticleControllerControllerRenderer(), pci, si,
+			pcfi);
+		return ret2;
+	}
+
+	@Override
+	protected void render (ModelBatch batch, Array<ModelInstance> instances) {
+		if (emitters.size > 0) {
+			// Update
+			float delta = Gdx.graphics.getDeltaTime();
+			builder.delete(0, builder.length());
+			builder.append(Gdx.graphics.getFramesPerSecond());
+			fpsLabel.setText(builder);
+			ui.act(delta);
+
+			billboardParticleBatch.begin();
+			for (ParticleController controller : emitters) {
+				controller.update();
+				controller.draw();
+			}
+			billboardParticleBatch.end();
+			batch.render(billboardParticleBatch, environment);
+		}
+		batch.render(instances, environment);
+		ui.draw();
+	}
+}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/PolarAccelerationTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/PolarAccelerationTest.java
@@ -1,0 +1,157 @@
+
+package com.badlogic.gdx.tests.g3d;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g3d.Environment;
+import com.badlogic.gdx.graphics.g3d.ModelBatch;
+import com.badlogic.gdx.graphics.g3d.ModelInstance;
+import com.badlogic.gdx.graphics.g3d.particles.ParticleController;
+import com.badlogic.gdx.graphics.g3d.particles.batches.BillboardParticleBatch;
+import com.badlogic.gdx.graphics.g3d.particles.emitters.RegularEmitter;
+import com.badlogic.gdx.graphics.g3d.particles.influencers.DynamicsInfluencer;
+import com.badlogic.gdx.graphics.g3d.particles.influencers.DynamicsModifier.PolarAcceleration;
+import com.badlogic.gdx.graphics.g3d.particles.influencers.RegionInfluencer;
+import com.badlogic.gdx.graphics.g3d.particles.influencers.SpawnInfluencer;
+import com.badlogic.gdx.graphics.g3d.particles.renderers.BillboardRenderer;
+import com.badlogic.gdx.graphics.g3d.particles.values.CylinderSpawnShapeValue;
+import com.badlogic.gdx.math.Matrix4;
+import com.badlogic.gdx.math.Quaternion;
+import com.badlogic.gdx.math.Vector3;
+import com.badlogic.gdx.scenes.scene2d.Stage;
+import com.badlogic.gdx.scenes.scene2d.ui.Label;
+import com.badlogic.gdx.scenes.scene2d.ui.Skin;
+import com.badlogic.gdx.scenes.scene2d.ui.Table;
+import com.badlogic.gdx.utils.Array;
+
+/** @author ryanastout */
+public class PolarAccelerationTest extends BaseG3dTest {
+	public static final String DEFAULT_PARTICLE = "data/pre_particle.png", DEFAULT_SKIN = "data/uiskin.json";
+	Quaternion tmpQuaternion = new Quaternion();
+	Matrix4 tmpMatrix = new Matrix4(), tmpMatrix4 = new Matrix4();
+	Vector3 tmpVector = new Vector3();
+
+	// Simulation
+	Array<ParticleController> emitters;
+
+	// Rendering
+	Environment environment;
+	BillboardParticleBatch billboardParticleBatch;
+
+	// UI
+	Stage ui;
+	Label fpsLabel;
+	StringBuilder builder;
+
+	@Override
+	public void create () {
+		super.create();
+		emitters = new Array<ParticleController>();
+		assets.load(DEFAULT_PARTICLE, Texture.class);
+		assets.load(DEFAULT_SKIN, Skin.class);
+		loading = true;
+		environment = new Environment();
+		billboardParticleBatch = new BillboardParticleBatch();
+		billboardParticleBatch.setCamera(cam);
+		ui = new Stage();
+		builder = new StringBuilder();
+	}
+
+	@Override
+	public void resize (int width, int height) {
+		super.resize(width, height);
+		ui.getViewport().setWorldSize(width, height);
+		ui.getViewport().update(width, height, true);
+	}
+
+	@Override
+	protected void onLoaded () {
+		Texture particleTexture = assets.get(DEFAULT_PARTICLE);
+		billboardParticleBatch.setTexture(assets.get(DEFAULT_PARTICLE, Texture.class));
+		addEmitter(particleTexture);
+		setupUI();
+	}
+
+	private void addEmitter (Texture particleTexture) {
+		ParticleController controller = createBillboardController(particleTexture);
+		controller.init();
+		controller.start();
+		emitters.add(controller);
+
+		controller.translate(new Vector3(5, 0, 5));
+		controller.rotate(new Vector3(.707f, .707f, 0), 135);
+	}
+
+	private void setupUI () {
+		Skin skin = assets.get(DEFAULT_SKIN);
+		Table table = new Table();
+		table.setFillParent(true);
+		table.top().left().add(new Label("FPS ", skin)).left();
+		table.add(fpsLabel = new Label("", skin)).left().expandX().row();
+		ui.addActor(table);
+	}
+
+	private ParticleController createBillboardController (Texture particleTexture) {
+		// Emission
+		RegularEmitter emitter = new RegularEmitter();
+		emitter.getDuration().setLow(3000);
+		emitter.getEmission().setHigh(300);
+		emitter.getLife().setHigh(4000);
+		emitter.setMaxParticleCount(3000);
+
+		// Spawn
+
+		CylinderSpawnShapeValue cylinderSpawnShapeValue = new CylinderSpawnShapeValue();
+		cylinderSpawnShapeValue.spawnWidthValue.setHigh(5);// x
+		cylinderSpawnShapeValue.spawnHeightValue.setHigh(10);// y
+		cylinderSpawnShapeValue.spawnDepthValue.setHigh(5);// z
+		cylinderSpawnShapeValue.setEdges(true);
+
+		SpawnInfluencer spawnSource = new SpawnInfluencer(cylinderSpawnShapeValue);
+		// Dynamics
+		DynamicsInfluencer dynamicsInfluencer = new DynamicsInfluencer();
+
+		PolarAcceleration polarAcceleration = new PolarAcceleration();
+		polarAcceleration.thetaValue.setActive(true);
+		polarAcceleration.thetaValue.setTimeline(new float[] {0});
+		polarAcceleration.thetaValue.setScaling(new float[] {1});
+		polarAcceleration.thetaValue.setHigh(90);
+		polarAcceleration.phiValue.setActive(true);
+		polarAcceleration.phiValue.setTimeline(new float[] {0});
+		polarAcceleration.phiValue.setScaling(new float[] {1});
+		polarAcceleration.phiValue.setHigh(0);
+		polarAcceleration.strengthValue.setActive(true);
+		polarAcceleration.strengthValue.setHigh(10);
+		polarAcceleration.strengthValue.setTimeline(new float[] {0});
+		polarAcceleration.strengthValue.setScaling(new float[] {1});
+		polarAcceleration.isGlobal = false;
+		dynamicsInfluencer.velocities.add(polarAcceleration);
+
+		ParticleController ret = new ParticleController("Billboard Controller", emitter, new BillboardRenderer(
+			billboardParticleBatch), new RegionInfluencer.Single(particleTexture), spawnSource, dynamicsInfluencer);
+
+		return ret;
+	}
+
+	@Override
+	protected void render (ModelBatch batch, Array<ModelInstance> instances) {
+		if (emitters.size > 0) {
+			// Update
+			float delta = Gdx.graphics.getDeltaTime();
+			builder.delete(0, builder.length());
+			builder.append(Gdx.graphics.getFramesPerSecond());
+			fpsLabel.setText(builder);
+			ui.act(delta);
+
+			billboardParticleBatch.begin();
+			for (ParticleController controller : emitters) {
+				controller.update();
+				controller.draw();
+			}
+			billboardParticleBatch.end();
+			batch.render(billboardParticleBatch, environment);
+		}
+		batch.render(instances, environment);
+		ui.draw();
+	}
+}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/TangentialAccelerationTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/TangentialAccelerationTest.java
@@ -1,0 +1,157 @@
+
+package com.badlogic.gdx.tests.g3d;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g3d.Environment;
+import com.badlogic.gdx.graphics.g3d.ModelBatch;
+import com.badlogic.gdx.graphics.g3d.ModelInstance;
+import com.badlogic.gdx.graphics.g3d.particles.ParticleController;
+import com.badlogic.gdx.graphics.g3d.particles.batches.BillboardParticleBatch;
+import com.badlogic.gdx.graphics.g3d.particles.emitters.RegularEmitter;
+import com.badlogic.gdx.graphics.g3d.particles.influencers.DynamicsInfluencer;
+import com.badlogic.gdx.graphics.g3d.particles.influencers.DynamicsModifier.TangentialAcceleration;
+import com.badlogic.gdx.graphics.g3d.particles.influencers.RegionInfluencer;
+import com.badlogic.gdx.graphics.g3d.particles.influencers.SpawnInfluencer;
+import com.badlogic.gdx.graphics.g3d.particles.renderers.BillboardRenderer;
+import com.badlogic.gdx.graphics.g3d.particles.values.CylinderSpawnShapeValue;
+import com.badlogic.gdx.math.Matrix4;
+import com.badlogic.gdx.math.Quaternion;
+import com.badlogic.gdx.math.Vector3;
+import com.badlogic.gdx.scenes.scene2d.Stage;
+import com.badlogic.gdx.scenes.scene2d.ui.Label;
+import com.badlogic.gdx.scenes.scene2d.ui.Skin;
+import com.badlogic.gdx.scenes.scene2d.ui.Table;
+import com.badlogic.gdx.utils.Array;
+
+/** @author ryanastout */
+public class TangentialAccelerationTest extends BaseG3dTest {
+	public static final String DEFAULT_PARTICLE = "data/pre_particle.png", DEFAULT_SKIN = "data/uiskin.json";
+	Quaternion tmpQuaternion = new Quaternion();
+	Matrix4 tmpMatrix = new Matrix4(), tmpMatrix4 = new Matrix4();
+	Vector3 tmpVector = new Vector3();
+
+	// Simulation
+	Array<ParticleController> emitters;
+
+	// Rendering
+	Environment environment;
+	BillboardParticleBatch billboardParticleBatch;
+
+	// UI
+	Stage ui;
+	Label fpsLabel;
+	StringBuilder builder;
+
+	@Override
+	public void create () {
+		super.create();
+		emitters = new Array<ParticleController>();
+		assets.load(DEFAULT_PARTICLE, Texture.class);
+		assets.load(DEFAULT_SKIN, Skin.class);
+		loading = true;
+		environment = new Environment();
+		billboardParticleBatch = new BillboardParticleBatch();
+		billboardParticleBatch.setCamera(cam);
+		ui = new Stage();
+		builder = new StringBuilder();
+	}
+
+	@Override
+	public void resize (int width, int height) {
+		super.resize(width, height);
+		ui.getViewport().setWorldSize(width, height);
+		ui.getViewport().update(width, height, true);
+	}
+
+	@Override
+	protected void onLoaded () {
+		Texture particleTexture = assets.get(DEFAULT_PARTICLE);
+		billboardParticleBatch.setTexture(assets.get(DEFAULT_PARTICLE, Texture.class));
+		addEmitter(particleTexture);
+		setupUI();
+	}
+
+	private void addEmitter (Texture particleTexture) {
+		ParticleController controller = createBillboardController(particleTexture);
+		controller.init();
+		controller.start();
+		emitters.add(controller);
+
+		controller.translate(new Vector3(5, 0, 5));
+		controller.rotate(new Vector3(.707f, .707f, 0), 135);
+	}
+
+	private void setupUI () {
+		Skin skin = assets.get(DEFAULT_SKIN);
+		Table table = new Table();
+		table.setFillParent(true);
+		table.top().left().add(new Label("FPS ", skin)).left();
+		table.add(fpsLabel = new Label("", skin)).left().expandX().row();
+		ui.addActor(table);
+	}
+
+	private ParticleController createBillboardController (Texture particleTexture) {
+		// Emission
+		RegularEmitter emitter = new RegularEmitter();
+		emitter.getDuration().setLow(3000);
+		emitter.getEmission().setHigh(300);
+		emitter.getLife().setHigh(4000);
+		emitter.setMaxParticleCount(3000);
+
+		// Spawn
+
+		CylinderSpawnShapeValue cylinderSpawnShapeValue = new CylinderSpawnShapeValue();
+		cylinderSpawnShapeValue.spawnWidthValue.setHigh(5);// x
+		cylinderSpawnShapeValue.spawnHeightValue.setHigh(10);// y
+		cylinderSpawnShapeValue.spawnDepthValue.setHigh(5);// z
+		cylinderSpawnShapeValue.setEdges(true);
+
+		SpawnInfluencer spawnSource = new SpawnInfluencer(cylinderSpawnShapeValue);
+		// Dynamics
+		DynamicsInfluencer dynamicsInfluencer = new DynamicsInfluencer();
+
+		TangentialAcceleration tangentialAcceleration = new TangentialAcceleration();
+		tangentialAcceleration.thetaValue.setActive(true);
+		tangentialAcceleration.thetaValue.setTimeline(new float[] {0});
+		tangentialAcceleration.thetaValue.setScaling(new float[] {1});
+		tangentialAcceleration.thetaValue.setHigh(90);
+		tangentialAcceleration.phiValue.setActive(true);
+		tangentialAcceleration.phiValue.setTimeline(new float[] {0});
+		tangentialAcceleration.phiValue.setScaling(new float[] {1});
+		tangentialAcceleration.phiValue.setHigh(0);
+		tangentialAcceleration.strengthValue.setActive(true);
+		tangentialAcceleration.strengthValue.setHigh(10);
+		tangentialAcceleration.strengthValue.setTimeline(new float[] {0});
+		tangentialAcceleration.strengthValue.setScaling(new float[] {1});
+		tangentialAcceleration.isGlobal = false;
+		dynamicsInfluencer.velocities.add(tangentialAcceleration);
+
+		ParticleController ret = new ParticleController("Billboard Controller", emitter, new BillboardRenderer(
+			billboardParticleBatch), new RegionInfluencer.Single(particleTexture), spawnSource, dynamicsInfluencer);
+
+		return ret;
+	}
+
+	@Override
+	protected void render (ModelBatch batch, Array<ModelInstance> instances) {
+		if (emitters.size > 0) {
+			// Update
+			float delta = Gdx.graphics.getDeltaTime();
+			builder.delete(0, builder.length());
+			builder.append(Gdx.graphics.getFramesPerSecond());
+			fpsLabel.setText(builder);
+			ui.act(delta);
+
+			billboardParticleBatch.begin();
+			for (ParticleController controller : emitters) {
+				controller.update();
+				controller.draw();
+			}
+			billboardParticleBatch.end();
+			batch.render(billboardParticleBatch, environment);
+		}
+		batch.render(instances, environment);
+		ui.draw();
+	}
+}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
@@ -62,11 +62,14 @@ import com.badlogic.gdx.tests.g3d.MeshBuilderTest;
 import com.badlogic.gdx.tests.g3d.ModelCacheTest;
 import com.badlogic.gdx.tests.g3d.ModelTest;
 import com.badlogic.gdx.tests.g3d.MultipleRenderTargetTest;
+import com.badlogic.gdx.tests.g3d.ParticleControllerInfluencerSingleTest;
 import com.badlogic.gdx.tests.g3d.ParticleControllerTest;
+import com.badlogic.gdx.tests.g3d.PolarAccelerationTest;
 import com.badlogic.gdx.tests.g3d.ShaderCollectionTest;
 import com.badlogic.gdx.tests.g3d.ShaderTest;
 import com.badlogic.gdx.tests.g3d.ShadowMappingTest;
 import com.badlogic.gdx.tests.g3d.SkeletonTest;
+import com.badlogic.gdx.tests.g3d.TangentialAccelerationTest;
 import com.badlogic.gdx.tests.g3d.TextureArrayTest;
 import com.badlogic.gdx.tests.g3d.TextureRegion3DTest;
 import com.badlogic.gdx.tests.gles2.HelloTriangle;
@@ -179,6 +182,7 @@ public class GdxTests {
 		OnscreenKeyboardTest.class,
 		PathTest.class,
 		ParallaxTest.class,
+		ParticleControllerInfluencerSingleTest.class,
 		ParticleControllerTest.class,
 		ParticleEmitterTest.class,
 		ParticleEmittersTest.class,
@@ -187,6 +191,7 @@ public class GdxTests {
 		PixmapBlendingTest.class,
 		PixmapPackerTest.class,
 		PixmapTest.class,
+		PolarAccelerationTest.class,
 		PolygonRegionTest.class,
 		PolygonSpriteTest.class,
 		PreferencesTest.class,
@@ -226,6 +231,7 @@ public class GdxTests {
 		SuperKoalio.class,
 		TableLayoutTest.class,
 		TableTest.class,
+		TangentialAccelerationTest.class,
 		TextAreaTest.class,
 		TextAreaTest2.class,		
 		TextButtonTest.class,


### PR DESCRIPTION
Tangential and Polar acceleration didn't respect the global/relative setting in Flame. this fixes https://github.com/libgdx/libgdx/issues/4894

Also fixed a bug in which rotation information wasn't passed to from SpawnInfluencer to ParticleControllers