### PR TITLE
Fix #4934: Option in TexturePacker.Settings to specify the InterpolationMode when scaling

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -34,6 +34,7 @@
 - API Change: ParticleEmitter getSprite, setSprite, getImagePath, setImagePath are now getSprites, setSprites, getImagePaths, setImagePaths.
 - Added support for 2d particles independant scale X and Y.
 - API Change: ParticleEmitter getScale, matchSize are now getScaleX/getScaleY, matchSizeX/matchSizeY. Added scaleSize(float scaleX, float scaleY)
+- API Addition: Possibility to specify TexturePacker settings interpolation mode when scaling.
 
 [1.9.6]
 - Fix performance regression in LWJGL3 backend, use java.nio instead of BufferUtils. Those are intrinsics and quite a bit faster than BufferUtils on HotSpot.

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/texturepacker/ImageProcessor.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/texturepacker/ImageProcessor.java
@@ -47,6 +47,7 @@ public class ImageProcessor {
 	private final HashMap<String, Rect> crcs = new HashMap();
 	private final Array<Rect> rects = new Array();
 	private float scale = 1;
+	private TexturePacker.InterpolationMode interpolationMode = TexturePacker.InterpolationMode.Bicubic;
 
 	/** @param rootDir Used to strip the root directory prefix from image file names, can be null. */
 	public ImageProcessor (File rootDir, Settings settings) {
@@ -117,6 +118,10 @@ public class ImageProcessor {
 		this.scale = scale;
 	}
 
+	public void setInterpolation(TexturePacker.InterpolationMode mode) {
+		interpolationMode = mode;
+	}
+
 	public Array<Rect> getImages () {
 		return rects;
 	}
@@ -165,7 +170,7 @@ public class ImageProcessor {
 			} else {
 				Graphics2D g = (Graphics2D)newImage.getGraphics();
 				g.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
-				g.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);
+				g.setRenderingHint(RenderingHints.KEY_INTERPOLATION, interpolationMode.value);
 				g.drawImage(image, 0, 0, width, height, null);
 			}
 			image = newImage;

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/texturepacker/TexturePacker.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/texturepacker/TexturePacker.java
@@ -16,8 +16,7 @@
 
 package com.badlogic.gdx.tools.texturepacker;
 
-import java.awt.Color;
-import java.awt.Graphics2D;
+import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -114,6 +113,15 @@ public class TexturePacker {
 
 			progress.start(0.35f);
 			imageProcessor.setScale(settings.scale[i]);
+
+			// Be forgiving about interpolation - for backwards-compatibility assume it can be unset, null,
+			// empty or missing elements. Missing elements will simply default to the original 'bicubic'.
+			if (settings.interpolation != null && settings.interpolation.length > i) {
+				if (settings.interpolation[i] != null) {
+					imageProcessor.setInterpolation(settings.interpolation[i]);
+				}
+			}
+
 			for (int ii = 0, nn = inputImages.size; ii < nn; ii++) {
 				InputImage inputImage = inputImages.get(ii);
 				if (inputImage.file != null)
@@ -601,6 +609,7 @@ public class TexturePacker {
 		public boolean limitMemory = true;
 		public boolean grid;
 		public float[] scale = {1};
+		public InterpolationMode[] interpolation = {InterpolationMode.Bicubic};
 		public String[] scaleSuffix = {""};
 		public String atlasExtension = ".atlas";
 
@@ -651,6 +660,7 @@ public class TexturePacker {
 			grid = settings.grid;
 			scale = Arrays.copyOf(settings.scale, settings.scale.length);
 			scaleSuffix = Arrays.copyOf(settings.scaleSuffix, settings.scaleSuffix.length);
+			interpolation = Arrays.copyOf(settings.interpolation, settings.interpolation.length);
 			atlasExtension = settings.atlasExtension;
 		}
 
@@ -850,5 +860,19 @@ public class TexturePacker {
 		if (settings == null) settings = new Settings();
 
 		process(settings, input, output, packFileName);
+	}
+
+	public static enum InterpolationMode {
+
+		Nearest(RenderingHints.VALUE_INTERPOLATION_NEAREST_NEIGHBOR),
+		Bilinear(RenderingHints.VALUE_INTERPOLATION_BILINEAR),
+		Bicubic(RenderingHints.VALUE_INTERPOLATION_BICUBIC);
+
+		final Object value;
+
+		InterpolationMode(Object value) {
+			this.value = value;
+		}
+
 	}
 }

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/texturepacker/TexturePackerUpscaleTest.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/texturepacker/TexturePackerUpscaleTest.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogic.gdx.tools.texturepacker;
+
+import java.io.File;
+
+public class TexturePackerUpscaleTest {
+
+	public static void main(String[] args) {
+		TexturePacker.Settings settings = new TexturePacker.Settings();
+		settings.scale = new float[] {4};
+		settings.interpolation = new TexturePacker.InterpolationMode[] {TexturePacker.InterpolationMode.Nearest};
+
+		TexturePacker packer = new TexturePacker(settings);
+		packer.addImage(new File("tests/gdx-tests-gwt/war/assets/data/bobrgb888-32x32.png"));
+
+		File out = new File("tmp/packout");
+
+		// Create or clean up packout directory
+		if (out.exists()) {
+			for (File f : out.listFiles()) {
+				f.delete();
+			}
+		} else {
+			out.mkdirs();
+		}
+
+		packer.pack(out, "main");
+	}
+
+}


### PR DESCRIPTION
As per request in #4934, new option addition in Settings under TexturePacker to specify the array of interpolation modes per scale factor. No breaking changes in the API, and fully backwards-compatible assuming Bicubic (which was the default) in case nothing is being specified.

Contributor agreement has been signed and emailed.