### PR TITLE
Fix flush() to force synchronous write to disk

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidPreferences.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidPreferences.java
@@ -150,11 +150,8 @@ public class AndroidPreferences implements Preferences {
 	@Override
 	public void flush () {
 		if (editor != null) {
-			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.GINGERBREAD) {
-    				editor.apply();
-			} else {
-				editor.commit();
-			}
+			// Avoid editor.apply(), which only starts an asynchronous write.
+			editor.commit();
 			editor = null;
 		}
 	}

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidPreferences.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidPreferences.java
@@ -148,12 +148,14 @@ public class AndroidPreferences implements Preferences {
 	}
 
 	@Override
-	public void flush () {
+	public boolean flush () {
+		boolean success = false;
 		if (editor != null) {
 			// Avoid editor.apply(), which only starts an asynchronous write.
-			editor.commit();
+			success = editor.commit();
 			editor = null;
 		}
+		return success;
 	}
 
 	@Override

--- a/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/HeadlessPreferences.java
+++ b/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/HeadlessPreferences.java
@@ -173,7 +173,7 @@ public class HeadlessPreferences implements Preferences {
 
 	@Override
 	public boolean flush () {
-		success = false;
+		boolean success = false;
 		OutputStream out = null;
 		try {
 			out = new BufferedOutputStream(file.write(false));

--- a/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/HeadlessPreferences.java
+++ b/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/HeadlessPreferences.java
@@ -172,16 +172,19 @@ public class HeadlessPreferences implements Preferences {
 	}
 
 	@Override
-	public void flush () {
+	public boolean flush () {
+		success = false;
 		OutputStream out = null;
 		try {
 			out = new BufferedOutputStream(file.write(false));
 			properties.storeToXML(out, null);
+			success = true;
 		} catch (Exception ex) {
 			throw new GdxRuntimeException("Error writing preferences: " + file, ex);
 		} finally {
 			StreamUtils.closeQuietly(out);
 		}
+		return success;
 	}
 
 	@Override

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglPreferences.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglPreferences.java
@@ -175,7 +175,7 @@ public class LwjglPreferences implements Preferences {
 
 	@Override
 	public boolean flush () {
-		success = false;
+		boolean success = false;
 		OutputStream out = null;
 		try {
 			out = new BufferedOutputStream(file.write(false));

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglPreferences.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglPreferences.java
@@ -174,16 +174,19 @@ public class LwjglPreferences implements Preferences {
 	}
 
 	@Override
-	public void flush () {
+	public boolean flush () {
+		success = false;
 		OutputStream out = null;
 		try {
 			out = new BufferedOutputStream(file.write(false));
 			properties.storeToXML(out, null);
+			success = true;
 		} catch (Exception ex) {
 			throw new GdxRuntimeException("Error writing preferences: " + file, ex);
 		} finally {
 			StreamUtils.closeQuietly(out);
 		}
+		return success;
 	}
 
 	@Override

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Preferences.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Preferences.java
@@ -172,16 +172,19 @@ public class Lwjgl3Preferences implements Preferences {
 	}
 
 	@Override
-	public void flush () {
+	public boolean flush () {
+		boolean success = false;
 		OutputStream out = null;
 		try {
 			out = new BufferedOutputStream(file.write(false));
 			properties.storeToXML(out, null);
+			success = true;
 		} catch (Exception ex) {
 			throw new GdxRuntimeException("Error writing preferences: " + file, ex);
 		} finally {
 			StreamUtils.closeQuietly(out);
 		}
+		return success;
 	}
 
 	@Override

--- a/backends/gdx-backend-moe/src/com/badlogic/gdx/backends/iosmoe/IOSPreferences.java
+++ b/backends/gdx-backend-moe/src/com/badlogic/gdx/backends/iosmoe/IOSPreferences.java
@@ -195,6 +195,6 @@ public class IOSPreferences implements Preferences {
 				}
 			}
 		});
-		return success[0];.
+		return success[0];
 	}
 }

--- a/backends/gdx-backend-moe/src/com/badlogic/gdx/backends/iosmoe/IOSPreferences.java
+++ b/backends/gdx-backend-moe/src/com/badlogic/gdx/backends/iosmoe/IOSPreferences.java
@@ -185,17 +185,16 @@ public class IOSPreferences implements Preferences {
 
 	@Override
 	public boolean flush () {
-		boolean success = false;
-		// FIXME: how to hoist the success or failure of write to return it?
+		final boolean[] success = {false};
 		ObjCRuntime.autoreleasepool(new Runnable() {
 			@Override
 			public void run() {
 				if (!nsDictionary.writeToFileAtomically(file.getAbsolutePath(), false)) {
 					Gdx.app.debug("IOSPreferences", "Failed to write NSDictionary to file " + file);
+					success[0] = true;
 				}
 			}
 		});
-		success = true; // FIXME: should reflect the success of NSDictionary write.
-		return success;
+		return success[0];.
 	}
 }

--- a/backends/gdx-backend-moe/src/com/badlogic/gdx/backends/iosmoe/IOSPreferences.java
+++ b/backends/gdx-backend-moe/src/com/badlogic/gdx/backends/iosmoe/IOSPreferences.java
@@ -184,7 +184,9 @@ public class IOSPreferences implements Preferences {
 	}
 
 	@Override
-	public void flush () {
+	public boolean flush () {
+		boolean success = false;
+		// FIXME: how to hoist the success or failure of write to return it?
 		ObjCRuntime.autoreleasepool(new Runnable() {
 			@Override
 			public void run() {
@@ -193,5 +195,7 @@ public class IOSPreferences implements Preferences {
 				}
 			}
 		});
+		success = true; // FIXME: should reflect the success of NSDictionary write.
+		return success;
 	}
 }

--- a/backends/gdx-backend-moe/src/com/badlogic/gdx/backends/iosmoe/IOSPreferences.java
+++ b/backends/gdx-backend-moe/src/com/badlogic/gdx/backends/iosmoe/IOSPreferences.java
@@ -189,9 +189,10 @@ public class IOSPreferences implements Preferences {
 		ObjCRuntime.autoreleasepool(new Runnable() {
 			@Override
 			public void run() {
-				if (!nsDictionary.writeToFileAtomically(file.getAbsolutePath(), false)) {
-					Gdx.app.debug("IOSPreferences", "Failed to write NSDictionary to file " + file);
+				if (nsDictionary.writeToFileAtomically(file.getAbsolutePath(), false)) {
 					success[0] = true;
+				} else {
+					Gdx.app.debug("IOSPreferences", "Failed to write NSDictionary to file " + file);
 				}
 			}
 		});

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSPreferences.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSPreferences.java
@@ -184,11 +184,15 @@ public class IOSPreferences implements Preferences {
 	}
 
 	@Override
-	public void flush () {
+	public boolean flush () {
+		boolean success = false;
 		NSAutoreleasePool pool = new NSAutoreleasePool();
 		if (!nsDictionary.write(file, false)) {
 			Gdx.app.debug("IOSPreferences", "Failed to write NSDictionary to file " + file);
+		} else {
+			success = true;
 		}
 		pool.close();
+		return success;
 	}
 }

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtPreferences.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtPreferences.java
@@ -60,7 +60,8 @@ public class GwtPreferences implements Preferences {
 	}
 
 	@Override
-	public void flush () {
+	public boolean flush () {
+		boolean success = false;
 		try {
 			// remove all old values
 			for (int i = 0; i < GwtFiles.LocalStorage.getLength(); i++) {
@@ -74,10 +75,13 @@ public class GwtPreferences implements Preferences {
 				String storageValue = "" + values.get(key).toString();
 				GwtFiles.LocalStorage.setItem(storageKey, storageValue);
 			}
+			
+			success = true;
 
 		} catch (Exception e) {
 			throw new GdxRuntimeException("Couldn't flush preferences");
 		}
+		return success;
 	}
 
 	@Override

--- a/gdx/src/com/badlogic/gdx/Preferences.java
+++ b/gdx/src/com/badlogic/gdx/Preferences.java
@@ -78,5 +78,5 @@ public interface Preferences {
 	public void remove (String key);
 
 	/** Makes sure the preferences are persisted. */
-	public void flush ();
+	public boolean flush ();
 }


### PR DESCRIPTION
editor.apply() starts an asynchronous request to write to disk, but does not guarantee
the write to be completed when it returns:
https://developer.android.com/reference/android/content/SharedPreferences.Editor.html#apply()

On the other hand, editor.commit() does require a synchronous write, and thus is a better
candidate to implement flush():
https://developer.android.com/reference/android/content/SharedPreferences.Editor.html#commit()

This fix comes from a real issue on a multithreaded app where calling flush() just before killing the
whole process does not actually write to disk before the process is killed.