### PR TITLE
fix AtlasTmxMapLoader tileset tile id offset

### DIFF
--- a/gdx/src/com/badlogic/gdx/maps/tiled/AtlasTmxMapLoader.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/AtlasTmxMapLoader.java
@@ -358,7 +358,7 @@ public class AtlasTmxMapLoader extends BaseTmxMapLoader<AtlasTmxMapLoader.AtlasT
 				for (AtlasRegion region : atlas.findRegions(regionsName)) {
 					// handle unused tile ids
 					if (region != null) {
-						int tileid = region.index + 1;
+						int tileid = region.index + firstgid;
 						if (tileid >= firstgid && tileid <= lastgid) {
 							StaticTiledMapTile tile = new StaticTiledMapTile(region);
 							tile.setId(tileid);


### PR DESCRIPTION
There was an issue with tile indexing in tileset when using the AtlasTMXMapLoader.

It actually fix the libgdx test named "TideMapAssetManagerTest", now you can see the missing ground !

I created a SSCCE to illustrate the problem but I saw it fixes an existing libgdx test. I provide my SSCCE though, just in case : there is a static variable "useOriginal" allowing to switch from original (using TMXMapLoader) to the same generated with the TiledMapPacker tool (using AtlasTMXMapLoader).

[tmx-sccce.zip](https://github.com/libgdx/libgdx/files/1463628/tmx-sccce.zip)
