### PR TITLE
Fix: Touchpad ignore Touchable value.

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Touchpad.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Touchpad.java
@@ -133,6 +133,7 @@ public class Touchpad extends Widget {
 
 	@Override
 	public Actor hit (float x, float y, boolean touchable) {
+		if (touchable && this.touchable != Touchable.enabled) return null;
 		return touchBounds.contains(x, y) ? this : null;
 	}
 


### PR DESCRIPTION
`Touchable.disabled` or `Touchable.childrenOnly` was ignoring for `Touchpad ` Actor. So `setTouchable(..)` for it didn't make sense.