### PR TITLE
Make Lwjgl3Window.getWindowHandle() public accessible to play nice with imgui

### DIFF
--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Window.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Window.java
@@ -356,7 +356,7 @@ public class Lwjgl3Window implements Disposable {
 		return input;
 	}
 
-	long getWindowHandle() {
+	public long getWindowHandle() {
 		return windowHandle;
 	}
 	


### PR DESCRIPTION
Hi,

This weekend we had some fun trying to make get [imgui](https://github.com/kotlin-graphics/imgui) work with libgdx, it took a while but we made it for the moment.

However the [solution](https://github.com/elect86/Platform-Creator/commit/ec27570dcae85702f6572f8677b0f5a38c1da378#diff-8c268ab50f87b7ce67e90b3b258ece0cR175) involvs reflection and doesn't shine as a perfect and clean implementation.

That's why I'd like to have `Lwjgl3Window.getWindowHandle()` as a public method (currently is package only) in order to avoid using reflection to access it.

