### PR TITLE
Fix for some Bluetooth keyboards not being detected

### DIFF
--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/android/AndroidManifest.xml
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/android/AndroidManifest.xml
@@ -13,7 +13,7 @@
             android:name="%PACKAGE%.AndroidLauncher"
             android:label="@string/app_name" 
             android:screenOrientation="landscape"
-            android:configChanges="keyboard|keyboardHidden|orientation|screenSize">
+            android:configChanges="keyboard|keyboardHidden|navigation|orientation|screenSize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/tests/gdx-tests-android/AndroidManifest.xml
+++ b/tests/gdx-tests-android/AndroidManifest.xml
@@ -17,7 +17,7 @@
 		
 	<application android:icon="@drawable/icon" android:label="@string/app_name">
 		<activity android:name=".AndroidTestStarter" android:label="@string/app_name"
-			android:configChanges="keyboard|keyboardHidden|orientation">
+			android:configChanges="keyboard|keyboardHidden|navigation|orientation">
 			<intent-filter>
 				<action android:name="android.intent.action.MAIN" />
 				<category android:name="android.intent.category.LAUNCHER" />
@@ -27,7 +27,7 @@
 		
 		<activity android:name=".FragmentTestStarter"
 				  android:label="@string/app_name_fragments"
-				  android:configChanges="keyboard|keyboardHidden|orientation"
+				  android:configChanges="keyboard|keyboardHidden|navigation|orientation"
 				  android:screenOrientation="landscape">
 			<intent-filter>
 				<action android:name="android.intent.action.MAIN" />
@@ -37,7 +37,7 @@
 
 		<activity android:name=".GdxTestActivity" 
 				  android:label="Gdx Test"
-				  android:configChanges="keyboard|keyboardHidden|orientation"
+				  android:configChanges="keyboard|keyboardHidden|navigation|orientation"
 				  android:screenOrientation="landscape"/>
 
 		<activity android:name=".LivewallpaperSettings" 


### PR DESCRIPTION
Some Bluetooth keyboards need to have the `navigation` element added to the `android:configChanges` part of AndroidManifest in order to trigger the `onConfigurationChanged()` method.

Without this, `Gdx.input.isPeripheralAvailable` will always return false as the `keyboardAvailable` variable doesn't get updated.

This fixes issue #4968 