### PR TITLE
perspective divide for shadow maps

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/default.vertex.glsl
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/default.vertex.glsl
@@ -243,7 +243,7 @@ void main() {
 	#ifdef shadowMapFlag
 		vec4 spos = u_shadowMapProjViewTrans * pos;
 		v_shadowMapUv.xy = (spos.xy / spos.w) * 0.5 + 0.5;
-		v_shadowMapUv.z = min(spos.z * 0.5 + 0.5, 0.998);
+		v_shadowMapUv.z = min(spos.z / spos.w * 0.5 + 0.5, 0.998);
 	#endif //shadowMapFlag
 	
 	#if defined(normalFlag)

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/depth.vertex.glsl
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/depth.vertex.glsl
@@ -118,7 +118,7 @@ void main() {
 	#endif
 
 	#ifdef PackedDepthFlag
-		v_depth = pos.z * 0.5 + 0.5;
+		v_depth = pos.z / pos.w * 0.5 + 0.5;
 	#endif //PackedDepthFlag
 
 	gl_Position = pos;


### PR DESCRIPTION
perspective divide is necessary for perspective cameras and is still correct for orthographic cameras since for ortho w is always 1. This change would allow users making shadow maps for point lights to use the depth.vertex.glsl and default.vertex.glsl vertex shaders if they want