### PR TITLE
Improved Android controllers detection

### DIFF
--- a/extensions/gdx-controllers/gdx-controllers-android/src/com/badlogic/gdx/controllers/android/AndroidControllers.java
+++ b/extensions/gdx-controllers/gdx-controllers-android/src/com/badlogic/gdx/controllers/android/AndroidControllers.java
@@ -306,7 +306,9 @@ public class AndroidControllers implements LifecycleListener, ControllerManager,
 	}
 	
 	private boolean isController(InputDevice device) {
-		return (device.getSources() & InputDevice.SOURCE_JOYSTICK) != 0;
+		return ((device.getSources() & InputDevice.SOURCE_CLASS_JOYSTICK) == InputDevice.SOURCE_CLASS_JOYSTICK)
+				&& (((device.getSources() & InputDevice.SOURCE_GAMEPAD) == InputDevice.SOURCE_GAMEPAD)
+				|| (device.getKeyboardType() != InputDevice.KEYBOARD_TYPE_ALPHABETIC));
 	}
 
 	@Override


### PR DESCRIPTION
This is a partial fix for issue #4969

Based on my testings, compiled in [this handy Google spreadsheet](https://docs.google.com/spreadsheets/d/1oYoYMfCv8QlOgEyPxwcdLifjXVIOveu9aopEXl6UjnE/edit?usp=sharing), I have modified the ``isController`` method to avoid false positives as some keyboard and mice are detected as game controllers with the current detection method.
