### PR TITLE
Actor fixes

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/Actor.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/Actor.java
@@ -589,7 +589,7 @@ public class Actor {
 	}
 
 	public void setOriginX (float originX) {
-		this.originX = originX;
+		this.originX = originX + x;
 	}
 
 	public float getOriginY () {
@@ -597,30 +597,30 @@ public class Actor {
 	}
 
 	public void setOriginY (float originY) {
-		this.originY = originY;
+		this.originY = originY + y;
 	}
 
 	/** Sets the origin position which is relative to the actor's bottom left corner. */
 	public void setOrigin (float originX, float originY) {
-		this.originX = originX;
-		this.originY = originY;
+		setOriginX(originX);
+		setOriginY(originY);
 	}
 
 	/** Sets the origin position to the specified {@link Align alignment}. */
 	public void setOrigin (int alignment) {
 		if ((alignment & left) != 0)
-			originX = 0;
+			originX = x;
 		else if ((alignment & right) != 0)
-			originX = width;
+			originX = x + width;
 		else
-			originX = width / 2;
+			originX = x + (width / 2);
 
 		if ((alignment & bottom) != 0)
-			originY = 0;
+			originY = y;
 		else if ((alignment & top) != 0)
-			originY = height;
+			originY = y + height;
 		else
-			originY = height / 2;
+			originY = y + (height / 2);
 	}
 
 	public float getScaleX () {

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/Actor.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/Actor.java
@@ -609,18 +609,18 @@ public class Actor {
 	/** Sets the origin position to the specified {@link Align alignment}. */
 	public void setOrigin (int alignment) {
 		if ((alignment & left) != 0)
-			originX = x;
+			setOriginX(0);
 		else if ((alignment & right) != 0)
-			originX = x + width;
+			setOriginX(width);
 		else
-			originX = x + (width / 2);
+			setOriginX(width / 2);
 
 		if ((alignment & bottom) != 0)
-			originY = y;
+			setOriginY(0);
 		else if ((alignment & top) != 0)
-			originY = y + height;
+			setOriginY(height);
 		else
-			originY = y + (height / 2);
+			setOriginY(height / 2);
 	}
 
 	public float getScaleX () {

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/Actor.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/Actor.java
@@ -413,9 +413,9 @@ public class Actor {
 	 * coordinates. */
 	public void setX (float x, int alignment) {
 
-		if ((alignment & right) != 0)
+		if ((alignment & left) != 0)
 			x -= width;
-		else if ((alignment & left) == 0) //
+		else if ((alignment & right) == 0) //
 			x -= width / 2;
 
 		if (this.x != x) {
@@ -440,9 +440,9 @@ public class Actor {
 	 * coordinates. */
 	public void setY (float y, int alignment) {
 
-		if ((alignment & top) != 0)
+		if ((alignment & bottom) != 0)
 			y -= height;
-		else if ((alignment & bottom) == 0) //
+		else if ((alignment & top) == 0) //
 			y -= height / 2;
 
 		if (this.y != y) {
@@ -473,14 +473,14 @@ public class Actor {
 	/** Sets the position using the specified {@link Align alignment}. Note this may set the position to non-integer
 	 * coordinates. */
 	public void setPosition (float x, float y, int alignment) {
-		if ((alignment & right) != 0)
+		if ((alignment & left) != 0)
 			x -= width;
-		else if ((alignment & left) == 0) //
+		else if ((alignment & right) == 0) //
 			x -= width / 2;
 
-		if ((alignment & top) != 0)
+		if ((alignment & bottom) != 0)
 			y -= height;
-		else if ((alignment & bottom) == 0) //
+		else if ((alignment & top) == 0) //
 			y -= height / 2;
 
 		if (this.x != x || this.y != y) {

--- a/gdx/src/com/badlogic/gdx/utils/Align.java
+++ b/gdx/src/com/badlogic/gdx/utils/Align.java
@@ -19,14 +19,14 @@ package com.badlogic.gdx.utils;
 /** Provides bit flag constants for alignment.
  * @author Nathan Sweet */
 public class Align {
-	static public final int center = 1 << 0;
-	static public final int top = 1 << 1;
-	static public final int bottom = 1 << 2;
-	static public final int left = 1 << 3;
-	static public final int right = 1 << 4;
+	static public final int center = 1 << 0;                //     1
+	static public final int top = 1 << 1;                   //    10
+	static public final int bottom = 1 << 2;                //   100
+	static public final int left = 1 << 3;                  //  1000
+	static public final int right = 1 << 4;                 // 10000
 
-	static public final int topLeft = top | left;
-	static public final int topRight = top | right;
-	static public final int bottomLeft = bottom | left;
-	static public final int bottomRight = bottom | right;
+	static public final int topLeft = top | left;           //  1010
+	static public final int topRight = top | right;         // 10010
+	static public final int bottomLeft = bottom | left;     //  1100
+	static public final int bottomRight = bottom | right;   // 10100
 }


### PR DESCRIPTION
Now functions:

myactor.setPosition(0, 0, Align.left); 
is equal to 
myactor.setX(0,Align.left);
myactor.setY(0,Align.center);
Move half actor to down and full to left (before that it moved only half actor down. All "aligns" were inverted - bottomLeft was topRight, left was right and so on)

And setOrigin is now relative to actor as is written in doc:
“Sets the origin position which is relative to the actor's bottom left corner."