### PR TITLE
Fix issue with polygon region out of bounds

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g2d/PolygonRegion.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/PolygonRegion.java
@@ -41,10 +41,10 @@ public class PolygonRegion {
 		float uvHeight = region.v2 - v;
 		int width = region.regionWidth;
 		int height = region.regionHeight;
-		for (int i = 0, n = vertices.length; i < n; i++) {
+		for (int i = 0; i < vertices.length;) {
 			textureCoords[i] = u + uvWidth * (vertices[i] / width);
-			i++;
-			textureCoords[i] = v + uvHeight * (1 - (vertices[i] / height));
+			textureCoords[i+1] = v + uvHeight * (1 - (vertices[i+1] / height));
+			i+=2;
 		}
 	}
 


### PR DESCRIPTION
This is a similar issue to [807c7c3](https://github.com/libgdx/libgdx/commit/807c7c323b740a0d6feddaf7d820124d39d6c230), where sometimes in some versions of Android 6 it throws ArrayIndexOutOfBoundsException when using PolygonRegion (appears that it has something to do with proguarding this file).
This issue has been also mentioned in the [community](http://www.badlogicgames.com/forum/viewtopic.php?f=11&t=23307).

After my changes it seems that the crash no longer happens.
Tested with problematic device and with devices that worked ok before the changes.

The functionality of the code has not changed.

Relevant stack trace part:
Fatal Exception: java.lang.ArrayIndexOutOfBoundsException: length=8; index=8
       at com.badlogic.gdx.graphics.g2d.PolygonRegion.(PolygonRegion.java)