### PR TITLE
Add cascading style support to Skin (updated)

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Skin.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Skin.java
@@ -431,7 +431,7 @@ public class Skin implements Disposable {
 
 			static final String CASCADE_PARENT_TAG = "parent";
 
-			protected boolean isNonexistantFieldKnown (Class type, String fieldName) {
+			protected boolean ignoreUnknownField (Class type, String fieldName) {
 				return fieldName.equals(CASCADE_PARENT_TAG);
 			}
 
@@ -463,7 +463,7 @@ public class Skin implements Disposable {
 								throw se;
 							}
 						}
-					} else if (!isIgnoreUnknownFields()) {
+					} else if (!getIgnoreUnknownFields()) {
 						SerializationException se = new SerializationException("Could not find parent with name " + parentName);
 						se.addTrace(jsonMap.child.trace());
 						throw se;

--- a/gdx/src/com/badlogic/gdx/utils/Json.java
+++ b/gdx/src/com/badlogic/gdx/utils/Json.java
@@ -78,7 +78,7 @@ public class Json {
 		this.ignoreUnknownFields = ignoreUnknownFields;
 	}
 
-	public boolean isIgnoreUnknownFields () {
+	public boolean getIgnoreUnknownFields () {
 		return ignoreUnknownFields;
 	}
 
@@ -130,10 +130,6 @@ public class Json {
 	 * "class". */
 	public void setTypeName (String typeName) {
 		this.typeName = typeName;
-	}
-	
-	public String getTypeName () {
-		return typeName;
 	}
 
 	/** Sets the serializer to use when the type being deserialized is not known (null).
@@ -808,7 +804,7 @@ public class Json {
 			FieldMetadata metadata = fields.get(child.name().replace(" ", "_"));
 			if (metadata == null) {
 				if (child.name.equals(typeName)) continue;
-				if (ignoreUnknownFields || isNonexistantFieldKnown(type, child.name)) {
+				if (ignoreUnknownFields || ignoreUnknownField(type, child.name)) {
 					if (debug) System.out.println("Ignoring unknown field: " + child.name + " (" + type.getName() + ")");
 					continue;
 				} else {
@@ -835,13 +831,13 @@ public class Json {
 		}
 	}
 
-	/** Override to allow subclasses to use fake field names for other purposes in {@link #readFields(Object, JsonValue)} without
-	 * triggering an exception for unknown fields.
+	/** Called for each unknown field name encountered by {@link #readFields(Object, JsonValue)} when 
+	 * {@link #ignoreUnknownFields} is false to determine whether a specific unknown field name should be ignored anyway.
 	 * @param type The object type being read.
 	 * @param fieldName A field name encountered in the Json map for which there is no actual field.
 	 * @return Whether the field name should be treated as known, i.e., not throw an exception when encountered in
-	 *         {@code readFields()}. */
-	protected boolean isNonexistantFieldKnown (Class type, String fieldName) {
+	 *         {@link #readFields(Object, JsonValue)}. */
+	protected boolean ignoreUnknownField (Class type, String fieldName) {
 		return false;
 	}
 

--- a/tests/gdx-tests-android/assets/data/uiskin.json
+++ b/tests/gdx-tests-android/assets/data/uiskin.json
@@ -11,11 +11,11 @@ com.badlogic.gdx.scenes.scene2d.ui.Skin$TintedDrawable: {
 },
 com.badlogic.gdx.scenes.scene2d.ui.Button$ButtonStyle: {
 	default: { down: default-round-down, up: default-round },
-	toggle: { down: default-round-down, checked: default-round-down, up: default-round }
+	toggle: { parent: default, checked: default-round-down }
 },
 com.badlogic.gdx.scenes.scene2d.ui.TextButton$TextButtonStyle: {
 	default: { down: default-round-down, up: default-round, font: default-font, fontColor: white },
-	toggle: { down: default-round-down, up: default-round, checked: default-round-down, font: default-font, fontColor: white, downFontColor: red }
+	toggle: { parent: default, checked: default-round-down, downFontColor: red }
 },
 com.badlogic.gdx.scenes.scene2d.ui.ScrollPane$ScrollPaneStyle: {
 	default: { vScroll: default-scroll, hScrollKnob: default-round-large, background: default-rect, hScroll: default-scroll, vScrollKnob: default-round-large }
@@ -33,7 +33,7 @@ com.badlogic.gdx.scenes.scene2d.ui.SplitPane$SplitPaneStyle: {
 },
 com.badlogic.gdx.scenes.scene2d.ui.Window$WindowStyle: {
 	default: { titleFont: default-font, background: default-window, titleFontColor: white },
-	dialog: { titleFont: default-font, background: default-window, titleFontColor: white, stageBackground: dialogDim }
+	dialog: { parent: default, stageBackground: dialogDim }
 },
 com.badlogic.gdx.scenes.scene2d.ui.ProgressBar$ProgressBarStyle: {
 	default-horizontal: { background: default-slider, knob: default-slider-knob },


### PR DESCRIPTION
This is #4287 revised. Sorry for creating a new PR. I had some kind of name conflict by giving my local branch the same name with different capitalization, and for the life of me cannot figure out how to push to the branch from the original PR.

@NathanSweet I made the method name changes you requested. I started trying out the idea you had for putting `copy()` methods into Json ([here](https://github.com/cypherdare/libgdx/tree/stylecascadeJsonCopy)), but it got really ugly when it came time to copy the classes that are typically used in a Skin. There are many references to Textures and various other objects deep in the object graph of a simple style. I don't think it makes sense to create a bunch of serializers to carefully handle all these fields. Skin has not been set up to write the style objects with Json, only to read them and take shortcuts for anything referencing a TextureRegion.