### PR TITLE
make ParticleController deltaTime not hard-coded

### DIFF
--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/FlameMain.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/FlameMain.java
@@ -750,17 +750,17 @@ public class FlameMain extends JFrame implements AssetErrorListener {
 		}
 
 		public void render () {
-			//float delta = Math.max(0, Gdx.graphics.getDeltaTime() * deltaMultiplier.getValue());
-			update();
+			float delta = Math.max(0, Gdx.graphics.getDeltaTime() * deltaMultiplier.getValue());
+			update(delta);
 			renderWorld();
 		}
 
-		private void update () {
+		private void update (float delta) {
 			worldCamera.fieldOfView = fovValue.getValue();
 			worldCamera.update();
 			cameraInputController.update();
 			if(isUpdate){
-				particleSystem.update();
+				particleSystem.update(delta);
 				//Update ui
 				stringBuilder.delete(0, stringBuilder.length);
 				stringBuilder.append("Point Sprites : ").append(pointSpriteBatch.getBufferedCount());

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/particles/ParticleController.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/particles/ParticleController.java
@@ -16,6 +16,7 @@
 
 package com.badlogic.gdx.graphics.g3d.particles;
 
+import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.assets.AssetManager;
 import com.badlogic.gdx.graphics.g3d.particles.ParallelArray.FloatChannel;
 import com.badlogic.gdx.graphics.g3d.particles.emitters.Emitter;
@@ -219,6 +220,12 @@ public class ParticleController implements Json.Serializable, ResourceData.Confi
 
 	/** Updates the particles data */
 	public void update () {
+		update(Gdx.graphics.getDeltaTime());
+	}
+
+	/** Updates the particles data */
+	public void update (float deltaTime) {
+		setTimeStep(deltaTime);
 		emitter.update();
 		for (Influencer influencer : influencers)
 			influencer.update();

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/particles/ParticleEffect.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/particles/ParticleEffect.java
@@ -71,6 +71,11 @@ public class ParticleEffect implements Disposable, ResourceData.Configurable {
 			controllers.get(i).update();
 	}
 
+	public void update (float deltaTime) {
+		for (int i = 0, n = controllers.size; i < n; i++)
+			controllers.get(i).update(deltaTime);
+	}
+
 	public void draw () {
 		for (int i = 0, n = controllers.size; i < n; i++)
 			controllers.get(i).draw();

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/particles/ParticleSystem.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/particles/ParticleSystem.java
@@ -70,6 +70,18 @@ public final class ParticleSystem implements RenderableProvider {
 		for (ParticleEffect effect : effects) {
 			effect.update();
 			effect.draw();
+		}		
+	}
+
+	public void update (float deltaTime) {
+		for (ParticleEffect effect : effects) {
+			effect.update(deltaTime);
+		}
+	}
+	public void updateAndDraw(float deltaTime) {
+		for (ParticleEffect effect : effects) {
+			effect.update(deltaTime);
+			effect.draw();
 		}
 	}
 

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/particles/emitters/RegularEmitter.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/particles/emitters/RegularEmitter.java
@@ -119,7 +119,7 @@ public class RegularEmitter extends Emitter implements Json.Serializable {
 	}
 
 	public void update () {
-		int deltaMillis = (int)(controller.deltaTime * 1000);
+		float deltaMillis = controller.deltaTime * 1000;
 
 		if (delayTimer < delay) {
 			delayTimer += deltaMillis;


### PR DESCRIPTION
-The ParticleController stores a frame time in its deltaTime member but this value is hard-coded at 1/60 regardless of framerate. This change adds an overload to the
ParticleController's update() method to take the delta time. This allows the particles to adjust
their time deltas for faster or slower framerate. The change also
allows callers to cause particle effects to be played back at faster or slower
speeds.
-This change also adds overloads for update() and updateAndDraw() of the ParticleSystem class,
each of which takes a frame time and adds an overload for the ParticleEffect update() method.
-RegularEmitter previously only used the floor of the number of milliseconds that had passed since
 the last update when calculating percent of the lifetime lived for each particle. For playback of
 particle effects that were being played at .1 times the speed of the default speed, .00016666 ms
were elapsed between calls to update(), which rounds down to 1 ms rather than 1.666 ms.
This meant that the particle effect being played at .1 speed was actually being animated for 16 times as long rather than 10 times as long as the same effect played back at 1x speed
(because the floor of .001666 times 1000 = 16 but floor of .00016666 * 1000 is 1.)
-This change also updates the Flame tool to make it respect the delta multiplier