### PR TITLE
Adding  getter for startX and startY in moveToAction

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/MoveToAction.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/MoveToAction.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -72,5 +72,13 @@ public class MoveToAction extends TemporalAction {
 
 	public void setAlignment (int alignment) {
 		this.alignment = alignment;
+	}
+
+	public float getStartX() {
+		return startX;
+	}
+
+	public float getStartY() {
+		return startY;
 	}
 }


### PR DESCRIPTION
Correcting the error specified in the issue 4980 (https://github.com/libgdx/libgdx/issues/4890). Since the attributes are private, there is no risk in exposing them via getter.