### PR TITLE
Fix Intersector#overlapConvexPolygons

### DIFF
--- a/gdx/test/com/badlogic/gdx/math/IntersectorTest.java
+++ b/gdx/test/com/badlogic/gdx/math/IntersectorTest.java
@@ -154,7 +154,7 @@ public class IntersectorTest {
 		assertTrue("They should overlap", overlaps);
 		assertEquals("MTV depth should be ~" + expectedDepth, expectedDepth, mtv.depth, 0.01f);
 		assertEquals("MTV shouldn't translate on the y-axis", 0f, mtv.normal.y, 0f);
-		assertTrue("MTV should translate to the right", mtv.normal.x > 0f); // fails
+		assertTrue("MTV should translate to the right", mtv.normal.x > 0f);
 	}
 
 }


### PR DESCRIPTION
In some rare cases it's possible that Intersector#overlapConvexPolygons calculates an incorrect MTV. Currently the direction of the MTV is negated depending on the number of points on either side of the checked edge. 

The correct way is to negate the direction of the MTV depending on the direction of the centers of both polygons.