### PR TITLE
Fix #5036 open URL on mobile device using HTML module

### DIFF
--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Net.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Net.java
@@ -64,21 +64,14 @@ public class Lwjgl3Net implements Net {
 
 	@Override
 	public boolean openURI (String URI) {
-		if(SharedLibraryLoader.isMac) {
-			try {
-				FileManager.openURL(URI);
-				return true;
-			} catch (IOException e) {
-				return false;
-			}
-		} else {
-			try {
-				Desktop.getDesktop().browse(new URI(URI));
-				return true;
-			} catch (Throwable t) {
-				return false;
-			}
+		class NativeWrapper {
+					public native void openURL(String url) /*-{
+	 					var aURL = url;
+  						$wnd.location.href = aURL;
+					}-*/;
 		}
+		new NativeWrapper().openURL(URI);
 	}
+	
 
 }


### PR DESCRIPTION
Fix #5036 open URL on mobile device using HTML module
Current implementation did not work on Mobile device (iOS or Android)
as the call is treated as a blocked pop-up.
This implementation redirects the browser windows using JSNI code
(http://www.gwtproject.org/doc/latest/DevGuideCodingBasicsJSNI.html)
  