### PR TITLE
Gdx.net.openURI blocked as popup when using iOS browser on iPhone or Chrome on Android phone #5036

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplication.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplication.java
@@ -210,7 +210,7 @@ public abstract class GwtApplication implements EntryPoint, Application {
 		Gdx.files = new GwtFiles(preloader);
 		this.input = new GwtInput(graphics.canvas);
 		Gdx.input = this.input;
-		this.net = new GwtNet();
+		this.net = new GwtNet(config);
 		Gdx.net = this.net;
 		this.clipboard = new GwtClipboard();
 		updateLogLabelSize();

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplicationConfiguration.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplicationConfiguration.java
@@ -55,6 +55,9 @@ public class GwtApplicationConfiguration {
 	/** screen-orientation to attempt locking as the application enters full-screen-mode. Note that on mobile browsers, full-screen
 	 * mode can typically only be entered on a user gesture (click, tap, key-stroke) **/
 	public OrientationLockType fullscreenOrientation;
+	/* Whether openURI will open page in new tab. By default it will, however if may be blocked by popup blocker. */
+	/* To prevent the page from being blocked you can redirect to the new page. However this will exit your game.  */
+	public boolean openURLInNewWindow = true;
 
 	public GwtApplicationConfiguration (int width, int height) {
 		this.width = width;

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtNet.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtNet.java
@@ -203,8 +203,9 @@ public class GwtNet implements Net {
 	}
 
 	@Override
-	public boolean openURI (String URI) {
-		Window.open(URI, "_blank", null);
-		return true;
-	}
+	public native boolean openURI (String URI) /*-{
+	 var aURL = URI;
+  $wnd.location.href = aURL;
+  	return true;
+}-*/;
 }

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtNet.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtNet.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Net;
 import com.badlogic.gdx.Net.Protocol;
 import com.badlogic.gdx.net.HttpStatus;
@@ -33,6 +34,7 @@ import com.badlogic.gdx.net.Socket;
 import com.badlogic.gdx.net.SocketHints;
 import com.badlogic.gdx.utils.GdxRuntimeException;
 import com.badlogic.gdx.utils.ObjectMap;
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.http.client.Header;
 import com.google.gwt.http.client.Request;
 import com.google.gwt.http.client.RequestBuilder;
@@ -45,6 +47,7 @@ public class GwtNet implements Net {
 
 	ObjectMap<HttpRequest, Request> requests;
 	ObjectMap<HttpRequest, HttpResponseListener> listeners;
+	GwtApplicationConfiguration config;
 
 	private final class HttpClientResponse implements HttpResponse {
 
@@ -101,7 +104,8 @@ public class GwtNet implements Net {
 		}
 	}
 
-	public GwtNet () {
+	public GwtNet (GwtApplicationConfiguration aConfig) {
+		config = aConfig;
 		requests = new ObjectMap<HttpRequest, Request>();
 		listeners = new ObjectMap<HttpRequest, HttpResponseListener>();
 	}
@@ -203,9 +207,26 @@ public class GwtNet implements Net {
 	}
 
 	@Override
-	public native boolean openURI (String URI) /*-{
-	 var aURL = URI;
-  $wnd.location.href = aURL;
-  	return true;
-}-*/;
+	public boolean openURI (String URI){
+
+		class NativeWrapper{
+			public native boolean redirectURI (String URI) /*-{
+	 			var aURL = URI;
+  				$wnd.location.href = aURL;
+  				return true;
+			}-*/;
+		}
+		if(config.openURLInNewWindow){
+			Window.open(URI, "_blank", null);
+		}
+		else{
+			Window.Location.assign(URI);
+		}
+		return true;
+	};
+
+
+
+
+
 }

--- a/tests/gdx-tests-gwt/src/com/badlogic/gdx/tests/gwt/client/GwtTestStarter.java
+++ b/tests/gdx-tests-gwt/src/com/badlogic/gdx/tests/gwt/client/GwtTestStarter.java
@@ -19,15 +19,14 @@ package com.badlogic.gdx.tests.gwt.client;
 import com.badlogic.gdx.ApplicationListener;
 import com.badlogic.gdx.backends.gwt.GwtApplication;
 import com.badlogic.gdx.backends.gwt.GwtApplicationConfiguration;
-import com.badlogic.gdx.tests.AssetManagerTest;
-import com.badlogic.gdx.tests.UITest;
-import com.badlogic.gdx.tests.g3d.ModelTest;
 import com.badlogic.gdx.tests.gwt.GwtTestWrapper;
 
 public class GwtTestStarter extends GwtApplication {
 	@Override
 	public GwtApplicationConfiguration getConfig () {
-		return new GwtApplicationConfiguration(480, 320);
+		GwtApplicationConfiguration config = new GwtApplicationConfiguration(480, 320);
+		//config.openURLInNewWindow = true;
+		return config;
 	}
 
 	@Override

--- a/tests/gdx-tests/src/com/badlogic/gdx/GdxTests.gwt.xml
+++ b/tests/gdx-tests/src/com/badlogic/gdx/GdxTests.gwt.xml
@@ -2,45 +2,45 @@
 <!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit trunk//EN" "http://google-web-toolkit.googlecode.com/svn/trunk/distro-source/core/src/gwt-module.dtd">
 <module>
 	<source path="tests">
+		<exclude name="**/AssetsFileGenerator.java"/> <!-- utility -->
 		<exclude name="**/AudioDeviceTest.java"/> <!-- audio missing -->
 		<exclude name="**/AudioRecorderTest.java"/> <!-- audio missing -->
 		<exclude name="**/BobTest.java"/> <!-- GL ES 1.0 -->
+		<exclude name="**/bullet/"/> <!-- native -->
+		<exclude name="**/BulletTestCollection.java"/> <!-- native -->
 		<exclude name="**/ContactListenerTest.java"/> <!-- String.format, Reflection -->
 		<exclude name="**/CullTest.java"/> <!-- GL ES 1.0 -->
 		<exclude name="**/DownloadTest.java"/> <!-- Incompatible Pixmap ctor -->
 		<exclude name="**/KTXTest.java"/> <!-- use ECT1 which is native -->
 		<exclude name="**/ETC1Test.java"/> <!-- native -->
 		<exclude name="**/FFTTest.java"/> <!-- native -->
+		<exclude name="**/FloatTextureTest.java"/> <!-- GLES 2.0 extension -->
 		<exclude name="**/FreeType*.java"/> <!-- native  -->
 		<exclude name="**/Gdx2DTest.java"/> <!-- native -->
+		<exclude name="**/GdxTests.java"/> <!-- utility -->
 		<exclude name="**/HeightField.java"/> <!-- Incompatible type due to emulation -->
 		<exclude name="**/HeightMapTest.java"/> <!-- Incompatible type due to emulation -->
 		<exclude name="**/I18NMessageTest.java"/> <!-- MessageBundle -->
+		<exclude name="**/InternationalFontsTest.java"/> <!-- utility -->
 		<exclude name="**/JpegTest.java"/> <!-- native -->
 		<exclude name="**/JsonReaderTest.java"/> <!-- uses ArrayList -->
 		<exclude name="**/Mpg123Test.java"/> <!-- native -->
-        <exclude name="**/NoncontinuousRenderingTest.java"/> <!-- Noncontinuous rendering not supported -->
+		<exclude name="**/NetAPITest.java"/> <!-- abuses FileHandle() -->
+		<exclude name="**/NoncontinuousRenderingTest.java"/> <!-- Noncontinuous rendering not supported -->
+		<exclude name="**/PingPongSocketExample.java"/> <!-- networking -->
 		<exclude name="**/PngTest.java"/> <!-- Not compatible -->
 		<exclude name="**/RemoteTest.java"/> <!-- networking -->
 		<exclude name="**/SelectTest.java"/> <!-- String.format -->
 		<exclude name="**/SensorTest.java"/> <!-- Tests device accelerometer, compass, gyro -->
 		<exclude name="**/SoundTouchTest.java"/> <!-- native -->
 		<exclude name="**/StbTrueTypeTest.java"/> <!-- native -->
+		<exclude name="**/TextureArrayTest.java"/> <!-- GLES 3.0 -->
 		<exclude name="**/TextureDownloadTest.java"/> <!-- http utils missing -->
 		<exclude name="**/TTFFactoryTest.java"/> <!-- native -->
+		<exclude name="**/VBOWithVAOPerformanceTest.java"/> <!-- GLES 3.0 -->
 		<exclude name="**/VorbisTest.java"/> <!-- native -->
 		<exclude name="**/WavTest.java"/> <!-- naive -->
-		<exclude name="**/AssetsFileGenerator.java"/> <!-- utility -->
-		<exclude name="**/GdxTests.java"/> <!-- utility -->
-		<exclude name="**/InternationalFontsTest.java"/> <!-- utility -->
-		<exclude name="**/BulletTestCollection.java"/> <!-- native -->
-		<exclude name="**/bullet/"/> <!-- native -->
-		<exclude name="**/FloatTextureTest.java"/> <!-- GLES 2.0 extension -->
-		<exclude name="**/NetAPITest.java"/> <!-- abuses FileHandle() -->
-		<exclude name="**/PingPongSocketExample.java"/> <!-- networking -->
 		<exclude name="**/voxel/*.java"/> <!-- PerlinNoiseGenerator uses a method not in the emulated version of Buffer -->
-		<exclude name="**/TextureArrayTest.java"/> <!-- GLES 3.0 -->
-		<exclude name="**/VBOWithVAOPerformanceTest.java"/> <!-- GLES 3.0 -->
 	</source>
 	<extend-configuration-property name="gdx.reflect.include" value="com.badlogic.gdx.tests.AnnotationTest" />
 	<extend-configuration-property name="gdx.reflect.include" value="com.badlogic.gdx.tests.ReflectionCorrectnessTest" />

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtTestWrapper.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtTestWrapper.java
@@ -16,9 +16,6 @@
 
 package com.badlogic.gdx.tests.gwt;
 
-import java.util.Arrays;
-import java.util.Comparator;
-
 import com.badlogic.gdx.Application;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
@@ -83,7 +80,6 @@ import com.badlogic.gdx.tests.MeshShaderTest;
 import com.badlogic.gdx.tests.MipMapTest;
 import com.badlogic.gdx.tests.MultitouchTest;
 import com.badlogic.gdx.tests.MusicTest;
-import com.badlogic.gdx.tests.NoncontinuousRenderingTest;
 import com.badlogic.gdx.tests.ParallaxTest;
 import com.badlogic.gdx.tests.ParticleEmitterTest;
 import com.badlogic.gdx.tests.PixelsPerInchTest;
@@ -113,8 +109,12 @@ import com.badlogic.gdx.tests.conformance.DisplayModeTest;
 import com.badlogic.gdx.tests.extensions.ControllersTest;
 import com.badlogic.gdx.tests.g3d.ModelCacheTest;
 import com.badlogic.gdx.tests.g3d.ShadowMappingTest;
+import com.badlogic.gdx.tests.net.OpenBrowserExample;
 import com.badlogic.gdx.tests.superkoalio.SuperKoalio;
 import com.badlogic.gdx.tests.utils.GdxTest;
+
+import java.util.Arrays;
+import java.util.Comparator;
 
 public class GwtTestWrapper extends GdxTest {
 	Stage ui;
@@ -650,6 +650,10 @@ public class GwtTestWrapper extends GdxTest {
 		}, new Instancer() {
 			public GdxTest instance () {
 				return new MusicTest();
+			}
+		}, new Instancer() {
+			public GdxTest instance () {
+				return new OpenBrowserExample();
 			}
 //		}, new Instancer() { public GdxTest instance () { return new NoncontinuousRenderingTest(); } // FIXME doesn't compile due to the use of Thread
 		}, new Instancer() {

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/net/OpenBrowserExample.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/net/OpenBrowserExample.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests.net;
 
-import com.badlogic.gdx.ApplicationAdapter;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.tests.utils.GdxTest;
 


### PR DESCRIPTION
When calling Gdx.net.openURI on a GWT module using 
an iPhone or Android phone you may get a popup blocked (see #5036). This addresses it by changing the windows location.
Tested on Chrome/Safari on computer and mobile devices.