### PR TITLE
Created "DescriptivePool" utility class

### DIFF
--- a/gdx/src/com/badlogic/gdx/utils/DescriptivePool.java
+++ b/gdx/src/com/badlogic/gdx/utils/DescriptivePool.java
@@ -62,7 +62,7 @@ abstract class DescriptivePool<T extends DescriptivePool.DescriptivePoolable> ex
 
     	/** Objects implementing this interface will have {@link #reset()} called when passed to {@link Pool#free(Object)}. */
     	static public interface DescriptivePoolable extends Poolable {
-		/** Called ONLY when an object is added to the pool.
+		/** Called when an object is added to the pool or created.
       	   	* Note: Will call after {@link #reset()} in {@link Pool#free(Object)} related methods */
         	public void onFree ();
 

--- a/gdx/src/com/badlogic/gdx/utils/DescriptivePool.java
+++ b/gdx/src/com/badlogic/gdx/utils/DescriptivePool.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogic.gdx.utils;
+
+/** A pool of objects that can be reused to avoid allocation. However, this implements
+ * {@link #onFree(DescriptivePoolable) and {@link #onObtain(DescriptivePoolable)}}
+ * @see Pools
+ * @author Carter Gale */
+abstract class DescriptivePool<T extends DescriptivePool.DescriptivePoolable> extends Pool<T> {
+	/** Creates a pool with an initial capacity of 16 and no maximum. */
+	public DescriptivePool () {
+                super();
+        }
+
+        /** Creates a pool with the specified initial capacity and no maximum. */
+        public DescriptivePool (int initialCapacity) {
+                super(initialCapacity);
+        }
+
+        /** @param max The maximum number of free objects to store in this pool. */
+        public DescriptivePool (int initialCapacity, int max) {
+                super(initialCapacity, max);
+        }
+
+        @Override
+        protected void onObtain (T object) {
+                object.onObtain();
+        }
+
+    	@Override
+    	protected void onFree (T object){
+        	object.onFree();
+    	}
+
+
+    	/** Objects implementing this interface will have {@link #reset()} called when passed to {@link Pool#free(Object)}. */
+    	static public interface DescriptivePoolable extends Poolable {
+       		/** Called ONLY when an object is added to the pool.
+      	   	* Note: Will call after {@link #reset()} in {@link Pool#free(Object)} related methods */
+        	public void onFree ();
+
+        	/** Called whenever the object is removed from the pool. */
+        	public void onObtain ();
+    	}
+}

--- a/gdx/src/com/badlogic/gdx/utils/DescriptivePool.java
+++ b/gdx/src/com/badlogic/gdx/utils/DescriptivePool.java
@@ -49,7 +49,7 @@ abstract class DescriptivePool<T extends DescriptivePool.DescriptivePoolable> ex
 
     	/** Objects implementing this interface will have {@link #reset()} called when passed to {@link Pool#free(Object)}. */
     	static public interface DescriptivePoolable extends Poolable {
-       		/** Called ONLY when an object is added to the pool.
+		/** Called ONLY when an object is added to the pool.
       	   	* Note: Will call after {@link #reset()} in {@link Pool#free(Object)} related methods */
         	public void onFree ();
 

--- a/gdx/src/com/badlogic/gdx/utils/DescriptivePool.java
+++ b/gdx/src/com/badlogic/gdx/utils/DescriptivePool.java
@@ -37,14 +37,27 @@ abstract class DescriptivePool<T extends DescriptivePool.DescriptivePoolable> ex
         }
 
         @Override
-        protected void onObtain (T object) {
-                object.onObtain();
-        }
+        public T obtain () {
+		T obj = super.obtain();
+		obj.onObtain();
+		return obj;
+	}
 
     	@Override
-    	protected void onFree (T object){
-        	object.onFree();
+    	public void free (T object){
+        	super.free(object);
+		object.onFree();
     	}
+	
+	@Override
+	public void freeAll (Array<T> objects) {
+		super.freeAll(objects);
+		for (int i = 0; i < objects.size; i++) {
+			T object = objects.get(i);
+			if (object == null) continue;
+			object.onFree();
+		}
+	}
 
 
     	/** Objects implementing this interface will have {@link #reset()} called when passed to {@link Pool#free(Object)}. */

--- a/gdx/src/com/badlogic/gdx/utils/Pool.java
+++ b/gdx/src/com/badlogic/gdx/utils/Pool.java
@@ -18,7 +18,7 @@ package com.badlogic.gdx.utils;
 
 /** A pool of objects that can be reused to avoid allocation.
  * @see Pools
- * @author Nathan Sweet & Carter Gale*/
+ * @author Nathan Sweet */
 abstract public class Pool<T> {
 	/** The maximum number of objects that will be pooled. */
 	public final int max;
@@ -48,18 +48,9 @@ abstract public class Pool<T> {
 	/** Returns an object from this pool. The object may be new (from {@link #newObject()}) or reused (previously
 	 * {@link #free(Object) freed}). */
 	public T obtain () {
-                if (freeObjects.size == 0) {
-                        return newObject();
-                } else {
-                        T object = freeObjects.pop();
-                        onObtain(object);
-                        return object;
-                }
+		return freeObjects.size == 0 ? newObject() : freeObjects.pop();
 	}
-	
-	/** Called when an object is retrieved from the pool using {@link #obtain()} */
-	protected void onObtain (T object){ }
-	
+
 	/** Puts the specified object in the pool, making it eligible to be returned by {@link #obtain()}. If the pool already contains
 	 * {@link #max} free objects, the specified object is reset but not added to the pool. */
 	public void free (T object) {
@@ -67,13 +58,9 @@ abstract public class Pool<T> {
 		if (freeObjects.size < max) {
 			freeObjects.add(object);
 			peak = Math.max(peak, freeObjects.size);
-			onFree(object);
 		}
 		reset(object);
 	}
-	
-	/** Called when an object is freed to the pool using {@link #free(Object)}} or {@link #freeAll(Array)} */
-	protected void onFree (T object){ }
 
 	/** Called when an object is freed to clear the state of the object for possible later reuse. The default implementation calls
 	 * {@link Poolable#reset()} if the object is {@link Poolable}. */
@@ -91,7 +78,6 @@ abstract public class Pool<T> {
 			T object = objects.get(i);
 			if (object == null) continue;
 			if (freeObjects.size < max) freeObjects.add(object);
-			onFree(object);
 			reset(object);
 		}
 		peak = Math.max(peak, freeObjects.size);

--- a/gdx/src/com/badlogic/gdx/utils/Pool.java
+++ b/gdx/src/com/badlogic/gdx/utils/Pool.java
@@ -58,7 +58,7 @@ abstract public class Pool<T> {
 	}
 	
 	/** Called when an object is retrieved from the pool using {@link #obtain()} */
-	protected void onObtain(T object){ }
+	protected void onObtain (T object){ }
 	
 	/** Puts the specified object in the pool, making it eligible to be returned by {@link #obtain()}. If the pool already contains
 	 * {@link #max} free objects, the specified object is reset but not added to the pool. */
@@ -73,7 +73,7 @@ abstract public class Pool<T> {
 	}
 	
 	/** Called when an object is freed to the pool using {@link #free(Object)}} or {@link #freeAll(Array)} */
-	protected void onFree(T object){ }
+	protected void onFree (T object){ }
 
 	/** Called when an object is freed to clear the state of the object for possible later reuse. The default implementation calls
 	 * {@link Poolable#reset()} if the object is {@link Poolable}. */


### PR DESCRIPTION
This PR created the "DescriptivePool" utility class which is used for calling methods `onObtain` and `onFree` whenever an object is freed/obtained from a DescriptivePool instance. Provides extension interface of `Poolable` named `DescriptivePoolable`.

Any comments, concerns, suggestions, etcetera would be appreciated if there is anything keeping this from being accepted.

p.s.: thanks @Darkyenus for the tip. x2