### PR TITLE
Fix compilation warnings in etc1_utils.cpp

### DIFF
--- a/gdx/jni/etc1/etc1_utils.cpp
+++ b/gdx/jni/etc1/etc1_utils.cpp
@@ -149,13 +149,13 @@ inline int divideBy255(int d) {
 static
 inline int convert8To4(int b) {
     int c = b & 0xff;
-    return divideBy255(b * 15);
+    return divideBy255(c * 15);
 }
 
 static
 inline int convert8To5(int b) {
     int c = b & 0xff;
-    return divideBy255(b * 31);
+    return divideBy255(c * 31);
 }
 
 static


### PR DESCRIPTION
Fix convert8To4, convert8To5
See "https://android.googlesource.com/platform/frameworks/native/+/2b93f0bf448160b002dec10c5bb1c9985a5950e6"