### PR TITLE
Prevent controller extension from swallowing keyboard events

### DIFF
--- a/extensions/gdx-controllers/gdx-controllers-android/src/com/badlogic/gdx/controllers/android/AndroidControllers.java
+++ b/extensions/gdx-controllers/gdx-controllers-android/src/com/badlogic/gdx/controllers/android/AndroidControllers.java
@@ -191,6 +191,9 @@ public class AndroidControllers implements LifecycleListener, ControllerManager,
 
 	@Override
 	public boolean onKey (View view, int keyCode, KeyEvent keyEvent) {
+		if (!keyEvent.isGamepadButton(keyCode)) {
+			return false;
+		}
 		AndroidController controller = controllerMap.get(keyEvent.getDeviceId());
 		if(controller != null) {
 			if(controller.getButton(keyCode) && keyEvent.getAction() == KeyEvent.ACTION_DOWN) {


### PR DESCRIPTION
This fixes #4969

On Android, when using a hybrid controller w/keyboard, the keyboard key presses were reported as controller buttons.