### PR TITLE
Update mappings for Xbox controller

### DIFF
--- a/extensions/gdx-controllers/gdx-controllers/src/com/badlogic/gdx/controllers/mappings/Xbox.java
+++ b/extensions/gdx-controllers/gdx-controllers/src/com/badlogic/gdx/controllers/mappings/Xbox.java
@@ -16,10 +16,12 @@
 
 package com.badlogic.gdx.controllers.mappings;
 
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Graphics;
 import com.badlogic.gdx.controllers.Controller;
 import com.badlogic.gdx.utils.SharedLibraryLoader;
 
-/** Mappings for the Xbox series of controllers. Works only on desktop so far.
+/** Mappings for the Xbox series of controllers.
  * 
  * See <a href="https://upload.wikimedia.org/wikipedia/commons/thumb/2/2c/360_controller.svg/450px-360_controller.svg.png">this
  * image</a> which describes each button and axes.
@@ -61,27 +63,51 @@ public class Xbox {
 
 	static {
 		if (SharedLibraryLoader.isWindows) {
-			A = -1;
-			B = -1;
-			X = -1;
-			Y = -1;
-			GUIDE = -1;
-			L_BUMPER = -1;
-			R_BUMPER = -1;
-			BACK = -1;
-			START = -1;
-			DPAD_UP = -1;
-			DPAD_DOWN = -1;
-			DPAD_LEFT = -1;
-			DPAD_RIGHT = -1;
-			L_TRIGGER = -1;
-			R_TRIGGER = -1;
-			L_STICK_VERTICAL_AXIS = -1;
-			L_STICK_HORIZONTAL_AXIS = -1;
-			L_STICK = -1;
-			R_STICK_VERTICAL_AXIS = -1;
-			R_STICK_HORIZONTAL_AXIS = -1;
-			R_STICK = -1;
+			if(Gdx.graphics.getType() == Graphics.GraphicsType.LWJGL3) {
+				A = 0;
+				B = 1;
+				X = 2;
+				Y = 3;
+				GUIDE = -1;
+				L_BUMPER = 4;
+				R_BUMPER = 5;
+				BACK = 6;
+				START = 7;
+				DPAD_UP = -1;
+				DPAD_DOWN = -1;
+				DPAD_LEFT = -1;
+				DPAD_RIGHT = -1;
+				L_TRIGGER = 4;
+				R_TRIGGER = 5;
+				L_STICK_VERTICAL_AXIS = 1;
+				L_STICK_HORIZONTAL_AXIS = 0;
+				L_STICK = 8;
+				R_STICK_VERTICAL_AXIS = 3;
+				R_STICK_HORIZONTAL_AXIS = 2;
+				R_STICK = 9;
+			} else {
+				A = 0;
+				B = 1;
+				X = 2;
+				Y = 3;
+				GUIDE = -1;
+				L_BUMPER = 4;
+				R_BUMPER = 5;
+				BACK = 6;
+				START = 7;
+				DPAD_UP = -1;
+				DPAD_DOWN = -1;
+				DPAD_LEFT = -1;
+				DPAD_RIGHT = -1;
+				L_TRIGGER = 4; // 0..1
+				R_TRIGGER = 4; // 0..-1
+				L_STICK_VERTICAL_AXIS = 0;
+				L_STICK_HORIZONTAL_AXIS = 1;
+				L_STICK = 8;
+				R_STICK_VERTICAL_AXIS = 2;
+				R_STICK_HORIZONTAL_AXIS = 3;
+				R_STICK = 9;
+			}
 		} else if (SharedLibraryLoader.isLinux) {
 			A = 0;
 			B = 1;
@@ -126,6 +152,28 @@ public class Xbox {
 			R_STICK_VERTICAL_AXIS = 5;
 			R_STICK_HORIZONTAL_AXIS = 4;
 			R_STICK = -1;
+		} else if (SharedLibraryLoader.isAndroid) {
+			A = 96;
+			B = 97;
+			X = 99;
+			Y = 100;
+			GUIDE = 110;
+			L_BUMPER = 102;
+			R_BUMPER = 103;
+			L_TRIGGER = 2;
+			R_TRIGGER = 5;
+			BACK = 109;
+			START = 108;
+			DPAD_UP = -1;
+			DPAD_DOWN = -1;
+			DPAD_LEFT = -1;
+			DPAD_RIGHT = -1;
+			L_STICK_VERTICAL_AXIS = 1;
+			L_STICK_HORIZONTAL_AXIS = 0;
+			L_STICK = 106;
+			R_STICK_VERTICAL_AXIS = 4;
+			R_STICK_HORIZONTAL_AXIS = 3;
+			R_STICK = 107;
 		} else {
 			A = -1;
 			B = -1;
@@ -154,6 +202,7 @@ public class Xbox {
 	/** @return whether the {@link Controller} is an Xbox controller
 	 */
 	public static boolean isXboxController(Controller controller) {
-		return controller.getName().contains("Xbox");
+		String controllerName = controller.getName().toLowerCase();
+		return (controllerName.contains("xbox") || controllerName.contains("x-box"));
 	}
 }


### PR DESCRIPTION
Fix for issue #5061

- Made the check for the "Xbox" string case insensitive as it differs between backends.
- Provided mappings for LWJGL and LWJGL3 backends
- Provided detection and mapping for the Android backend

The triggers on the LWJGL backed behave incorrectly since OIS treats the controller as a DirectInput controller and doesn't provide individual axes for them.