### PR TITLE
Fixes #5070 - Fixed and replaced Intersector intersectSegmentCircleDisplace

### DIFF
--- a/gdx/src/com/badlogic/gdx/math/Intersector.java
+++ b/gdx/src/com/badlogic/gdx/math/Intersector.java
@@ -301,8 +301,19 @@ public final class Intersector {
         v2a.set(v2c.x - circle.x, v2c.y - circle.y);
 
         if (mtv != null) {
-            mtv.normal.set(v2a).nor();
-            mtv.depth = circle.radius - v2a.len();
+			// Handle special case of segment containing circle center
+			if (v2a.equals(Vector2.Zero)) {
+				v2d.set(end.y - circle.y, circle.x - end.x);
+				// Handle special case of segment end point being circle center
+				if (v2d.equals(Vector2.Zero)) {
+					v2d.set(start.y - circle.y, circle.x - start.x );
+				}
+				mtv.normal.set(v2d).nor();
+				mtv.depth = circle.radius;
+			} else {
+				mtv.normal.set(v2a).nor();
+				mtv.depth = circle.radius - v2a.len();
+			}
         }
 
         return v2a.len2() <= circle.radius * circle.radius;

--- a/gdx/src/com/badlogic/gdx/math/Intersector.java
+++ b/gdx/src/com/badlogic/gdx/math/Intersector.java
@@ -16,15 +16,14 @@
 
 package com.badlogic.gdx.math;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
 import com.badlogic.gdx.math.Plane.PlaneSide;
 import com.badlogic.gdx.math.collision.BoundingBox;
 import com.badlogic.gdx.math.collision.Ray;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.FloatArray;
+
+import java.util.Arrays;
+import java.util.List;
 
 /** Class offering various static methods for intersection testing between different geometric objects.
  * 
@@ -209,6 +208,11 @@ public final class Intersector {
 		}
 	}
 
+    static Vector2 v2a = new Vector2();
+    static Vector2 v2b = new Vector2();
+    static Vector2 v2c = new Vector2();
+    static Vector2 v2d = new Vector2();
+
 	/** Returns the distance between the given line and point. Note the specified line is not a line segment. */
 	public static float distanceLinePoint (float startX, float startY, float endX, float endY, float pointX, float pointY) {
 		float normalLength = (float)Math.sqrt((endX - startX) * (endX - startX) + (endY - startY) * (endY - startY));
@@ -217,12 +221,12 @@ public final class Intersector {
 
 	/** Returns the distance between the given segment and point. */
 	public static float distanceSegmentPoint (float startX, float startY, float endX, float endY, float pointX, float pointY) {
-		return nearestSegmentPoint(startX, startY, endX, endY, pointX, pointY, v2tmp).dst(pointX, pointY);
+		return nearestSegmentPoint(startX, startY, endX, endY, pointX, pointY, v2a).dst(pointX, pointY);
 	}
 
 	/** Returns the distance between the given segment and point. */
 	public static float distanceSegmentPoint (Vector2 start, Vector2 end, Vector2 point) {
-		return nearestSegmentPoint(start, end, point, v2tmp).dst(point);
+		return nearestSegmentPoint(start, end, point, v2a).dst(point);
 	}
 
 	/** Returns a point on the segment nearest to the specified point. */
@@ -274,30 +278,36 @@ public final class Intersector {
 		return x * x + y * y <= squareRadius;
 	}
 
-	/** Checks whether the line segment and the circle intersect and returns by how much and in what direction the line has to move
-	 * away from the circle to not intersect.
-	 * 
-	 * @param start The line segment starting point
-	 * @param end The line segment end point
-	 * @param point The center of the circle
-	 * @param radius The radius of the circle
-	 * @param displacement The displacement vector set by the method having unit length
-	 * @return The displacement or Float.POSITIVE_INFINITY if no intersection is present */
-	public static float intersectSegmentCircleDisplace (Vector2 start, Vector2 end, Vector2 point, float radius,
-		Vector2 displacement) {
-		float u = (point.x - start.x) * (end.x - start.x) + (point.y - start.y) * (end.y - start.y);
-		float d = start.dst(end);
-		u /= d * d;
-		if (u < 0 || u > 1) return Float.POSITIVE_INFINITY;
-		tmp.set(end.x, end.y, 0).sub(start.x, start.y, 0);
-		tmp2.set(start.x, start.y, 0).add(tmp.scl(u));
-		d = tmp2.dst(point.x, point.y, 0);
-		if (d < radius) {
-			displacement.set(point).sub(tmp2.x, tmp2.y).nor();
-			return d;
-		} else
-			return Float.POSITIVE_INFINITY;
-	}
+    /** Returns whether the given line segment intersects the given circle.
+     * @param start The start point of the line segment
+     * @param end The end point of the line segment
+     * @param circle The circle
+     * @param mtv A Minimum Translation Vector to fill in the case of a collision, or null (optional).
+     * @return Whether the line segment and the circle intersect */
+    public static boolean intersectSegmentCircle (Vector2 start, Vector2 end, Circle circle, MinimumTranslationVector mtv) {
+        v2a.set(end).sub(start);
+        v2b.set(circle.x - start.x, circle.y - start.y);
+        float len = v2a.len();
+        float u = v2b.dot(v2a.nor());
+        if (u <= 0) {
+            v2c.set(start);
+        } else if (u >= len) {
+            v2c.set(end);
+        } else {
+            v2d.set(v2a.scl(u)); // remember v2a is already normalized
+            v2c.set(v2d).add(start);
+        }
+
+        v2a.set(v2c.x - circle.x, v2c.y - circle.y);
+
+        if (mtv != null) {
+            mtv.normal.set(v2a).nor();
+            mtv.depth = circle.radius - v2a.len();
+        }
+
+        return v2a.len2() <= circle.radius * circle.radius;
+    }
+
 
 	/** Intersect two 2D Rays and return the scalar parameter of the first ray at the intersection point. You can get the
 	 * intersection point by: Vector2 point(direction1).scl(scalar).add(start1); For more information, check:
@@ -608,7 +618,6 @@ public final class Intersector {
 	static Vector3 tmp1 = new Vector3();
 	static Vector3 tmp2 = new Vector3();
 	static Vector3 tmp3 = new Vector3();
-	static Vector2 v2tmp = new Vector2();
 
 	/** Intersects the given ray with list of triangles. Returns the nearest intersection point in intersection
 	 * 

--- a/gdx/src/com/badlogic/gdx/math/Intersector.java
+++ b/gdx/src/com/badlogic/gdx/math/Intersector.java
@@ -303,11 +303,7 @@ public final class Intersector {
         if (mtv != null) {
 			// Handle special case of segment containing circle center
 			if (v2a.equals(Vector2.Zero)) {
-				v2d.set(end.y - circle.y, circle.x - end.x);
-				// Handle special case of segment end point being circle center
-				if (v2d.equals(Vector2.Zero)) {
-					v2d.set(start.y - circle.y, circle.x - start.x );
-				}
+				v2d.set(end.y - start.y, start.x - end.x);
 				mtv.normal.set(v2d).nor();
 				mtv.depth = circle.radius;
 			} else {

--- a/gdx/test/com/badlogic/gdx/math/IntersectorTest.java
+++ b/gdx/test/com/badlogic/gdx/math/IntersectorTest.java
@@ -109,23 +109,34 @@ public class IntersectorTest {
 
 	@Test
 	public void intersectSegmentCircle() {
+		Circle circle = new Circle(5f, 5f, 4f);
 		// Segment intersects, both segment points outside circle
-		boolean intersects = Intersector.intersectSegmentCircle(new Vector2(0, 1f), new Vector2(12f, 3f), new Circle(5f, 5f, 4f), null);
+		boolean intersects = Intersector.intersectSegmentCircle(new Vector2(0, 1f), new Vector2(12f, 3f), circle, null);
 		assertTrue(intersects);
 		// Segment intersects, only one of the points inside circle (and is aligned with center)
-		intersects = Intersector.intersectSegmentCircle(new Vector2(0, 5f), new Vector2(2f, 5f), new Circle(5f, 5f, 4f), null);
+		intersects = Intersector.intersectSegmentCircle(new Vector2(0, 5f), new Vector2(2f, 5f), circle, null);
 		assertTrue(intersects);
 		// Segment intersects, no points outside circle
-		intersects = Intersector.intersectSegmentCircle(new Vector2(5.5f, 6f), new Vector2(7f, 5.5f), new Circle(5f, 5f, 4f), null);
+		intersects = Intersector.intersectSegmentCircle(new Vector2(5.5f, 6f), new Vector2(7f, 5.5f), circle, null);
 		assertTrue(intersects);
 		// Segment doesn't intersect
-		intersects = Intersector.intersectSegmentCircle(new Vector2(0f, 6f), new Vector2(0.5f, 2f), new Circle(5f, 5f, 4f), null);
+		intersects = Intersector.intersectSegmentCircle(new Vector2(0f, 6f), new Vector2(0.5f, 2f), circle, null);
 		assertFalse(intersects);
 		// Segment is parallel to Y axis left of circle's center
 		Intersector.MinimumTranslationVector mtv = new Intersector.MinimumTranslationVector();
-		intersects = Intersector.intersectSegmentCircle(new Vector2(1.5f, 6f), new Vector2(1.5f, 3f), new Circle(5f, 5f, 4f), mtv);
+		intersects = Intersector.intersectSegmentCircle(new Vector2(1.5f, 6f), new Vector2(1.5f, 3f), circle, mtv);
 		assertTrue(intersects);
 		assertTrue(mtv.normal.equals(new Vector2(-1f, 0)));
 		assertTrue(mtv.depth == 0.5f);
+		// Segment contains circle center point
+		intersects = Intersector.intersectSegmentCircle(new Vector2(4f, 5f), new Vector2(6f, 5f), circle, mtv);
+		assertTrue(intersects);
+		assertTrue(mtv.normal.equals(new Vector2(0, 1f)) || mtv.normal.equals(new Vector2(0f, -1f)));
+		assertTrue(mtv.depth == 4f);
+		// Segment contains circle center point which is the same as the end point
+		intersects = Intersector.intersectSegmentCircle(new Vector2(4f, 5f), new Vector2(5f, 5f), circle, mtv);
+		assertTrue(intersects);
+		assertTrue(mtv.normal.equals(new Vector2(0, 1f)) || mtv.normal.equals(new Vector2(0f, -1f)));
+		assertTrue(mtv.depth == 4f);
 	}
 }

--- a/gdx/test/com/badlogic/gdx/math/IntersectorTest.java
+++ b/gdx/test/com/badlogic/gdx/math/IntersectorTest.java
@@ -1,12 +1,12 @@
 
 package com.badlogic.gdx.math;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import com.badlogic.gdx.math.Intersector.SplitTriangle;
 
 import org.junit.Test;
 
-import com.badlogic.gdx.math.Intersector.SplitTriangle;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class IntersectorTest {
 
@@ -105,5 +105,27 @@ public class IntersectorTest {
 				|| (triangleEquals(base, 0, 3, secondWay[1]) && triangleEquals(base, 9, 3, secondWay[0]));
 			assertTrue("Either first or second way must be right (first: " + first + ", second: " + second + ")", first ^ second);
 		}
+	}
+
+	@Test
+	public void intersectSegmentCircle() {
+		// Segment intersects, both segment points outside circle
+		boolean intersects = Intersector.intersectSegmentCircle(new Vector2(0, 1f), new Vector2(12f, 3f), new Circle(5f, 5f, 4f), null);
+		assertTrue(intersects);
+		// Segment intersects, only one of the points inside circle (and is aligned with center)
+		intersects = Intersector.intersectSegmentCircle(new Vector2(0, 5f), new Vector2(2f, 5f), new Circle(5f, 5f, 4f), null);
+		assertTrue(intersects);
+		// Segment intersects, no points outside circle
+		intersects = Intersector.intersectSegmentCircle(new Vector2(5.5f, 6f), new Vector2(7f, 5.5f), new Circle(5f, 5f, 4f), null);
+		assertTrue(intersects);
+		// Segment doesn't intersect
+		intersects = Intersector.intersectSegmentCircle(new Vector2(0f, 6f), new Vector2(0.5f, 2f), new Circle(5f, 5f, 4f), null);
+		assertFalse(intersects);
+        // Segment is parallel to Y axis left of circle's center
+        Intersector.MinimumTranslationVector mtv = new Intersector.MinimumTranslationVector();
+        intersects = Intersector.intersectSegmentCircle(new Vector2(1.5f, 6f), new Vector2(1.5f, 3f), new Circle(5f, 5f, 4f), mtv);
+        assertTrue(intersects);
+        assertTrue(mtv.normal.equals(new Vector2(-1f, 0)));
+        assertTrue(mtv.depth == 0.5f);
 	}
 }

--- a/gdx/test/com/badlogic/gdx/math/IntersectorTest.java
+++ b/gdx/test/com/badlogic/gdx/math/IntersectorTest.java
@@ -121,11 +121,11 @@ public class IntersectorTest {
 		// Segment doesn't intersect
 		intersects = Intersector.intersectSegmentCircle(new Vector2(0f, 6f), new Vector2(0.5f, 2f), new Circle(5f, 5f, 4f), null);
 		assertFalse(intersects);
-        // Segment is parallel to Y axis left of circle's center
-        Intersector.MinimumTranslationVector mtv = new Intersector.MinimumTranslationVector();
-        intersects = Intersector.intersectSegmentCircle(new Vector2(1.5f, 6f), new Vector2(1.5f, 3f), new Circle(5f, 5f, 4f), mtv);
-        assertTrue(intersects);
-        assertTrue(mtv.normal.equals(new Vector2(-1f, 0)));
-        assertTrue(mtv.depth == 0.5f);
+		// Segment is parallel to Y axis left of circle's center
+		Intersector.MinimumTranslationVector mtv = new Intersector.MinimumTranslationVector();
+		intersects = Intersector.intersectSegmentCircle(new Vector2(1.5f, 6f), new Vector2(1.5f, 3f), new Circle(5f, 5f, 4f), mtv);
+		assertTrue(intersects);
+		assertTrue(mtv.normal.equals(new Vector2(-1f, 0)));
+		assertTrue(mtv.depth == 0.5f);
 	}
 }


### PR DESCRIPTION
Fixes #5070

`intersectSegmentCircleDisplace` has been replaced by an overloaded method of `intersectSegmentCircle` that now accepts a `MinimumTranslationVector` as optional parameter.

Some design choices justifications
1. Use Vector2 instead of Vector3. This has required creating some static Vector2 instances for temporary use similar to Vector3 ones. To keep simple naming prefix v2 + letter seems the more compact/readable. These instances can be used by any other method in the class that needs temporary Vector2.
2. Use Vector2 operations when possible for readability
3. Use Circle as argument (the old one didn't use it as Circle class was created later in time)

**Even if the new `intersectSegmentCircle` that accepts an MTV parameter could also replace the old one, it has been left for backwards compatibility (up for discussion, in my opinion we should remove it)**

I will squash all the changes when I get confirmation on what to do with the old method + code review.

