### PR TITLE
Add focusWindow() to Lwjgl3Window

### DIFF
--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Window.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Window.java
@@ -268,6 +268,13 @@ public class Lwjgl3Window implements Disposable {
 	}
 	
 	/**
+	 * Brings the window to front and sets input focus. The window should already be visible and not iconified.
+	 */
+	public void focusWindow() {
+		GLFW.glfwFocusWindow(windowHandle);
+	}
+	
+	/**
 	 * Sets the icon that will be used in the window's title bar. Has no effect in macOS, which doesn't use window icons.
 	 * @param image One or more images. The one closest to the system's desired size will be scaled. Good sizes include
 	 * 16x16, 32x32 and 48x48. Pixmap format {@link Pixmap.Format.RGBA8888 RGBA8888} is preferred so the images will not 


### PR DESCRIPTION
In most cases this can be annoying to the user, but I found it necessary after using SWT to pick a file from the native file chooser. Might also be handy if you're using multiple windows for some reason.