### PR TITLE
Fixes 5103. Items under a ScrollPane's fading scrollbar are not click…

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ScrollPane.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ScrollPane.java
@@ -729,8 +729,8 @@ public class ScrollPane extends WidgetGroup {
 
 	public Actor hit (float x, float y, boolean touchable) {
 		if (x < 0 || x >= getWidth() || y < 0 || y >= getHeight()) return null;
-		if (scrollX && hScrollBounds.contains(x, y)) return this;
-		if (scrollY && vScrollBounds.contains(x, y)) return this;
+		if (scrollX && touchScrollH && hScrollBounds.contains(x, y)) return this;
+		if (scrollY && touchScrollV && vScrollBounds.contains(x, y)) return this;
 		return super.hit(x, y, touchable);
 	}
 


### PR DESCRIPTION
…able even if the scrollbar is hidden (#5103)

In my tests it breaks nothing, scrollbars still get drawn if you drag around.