### PR TITLE
Fixed the missingGlyph of FreeTypeBitmapFontData doesn't initialized.

### DIFF
--- a/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGenerator.java
+++ b/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGenerator.java
@@ -399,6 +399,7 @@ public class FreeTypeFontGenerator implements Disposable {
 		Glyph missingGlyph = createGlyph('\0', data, parameter, stroker, baseLine, packer);
 		if (missingGlyph != null && missingGlyph.width != 0 && missingGlyph.height != 0) {
 			data.setGlyph('\0', missingGlyph);
+			data.missingGlyph = missingGlyph;
 			if (incremental) data.glyphs.add(missingGlyph);
 		}
 


### PR DESCRIPTION
Fixed the missingGlyph of FreeTypeBitmapFontData doesn't initialized.
If the missingGlyph doesn't initialized, any glyph which not found will not rendered by the default glyph.