### PR TITLE
Add SplitPane.isCursorOverHandle()

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/SplitPane.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/SplitPane.java
@@ -50,6 +50,7 @@ public class SplitPane extends WidgetGroup {
 	private Rectangle firstWidgetBounds = new Rectangle();
 	private Rectangle secondWidgetBounds = new Rectangle();
 	Rectangle handleBounds = new Rectangle();
+	boolean cursorOverHandle;
 	private Rectangle tempScissors = new Rectangle();
 
 	Vector2 lastPoint = new Vector2();
@@ -122,6 +123,11 @@ public class SplitPane extends WidgetGroup {
 					lastPoint.set(x, y);
 				}
 				invalidate();
+			}
+
+			public boolean mouseMoved (InputEvent event, float x, float y) {
+				cursorOverHandle = handleBounds.contains(x, y);
+				return false;
 			}
 		});
 	}
@@ -377,6 +383,10 @@ public class SplitPane extends WidgetGroup {
 			return true;
 		}
 		return false;
+	}
+	
+	public boolean isCursorOverHandle () {
+		return cursorOverHandle;
 	}
 
 	/** The style for a splitpane, see {@link SplitPane}.


### PR DESCRIPTION
Makes it possible on desktop to react to hovering over the handle, such as changing the cursor to indicate it's draggable.