### PR TITLE
Use UTF8 encoding for strings NetJavaImpl

### DIFF
--- a/gdx/src/com/badlogic/gdx/net/NetJavaImpl.java
+++ b/gdx/src/com/badlogic/gdx/net/NetJavaImpl.java
@@ -175,7 +175,7 @@ public class NetJavaImpl {
 							// we probably need to use the content as stream here instead of using it as a string.
 							String contentAsString = httpRequest.getContent();
 							if (contentAsString != null) {
-								OutputStreamWriter writer = new OutputStreamWriter(connection.getOutputStream());
+								OutputStreamWriter writer = new OutputStreamWriter(connection.getOutputStream(), "UTF8");
 								try {
 									writer.write(contentAsString);
 								} finally {

--- a/gdx/src/com/badlogic/gdx/net/NetJavaImpl.java
+++ b/gdx/src/com/badlogic/gdx/net/NetJavaImpl.java
@@ -82,7 +82,7 @@ public class NetJavaImpl {
 			}
 
 			try {
-				return StreamUtils.copyStreamToString(input, connection.getContentLength());
+				return StreamUtils.copyStreamToString(input, connection.getContentLength(), "UTF8");
 			} catch (IOException e) {
 				return "";
 			} finally {


### PR DESCRIPTION
Android uses UTF8 by default, and is a saner default than leaving it up to environment's default character set for desktop.

This could be fleshed out to add specifiable character set to requests, and to attempt to parse response character set from response headers.