### PR TITLE
#5137 isPeriphalAvailable HardwareKeyboard on GWT

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplication.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplication.java
@@ -45,6 +45,7 @@ import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.Style;
 import com.google.gwt.dom.client.Style.Unit;
+import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.HasHorizontalAlignment;
 import com.google.gwt.user.client.ui.HasVerticalAlignment;
 import com.google.gwt.user.client.ui.Image;
@@ -56,6 +57,9 @@ import com.google.gwt.user.client.ui.SimplePanel;
 import com.google.gwt.user.client.ui.TextArea;
 import com.google.gwt.user.client.ui.VerticalPanel;
 import com.google.gwt.user.client.ui.Widget;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /** Implementation of an {@link Application} based on GWT. Clients have to override {@link #getConfig()} and
  * {@link #createApplicationListener()}. Clients can override the default loading screen via
@@ -426,6 +430,20 @@ public abstract class GwtApplication implements EntryPoint, Application {
 	@Override
 	public void exit () {
 	}
+
+    /**
+     * @return {@code true} if application runs on a mobile device
+     */
+	public static boolean isMobileDevice() {
+	    // RegEx pattern from detectmobilebrowsers.com (public domain)
+        String pattern = "(android|bb\\d+|meego).+mobile|avantgo|bada\\/|blackberry|blazer|compal|elaine|fennec" +
+                "|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)" +
+                "i|palm( os)?|phone|p(ixi|re)\\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\\.(browser|link)" +
+                "|vodafone|wap|windows ce|xda|xiino|android|ipad|playbook|silk";
+        Pattern p = Pattern.compile(pattern);
+        Matcher m = p.matcher(Window.Navigator.getUserAgent().toLowerCase());
+        return m.matches();
+    }
 
 	/** Contains precomputed information on the user-agent. Useful for dealing with browser and OS behavioral differences. Kindly
 	 * borrowed from PlayN */

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtInput.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtInput.java
@@ -283,9 +283,9 @@ public class GwtInput implements Input {
 	public boolean isPeripheralAvailable (Peripheral peripheral) {
 		if (peripheral == Peripheral.Accelerometer) return false;
 		if (peripheral == Peripheral.Compass) return false;
-		if (peripheral == Peripheral.HardwareKeyboard) return true;
+		if (peripheral == Peripheral.HardwareKeyboard) return !GwtApplication.isMobileDevice();
 		if (peripheral == Peripheral.MultitouchScreen) return isTouchScreen();
-		if (peripheral == Peripheral.OnscreenKeyboard) return false;
+		if (peripheral == Peripheral.OnscreenKeyboard) return GwtApplication.isMobileDevice();
 		if (peripheral == Peripheral.Vibrator) return false;
 		return false;
 	}


### PR DESCRIPTION
At this point of time, it is not possible to detect if a hardware keyboard is connected on GWT. So we assume that a mobile device has a soft keyboard while a desktop device has a hardware keyboard.