### PR TITLE
GWT: AssetFilter changed to match Android build and file system restrictions

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/preloader/DefaultAssetFilter.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/preloader/DefaultAssetFilter.java
@@ -26,6 +26,9 @@ public class DefaultAssetFilter implements AssetFilter {
 
 	@Override
 	public boolean accept (String file, boolean isDirectory) {
+		String normFile = file.replace('\\', '/');
+		if (normFile.contains("/.")) return false;
+		if (normFile.contains("/_")) return false;
 		if (isDirectory && file.endsWith(".svn")) return false;
 		return true;
 	}


### PR DESCRIPTION
Fixed two issues with DefaultAssetFilter:

DefaultAssetFilter accepts files beginning with beginning full stops (for example .gitignore) and adds this files to the assets.txt. However, these files are (under Windows) not copied to war/assets leading to a JavaScript warning.

DefaultAssetFilter accepts files and folders beginning with an underscore in contrast to the Android build process were these files are not omitted when packaging the Android apk.