### PR TITLE
GWT: Default localization depending on user language

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/java/util/Locale.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/java/util/Locale.java
@@ -17,12 +17,7 @@
 
 package java.util;
 
-import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
-import java.io.ObjectStreamField;
 import java.io.Serializable;
-//import libcore.icu.ICU;
 
 
 /**
@@ -221,18 +216,7 @@ public final class Locale implements Cloneable, Serializable {
      */
     public static final Locale US = new Locale(true, "en", "US");
 
-//    /**
-//     * The current default locale. It is temporarily assigned to US because we
-//     * need a default locale to lookup the real default locale.
-//     */
-    private static Locale defaultLocale = US;
-
-//    static {
-//        String language = System.getProperty("user.language", "en");
-//        String region = System.getProperty("user.region", "US");
-//        String variant = System.getProperty("user.variant", "");
-//        defaultLocale = new Locale(language, region, variant);
-//    }
+    private static Locale defaultLocale = initDefault();
 
     private transient String countryCode;
     private transient String languageCode;
@@ -283,7 +267,6 @@ public final class Locale implements Cloneable, Serializable {
             return;
         }
 
-//        languageCode = language.toLowerCase(Locale.US);      // not supported by GWT
         languageCode = language.toLowerCase();
         // Map new language codes to the obsolete language
         // codes so the correct resource bundles will be used.
@@ -295,20 +278,11 @@ public final class Locale implements Cloneable, Serializable {
             languageCode = "ji";
         }
 
-//        countryCode = country.toUpperCase(Locale.US);      // not supported by GWT
         countryCode = country.toUpperCase();
 
         // Work around for be compatible with RI
         variantCode = variant;
     }
-
-//    @Override public Object clone() {
-//        try {
-//            return super.clone();
-//        } catch (CloneNotSupportedException e) {
-//            throw new AssertionError(e);
-//        }
-//    }
 
     /**
      * Returns true if {@code object} is a locale with the same language,
@@ -326,24 +300,6 @@ public final class Locale implements Cloneable, Serializable {
         }
         return false;
     }
-
-//    /**
-//     * Returns the system's installed locales. This array always includes {@code
-//     * Locale.US}, and usually several others. Most locale-sensitive classes
-//     * offer their own {@code getAvailableLocales} method, which should be
-//     * preferred over this general purpose method.
-//     *
-//     * @see java.text.BreakIterator#getAvailableLocales()
-//     * @see java.text.Collator#getAvailableLocales()
-//     * @see java.text.DateFormat#getAvailableLocales()
-//     * @see java.text.DateFormatSymbols#getAvailableLocales()
-//     * @see java.text.DecimalFormatSymbols#getAvailableLocales()
-//     * @see java.text.NumberFormat#getAvailableLocales()
-//     * @see java.util.Calendar#getAvailableLocales()
-//     */
-//    public static Locale[] getAvailableLocales() {
-//        return ICU.getAvailableLocales();
-//    }
 
     /**
      * Returns the country code for this locale, or {@code ""} if this locale
@@ -364,180 +320,26 @@ public final class Locale implements Cloneable, Serializable {
         return defaultLocale;
     }
 
-//    /**
-//     * Equivalent to {@code getDisplayCountry(Locale.getDefault())}.
-//     */
-//    public final String getDisplayCountry() {
-//        return getDisplayCountry(getDefault());
-//    }
-//
-//    /**
-//     * Returns the name of this locale's country, localized to {@code locale}.
-//     * Returns the empty string if this locale does not correspond to a specific
-//     * country.
-//     */
-//    public String getDisplayCountry(Locale locale) {
-//        if (countryCode.isEmpty()) {
-//            return "";
-//        }
-//        String result = ICU.getDisplayCountryNative(toString(), locale.toString());
-//        if (result == null) { // TODO: do we need to do this, or does ICU do it for us?
-//            result = ICU.getDisplayCountryNative(toString(), Locale.getDefault().toString());
-//        }
-//        return result;
-//    }
-//
-//    /**
-//     * Equivalent to {@code getDisplayLanguage(Locale.getDefault())}.
-//     */
-//    public final String getDisplayLanguage() {
-//        return getDisplayLanguage(getDefault());
-//    }
-//
-//    /**
-//     * Returns the name of this locale's language, localized to {@code locale}.
-//     * If the language name is unknown, the language code is returned.
-//     */
-//    public String getDisplayLanguage(Locale locale) {
-//        if (languageCode.isEmpty()) {
-//            return "";
-//        }
-//
-//        // http://b/8049507 --- frameworks/base should use fil_PH instead of tl_PH.
-//        // Until then, we're stuck covering their tracks, making it look like they're
-//        // using "fil" when they're not.
-//        String localeString = toString();
-//        if (languageCode.equals("tl")) {
-//            localeString = toNewString("fil", countryCode, variantCode);
-//        }
-//
-//        String result = ICU.getDisplayLanguageNative(localeString, locale.toString());
-//        if (result == null) { // TODO: do we need to do this, or does ICU do it for us?
-//            result = ICU.getDisplayLanguageNative(localeString, Locale.getDefault().toString());
-//        }
-//        return result;
-//    }
-//
-//    /**
-//     * Equivalent to {@code getDisplayName(Locale.getDefault())}.
-//     */
-//    public final String getDisplayName() {
-//        return getDisplayName(getDefault());
-//    }
-//
-//    /**
-//     * Returns this locale's language name, country name, and variant, localized
-//     * to {@code locale}. The exact output form depends on whether this locale
-//     * corresponds to a specific language, country and variant.
-//     *
-//     * <p>For example:
-//     * <ul>
-//     * <li>{@code new Locale("en").getDisplayName(Locale.US)} -> {@code English}
-//     * <li>{@code new Locale("en", "US").getDisplayName(Locale.US)} -> {@code English (United States)}
-//     * <li>{@code new Locale("en", "US", "POSIX").getDisplayName(Locale.US)} -> {@code English (United States,Computer)}
-//     * <li>{@code new Locale("en").getDisplayName(Locale.FRANCE)} -> {@code anglais}
-//     * <li>{@code new Locale("en", "US").getDisplayName(Locale.FRANCE)} -> {@code anglais (tats-Unis)}
-//     * <li>{@code new Locale("en", "US", "POSIX").getDisplayName(Locale.FRANCE)} -> {@code anglais (tats-Unis,informatique)}.
-//     * </ul>
-//     */
-//    public String getDisplayName(Locale locale) {
-//        int count = 0;
-//        StringBuilder buffer = new StringBuilder();
-//        if (!languageCode.isEmpty()) {
-//            String displayLanguage = getDisplayLanguage(locale);
-//            buffer.append(displayLanguage.isEmpty() ? languageCode : displayLanguage);
-//            ++count;
-//        }
-//        if (!countryCode.isEmpty()) {
-//            if (count == 1) {
-//                buffer.append(" (");
-//            }
-//            String displayCountry = getDisplayCountry(locale);
-//            buffer.append(displayCountry.isEmpty() ? countryCode : displayCountry);
-//            ++count;
-//        }
-//        if (!variantCode.isEmpty()) {
-//            if (count == 1) {
-//                buffer.append(" (");
-//            } else if (count == 2) {
-//                buffer.append(",");
-//            }
-//            String displayVariant = getDisplayVariant(locale);
-//            buffer.append(displayVariant.isEmpty() ? variantCode : displayVariant);
-//            ++count;
-//        }
-//        if (count > 1) {
-//            buffer.append(")");
-//        }
-//        return buffer.toString();
-//    }
-//
-//    /**
-//     * Returns the full variant name in the default {@code Locale} for the variant code of
-//     * this {@code Locale}. If there is no matching variant name, the variant code is
-//     * returned.
-//     */
-//    public final String getDisplayVariant() {
-//        return getDisplayVariant(getDefault());
-//    }
-//
-//    /**
-//     * Returns the full variant name in the specified {@code Locale} for the variant code
-//     * of this {@code Locale}. If there is no matching variant name, the variant code is
-//     * returned.
-//     */
-//    public String getDisplayVariant(Locale locale) {
-//        if (variantCode.length() == 0) {
-//            return variantCode;
-//        }
-//        String result = ICU.getDisplayVariantNative(toString(), locale.toString());
-//        if (result == null) { // TODO: do we need to do this, or does ICU do it for us?
-//            result = ICU.getDisplayVariantNative(toString(), Locale.getDefault().toString());
-//        }
-//        return result;
-//    }
-//
-//    /**
-//     * Returns the three-letter ISO 3166 country code which corresponds to the country
-//     * code for this {@code Locale}.
-//     * @throws MissingResourceException if there's no 3-letter country code for this locale.
-//     */
-//    public String getISO3Country() {
-//        String code = ICU.getISO3CountryNative(toString());
-//        if (!countryCode.isEmpty() && code.isEmpty()) {
-//            throw new MissingResourceException("No 3-letter country code for locale: " + this, "FormatData_" + this, "ShortCountry");
-//        }
-//        return code;
-//    }
-//
-//    /**
-//     * Returns the three-letter ISO 639-2/T language code which corresponds to the language
-//     * code for this {@code Locale}.
-//     * @throws MissingResourceException if there's no 3-letter language code for this locale.
-//     */
-//    public String getISO3Language() {
-//        String code = ICU.getISO3LanguageNative(toString());
-//        if (!languageCode.isEmpty() && code.isEmpty()) {
-//            throw new MissingResourceException("No 3-letter language code for locale: " + this, "FormatData_" + this, "ShortLanguage");
-//        }
-//        return code;
-//    }
-//
-//    /**
-//     * Returns an array of strings containing all the two-letter ISO 3166 country codes that can be
-//     * used as the country code when constructing a {@code Locale}.
-//     */
-//    public static String[] getISOCountries() {
-//        return ICU.getISOCountries();
-//    }
-//
-//    /**
-//     * Returns an array of strings containing all the two-letter ISO 639-1 language codes that can be
-//     * used as the language code when constructing a {@code Locale}.
-//     */
-//    public static String[] getISOLanguages() {
-//        return ICU.getISOLanguages();
-//    }
+    private static Locale initDefault() {
+        Locale defaultLoc = US;
+
+        String browserLanguage = getBrowserLanguage();
+
+        if (browserLanguage != null && browserLanguage.length() > 0) {
+            String[] locale = browserLanguage.split("-");
+
+            defaultLoc = new Locale(true, locale[0].toLowerCase(), locale.length > 1 ? locale[1].toUpperCase() : "");
+        }
+
+        return defaultLoc;
+    }
+
+    /**
+     * @return browser language in format "de", "en-US"
+     */
+    private native static String getBrowserLanguage() /*-{
+       return $wnd.navigator.languages ? $wnd.navigator.languages[0] : $wnd.navigator.userLanguage || $wnd.navigator.language;
+    }-*/;
 
     /**
      * Returns the language code for this {@code Locale} or the empty string if no language
@@ -618,26 +420,4 @@ public final class Locale implements Cloneable, Serializable {
         return result.toString();
     }
 
-//    private static final ObjectStreamField[] serialPersistentFields = {
-//        new ObjectStreamField("country", String.class),
-//        new ObjectStreamField("hashcode", int.class),
-//        new ObjectStreamField("language", String.class),
-//        new ObjectStreamField("variant", String.class),
-//    };
-//
-//    private void writeObject(ObjectOutputStream stream) throws IOException {
-//        ObjectOutputStream.PutField fields = stream.putFields();
-//        fields.put("country", countryCode);
-//        fields.put("hashcode", -1);
-//        fields.put("language", languageCode);
-//        fields.put("variant", variantCode);
-//        stream.writeFields();
-//    }
-//
-//    private void readObject(ObjectInputStream stream) throws IOException, ClassNotFoundException {
-//        ObjectInputStream.GetField fields = stream.readFields();
-//        countryCode = (String) fields.get("country", "");
-//        languageCode = (String) fields.get("language", "");
-//        variantCode = (String) fields.get("variant", "");
-//    }
 }


### PR DESCRIPTION
This commit gives I18NBundles on GWT backend the ability to switch to the user language returned from the browser by default, matching the behaviour on other platforms.

For testing, use Firefox and change the preferred language settings or use Chrome on Android and change the system language. (Chrome on desktop always returns the language of the operating system)

I made also a cleanup of the class, deleting all the lines that are just commented out for four years.