### PR TITLE
Overload AssetManager#isLoaded and #finishLoadingAsset to take AssetDescriptor as parameter

### DIFF
--- a/gdx/src/com/badlogic/gdx/assets/AssetManager.java
+++ b/gdx/src/com/badlogic/gdx/assets/AssetManager.java
@@ -262,6 +262,12 @@ public class AssetManager implements Disposable {
 		return null;
 	}
 
+	/** @param assetDesc the AssetDescriptor of the asset
+	 * @return whether the asset is loaded */
+	public synchronized boolean isLoaded (AssetDescriptor assetDesc) {
+		return isLoaded(assetDesc.fileName);
+	}
+	
 	/** @param fileName the file name of the asset
 	 * @return whether the asset is loaded */
 	public synchronized boolean isLoaded (String fileName) {
@@ -406,6 +412,12 @@ public class AssetManager implements Disposable {
 		log.debug("Loading complete.");
 	}
 
+	/** Blocks until the specified asset is loaded.
+	 * @param assetDesc the AssetDescriptor of the asset */
+	public void finishLoadingAsset (AssetDescriptor assetDesc) {
+		finishLoadingAsset(assetDesc.fileName);
+	}
+	
 	/** Blocks until the specified asset is loaded.
 	 * @param fileName the file name (interpretation depends on {@link AssetLoader}) */
 	public void finishLoadingAsset (String fileName) {


### PR DESCRIPTION
AssetManager#isLoaded and AssetManager#finishLoadingAsset normally only take a String for the filename of the asset.

If you want to check if an asset is loaded or you want the AssetManager to block for it to finish loading using an AssetDescriptor, you must use AssetDescriptor.fileName for these methods.

This change adds overloaded methods for both isLoaded and finishLoadingAsset to take an AssetDescriptor for convenience.