### PR TITLE
Fix issues with FileHandle's handling of extensions

### DIFF
--- a/gdx/src/com/badlogic/gdx/files/FileHandle.java
+++ b/gdx/src/com/badlogic/gdx/files/FileHandle.java
@@ -94,7 +94,7 @@ public class FileHandle {
 
 	public String extension () {
 		String name = file.getName();
-		int dotIndex = name.lastIndexOf('.');
+		int dotIndex = name.indexOf('.');
 		if (dotIndex == -1) return "";
 		return name.substring(dotIndex + 1);
 	}
@@ -102,7 +102,7 @@ public class FileHandle {
 	/** @return the name of the file, without parent paths or the extension. */
 	public String nameWithoutExtension () {
 		String name = file.getName();
-		int dotIndex = name.lastIndexOf('.');
+		int dotIndex = name.indexOf('.');
 		if (dotIndex == -1) return name;
 		return name.substring(0, dotIndex);
 	}
@@ -110,10 +110,8 @@ public class FileHandle {
 	/** @return the path and filename without the extension, e.g. dir/dir2/file.png -> dir/dir2/file. backward slashes will be
 	 *         returned as forward slashes. */
 	public String pathWithoutExtension () {
-		String path = file.getPath().replace('\\', '/');
-		int dotIndex = path.lastIndexOf('.');
-		if (dotIndex == -1) return path;
-		return path.substring(0, dotIndex);
+		File fileWithoutExtension = new File(file.getParent(), nameWithoutExtension());
+		return fileWithoutExtension.getPath().replace('\\', '/');
 	}
 
 	public FileType type () {


### PR DESCRIPTION
When calling FileHandle.extension() on "multi-part" file extensions (such as .tar.gz, .tar.bz2, etc) currently libgdx only returns the very end (gz, bz2) and doesn't include the first part (tar). This was creating a mess when searching for .tar.gz files.

There was also a problem with pathWithoutExtension() - paths with a dot in one of the parent directories but no actual file extension got truncated. (For example, "/adirectorywitha.dot/myfile" was truncated to "/adirectorywitha" instead of returning the original "/adirectorywitha.dot/myfile")

This PR fixes both issues.