### PR TITLE
gdx-controllers: LWJGL3 remove a redundant controller scan

### DIFF
--- a/extensions/gdx-controllers/gdx-controllers-lwjgl3/src/com/badlogic/gdx/controllers/lwjgl3/Lwjgl3ControllerManager.java
+++ b/extensions/gdx-controllers/gdx-controllers-lwjgl3/src/com/badlogic/gdx/controllers/lwjgl3/Lwjgl3ControllerManager.java
@@ -15,12 +15,6 @@ public class Lwjgl3ControllerManager implements ControllerManager {
 	final Array<ControllerListener> listeners = new Array<ControllerListener>();
 	
 	public Lwjgl3ControllerManager() {
-		for(int i = GLFW.GLFW_JOYSTICK_1; i < GLFW.GLFW_JOYSTICK_LAST; i++) {
-			if(GLFW.glfwJoystickPresent(i)) {
-				controllers.add(new Lwjgl3Controller(this, i));
-			}
-		}
-		
 		Gdx.app.postRunnable(new Runnable() {
 			@Override
 			public void run () {


### PR DESCRIPTION
Every call to `pollState()` will scan the list of controllers and allocate a new one if needed already.