### PR TITLE
Update Intersector.intersectPolygons()

### DIFF
--- a/gdx/src/com/badlogic/gdx/math/Intersector.java
+++ b/gdx/src/com/badlogic/gdx/math/Intersector.java
@@ -149,7 +149,7 @@ public final class Intersector {
 	private final static Vector2 s = new Vector2();
 	private final static Vector2 e = new Vector2();
 
-	/** Intersects two resulting polygons with the same winding and sets the overlap polygon resulting from the intersection.
+	/** Intersects two polygons with clockwise vertices and sets the overlap polygon resulting from the intersection.
 	 * Follows the Sutherland-Hodgman algorithm.
 	 *
 	 * @param p1 The polygon that is being clipped
@@ -157,13 +157,13 @@ public final class Intersector {
 	 * @param overlap The intersection of the two polygons (optional)
 	 * @return Whether the two polygons intersect. */
 	public static boolean intersectPolygons (Polygon p1, Polygon p2, Polygon overlap) {
+		if (p1.getVertices().length == 0 || p2.getVertices().length == 0) {
+			return false;
+		}
 		// reusable points to trace edges around polygon
 		floatArray2.clear();
 		floatArray.clear();
 		floatArray2.addAll(p1.getTransformedVertices());
-		if (p1.getVertices().length == 0 || p2.getVertices().length == 0) {
-			return false;
-		}
 		for (int i = 0; i < p2.getTransformedVertices().length; i += 2) {
 			ep1.set(p2.getTransformedVertices()[i], p2.getTransformedVertices()[i + 1]);
 			// wrap around to beginning of array if index points to end;
@@ -202,12 +202,15 @@ public final class Intersector {
 			floatArray.clear();
 		}
 		if (!(floatArray2.size == 0)) {
-			overlap.setVertices(floatArray2.toArray());
+			if(overlap != null)
+			{
+				overlap.setVertices(floatArray2.toArray());
+			}
 			return true;
 		} else {
 			return false;
 		}
-	}
+	}	
 
 	/** Returns the distance between the given line and point. Note the specified line is not a line segment. */
 	public static float distanceLinePoint (float startX, float startY, float endX, float endY, float pointX, float pointY) {

--- a/gdx/src/com/badlogic/gdx/math/Intersector.java
+++ b/gdx/src/com/badlogic/gdx/math/Intersector.java
@@ -202,8 +202,7 @@ public final class Intersector {
 			floatArray.clear();
 		}
 		if (!(floatArray2.size == 0)) {
-			if(overlap != null)
-			{
+			if (overlap != null) {
 				overlap.setVertices(floatArray2.toArray());
 			}
 			return true;

--- a/gdx/src/com/badlogic/gdx/math/Intersector.java
+++ b/gdx/src/com/badlogic/gdx/math/Intersector.java
@@ -154,7 +154,7 @@ public final class Intersector {
 	 *
 	 * @param p1 The polygon that is being clipped
 	 * @param p2 The clip polygon
-	 * @param overlap The intersection of the two polygons (optional)
+	 * @param overlap The intersection of the two polygons (can be null, if an intersection polygon is not needed)
 	 * @return Whether the two polygons intersect. */
 	public static boolean intersectPolygons (Polygon p1, Polygon p2, Polygon overlap) {
 		if (p1.getVertices().length == 0 || p2.getVertices().length == 0) {

--- a/gdx/src/com/badlogic/gdx/math/Intersector.java
+++ b/gdx/src/com/badlogic/gdx/math/Intersector.java
@@ -149,7 +149,7 @@ public final class Intersector {
 	private final static Vector2 s = new Vector2();
 	private final static Vector2 e = new Vector2();
 
-	/** Intersects two polygons with clockwise vertices and sets the overlap polygon resulting from the intersection.
+	/** Intersects two convex polygons with clockwise vertices and sets the overlap polygon resulting from the intersection.
 	 * Follows the Sutherland-Hodgman algorithm.
 	 *
 	 * @param p1 The polygon that is being clipped
@@ -210,7 +210,7 @@ public final class Intersector {
 		} else {
 			return false;
 		}
-	}	
+	}
 
 	/** Returns the distance between the given line and point. Note the specified line is not a line segment. */
 	public static float distanceLinePoint (float startX, float startY, float endX, float endY, float pointX, float pointY) {


### PR DESCRIPTION
Update to intersectPolygons:
- Move initial zero length vertices check up (minor optimization)
- Prevent crash when overlap polygon is null
- Update Javadoc to reflect that vertices need to be clockwise and the polygons need to be convex