### PR TITLE
Added missing ScrollPaneTextAreaTest to GdxTests

### DIFF
--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ScrollPaneTextAreaTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ScrollPaneTextAreaTest.java
@@ -13,7 +13,7 @@ import com.badlogic.gdx.tests.utils.GdxTest;
 import com.badlogic.gdx.utils.FloatArray;
 import com.badlogic.gdx.utils.viewport.ScreenViewport;
 
-public class TextAreaScrollTest  extends GdxTest {
+public class ScrollPaneTextAreaTest extends GdxTest {
 	Stage stage;
    TextArea textArea;
    ScrollPane scrollPane;

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
@@ -202,6 +202,7 @@ public class GdxTests {
 		ScrollPane2Test.class,
 		ScrollPaneScrollBarsTest.class,
 		ScrollPaneTest.class,
+		ScrollPaneTextAreaTest.class,
 		SelectTest.class,
 		SensorTest.class,
 		ShaderCollectionTest.class,


### PR DESCRIPTION
Renamed the test as to appear among the ScrollPane tests in the test launcher.
There are still bugs when embedding a TextArea in a scroll panel, one line always falls outside the scroll range.