### PR TITLE
Freetype - Add generator constructor which can specify which faceIndex to use

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,7 @@
 - SkinLoader can be used on subclasses of Skin by overriding generateSkin(). 
 - API addition: Tree indentation can be customized.
 - Fixed GlyphLayout not respecting BitmapFontData#down.
+- API Addition: Added faceIndex paramter to #FreeTypeFontGenerator(FileHandle, int).
 
 [1.9.8]
 - Add iPhoneX images

--- a/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGenerator.java
+++ b/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGenerator.java
@@ -84,10 +84,15 @@ public class FreeTypeFontGenerator implements Disposable {
 	boolean bitmapped = false;
 	private int pixelWidth, pixelHeight;
 
+	/** {@link #FreeTypeFontGenerator(FileHandle, int)} */
+	public FreeTypeFontGenerator (FileHandle fontFile) {
+		this(fontFile, 0);
+	}
+	
 	/** Creates a new generator from the given font file. Uses {@link FileHandle#length()} to determine the file size. If the file
 	 * length could not be determined (it was 0), an extra copy of the font bytes is performed. Throws a
 	 * {@link GdxRuntimeException} if loading did not succeed. */
-	public FreeTypeFontGenerator (FileHandle fontFile) {
+	public FreeTypeFontGenerator (FileHandle fontFile, int faceIndex) {
 		name = fontFile.pathWithoutExtension();
 		int fileSize = (int)fontFile.length();
 
@@ -113,7 +118,7 @@ public class FreeTypeFontGenerator implements Disposable {
 			StreamUtils.closeQuietly(input);
 		}
 
-		face = library.newMemoryFace(buffer, 0);
+		face = library.newMemoryFace(buffer, faceIndex);
 		if (face == null) throw new GdxRuntimeException("Couldn't create face for font: " + fontFile);
 
 		if (checkForBitmapFont()) return;


### PR DESCRIPTION
Faces are required to support [language dependent glyphs](https://en.wikipedia.org/wiki/Han_unification#Examples_of_language-dependent_glyphs) for most fonts.

An example/text vector would be [Noto Sans](https://noto-website-2.storage.googleapis.com/pkgs/NotoSansCJK-Medium.ttc.zip) where "今" changes between face 0 and 2.

Addition is backwards compatible to avoid breaking changes for such a minor addition.