### PR TITLE
GlyphLayout: wrap: remove whitespace at line end

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g2d/GlyphLayout.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/GlyphLayout.java
@@ -298,6 +298,17 @@ public class GlyphLayout implements Poolable {
 		while (widthIndex < wrapIndex)
 			first.width += first.xAdvances.get(widthIndex++);
 
+        // Remove whitespaces at the end of the line
+        int spaceIndex = wrapIndex - 1;
+        while (fontData.isWhitespace((char) first.glyphs.get(spaceIndex).id)) {
+            first.glyphs.removeIndex(spaceIndex);
+            final float removedXAdvance = first.xAdvances.removeIndex(spaceIndex);
+            first.width -= removedXAdvance;
+            spaceIndex--;
+            wrapIndex--;
+            widthIndex--;
+        }
+
 		// Reduce first run width by the wrapped glyphs that have contributed to the width.
 		while (widthIndex > wrapIndex + 1)
 			first.width -= first.xAdvances.get(--widthIndex);


### PR DESCRIPTION
Current behaviour:
GlyphLayout wrap does not remove spaces from line ends.
When the GlyphLayout wraps the text and halign is Align.right or Align.center the glyphs of all lines but the last line (which is fine as there are no space characters at the end) are not positioned where they should be:
Align.right: As the space character is still at the end of the line, the position is offset by xAdvanceOfSpaceCharacter from the very right where it should be
Align.center: As the space character is still at the end of the line, the position is offset by xAdvanceOfSpaceCharacter/2 from the very right where it should be

Fix:
Remove whitespace on wrap