### PR TITLE
Bugfix for GlyphLayout.wrap

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g2d/GlyphLayout.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/GlyphLayout.java
@@ -319,7 +319,7 @@ public class GlyphLayout implements Poolable {
 			FloatArray xAdvances2 = first.xAdvances; // Starts with all the xAdvances.
 			xAdvances1.addAll(xAdvances2, 0, wrapIndex + 1);
 			xAdvances2.removeRange(1, wrapIndex); // Leave first entry to be overwritten by next line.
-			xAdvances2.set(0, -glyphs2.first().xoffset * fontData.scaleX - fontData.padLeft);
+			xAdvances2.set(0, 0);
 			first.xAdvances = xAdvances1;
 			second.xAdvances = xAdvances2;
 			// Equivalent to:


### PR DESCRIPTION
GlyphLayout: wrap:
(Bug only visible with Align.left and wrapped lines)
On wrap the xAdvance of the seconds line should be 0.
The xAdvance of the second+ lines is aligned with that of the first line, so it should be 0.

In BitmapFontTest it can be observed: 

Adjust text to be Align.left, the top left text should look like this:

Sphinx of black
quartz, judge my
vow.

The second and third line are drawn 1 unit too far left because of:
GlyphLayout line 322:
xAdvances2.set(0, -glyphs2.first().xoffset * fontData.scaleX - fontData.padLeft);

-glyphs2.first().xoffset * fontData.scaleX - fontData.padLeft  = -(-19)*1 - 20 = -1

The second and third line start -1 units left of the first line.

It gets more obvious with bigger fontData.scaleX or not nearly equal glyphs2.first().xoffset and fontData.padLeft