### PR TITLE
 Put Batch calls in try-finally to allow recovery from thrown exceptions

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/Stage.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/Stage.java
@@ -125,8 +125,11 @@ public class Stage extends InputAdapter implements Disposable {
 		Batch batch = this.batch;
 		batch.setProjectionMatrix(camera.combined);
 		batch.begin();
-		root.draw(batch, 1);
-		batch.end();
+		try {
+			root.draw(batch, 1);
+		} finally {
+			batch.end();
+		}
 
 		if (debug) drawDebug();
 	}
@@ -165,8 +168,11 @@ public class Stage extends InputAdapter implements Disposable {
 		Gdx.gl.glEnable(GL20.GL_BLEND);
 		debugShapes.setProjectionMatrix(viewport.getCamera().combined);
 		debugShapes.begin();
-		root.drawDebug(debugShapes);
-		debugShapes.end();
+		try {
+			root.drawDebug(debugShapes);
+		} finally {
+			debugShapes.end();
+		}
 	}
 
 	/** Disables debug on all actors recursively except the specified actor and any children. */


### PR DESCRIPTION
Basically this will reset the state of the Batch objects so that if the code handles the exception they can go back to rendering normally without the complications of trying to call .end() on both Batch objects.

Git seems to give me issues with squishing my fork...
Hopefully next time I submit a pull request I'll get that working,
in the meantime sorry for the inconvenience...