### PR TITLE
GlyphLayout: Remove whitespace on line wrap

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g2d/GlyphLayout.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/GlyphLayout.java
@@ -177,6 +177,14 @@ public class GlyphLayout implements Poolable {
 								} else {
 									next = wrap(fontData, run, glyphRunPool, wrapIndex, i);
 									runs.add(next);
+
+									// Remove whitespace at the end of the run after wrap
+									if(fontData.isWhitespace((char)run.glyphs.peek().id)){
+										run.glyphs.pop();
+										float removedXAdvance = run.xAdvances.pop();
+										run.width -= removedXAdvance;
+									}
+
 									width = Math.max(width, run.x + run.width);
 								}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/GlyphLayoutWrapTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/GlyphLayoutWrapTest.java
@@ -1,0 +1,130 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogic.gdx.tests;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.Colors;
+import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.g2d.BitmapFont;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
+import com.badlogic.gdx.graphics.glutils.ShapeRenderer.ShapeType;
+import com.badlogic.gdx.scenes.scene2d.Stage;
+import com.badlogic.gdx.scenes.scene2d.ui.Label;
+import com.badlogic.gdx.scenes.scene2d.ui.Skin;
+import com.badlogic.gdx.tests.utils.GdxTest;
+import com.badlogic.gdx.utils.Align;
+import com.badlogic.gdx.utils.viewport.ScreenViewport;
+
+public class GlyphLayoutWrapTest extends GdxTest {
+    private Stage stage;
+    private SpriteBatch spriteBatch;
+    private BitmapFont font;
+    private ShapeRenderer renderer;
+    private Label label;
+
+    @Override
+    public void create() {
+        spriteBatch = new SpriteBatch();
+        // font = new BitmapFont(Gdx.files.internal("data/verdana39.fnt"), false);
+        font = new BitmapFont(Gdx.files.internal("data/arial-32-pad.fnt"), false);
+        // font = new FreeTypeFontGenerator(Gdx.files.internal("data/arial.ttf")).generateFont(new FreeTypeFontParameter());
+        font.getData().markupEnabled = true;
+        font.getData().breakChars = new char[]{'-'};
+
+        // Add user defined color
+        renderer = new ShapeRenderer();
+        renderer.setProjectionMatrix(spriteBatch.getProjectionMatrix());
+
+        stage = new Stage(new ScreenViewport());
+
+        Skin skin = new Skin(Gdx.files.internal("data/uiskin.json"));
+
+        BitmapFont labelFont = skin.get("default-font", BitmapFont.class);
+        labelFont.getData().markupEnabled = true;
+
+        // Notice that the last [] has been deliberately added to test the effect of excessive pop operations.
+        // They are silently ignored, as expected.
+        label = new Label("", skin);
+        stage.addActor(label);
+    }
+
+    @Override
+    public void render() {
+        if (Gdx.input.justTouched()) {
+            final float newScale = font.getData().scaleX == 1 ? 2 : 1;
+            font.getData().setScale(newScale);
+        }
+        label.setText("Resize window to adjust targetWidth of glyphLayouts\n" +
+                "Click to change scale of font (current: " + font.getData().scaleX + ")");
+        label.pack();
+
+        int viewHeight = Gdx.graphics.getHeight();
+
+        Gdx.gl.glClearColor(0, 0, 0, 1);
+        Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+
+        final int screenWidth = stage.getViewport().getScreenWidth();
+
+        label.setPosition(screenWidth / 2 - label.getWidth() / 2, 8);
+
+        // Test various font features.
+        spriteBatch.begin();
+
+        String text = "Sphinx of black quartz, judge my vow.";
+        font.setColor(Color.RED);
+
+        float spacing = 20;
+        float y = spacing;
+        float targetWidth = screenWidth / 3 - 2f * spacing;
+
+        font.draw(spriteBatch, text, spacing, viewHeight - y, targetWidth, Align.right, true);
+        font.draw(spriteBatch, text, targetWidth + 2 * spacing, viewHeight - y, targetWidth, Align.center, true);
+        font.draw(spriteBatch, text, 2 * targetWidth + 3 * spacing, viewHeight - y, targetWidth, Align.left, true);
+
+        spriteBatch.end();
+
+        float rectangleHeight = 400;
+
+        renderer.begin(ShapeType.Line);
+        renderer.setColor(Color.GREEN);
+        renderer.rect(spacing, viewHeight - y - rectangleHeight, targetWidth, rectangleHeight);
+        renderer.rect(targetWidth + 2 * spacing, viewHeight - y - rectangleHeight, targetWidth, rectangleHeight);
+        renderer.rect(2 * targetWidth + 3 * spacing, viewHeight - y - rectangleHeight, targetWidth, rectangleHeight);
+        renderer.end();
+
+        stage.act(Gdx.graphics.getDeltaTime());
+        stage.draw();
+    }
+
+    public void resize(int width, int height) {
+        spriteBatch.getProjectionMatrix().setToOrtho2D(0, 0, width, height);
+        renderer.setProjectionMatrix(spriteBatch.getProjectionMatrix());
+        stage.getViewport().update(width, height, true);
+    }
+
+    @Override
+    public void dispose() {
+        spriteBatch.dispose();
+        renderer.dispose();
+        font.dispose();
+
+        // Restore predefined colors
+        Colors.reset();
+    }
+}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
@@ -140,6 +140,7 @@ public class GdxTests {
 		GestureDetectorTest.class,
 		GLES30Test.class,
 		GLProfilerErrorTest.class,
+		GlyphLayoutWrapTest.class,
 		GroupCullingTest.class,
 		GroupFadeTest.class,
 		GroupTest.class,


### PR DESCRIPTION
GlyphLayout:
On line wrap the trailing whitepsace is not deleted and so all lines except the last are shifted left (in case of Align.right or Align.center) by the whitespace xAdvance.
Expected: Automatic line wrapping gives the same result as "\n" newline. 

Screenshots from BitmapFontTest, changed color of rectangle in line 212 to GREEN.

Before (with Align.right):
![beforeremovewhitespaceatend](https://user-images.githubusercontent.com/17275393/39301225-a797d65e-494e-11e8-9355-ddb899a7e343.png)

With (one) whitespace removed at run end after wrap (with Align.right):
![removewhitespaceatend](https://user-images.githubusercontent.com/17275393/39301295-e043fd3e-494e-11e8-9fca-d7091305c3e2.png)

Why after wrap? Because then you can just use peek() and pop() on the arrays and not removeIndex() which has to move whole arrays around.

If you scale the font e.g. set font.getData().scaleX = 2; in line 162 of BitmapFontTest and use Align.left, then there is a bug which is fixed by my other pull request:
https://github.com/libgdx/libgdx/pull/5189