### PR TITLE
Add game category to AndroidManifest

### DIFF
--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/android/AndroidManifest.xml
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/android/AndroidManifest.xml
@@ -7,6 +7,8 @@
     <application
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
+        android:isGame="true"
+        android:appCategory="game"
         android:label="@string/app_name"
         android:theme="@style/GdxTheme" >
         <activity


### PR DESCRIPTION
The category is used by some launchers to categorize the app icons.