### PR TITLE
Add focused to ButtonStyle

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Button.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Button.java
@@ -26,6 +26,7 @@ import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener.ChangeEvent;
 import com.badlogic.gdx.scenes.scene2d.utils.ClickListener;
 import com.badlogic.gdx.scenes.scene2d.utils.Disableable;
 import com.badlogic.gdx.scenes.scene2d.utils.Drawable;
+import com.badlogic.gdx.scenes.scene2d.utils.FocusListener;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.Pools;
 
@@ -43,6 +44,7 @@ import com.badlogic.gdx.utils.Pools;
 public class Button extends Table implements Disableable {
 	private ButtonStyle style;
 	boolean isChecked, isDisabled;
+	boolean focused;
 	ButtonGroup buttonGroup;
 	private ClickListener clickListener;
 	private boolean programmaticChangeEvents = true;
@@ -90,6 +92,12 @@ public class Button extends Table implements Disableable {
 			public void clicked (InputEvent event, float x, float y) {
 				if (isDisabled()) return;
 				setChecked(!isChecked, true);
+			}
+		});
+		addListener(new FocusListener() {
+			@Override
+			public void keyboardFocusChanged(FocusEvent event, Actor actor, boolean focused) {
+				Button.this.focused = focused;
 			}
 		});
 	}
@@ -171,14 +179,23 @@ public class Button extends Table implements Disableable {
 		if (isPressed() && !isDisabled()) {
 			background = style.down == null ? style.up : style.down;
 		} else {
-			if (isDisabled() && style.disabled != null)
+			if (isDisabled() && style.disabled != null) {
 				background = style.disabled;
-			else if (isChecked && style.checked != null)
-				background = (isOver() && style.checkedOver != null) ? style.checkedOver : style.checked;
-			else if (isOver() && style.over != null)
+			} else if (isChecked && style.checked != null) {
+				if (isOver() && style.checkedOver != null) {
+					background = style.checkedOver;
+				} else if(focused && style.checkedFocused != null) {
+					background = style.checkedFocused;
+				}else {
+					background = style.checked;
+				}
+			} else if (isOver() && style.over != null) {
 				background = style.over;
-			else
+			} else if(focused && style.focused != null) {
+				background = style.focused;
+			}else {
 				background = style.up;
+			}
 		}
 		setBackground(background);
 	}
@@ -203,16 +220,26 @@ public class Button extends Table implements Disableable {
 		boolean isOver = isOver();
 
 		Drawable background = null;
-		if (isDisabled && style.disabled != null)
+		if (isDisabled && style.disabled != null) {
 			background = style.disabled;
-		else if (isPressed && style.down != null)
+		} else if (isPressed && style.down != null) {
 			background = style.down;
-		else if (isChecked && style.checked != null)
-			background = (style.checkedOver != null && isOver) ? style.checkedOver : style.checked;
-		else if (isOver && style.over != null)
+		} else if (isChecked && style.checked != null) {
+			if (style.checkedOver != null && isOver) {
+				background = style.checkedOver;
+			} else if(style.checkedFocused != null && focused) {
+				background = style.checkedFocused;
+			} else {
+				background = style.checked;
+			}
+		} else if (isOver && style.over != null) {
 			background = style.over;
-		else if (style.up != null) //
+		} else if (focused && style.focused != null) {
+			background = style.focused;
+		}else if (style.up != null) //
+		{
 			background = style.up;
+		}
 		setBackground(background);
 
 		float offsetX = 0, offsetY = 0;
@@ -267,7 +294,7 @@ public class Button extends Table implements Disableable {
 	 * @author mzechner */
 	static public class ButtonStyle {
 		/** Optional. */
-		public Drawable up, down, over, checked, checkedOver, disabled;
+		public Drawable up, down, over, focused, checked, checkedOver, checkedFocused, disabled;
 		/** Optional. */
 		public float pressedOffsetX, pressedOffsetY, unpressedOffsetX, unpressedOffsetY, checkedOffsetX, checkedOffsetY;
 
@@ -284,8 +311,10 @@ public class Button extends Table implements Disableable {
 			this.up = style.up;
 			this.down = style.down;
 			this.over = style.over;
+			this.focused = style.focused;
 			this.checked = style.checked;
 			this.checkedOver = style.checkedOver;
+			this.checkedFocused = style.checkedFocused;
 			this.disabled = style.disabled;
 			this.pressedOffsetX = style.pressedOffsetX;
 			this.pressedOffsetY = style.pressedOffsetY;


### PR DESCRIPTION
This allows setting a background image for a button in focus.

Modeled it after the was the `focused` field is handled in `TextField`.

It's completely optional, shouldn't break any existing code.  `over` takes priority over `focused`.

`checkedFocused` also included.

Didn't add anything for the `Button` subclasses, but it would be reasonably simple to add equivalent fields for font color, checkbox, etc... in the appropriate subclasses.

The `if` statements I modified also have had curly braces added to match the recommendations in https://github.com/libgdx/libgdx/blob/master/.github/CONTRIBUTING.md

I've contributed in the past so I *believe* I've signed the CLA but if it's not on record I'd be happy to sign again.  I also didn't update `CONTRIBUTORS` or `CHANGES` since it's such a small change, but I'd be happy to do that as well if deemed appropriate.