### PR TITLE
Fixes #5191. Clear touch points on Android multi-touch ACTION_CANCEL event

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidMultiTouchHandler.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidMultiTouchHandler.java
@@ -60,7 +60,6 @@ public class AndroidMultiTouchHandler implements AndroidTouchHandler {
 			case MotionEvent.ACTION_UP:
 			case MotionEvent.ACTION_POINTER_UP:
 			case MotionEvent.ACTION_OUTSIDE:
-			case MotionEvent.ACTION_CANCEL:
 				realPointerIndex = input.lookUpPointerIndex(pointerId);
 				if (realPointerIndex == -1) break;
 				if (realPointerIndex >= AndroidInput.NUM_TOUCHES) break;
@@ -75,6 +74,18 @@ public class AndroidMultiTouchHandler implements AndroidTouchHandler {
 				input.deltaY[realPointerIndex] = 0;
 				input.touched[realPointerIndex] = false;
 				input.button[realPointerIndex] = 0;
+				break;
+
+			case MotionEvent.ACTION_CANCEL:
+				for (int i = 0; i < input.realId.length; i++) {
+					input.realId[i] = -1;
+					input.touchX[i] = 0;
+					input.touchY[i] = 0;
+					input.deltaX[i] = 0;
+					input.deltaY[i] = 0;
+					input.touched[i] = false;
+					input.button[i] = 0;
+				}
 				break;
 
 			case MotionEvent.ACTION_MOVE:


### PR DESCRIPTION
Fixes #5191. 

Tested on Samsung Galaxy S7 and Nexus 5X with libGDX test MultiTouchTest