### PR TITLE
fix TextureAtlas charset problem

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g2d/TextureAtlas.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/TextureAtlas.java
@@ -100,7 +100,7 @@ public class TextureAtlas implements Disposable {
 		final Array<Region> regions = new Array();
 
 		public TextureAtlasData (FileHandle packFile, FileHandle imagesDir, boolean flip) {
-			BufferedReader reader = new BufferedReader(new InputStreamReader(packFile.read()), 64);
+			BufferedReader reader = new BufferedReader(new InputStreamReader(packFile.read(), "UTF-8"), 64);
 			try {
 				Page pageImage = null;
 				while (true) {


### PR DESCRIPTION
It seems that .atlas files are always utf8. so the change will fix the unicode regionnames in atlas when the default charset is not utf8.