### PR TITLE
[Gradle] Android build.gradle - project.configurations.compile is deprecated

### DIFF
--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/android/build.gradle
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/android/build.gradle
@@ -97,7 +97,7 @@ eclipse {
     }
 
     classpath {
-        plusConfigurations += [ project.configurations.compile ]        
+        plusConfigurations += [ project.configurations.implementation ]        
         containers 'com.android.ide.eclipse.adt.ANDROID_FRAMEWORK', 'com.android.ide.eclipse.adt.LIBRARIES'       
     }
 
@@ -116,7 +116,7 @@ eclipse {
 idea {
     module {
         sourceDirs += file("src");
-        scopes = [ COMPILE: [plus:[project.configurations.compile]]]        
+        scopes = [ COMPILE: [plus:[project.configurations.implementation]]]        
 
         iml {
             withXml {


### PR DESCRIPTION
The task `project.configurations.compile` is deprecated and likely to be removed by the end of 2018. `implementation` is what is supposed to be used now. There may be more that needs to be changed, but this seems to conform with new Gradle guidelines.