### PR TITLE
FreeType - Use zero copy memory mapping when possible

### DIFF
--- a/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeType.java
+++ b/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeType.java
@@ -67,7 +67,8 @@ public class FreeType {
 		public void dispose () {
 			doneFreeType(address);
 			for(ByteBuffer buffer: fontData.values()) {
-				BufferUtils.disposeUnsafeByteBuffer(buffer);
+				if (BufferUtils.isUnsafeByteBuffer(buffer)) 
+					BufferUtils.disposeUnsafeByteBuffer(buffer);
 			}
 		}
 

--- a/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeType.java
+++ b/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeType.java
@@ -140,7 +140,8 @@ public class FreeType {
 			ByteBuffer buffer = library.fontData.get(address);
 			if(buffer != null) {
 				library.fontData.remove(address);
-				BufferUtils.disposeUnsafeByteBuffer(buffer);
+				if (BufferUtils.isUnsafeByteBuffer(buffer)) 
+					BufferUtils.disposeUnsafeByteBuffer(buffer);
 			}
 		}
 

--- a/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeType.java
+++ b/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeType.java
@@ -90,7 +90,8 @@ public class FreeType {
 		public Face newMemoryFace(ByteBuffer buffer, int faceIndex) {
 			long face = newMemoryFace(address, buffer, buffer.remaining(), faceIndex);
 			if(face == 0) {
-				BufferUtils.disposeUnsafeByteBuffer(buffer);
+				if (BufferUtils.isUnsafeByteBuffer(buffer)) 
+					BufferUtils.disposeUnsafeByteBuffer(buffer);
 				throw new GdxRuntimeException("Couldn't load font, FreeType error code: " + getLastErrorCode());
 			}
 			else {

--- a/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGenerator.java
+++ b/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGenerator.java
@@ -99,23 +99,32 @@ public class FreeTypeFontGenerator implements Disposable {
 		library = FreeType.initFreeType();
 		if (library == null) throw new GdxRuntimeException("Couldn't initialize FreeType");
 
-		ByteBuffer buffer;
-		InputStream input = fontFile.read();
+		ByteBuffer buffer = null;
+		
 		try {
-			if (fileSize == 0) {
-				// Copy to a byte[] to get the file size, then copy to the buffer.
-				byte[] data = StreamUtils.copyStreamToByteArray(input, fileSize > 0 ? (int)(fileSize * 1.5f) : 1024 * 16);
-				buffer = BufferUtils.newUnsafeByteBuffer(data.length);
-				BufferUtils.copy(data, 0, buffer, data.length);
-			} else {
-				// Trust the specified file size.
-				buffer = BufferUtils.newUnsafeByteBuffer(fileSize);
-				StreamUtils.copyStream(input, buffer);
+			buffer = fontFile.map();
+		} catch (GdxRuntimeException e) {
+			//Silently error, certain platforms do not support file mapping.
+		}
+		
+		if (buffer == null) {
+			InputStream input = fontFile.read();
+			try {
+				if (fileSize == 0) {
+					// Copy to a byte[] to get the file size, then copy to the buffer.
+					byte[] data = StreamUtils.copyStreamToByteArray(input, 1024 * 16);
+					buffer = BufferUtils.newUnsafeByteBuffer(data.length);
+					BufferUtils.copy(data, 0, buffer, data.length);
+				} else {
+					// Trust the specified file size.
+					buffer = BufferUtils.newUnsafeByteBuffer(fileSize);
+					StreamUtils.copyStream(input, buffer);
+				}
+			} catch (IOException ex) {
+				throw new GdxRuntimeException(ex);
+			} finally {
+				StreamUtils.closeQuietly(input);
 			}
-		} catch (IOException ex) {
-			throw new GdxRuntimeException(ex);
-		} finally {
-			StreamUtils.closeQuietly(input);
 		}
 
 		face = library.newMemoryFace(buffer, faceIndex);

--- a/gdx/src/com/badlogic/gdx/utils/BufferUtils.java
+++ b/gdx/src/com/badlogic/gdx/utils/BufferUtils.java
@@ -509,6 +509,12 @@ public final class BufferUtils {
 		allocatedUnsafe -= size;
 		freeMemory(buffer);
 	}
+	
+	public static boolean isUnsafeByteBuffer(ByteBuffer buffer) {
+		synchronized(unsafeBuffers) {
+			return unsafeBuffers.contains(buffer, true);
+		}
+	}
 
 	/** Allocates a new direct ByteBuffer from native heap memory using the native byte order. Needs to be disposed with
 	 * {@link #freeMemory(ByteBuffer)}.


### PR DESCRIPTION
Should allow a lower memory footprint and faster startup times on Desktop/Android.

Android requires users to manually edit their gradle config to include certain aaptOptions to not compress font files. Would we want to include this in the default project setup?

Such as:
`android {
aaptOptions {
    noCompress 'ttf', 'ttc', 'otf'
}
}`