### PR TITLE
fix buffer underflow with WAV file music read from jar, fixes #5254

### DIFF
--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/audio/Wav.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/audio/Wav.java
@@ -157,10 +157,17 @@ public class Wav {
 
 		public int read (byte[] buffer) throws IOException {
 			if (dataRemaining == 0) return -1;
-			int length = Math.min(super.read(buffer), dataRemaining);
-			if (length == -1) return -1;
-			dataRemaining -= length;
-			return length;
+			int offset = 0;
+			do {
+				int length = Math.min(super.read(buffer, offset, buffer.length - offset), dataRemaining);
+				if (length == -1) {
+					if (offset > 0) return offset;
+					return -1;
+				}
+				offset += length;
+				dataRemaining -= length;
+			} while (offset < buffer.length);
+			return offset;
 		}
 	}
 }

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/Wav.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/Wav.java
@@ -133,10 +133,17 @@ public class Wav {
 
 		public int read (byte[] buffer) throws IOException {
 			if (dataRemaining == 0) return -1;
-			int length = Math.min(super.read(buffer), dataRemaining);
-			if (length == -1) return -1;
-			dataRemaining -= length;
-			return length;
+			int offset = 0;
+			do {
+				int length = Math.min(super.read(buffer, offset, buffer.length - offset), dataRemaining);
+				if (length == -1) {
+					if (offset > 0) return offset;
+					return -1;
+				}
+				offset += length;
+				dataRemaining -= length;
+			} while (offset < buffer.length);
+			return offset;
 		}
 	}
 }


### PR DESCRIPTION
as explained in #5254 when a WAV file is read from a jar (desktop packaging), the music buffers are not correctly filled (not frame aligned) and OpenAL returns an error. The underlying input stream in this case doesn't respect Java specification : 

> Reads up to len bytes of data from this input stream into an array of bytes. If len is not zero, the method blocks until some input is available

I didn't investigate further since it's related to [zlib native java code](http://hg.openjdk.java.net/jdk7/jdk7/jdk/file/tip/src/share/classes/java/util/zip/ZipFile.java#l744) but i suspect inflater to just inflate a chunk which could give some random output sizes : I checked with debugger, the size returned was always different, sometimes odd sometimes even ...

I was able to test it locally by packaging a jar with the wav file, added it to the gdx-test project classpath and modify the MusicTest class as follow : 

```java
case WAV:
	music = Gdx.audio.newMusic(Gdx.files.classpath("music.wav"));
	songDuration = 13; // duration of music.wav in seconds
	break;
```