### PR TITLE
FileHandle#map compatibility for GWT

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidFileHandle.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidFileHandle.java
@@ -22,8 +22,8 @@ import java.io.FileInputStream;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
 
 import android.content.res.AssetFileDescriptor;
@@ -85,7 +85,7 @@ public class AndroidFileHandle extends FileHandle {
 		return super.read();
 	}
 
-	public MappedByteBuffer map (FileChannel.MapMode mode) {
+	public ByteBuffer map (FileChannel.MapMode mode) {
 		if (type == FileType.Internal) {
 			FileInputStream input = null;
 			try {
@@ -93,7 +93,7 @@ public class AndroidFileHandle extends FileHandle {
 				long startOffset = fd.getStartOffset();
 				long declaredLength = fd.getDeclaredLength();
 				input = new FileInputStream(fd.getFileDescriptor());
-				MappedByteBuffer map = input.getChannel().map(mode, startOffset, declaredLength);
+				ByteBuffer map = input.getChannel().map(mode, startOffset, declaredLength);
 				map.order(ByteOrder.nativeOrder());
 				return map;
 			} catch (Exception ex) {

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtFileHandle.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtFileHandle.java
@@ -28,7 +28,7 @@ import java.io.OutputStream;
 import java.io.Reader;
 import java.io.UnsupportedEncodingException;
 import java.io.Writer;
-import java.nio.MappedByteBuffer;
+import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 
 import com.badlogic.gdx.Files.FileType;
@@ -219,7 +219,7 @@ public class GwtFileHandle extends FileHandle {
 		return position - offset;
 	}
 
-	public MappedByteBuffer map (FileChannel.MapMode mode) {
+	public ByteBuffer map (FileChannel.MapMode mode) {
 		throw new GdxRuntimeException("Cannot map files in GWT backend");
 	}
 

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/java/io/RandomAccessFile.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/java/io/RandomAccessFile.java
@@ -16,6 +16,8 @@
 
 package java.io;
 
+import java.nio.channels.FileChannel;
+
 import com.google.gwt.storage.client.Storage;
 
 /** Saves binary data to the local storage; currently using hex encoding. The string is prefixed with "hex:"
@@ -23,7 +25,7 @@ import com.google.gwt.storage.client.Storage;
 public class RandomAccessFile /* implements DataOutput, DataInput, Closeable */{
 	
 /*
- * public final FileDescriptor getFD() throws IOException { } public final FileChannel getChannel() { }
+ * public final FileDescriptor getFD() throws IOException { }
  */
 	final String name;
 	final boolean writeable;
@@ -269,7 +271,7 @@ public class RandomAccessFile /* implements DataOutput, DataInput, Closeable */{
 		dos.writeUTF(str);
 	}
 
-// public final FileChannel getChannel() throws IOException { }
+	public final FileChannel getChannel() throws IOException { return null; }
 
 	class RafInputStream extends InputStream {
 		@Override

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/java/nio/channels/FileChannel.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/java/nio/channels/FileChannel.java
@@ -1,0 +1,17 @@
+package java.nio.channels;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel.MapMode;
+
+public abstract class FileChannel {
+
+   public static class MapMode {
+       public static final MapMode READ_ONLY = new MapMode();
+       public static final MapMode READ_WRITE = new MapMode();
+       public static final MapMode PRIVATE = new MapMode();
+   }
+
+   public abstract ByteBuffer map(MapMode mode, long position, long size);
+}

--- a/gdx/src/com/badlogic/gdx/files/FileHandle.java
+++ b/gdx/src/com/badlogic/gdx/files/FileHandle.java
@@ -33,8 +33,8 @@ import java.io.RandomAccessFile;
 import java.io.Reader;
 import java.io.UnsupportedEncodingException;
 import java.io.Writer;
+import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileChannel.MapMode;
 
@@ -264,19 +264,19 @@ public class FileHandle {
 
 	/** Attempts to memory map this file in READ_ONLY mode. Android files must not be compressed.
 	 * @throws GdxRuntimeException if this file handle represents a directory, doesn't exist, or could not be read, or memory mapping fails, or is a {@link FileType#Classpath} file. */
-	public MappedByteBuffer map () {
+	public ByteBuffer map () {
 		return map(MapMode.READ_ONLY);
 	}
 
 	/** Attempts to memory map this file. Android files must not be compressed.
 	 * @throws GdxRuntimeException if this file handle represents a directory, doesn't exist, or could not be read, or memory mapping fails, or is a {@link FileType#Classpath} file. */
-	public MappedByteBuffer map (FileChannel.MapMode mode) {
+	public ByteBuffer map (FileChannel.MapMode mode) {
 		if (type == FileType.Classpath) throw new GdxRuntimeException("Cannot map a classpath file: " + this);
 		RandomAccessFile raf = null;
 		try {
 			raf = new RandomAccessFile(file, mode == MapMode.READ_ONLY ? "r" : "rw");
 			FileChannel fileChannel = raf.getChannel();
-			MappedByteBuffer map = fileChannel.map(mode, 0, file.length());
+			ByteBuffer map = fileChannel.map(mode, 0, file.length());
 			map.order(ByteOrder.nativeOrder());
 			return map;
 		} catch (Exception ex) {


### PR DESCRIPTION
Fixes #5257

I don't think implementing a MappedByteBuffer class in GWT emu classes is worth the hassle. Android/Desktop specific code can always cast to MappedByteBuffer to invoke the 3 utility functions it implements.