### PR TITLE
StringBuilder.clear()

### DIFF
--- a/gdx/src/com/badlogic/gdx/utils/StringBuilder.java
+++ b/gdx/src/com/badlogic/gdx/utils/StringBuilder.java
@@ -1003,6 +1003,11 @@ public class StringBuilder implements Appendable, CharSequence {
 		return this;
 	}
 
+	/** Sets length to 0. */
+	public void clear () {
+		length = 0;
+	}
+
 	/** Inserts the string representation of the specified {@code boolean} value at the specified {@code offset}. The
 	 * {@code boolean} value is converted to a string according to the rule defined by {@link String#valueOf(boolean)}.
 	 * 


### PR DESCRIPTION
Convenience method clear() for StringBuilder.
Does exatcly the same thing as "stringBuilder.delete(0, stringBuilder.length)" without the in this case unnecessary System.arraycopy and is much nicer to write and understand.