### PR TITLE
Reverse the requirements on fields in copyFields()

### DIFF
--- a/gdx/src/com/badlogic/gdx/utils/Json.java
+++ b/gdx/src/com/badlogic/gdx/utils/Json.java
@@ -1056,18 +1056,18 @@ public class Json {
 	}
 
 	/** Each field on the <code>to</code> object is set to the value for the field with the same name on the <code>from</code>
-	 * object. The <code>from</code> object must have at least all the fields as the <code>to</code> object with the same name and
+	 * object. The <code>to</code> object must have at least all the fields of the <code>from</code> object with the same name and
 	 * type. */
 	public void copyFields (Object from, Object to) {
-		ObjectMap<String, FieldMetadata> fromFields = getFields(from.getClass());
-		for (ObjectMap.Entry<String, FieldMetadata> entry : getFields(to.getClass())) {
-			Field toField = entry.value.field;
-			FieldMetadata fromField = fromFields.get(entry.key);
-			if (fromField == null) throw new SerializationException("From object is missing field: " + toField.getName());
+		ObjectMap<String, FieldMetadata> toFields = getFields(from.getClass());
+		for (ObjectMap.Entry<String, FieldMetadata> entry: getFields(from.getClass())) {
+			FieldMetadata toField = toFields.get(entry.key);
+			Field fromField = entry.value.field;
+			if (toField == null) throw new SerializationException("To object is missing field" + entry.key);
 			try {
-				toField.set(to, fromField.field.get(from));
+				toField.field.set(to, fromField.get(from));
 			} catch (ReflectionException ex) {
-				throw new SerializationException("Error copying field: " + toField.getName(), ex);
+				throw new SerializationException("Error copying field: " + fromField.getName(), ex);
 			}
 		}
 	}

--- a/tests/gdx-tests-android/assets/data/uiskin.json
+++ b/tests/gdx-tests-android/assets/data/uiskin.json
@@ -14,7 +14,7 @@ ButtonStyle: {
 	toggle: { parent: default, checked: default-round-down }
 },
 TextButtonStyle: {
-	default: { down: default-round-down, up: default-round, font: default-font, fontColor: white },
+	default: { parent: default, font: default-font, fontColor: white },
 	toggle: { parent: default, checked: default-round-down, downFontColor: red }
 },
 ScrollPaneStyle: {
@@ -40,8 +40,8 @@ ProgressBarStyle: {
 	default-vertical: { background: default-slider, knob: default-round-large }
 },
 SliderStyle: {
-	default-horizontal: { background: default-slider, knob: default-slider-knob },
-	default-vertical: { background: default-slider, knob: default-round-large }
+	default-horizontal: { parent: default-horizontal },
+	default-vertical: { parent: default-vertical }
 },
 LabelStyle: {
 	default: { font: default-font, fontColor: white }


### PR DESCRIPTION
Reverse the requirements on fields in copyFields(), so superclass objects can be copied to subclass objects.

Fixes #5268: Allow superclasses to be used as parent styles in Skins