### PR TITLE
Shorthand constant for WHITE.toFloatBits()

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,7 @@
 - API Change: Actor#hit is now responsible for returning null if invisible. #5264
 - API Addition: Added [Collection]#isEmpty() method to all 22 custom LibGDX-collections (e.g. Array, ObjectMap, ObjectSet, Queue, ...)
 - API Addition: StringBuilder#clear()
+- API Addition: Color#WHITE_FLOAT_BITS
 
 [1.9.8]
 - Add iPhoneX images

--- a/gdx/src/com/badlogic/gdx/graphics/Color.java
+++ b/gdx/src/com/badlogic/gdx/graphics/Color.java
@@ -23,13 +23,16 @@ import com.badlogic.gdx.utils.NumberUtils;
  * 
  * @author mzechner */
 public class Color {
-	public static final Color CLEAR = new Color(0, 0, 0, 0);
-	public static final Color BLACK = new Color(0, 0, 0, 1);
-
-	public static final Color WHITE = new Color(0xffffffff);
+	public static final Color WHITE = new Color(1, 1, 1,1);
 	public static final Color LIGHT_GRAY = new Color(0xbfbfbfff);
 	public static final Color GRAY = new Color(0x7f7f7fff);
 	public static final Color DARK_GRAY = new Color(0x3f3f3fff);
+	public static final Color BLACK = new Color(0, 0, 0, 1);
+
+	/** Convenience for frequently used <code>WHITE.toFloatBits()</code> */
+	public static final float WHITE_FLOAT_BITS = WHITE.toFloatBits();
+
+	public static final Color CLEAR = new Color(0, 0, 0, 0);
 
 	public static final Color BLUE = new Color(0, 0, 1, 1);
 	public static final Color NAVY = new Color(0, 0, 0.5f, 1);

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFontCache.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFontCache.java
@@ -34,7 +34,6 @@ import com.badlogic.gdx.utils.Pools;
  * @author Alexander Dorokhov */
 public class BitmapFontCache {
 	static private final Color tempColor = new Color(1, 1, 1, 1);
-	static private final float whiteTint = Color.WHITE.toFloatBits();
 
 	private final BitmapFont font;
 	private boolean integer;
@@ -381,7 +380,7 @@ public class BitmapFontCache {
 			}
 		}
 
-		currentTint = whiteTint; // Cached glyphs have changed, reset the current tint.
+		currentTint = Color.WHITE_FLOAT_BITS; // Cached glyphs have changed, reset the current tint.
 	}
 
 	private void addGlyph (Glyph glyph, float x, float y, float color) {

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/NinePatch.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/NinePatch.java
@@ -222,7 +222,7 @@ public class NinePatch {
 	}
 
 	private void load (TextureRegion[] patches) {
-		final float color = Color.WHITE.toFloatBits(); // placeholder color, overwritten at draw time
+		final float color = Color.WHITE_FLOAT_BITS; // placeholder color, overwritten at draw time
 
 		if (patches[BOTTOM_LEFT] != null) {
 			bottomLeft = add(patches[BOTTOM_LEFT], color, false, false);

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/PolygonSpriteBatch.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/PolygonSpriteBatch.java
@@ -80,7 +80,7 @@ public class PolygonSpriteBatch implements Batch {
 	private ShaderProgram customShader;
 	private boolean ownsShader;
 
-	float color = Color.WHITE.toFloatBits();
+	float color = Color.WHITE_FLOAT_BITS;
 	private Color tempColor = new Color(1, 1, 1, 1);
 
 	/** Number of render calls since the last {@link #begin()}. **/

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/SpriteBatch.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/SpriteBatch.java
@@ -62,7 +62,7 @@ public class SpriteBatch implements Batch {
 	private ShaderProgram customShader = null;
 	private boolean ownsShader;
 
-	float color = Color.WHITE.toFloatBits();
+	float color = Color.WHITE_FLOAT_BITS;
 	private Color tempColor = new Color(1, 1, 1, 1);
 
 	/** Number of render calls since the last {@link #begin()}. **/

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/SpriteCache.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/SpriteCache.java
@@ -82,7 +82,7 @@ public class SpriteCache implements Disposable {
 	private final Array<Texture> textures = new Array(8);
 	private final IntArray counts = new IntArray(8);
 
-	private float color = Color.WHITE.toFloatBits();
+	private float color = Color.WHITE_FLOAT_BITS;
 	private Color tempColor = new Color(1, 1, 1, 1);
 
 	private ShaderProgram customShader = null;

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/MeshShaderTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/MeshShaderTest.java
@@ -34,8 +34,6 @@ public class MeshShaderTest extends GdxTest {
 	Mesh mesh, meshCustomVA;
 	Texture texture;
 	Matrix4 matrix = new Matrix4();
-	
-	private static final float FLOAT_WHITE = Color.WHITE.toFloatBits();
 
 	@Override
 	public void create () {
@@ -64,10 +62,10 @@ public class MeshShaderTest extends GdxTest {
 		meshCustomVA = new Mesh(true, 4, 6, VertexAttribute.Position(), VertexAttribute.ColorPacked(), 
 			new VertexAttribute(Usage.TextureCoordinates, 2, GL20.GL_UNSIGNED_SHORT, true, ShaderProgram.TEXCOORD_ATTRIBUTE + "0", 0));
 		meshCustomVA.setVertices(new float[] {
-			-0.5f, -0.5f, 0, FLOAT_WHITE, toSingleFloat(0, 1), 
-			0.5f, -0.5f, 0, FLOAT_WHITE, toSingleFloat(1, 1), 
-			0.5f, 0.5f, 0, FLOAT_WHITE, toSingleFloat(1, 0), 
-			-0.5f, 0.5f, 0, FLOAT_WHITE, toSingleFloat(0, 0)
+			-0.5f, -0.5f, 0, Color.WHITE_FLOAT_BITS, toSingleFloat(0, 1),
+			0.5f, -0.5f, 0, Color.WHITE_FLOAT_BITS, toSingleFloat(1, 1),
+			0.5f, 0.5f, 0, Color.WHITE_FLOAT_BITS, toSingleFloat(1, 0),
+			-0.5f, 0.5f, 0, Color.WHITE_FLOAT_BITS, toSingleFloat(0, 0)
 			});
 		meshCustomVA.setIndices(new short[] {0, 1, 2, 2, 3, 0});
 		


### PR DESCRIPTION
It is used often in libGDX, sometimes as a private constant. In my projects I often ended up creating such constant myself, but the correct place for it is arguably in the `Color` class itself.

One could argue that this special treatment of single color creates API asymmetry, but WHITE is somewhat special color, so this should be fine.

Some colors were reordered for consistency.