### PR TITLE
Fix #5280 - Added Independent setting to Particle Editor Life properties

### DIFF
--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/ScaledNumericPanel.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/ScaledNumericPanel.java
@@ -31,6 +31,7 @@ import javax.swing.JPanel;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 
+import com.badlogic.gdx.graphics.g2d.ParticleEmitter;
 import com.badlogic.gdx.graphics.g2d.ParticleEmitter.ScaledNumericValue;
 
 class ScaledNumericPanel extends EditorPanel {
@@ -38,6 +39,7 @@ class ScaledNumericPanel extends EditorPanel {
 	Slider lowMinSlider, lowMaxSlider;
 	Slider highMinSlider, highMaxSlider;
 	JCheckBox relativeCheckBox;
+	JCheckBox independentCheckbox;
 	Chart chart;
 	JPanel formPanel;
 	JButton expandButton;
@@ -48,7 +50,8 @@ class ScaledNumericPanel extends EditorPanel {
 		super(value, name, description);
 		this.value = value;
 
-		initializeComponents(chartTitle);
+		final boolean hasIndependent = value instanceof ParticleEmitter.IndependentScaledNumericValue;
+		initializeComponents(chartTitle, hasIndependent);
 
 		lowMinSlider.setValue(value.getLowMin());
 		lowMaxSlider.setValue(value.getLowMax());
@@ -56,6 +59,9 @@ class ScaledNumericPanel extends EditorPanel {
 		highMaxSlider.setValue(value.getHighMax());
 		chart.setValues(value.getTimeline(), value.getScaling());
 		relativeCheckBox.setSelected(value.isRelative());
+		if (hasIndependent) {
+			independentCheckbox.setSelected(((ParticleEmitter.IndependentScaledNumericValue)value).isIndependent());
+		}
 
 		lowMinSlider.addChangeListener(new ChangeListener() {
 			public void stateChanged (ChangeEvent event) {
@@ -85,6 +91,13 @@ class ScaledNumericPanel extends EditorPanel {
 				value.setRelative(relativeCheckBox.isSelected());
 			}
 		});
+		if (hasIndependent) {
+			independentCheckbox.addActionListener(new ActionListener() {
+				public void actionPerformed(ActionEvent event) {
+					((ParticleEmitter.IndependentScaledNumericValue) value).setIndependent(independentCheckbox.isSelected());
+				}
+			});
+		}
 
 		lowRangeButton.addActionListener(new ActionListener() {
 			public void actionPerformed (ActionEvent event) {
@@ -135,6 +148,9 @@ class ScaledNumericPanel extends EditorPanel {
 				layout.setConstraints(chart, chartConstraints);
 				layout.setConstraints(expandButton, expandButtonConstraints);
 				relativeCheckBox.setVisible(!expanded);
+				if (hasIndependent) {
+					independentCheckbox.setVisible(!expanded);
+				}
 				formPanel.setVisible(!expanded);
 				chart.revalidate();
 			}
@@ -148,7 +164,7 @@ class ScaledNumericPanel extends EditorPanel {
 		return formPanel;
 	}
 
-	private void initializeComponents (String chartTitle) {
+	private void initializeComponents (String chartTitle, boolean hasIndependent) {
 		JPanel contentPanel = getContentPanel();
 		{
 			formPanel = new JPanel(new GridBagLayout());
@@ -210,14 +226,21 @@ class ScaledNumericPanel extends EditorPanel {
 		}
 		{
 			expandButton = new JButton("+");
-			contentPanel.add(expandButton, new GridBagConstraints(7, 5, 1, 1, 1, 0, GridBagConstraints.SOUTHWEST,
+			contentPanel.add(expandButton, new GridBagConstraints(7, 5, 1, 1, 0, 0, GridBagConstraints.SOUTHWEST,
 				GridBagConstraints.NONE, new Insets(0, 5, 0, 0), 0, 0));
 			expandButton.setBorder(BorderFactory.createEmptyBorder(4, 8, 4, 8));
 		}
 		{
 			relativeCheckBox = new JCheckBox("Relative");
-			contentPanel.add(relativeCheckBox, new GridBagConstraints(7, 5, 1, 1, 0, 0, GridBagConstraints.NORTHWEST,
+			contentPanel.add(relativeCheckBox, new GridBagConstraints(8, 5, 1, 1, 1, 0, GridBagConstraints.NORTHWEST,
 				GridBagConstraints.NONE, new Insets(0, 6, 0, 0), 0, 0));
+		}
+		{
+			if (hasIndependent) {
+				independentCheckbox = new JCheckBox("Independent");
+				contentPanel.add(independentCheckbox, new GridBagConstraints(8, 5, 1, 1, 1, 0, GridBagConstraints.WEST,
+						GridBagConstraints.NONE, new Insets(0, 6, 0, 0), 0, 0));
+			}
 		}
 	}
 }

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/ScaledNumericPanel.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/ScaledNumericPanel.java
@@ -59,10 +59,8 @@ class ScaledNumericPanel extends EditorPanel {
 		highMaxSlider.setValue(value.getHighMax());
 		chart.setValues(value.getTimeline(), value.getScaling());
 		relativeCheckBox.setSelected(value.isRelative());
-		if (hasIndependent) {
+		if (hasIndependent)
 			independentCheckbox.setSelected(((ParticleEmitter.IndependentScaledNumericValue)value).isIndependent());
-		}
-
 		lowMinSlider.addChangeListener(new ChangeListener() {
 			public void stateChanged (ChangeEvent event) {
 				value.setLowMin((Float)lowMinSlider.getValue());
@@ -148,9 +146,8 @@ class ScaledNumericPanel extends EditorPanel {
 				layout.setConstraints(chart, chartConstraints);
 				layout.setConstraints(expandButton, expandButtonConstraints);
 				relativeCheckBox.setVisible(!expanded);
-				if (hasIndependent) {
+				if (hasIndependent)
 					independentCheckbox.setVisible(!expanded);
-				}
 				formPanel.setVisible(!expanded);
 				chart.revalidate();
 			}

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/ParticleEmitter.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/ParticleEmitter.java
@@ -22,7 +22,6 @@ import java.io.Writer;
 import java.util.Arrays;
 
 import com.badlogic.gdx.graphics.GL20;
-import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.math.Rectangle;
 import com.badlogic.gdx.math.collision.BoundingBox;
@@ -39,9 +38,9 @@ public class ParticleEmitter {
 	static private final int UPDATE_SPRITE = 1 << 7;
 	
 	private RangedNumericValue delayValue = new RangedNumericValue();
-	private ScaledNumericValue lifeOffsetValue = new ScaledNumericValue();
+	private IndependentScaledNumericValue lifeOffsetValue = new IndependentScaledNumericValue();
 	private RangedNumericValue durationValue = new RangedNumericValue();
-	private ScaledNumericValue lifeValue = new ScaledNumericValue();
+	private IndependentScaledNumericValue lifeValue = new IndependentScaledNumericValue();
 	private ScaledNumericValue emissionValue = new ScaledNumericValue();
 	private ScaledNumericValue xScaleValue = new ScaledNumericValue();
 	private ScaledNumericValue yScaleValue = new ScaledNumericValue();
@@ -361,13 +360,13 @@ public class ParticleEmitter {
 		emissionDiff = (int)emissionValue.newHighValue();
 		if (!emissionValue.isRelative()) emissionDiff -= emission;
 
-		life = (int)lifeValue.newLowValue();
-		lifeDiff = (int)lifeValue.newHighValue();
-		if (!lifeValue.isRelative()) lifeDiff -= life;
+		if (!lifeValue.independent) {
+			generateLifeValues();
+		}
 
-		lifeOffset = lifeOffsetValue.active ? (int)lifeOffsetValue.newLowValue() : 0;
-		lifeOffsetDiff = (int)lifeOffsetValue.newHighValue();
-		if (!lifeOffsetValue.isRelative()) lifeOffsetDiff -= lifeOffset;
+		if (!lifeOffsetValue.independent) {
+			generateLifeOffsetValues();
+		}
 
 		spawnWidth = spawnWidthValue.newLowValue();
 		spawnWidthDiff = spawnWidthValue.newHighValue();
@@ -419,6 +418,14 @@ public class ParticleEmitter {
 
 		float percent = durationTimer / (float)duration;
 		int updateFlags = this.updateFlags;
+
+		if (lifeValue.independent) {
+			generateLifeValues();
+		}
+
+		if (lifeOffsetValue.independent) {
+			generateLifeOffsetValues();
+		}
 
 		particle.currentLife = particle.life = life + (int)(lifeDiff * lifeValue.getScale(percent));
 
@@ -648,6 +655,20 @@ public class ParticleEmitter {
 		
 		return true;
 	}
+
+
+	private void generateLifeValues() {
+		life = (int) lifeValue.newLowValue();
+		lifeDiff = (int) lifeValue.newHighValue();
+		if (!lifeValue.isRelative()) lifeDiff -= life;
+	}
+
+	private void generateLifeOffsetValues() {
+		lifeOffset = lifeOffsetValue.active ? (int) lifeOffsetValue.newLowValue() : 0;
+		lifeOffsetDiff = (int) lifeOffsetValue.newHighValue();
+		if (!lifeOffsetValue.isRelative()) lifeOffsetDiff -= lifeOffset;
+	}
+
 
 	public void setPosition (float x, float y) {
 		if (attached) {
@@ -1484,6 +1505,54 @@ public class ParticleEmitter {
 			timeline = new float[value.timeline.length];
 			System.arraycopy(value.timeline, 0, timeline, 0, timeline.length);
 			relative = value.relative;
+		}
+	}
+
+	static public class IndependentScaledNumericValue extends ScaledNumericValue {
+
+		private boolean independent;
+
+		public boolean isIndependent() {
+			return independent;
+		}
+
+		public void setIndependent(boolean independent) {
+			this.independent = independent;
+		}
+
+
+		public void set (RangedNumericValue value){
+			if (value instanceof IndependentScaledNumericValue)
+				set((IndependentScaledNumericValue)value);
+			else
+				super.set(value);
+		}
+
+		public void set (ScaledNumericValue value){
+			super.set(value);
+			this.independent = independent;
+		}
+
+		public void save (Writer output) throws IOException {
+			super.save(output);
+			output.write("independent: " + independent + "\n");
+		}
+
+		public void load (BufferedReader reader) throws IOException {
+			super.load(reader);
+			// For backwards compatibility, independent property may not be defined
+			reader.mark(100);
+			String line = reader.readLine();
+			if (line == null) throw new IOException("Missing value: " + "independent");
+			if (line.contains("independent"))
+				independent = Boolean.parseBoolean(readString(line));
+			else
+				reader.reset();
+		}
+
+		public void load (IndependentScaledNumericValue value) {
+			super.load(value);
+			independent = value.independent;
 		}
 	}
 

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/ParticleEmitter.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/ParticleEmitter.java
@@ -360,13 +360,11 @@ public class ParticleEmitter {
 		emissionDiff = (int)emissionValue.newHighValue();
 		if (!emissionValue.isRelative()) emissionDiff -= emission;
 
-		if (!lifeValue.independent) {
+		if (!lifeValue.independent)
 			generateLifeValues();
-		}
 
-		if (!lifeOffsetValue.independent) {
+		if (!lifeOffsetValue.independent)
 			generateLifeOffsetValues();
-		}
 
 		spawnWidth = spawnWidthValue.newLowValue();
 		spawnWidthDiff = spawnWidthValue.newHighValue();
@@ -419,13 +417,11 @@ public class ParticleEmitter {
 		float percent = durationTimer / (float)duration;
 		int updateFlags = this.updateFlags;
 
-		if (lifeValue.independent) {
+		if (lifeValue.independent)
 			generateLifeValues();
-		}
 
-		if (lifeOffsetValue.independent) {
+		if (lifeOffsetValue.independent)
 			generateLifeOffsetValues();
-		}
 
 		particle.currentLife = particle.life = life + (int)(lifeDiff * lifeValue.getScale(percent));
 


### PR DESCRIPTION
Fixes #5280.

Added a new setting ("Independent" checkbox) to Life and Life Offset properties that allows that when defining a ranged value it affects each particle independently instead of all particles. The change is backwards compatible with previously created effects which should behave exactly like before.

As a side note, it has been quite challenging to add the new setting in a clean way (and it's still not great) due to how the Particle Editor is designed and the rigid particle effects file descriptor format. The 2D Particle system definitely deserves a good refactoring :).

There's a link to the new 2D Particle Editor .jar in the issue comments if you want to try it.

I'll squash changes when I get the Ok.

**Do changes to the Wiki need to be part of the PR?**