### PR TITLE
Add getter for the internal buffer in StringWriter

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/java/io/StringWriter.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/java/io/StringWriter.java
@@ -28,6 +28,10 @@ public class StringWriter extends Writer {
 	public String toString () {
 		return out.toString();
 	}
+	
+	public StringBuilder getBuffer() {
+		return out;
+	}
 
 	public void flush () throws IOException {
 	}


### PR DESCRIPTION
In contrast to the regular Java version of StringWriter, there is currently no way to access the internal buffer of the StringWriter used in libGDX. This patch adds a simple getter to allow this.

I realise that this will not be 100% source compatible with the Java StringWriter due to the use of StringBuffer and StringBuilder in the different implementations (but this is no different from the current situation). But it does make it possible to re-use StringWriter objects, and manipulate the buffer using the same function calls as in regular Java.