### PR TITLE
Small update to Intersector intersectSegmentPlane

### DIFF
--- a/gdx/src/com/badlogic/gdx/math/Intersector.java
+++ b/gdx/src/com/badlogic/gdx/math/Intersector.java
@@ -84,6 +84,7 @@ public final class Intersector {
 	public static boolean intersectSegmentPlane (Vector3 start, Vector3 end, Plane plane, Vector3 intersection) {
 		Vector3 dir = v0.set(end).sub(start);
 		float denom = dir.dot(plane.getNormal());
+		if (denom == 0f) return false;
 		float t = -(start.dot(plane.getNormal()) + plane.getD()) / denom;
 		if (t < 0 || t > 1) return false;
 


### PR DESCRIPTION
On rare occasions, Intersector.intersectSegmentPlane would set the intersect vector to (NaN,NaN,NaN) and return true. I found this was due to divide by zero error from denom. This could be my problem of not validating parameters but it would be helpful if a check was added to return false if denom == 0 or within epsilon.