### PR TITLE
Add getter for the internal buffer in StringWriter. In contrast to th…

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/java/io/StringWriter.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/java/io/StringWriter.java
@@ -11,14 +11,14 @@
 package java.io;
 
 public class StringWriter extends Writer {
-	private final StringBuilder out;
+	private final StringBuffer out;
 
 	public StringWriter() {
-		out = new StringBuilder();
+		out = new StringBuffer();
 	}
 	
 	public StringWriter(int initialCapacity) {
-		out = new StringBuilder(initialCapacity);
+		out = new StringBuffer(initialCapacity);
 	}
 	
 	public void write (char[] b, int offset, int length) throws IOException {
@@ -27,6 +27,10 @@ public class StringWriter extends Writer {
 
 	public String toString () {
 		return out.toString();
+	}
+	
+	public StringBuffer getBuffer() {
+		return out;
 	}
 
 	public void flush () throws IOException {


### PR DESCRIPTION
…e regular Java version of StringWriter, there is currently no way to access the internal buffer of the StringWriter used in libGDX. This patch adds a simple getter to allow this.

Use StringBuffer instead of StringBuilder to match API in regular JDK. There is no performance penalty incured in GWT by using StringBuffer.