### PR TITLE
Specify arrayType to avoid casting requirement in InputMultiplexer

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gwtref/GwtReflect.gwt.xml
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gwtref/GwtReflect.gwt.xml
@@ -42,6 +42,8 @@
 		value="com.badlogic.gdx.graphics.VertexAttribute" />
 	<extend-configuration-property name="gdx.reflect.include"
 		value="com.badlogic.gdx.graphics.g3d.model" />
+	<extend-configuration-property name="gdx.reflect.include"
+		value="com.badlogic.gdx.InputProcessor" />
 
 	<extend-configuration-property name="gdx.reflect.include"
 		value="com.badlogic.gdx.Net" />

--- a/gdx/src/com/badlogic/gdx/InputMultiplexer.java
+++ b/gdx/src/com/badlogic/gdx/InputMultiplexer.java
@@ -23,7 +23,7 @@ import com.badlogic.gdx.utils.SnapshotArray;
  * processor returns true, which indicates that the event was handled.
  * @author Nathan Sweet */
 public class InputMultiplexer implements InputProcessor {
-	private SnapshotArray<InputProcessor> processors = new SnapshotArray(4);
+	private SnapshotArray<InputProcessor> processors = new SnapshotArray(true, 4, InputProcessor.class);
 
 	public InputMultiplexer () {
 	}
@@ -74,10 +74,10 @@ public class InputMultiplexer implements InputProcessor {
 	}
 
 	public boolean keyDown (int keycode) {
-		Object[] items = processors.begin();
+		InputProcessor[] items = processors.begin();
 		try {
 			for (int i = 0, n = processors.size; i < n; i++)
-				if (((InputProcessor)items[i]).keyDown(keycode)) return true;
+				if (items[i].keyDown(keycode)) return true;
 		} finally {
 			processors.end();
 		}
@@ -85,10 +85,10 @@ public class InputMultiplexer implements InputProcessor {
 	}
 
 	public boolean keyUp (int keycode) {
-		Object[] items = processors.begin();
+		InputProcessor[] items = processors.begin();
 		try {
 			for (int i = 0, n = processors.size; i < n; i++)
-				if (((InputProcessor)items[i]).keyUp(keycode)) return true;
+				if (items[i].keyUp(keycode)) return true;
 		} finally {
 			processors.end();
 		}
@@ -96,10 +96,10 @@ public class InputMultiplexer implements InputProcessor {
 	}
 
 	public boolean keyTyped (char character) {
-		Object[] items = processors.begin();
+		InputProcessor[] items = processors.begin();
 		try {
 			for (int i = 0, n = processors.size; i < n; i++)
-				if (((InputProcessor)items[i]).keyTyped(character)) return true;
+				if (items[i].keyTyped(character)) return true;
 		} finally {
 			processors.end();
 		}
@@ -107,10 +107,10 @@ public class InputMultiplexer implements InputProcessor {
 	}
 
 	public boolean touchDown (int screenX, int screenY, int pointer, int button) {
-		Object[] items = processors.begin();
+		InputProcessor[] items = processors.begin();
 		try {
 			for (int i = 0, n = processors.size; i < n; i++)
-				if (((InputProcessor)items[i]).touchDown(screenX, screenY, pointer, button)) return true;
+				if (items[i].touchDown(screenX, screenY, pointer, button)) return true;
 		} finally {
 			processors.end();
 		}
@@ -118,10 +118,10 @@ public class InputMultiplexer implements InputProcessor {
 	}
 
 	public boolean touchUp (int screenX, int screenY, int pointer, int button) {
-		Object[] items = processors.begin();
+		InputProcessor[] items = processors.begin();
 		try {
 			for (int i = 0, n = processors.size; i < n; i++)
-				if (((InputProcessor)items[i]).touchUp(screenX, screenY, pointer, button)) return true;
+				if (items[i].touchUp(screenX, screenY, pointer, button)) return true;
 		} finally {
 			processors.end();
 		}
@@ -129,10 +129,10 @@ public class InputMultiplexer implements InputProcessor {
 	}
 
 	public boolean touchDragged (int screenX, int screenY, int pointer) {
-		Object[] items = processors.begin();
+		InputProcessor[] items = processors.begin();
 		try {
 			for (int i = 0, n = processors.size; i < n; i++)
-				if (((InputProcessor)items[i]).touchDragged(screenX, screenY, pointer)) return true;
+				if (items[i].touchDragged(screenX, screenY, pointer)) return true;
 		} finally {
 			processors.end();
 		}
@@ -140,10 +140,10 @@ public class InputMultiplexer implements InputProcessor {
 	}
 
 	public boolean mouseMoved (int screenX, int screenY) {
-		Object[] items = processors.begin();
+		InputProcessor[] items = processors.begin();
 		try {
 			for (int i = 0, n = processors.size; i < n; i++)
-				if (((InputProcessor)items[i]).mouseMoved(screenX, screenY)) return true;
+				if (items[i].mouseMoved(screenX, screenY)) return true;
 		} finally {
 			processors.end();
 		}
@@ -151,10 +151,10 @@ public class InputMultiplexer implements InputProcessor {
 	}
 
 	public boolean scrolled (int amount) {
-		Object[] items = processors.begin();
+		InputProcessor[] items = processors.begin();
 		try {
 			for (int i = 0, n = processors.size; i < n; i++)
-				if (((InputProcessor)items[i]).scrolled(amount)) return true;
+				if (items[i].scrolled(amount)) return true;
 		} finally {
 			processors.end();
 		}


### PR DESCRIPTION
Only downside is inconsequentially slower initialization time, but faster input processing should make up for that.