### PR TITLE
Set Android audio content type to music

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidAudio.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidAudio.java
@@ -52,7 +52,7 @@ public final class AndroidAudio implements Audio {
 			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
 				AudioAttributes audioAttrib = new AudioAttributes.Builder()
 						.setUsage(AudioAttributes.USAGE_GAME)
-						.setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+						.setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
 						.build();
 				soundPool = new SoundPool.Builder().setAudioAttributes(audioAttrib).setMaxStreams(config.maxSimultaneousSounds).build();
 			}else {


### PR DESCRIPTION
On https://github.com/libgdx/libgdx/pull/5091 I made a PR to update the SoundPool instantiation to use the new Builder API.

After some extensive testing with several devices I've found `AudioAttributes.CONTENT_TYPE_MUSIC` to be higher quality than `AudioAttributes.CONTENT_TYPE_SONIFICATION`. On Nexus devices (4, 5 and 5X) the difference is hardly noticeable but on a Samsung Galaxy S7 under stress (lots of sound played simultaneously) the difference is huge.

Even if the `AudioAttributes` class docs (https://developer.android.com/reference/android/media/AudioAttributes) says:

_CONTENT_TYPE_SONIFICATION Content type value to use when the content type is a sound used to accompany a user action, such as a beep or sound effect expressing a key click, or event, **such as the type of a sound for a bonus being received in a game.**_

what ends up happening in some implementations under stress is that sound quality decreases a lot and sounds "canned".

Also, according to Android documentation this is how mappings to old `STREAM_MUSIC` are made: https://source.android.com/devices/audio/attributes. Note how `CONTENT_TYPE_MUSIC` maps to `STREAM_MUSIC` which is more consistent with this change.

