### PR TITLE
Add proguard rule for AndroidVisibilityListener

### DIFF
--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/android/proguard-rules.pro
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/android/proguard-rules.pro
@@ -29,6 +29,7 @@
 -dontwarn com.badlogic.gdx.graphics.g2d.freetype.FreetypeBuild
 
 -keep class com.badlogic.gdx.controllers.android.AndroidControllers
+-keep class com.badlogic.gdx.backends.android.AndroidVisibilityListener { *; }
 
 -keepclassmembers class com.badlogic.gdx.backends.android.AndroidInput* {
    <init>(com.badlogic.gdx.Application, android.content.Context, java.lang.Object, com.badlogic.gdx.backends.android.AndroidApplicationConfiguration);


### PR DESCRIPTION
It is instantiated [via reflection](https://github.com/libgdx/libgdx/blob/master/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplication.java#L190) so proguard needs to know or else you get:

```
08-01 21:42:30.468 11993-11993/com.keenant.racer I/AndroidApplication: Failed to create AndroidVisibilityListener
    java.lang.NoSuchMethodException: createListener [interface com.badlogic.gdx.backends.android.AndroidApplicationBase]
        at java.lang.Class.getMethod(Class.java:2068)
        at java.lang.Class.getDeclaredMethod(Class.java:2047)
        at com.badlogic.gdx.backends.android.AndroidApplication.init(AndroidApplication.java:192)
        at com.badlogic.gdx.backends.android.AndroidApplication.initialize(AndroidApplication.java:100)
        at com.keenant.racer.AndroidLauncher.onCreate(AndroidLauncher.java:55)
        at android.app.Activity.performCreate(Activity.java:7009)
        at android.app.Activity.performCreate(Activity.java:7000)
        at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1214)
        at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2731)
        at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2856)
        at android.app.ActivityThread.-wrap11(Unknown Source:0)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1589)
        at android.os.Handler.dispatchMessage(Handler.java:106)
        at android.os.Looper.loop(Looper.java:164)
        at android.app.ActivityThread.main(ActivityThread.java:6494)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:438)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:807)
```