### PR TITLE
Removed unused minSDK and targetSDK on android manifest

### DIFF
--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/android/AndroidManifest.xml
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/android/AndroidManifest.xml
@@ -2,8 +2,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="%PACKAGE%" >
 
-    <uses-sdk android:minSdkVersion="9" android:targetSdkVersion="%API_LEVEL%" />
-
     <application
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"


### PR DESCRIPTION
The minSDK and targetSDK are configured on build.gradle, this settings are unused