### PR TITLE
Fixed comment typo in Music class

### DIFF
--- a/gdx/src/com/badlogic/gdx/audio/Music.java
+++ b/gdx/src/com/badlogic/gdx/audio/Music.java
@@ -37,7 +37,7 @@ import com.badlogic.gdx.utils.Disposable;
  * </p>
  * 
  * <p>
- * <b>Note<b>: any values provided will not be clamped, it is the developer's responsibility to do so
+ * <b>Note</b>: any values provided will not be clamped, it is the developer's responsibility to do so
  * </p>
  * 
  * @author mzechner */


### PR DESCRIPTION
The bold HTML tag class header comment was not closed. The same HTML tag is closed in the Sound class.

You can see this issue when viewing the Javadoc for the respective classes.

https://libgdx.badlogicgames.com/ci/nightlies/docs/api/com/badlogic/gdx/audio/Music.html
https://libgdx.badlogicgames.com/ci/nightlies/docs/api/com/badlogic/gdx/audio/Sound.html

Note that the _note_ at the of the comments are different.  This issue can be easily fixed by simply closing the bold tag in the Music class.