### PR TITLE
Fixed documentation for rotation in TiledMapTileLayer.Cell

### DIFF
--- a/gdx/src/com/badlogic/gdx/maps/tiled/TiledMapTileLayer.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/TiledMapTileLayer.java
@@ -137,14 +137,14 @@ public class TiledMapTileLayer extends MapLayer {
 			return this;
 		}
 
-		/** @return The rotation of this cell, in degrees. */
+		/** @return The rotation of this cell, in 90 degree increments. */
 		public int getRotation () {
 			return rotation;
 		}
 
-		/** Sets the rotation of this cell, in degrees.
+		/** Sets the rotation of this cell, in 90 degree increments.
 		 * 
-		 * @param rotation the rotation in degrees. 
+		 * @param rotation the rotation in 90 degree increments (see ints below). 
 		 * @return this, for method chaining */
 		public Cell setRotation (int rotation) {
 			this.rotation = rotation;


### PR DESCRIPTION
Documentation used to say it was in degrees, but it isn't. It's in 0-3 integer value which denotes 90 degree turns.

It is /never/ used as degrees. As shown in the screenshot below
https://i.imgur.com/RYeIucN.png