### PR TITLE
Fixes error with resolving android lint tool

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ allprojects {
         mavenCentral()
         jcenter()
         maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
-		google()
+        google()
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ allprojects {
         mavenCentral()
         jcenter()
         maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
+		google()
     }
 }
 


### PR DESCRIPTION
Fixes the error I get when I use ./gradlew build

>Execution failed for task ':tests:gdx-tests-android:lint'.
> Could not resolve all files for configuration ':tests:gdx-tests-android:lintClassPath'.
   > Could not find com.android.tools.lint:lint-gradle:26.1.0.
     Searched in the following locations:
         file:/opt/android-sdk/extras/m2repository/com/android/tools/lint/lint-gradle/26.1.0/lint-gradle-26.1.0.pom
         file:/opt/android-sdk/extras/m2repository/com/android/tools/lint/lint-gradle/26.1.0/lint-gradle-26.1.0.jar
         file:/opt/android-sdk/extras/google/m2repository/com/android/tools/lint/lint-gradle/26.1.0/lint-gradle-26.1.0.pom
         file:/opt/android-sdk/extras/google/m2repository/com/android/tools/lint/lint-gradle/26.1.0/lint-gradle-26.1.0.jar
         file:/opt/android-sdk/extras/android/m2repository/com/android/tools/lint/lint-gradle/26.1.0/lint-gradle-26.1.0.pom
         file:/opt/android-sdk/extras/android/m2repository/com/android/tools/lint/lint-gradle/26.1.0/lint-gradle-26.1.0.jar
         https://repo.maven.apache.org/maven2/com/android/tools/lint/lint-gradle/26.1.0/lint-gradle-26.1.0.pom
         https://repo.maven.apache.org/maven2/com/android/tools/lint/lint-gradle/26.1.0/lint-gradle-26.1.0.jar
         https://jcenter.bintray.com/com/android/tools/lint/lint-gradle/26.1.0/lint-gradle-26.1.0.pom
         https://jcenter.bintray.com/com/android/tools/lint/lint-gradle/26.1.0/lint-gradle-26.1.0.jar
         https://oss.sonatype.org/content/repositories/snapshots/com/android/tools/lint/lint-gradle/26.1.0/lint-gradle-26.1.0.pom
         https://oss.sonatype.org/content/repositories/snapshots/com/android/tools/lint/lint-gradle/26.1.0/lint-gradle-26.1.0.jar
     Required by:
         project :tests:gdx-tests-android
