### PR TITLE
Sprite class optimization

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g2d/Sprite.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/Sprite.java
@@ -135,6 +135,10 @@ public class Sprite extends TextureRegion {
 		this.height = height;
 
 		if (dirty) return;
+		if (rotation != 0 || scaleX != 1 || scaleY != 1) {
+			dirty = true;
+			return;
+		}
 
 		float x2 = x + width;
 		float y2 = y + height;
@@ -150,8 +154,6 @@ public class Sprite extends TextureRegion {
 
 		vertices[X4] = x2;
 		vertices[Y4] = y;
-
-		if (rotation != 0 || scaleX != 1 || scaleY != 1) dirty = true;
 	}
 
 	/** Sets the size of the sprite when drawn, before scaling and rotation are applied. If origin, rotation, or scale are changed,
@@ -162,6 +164,10 @@ public class Sprite extends TextureRegion {
 		this.height = height;
 
 		if (dirty) return;
+		if (rotation != 0 || scaleX != 1 || scaleY != 1) {
+			dirty = true;
+			return;
+		}
 
 		float x2 = x + width;
 		float y2 = y + height;
@@ -177,15 +183,13 @@ public class Sprite extends TextureRegion {
 
 		vertices[X4] = x2;
 		vertices[Y4] = y;
-
-		if (rotation != 0 || scaleX != 1 || scaleY != 1) dirty = true;
 	}
 
 	/** Sets the position where the sprite will be drawn. If origin, rotation, or scale are changed, it is slightly more efficient
 	 * to set the position after those operations. If both position and size are to be changed, it is better to use
 	 * {@link #setBounds(float, float, float, float)}. */
 	public void setPosition (float x, float y) {
-		translate(x - this.x, y - this.y);
+		setBounds(x, y, width, height);
 	}
 
 	/** Sets the position where the sprite will be drawn, relative to its current origin.  */
@@ -206,17 +210,17 @@ public class Sprite extends TextureRegion {
 	public void setY (float y) {
 		translateY(y - this.y);
 	}
-	
+
 	/** Sets the x position so that it is centered on the given x parameter */
 	public void setCenterX(float x){
 		setX(x - width / 2);
 	}
-	
+
 	/** Sets the y position so that it is centered on the given y parameter */
 	public void setCenterY(float y){
 		setY(y - height / 2);
 	}
-	
+
 	/** Sets the position so that the sprite is centered on (x, y) */
 	public void setCenter(float x, float y){
 		setCenterX(x);
@@ -482,7 +486,7 @@ public class Sprite extends TextureRegion {
 	/** Returns the bounding axis aligned {@link Rectangle} that bounds this sprite. The rectangles x and y coordinates describe its
 	 * bottom left corner. If you change the position or size of the sprite, you have to fetch the triangle again for it to be
 	 * recomputed.
-	 * 
+	 *
 	 * @return the bounding Rectangle */
 	public Rectangle getBoundingRectangle () {
 		final float[] vertices = getVertices();


### PR DESCRIPTION
After getting a suspicion, i modified my in-game code like this: (where o is a variable that gets incremented every frame) (this is part of a render() method)
```kotlin
if (o++ % 2 == 0) {
            shadow.setPosition(render.x, render.y - 3.px)
            body.setPosition(render.x + 4.5f.px, render.y + .5f.px)
            shirt.setPosition(render.x + 6f.px, render.y + 8f.px)
            pants.setPosition(render.x + 6f.px, render.y + 2f.px)
            if (!isCustomer) card.setPosition(render.x + 7.5f.px, render.y + 11.5f.px)
            head.setPosition(render.x + 3.5f.px, render.y + 13.5f.px + breathingY)
            face.setPosition(
                render.x + 5.px + bodyPartDiff.x * .5f,
                render.y + 15.px + bodyPartDiff.y * .5f
            )
            boots.rotation = MathUtils.sin(bootsSin) * 2f
            boots.setPosition(render.x + 4.5f.px, render.y)
        } else {
            shadow.setBounds(render.x, render.y - 3.px, shadow.width, shadow.height)
            body.setBounds(render.x + 4.5f.px, render.y + .5f.px, body.width, body.height)
            shirt.setBounds(render.x + 6f.px, render.y + 8f.px, shirt.width, shirt.height)
            pants.setBounds(render.x + 6f.px, render.y + 2f.px, pants.width, pants.height)
            if (!isCustomer) card.setBounds(render.x + 7.5f.px, render.y + 11.5f.px, card.width, card.height)
            head.setBounds(render.x + 3.5f.px, render.y + 13.5f.px + breathingY, head.width, head.height)
            face.setBounds(
                render.x + 5.px + bodyPartDiff.x * .5f,
                render.y + 15.px + bodyPartDiff.y * .5f,
                face.width, face.height
            )
            boots.rotation = MathUtils.sin(bootsSin) * 2f
            boots.setBounds(render.x + 4.5f.px, render.y, boots.width, boots.height)
        }
```
and ran the profiler:
![image](https://user-images.githubusercontent.com/1223388/45328599-ec3f7300-b55c-11e8-9564-bea5f3f85c2b.png)
my suspicions were confirmed - using `setBounds()` for changing position of a `Sprite` is faster than using `translate` with diff calculation - probably because `translate()` uses (almost?) twice as much memory access.

I've also modified `Sprite.setBounds()` and `Sprite.setSize()` function but i haven't profiled that. I just hope you guys agree it should make it faster in certain cases.