### PR TITLE
Upgrade source compatibility to Java 7

### DIFF
--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/android/build.gradle
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/android/build.gradle
@@ -92,8 +92,8 @@ eclipse {
     }
 
     jdt {
-        sourceCompatibility = 1.6
-        targetCompatibility = 1.6
+        sourceCompatibility = 1.7
+        targetCompatibility = 1.7
     }
 
     classpath {

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/core/build.gradle
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/core/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: "%LANG%"
 
-sourceCompatibility = 1.6
+sourceCompatibility = 1.7
 [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
 
 sourceSets.main.java.srcDirs = [ "src/" ]

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/desktop/build.gradle
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/desktop/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: "%LANG%"
 
-sourceCompatibility = 1.6
+sourceCompatibility = 1.7
 sourceSets.main.java.srcDirs = [ "src/" ]
 
 project.ext.mainClassName = "%PACKAGE%.desktop.DesktopLauncher"

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/html/build.gradle
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/html/build.gradle
@@ -76,7 +76,7 @@ task addSource {
 tasks.compileGwt.dependsOn(addSource)
 tasks.draftCompileGwt.dependsOn(addSource)
 
-sourceCompatibility = 1.6
+sourceCompatibility = 1.7
 sourceSets.main.java.srcDirs = [ "src/" ]
 
 


### PR DESCRIPTION
It should be safe now to upgrade source compatibility to Java 7 

Related https://github.com/libgdx/libgdx/issues/3244