### PR TITLE
Add overriden writePNG method with flipY as parameter

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/PixmapIO.java
+++ b/gdx/src/com/badlogic/gdx/graphics/PixmapIO.java
@@ -57,11 +57,11 @@ public class PixmapIO {
 
 	/** Writes the pixmap as a PNG with compression. See {@link PNG} to configure the compression level, more efficiently flip the
 	 * pixmap vertically, and to write out multiple PNGs with minimal allocation. */
-	static public void writePNG (FileHandle file, Pixmap pixmap) {
+	static public void writePNG (FileHandle file, Pixmap pixmap, boolean flipY) {
 		try {
 			PNG writer = new PNG((int)(pixmap.getWidth() * pixmap.getHeight() * 1.5f)); // Guess at deflated size.
 			try {
-				writer.setFlipY(false);
+				writer.setFlipY(flipY);
 				writer.write(file, pixmap);
 			} finally {
 				writer.dispose();
@@ -69,6 +69,10 @@ public class PixmapIO {
 		} catch (IOException ex) {
 			throw new GdxRuntimeException("Error writing PNG: " + file, ex);
 		}
+	}
+
+	static public void writePNG (FileHandle file, Pixmap pixmap) {
+		writePNG(file, pixmap, false);
 	}
 
 	/** @author mzechner */

--- a/gdx/src/com/badlogic/gdx/graphics/PixmapIO.java
+++ b/gdx/src/com/badlogic/gdx/graphics/PixmapIO.java
@@ -55,8 +55,9 @@ public class PixmapIO {
 		return CIM.read(file);
 	}
 
-	/** Writes the pixmap as a PNG with compression. See {@link PNG} to configure the compression level, more efficiently flip the
-	 * pixmap vertically, and to write out multiple PNGs with minimal allocation. */
+	/** Writes the pixmap as a PNG with compression. See {@link PNG} to configure the compression level
+	 *  and to write out multiple PNGs with minimal allocation.
+	 *  @param flipY flips the Pixmap vertically if true */
 	static public void writePNG (FileHandle file, Pixmap pixmap, boolean flipY) {
 		try {
 			PNG writer = new PNG((int)(pixmap.getWidth() * pixmap.getHeight() * 1.5f)); // Guess at deflated size.
@@ -71,6 +72,8 @@ public class PixmapIO {
 		}
 	}
 
+	/** Writes the pixmap as a PNG with compression. See {@link PNG} to configure the compression level, more efficiently flip the
+	 * pixmap vertically, and to write out multiple PNGs with minimal allocation. */
 	static public void writePNG (FileHandle file, Pixmap pixmap) {
 		writePNG(file, pixmap, false);
 	}

--- a/gdx/src/com/badlogic/gdx/graphics/PixmapIO.java
+++ b/gdx/src/com/badlogic/gdx/graphics/PixmapIO.java
@@ -55,14 +55,15 @@ public class PixmapIO {
 		return CIM.read(file);
 	}
 
-	/** Writes the pixmap as a PNG with compression. See {@link PNG} to configure the compression level
-	 *  and to write out multiple PNGs with minimal allocation.
-	 *  @param flipY flips the Pixmap vertically if true */
-	static public void writePNG (FileHandle file, Pixmap pixmap, boolean flipY) {
+	/** Writes the pixmap as a PNG. See {@link PNG} to write out multiple PNGs with minimal allocation.
+	 * @param compression sets the deflate compression level. Default is {@link Deflater#DEFAULT_COMPRESSION}
+	 * @param flipY flips the Pixmap vertically if true */
+	static public void writePNG (FileHandle file, Pixmap pixmap, int compression, boolean flipY) {
 		try {
 			PNG writer = new PNG((int)(pixmap.getWidth() * pixmap.getHeight() * 1.5f)); // Guess at deflated size.
 			try {
 				writer.setFlipY(flipY);
+				writer.setCompression(compression);
 				writer.write(file, pixmap);
 			} finally {
 				writer.dispose();
@@ -75,7 +76,7 @@ public class PixmapIO {
 	/** Writes the pixmap as a PNG with compression. See {@link PNG} to configure the compression level, more efficiently flip the
 	 * pixmap vertically, and to write out multiple PNGs with minimal allocation. */
 	static public void writePNG (FileHandle file, Pixmap pixmap) {
-		writePNG(file, pixmap, false);
+		writePNG(file, pixmap, Deflater.DEFAULT_COMPRESSION, false);
 	}
 
 	/** @author mzechner */


### PR DESCRIPTION
PNG libGDX class has an extremely efficient way to flip the Pixmap. Currently the writePNG utility method assumes the Pixmap is already flipped which is quite a heavy task if you need to flip it manually before. For example taking a screenshot using libGDX classes does this https://github.com/libgdx/libgdx/wiki/Taking-a-Screenshot. 

The new overriden method makes taking a screenshot more efficient (30ms improvement on a Nexus 5X) and simplifies the code to 3 lines:

`Pixmap pixmap = ScreenUtils.getFrameBufferPixmap(0, 0, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());`
`PixmapIO.writePNG(fh, pixmap, true);`
`pixmap.dispose();`


 