### PR TITLE
Ensure GWT backward compatibility for #5280 and #5373

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g2d/ParticleEmitter.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/ParticleEmitter.java
@@ -16,16 +16,16 @@
 
 package com.badlogic.gdx.graphics.g2d;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.Writer;
-import java.util.Arrays;
-
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.math.Rectangle;
 import com.badlogic.gdx.math.collision.BoundingBox;
 import com.badlogic.gdx.utils.Array;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.Writer;
+import java.util.Arrays;
 
 public class ParticleEmitter {
 	static private final int UPDATE_SCALE = 1 << 0;
@@ -1111,9 +1111,15 @@ public class ParticleEmitter {
 			emissionValue.load(reader);
 			reader.readLine();
 			lifeValue.load(reader);
-			reader.readLine();
+			// to ensure backward compatibility if independent paramater not defined
+			if(lifeValue.isIndependentDefined()) {
+				reader.readLine();
+			}
 			lifeOffsetValue.load(reader);
-			reader.readLine();
+			// to ensure backward compatibility if independent paramater not defined
+			if(lifeOffsetValue.isIndependentDefined) {
+				reader.readLine();
+			}
 			xOffsetValue.load(reader);
 			reader.readLine();
 			yOffsetValue.load(reader);
@@ -1503,12 +1509,18 @@ public class ParticleEmitter {
 
 	static public class IndependentScaledNumericValue extends ScaledNumericValue {
 		boolean independent;
+		boolean isIndependentDefined;
 
 		public boolean isIndependent () {
 			return independent;
 		}
 
+		public boolean isIndependentDefined () {
+			return isIndependentDefined;
+		}
+
 		public void setIndependent (boolean independent) {
+			this.isIndependentDefined = true;
 			this.independent = independent;
 		}
 
@@ -1529,6 +1541,7 @@ public class ParticleEmitter {
 		public void set (IndependentScaledNumericValue value) {
 			super.set(value);
 			independent = value.independent;
+			isIndependentDefined = value.isIndependentDefined;
 		}
 
 		public void save (Writer output) throws IOException {
@@ -1539,18 +1552,17 @@ public class ParticleEmitter {
 		public void load (BufferedReader reader) throws IOException {
 			super.load(reader);
 			// For backwards compatibility, independent property may not be defined
-			reader.mark(100);
 			String line = reader.readLine();
 			if (line == null) throw new IOException("Missing value: " + "independent");
-			if (line.contains("independent"))
-				independent = Boolean.parseBoolean(readString(line));
-			else
-				reader.reset();
+			if (line.contains("independent")) {
+				this.setIndependent(Boolean.parseBoolean(readString(line)));
+			}
 		}
 
 		public void load (IndependentScaledNumericValue value) {
 			super.load(value);
 			independent = value.independent;
+			isIndependentDefined = value.isIndependentDefined;
 		}
 	}
 

--- a/tests/gdx-tests-android/assets/data/particle-animation.p
+++ b/tests/gdx-tests-android/assets/data/particle-animation.p
@@ -31,7 +31,7 @@ timelineCount: 3
 timeline0: 0.0
 timeline1: 0.66
 timeline2: 1.0
-independent: true
+independent: false
 - Life Offset - 
 active: false
 independent: false

--- a/tests/gdx-tests-android/assets/data/particle-animation.p
+++ b/tests/gdx-tests-android/assets/data/particle-animation.p
@@ -31,6 +31,7 @@ timelineCount: 3
 timeline0: 0.0
 timeline1: 0.66
 timeline2: 1.0
+independent: true
 - Life Offset - 
 active: false
 - X Offset - 

--- a/tests/gdx-tests-android/assets/data/particle-animation.p
+++ b/tests/gdx-tests-android/assets/data/particle-animation.p
@@ -34,6 +34,7 @@ timeline2: 1.0
 independent: true
 - Life Offset - 
 active: false
+independent: false
 - X Offset - 
 active: false
 - Y Offset - 
@@ -60,7 +61,7 @@ scalingCount: 1
 scaling0: 1.0
 timelineCount: 1
 timeline0: 0.0
-- Scale - 
+- X Scale - 
 lowMin: 0.0
 lowMax: 0.0
 highMin: 32.0
@@ -70,6 +71,8 @@ scalingCount: 1
 scaling0: 1.0
 timelineCount: 1
 timeline0: 0.0
+- Y Scale - 
+active: false
 - Velocity - 
 active: true
 lowMin: 0.0

--- a/tests/gdx-tests-android/assets/data/singleTextureAllAdditive.p
+++ b/tests/gdx-tests-android/assets/data/singleTextureAllAdditive.p
@@ -30,6 +30,7 @@ timeline0: 0.0
 independent: true
 - Life Offset - 
 active: false
+independent: false
 - X Offset - 
 active: false
 - Y Offset - 
@@ -56,7 +57,7 @@ scalingCount: 1
 scaling0: 1.0
 timelineCount: 1
 timeline0: 0.0
-- Scale - 
+- X Scale - 
 lowMin: 0.0
 lowMax: 0.0
 highMin: 64.0
@@ -76,6 +77,8 @@ timeline2: 0.28767124
 timeline3: 0.4041096
 timeline4: 0.5753425
 timeline5: 0.70547944
+- Y Scale - 
+active: false
 - Velocity - 
 active: true
 lowMin: 0.0
@@ -147,7 +150,8 @@ aligned: false
 additive: true
 behind: false
 premultipliedAlpha: false
-- Image Path -
+spriteMode: single
+- Image Paths -
 particle-star.png
 
 
@@ -180,8 +184,10 @@ scalingCount: 1
 scaling0: 1.0
 timelineCount: 1
 timeline0: 0.0
+independent: false
 - Life Offset - 
 active: false
+independent: false
 - X Offset - 
 active: false
 - Y Offset - 
@@ -208,7 +214,7 @@ scalingCount: 1
 scaling0: 1.0
 timelineCount: 1
 timeline0: 0.0
-- Scale - 
+- X Scale - 
 lowMin: 0.0
 lowMax: 0.0
 highMin: 128.0
@@ -228,6 +234,8 @@ timeline2: 0.29452056
 timeline3: 0.4041096
 timeline4: 0.58219177
 timeline5: 0.70547944
+- Y Scale - 
+active: false
 - Velocity - 
 active: true
 lowMin: 0.0
@@ -299,7 +307,8 @@ aligned: false
 additive: true
 behind: false
 premultipliedAlpha: false
-- Image Path -
+spriteMode: single
+- Image Paths -
 particle-star.png
 
 
@@ -332,8 +341,10 @@ scalingCount: 1
 scaling0: 1.0
 timelineCount: 1
 timeline0: 0.0
+independent: false
 - Life Offset - 
 active: false
+independent: false
 - X Offset - 
 active: false
 - Y Offset - 
@@ -360,7 +371,7 @@ scalingCount: 1
 scaling0: 1.0
 timelineCount: 1
 timeline0: 0.0
-- Scale - 
+- X Scale - 
 lowMin: 0.0
 lowMax: 0.0
 highMin: 32.0
@@ -380,6 +391,8 @@ timeline2: 0.28767124
 timeline3: 0.4041096
 timeline4: 0.5753425
 timeline5: 0.70547944
+- Y Scale - 
+active: false
 - Velocity - 
 active: true
 lowMin: 0.0
@@ -455,5 +468,7 @@ aligned: false
 additive: true
 behind: false
 premultipliedAlpha: false
-- Image Path -
+spriteMode: single
+- Image Paths -
 particle-star.png
+

--- a/tests/gdx-tests-android/assets/data/singleTextureAllAdditive.p
+++ b/tests/gdx-tests-android/assets/data/singleTextureAllAdditive.p
@@ -27,6 +27,7 @@ scalingCount: 1
 scaling0: 1.0
 timelineCount: 1
 timeline0: 0.0
+independent: true
 - Life Offset - 
 active: false
 - X Offset - 

--- a/tests/gdx-tests-android/assets/data/singleTextureAllAdditive.p
+++ b/tests/gdx-tests-android/assets/data/singleTextureAllAdditive.p
@@ -27,7 +27,7 @@ scalingCount: 1
 scaling0: 1.0
 timelineCount: 1
 timeline0: 0.0
-independent: true
+independent: false
 - Life Offset - 
 active: false
 independent: false

--- a/tests/gdx-tests-android/assets/data/test.p
+++ b/tests/gdx-tests-android/assets/data/test.p
@@ -30,6 +30,7 @@ timeline0: 0.0
 independent: true
 - Life Offset - 
 active: false
+independent: false
 - X Offset - 
 active: false
 - Y Offset - 
@@ -56,7 +57,7 @@ scalingCount: 1
 scaling0: 1.0
 timelineCount: 1
 timeline0: 0.0
-- Scale - 
+- X Scale - 
 lowMin: 0.0
 lowMax: 0.0
 highMin: 32.0
@@ -66,6 +67,8 @@ scalingCount: 1
 scaling0: 1.0
 timelineCount: 1
 timeline0: 0.0
+- Y Scale - 
+active: false
 - Velocity - 
 active: true
 lowMin: 0.0
@@ -124,7 +127,8 @@ aligned: false
 additive: true
 behind: false
 premultipliedAlpha: false
-- Image Path -
+spriteMode: single
+- Image Paths -
 \Dev\libgdx\tests\gdx-tests-lwjgl\data/particle.png
 
 
@@ -157,8 +161,10 @@ scalingCount: 1
 scaling0: 1.0
 timelineCount: 1
 timeline0: 0.0
+independent: false
 - Life Offset - 
 active: false
+independent: false
 - X Offset - 
 active: false
 - Y Offset - 
@@ -185,7 +191,7 @@ scalingCount: 1
 scaling0: 1.0
 timelineCount: 1
 timeline0: 0.0
-- Scale - 
+- X Scale - 
 lowMin: 0.0
 lowMax: 0.0
 highMin: 80.0
@@ -195,6 +201,8 @@ scalingCount: 1
 scaling0: 1.0
 timelineCount: 1
 timeline0: 0.0
+- Y Scale - 
+active: false
 - Velocity - 
 active: true
 lowMin: 0.0
@@ -262,7 +270,8 @@ aligned: false
 additive: true
 behind: false
 premultipliedAlpha: false
-- Image Path -
+spriteMode: single
+- Image Paths -
 \Dev\libgdx\tests\gdx-tests-lwjgl\data/particle-fire.png
 
 
@@ -295,8 +304,10 @@ scalingCount: 1
 scaling0: 1.0
 timelineCount: 1
 timeline0: 0.0
+independent: false
 - Life Offset - 
 active: false
+independent: false
 - X Offset - 
 active: false
 - Y Offset - 
@@ -323,7 +334,7 @@ scalingCount: 1
 scaling0: 1.0
 timelineCount: 1
 timeline0: 0.0
-- Scale - 
+- X Scale - 
 lowMin: 0.0
 lowMax: 0.0
 highMin: 64.0
@@ -343,6 +354,8 @@ timeline2: 0.28767124
 timeline3: 0.4041096
 timeline4: 0.5753425
 timeline5: 0.70547944
+- Y Scale - 
+active: false
 - Velocity - 
 active: true
 lowMin: 0.0
@@ -424,7 +437,8 @@ aligned: false
 additive: true
 behind: false
 premultipliedAlpha: false
-- Image Path -
+spriteMode: single
+- Image Paths -
 \Dev\libgdx\tests\gdx-tests-lwjgl\data/particle-star.png
 
 
@@ -457,8 +471,10 @@ scalingCount: 1
 scaling0: 1.0
 timelineCount: 1
 timeline0: 0.0
+independent: false
 - Life Offset - 
 active: false
+independent: false
 - X Offset - 
 active: false
 - Y Offset - 
@@ -485,7 +501,7 @@ scalingCount: 1
 scaling0: 1.0
 timelineCount: 1
 timeline0: 0.0
-- Scale - 
+- X Scale - 
 lowMin: 0.0
 lowMax: 0.0
 highMin: 256.0
@@ -495,6 +511,8 @@ scalingCount: 1
 scaling0: 1.0
 timelineCount: 1
 timeline0: 0.0
+- Y Scale - 
+active: false
 - Velocity - 
 active: true
 lowMin: -25.0
@@ -568,5 +586,6 @@ aligned: false
 additive: true
 behind: false
 premultipliedAlpha: false
-- Image Path -
+spriteMode: single
+- Image Paths -
 \Dev\libgdx\tests\gdx-tests-lwjgl\data/particle-cloud.png

--- a/tests/gdx-tests-android/assets/data/test.p
+++ b/tests/gdx-tests-android/assets/data/test.p
@@ -27,6 +27,7 @@ scalingCount: 1
 scaling0: 1.0
 timelineCount: 1
 timeline0: 0.0
+independent: true
 - Life Offset - 
 active: false
 - X Offset - 

--- a/tests/gdx-tests-android/assets/data/test.p
+++ b/tests/gdx-tests-android/assets/data/test.p
@@ -27,7 +27,7 @@ scalingCount: 1
 scaling0: 1.0
 timelineCount: 1
 timeline0: 0.0
-independent: true
+independent: false
 - Life Offset - 
 active: false
 independent: false


### PR DESCRIPTION
This is to ensure the newly added `inpendendent` parameter (added here #5280) does not break the gwt module (as described here #5373)
Instead of using mark() and reset() which are not supported we read the line,
if it contains the new parameter we use it, if not we move on..

Tested on Desktop and as HTML module.