### PR TITLE
A Minor Problem Fix in ObjectMaps

### DIFF
--- a/gdx/src/com/badlogic/gdx/utils/ObjectFloatMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/ObjectFloatMap.java
@@ -373,6 +373,7 @@ public class ObjectFloatMap<K> implements Iterable<ObjectFloatMap.Entry<K>> {
 		if (index < lastIndex) {
 			keyTable[index] = keyTable[lastIndex];
 			valueTable[index] = valueTable[lastIndex];
+			keyTable[lastIndex] = null;
 		}
 	}
 

--- a/gdx/src/com/badlogic/gdx/utils/ObjectIntMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/ObjectIntMap.java
@@ -373,6 +373,7 @@ public class ObjectIntMap<K> implements Iterable<ObjectIntMap.Entry<K>> {
 		if (index < lastIndex) {
 			keyTable[index] = keyTable[lastIndex];
 			valueTable[index] = valueTable[lastIndex];
+			keyTable[lastIndex] = null;
 		}
 	}
 

--- a/gdx/src/com/badlogic/gdx/utils/ObjectMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/ObjectMap.java
@@ -372,9 +372,12 @@ public class ObjectMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 		if (index < lastIndex) {
 			keyTable[index] = keyTable[lastIndex];
 			valueTable[index] = valueTable[lastIndex];
+			keyTable[lastIndex] = null;
 			valueTable[lastIndex] = null;
-		} else
+		} else {
+			keyTable[lastIndex] = null;
 			valueTable[index] = null;
+		}
 	}
 
 	/** Returns true if the map is empty. */

--- a/gdx/src/com/badlogic/gdx/utils/ObjectSet.java
+++ b/gdx/src/com/badlogic/gdx/utils/ObjectSet.java
@@ -307,7 +307,10 @@ public class ObjectSet<T> implements Iterable<T> {
 		// If the removed location was not last, move the last tuple to the removed location.
 		stashSize--;
 		int lastIndex = capacity + stashSize;
-		if (index < lastIndex) keyTable[index] = keyTable[lastIndex];
+		if (index < lastIndex) {
+			keyTable[index] = keyTable[lastIndex];
+			keyTable[lastIndex] = null;
+		}
 	}
 
 	/** Returns true if the set is empty. */


### PR DESCRIPTION
```ObjectMap.removeStashIndex``` is not setting ```keyTable[lastIndex]``` back to null.
Though the conflicts are rare and the behavior is correct, in some cases it may cause a huge object stored in unaccesible ```keyTable``` regions but cannot be GCed.
Simple code to reproduce the case:
```java
import com.badlogic.gdx.utils.ObjectMap;
import com.badlogic.gdx.utils.reflect.ClassReflection;
import com.badlogic.gdx.utils.reflect.Field;
import com.badlogic.gdx.utils.reflect.ReflectionException;

public class TestGdxBuggyHashmap {
	public static class IllHashProducer {
		@Override
		public int hashCode() {
			return 0;
		}
	}
	
	public static void main(String[] args) {
		ObjectMap<IllHashProducer, Integer> testMap = new ObjectMap<>();
		// We now have a map of base capacity 64 and a small amount of stash capacity
		IllHashProducer key1 = new IllHashProducer();
		IllHashProducer key2 = new IllHashProducer();
		IllHashProducer key3 = new IllHashProducer();
		IllHashProducer key4 = new IllHashProducer();
		IllHashProducer key5 = new IllHashProducer();
		testMap.put(key1, 10);  // No conflicts
		testMap.put(key2, 12);  // No conflicts
		testMap.put(key3, 13);  // No conflicts
		
		testMap.put(key4, 14);  // Should be in stash
		testMap.put(key5, 15);  // Should be in stash
		System.out.println(testMap.remove(key4));
		// Remove from stash, now key5 is moved to the front
		System.out.println(testMap.remove(key5));
		// Remove from stash, but keyTable[lastIndex] is still storing key5
		System.out.println(testMap.remove(key2));
		// Control group
		
		try {
			Field field = ClassReflection.getDeclaredField(ObjectMap.class, "stashSize");
			field.setAccessible(true);
			field.set(testMap, 10);
			// Use an arbitary size to see whether key5 exists in the stash
			System.out.println(testMap.get(key5, 20));
			// Should give 20, but outputs null
			// So we can conclude that the key5 still exists in the keyTable
			System.out.println(testMap.get(key2, 20));
			// Gives 20 correctly
		} catch (ReflectionException e) {
			e.printStackTrace();
		}
	}
}
```
In my humble opinion, it's good to fix this.