### PR TITLE
Fix pixmap packer concurrency issue in splits

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g2d/PixmapPacker.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/PixmapPacker.java
@@ -715,7 +715,7 @@ public class PixmapPacker implements Disposable {
 		return pads;
 	}
 
-	private static Color c = new Color();
+	private Color c = new Color();
 	private int getSplitPoint (Pixmap raster, int startX, int startY, boolean startPoint, boolean xAxis) {
 		int[] rgba = new int[4];
 


### PR DESCRIPTION
Fixes an issue where using PixmapPacker in multiple threads would cause incorrect split values.