### PR TITLE
Add device information for new iPhone Xs models

### DIFF
--- a/backends/gdx-backend-moe/src/com/badlogic/gdx/backends/iosmoe/IOSDevice.java
+++ b/backends/gdx-backend-moe/src/com/badlogic/gdx/backends/iosmoe/IOSDevice.java
@@ -46,6 +46,10 @@ public enum IOSDevice {
 	IPHONE_8("iPhone10,4", 326),
     	IPHONE_8_PLUS("iPhone10,5", 401),
 	IPHONE_X("iPhone10,6", 458),
+	IPHONE_XR("iPhone11,8", 326),
+	IPHONE_XS("iPhone11,2", 458),
+	IPHONE_XS_MAX("iPhone11,4", 458),
+	IPHONE_XS_MAX_2_NANO_SIM("iPhone11,6", 458),
 	
 	IPOD_TOUCH_1G("iPod1,1", 163),
 	IPOD_TOUCH_2G("iPod2,1", 163),


### PR DESCRIPTION
Provide screen density information for the recent iPhone Xs models.

Information gathered from:

    https://www.theiphonewiki.com/wiki/Models ("iPhone10,3" style labels & screen density info)
    http://www.gsmarena.com/

Similar to #5295, #4911, #4037