### PR TITLE
Fix Missing Diamond Op

### DIFF
--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/Box2DTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/Box2DTest.java
@@ -163,7 +163,7 @@ public class Box2DTest extends GdxTest implements InputProcessor {
 
 		createBoxes();
 
-		Array<Fixture> fixtures = new Array<>();
+		Array<Fixture> fixtures = new Array<Fixture>();
 		world.getFixtures(fixtures);
 
 		// You can savely ignore the rest of this method :)


### PR DESCRIPTION
A diamond op is missing from `Box2DTest` which causes `gradle build` to fail.

#### If #5370 is pulled in, this PR may no longer be necessary as the generic `<>` operator was added in JDK 1.7.  
