### PR TITLE
[Scene2d] Fixed NPE for Cell.uniform

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Cell.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Cell.java
@@ -28,7 +28,7 @@ public class Cell<T extends Actor> implements Poolable {
 	Integer align;
 	Integer expandX, expandY;
 	Integer colspan;
-	Boolean uniformX, uniformY;
+	boolean uniformX, uniformY;
 
 	Actor actor;
 	float actorX, actorY;
@@ -607,20 +607,20 @@ public class Cell<T extends Actor> implements Poolable {
 
 	/** Sets uniformX and uniformY to true. */
 	public Cell<T> uniform () {
-		uniformX = Boolean.TRUE;
-		uniformY = Boolean.TRUE;
+		uniformX = true;
+		uniformY = true;
 		return this;
 	}
 
 	/** Sets uniformX to true. */
 	public Cell<T> uniformX () {
-		uniformX = Boolean.TRUE;
+		uniformX = true;
 		return this;
 	}
 
 	/** Sets uniformY to true. */
 	public Cell<T> uniformY () {
-		uniformY = Boolean.TRUE;
+		uniformY = true;
 		return this;
 	}
 
@@ -908,8 +908,8 @@ public class Cell<T extends Actor> implements Poolable {
 		expandX = null;
 		expandY = null;
 		colspan = null;
-		uniformX = null;
-		uniformY = null;
+		uniformX = false;
+		uniformY = false;
 	}
 
 	/** Reset state so the cell can be reused, setting all constraints to their {@link #defaults() default} values. */
@@ -971,8 +971,8 @@ public class Cell<T extends Actor> implements Poolable {
 		if (cell.expandX != null) expandX = cell.expandX;
 		if (cell.expandY != null) expandY = cell.expandY;
 		if (cell.colspan != null) colspan = cell.colspan;
-		if (cell.uniformX != null) uniformX = cell.uniformX;
-		if (cell.uniformY != null) uniformY = cell.uniformY;
+		uniformX = cell.uniformX;
+		uniformY = cell.uniformY;
 	}
 
 	public String toString () {
@@ -1005,8 +1005,8 @@ public class Cell<T extends Actor> implements Poolable {
 			defaults.expandX = zeroi;
 			defaults.expandY = zeroi;
 			defaults.colspan = onei;
-			defaults.uniformX = null;
-			defaults.uniformY = null;
+			defaults.uniformX = false;
+			defaults.uniformY = false;
 		}
 		return defaults;
 	}

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Table.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Table.java
@@ -874,12 +874,12 @@ public class Table extends WidgetGroup {
 			}
 
 			// Collect uniform sizes.
-			if (c.uniformX == Boolean.TRUE && c.colspan == 1) {
+			if (c.uniformX && c.colspan == 1) {
 				float hpadding = c.computedPadLeft + c.computedPadRight;
 				uniformMinWidth = Math.max(uniformMinWidth, columnMinWidth[column] - hpadding);
 				uniformPrefWidth = Math.max(uniformPrefWidth, columnPrefWidth[column] - hpadding);
 			}
-			if (c.uniformY == Boolean.TRUE) {
+			if (c.uniformY) {
 				float vpadding = c.computedPadTop + c.computedPadBottom;
 				uniformMinHeight = Math.max(uniformMinHeight, rowMinHeight[c.row] - vpadding);
 				uniformPrefHeight = Math.max(uniformPrefHeight, rowPrefHeight[c.row] - vpadding);
@@ -890,12 +890,12 @@ public class Table extends WidgetGroup {
 		if (uniformPrefWidth > 0 || uniformPrefHeight > 0) {
 			for (int i = 0; i < cellCount; i++) {
 				Cell c = cells.get(i);
-				if (uniformPrefWidth > 0 && c.uniformX == Boolean.TRUE && c.colspan == 1) {
+				if (uniformPrefWidth > 0 && c.uniformX && c.colspan == 1) {
 					float hpadding = c.computedPadLeft + c.computedPadRight;
 					columnMinWidth[c.column] = uniformMinWidth + hpadding;
 					columnPrefWidth[c.column] = uniformPrefWidth + hpadding;
 				}
-				if (uniformPrefHeight > 0 && c.uniformY == Boolean.TRUE) {
+				if (uniformPrefHeight > 0 && c.uniformY) {
 					float vpadding = c.computedPadTop + c.computedPadBottom;
 					rowMinHeight[c.row] = uniformMinHeight + vpadding;
 					rowPrefHeight[c.row] = uniformPrefHeight + vpadding;


### PR DESCRIPTION
uniformX, uniformY being Boolean and uninitialized causes many crashes on iOS.

No need for Boolean, primitive type is enough here.