### PR TITLE
Removed final from Material.copy

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g3d/Material.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/Material.java
@@ -70,7 +70,7 @@ public class Material extends Attributes {
 	}
 
 	/** Create a copy of this material */
-	public final Material copy () {
+	public Material copy () {
 		return new Material(this);
 	}
 	


### PR DESCRIPTION
This allows subclasses of Material to correctly copy themselves.
Also, the final keyword is rarely used on functions in LibGDX elsewhere.