### PR TITLE
Fix support for FontAwesome

### DIFF
--- a/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGenerator.java
+++ b/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGenerator.java
@@ -435,7 +435,7 @@ public class FreeTypeFontGenerator implements Disposable {
 			}
 
 			char c = characters[best];
-			if (getGlyph(c) == null) {
+			if (data.getGlyph(c) == null) {
 				Glyph glyph = createGlyph(c, data, parameter, stroker, baseLine, packer);
 				if (glyph != null) {
 					data.setGlyph(c, glyph);

--- a/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGenerator.java
+++ b/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGenerator.java
@@ -435,7 +435,7 @@ public class FreeTypeFontGenerator implements Disposable {
 			}
 
 			char c = characters[best];
-			if (!data.hasGlyph(c)) {
+			if (getGlyph(c) == null) {
 				Glyph glyph = createGlyph(c, data, parameter, stroker, baseLine, packer);
 				if (glyph != null) {
 					data.setGlyph(c, glyph);


### PR DESCRIPTION
For roboto.ttf, missingGlyph loaded in line 413 is not set because width/height are 0. However, when loading FontAwesome, missingGlyph is set, and then data.hasGlyph(c) returns true for all characters, even before they are loaded.