### PR TITLE
GWT: Set the viewport for mobiles to device's native resolution

### DIFF
--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/html/war/index
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/html/war/index
@@ -3,6 +3,7 @@
        <head>
               <title>%APP_NAME%</title>
               <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+              <meta id="gameViewport" name="viewport" content="width=device-width initial-scale=1">
               <link href="styles.css" rel="stylesheet" type="text/css">
               <script src="soundmanager2-setup.js"></script>
   			  <script src="soundmanager2-jsmin.js"></script>
@@ -15,6 +16,9 @@
        </body>
 
        <script>
+              document.getElementById('gameViewport').setAttribute('content',
+                 'width=device-width initial-scale=' + 1/window.devicePixelRatio);
+
               function handleMouseDown(evt) {
                 evt.preventDefault();
                 evt.stopPropagation();


### PR DESCRIPTION
This PR avoids blurry resolution when HTML5 build is played on smartphones. See #5340 for more information.