### PR TITLE
Minor JNI/C fixes

### DIFF
--- a/extensions/gdx-box2d/gdx-box2d/jni/com.badlogic.gdx.physics.box2d.joints.RopeJoint.cpp
+++ b/extensions/gdx-box2d/gdx-box2d/jni/com.badlogic.gdx.physics.box2d.joints.RopeJoint.cpp
@@ -42,7 +42,7 @@ JNIEXPORT jfloat JNICALL Java_com_badlogic_gdx_physics_box2d_joints_RopeJoint_jn
 
 }
 
-JNIEXPORT jfloat JNICALL Java_com_badlogic_gdx_physics_box2d_joints_RopeJoint_jniSetMaxLength(JNIEnv* env, jobject object, jlong addr, jfloat length) {
+JNIEXPORT void JNICALL Java_com_badlogic_gdx_physics_box2d_joints_RopeJoint_jniSetMaxLength(JNIEnv* env, jobject object, jlong addr, jfloat length) {
 
 
 //@line:80

--- a/extensions/gdx-box2d/gdx-box2d/jni/com.badlogic.gdx.physics.box2d.joints.RopeJoint.h
+++ b/extensions/gdx-box2d/gdx-box2d/jni/com.badlogic.gdx.physics.box2d.joints.RopeJoint.h
@@ -34,9 +34,9 @@ JNIEXPORT jfloat JNICALL Java_com_badlogic_gdx_physics_box2d_joints_RopeJoint_jn
 /*
  * Class:     com_badlogic_gdx_physics_box2d_joints_RopeJoint
  * Method:    jniSetMaxLength
- * Signature: (JF)F
+ * Signature: (JF)V
  */
-JNIEXPORT jfloat JNICALL Java_com_badlogic_gdx_physics_box2d_joints_RopeJoint_jniSetMaxLength
+JNIEXPORT void JNICALL Java_com_badlogic_gdx_physics_box2d_joints_RopeJoint_jniSetMaxLength
   (JNIEnv *, jobject, jlong, jfloat);
 
 #ifdef __cplusplus

--- a/extensions/gdx-box2d/gdx-box2d/src/com/badlogic/gdx/physics/box2d/joints/RopeJoint.java
+++ b/extensions/gdx-box2d/gdx-box2d/src/com/badlogic/gdx/physics/box2d/joints/RopeJoint.java
@@ -77,7 +77,7 @@ public class RopeJoint extends Joint {
 		jniSetMaxLength(addr, length);
 	}
 
-	private native float jniSetMaxLength (long addr, float length); /*
+	private native void jniSetMaxLength (long addr, float length); /*
 		b2RopeJoint* rope = (b2RopeJoint*)addr;
 		rope->SetMaxLength(length);
 	*/

--- a/gdx/jni/gdx2d/gdx2d.c
+++ b/gdx/jni/gdx2d/gdx2d.c
@@ -848,9 +848,9 @@ static inline void blit_bilinear(const gdx2d_pixmap* src_pixmap, const gdx2d_pix
 			const void* src_ptr = src_pixmap->pixels + sx * sbpp + sy * spitch;
 			uint32_t c1 = 0, c2 = 0, c3 = 0, c4 = 0;
 			c1 = to_RGBA8888(src_pixmap->format, pget((void*)src_ptr));
-			if(sx + 1 < src_width) c2 = to_RGBA8888(src_pixmap->format, pget((void*)(src_ptr + sbpp))); else c2 = c1;
-			if(sy + 1< src_height) c3 = to_RGBA8888(src_pixmap->format, pget((void*)(src_ptr + spitch))); else c3 = c1;
-			if(sx + 1< src_width && sy + 1 < src_height) c4 = to_RGBA8888(src_pixmap->format, pget((void*)(src_ptr + spitch + sbpp))); else c4 = c1;
+			if(sx + 1 < src_width) c2 = to_RGBA8888(src_pixmap->format, pget((void*)((char*)src_ptr + sbpp))); else c2 = c1;
+			if(sy + 1< src_height) c3 = to_RGBA8888(src_pixmap->format, pget((void*)((char*)src_ptr + spitch))); else c3 = c1;
+			if(sx + 1< src_width && sy + 1 < src_height) c4 = to_RGBA8888(src_pixmap->format, pget((void*)((char*)src_ptr + spitch + sbpp))); else c4 = c1;
 
 			float ta = (1 - x_diff) * (1 - y_diff);
 			float tb = (x_diff) * (1 - y_diff);


### PR DESCRIPTION
Discovered these while compiling with VC:
* gdx2d.c: use char* instead of void* for pointer arithmetic.
* gdx-box2d: fixed return type for jniSetMaxLength (should be void).