### PR TITLE
Allow handling of zero length indices which indicates a non-indexed mesh part.

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g3d/Model.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/Model.java
@@ -237,6 +237,7 @@ public class Model implements Disposable {
 		for (ModelMeshPart part : modelMesh.parts) {
 			numIndices += part.indices.length;
 		}
+		boolean hasIndices = numIndices > 0;
 		VertexAttributes attributes = new VertexAttributes(modelMesh.attributes);
 		int numVertices = modelMesh.vertices.length / (attributes.vertexSize / 4);
 
@@ -252,9 +253,11 @@ public class Model implements Disposable {
 			meshPart.id = part.id;
 			meshPart.primitiveType = part.primitiveType;
 			meshPart.offset = offset;
-			meshPart.size = part.indices.length > 0 ? part.indices.length : numVertices;
+			meshPart.size = hasIndices ? part.indices.length : numVertices;
 			meshPart.mesh = mesh;
-			mesh.getIndicesBuffer().put(part.indices);
+			if (hasIndices) {
+				mesh.getIndicesBuffer().put(part.indices);
+			}
 			offset += meshPart.size;
 			meshParts.add(meshPart);
 		}

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/Model.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/Model.java
@@ -252,7 +252,7 @@ public class Model implements Disposable {
 			meshPart.id = part.id;
 			meshPart.primitiveType = part.primitiveType;
 			meshPart.offset = offset;
-			meshPart.size = part.indices.length;
+			meshPart.size = part.indices.length > 0 ? part.indices.length : numVertices;
 			meshPart.mesh = mesh;
 			mesh.getIndicesBuffer().put(part.indices);
 			offset += meshPart.size;


### PR DESCRIPTION
I know the ObjLoader isn't considered production ready, but I have an improvement that allows loading large models without using indexing. Although there is talk about the number of vertices in an OBJ needing to be less than 32k to prevent index overflow, it appears there is some effort made to fall back to not using indexing in these cases. As seen in ObjLoader.loadModelData() (234):
```
// if there are too many vertices in a mesh, we can't use indices
if (numIndices > 0) {
	for (int i = 0; i < numIndices; i++) {
		finalIndices[i] = (short)i;
	}
}
```
This leaves the finalIndices to be an array of zero. All of the other Model/Mesh classes all support non-indexed configurations except for Model.convertMesh():
```
meshPart.size = part.indices.length;
```
This causes the mesh part size to be zero which later causes a crash. If we change this to:
```
meshPart.size = part.indices.length > 0 ? part.indices.length : numVertices;
```
That properly sets the mesh part size to be the number of vertices instead of the number of indexes into the vertices.