### PR TITLE
flag "prefersHomeIndicatorAutoHidden" is now configurable

### DIFF
--- a/backends/gdx-backend-moe/src/com/badlogic/gdx/backends/iosmoe/IOSApplicationConfiguration.java
+++ b/backends/gdx-backend-moe/src/com/badlogic/gdx/backends/iosmoe/IOSApplicationConfiguration.java
@@ -101,6 +101,9 @@ public class IOSApplicationConfiguration {
 	/** whether the status bar should be visible or not **/
 	public boolean statusBarVisible = false;
 	
+	/** whether the home indicator should be hidden or not **/
+	public boolean hideHomeIndicator = true;
+	
 	/** Whether to override the ringer/mute switch, see https://github.com/libgdx/libgdx/issues/4430 */
 	public boolean overrideRingerSwitch = false;
 }

--- a/backends/gdx-backend-moe/src/com/badlogic/gdx/backends/iosmoe/IOSUIViewController.java
+++ b/backends/gdx-backend-moe/src/com/badlogic/gdx/backends/iosmoe/IOSUIViewController.java
@@ -107,4 +107,9 @@ class IOSUIViewController extends GLKViewController {
 	public boolean prefersStatusBarHidden() {
 		return !app.config.statusBarVisible;
 	}
+	
+	@Override
+	public boolean prefersHomeIndicatorAutoHidden() {
+		return app.config.hideHomeIndicator;
+	}
 }

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSApplicationConfiguration.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSApplicationConfiguration.java
@@ -99,6 +99,9 @@ public class IOSApplicationConfiguration {
 	 * @deprecated this option is currently experimental and not yet fully supported, expect issues. */
 	@Deprecated public boolean useGL30 = false;
 	
+	/** whether the home indicator should be hidden or not **/
+	public boolean hideHomeIndicator = true;
+	
 	/** Whether to override the ringer/mute switch, see https://github.com/libgdx/libgdx/issues/4430 */
 	public boolean overrideRingerSwitch = false;
 

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
@@ -124,6 +124,11 @@ public class IOSGraphics extends NSObject implements Graphics, GLKViewDelegate, 
 				app.listener.resize(graphics.width, graphics.height);
 			}
 		}
+		
+		@Override
+		public boolean prefersHomeIndicatorAutoHidden() {
+			return app.config.hideHomeIndicator;
+		}
 
 		@Callback
 		@BindSelector("shouldAutorotateToInterfaceOrientation:")


### PR DESCRIPTION
On new iPhones, all modern games hide the home indicator. In LibGDX there should be this option too.