### PR TITLE
removed @Override from prefersHomeIndicatorAutoHidden

### DIFF
--- a/backends/gdx-backend-moe/src/com/badlogic/gdx/backends/iosmoe/IOSUIViewController.java
+++ b/backends/gdx-backend-moe/src/com/badlogic/gdx/backends/iosmoe/IOSUIViewController.java
@@ -108,7 +108,6 @@ class IOSUIViewController extends GLKViewController {
 		return !app.config.statusBarVisible;
 	}
 	
-	@Override
 	public boolean prefersHomeIndicatorAutoHidden() {
 		return app.config.hideHomeIndicator;
 	}


### PR DESCRIPTION
I got a compilation error when making a local maven package. The error was 
[ERROR] bootstrap class path not set in conjunction with -source 1.6
[ERROR] libgdx/backends/gdx-backend-moe/src/com/badlogic/gdx/backends/iosmoe/IOSUIViewController.java:[111,1] error: method does not override or implement a method from a supertype
