### PR TITLE
Added debug mode to I18NBundle

### DIFF
--- a/gdx/src/com/badlogic/gdx/utils/I18NBundle.java
+++ b/gdx/src/com/badlogic/gdx/utils/I18NBundle.java
@@ -452,5 +452,17 @@ public class I18NBundle {
 	public String format (String key, Object... args) {
 		return formatter.format(get(key), args);
 	}
-
+	
+	/** Sets the value of all localized strings to String placeholder so hardcoded, unlocalized values can be easily spotted.
+	 *  The I18NBundle won't be able to reset values after calling debug and should only be using during testing.
+	 * 
+	 * @param placeholder */
+	public void debug(String placeholder) {
+		ObjectMap.Keys<String> keys = properties.keys();
+		if(keys == null) return;
+		
+		for(String s : keys) {
+		    properties.put(s, placeholder);
+		}	
+	}
 }


### PR DESCRIPTION
When developing a project, it's common to hardcode strings during testing rather than localizing them. Usually the developer will miss lots of unlocalized strings. A common method to spot unlocalized strings is to create another localization file with some placeholder value like "X" for every single value. This makes it easy to see what strings haven't been localized in game. To avoid having to maintain another localization file, the debug() method in I18NBundle will set all strings to placeholder to simplify this process. 
