### PR TITLE
Made ViewController call super.viewDidAppear to allow hooks for screen tracking

### DIFF
--- a/backends/gdx-backend-moe/src/com/badlogic/gdx/backends/iosmoe/IOSUIViewController.java
+++ b/backends/gdx-backend-moe/src/com/badlogic/gdx/backends/iosmoe/IOSUIViewController.java
@@ -59,6 +59,7 @@ class IOSUIViewController extends GLKViewController {
 
 	@Override
 	public void viewDidAppear (boolean animated) {
+		super.viewDidAppear(animated);
 		if (app.viewControllerListener != null)
 			app.viewControllerListener.viewDidAppear(animated);
 	}

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
@@ -75,6 +75,7 @@ public class IOSGraphics extends NSObject implements Graphics, GLKViewDelegate, 
 
 		@Override
 		public void viewDidAppear (boolean animated) {
+			super.viewDidAppear(animated);
 			if (app.viewControllerListener != null) app.viewControllerListener.viewDidAppear(animated);
 		}
 


### PR DESCRIPTION
Using the Firebase Analytics api for iOS (https://firebase.google.com/) and using the MOE backend, the analytics will not generate "screen_view" events either automatically or manually due to the fact the IOSUIViewController overrides the `viewDidAppear(boolean)` method, but does not call `super.viewDidAppear(boolean)`.  So firebase thinks there are no screens showing and does not track the screen view.  In addition, it also does not let you manually set the screen information (to hook it up to scene2d screen views) because it requires at least one view controller appears before doing so.

This issue fixes the issue with Firebase Analytics not detecting that a view controller has appeared so even manual screen tracking gets ignored and you would see this log line:
```
2018-10-26 17:51:11.407667-0700 app-analytics-example[694:1165898] 5.11.0 - [Firebase/Analytics][I-ACS031003] setScreenName:screenClass: must be called after a view controller has appeared
```