### PR TITLE
Fixing touchpad scroll under OSX 

### DIFF
--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Input.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Input.java
@@ -42,6 +42,7 @@ public class Lwjgl3Input implements Input, Disposable {
 	private boolean keyJustPressed;
 	private boolean[] justPressedKeys = new boolean[256];
 	private char lastCharacter;
+	private float scrollFrac;
 		
 	private GLFWKeyCallback keyCallback = new GLFWKeyCallback() {		
 		@Override
@@ -83,7 +84,7 @@ public class Lwjgl3Input implements Input, Disposable {
 			eventQueue.keyTyped((char)codepoint);
 		}
 	};
-	private double scrollFrac = 0;
+
 	private GLFWScrollCallback scrollCallback = new GLFWScrollCallback() {
 		@Override
 		public void invoke(long window, double scrollX, double scrollY) {

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Input.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Input.java
@@ -83,12 +83,18 @@ public class Lwjgl3Input implements Input, Disposable {
 			eventQueue.keyTyped((char)codepoint);
 		}
 	};
-	
+	private double scrollFrac = 0;
 	private GLFWScrollCallback scrollCallback = new GLFWScrollCallback() {
 		@Override
 		public void invoke(long window, double scrollX, double scrollY) {
 			Lwjgl3Input.this.window.getGraphics().requestRendering();
-			eventQueue.scrolled((int)-Math.signum(scrollY));
+			scrollFrac += scrollY;
+			while (Math.abs(scrollFrac) > 1) {
+				int scrollAmount = (int)-Math.signum(scrollY);
+				eventQueue.scrolled(scrollAmount);
+				scrollFrac += scrollAmount;
+			}
+
 		}
 	};
 	

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Input.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Input.java
@@ -89,13 +89,24 @@ public class Lwjgl3Input implements Input, Disposable {
 		@Override
 		public void invoke(long window, double scrollX, double scrollY) {
 			Lwjgl3Input.this.window.getGraphics().requestRendering();
+			//eventQueue.scrolled((int)(-scrollY*1024d));
+
+			if (scrollFrac > 0 && scrollY < 0 || scrollFrac < 0 && scrollY > 0) 
+				// Reset scrollFrac when changing direction.
+				// This triggers a scroll event as soon as the users changes the scroll direction
+				scrollFrac = 0;
+
+			if (scrollFrac == 0) {
+				// fire a scroll event as soon as the user moves the wheel
+				int scrollAmount = (int)-Math.signum(scrollY);
+				eventQueue.scrolled(scrollAmount);
+			}
 			scrollFrac += scrollY;
-			while (Math.abs(scrollFrac) > 1) {
+			while (Math.abs(scrollFrac) >= 1) {
 				int scrollAmount = (int)-Math.signum(scrollY);
 				eventQueue.scrolled(scrollAmount);
 				scrollFrac += scrollAmount;
 			}
-
 		}
 	};
 	

--- a/tests/gdx-tests-android/obb.gradle
+++ b/tests/gdx-tests-android/obb.gradle
@@ -15,8 +15,7 @@ task zipAssets(type: Zip) {
     destinationDir = file("build/obb")
     entryCompression = ZipEntryCompression.STORED
     from "build/obbassets"
-    baseName = "main.1.com.badlogic.gdx.tests.android"
-    extension = "obb"
+    archiveName = "main.1.com.badlogic.gdx.tests.android.obb"
 }
 
 def getADBPath() {


### PR DESCRIPTION
Hi,

OSX generates many events when scrolling with the touch pad. Lwjgl3 reports small movements with a scroll value lower than 1. This is rounded to 1 or -1. If there are many such "small" events the
scrolling becomes ultra fast because the backend floods gdx with scroll events of 1 or -1.

The current fix acculates the scrolling reported by Lwjgl3 and sends a Gdx scroll event when the accumulated value is greater than 1. This is done until the accumulated value is lower than 1. This approach also supports accelerations which are reported as scrolling value greater than 1.

The drawback of the current approach is that it does not send a scroll event until the accumulated value is greater than 1. Doing this would need to use a float in the gdx event and change the API.

Cheers,

Julien