### PR TITLE
Changed the zipAssets task to produce a proper file name

### DIFF
--- a/tests/gdx-tests-android/obb.gradle
+++ b/tests/gdx-tests-android/obb.gradle
@@ -15,8 +15,7 @@ task zipAssets(type: Zip) {
     destinationDir = file("build/obb")
     entryCompression = ZipEntryCompression.STORED
     from "build/obbassets"
-    baseName = "main.1.com.badlogic.gdx.tests.android"
-    extension = "obb"
+    archiveName = "main.1.com.badlogic.gdx.tests.android.obb"
 }
 
 def getADBPath() {


### PR DESCRIPTION
In the _build.gradle_ file inside the main project's root folder, the following is set:

`version = '1.9.9-SNAPSHOT'`


In the _zipAssets_ task of _obb.gradle_, which sits in the _tests/gdx-tests-android/_ folder, Gradle appends the value of _baseName_ with the value of version from above.  This results in the tasks depending on _zipAssets_ to fail.

The fix involves the following in the _zipAssets_ task:
    a)  Replacing "_baseName_" with "_archiveName_"
    b)  Adding _.obb_ to the end of the file name
    c)  Deleting _extension_ and its value