### PR TITLE
Fixing scroll event rate

### DIFF
--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Input.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Input.java
@@ -92,7 +92,6 @@ public class Lwjgl3Input implements Input, Disposable {
 		@Override
 		public void invoke(long window, double scrollX, double scrollY) {
 			Lwjgl3Input.this.window.getGraphics().requestRendering();
-
 			if (scrollYRemainder > 0 && scrollY < 0 || scrollYRemainder < 0 && scrollY > 0 ||
 				TimeUtils.nanoTime() - lastScrollEventTime > pauseTime ) { 
 				// fire a scroll event immediately:
@@ -103,13 +102,14 @@ public class Lwjgl3Input implements Input, Disposable {
 				eventQueue.scrolled(scrollAmount);
 				lastScrollEventTime = TimeUtils.nanoTime();
 			}
-
-			scrollYRemainder += scrollY;
-			while (Math.abs(scrollYRemainder) >= 1) {
-				int scrollAmount = (int)-Math.signum(scrollY);
-				eventQueue.scrolled(scrollAmount);
-				lastScrollEventTime = TimeUtils.nanoTime();
-				scrollYRemainder += scrollAmount;
+			else {
+				scrollYRemainder += scrollY;
+				while (Math.abs(scrollYRemainder) >= 1) {
+					int scrollAmount = (int)-Math.signum(scrollY);
+					eventQueue.scrolled(scrollAmount);
+					lastScrollEventTime = TimeUtils.nanoTime();
+					scrollYRemainder += scrollAmount;
+				}
 			}
 		}
 	};

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Input.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Input.java
@@ -28,6 +28,7 @@ import com.badlogic.gdx.InputEventQueue;
 import com.badlogic.gdx.InputProcessor;
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3ApplicationConfiguration.HdpiMode;
 import com.badlogic.gdx.utils.Disposable;
+import com.badlogic.gdx.utils.TimeUtils;
 
 public class Lwjgl3Input implements Input, Disposable {
 	private final Lwjgl3Window window;
@@ -42,6 +43,8 @@ public class Lwjgl3Input implements Input, Disposable {
 	private boolean keyJustPressed;
 	private boolean[] justPressedKeys = new boolean[256];
 	private char lastCharacter;
+	private float scrollYRemainder;
+	private long lastScrollEventTime;
 		
 	private GLFWKeyCallback keyCallback = new GLFWKeyCallback() {		
 		@Override
@@ -85,10 +88,29 @@ public class Lwjgl3Input implements Input, Disposable {
 	};
 	
 	private GLFWScrollCallback scrollCallback = new GLFWScrollCallback() {
+		long pauseTime = 250000000L; //250ms
 		@Override
 		public void invoke(long window, double scrollX, double scrollY) {
 			Lwjgl3Input.this.window.getGraphics().requestRendering();
-			eventQueue.scrolled((int)-Math.signum(scrollY));
+
+			if (scrollYRemainder > 0 && scrollY < 0 || scrollYRemainder < 0 && scrollY > 0 ||
+				TimeUtils.nanoTime() - lastScrollEventTime > pauseTime ) { 
+				// fire a scroll event immediately:
+				//  - if the scroll direction changes; 
+				//  - if the user did not move the wheel for more than 250ms
+				scrollYRemainder = 0;
+				int scrollAmount = (int)-Math.signum(scrollY);
+				eventQueue.scrolled(scrollAmount);
+				lastScrollEventTime = TimeUtils.nanoTime();
+			}
+
+			scrollYRemainder += scrollY;
+			while (Math.abs(scrollYRemainder) >= 1) {
+				int scrollAmount = (int)-Math.signum(scrollY);
+				eventQueue.scrolled(scrollAmount);
+				lastScrollEventTime = TimeUtils.nanoTime();
+				scrollYRemainder += scrollAmount;
+			}
 		}
 	};
 	

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Input.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Input.java
@@ -43,8 +43,6 @@ public class Lwjgl3Input implements Input, Disposable {
 	private boolean keyJustPressed;
 	private boolean[] justPressedKeys = new boolean[256];
 	private char lastCharacter;
-	private float scrollYRemainder;
-	private long lastScrollEventTime;
 		
 	private GLFWKeyCallback keyCallback = new GLFWKeyCallback() {		
 		@Override
@@ -88,7 +86,9 @@ public class Lwjgl3Input implements Input, Disposable {
 	};
 	
 	private GLFWScrollCallback scrollCallback = new GLFWScrollCallback() {
-		long pauseTime = 250000000L; //250ms
+		private long pauseTime = 250000000L; //250ms
+		private float scrollYRemainder;
+		private long lastScrollEventTime;
 		@Override
 		public void invoke(long window, double scrollX, double scrollY) {
 			Lwjgl3Input.this.window.getGraphics().requestRendering();


### PR DESCRIPTION
Opening a new PR with a proper branch, some improvements and squashed commits.

OSX generates many events when scrolling with the touch pad. This is
also the case for mouses that have a continuous wheel. Lwjgl3 reports
small movements with a scroll value lower than 1. The Lwjgl3 backend
rounds these values to 1 or -1. If there are many such "small" events
the scrolling becomes ultra fast.

The current fix accumulates the scrolling values reported by Lwjgl3
and sends a Gdx scroll event when the summed value is greater than
1. This is done until the accumulated value is lower than 1. This
approach also supports accelerations which are reported as scrolling
value greater than 1. These values become a stream of 1 or -1 scroll
events.

There is also an event which is triggered when the user starts acting
on the wheel or when the user changes the scrolling direction. This
gives a better reactivity, you don't have to scroll until you reach 1
for the scrolling to start.

Cheers,

Julien