### PR TITLE
Fixed nullpointer due to Vibrator instance being null on some devices

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidInput.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidInput.java
@@ -617,17 +617,20 @@ public class AndroidInput implements Input, OnKeyListener, OnTouchListener {
 
 	@Override
 	public void vibrate (int milliseconds) {
-		vibrator.vibrate(milliseconds);
+		if (vibrator != null)
+			vibrator.vibrate(milliseconds);
 	}
 
 	@Override
 	public void vibrate (long[] pattern, int repeat) {
-		vibrator.vibrate(pattern, repeat);
+		if (vibrator != null)
+			vibrator.vibrate(pattern, repeat);
 	}
 
 	@Override
 	public void cancelVibrate () {
-		vibrator.cancel();
+		if (vibrator != null)
+			vibrator.cancel();
 	}
 
 	@Override


### PR DESCRIPTION
User _hoangtunho2611_ has reported a crash when using `Gdx.input.vibrate()` on some Samsung devices using Android OS version 8.1 (https://www.badlogicgames.com/forum/viewtopic.php?f=11&t=28507&p=112037#p112037)

Even if this is probably a bug on those devices which should instead return an instance of Vibrator that returns `false` on `hasVibrator`, a cheap null check fixes the issue on the libGDX side.

Otherwise users who want to use vibration in a safe manner need to make the following check first `Gdx.input.isPeripheralAvailable(Peripheral.Vibrator)` which is not obvious in the way the API is designed.