### PR TITLE
fix for issue #5458: ParticleEmitter copy Constructor does not copy position

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g2d/ParticleEmitter.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/ParticleEmitter.java
@@ -16,16 +16,16 @@
 
 package com.badlogic.gdx.graphics.g2d;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.Writer;
-import java.util.Arrays;
-
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.math.Rectangle;
 import com.badlogic.gdx.math.collision.BoundingBox;
 import com.badlogic.gdx.utils.Array;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.Writer;
+import java.util.Arrays;
 
 public class ParticleEmitter {
 	static private final int UPDATE_SCALE = 1 << 0;
@@ -135,6 +135,7 @@ public class ParticleEmitter {
 		premultipliedAlpha = emitter.premultipliedAlpha;
 		cleansUpBlendFunction = emitter.cleansUpBlendFunction;
 		spriteMode = emitter.spriteMode;
+		setPosition(emitter.getX(),emitter.getY());
 	}
 
 	private void initialize () {

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ParticleEmitterTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ParticleEmitterTest.java
@@ -82,6 +82,9 @@ public class ParticleEmitterTest extends GdxTest {
 				ParticleEmitter emitter = emitters.get(emitterIndex);
 				if (keycode == Input.Keys.DPAD_UP)
 					particleCount += 5;
+				else if (keycode == Input.Keys.PLUS) {
+					emitter = new ParticleEmitter(emitter);
+				}
 				else if (keycode == Input.Keys.DPAD_DOWN)
 					particleCount -= 5;
 				else if (keycode == Input.Keys.SPACE) {


### PR DESCRIPTION
fix for issue #5458
If you press '+' while running the particleEmitter test you now create a copy of the existing particleEmitter.
Before the fix the copy is created at position 0,0 after the fix the copy is created at the source position