### PR TITLE
[Scene2d.ui] Adding support for horizontal scrolling (touch pad and touch screen) + fix fractional scroll events

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -59,6 +59,8 @@
 - API Addition: Added Group#removeActorAt(int,boolean) to avoid looking up the actor index. Subclasses intending to take action when an actor is removed may need to override this new method.
 - API Change: If Group#addActorAfter is called with an afterActor not in the group, the actor is added as the last child (not the first).
 
+[1.9.10]
+- API Change: InputProcessor scrolled method now receives scroll amount for X and Y. Changed type to float to support devices which report fractional scroll amounts. Updated InputEvent in scene2d accordingly: added scrollAmountX, scrollAmountY attributes and corresponding setters and getters.
 [1.9.9]
 - API Addition: Add support for stripping whitespace in PixmapPacker
 - API Addition: Add support for 9 patch packing in PixmapPacker

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidInput.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidInput.java
@@ -76,7 +76,8 @@ public class AndroidInput implements Input, OnKeyListener, OnTouchListener {
 		int type;
 		int x;
 		int y;
-		int scrollAmount;
+		int scrollAmountX;
+		int scrollAmountY;
 		int button;
 		int pointer;
 	}
@@ -412,7 +413,7 @@ public class AndroidInput implements Input, OnKeyListener, OnTouchListener {
 						processor.mouseMoved(e.x, e.y);
 						break;
 					case TouchEvent.TOUCH_SCROLLED:
-						processor.scrolled(e.scrollAmount);
+						processor.scrolled(e.scrollAmountX, e.scrollAmountY);
 					}
 					usedTouchEvents.free(e);
 				}

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidMouseHandler.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidMouseHandler.java
@@ -38,7 +38,8 @@ public class AndroidMouseHandler {
 		final int action = event.getAction() & MotionEvent.ACTION_MASK;
 
 		int x = 0, y = 0;
-		int scrollAmount = 0;
+		int scrollAmountX = 0;
+		int scrollAmountY = 0;
 
 		long timeStamp = System.nanoTime();
 		synchronized (input) {
@@ -47,15 +48,16 @@ public class AndroidMouseHandler {
 				x = (int)event.getX();
 				y = (int)event.getY();
 				if ((x != deltaX) || (y != deltaY)) { // Avoid garbage events
-					postTouchEvent(input, TouchEvent.TOUCH_MOVED, x, y, 0, timeStamp);
+					postTouchEvent(input, TouchEvent.TOUCH_MOVED, x, y, 0, 0, timeStamp);
 					deltaX = x;
 					deltaY = y;
 				}
 				break;
 
 			case MotionEvent.ACTION_SCROLL:
-				scrollAmount = (int)-Math.signum(event.getAxisValue(MotionEvent.AXIS_VSCROLL));
-				postTouchEvent(input, TouchEvent.TOUCH_SCROLLED, 0, 0, scrollAmount, timeStamp);
+				scrollAmountY = (int)-Math.signum(event.getAxisValue(MotionEvent.AXIS_VSCROLL));
+				scrollAmountX = (int)-Math.signum(event.getAxisValue(MotionEvent.AXIS_HSCROLL));
+				postTouchEvent(input, TouchEvent.TOUCH_SCROLLED, 0, 0, scrollAmountX, scrollAmountY, timeStamp);
 
 			}
 		}
@@ -78,13 +80,14 @@ public class AndroidMouseHandler {
 		Gdx.app.log("AndroidMouseHandler", "action " + actionStr);
 	}
 
-	private void postTouchEvent (AndroidInput input, int type, int x, int y, int scrollAmount, long timeStamp) {
+	private void postTouchEvent (AndroidInput input, int type, int x, int y, int scrollAmountX, int scrollAmountY, long timeStamp) {
 		TouchEvent event = input.usedTouchEvents.obtain();
 		event.timeStamp = timeStamp;
 		event.x = x;
 		event.y = y;
 		event.type = type;
-		event.scrollAmount = scrollAmount;
+		event.scrollAmountX = scrollAmountX;
+		event.scrollAmountY = scrollAmountY;
 		input.touchEvents.add(event);
 	}
 

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglAWTInput.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglAWTInput.java
@@ -383,7 +383,7 @@ public class LwjglAWTInput implements Input, MouseMotionListener, MouseListener,
 						processor.mouseMoved(e.x, e.y);
 						break;
 					case TouchEvent.TOUCH_SCROLLED:
-						processor.scrolled(e.scrollAmount);
+						processor.scrolled(0, e.scrollAmount);
 						break;
 					}
 					usedTouchEvents.free(e);

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglInput.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglInput.java
@@ -366,7 +366,7 @@ final public class LwjglInput implements Input {
 						processor.mouseMoved(e.x, e.y);
 						break;
 					case TouchEvent.TOUCH_SCROLLED:
-						processor.scrolled(e.scrollAmount);
+						processor.scrolled(0,e.scrollAmount);
 					}
 					usedTouchEvents.free(e);
 				}

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Input.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Input.java
@@ -93,25 +93,7 @@ public class Lwjgl3Input implements Input, Disposable {
 		@Override
 		public void invoke(long window, double scrollX, double scrollY) {
 			Lwjgl3Input.this.window.getGraphics().requestRendering();
-			if (scrollYRemainder > 0 && scrollY < 0 || scrollYRemainder < 0 && scrollY > 0 ||
-				TimeUtils.nanoTime() - lastScrollEventTime > pauseTime ) { 
-				// fire a scroll event immediately:
-				//  - if the scroll direction changes; 
-				//  - if the user did not move the wheel for more than 250ms
-				scrollYRemainder = 0;
-				int scrollAmount = (int)-Math.signum(scrollY);
-				eventQueue.scrolled(scrollAmount);
-				lastScrollEventTime = TimeUtils.nanoTime();
-			}
-			else {
-				scrollYRemainder += scrollY;
-				while (Math.abs(scrollYRemainder) >= 1) {
-					int scrollAmount = (int)-Math.signum(scrollY);
-					eventQueue.scrolled(scrollAmount);
-					lastScrollEventTime = TimeUtils.nanoTime();
-					scrollYRemainder += scrollAmount;
-				}
-			}
+			eventQueue.scrolled(-(float)scrollX, -(float)scrollY);
 		}
 	};
 	

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtInput.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtInput.java
@@ -646,7 +646,7 @@ public class GwtInput implements Input {
 		}
 		if (e.getType().equals(getMouseWheelEvent())) {
 			if (processor != null) {
-				processor.scrolled((int)getMouseWheelVelocity(e));
+				processor.scrolled(0,(int)getMouseWheelVelocity(e));
 			}
 			this.currentEventTimeStamp = TimeUtils.nanoTime();
 			e.preventDefault();

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/ParticleEditor.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/ParticleEditor.java
@@ -350,11 +350,11 @@ public class ParticleEditor extends JFrame {
 			}
 
 			@Override
-			public boolean scrolled (int amount) {
-				worldCamera.zoom += amount * 0.01f;
+			public boolean scrolled (float amountX, float amountY) {
+				worldCamera.zoom += amountY * 0.01f;
 				worldCamera.zoom = MathUtils.clamp(worldCamera.zoom, 0.01f, 5000);
 				worldCamera.update();
-				return super.scrolled(amount);
+				return super.scrolled(amountX,amountY);
 			}
 
 			@Override
@@ -599,7 +599,7 @@ public class ParticleEditor extends JFrame {
 		}
 
 		@Override
-		public boolean scrolled (int amount) {
+		public boolean scrolled (float amountX, float amountY) {
 			return false;
 		}
 

--- a/gdx/src/com/badlogic/gdx/InputAdapter.java
+++ b/gdx/src/com/badlogic/gdx/InputAdapter.java
@@ -50,7 +50,7 @@ public class InputAdapter implements InputProcessor {
 	}
 
 	@Override
-	public boolean scrolled (int amount) {
+	public boolean scrolled (float amountX, float amountY) {
 		return false;
 	}
 }

--- a/gdx/src/com/badlogic/gdx/InputEventQueue.java
+++ b/gdx/src/com/badlogic/gdx/InputEventQueue.java
@@ -92,7 +92,7 @@ public class InputEventQueue implements InputProcessor {
 				localProcessor.mouseMoved(q[i++], q[i++]);
 				break;
 			case SCROLLED:
-				localProcessor.scrolled(q[i++]);
+				localProcessor.scrolled(q[i++] / 256f, q[i++] / 256f);
 				break;
 			default:
 				throw new RuntimeException();
@@ -133,7 +133,7 @@ public class InputEventQueue implements InputProcessor {
 				i += 2;
 				break;
 			case SCROLLED:
-				i++;
+				i += 2;
 				break;
 			default:
 				throw new RuntimeException();
@@ -218,10 +218,11 @@ public class InputEventQueue implements InputProcessor {
 		return false;
 	}
 
-	public synchronized boolean scrolled (int amount) {
+	public synchronized boolean scrolled(float amountX, float amountY) {
 		queue.add(SCROLLED);
 		queueTime();
-		queue.add(amount);
+		queue.add((int)(amountX * 256));
+		queue.add((int)(amountY * 256));
 		return false;
 	}
 

--- a/gdx/src/com/badlogic/gdx/InputMultiplexer.java
+++ b/gdx/src/com/badlogic/gdx/InputMultiplexer.java
@@ -150,11 +150,11 @@ public class InputMultiplexer implements InputProcessor {
 		return false;
 	}
 
-	public boolean scrolled (int amount) {
+	public boolean scrolled (float amountX,float amountY) {
 		Object[] items = processors.begin();
 		try {
 			for (int i = 0, n = processors.size; i < n; i++)
-				if (((InputProcessor)items[i]).scrolled(amount)) return true;
+				if (((InputProcessor)items[i]).scrolled(amountX, amountY)) return true;
 		} finally {
 			processors.end();
 		}

--- a/gdx/src/com/badlogic/gdx/InputProcessor.java
+++ b/gdx/src/com/badlogic/gdx/InputProcessor.java
@@ -67,7 +67,8 @@ public interface InputProcessor {
 	public boolean mouseMoved (int screenX, int screenY);
 
 	/** Called when the mouse wheel was scrolled. Will not be called on iOS.
-	 * @param amount the scroll amount, -1 or 1 depending on the direction the wheel was scrolled.
+	 * @param amountX the horizontal scroll amount, negative or positive depending on the direction the wheel was scrolled.
+	 * @param amountY the vertical scroll amount, negative or positive depending on the direction the wheel was scrolled.
 	 * @return whether the input was processed. */
-	public boolean scrolled (int amount);
+	public boolean scrolled (float amountX, float amountY);
 }

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/utils/CameraInputController.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/utils/CameraInputController.java
@@ -203,8 +203,8 @@ public class CameraInputController extends GestureDetector {
 	}
 
 	@Override
-	public boolean scrolled (int amount) {
-		return zoom(amount * scrollFactor * translateUnits);
+	public boolean scrolled (float amountX, float amountY) {
+		return zoom(amountY * scrollFactor * translateUnits);
 	}
 
 	public boolean zoom (float amount) {

--- a/gdx/src/com/badlogic/gdx/input/RemoteSender.java
+++ b/gdx/src/com/badlogic/gdx/input/RemoteSender.java
@@ -198,7 +198,7 @@ public class RemoteSender implements InputProcessor {
 	}
 
 	@Override
-	public boolean scrolled (int amount) {
+	public boolean scrolled (float amountX, float amountY) {
 		return false;
 	}
 

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/InputEvent.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/InputEvent.java
@@ -24,8 +24,8 @@ import com.badlogic.gdx.utils.Null;
  * @see InputListener */
 public class InputEvent extends Event {
 	private Type type;
-	private float stageX, stageY;
-	private int pointer, button, keyCode, scrollAmount;
+	private float stageX, stageY, scrollAmountX, scrollAmountY;
+	private int pointer, button, keyCode;
 	private char character;
 	@Null private Actor relatedActor;
 
@@ -100,13 +100,21 @@ public class InputEvent extends Event {
 		this.character = character;
 	}
 
-	/** The amount the mouse was scrolled. Valid for: scrolled. */
-	public int getScrollAmount () {
-		return scrollAmount;
+	/** The amount the mouse was scrolled horizontally. Valid for: scrolled. */
+	public float getScrollAmountX () {
+		return scrollAmountX;
+	}
+	/** The amount the mouse was scrolled vertically. Valid for: scrolled. */
+	public float getScrollAmountY () {
+		return scrollAmountY;
 	}
 
-	public void setScrollAmount (int scrollAmount) {
-		this.scrollAmount = scrollAmount;
+	public void setScrollAmountX (float scrollAmount) {
+		this.scrollAmountX = scrollAmount;
+	}
+
+	public void setScrollAmountY (float scrollAmount) {
+		this.scrollAmountY = scrollAmount;
 	}
 
 	/** The actor related to the event. Valid for: enter and exit. For enter, this is the actor being exited, or null. For exit,

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/InputListener.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/InputListener.java
@@ -65,7 +65,7 @@ public class InputListener implements EventListener {
 		case mouseMoved:
 			return mouseMoved(event, tmpCoords.x, tmpCoords.y);
 		case scrolled:
-			return scrolled(event, tmpCoords.x, tmpCoords.y, event.getScrollAmount());
+			return scrolled(event, tmpCoords.x, tmpCoords.y, event.getScrollAmountX(), event.getScrollAmountY());
 		case enter:
 			enter(event, tmpCoords.x, tmpCoords.y, event.getPointer(), event.getRelatedActor());
 			return false;
@@ -119,7 +119,7 @@ public class InputListener implements EventListener {
 	}
 
 	/** Called when the mouse wheel has been scrolled. When true is returned, the event is {@link Event#handle() handled}. */
-	public boolean scrolled (InputEvent event, float x, float y, int amount) {
+	public boolean scrolled (InputEvent event, float x, float y, float amountX, float amountY) {
 		return false;
 	}
 

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/Stage.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/Stage.java
@@ -387,7 +387,7 @@ public class Stage extends InputAdapter implements Disposable {
 
 	/** Applies a mouse scroll event to the stage and returns true if an actor in the scene {@link Event#handle() handled} the
 	 * event. This event only occurs on the desktop. */
-	public boolean scrolled (int amount) {
+	public boolean scrolled (float amountX, float amountY) {
 		Actor target = scrollFocus == null ? root : scrollFocus;
 
 		screenToStageCoordinates(tempCoords.set(mouseScreenX, mouseScreenY));
@@ -395,7 +395,8 @@ public class Stage extends InputAdapter implements Disposable {
 		InputEvent event = Pools.obtain(InputEvent.class);
 		event.setStage(this);
 		event.setType(InputEvent.Type.scrolled);
-		event.setScrollAmount(amount);
+		event.setScrollAmountX(amountX);
+		event.setScrollAmountY(amountY);
 		event.setStageX(tempCoords.x);
 		event.setStageY(tempCoords.y);
 		target.fire(event);

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ScrollPane.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ScrollPane.java
@@ -214,13 +214,12 @@ public class ScrollPane extends WidgetGroup {
 		addListener(flickScrollListener);
 
 		addListener(new InputListener() {
-			public boolean scrolled (InputEvent event, float x, float y, int amount) {
+			public boolean scrolled (InputEvent event, float x, float y, float scrollAmountX, float scrollAmountY) {
 				setScrollbarsVisible(true);
-				if (scrollY)
-					setScrollY(amountY + getMouseWheelY() * amount);
-				else if (scrollX) //
-					setScrollX(amountX + getMouseWheelX() * amount);
-				else
+				if (scrollY || scrollX) {
+					setScrollY(amountY + getMouseWheelY() * scrollAmountY);
+					setScrollX(amountX + getMouseWheelX() * scrollAmountX);
+				} else
 					return false;
 				return true;
 			}


### PR DESCRIPTION
Hi,

Since we just start with the new version. I prepared a new PR to fix horizontal scrolling support and fractional scrolling.

Currently horizontal scrolling with a touch pad is not supported. More over, devices which report fractional scrolling values, such as touch pads and mouses with continuous wheels are not supported. The scrolling is super fast, because small scroll increments (0.1) are converted to 1 or -1. See my previous PR for more details.

Cheers,

Julien

Commit message:

Adding support for horizontal scrolling (touch pad and touch screen)

Also, adding support for devices which report fractional scrolling
amounts. E.g. a mouse with a continuous mouse wheel, or a Mac touch
pad. This is currently only supported in lwjgl3. It can probably be
added to android and maybe to gwt.

InputProcessor scrolled method now receives scroll amount for X and
Y. Changed type to float to support devices which report fractional
scroll amounts. Updated InputEvent in scene2d accordingly: added
scrollAmountX, scrollAmountY attributes and corresponding setters and
getters.

Input event queue can receive float scrolling values. Since the queue
stores the events with integers. Scrolling values are stored in fixed
precision format, with 8 bits for the fraction.

Updated backends accordingly: lwjgl, lwjgl3, android and gwt.