### PR TITLE
Change how we compute indexOf to account for a moving head value.

### DIFF
--- a/gdx/src/com/badlogic/gdx/utils/Queue.java
+++ b/gdx/src/com/badlogic/gdx/utils/Queue.java
@@ -183,7 +183,7 @@ public class Queue<T> implements Iterable<T> {
 		if (identity || value == null) {
 			if (head < tail) {
 				for (int i = head; i < tail; i++)
-					if (values[i] == value) return i;
+					if (values[i] == value) return i - head;
 			} else {
 				for (int i = head, n = values.length; i < n; i++)
 					if (values[i] == value) return i - head;
@@ -193,7 +193,7 @@ public class Queue<T> implements Iterable<T> {
 		} else {
 			if (head < tail) {
 				for (int i = head; i < tail; i++)
-					if (value.equals(values[i])) return i;
+					if (value.equals(values[i])) return i - head;
 			} else {
 				for (int i = head, n = values.length; i < n; i++)
 					if (value.equals(values[i])) return i - head;

--- a/gdx/test/com/badlogic/gdx/utils/QueueTest.java
+++ b/gdx/test/com/badlogic/gdx/utils/QueueTest.java
@@ -9,6 +9,73 @@ import org.junit.Assert;
 import org.junit.Test;
 
 public class QueueTest {
+	@Test
+	public void addFirstAndLastTest() {
+		Queue<Integer> queue = new Queue<Integer>();
+		queue.addFirst(1);
+		queue.addLast(2);
+		queue.addFirst(3);
+		queue.addLast(4);
+
+		assertEquals(0, queue.indexOf(3, true));
+		assertEquals(1, queue.indexOf(1, true));
+		assertEquals(2, queue.indexOf(2, true));
+		assertEquals(3, queue.indexOf(4, true));
+	}
+
+	@Test
+	public void removeLastTest() {
+		Queue<Integer> queue = new Queue<Integer>();
+		queue.addLast(1);
+		queue.addLast(2);
+		queue.addLast(3);
+		queue.addLast(4);
+
+		assertEquals(4, queue.size);
+		assertEquals(3, queue.indexOf(4, true));
+		assertEquals(4, (Object)queue.removeLast());
+
+		assertEquals(3, queue.size);
+		assertEquals(2, queue.indexOf(3, true));
+		assertEquals(3, (Object)queue.removeLast());
+
+		assertEquals(2, queue.size);
+		assertEquals(1, queue.indexOf(2, true));
+		assertEquals(2, (Object)queue.removeLast());
+
+		assertEquals(1, queue.size);
+		assertEquals(0, queue.indexOf(1, true));
+		assertEquals(1, (Object)queue.removeLast());
+
+		assertEquals(0, queue.size);
+	}
+
+	@Test
+	public void removeFirstTest() {
+		Queue<Integer> queue = new Queue<Integer>();
+		queue.addLast(1);
+		queue.addLast(2);
+		queue.addLast(3);
+		queue.addLast(4);
+
+		assertEquals(4, queue.size);
+		assertEquals(0, queue.indexOf(1, true));
+		assertEquals(1, (Object)queue.removeFirst());
+
+		assertEquals(3, queue.size);
+		assertEquals(0, queue.indexOf(2, true));
+		assertEquals(2, (Object)queue.removeFirst());
+
+		assertEquals(2, queue.size);
+		assertEquals(0, queue.indexOf(3, true));
+		assertEquals(3, (Object)queue.removeFirst());
+
+		assertEquals(1, queue.size);
+		assertEquals(0, queue.indexOf(4, true));
+		assertEquals(4, (Object)queue.removeFirst());
+
+		assertEquals(0, queue.size);
+	}
 
 	@Test
 	public void resizableQueueTest () {


### PR DESCRIPTION
Fix for https://github.com/libgdx/libgdx/issues/5471

If head < tail, we weren't accounting for head when computing the index, resulting in the returned index being far too large.