### PR TITLE
#5020 Possibility to define caught keys on Android

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidInput.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidInput.java
@@ -49,6 +49,7 @@ import com.badlogic.gdx.Input;
 import com.badlogic.gdx.Input.TextInputListener;
 import com.badlogic.gdx.InputProcessor;
 import com.badlogic.gdx.backends.android.AndroidLiveWallpaperService.AndroidWallpaperEngine;
+import com.badlogic.gdx.utils.IntArray;
 import com.badlogic.gdx.utils.IntSet;
 import com.badlogic.gdx.utils.Pool;
 
@@ -127,8 +128,7 @@ public class AndroidInput implements Input, OnKeyListener, OnTouchListener {
 	final Context context;
 	protected final AndroidTouchHandler touchHandler;
 	private int sleepTime = 0;
-	private boolean catchBack = false;
-	private boolean catchMenu = false;
+	private IntArray catchedKeys = new IntArray();
 	protected final Vibrator vibrator;
 	private boolean compassAvailable = false;
 	private boolean rotationVectorAvailable = false;
@@ -184,6 +184,10 @@ public class AndroidInput implements Input, OnKeyListener, OnTouchListener {
 		} else {
 			nativeOrientation = Orientation.Portrait;
 		}
+
+		// this is for backward compatibility: libGDX always catched the circle button, original comment:
+		// circle button on Xperia Play shouldn't need catchBack == true
+		catchedKeys.add(Keys.BUTTON_CIRCLE);
 	}
 
 	@Override
@@ -571,11 +575,7 @@ public class AndroidInput implements Input, OnKeyListener, OnTouchListener {
 			app.getGraphics().requestRendering();
 		}
 
-		// circle button on Xperia Play shouldn't need catchBack == true
-		if (keyCode == Keys.BUTTON_CIRCLE) return true;
-		if (catchBack && keyCode == android.view.KeyEvent.KEYCODE_BACK) return true;
-		if (catchMenu && keyCode == android.view.KeyEvent.KEYCODE_MENU) return true;
-		return false;
+		return catchedKeys.contains(keyCode);
 	}
 
 	@Override
@@ -597,22 +597,30 @@ public class AndroidInput implements Input, OnKeyListener, OnTouchListener {
 
 	@Override
 	public void setCatchBackKey (boolean catchBack) {
-		this.catchBack = catchBack;
+		setCatchKey(Keys.BACK, catchBack);
 	}
 
 	@Override
 	public boolean isCatchBackKey() {
-		return catchBack;
+		return catchedKeys.contains(Keys.BACK);
 	}
 
 	@Override
 	public void setCatchMenuKey (boolean catchMenu) {
-		this.catchMenu = catchMenu;
+		setCatchKey(Keys.MENU, catchMenu);
 	}
 	
 	@Override
 	public boolean isCatchMenuKey () {
-		return catchMenu;
+		return catchedKeys.contains(Keys.MENU);
+	}
+
+	@Override
+	public void setCatchKey(int keycode, boolean catchKey) {
+		if (!catchKey)
+			catchedKeys.removeValue(keycode);
+		else if (catchKey && !catchedKeys.contains(keycode))
+			catchedKeys.add(keycode);
 	}
 
 	@Override

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidInput.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidInput.java
@@ -49,7 +49,6 @@ import com.badlogic.gdx.Input;
 import com.badlogic.gdx.Input.TextInputListener;
 import com.badlogic.gdx.InputProcessor;
 import com.badlogic.gdx.backends.android.AndroidLiveWallpaperService.AndroidWallpaperEngine;
-import com.badlogic.gdx.utils.IntArray;
 import com.badlogic.gdx.utils.IntSet;
 import com.badlogic.gdx.utils.Pool;
 
@@ -128,7 +127,7 @@ public class AndroidInput implements Input, OnKeyListener, OnTouchListener {
 	final Context context;
 	protected final AndroidTouchHandler touchHandler;
 	private int sleepTime = 0;
-	private IntArray catchedKeys = new IntArray();
+	private IntSet keysToCatch = new IntSet();
 	protected final Vibrator vibrator;
 	private boolean compassAvailable = false;
 	private boolean rotationVectorAvailable = false;
@@ -185,9 +184,9 @@ public class AndroidInput implements Input, OnKeyListener, OnTouchListener {
 			nativeOrientation = Orientation.Portrait;
 		}
 
-		// this is for backward compatibility: libGDX always catched the circle button, original comment:
+		// this is for backward compatibility: libGDX always caught the circle button, original comment:
 		// circle button on Xperia Play shouldn't need catchBack == true
-		catchedKeys.add(Keys.BUTTON_CIRCLE);
+		keysToCatch.add(Keys.BUTTON_CIRCLE);
 	}
 
 	@Override
@@ -575,7 +574,7 @@ public class AndroidInput implements Input, OnKeyListener, OnTouchListener {
 			app.getGraphics().requestRendering();
 		}
 
-		return catchedKeys.contains(keyCode);
+		return keysToCatch.contains(keyCode);
 	}
 
 	@Override
@@ -602,25 +601,25 @@ public class AndroidInput implements Input, OnKeyListener, OnTouchListener {
 
 	@Override
 	public boolean isCatchBackKey() {
-		return catchedKeys.contains(Keys.BACK);
+		return keysToCatch.contains(Keys.BACK);
 	}
 
 	@Override
 	public void setCatchMenuKey (boolean catchMenu) {
 		setCatchKey(Keys.MENU, catchMenu);
 	}
-	
+
 	@Override
 	public boolean isCatchMenuKey () {
-		return catchedKeys.contains(Keys.MENU);
+		return keysToCatch.contains(Keys.MENU);
 	}
 
 	@Override
 	public void setCatchKey(int keycode, boolean catchKey) {
 		if (!catchKey)
-			catchedKeys.removeValue(keycode);
-		else if (catchKey && !catchedKeys.contains(keycode))
-			catchedKeys.add(keycode);
+			keysToCatch.remove(keycode);
+		else if (catchKey)
+			keysToCatch.add(keycode);
 	}
 
 	@Override

--- a/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/mock/input/MockInput.java
+++ b/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/mock/input/MockInput.java
@@ -206,6 +206,11 @@ public class MockInput implements Input {
 	}
 
 	@Override
+	public void setCatchKey(int keycode, boolean catchKey) {
+
+	}
+
+	@Override
 	public void setInputProcessor(InputProcessor processor) {
 
 	}

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglAWTInput.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglAWTInput.java
@@ -421,6 +421,11 @@ public class LwjglAWTInput implements Input, MouseMotionListener, MouseListener,
 	}
 
 	@Override
+	public void setCatchKey(int keycode, boolean catchKey) {
+
+	}
+
+	@Override
 	public void setOnscreenKeyboardVisible (boolean visible) {
 
 	}

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglInput.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglInput.java
@@ -309,6 +309,11 @@ final public class LwjglInput implements Input {
 		return false;
 	}
 
+	@Override
+	public void setCatchKey(int keycode, boolean catchKey) {
+
+	}
+
 	void processEvents () {
 		synchronized (this) {
 			if (processor != null) {

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Input.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Input.java
@@ -820,7 +820,12 @@ public class Lwjgl3Input implements Input, Disposable {
 	public boolean isCatchMenuKey() {
 		return false;
 	}
-	
+
+	@Override
+	public void setCatchKey(int keycode, boolean catchKey) {
+
+	}
+
 	@Override
 	public float getAccelerometerX() {
 		return 0;

--- a/backends/gdx-backend-moe/src/com/badlogic/gdx/backends/iosmoe/IOSInput.java
+++ b/backends/gdx-backend-moe/src/com/badlogic/gdx/backends/iosmoe/IOSInput.java
@@ -475,6 +475,11 @@ public class IOSInput implements Input {
 	}
 
 	@Override
+	public void setCatchKey(int keycode, boolean catchKey) {
+
+	}
+
+	@Override
 	public void setInputProcessor (InputProcessor processor) {
 		this.inputProcessor = processor;
 	}

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSInput.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSInput.java
@@ -540,6 +540,11 @@ public class IOSInput implements Input {
 	}
 
 	@Override
+	public void setCatchKey(int keycode, boolean catchKey) {
+
+	}
+
+	@Override
 	public void setInputProcessor (InputProcessor processor) {
 		this.inputProcessor = processor;
 	}

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtInput.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtInput.java
@@ -282,6 +282,11 @@ public class GwtInput implements Input {
 	}
 
 	@Override
+	public void setCatchKey(int keycode, boolean catchKey) {
+
+	}
+
+	@Override
 	public void setInputProcessor (InputProcessor processor) {
 		this.processor = processor;
 	}

--- a/gdx/src/com/badlogic/gdx/Input.java
+++ b/gdx/src/com/badlogic/gdx/Input.java
@@ -744,13 +744,12 @@ public interface Input {
 
 	/**
 	 * Sets whether the given key on Android should be caught. No effect on other platforms.
-	 * All keys that are not catched may handled by other apps or background processes. For example, media or volume
+	 * All keys that are not caught may be handled by other apps or background processes. For example, media or volume
 	 * buttons are handled by background media players if present. If you use these keys to control your game, they
 	 * must be catched to prevent unintended behaviour.
 	 *
 	 * @param keycode  keycode to catch
 	 * @param catchKey whether to catch the given keycode
-	 * @return
 	 */
 	public void setCatchKey(int keycode, boolean catchKey);
 

--- a/gdx/src/com/badlogic/gdx/Input.java
+++ b/gdx/src/com/badlogic/gdx/Input.java
@@ -742,6 +742,18 @@ public interface Input {
 	/** @return whether the menu button is currently being caught */
 	public boolean isCatchMenuKey ();
 
+	/**
+	 * Sets whether the given key on Android should be caught. No effect on other platforms.
+	 * All keys that are not catched may handled by other apps or background processes. For example, media or volume
+	 * buttons are handled by background media players if present. If you use these keys to control your game, they
+	 * must be catched to prevent unintended behaviour.
+	 *
+	 * @param keycode  keycode to catch
+	 * @param catchKey whether to catch the given keycode
+	 * @return
+	 */
+	public void setCatchKey(int keycode, boolean catchKey);
+
 	/** Sets the {@link InputProcessor} that will receive all touch and key input events. It will be called before the
 	 * {@link ApplicationListener#render()} method each frame.
 	 * 

--- a/gdx/src/com/badlogic/gdx/input/RemoteInput.java
+++ b/gdx/src/com/badlogic/gdx/input/RemoteInput.java
@@ -495,6 +495,10 @@ public class RemoteInput implements Runnable, Input {
 		return false;
 	}
 
+	@Override
+	public void setCatchKey(int keycode, boolean catchKey) {
+
+	}
 
 	@Override
 	public void setInputProcessor (InputProcessor processor) {

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtTestWrapper.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtTestWrapper.java
@@ -419,6 +419,11 @@ public class GwtTestWrapper extends GdxTest {
 		}
 
 		@Override
+		public void setCatchKey(int keycode, boolean catchKey) {
+
+		}
+
+		@Override
 		public void setInputProcessor (InputProcessor processor) {
 			multiplexer.removeProcessor(lastProcessor);
 			multiplexer.addProcessor(processor);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtTestWrapper.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtTestWrapper.java
@@ -420,7 +420,7 @@ public class GwtTestWrapper extends GdxTest {
 
 		@Override
 		public void setCatchKey(int keycode, boolean catchKey) {
-
+			input.setCatchKey(keycode, catchKey);
 		}
 
 		@Override


### PR DESCRIPTION
See #5020:

Besides the menu or back key, there are some other keys that need to be catched when used: Volume Up/Down, Fast Foward buttons are some examples. When targetting for FireTV devices and using the buttons available on the FireTV Remote Controller, Amazon rejects the game submission if the game does not return that the key event was handled. (They give the reason that a media player in background will react on the key events, which is true.) There is no easy way to solve this problem at the moment.

This PR adds the ability to set other catched keys than just back/menu.