### PR TITLE
fix horizontal ellipsis shape in particle emitter

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g2d/ParticleEmitter.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/ParticleEmitter.java
@@ -533,7 +533,7 @@ public class ParticleEmitter {
 				float radius2 = radiusX * radiusX;
 				while (true) {
 					float px = MathUtils.random(width) - radiusX;
-					float py = MathUtils.random(height) - radiusY;
+					float py = MathUtils.random(width) - radiusX;
 					if (px * px + py * py <= radius2) {
 						x += px;
 						y += py / scaleY;


### PR DESCRIPTION
There's a bug in the particle emitter when using ellipsis as the spawn shape.

# Reproduce
Uncompress and load this file in the [ParticleEditor](https://github.com/libgdx/libgdx/wiki/2D-Particle-Editor):
[test.tar.gz](https://github.com/libgdx/libgdx/files/2683939/test.tar.gz)
The rendered effect is not an ellipsis:
![2018-12-16-165921_277x228_scrot](https://user-images.githubusercontent.com/5374768/50058480-8532eb00-0157-11e9-801a-c2e248a0c18e.png)

# Problem
Ellipsis shape is created by generating points in a circle of radius `width/2` and then stretching Y axis to height. The circle was getting clipped since the particles were being generated inside the bounding box of the spawn, which can be smaller than the circle of radius `width/2`.

# Solution
Generate the particles inside a box of `width` by `width`. Then the stretching will be done properly. Only one line changed.

This is how it looks with the fix.
![2018-12-16-165926_297x226_scrot](https://user-images.githubusercontent.com/5374768/50058481-86fcae80-0157-11e9-9b68-ceea070ed540.png)
