### PR TITLE
[scene2d] UI debug enables GL blending and leaves it enabled

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/Stage.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/Stage.java
@@ -167,6 +167,7 @@ public class Stage extends InputAdapter implements Disposable {
 		debugShapes.begin();
 		root.drawDebug(debugShapes);
 		debugShapes.end();
+        Gdx.gl.glDisable(GL20.GL_BLEND);
 	}
 
 	/** Disables debug on all actors recursively except the specified actor and any children. */


### PR DESCRIPTION
This can affect scene rendering results when UI debug is enabled and certain frame buffers require (and expect) blending to be disabled by default at the beginning of their rendering cycle.