### PR TITLE
Setting the "real" clipboard in gwt

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtClipboard.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtClipboard.java
@@ -18,8 +18,13 @@ package com.badlogic.gdx.backends.gwt;
 
 import com.badlogic.gdx.utils.Clipboard;
 
-/** Basic implementation of clipboard in GWT. Copy-paste only works inside the libgdx application. */
+/** Basic implementation of clipboard in GWT. Paste only works inside the libgdx application. */
 public class GwtClipboard implements Clipboard {
+
+	private boolean requestedWritePermissions = false;
+	private boolean hasWritePermissions = true;
+
+	private ClipboardWriteHandler writeHandler = new ClipboardWriteHandler();
 
 	private String content = "";
 
@@ -31,5 +36,37 @@ public class GwtClipboard implements Clipboard {
 	@Override
 	public void setContents (String content) {
 		this.content = content;
+		if (requestedWritePermissions) {
+			if (hasWritePermissions)
+				setContentJSNI(content);
+		} else {
+			GwtPermissions.queryPermission("clipboard-write", writeHandler);
+			requestedWritePermissions = true;
+		}
+	}
+
+	private native void setContentJSNI (String content) /*-{
+		if ("clipboard" in $wnd.navigator) {
+			$wnd.navigator.clipboard.writeText(content);
+		}
+	}-*/;
+
+	private class ClipboardWriteHandler implements GwtPermissions.GwtPermissionResult {
+		@Override
+		public void granted() {
+			hasWritePermissions = true;
+			setContentJSNI(content);
+		}
+
+		@Override
+		public void denied() {
+			hasWritePermissions = false;
+		}
+
+		@Override
+		public void prompt() {
+			hasWritePermissions = true;
+			setContentJSNI(content);
+		}
 	}
 }

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtPermissions.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtPermissions.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogic.gdx.backends.gwt;
+
+public class GwtPermissions {
+	/**
+	 * Returns the user permission status for a given API via the <a href="https://w3c.github.io/permissions/">Permissions API</a>
+	 * @param permission the permission, see <a href="https://w3c.github.io/permissions/#permission-registry">w3c</a> for all permissions
+	 * @param result handler of permission result
+	 */
+	native static public void queryPermission(String permission, GwtPermissionResult result) /*-{
+		if ("permissions" in $wnd.navigator) {
+			$wnd.navigator.permissions.query({
+				name: permission
+			}).then(function (permissionStatus) {
+				if (permissionStatus.state === 'granted') {
+					result.@com.badlogic.gdx.backends.gwt.GwtPermissions.GwtPermissionResult::granted()();
+				} else if (permissionStatus.state === 'denied') {
+					result.@com.badlogic.gdx.backends.gwt.GwtPermissions.GwtPermissionResult::denied()();
+				} else if (permissionStatus.state === 'prompt') {
+					result.@com.badlogic.gdx.backends.gwt.GwtPermissions.GwtPermissionResult::prompt()();
+				}
+				permissionStatus.onchange = function() {
+					if (this.state === 'granted') {
+						result.@com.badlogic.gdx.backends.gwt.GwtPermissions.GwtPermissionResult::granted()();
+					} else if (this.state === 'denied') {
+						result.@com.badlogic.gdx.backends.gwt.GwtPermissions.GwtPermissionResult::denied()();
+					} else if (this.state === 'prompt') {
+						result.@com.badlogic.gdx.backends.gwt.GwtPermissions.GwtPermissionResult::prompt()();
+					}
+				};
+			});
+		}
+	}-*/;
+
+	/**
+	 * See <a href="https://w3c.github.io/permissions/#status-of-a-permission">status-of-a-permission</a> for more information
+	 */
+	public interface GwtPermissionResult {
+		/**
+		 * the permission to access the feature is granted without asking the user
+		 */
+		void granted();
+
+		/**
+		 * accessing the feature is not allowed
+		 */
+		void denied();
+
+		/**
+		 * the user will be asked on permission if the feature is tried to access
+		 */
+		void prompt();
+	}
+}

--- a/gdx/src/com/badlogic/gdx/utils/Clipboard.java
+++ b/gdx/src/com/badlogic/gdx/utils/Clipboard.java
@@ -20,7 +20,7 @@ package com.badlogic.gdx.utils;
  * @author mzechner */
 public interface Clipboard {
 	/** gets the current content of the clipboard if it contains text
-	 * for WebGL app, setting the system clipboard is currently not supported. It works only inside the app
+	 * for WebGL app, getting the system clipboard is currently not supported. It works only inside the app
 	 * @return the clipboard content or null */
 	public String getContents ();
 

--- a/gdx/src/com/badlogic/gdx/utils/Clipboard.java
+++ b/gdx/src/com/badlogic/gdx/utils/Clipboard.java
@@ -20,10 +20,13 @@ package com.badlogic.gdx.utils;
  * @author mzechner */
 public interface Clipboard {
 	/** gets the current content of the clipboard if it contains text
+	 * for WebGL app, setting the system clipboard is currently not supported. It works only inside the app
 	 * @return the clipboard content or null */
 	public String getContents ();
 
 	/** Sets the content of the system clipboard.
+	 * for WebGL app, clipboard content might not be set if user denied permission, setting clipboard is not synchronous
+	 * so you can't rely on getting same content just after setting it
 	 * @param content the content */
 	public void setContents (String content);
 }

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ClipboardTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ClipboardTest.java
@@ -1,3 +1,19 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
 package com.badlogic.gdx.tests;
 
 import com.badlogic.gdx.Gdx;

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ClipboardTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ClipboardTest.java
@@ -1,0 +1,61 @@
+package com.badlogic.gdx.tests;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.scenes.scene2d.Actor;
+import com.badlogic.gdx.scenes.scene2d.Stage;
+import com.badlogic.gdx.scenes.scene2d.ui.Skin;
+import com.badlogic.gdx.scenes.scene2d.ui.TextArea;
+import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
+import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
+import com.badlogic.gdx.tests.utils.GdxTest;
+
+public class ClipboardTest extends GdxTest {
+
+	Stage stage;
+	TextArea textArea;
+	TextButton buttonCopy;
+	TextButton buttonPaste;
+
+	@Override
+	public void create() {
+		stage = new Stage();
+		Skin skin = new Skin(Gdx.files.internal("data/uiskin.json"));
+		textArea = new TextArea("", skin);
+		buttonCopy = new TextButton("Copy", skin);
+		buttonPaste = new TextButton("Paste", skin);
+
+		textArea.setSize(Gdx.graphics.getWidth() / 3f, Gdx.graphics.getHeight() / 3f);
+
+		textArea.setPosition(Gdx.graphics.getWidth() / 2f - textArea.getWidth() / 2f,
+				Gdx.graphics.getHeight() / 2f - textArea.getHeight() / 2f);
+		buttonCopy.setPosition(Gdx.graphics.getWidth() / 4f - buttonCopy.getWidth() / 2f,
+				Gdx.graphics.getHeight() / 4f - buttonCopy.getHeight() / 2f);
+		buttonPaste.setPosition(3 * Gdx.graphics.getWidth() / 4f - buttonPaste.getWidth() / 2f,
+				Gdx.graphics.getHeight() / 4f - buttonPaste.getHeight() / 2f);
+
+		buttonCopy.addListener(new ChangeListener() {
+			@Override
+			public void changed(ChangeEvent event, Actor actor) {
+				Gdx.app.getClipboard().setContents(textArea.getText());
+			}
+		});
+		buttonPaste.addListener(new ChangeListener() {
+			@Override
+			public void changed(ChangeEvent event, Actor actor) {
+				textArea.setText(Gdx.app.getClipboard().getContents());
+			}
+		});
+
+		stage.addActor(textArea);
+		stage.addActor(buttonCopy);
+		stage.addActor(buttonPaste);
+
+		Gdx.input.setInputProcessor(stage);
+	}
+
+	@Override
+	public void render() {
+		stage.act();
+		stage.draw();
+	}
+}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtTestWrapper.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtTestWrapper.java
@@ -34,78 +34,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.Skin;
 import com.badlogic.gdx.scenes.scene2d.ui.Table;
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
 import com.badlogic.gdx.scenes.scene2d.utils.ClickListener;
-import com.badlogic.gdx.tests.AccelerometerTest;
-import com.badlogic.gdx.tests.ActionSequenceTest;
-import com.badlogic.gdx.tests.ActionTest;
-import com.badlogic.gdx.tests.AlphaTest;
-import com.badlogic.gdx.tests.AnimationTest;
-import com.badlogic.gdx.tests.AnnotationTest;
-import com.badlogic.gdx.tests.AssetManagerTest;
-import com.badlogic.gdx.tests.AtlasIssueTest;
-import com.badlogic.gdx.tests.BitmapFontAlignmentTest;
-import com.badlogic.gdx.tests.BitmapFontFlipTest;
-import com.badlogic.gdx.tests.BitmapFontMetricsTest;
-import com.badlogic.gdx.tests.BitmapFontTest;
-import com.badlogic.gdx.tests.BlitTest;
-import com.badlogic.gdx.tests.Box2DCharacterControllerTest;
-import com.badlogic.gdx.tests.Box2DTest;
-import com.badlogic.gdx.tests.Box2DTestCollection;
-import com.badlogic.gdx.tests.BufferUtilsTest;
-import com.badlogic.gdx.tests.ColorTest;
-import com.badlogic.gdx.tests.ComplexActionTest;
-import com.badlogic.gdx.tests.CustomShaderSpriteBatchTest;
-import com.badlogic.gdx.tests.DecalTest;
-import com.badlogic.gdx.tests.EdgeDetectionTest;
-import com.badlogic.gdx.tests.FilterPerformanceTest;
-import com.badlogic.gdx.tests.FrameBufferTest;
-import com.badlogic.gdx.tests.FramebufferToTextureTest;
-import com.badlogic.gdx.tests.GLProfilerErrorTest;
-import com.badlogic.gdx.tests.GWTLossyPremultipliedAlphaTest;
-import com.badlogic.gdx.tests.GestureDetectorTest;
-import com.badlogic.gdx.tests.GroupCullingTest;
-import com.badlogic.gdx.tests.GroupFadeTest;
-import com.badlogic.gdx.tests.I18NSimpleMessageTest;
-import com.badlogic.gdx.tests.ImageScaleTest;
-import com.badlogic.gdx.tests.ImageTest;
-import com.badlogic.gdx.tests.IndexBufferObjectShaderTest;
-import com.badlogic.gdx.tests.IntegerBitmapFontTest;
-import com.badlogic.gdx.tests.InterpolationTest;
-import com.badlogic.gdx.tests.InverseKinematicsTest;
-import com.badlogic.gdx.tests.IsometricTileTest;
-import com.badlogic.gdx.tests.KinematicBodyTest;
-import com.badlogic.gdx.tests.LabelScaleTest;
-import com.badlogic.gdx.tests.LabelTest;
-import com.badlogic.gdx.tests.LifeCycleTest;
-import com.badlogic.gdx.tests.MeshShaderTest;
-import com.badlogic.gdx.tests.MipMapTest;
-import com.badlogic.gdx.tests.MultitouchTest;
-import com.badlogic.gdx.tests.MusicTest;
-import com.badlogic.gdx.tests.ParallaxTest;
-import com.badlogic.gdx.tests.ParticleEmitterTest;
-import com.badlogic.gdx.tests.PixelsPerInchTest;
-import com.badlogic.gdx.tests.ProjectiveTextureTest;
-import com.badlogic.gdx.tests.ReflectionCorrectnessTest;
-import com.badlogic.gdx.tests.ReflectionTest;
-import com.badlogic.gdx.tests.RotationTest;
-import com.badlogic.gdx.tests.Scene2dTest;
-import com.badlogic.gdx.tests.ShapeRendererTest;
-import com.badlogic.gdx.tests.SimpleAnimationTest;
-import com.badlogic.gdx.tests.SimpleDecalTest;
-import com.badlogic.gdx.tests.SimpleStageCullingTest;
-import com.badlogic.gdx.tests.SortedSpriteTest;
-import com.badlogic.gdx.tests.SoundTest;
-import com.badlogic.gdx.tests.SpriteBatchShaderTest;
-import com.badlogic.gdx.tests.SpriteCacheOffsetTest;
-import com.badlogic.gdx.tests.SpriteCacheTest;
-import com.badlogic.gdx.tests.StageTest;
-import com.badlogic.gdx.tests.TableTest;
-import com.badlogic.gdx.tests.TextButtonTest;
-import com.badlogic.gdx.tests.TextureAtlasTest;
-import com.badlogic.gdx.tests.TiledMapAtlasAssetManagerTest;
-import com.badlogic.gdx.tests.TimeUtilsTest;
-import com.badlogic.gdx.tests.UITest;
-import com.badlogic.gdx.tests.VertexBufferObjectShaderTest;
-import com.badlogic.gdx.tests.YDownTest;
+import com.badlogic.gdx.tests.*;
 import com.badlogic.gdx.tests.conformance.DisplayModeTest;
 import com.badlogic.gdx.tests.extensions.ControllersTest;
 import com.badlogic.gdx.tests.g3d.ModelCacheTest;
@@ -538,6 +467,10 @@ public class GwtTestWrapper extends GdxTest {
 	}, new Instancer() {
 		public GdxTest instance () {
 			return new BufferUtilsTest();
+		}
+	}, new Instancer() {
+		public GdxTest instance() {
+			return new ClipboardTest();
 		}
 	}, new Instancer() {
 		public GdxTest instance () {

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
@@ -111,6 +111,7 @@ public class GdxTests {
 		Bresenham2Test.class,
 		BufferUtilsTest.class,
 		BulletTestCollection.class,
+		ClipboardTest.class,
 		CollectionsTest.class,
 		ColorTest.class,
 		ContainerTest.class,


### PR DESCRIPTION
Here's an implementation for setting the clipboard in gwt using the [Clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API). For getting the clipboard I see no possibility because it is an asynchronous event which returns the content of the clipboard asynchronously. Or do you got an idea how to do it?

> Access to the contents of the clipboard is gated behind the Permissions API; without user permission, reading or altering the clipboard contents is not permitted.

For this I created a separate class for querying the permission. It could be also useful in the future for accessing for example the [Accelerometer ](https://developer.mozilla.org/en-US/docs/Web/API/Accelerometer) which needs also permissions.

I added also a test for the clipboard which makes it easier to test it.