### PR TITLE
Fix parameters annotation in BezierTest

### DIFF
--- a/gdx/test/com/badlogic/gdx/math/BezierTest.java
+++ b/gdx/test/com/badlogic/gdx/math/BezierTest.java
@@ -25,7 +25,7 @@ public class BezierTest {
 		LibGDXArrays, JavaArrays, JavaVarArgs
 	}
 
-	@Parameters(name = "use setter {0} imported type {1}")
+	@Parameters(name = "imported type {0} use setter {1}")
 	public static Collection<Object[]> parameters () {
 		Collection<Object[]> parameters = new ArrayList<Object[]>();
 		for(ImportType type : ImportType.values()){


### PR DESCRIPTION
Parameter {0} should be type and {1} should be "use setter" boolean.