### PR TITLE
Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ branches:
 os: osx
 
 before_install:
+  - brew update
   - brew install ant
 
 install:


### PR DESCRIPTION
I recognized that the recent travis builds fail with this error:
```
Error: HOMEBREW_LOGS was not exported!
Please don't worry, you likely hit a bug auto-updating from an old version.
Rerun your command, everything is up-to-date and fine now.
The command "brew install ant" failed and exited with 1 during .
```

With `brew update` before installing ant the builds are not failing. (In [my](https://travis-ci.com/SimonIT/libgdx/builds) travis builds)