### PR TITLE
fix #5238 asset folder classpath with eclipse

### DIFF
--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetup.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetup.java
@@ -618,7 +618,6 @@ public class GdxSetup {
 		String argString = "";
 		if (args == null) return argString;
 		for (String argument : args) {
-			if (argument.equals("afterEclipseImport") && !modules.contains(ProjectType.DESKTOP)) continue;
 			argString += " " + argument;
 		}
 		return argString;

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/SettingsDialog.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/SettingsDialog.java
@@ -273,7 +273,6 @@ public class SettingsDialog extends JDialog {
 		}
 		if (eclipseBox.isSelected()) {
 			list.add("eclipse");
-			list.add("afterEclipseImport");
 		}
 		if (ideaBox.isSelected()) {
 			list.add("idea");

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/desktop/build.gradle
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/desktop/build.gradle
@@ -1,10 +1,12 @@
 apply plugin: "%LANG%"
 
+project.ext.assetsDir = new File("../%ASSET_PATH%");
+
 sourceCompatibility = 1.6
 sourceSets.main.java.srcDirs = [ "src/" ]
+sourceSets.main.resources.srcDirs = [ assetsDir ]
 
 project.ext.mainClassName = "%PACKAGE%.desktop.DesktopLauncher"
-project.ext.assetsDir = new File("../%ASSET_PATH%");
 
 task run(dependsOn: classes, type: JavaExec) {
     main = project.mainClassName
@@ -27,7 +29,6 @@ task dist(type: Jar) {
     from files(sourceSets.main.output.classesDir)
     from files(sourceSets.main.output.resourcesDir)
     from {configurations.compile.collect {zipTree(it)}}
-    from files(project.assetsDir);
  
     manifest {
         attributes 'Main-Class': project.mainClassName
@@ -41,15 +42,4 @@ eclipse {
         name = appName + "-desktop"
         linkedResource name: 'assets', type: '2', location: 'PARENT-1-PROJECT_LOC/%ASSET_PATH%'
     }
-}
-
-task afterEclipseImport(description: "Post processing after project generation", group: "IDE") {
-  doLast {
-    def classpath = new XmlParser().parse(file(".classpath"))
-    new Node(classpath, "classpathentry", [ kind: 'src', path: 'assets' ]);
-    def writer = new FileWriter(file(".classpath"))
-    def printer = new XmlNodePrinter(new PrintWriter(writer))
-    printer.setPreserveWhitespace(true)
-    printer.print(classpath)
-  }
 }


### PR DESCRIPTION
More details about my changes in #5238

Tested with eclipse Neon.1a Release (4.6.1) and EGradle Version 2.4.0.

Test steps i made : 

* test 1 :
    * generate a new libgdx project for eclipse IDE
    * import into eclipse as existing eclipse project
    * run desktop launcher
    * build desktop jar (gradlew desktop:dist) and run it
    * verify there is no asset file duplication in the jar
* test 2 :
    * generate a new libgdx project without any IDE option
    * import into eclipse as existing gradle project
    * run desktop launcher
    * build desktop jar (gradlew desktop:dist) and run it
    * verify there is no asset file duplication in the jar

I'm not very confident with this change, there might be important things i missed, so it would be nice if several people test it with other IDE before merging it.