### PR TITLE
Implement double to-and-from long on GWT

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -180,3 +180,4 @@ code-disaster https://github.com/code-disaster
 3xp0n3nt https://github.com/3xp0n3nt
 Zomby2D https://github.com/Zomby2D
 cypherdare https://github.com/cypherdare
+tommyettinger https://github.com/tommyettinger

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/utils/NumberUtils.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/utils/NumberUtils.java
@@ -29,7 +29,10 @@ public final class NumberUtils {
 	}
 
 	public static int floatToIntColor (float value) {
-		return Numbers.floatToIntBits(value);
+		// matches non-emulated behavior except for floats that are infinite or NaN
+		int intBits = Numbers.floatToIntBits(value);
+		intBits |= (int)((intBits >>> 24) * (255f / 254f)) << 24;
+		return intBits;
 	}
 
 	public static float intToFloatColor (int value) {
@@ -43,10 +46,10 @@ public final class NumberUtils {
 	}
 
 	public static long doubleToLongBits (double value) {
-		return 0; // FIXME
+		return Numbers.doubleToLongBits(value);
 	}
 
 	public static double longBitsToDouble (long value) {
-		return 0; // FIXME
+		return Numbers.longBitsToDouble(value);
 	}
 }

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/google/gwt/corp/compatibility/Numbers.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/google/gwt/corp/compatibility/Numbers.java
@@ -17,16 +17,16 @@
 package com.google.gwt.corp.compatibility;
 
 import com.google.gwt.typedarrays.client.Float32ArrayNative;
+import com.google.gwt.typedarrays.client.Float64ArrayNative;
 import com.google.gwt.typedarrays.client.Int32ArrayNative;
 import com.google.gwt.typedarrays.client.Int8ArrayNative;
 import com.google.gwt.typedarrays.shared.Float32Array;
+import com.google.gwt.typedarrays.shared.Float64Array;
 import com.google.gwt.typedarrays.shared.Int32Array;
 import com.google.gwt.typedarrays.shared.Int8Array;
 
-public class Numbers {
-
-	static final double LN2 = Math.log(2);
-
+public final class Numbers {
+	
 	public static final int floatToIntBits (float f) {
 		wfa.set(0, f);
 		return wia.get(0);
@@ -69,9 +69,10 @@ public class Numbers {
 // return signBit | ((exponent + 127) << 23) | (significand & 0x007fffff);
 	}
 
-	static Int8Array wba = Int8ArrayNative.create(4);
-	static Int32Array wia = Int32ArrayNative.create(wba.buffer(), 0, 1);
-	static Float32Array wfa = Float32ArrayNative.create(wba.buffer(), 0, 1);
+	private static final Int8Array wba = Int8ArrayNative.create(8);
+	private static final Int32Array wia = Int32ArrayNative.create(wba.buffer(), 0, 2);
+	private static final Float32Array wfa = Float32ArrayNative.create(wba.buffer(), 0, 1);
+	private static final Float64Array wda = Float64ArrayNative.create(wba.buffer(), 0, 1);
 
 	public static final float intBitsToFloat (int i) {
 // wba.set(0, (byte) (i >> 24));
@@ -96,15 +97,19 @@ public class Numbers {
 // return (i & 0x80000000) == 0 ? result : -result;
 	}
 
-	public static final long doubleToLongBits (Double d) {
-		throw new RuntimeException("NYI");
+	public static final long doubleToLongBits (double d) {
+		wda.set(0, d);
+		return ((long)wia.get(1) << 32) | (wia.get(0) & 0xffffffffL);
 	}
 
 	public static final double longBitsToDouble (long l) {
-		throw new RuntimeException("NYI");
+		wia.set(1, (int)(l >>> 32));
+		wia.set(0, (int)(l & 0xffffffffL));
+		return wda.get(0);
 	}
 
-	public static long doubleToRawLongBits (double value) {
-		throw new RuntimeException("NYI: Numbers.doubleToRawLongBits");
+	public static final long doubleToRawLongBits (double d) {
+		wda.set(0, d);
+		return ((long)wia.get(1) << 32) | (wia.get(0) & 0xffffffffL);
 	}
 }

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/google/gwt/corp/compatibility/Numbers.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/google/gwt/corp/compatibility/Numbers.java
@@ -27,46 +27,9 @@ import com.google.gwt.typedarrays.shared.Int8Array;
 
 public final class Numbers {
 	
-	public static final int floatToIntBits (float f) {
+	public static int floatToIntBits (float f) {
 		wfa.set(0, f);
 		return wia.get(0);
-
-// if (Float.isNaN(f)) {
-// return 0x7f800001;
-// }
-// int signBit;
-// if (f == 0) {
-// return (1/f == Float.NEGATIVE_INFINITY) ? 0x80000000 : 0;
-// } else if (f < 0) {
-// f = -f;
-// signBit = 0x80000000;
-// } else {
-// signBit = 0;
-// }
-// if (f == Float.POSITIVE_INFINITY) {
-// return signBit | 0x7f800000;
-// }
-//
-// int exponent = (int) (Math.log(f) / LN2);
-// if (exponent < -126) {
-// exponent = -126;
-// }
-// int significand = (int) (0.5 + f * Math.exp(-(exponent - 23) * LN2));
-//
-// // Handle exponent rounding issues & denorm
-// if ((significand & 0x01000000) != 0) {
-// significand >>= 1;
-// exponent++;
-// } else if ((significand & 0x00800000) == 0) {
-// if (exponent == -126) {
-// return signBit | significand;
-// } else {
-// significand <<= 1;
-// exponent--;
-// }
-// }
-//
-// return signBit | ((exponent + 127) << 23) | (significand & 0x007fffff);
 	}
 
 	private static final Int8Array wba = Int8ArrayNative.create(8);
@@ -74,41 +37,23 @@ public final class Numbers {
 	private static final Float32Array wfa = Float32ArrayNative.create(wba.buffer(), 0, 1);
 	private static final Float64Array wda = Float64ArrayNative.create(wba.buffer(), 0, 1);
 
-	public static final float intBitsToFloat (int i) {
-// wba.set(0, (byte) (i >> 24));
-// wba.set(1, (byte) (i >> 16));
-// wba.set(2, (byte) (i >> 8));
-// wba.set(3, (byte) (i));
+	public static float intBitsToFloat (int i) {
 		wia.set(0, i);
 		return wfa.get(0);
-//
-//
-// int exponent = (i >>> 23) & 255;
-// int significand = i & 0x007fffff;
-// float result;
-// if (exponent == 0) {
-// result = (float) (Math.exp((-126 - 23) * LN2) * significand);
-// } else if (exponent == 255) {
-// result = significand == 0 ? Float.POSITIVE_INFINITY : Float.NaN;
-// } else {
-// result = (float) (Math.exp((exponent - 127 - 23) * LN2) * (0x00800000 | significand));
-// }
-//
-// return (i & 0x80000000) == 0 ? result : -result;
 	}
 
-	public static final long doubleToLongBits (double d) {
+	public static long doubleToLongBits (double d) {
 		wda.set(0, d);
 		return ((long)wia.get(1) << 32) | (wia.get(0) & 0xffffffffL);
 	}
 
-	public static final double longBitsToDouble (long l) {
+	public static double longBitsToDouble (long l) {
 		wia.set(1, (int)(l >>> 32));
 		wia.set(0, (int)(l & 0xffffffffL));
 		return wda.get(0);
 	}
 
-	public static final long doubleToRawLongBits (double d) {
+	public static long doubleToRawLongBits (double d) {
 		wda.set(0, d);
 		return ((long)wia.get(1) << 32) | (wia.get(0) & 0xffffffffL);
 	}

--- a/gdx/src/com/badlogic/gdx/utils/NumberUtils.java
+++ b/gdx/src/com/badlogic/gdx/utils/NumberUtils.java
@@ -16,8 +16,6 @@
 
 package com.badlogic.gdx.utils;
 
-import com.badlogic.gdx.graphics.Color;
-
 public final class NumberUtils {
 	public static int floatToIntBits (float value) {
 		return Float.floatToIntBits(value);


### PR DESCRIPTION
This has been marked NYI and FIXME for a long, long time, and it's an easy fix, following the behavior of the float and int conversion. This also fixes a compatibility bug introduced in 1.9.9; `NumberUtils.floatToIntColor()` was changed in the main project but not in GWT. There was also an unused import of `Color` in `NumberUtils`. I believe at least one test on GWT fails without this PR, calling `Numbers.doubleToLongBits()`, `Numbers.doubleToRawLongBits()` or `Numbers.longBitsToDouble()` and getting a NYI exception, but I don't know which one it was.