### PR TITLE
fix libgdx/libgdx#5488 ScrollPane scrollTo

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ScrollPane.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ScrollPane.java
@@ -873,7 +873,6 @@ public class ScrollPane extends WidgetGroup {
 	/** Sets the scroll offset so the specified rectangle is fully in view, and optionally centered vertically and/or horizontally,
 	 * if possible. Coordinates are in the scroll pane widget's coordinate system. */
 	public void scrollTo (float x, float y, float width, float height, boolean centerHorizontal, boolean centerVertical) {
-		// ensure we have a fresh area size
 		validate();
 
 		float amountX = this.amountX;

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ScrollPane.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ScrollPane.java
@@ -873,6 +873,9 @@ public class ScrollPane extends WidgetGroup {
 	/** Sets the scroll offset so the specified rectangle is fully in view, and optionally centered vertically and/or horizontally,
 	 * if possible. Coordinates are in the scroll pane widget's coordinate system. */
 	public void scrollTo (float x, float y, float width, float height, boolean centerHorizontal, boolean centerVertical) {
+		// ensure we have a fresh area size
+		validate();
+
 		float amountX = this.amountX;
 		if (centerHorizontal) {
 			amountX = x - areaWidth / 2 + width / 2;

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ScrollPaneWithDynamicScrolling.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ScrollPaneWithDynamicScrolling.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2011 See AUTHORS file.
+ * Copyright 2019 See AUTHORS file.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ScrollPaneWithDynamicScrolling.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ScrollPaneWithDynamicScrolling.java
@@ -1,0 +1,97 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogic.gdx.tests;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.scenes.scene2d.Actor;
+import com.badlogic.gdx.scenes.scene2d.InputEvent;
+import com.badlogic.gdx.scenes.scene2d.InputListener;
+import com.badlogic.gdx.scenes.scene2d.Stage;
+import com.badlogic.gdx.scenes.scene2d.ui.Label;
+import com.badlogic.gdx.scenes.scene2d.ui.ScrollPane;
+import com.badlogic.gdx.scenes.scene2d.ui.Skin;
+import com.badlogic.gdx.scenes.scene2d.ui.Slider;
+import com.badlogic.gdx.scenes.scene2d.ui.Table;
+import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
+import com.badlogic.gdx.scenes.scene2d.ui.TextButton.TextButtonStyle;
+import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
+import com.badlogic.gdx.scenes.scene2d.utils.ClickListener;
+import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener.ChangeEvent;
+import com.badlogic.gdx.tests.utils.GdxTest;
+import com.badlogic.gdx.utils.Align;
+
+public class ScrollPaneWithDynamicScrolling extends GdxTest {
+	private Stage stage;
+	private Table container;
+	private Label dynamicLabel;
+	private ScrollPane scrollPane;
+	private int count;
+	
+	public void create () {
+		stage = new Stage();
+		Skin skin = new Skin(Gdx.files.internal("data/uiskin.json"));
+		Gdx.input.setInputProcessor(stage);
+		
+		dynamicLabel = new Label("Chat box begin here", skin);
+
+		float chatWidth = 200;
+		float controlHeight = 300;
+		
+		scrollPane = new ScrollPane(dynamicLabel, skin);
+
+		Table main = new Table();
+		
+		main.setFillParent(true);
+		
+		TextButton btAdd = new TextButton("Add text and scroll down", skin);
+		
+		main.add(btAdd).row();
+		main.add(scrollPane).size(200, 100);
+		
+		stage.addActor(main);
+		
+		stage.setDebugAll(true);
+		
+		btAdd.addListener(new ChangeListener() {
+			@Override
+			public void changed (ChangeEvent event, Actor actor) {
+				dynamicLabel.setText(dynamicLabel.getText() + "\nline " + count++);
+				scrollPane.scrollTo(0, 0, 0, 0);
+			}
+		});
+		
+	}
+
+	public void render () {
+		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		stage.act(Gdx.graphics.getDeltaTime());
+		stage.draw();
+	}
+
+	public void resize (int width, int height) {
+		stage.getViewport().update(width, height, true);
+	}
+
+	public void dispose () {
+		stage.dispose();
+	}
+
+	public boolean needsGL20 () {
+		return false;
+	}
+}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
@@ -204,6 +204,7 @@ public class GdxTests {
 		ScrollPaneScrollBarsTest.class,
 		ScrollPaneTest.class,
 		ScrollPaneTextAreaTest.class,
+		ScrollPaneWithDynamicScrolling.class,
 		SelectTest.class,
 		SensorTest.class,
 		ShaderCollectionTest.class,


### PR DESCRIPTION
Calling ScrollPane scrollTo just after changing children size didn't work.

A another way (workaround) was to manually validate scrollPane before calling scrollTo but i think it's better to do it automatically in ScrollPane class. @NathanSweet What do you think?

It fixes #5488 and in some way #4561 as well : I'll comment on the latest issue.