### PR TITLE
Don't refer to freed element. Fix by order change.

### DIFF
--- a/gdx/src/com/badlogic/gdx/utils/PooledLinkedList.java
+++ b/gdx/src/com/badlogic/gdx/utils/PooledLinkedList.java
@@ -170,8 +170,8 @@ public class PooledLinkedList<T> {
 			head = null;
 			tail = null;
 		} else {
-			tail.next = null;
 			tail = p;
+			tail.next = null;
 		}
 
 


### PR DESCRIPTION
tail.next is still referring to the old (now freed) tail.
So first assign the new value to tail, then change the tail.next value.