### PR TITLE
Remove unused Pixmap's from AssetLoaders

### DIFF
--- a/gdx/src/com/badlogic/gdx/assets/loaders/CubemapLoader.java
+++ b/gdx/src/com/badlogic/gdx/assets/loaders/CubemapLoader.java
@@ -22,15 +22,11 @@ import com.badlogic.gdx.assets.AssetManager;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.Cubemap;
 import com.badlogic.gdx.graphics.CubemapData;
-import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.Pixmap.Format;
-import com.badlogic.gdx.graphics.PixmapIO;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.Texture.TextureFilter;
 import com.badlogic.gdx.graphics.Texture.TextureWrap;
 import com.badlogic.gdx.graphics.TextureData;
-import com.badlogic.gdx.graphics.glutils.ETC1TextureData;
-import com.badlogic.gdx.graphics.glutils.FileTextureData;
 import com.badlogic.gdx.graphics.glutils.KTXTextureData;
 import com.badlogic.gdx.utils.Array;
 
@@ -56,7 +52,6 @@ public class CubemapLoader extends AsynchronousAssetLoader<Cubemap, CubemapLoade
 	public void loadAsync (AssetManager manager, String fileName, FileHandle file, CubemapParameter parameter) {
 		info.filename = fileName;
 		if (parameter == null || parameter.cubemapData == null) {
-			Pixmap pixmap = null;
 			Format format = null;
 			boolean genMipMaps = false;
 			info.cubemap = null;

--- a/gdx/src/com/badlogic/gdx/assets/loaders/TextureLoader.java
+++ b/gdx/src/com/badlogic/gdx/assets/loaders/TextureLoader.java
@@ -20,17 +20,11 @@ import com.badlogic.gdx.assets.AssetDescriptor;
 import com.badlogic.gdx.assets.AssetLoaderParameters;
 import com.badlogic.gdx.assets.AssetManager;
 import com.badlogic.gdx.files.FileHandle;
-import com.badlogic.gdx.graphics.GLTexture;
-import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.Pixmap.Format;
-import com.badlogic.gdx.graphics.PixmapIO;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.Texture.TextureFilter;
 import com.badlogic.gdx.graphics.Texture.TextureWrap;
 import com.badlogic.gdx.graphics.TextureData;
-import com.badlogic.gdx.graphics.glutils.ETC1TextureData;
-import com.badlogic.gdx.graphics.glutils.FileTextureData;
-import com.badlogic.gdx.graphics.glutils.KTXTextureData;
 import com.badlogic.gdx.utils.Array;
 
 /** {@link AssetLoader} for {@link Texture} instances. The pixel data is loaded asynchronously. The texture is then created on the
@@ -55,7 +49,6 @@ public class TextureLoader extends AsynchronousAssetLoader<Texture, TextureLoade
 	public void loadAsync (AssetManager manager, String fileName, FileHandle file, TextureParameter parameter) {
 		info.filename = fileName;
 		if (parameter == null || parameter.textureData == null) {
-			Pixmap pixmap = null;
 			Format format = null;
 			boolean genMipMaps = false;
 			info.texture = null;


### PR DESCRIPTION
These look to just be left over copy paste artifacts.