### PR TITLE
Fixes #5540, improved Align.toString

### DIFF
--- a/gdx/src/com/badlogic/gdx/utils/Align.java
+++ b/gdx/src/com/badlogic/gdx/utils/Align.java
@@ -19,55 +19,68 @@ package com.badlogic.gdx.utils;
 /** Provides bit flag constants for alignment.
  * @author Nathan Sweet */
 public class Align {
-	static public final int center = 1 << 0;
-	static public final int top = 1 << 1;
-	static public final int bottom = 1 << 2;
-	static public final int left = 1 << 3;
-	static public final int right = 1 << 4;
 
-	static public final int topLeft = top | left;
-	static public final int topRight = top | right;
-	static public final int bottomLeft = bottom | left;
-	static public final int bottomRight = bottom | right;
+    static public final int center = 1 << 0;
+    static public final int top = 1 << 1;
+    static public final int bottom = 1 << 2;
+    static public final int left = 1 << 3;
+    static public final int right = 1 << 4;
 
-	static public final boolean isLeft (int align) {
-		return (align & left) != 0;
-	}
+    static public final int topLeft = top | left;
+    static public final int topCenter = top | left | right;
+    static public final int topRight = top | right;
+    static public final int centerLeft = top | bottom | left;
+    static public final int centerRight = top | bottom | right;
+    static public final int bottomLeft = bottom | left;
+    static public final int bottomCenter = bottom | left | right;
+    static public final int bottomRight = bottom | right;
 
-	static public final boolean isRight (int align) {
-		return (align & right) != 0;
-	}
+    static public boolean isLeft(int align) {
+        return (align & left) != 0;
+    }
 
-	static public final boolean isTop (int align) {
-		return (align & top) != 0;
-	}
+    static public boolean isRight(int align) {
+        return (align & right) != 0;
+    }
 
-	static public final boolean isBottom (int align) {
-		return (align & bottom) != 0;
-	}
+    static public boolean isTop(int align) {
+        return (align & top) != 0;
+    }
 
-	static public final boolean isCenterVertical (int align) {
-		return (align & top) == 0 && (align & bottom) == 0;
-	}
+    static public boolean isBottom(int align) {
+        return (align & bottom) != 0;
+    }
 
-	static public final boolean isCenterHorizontal (int align) {
-		return (align & left) == 0 && (align & right) == 0;
-	}
+    static public boolean isCenterVertical(int align) {
+        return isTop(align) && isBottom(align) || align == center;
+    }
 
-	static public String toString (int align) {
-		StringBuilder buffer = new StringBuilder(13);
-		if ((align & top) != 0)
-			buffer.append("top,");
-		else if ((align & bottom) != 0)
-			buffer.append("bottom,");
-		else
-			buffer.append("center,");
-		if ((align & left) != 0)
-			buffer.append("left");
-		else if ((align & right) != 0)
-			buffer.append("right");
-		else
-			buffer.append("center");
-		return buffer.toString();
-	}
+    static public boolean isCenterHorizontal(int align) {
+        return isLeft(align) && isRight(align) || align == center;
+    }
+
+    static public String toString(int align) {
+        if (align == center) return "center";
+
+        StringBuilder buffer = new StringBuilder(11);
+
+        if (isCenterVertical(align)) {
+            buffer.append("center ");
+        } else if (isTop(align)) {
+            buffer.append("top ");
+        } else if (isBottom(align)) {
+            buffer.append("bottom ");
+        }
+
+        if (isCenterHorizontal(align)) {
+            buffer.append("center ");
+        } else if (isLeft(align)) {
+            buffer.append("left ");
+        } else if (isRight(align)) {
+            buffer.append("right ");
+        }
+
+        buffer.deleteCharAt(buffer.length - 1);
+        return buffer.toString();
+    }
 }


### PR DESCRIPTION
- Improved the toString method to give meaningful results for alignments centered only on one axis, e.g.: `top center` and `center right`.
- Added a few more constants for alignements centered only on one axis.