### PR TITLE
change 'compile' to 'implementation' in gdx-setup.jar

### DIFF
--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/BuildScriptHelper.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/BuildScriptHelper.java
@@ -100,7 +100,7 @@ public class BuildScriptHelper {
 	private static void addDependencies(Language language, ProjectType project, List<Dependency> dependencyList, BufferedWriter wr) throws IOException {
 		write(wr, "dependencies {");
 		if (!project.equals(ProjectType.CORE)) {
-			write(wr, "compile project(\":" + ProjectType.CORE.getName() + "\")");
+			write(wr, "implementation project(\":" + ProjectType.CORE.getName() + "\")");
 		}
 		for (Dependency dep : dependencyList) {
 			if (dep.getDependencies(project) == null) continue;
@@ -109,7 +109,7 @@ public class BuildScriptHelper {
 				if ((project.equals(ProjectType.ANDROID) || project.equals(ProjectType.IOSMOE)) && moduleDependency.contains("native")) {
 					write(wr, "natives \"" + moduleDependency + "\"");
 				} else {
-					write(wr, "compile \"" + moduleDependency + "\"");
+					write(wr, "implementation \"" + moduleDependency + "\"");
 				}
 			}
 		}


### PR DESCRIPTION
This fixes the "WARNING: Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'. " warning from Gradle. 
Rather than using "compile" for dependencies, uses "implementation" instead.
See 
https://developer.android.com/studio/build/dependencies?utm_source=android-studio#dependency_configurations

To test this, I built the gdx-setup.jar by running "ant" in the libgdx/extensions/gdx-setup directory, then I created a new gdx project with the gdx-setup.jar file it created. I also verified that occurrences of "compile" in the generated project's build.gradle file had all be replaced with "implementation"