### PR TITLE
Fix GlyphLayout height calculation when using flipped fonts.

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g2d/GlyphLayout.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/GlyphLayout.java
@@ -302,7 +302,10 @@ public class GlyphLayout implements Poolable {
 		}
 
 		this.width = width;
-		this.height = fontData.capHeight - lines * fontData.down - blankLines * fontData.down * fontData.blankLineScale;
+		if(fontData.flipped)
+			this.height = fontData.capHeight + lines * fontData.down + blankLines * fontData.down * fontData.blankLineScale;
+		else
+			this.height = fontData.capHeight - lines * fontData.down - blankLines * fontData.down * fontData.blankLineScale;
 	}
 
 	/** @param truncate May be empty string. */


### PR DESCRIPTION
Bug introduced in f78d903329de901f5beaa92de124457b4e122271

[`down` is positive when using flipped fonts](https://github.com/libgdx/libgdx/blob/5b623668791dde2fa93a95af0d2f6a08a465d194/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFont.java#L703) so we should use addition like we used to with lineHeight.