### PR TITLE
NativeBuild/Jnigen: add option to strip desktop binaries.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -12,7 +12,7 @@
 	<property name="build-natives" value="false"/>
 
 	<!-- should we build natives in release mode -->
-	<property name="release" value="false"/>
+	<property name="release" value="true"/>
 
 	<!-- clean distribution/output directory -->
 	<target name="clean">

--- a/build.xml
+++ b/build.xml
@@ -11,6 +11,9 @@
 	<!-- should we build natives? -->
 	<property name="build-natives" value="false"/>
 
+	<!-- should we build natives in release mode -->
+	<property name="release" value="false"/>
+
 	<!-- clean distribution/output directory -->
 	<target name="clean">
 		<delete dir="${distDir}"/>

--- a/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/resources/scripts/build-target.xml.template
+++ b/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/resources/scripts/build-target.xml.template
@@ -36,6 +36,9 @@
 	<property name="linker" value="${compilerPrefix}g++${compilerSuffix}"/>
 	<property name="linker-opts" value="%linkerFlags%"/>
 	<property name="libraries" value="%libraries%"/>
+
+	<!-- define stripper -->
+	<property name="stripper" value="${compilerPrefix}strip${compilerSuffix}"/>
 	
 	<!-- cleans the build directory, removes all object files and shared libs -->
 	<target name="clean">
@@ -62,6 +65,23 @@
 		</condition>
 		<condition property="has-compiler">
 			<equals arg1="${compiler-found}" arg2="true"/>
+		</condition>
+		<condition property="stripper-found">
+			<or>
+				<!-- Include both b/c Windows might be either -->
+				<available file="${stripper}" filepath="${env.PATH}"/>
+				<available file="${stripper}" filepath="${env.Path}"/>
+			</or>
+		</condition>
+		<condition property="should-strip">
+			<and>
+				<equals arg1="${stripper-found}" arg2="true"/>
+				<equals arg1="${release}" arg2="true"/>
+				<!-- Don't strip mac osx libs -->
+				<not>
+					<contains string="${libName}" substring="dylib"/>
+				</not>
+			</and>
 		</condition>
 		%precompile%
 	</target>
@@ -132,8 +152,16 @@
 			<arg line="${libraries}" />
 		</exec>
 	</target>	
+
+	<!-- strips the shared library of debug symbols -->
+	<target name="strip" depends="link" if="should-strip">
+		<exec executable="${stripper}" failonerror="true" dir="${buildDir}">
+			<arg value="--strip-unneeded"/>
+			<arg path="${libsDir}/${libName}" />
+		</exec>
+	</target>
 	
-	<target name="postcompile" depends="link">
+	<target name="postcompile" depends="strip">
 		%postcompile%
 	</target>
 </project>


### PR DESCRIPTION
* Adding "-Drelease=true" will call "${compilerPrefix}strip --strip-unneeded ${libName}" after compilation.
* Default value for release is "false"
* Stripping has no influence on ram usage, symbol tables are not loaded into ram.
* OSX is not stripped as they appear pre-stripped (in 1.9.9 release) and OSX's gcc implementation lacks `--strip-unnecessary` as an option.

Would allow desktop builds which bundle all libs into a single jar to be ~2.5MB smaller.

```
16614038 1.9.9-unstripped.zip
14134108 1.9.9-stripped.zip
```

1.9.9 unstripped raw sizes:
```
   453284   gdx64.dll
   711442   gdx-box2d64.dll
   609229   gdx-box2d.dll
  8445098   gdx-bullet64.dll
  8089255   gdx-bullet.dll
  2665154   gdx-controllers-desktop64.dll
  2153195   gdx-controllers-desktop.dll
   390774   gdx.dll
   784149   gdx-freetype64.dll
   722171   gdx-freetype.dll
   246112   libgdx64.so
   400064   libgdx-box2d64.so
   393480   libgdx-box2d.so
  7062496   libgdx-bullet64.so
  7354840   libgdx-bullet.so
   178688   libgdx-controllers-desktop64.so
   163736   libgdx-controllers-desktop.so
   811616   libgdx-freetype64.so
   820888   libgdx-freetype.so
   260848   libgdx.so
```

1.9.9 stripped raw sizes
```
   281101   gdx64.dll
   347343   gdx-box2d64.dll
   329897   gdx-box2d.dll
  5154137   gdx-bullet64.dll
  5444343   gdx-bullet.dll
   995634   gdx-controllers-desktop64.dll
   970499   gdx-controllers-desktop.dll
   259021   gdx.dll
   608045   gdx-freetype64.dll
   571663   gdx-freetype.dll
   220416   libgdx64.so
   319752   libgdx-box2d64.so
   322120   libgdx-box2d.so
  5488608   libgdx-bullet64.so
  5896208   libgdx-bullet.so
   142920   libgdx-controllers-desktop64.so
   133248   libgdx-controllers-desktop.so
   728784   libgdx-freetype64.so
   743640   libgdx-freetype.so
   227324   libgdx.so
```

No generated files are included in this PR for readability sake. The following snippet may be used to generate all automatically.

```
cd gdx
mvn clean compile exec:java -Dexec.mainClass="com.badlogic.gdx.utils.GdxBuild"

cd ../extensions/gdx-controllers/gdx-controllers-desktop/
mvn clean compile exec:java -Dexec.mainClass="com.badlogic.gdx.controllers.desktop.DesktopControllersBuild"

cd ../../gdx-freetype/
mvn clean compile exec:java -Dexec.mainClass="com.badlogic.gdx.graphics.g2d.freetype.FreetypeBuild"

cd ../gdx-box2d/gdx-box2d
mvn clean compile exec:java -Dexec.mainClass="com.badlogic.gdx.physics.box2d.utils.Box2DBuild"

cd ../../gdx-bullet/
mvn clean compile exec:java -Dexec.mainClass="com.badlogic.gdx.physics.bullet.BulletBuild"
```