### PR TITLE
libgdx/jnigen armhf/aarch64 native build support

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -70,6 +70,10 @@
 - API Addition: New MathUtils norm and map methods
 - API Change: Pixmap blending was incorrect. Generated fonts may change for the better, but may require adjusting font settings.
 - API Change: Particle effects obtained from a ParticleEffectPool are now automatically started
+- Added support for Linux ARM builds.
+	- 32-bit: ARMv7/armhf
+	- 64-bit: ARMv8/AArch64
+- API Change: Removed arm abi from SharedLibraryLoader
 - Removed OSX 32-bit support
 - API Change: By default LWJGL2 backend no longer does pause/resume when becoming background/foreground window. New app config setting was added to enable the old behavior.
 - API Change: By default LWJGL2 backend now does pause/resume when window is minimized/restored. New app config setting was added to disable this behavior.

--- a/CHANGES
+++ b/CHANGES
@@ -51,6 +51,10 @@
 - Fixed Label text wrapping when it shouldn't (#6098).
 - Fixed ShapeRenderer not being able to render alpha 0xff (was max 0xfe).
 - API Change: glGetActiveUniform and glGetActiveAttrib paramter changed from Buffer to IntBuffer.
+- Added support for Linux ARM builds.
+	- 32-bit: ARMv7/armhf
+	- 64-bit: ARMv8/AArch64
+- API Change: Removed arm abi from SharedLibraryLoader
 
 [1.9.10]
 - API Addition: Allow target display for maximization LWJGL3 backend
@@ -70,10 +74,6 @@
 - API Addition: New MathUtils norm and map methods
 - API Change: Pixmap blending was incorrect. Generated fonts may change for the better, but may require adjusting font settings.
 - API Change: Particle effects obtained from a ParticleEffectPool are now automatically started
-- Added support for Linux ARM builds.
-	- 32-bit: ARMv7/armhf
-	- 64-bit: ARMv8/AArch64
-- API Change: Removed arm abi from SharedLibraryLoader
 - Removed OSX 32-bit support
 - API Change: By default LWJGL2 backend no longer does pause/resume when becoming background/foreground window. New app config setting was added to enable the old behavior.
 - API Change: By default LWJGL2 backend now does pause/resume when window is minimized/restored. New app config setting was added to disable this behavior.

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglNativesLoader.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglNativesLoader.java
@@ -59,9 +59,16 @@ public final class LwjglNativesLoader {
 				nativesDir = loader.extractFile("liblwjgl.dylib", null).getParentFile();
 				if (!LwjglApplicationConfiguration.disableAudio) loader.extractFileTo("openal.dylib", nativesDir);
 			} else if (isLinux) {
-				nativesDir = loader.extractFile(is64Bit ? "liblwjgl64.so" : "liblwjgl.so", null).getParentFile();
-				if (!LwjglApplicationConfiguration.disableAudio)
-					loader.extractFileTo(is64Bit ? "libopenal64.so" : "libopenal.so", nativesDir);
+				if (SharedLibraryLoader.isARM) {
+					nativesDir = loader.extractFile(loader.mapLibraryName("lwjgl"), null, "liblwjgl.so").getParentFile();
+					if (!LwjglApplicationConfiguration.disableAudio)
+						loader.extractFileTo(loader.mapLibraryName("openal"), nativesDir, "libopenal.so");
+				}
+				else {
+					nativesDir = loader.extractFile(is64Bit ? "liblwjgl64.so" : "liblwjgl.so", null).getParentFile();
+					if (!LwjglApplicationConfiguration.disableAudio)
+						loader.extractFileTo(is64Bit ? "libopenal64.so" : "libopenal.so", nativesDir);
+				}
 			}
 		} catch (Throwable ex) {
 			throw new GdxRuntimeException("Unable to extract LWJGL natives.", ex);

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglNativesLoader.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglNativesLoader.java
@@ -59,16 +59,9 @@ public final class LwjglNativesLoader {
 				nativesDir = loader.extractFile("liblwjgl.dylib", null).getParentFile();
 				if (!LwjglApplicationConfiguration.disableAudio) loader.extractFileTo("openal.dylib", nativesDir);
 			} else if (isLinux) {
-				if (SharedLibraryLoader.isARM) {
-					nativesDir = loader.extractFile(loader.mapLibraryName("lwjgl"), null, "liblwjgl.so").getParentFile();
-					if (!LwjglApplicationConfiguration.disableAudio)
-						loader.extractFileTo(loader.mapLibraryName("openal"), nativesDir, "libopenal.so");
-				}
-				else {
-					nativesDir = loader.extractFile(is64Bit ? "liblwjgl64.so" : "liblwjgl.so", null).getParentFile();
-					if (!LwjglApplicationConfiguration.disableAudio)
-						loader.extractFileTo(is64Bit ? "libopenal64.so" : "libopenal.so", nativesDir);
-				}
+				nativesDir = loader.extractFile(is64Bit ? "liblwjgl64.so" : "liblwjgl.so", null).getParentFile();
+				if (!LwjglApplicationConfiguration.disableAudio)
+					loader.extractFileTo(is64Bit ? "libopenal64.so" : "libopenal.so", nativesDir);
 			}
 		} catch (Throwable ex) {
 			throw new GdxRuntimeException("Unable to extract LWJGL natives.", ex);

--- a/extensions/gdx-box2d/gdx-box2d/jni/maven/pom.xml
+++ b/extensions/gdx-box2d/gdx-box2d/jni/maven/pom.xml
@@ -134,6 +134,8 @@
                             <resources>
                                 <resource><directory>${basedir}/../../libs/linux32</directory></resource>
                                 <resource><directory>${basedir}/../../libs/linux64</directory></resource>
+                                <resource><directory>${basedir}/../../libs/linuxarm64</directory></resource>
+                                <resource><directory>${basedir}/../../libs/linuxarmgnueabihf32</directory></resource>
                                 <resource><directory>${basedir}/../../libs/windows32</directory></resource>
                                 <resource><directory>${basedir}/../../libs/windows64</directory></resource>
                             </resources>

--- a/extensions/gdx-box2d/gdx-box2d/jni/maven/pom.xml
+++ b/extensions/gdx-box2d/gdx-box2d/jni/maven/pom.xml
@@ -134,8 +134,8 @@
                             <resources>
                                 <resource><directory>${basedir}/../../libs/linux32</directory></resource>
                                 <resource><directory>${basedir}/../../libs/linux64</directory></resource>
+                                <resource><directory>${basedir}/../../libs/linuxarm32</directory></resource>
                                 <resource><directory>${basedir}/../../libs/linuxarm64</directory></resource>
-                                <resource><directory>${basedir}/../../libs/linuxarmgnueabihf32</directory></resource>
                                 <resource><directory>${basedir}/../../libs/windows32</directory></resource>
                                 <resource><directory>${basedir}/../../libs/windows64</directory></resource>
                             </resources>

--- a/extensions/gdx-box2d/gdx-box2d/src/com/badlogic/gdx/physics/box2d/utils/Box2DBuild.java
+++ b/extensions/gdx-box2d/gdx-box2d/src/com/badlogic/gdx/physics/box2d/utils/Box2DBuild.java
@@ -14,12 +14,12 @@ public class Box2DBuild {
 		BuildTarget win64 = BuildTarget.newDefaultTarget(TargetOs.Windows, true);
 		BuildTarget lin32 = BuildTarget.newDefaultTarget(TargetOs.Linux, false);
 		BuildTarget lin64 = BuildTarget.newDefaultTarget(TargetOs.Linux, true);
-		BuildTarget linarmgnueabihf = BuildTarget.newDefaultTarget(TargetOs.Linux, false, true, "gnueabihf");
-		BuildTarget linarm64 = BuildTarget.newDefaultTarget(TargetOs.Linux, true, true, "");
+		BuildTarget linarm32 = BuildTarget.newDefaultTarget(TargetOs.Linux, false, true);
+		BuildTarget linarm64 = BuildTarget.newDefaultTarget(TargetOs.Linux, true, true);
 		BuildTarget android = BuildTarget.newDefaultTarget(TargetOs.Android, false);
 		BuildTarget mac64 = BuildTarget.newDefaultTarget(TargetOs.MacOsX, true);
 		BuildTarget ios = BuildTarget.newDefaultTarget(TargetOs.IOS, false);
 		new NativeCodeGenerator().generate("src", "bin" + File.pathSeparator + "../../../gdx/bin", "jni");
-		new AntScriptGenerator().generate(new BuildConfig("gdx-box2d"), win32, win64, lin32, lin64, linarmgnueabihf, linarm64, mac64, android, ios);
+		new AntScriptGenerator().generate(new BuildConfig("gdx-box2d"), win32, win64, lin32, lin64, linarm32, linarm64, mac64, android, ios);
 	}
 }

--- a/extensions/gdx-box2d/gdx-box2d/src/com/badlogic/gdx/physics/box2d/utils/Box2DBuild.java
+++ b/extensions/gdx-box2d/gdx-box2d/src/com/badlogic/gdx/physics/box2d/utils/Box2DBuild.java
@@ -5,8 +5,8 @@ import java.io.File;
 import com.badlogic.gdx.jnigen.AntScriptGenerator;
 import com.badlogic.gdx.jnigen.BuildConfig;
 import com.badlogic.gdx.jnigen.BuildTarget;
-import com.badlogic.gdx.jnigen.NativeCodeGenerator;
 import com.badlogic.gdx.jnigen.BuildTarget.TargetOs;
+import com.badlogic.gdx.jnigen.NativeCodeGenerator;
 
 public class Box2DBuild {
 	public static void main(String[] args) throws Exception {
@@ -14,10 +14,12 @@ public class Box2DBuild {
 		BuildTarget win64 = BuildTarget.newDefaultTarget(TargetOs.Windows, true);
 		BuildTarget lin32 = BuildTarget.newDefaultTarget(TargetOs.Linux, false);
 		BuildTarget lin64 = BuildTarget.newDefaultTarget(TargetOs.Linux, true);
+		BuildTarget linarmgnueabihf = BuildTarget.newDefaultTarget(TargetOs.Linux, false, true, "gnueabihf");
+		BuildTarget linarm64 = BuildTarget.newDefaultTarget(TargetOs.Linux, true, true, "");
 		BuildTarget android = BuildTarget.newDefaultTarget(TargetOs.Android, false);
 		BuildTarget mac64 = BuildTarget.newDefaultTarget(TargetOs.MacOsX, true);
 		BuildTarget ios = BuildTarget.newDefaultTarget(TargetOs.IOS, false);
 		new NativeCodeGenerator().generate("src", "bin" + File.pathSeparator + "../../../gdx/bin", "jni");
-		new AntScriptGenerator().generate(new BuildConfig("gdx-box2d"), win32, win64, lin32, lin64, mac64, android, ios);		
+		new AntScriptGenerator().generate(new BuildConfig("gdx-box2d"), win32, win64, lin32, lin64, linarmgnueabihf, linarm64, mac64, android, ios);
 	}
 }

--- a/extensions/gdx-bullet/jni/maven/pom.xml
+++ b/extensions/gdx-bullet/jni/maven/pom.xml
@@ -131,8 +131,8 @@
                             <resources>
                                 <resource><directory>${basedir}/../../libs/linux32</directory></resource>
                                 <resource><directory>${basedir}/../../libs/linux64</directory></resource>
+                                <resource><directory>${basedir}/../../libs/linuxarm32</directory></resource>
                                 <resource><directory>${basedir}/../../libs/linuxarm64</directory></resource>
-                                <resource><directory>${basedir}/../../libs/linuxarmgnueabihf32</directory></resource>
                                 <resource><directory>${basedir}/../../libs/macosx64</directory></resource>
                                 <resource><directory>${basedir}/../../libs/windows32</directory></resource>
                                 <resource><directory>${basedir}/../../libs/windows64</directory></resource>

--- a/extensions/gdx-bullet/jni/maven/pom.xml
+++ b/extensions/gdx-bullet/jni/maven/pom.xml
@@ -131,6 +131,8 @@
                             <resources>
                                 <resource><directory>${basedir}/../../libs/linux32</directory></resource>
                                 <resource><directory>${basedir}/../../libs/linux64</directory></resource>
+                                <resource><directory>${basedir}/../../libs/linuxarm64</directory></resource>
+                                <resource><directory>${basedir}/../../libs/linuxarmgnueabihf32</directory></resource>
                                 <resource><directory>${basedir}/../../libs/macosx64</directory></resource>
                                 <resource><directory>${basedir}/../../libs/windows32</directory></resource>
                                 <resource><directory>${basedir}/../../libs/windows64</directory></resource>

--- a/extensions/gdx-bullet/src/com/badlogic/gdx/physics/bullet/BulletBuild.java
+++ b/extensions/gdx-bullet/src/com/badlogic/gdx/physics/bullet/BulletBuild.java
@@ -80,12 +80,12 @@ public class BulletBuild {
 		lin64.headerDirs = headers;
 		lin64.cppFlags += cppFlags;
 
-		BuildTarget linarmgnueabihf = BuildTarget.newDefaultTarget(TargetOs.Linux, false, true, "gnueabihf");
-		linarmgnueabihf.cExcludes = linarmgnueabihf.cppExcludes = excludes;
-		linarmgnueabihf.headerDirs = headers;
-		linarmgnueabihf.cppFlags += cppFlags;
+		BuildTarget linarm32 = BuildTarget.newDefaultTarget(TargetOs.Linux, false, true);
+		linarm32.cExcludes = linarm32.cppExcludes = excludes;
+		linarm32.headerDirs = headers;
+		linarm32.cppFlags += cppFlags;
 
-		BuildTarget linarm64 = BuildTarget.newDefaultTarget(TargetOs.Linux, true, true, "");
+		BuildTarget linarm64 = BuildTarget.newDefaultTarget(TargetOs.Linux, true, true);
 		linarm64.cExcludes = linarm64.cppExcludes = excludes;
 		linarm64.headerDirs = headers;
 		linarm64.cppFlags += cppFlags;
@@ -106,7 +106,7 @@ public class BulletBuild {
 		ios.cppFlags += cppFlags;
 		ios.cppFlags += " -stdlib=libc++";
 
-		new AntScriptGenerator().generate(new BuildConfig("gdx-bullet"), win32home, win32, win64, lin32, lin64, linarmgnueabihf, linarm64, mac64, android, ios);
+		new AntScriptGenerator().generate(new BuildConfig("gdx-bullet"), win32home, win32, win64, lin32, lin64, linarm32, linarm64, mac64, android, ios);
 		new FileHandle(new File("jni/Application.mk")).writeString("\nAPP_STL := stlport_static\n", true);
 
 		// build natives

--- a/extensions/gdx-bullet/src/com/badlogic/gdx/physics/bullet/BulletBuild.java
+++ b/extensions/gdx-bullet/src/com/badlogic/gdx/physics/bullet/BulletBuild.java
@@ -79,7 +79,17 @@ public class BulletBuild {
 		lin64.cExcludes = lin64.cppExcludes = excludes;
 		lin64.headerDirs = headers;
 		lin64.cppFlags += cppFlags;
-		
+
+		BuildTarget linarmgnueabihf = BuildTarget.newDefaultTarget(TargetOs.Linux, false, true, "gnueabihf");
+		linarmgnueabihf.cExcludes = linarmgnueabihf.cppExcludes = excludes;
+		linarmgnueabihf.headerDirs = headers;
+		linarmgnueabihf.cppFlags += cppFlags;
+
+		BuildTarget linarm64 = BuildTarget.newDefaultTarget(TargetOs.Linux, true, true, "");
+		linarm64.cExcludes = linarm64.cppExcludes = excludes;
+		linarm64.headerDirs = headers;
+		linarm64.cppFlags += cppFlags;
+
 		BuildTarget mac64 = BuildTarget.newDefaultTarget(TargetOs.MacOsX, true);
 		mac64.cExcludes = mac64.cppExcludes = excludes;
 		mac64.headerDirs = headers;
@@ -89,14 +99,14 @@ public class BulletBuild {
 		android.cExcludes = android.cppExcludes = excludes;
 		android.headerDirs = headers;	
 		android.cppFlags += cppFlags + " -fexceptions";
-		
+
 		BuildTarget ios = BuildTarget.newDefaultTarget(TargetOs.IOS, false);
 		ios.cExcludes = ios.cppExcludes = excludes;
 		ios.headerDirs = headers;
 		ios.cppFlags += cppFlags;
 		ios.cppFlags += " -stdlib=libc++";
 
-		new AntScriptGenerator().generate(new BuildConfig("gdx-bullet"), win32home, win32, win64, lin32, lin64, mac64, android, ios);
+		new AntScriptGenerator().generate(new BuildConfig("gdx-bullet"), win32home, win32, win64, lin32, lin64, linarmgnueabihf, linarm64, mac64, android, ios);
 		new FileHandle(new File("jni/Application.mk")).writeString("\nAPP_STL := stlport_static\n", true);
 
 		// build natives

--- a/extensions/gdx-controllers/gdx-controllers-desktop/jni/maven/pom.xml
+++ b/extensions/gdx-controllers/gdx-controllers-desktop/jni/maven/pom.xml
@@ -63,6 +63,8 @@
                             <resources>
                                 <resource><directory>${basedir}/../../libs/linux32</directory></resource>
                                 <resource><directory>${basedir}/../../libs/linux64</directory></resource>
+                                <resource><directory>${basedir}/../../libs/linuxarm64</directory></resource>
+                                <resource><directory>${basedir}/../../libs/linuxarmgnueabihf32</directory></resource>
                                 <resource><directory>${basedir}/../../libs/macosx64</directory></resource>
                                 <resource><directory>${basedir}/../../libs/windows32</directory></resource>
                                 <resource><directory>${basedir}/../../libs/windows64</directory></resource>

--- a/extensions/gdx-controllers/gdx-controllers-desktop/jni/maven/pom.xml
+++ b/extensions/gdx-controllers/gdx-controllers-desktop/jni/maven/pom.xml
@@ -63,8 +63,8 @@
                             <resources>
                                 <resource><directory>${basedir}/../../libs/linux32</directory></resource>
                                 <resource><directory>${basedir}/../../libs/linux64</directory></resource>
+                                <resource><directory>${basedir}/../../libs/linuxarm32</directory></resource>
                                 <resource><directory>${basedir}/../../libs/linuxarm64</directory></resource>
-                                <resource><directory>${basedir}/../../libs/linuxarmgnueabihf32</directory></resource>
                                 <resource><directory>${basedir}/../../libs/macosx64</directory></resource>
                                 <resource><directory>${basedir}/../../libs/windows32</directory></resource>
                                 <resource><directory>${basedir}/../../libs/windows64</directory></resource>

--- a/extensions/gdx-controllers/gdx-controllers-desktop/src/com/badlogic/gdx/controllers/desktop/DesktopControllersBuild.java
+++ b/extensions/gdx-controllers/gdx-controllers-desktop/src/com/badlogic/gdx/controllers/desktop/DesktopControllersBuild.java
@@ -18,7 +18,6 @@ package com.badlogic.gdx.controllers.desktop;
 
 import com.badlogic.gdx.jnigen.AntScriptGenerator;
 import com.badlogic.gdx.jnigen.BuildConfig;
-import com.badlogic.gdx.jnigen.BuildExecutor;
 import com.badlogic.gdx.jnigen.BuildTarget;
 import com.badlogic.gdx.jnigen.NativeCodeGenerator;
 import com.badlogic.gdx.jnigen.BuildTarget.TargetOs;
@@ -66,14 +65,24 @@ public class DesktopControllersBuild {
 		lin64.cppIncludes = linuxSrc;
 		lin64.headerDirs = includes;
 		lin64.libraries = "-lX11";
-		
+
+		BuildTarget linarmgnueabihf = BuildTarget.newDefaultTarget(TargetOs.Linux, false, true, "gnueabihf");
+		linarmgnueabihf.cppIncludes = linuxSrc;
+		linarmgnueabihf.headerDirs = includes;
+		linarmgnueabihf.libraries = "-lX11";
+
+		BuildTarget linarm64 = BuildTarget.newDefaultTarget(TargetOs.Linux, true, true, "");
+		linarm64.cppIncludes = linuxSrc;
+		linarm64.headerDirs = includes;
+		linarm64.libraries = "-lX11";
+
 		BuildTarget mac64 = BuildTarget.newDefaultTarget(TargetOs.MacOsX, true);
 		mac64.cppIncludes = mac64Src;
 		mac64.headerDirs = includes;
 		mac64.cppFlags += " -x objective-c++";
 		mac64.libraries = "-framework CoreServices -framework Carbon -framework IOKit -framework Cocoa";
 
-		new AntScriptGenerator().generate(buildConfig, win32home, win32, win64, lin32, lin64, mac64);
+		new AntScriptGenerator().generate(buildConfig, win32home, win32, win64, lin32, lin64, linarmgnueabihf, linarm64, mac64);
 //		if (!BuildExecutor.executeAnt("jni/build-macosx32.xml", "-Dhas-compiler=true -v postcompile")) {
 //			throw new Exception("build failed");
 //		}

--- a/extensions/gdx-controllers/gdx-controllers-desktop/src/com/badlogic/gdx/controllers/desktop/DesktopControllersBuild.java
+++ b/extensions/gdx-controllers/gdx-controllers-desktop/src/com/badlogic/gdx/controllers/desktop/DesktopControllersBuild.java
@@ -66,12 +66,12 @@ public class DesktopControllersBuild {
 		lin64.headerDirs = includes;
 		lin64.libraries = "-lX11";
 
-		BuildTarget linarmgnueabihf = BuildTarget.newDefaultTarget(TargetOs.Linux, false, true, "gnueabihf");
-		linarmgnueabihf.cppIncludes = linuxSrc;
-		linarmgnueabihf.headerDirs = includes;
-		linarmgnueabihf.libraries = "-lX11";
+		BuildTarget linarm32 = BuildTarget.newDefaultTarget(TargetOs.Linux, false, true);
+		linarm32.cppIncludes = linuxSrc;
+		linarm32.headerDirs = includes;
+		linarm32.libraries = "-lX11";
 
-		BuildTarget linarm64 = BuildTarget.newDefaultTarget(TargetOs.Linux, true, true, "");
+		BuildTarget linarm64 = BuildTarget.newDefaultTarget(TargetOs.Linux, true, true);
 		linarm64.cppIncludes = linuxSrc;
 		linarm64.headerDirs = includes;
 		linarm64.libraries = "-lX11";
@@ -82,7 +82,7 @@ public class DesktopControllersBuild {
 		mac64.cppFlags += " -x objective-c++";
 		mac64.libraries = "-framework CoreServices -framework Carbon -framework IOKit -framework Cocoa";
 
-		new AntScriptGenerator().generate(buildConfig, win32home, win32, win64, lin32, lin64, linarmgnueabihf, linarm64, mac64);
+		new AntScriptGenerator().generate(buildConfig, win32home, win32, win64, lin32, lin64, linarm32, linarm64, mac64);
 //		if (!BuildExecutor.executeAnt("jni/build-macosx32.xml", "-Dhas-compiler=true -v postcompile")) {
 //			throw new Exception("build failed");
 //		}

--- a/extensions/gdx-freetype/jni/maven/pom.xml
+++ b/extensions/gdx-freetype/jni/maven/pom.xml
@@ -134,8 +134,8 @@
                             <resources>
                                 <resource><directory>${basedir}/../../libs/linux32</directory></resource>
                                 <resource><directory>${basedir}/../../libs/linux64</directory></resource>
+                                <resource><directory>${basedir}/../../libs/linuxarm32</directory></resource>
                                 <resource><directory>${basedir}/../../libs/linuxarm64</directory></resource>
-                                <resource><directory>${basedir}/../../libs/linuxarmgnueabihf32</directory></resource>
                                 <resource><directory>${basedir}/../../libs/macosx64</directory></resource>
                                 <resource><directory>${basedir}/../../libs/windows32</directory></resource>
                                 <resource><directory>${basedir}/../../libs/windows64</directory></resource>

--- a/extensions/gdx-freetype/jni/maven/pom.xml
+++ b/extensions/gdx-freetype/jni/maven/pom.xml
@@ -134,6 +134,8 @@
                             <resources>
                                 <resource><directory>${basedir}/../../libs/linux32</directory></resource>
                                 <resource><directory>${basedir}/../../libs/linux64</directory></resource>
+                                <resource><directory>${basedir}/../../libs/linuxarm64</directory></resource>
+                                <resource><directory>${basedir}/../../libs/linuxarmgnueabihf32</directory></resource>
                                 <resource><directory>${basedir}/../../libs/macosx64</directory></resource>
                                 <resource><directory>${basedir}/../../libs/windows32</directory></resource>
                                 <resource><directory>${basedir}/../../libs/windows64</directory></resource>

--- a/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreetypeBuild.java
+++ b/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreetypeBuild.java
@@ -84,13 +84,13 @@ public class FreetypeBuild {
 		lin64.cFlags += "  -DFT2_BUILD_LIBRARY";
 		lin64.cppFlags += "  -DFT2_BUILD_LIBRARY";
 
-		BuildTarget linarmgnueabihf = BuildTarget.newDefaultTarget(TargetOs.Linux, false, true, "gnueabihf");
-		linarmgnueabihf.headerDirs = headers;
-		linarmgnueabihf.cIncludes = sources;
-		linarmgnueabihf.cFlags += "  -DFT2_BUILD_LIBRARY";
-		linarmgnueabihf.cppFlags += "  -DFT2_BUILD_LIBRARY";
+		BuildTarget linarm32 = BuildTarget.newDefaultTarget(TargetOs.Linux, false, true);
+		linarm32.headerDirs = headers;
+		linarm32.cIncludes = sources;
+		linarm32.cFlags += "  -DFT2_BUILD_LIBRARY";
+		linarm32.cppFlags += "  -DFT2_BUILD_LIBRARY";
 
-		BuildTarget linarm64 = BuildTarget.newDefaultTarget(TargetOs.Linux, true, true, "");
+		BuildTarget linarm64 = BuildTarget.newDefaultTarget(TargetOs.Linux, true, true);
 		linarm64.headerDirs = headers;
 		linarm64.cIncludes = sources;
 		linarm64.cFlags += "  -DFT2_BUILD_LIBRARY";
@@ -116,7 +116,7 @@ public class FreetypeBuild {
 		ios.cppFlags += " -DFT2_BUILD_LIBRARY";
 
 		new NativeCodeGenerator().generate("src", "bin:../../gdx/bin", "jni");
-		new AntScriptGenerator().generate(new BuildConfig("gdx-freetype"), win32home, win32, win64, lin32, lin64, linarmgnueabihf, linarm64,
+		new AntScriptGenerator().generate(new BuildConfig("gdx-freetype"), win32home, win32, win64, lin32, lin64, linarm32, linarm64,
 			mac64, android, ios);
 // BuildExecutor.executeAnt("jni/build-windows32home.xml", "-v clean");
 // BuildExecutor.executeAnt("jni/build-windows32home.xml", "-v");

--- a/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreetypeBuild.java
+++ b/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreetypeBuild.java
@@ -84,6 +84,18 @@ public class FreetypeBuild {
 		lin64.cFlags += "  -DFT2_BUILD_LIBRARY";
 		lin64.cppFlags += "  -DFT2_BUILD_LIBRARY";
 
+		BuildTarget linarmgnueabihf = BuildTarget.newDefaultTarget(TargetOs.Linux, false, true, "gnueabihf");
+		linarmgnueabihf.headerDirs = headers;
+		linarmgnueabihf.cIncludes = sources;
+		linarmgnueabihf.cFlags += "  -DFT2_BUILD_LIBRARY";
+		linarmgnueabihf.cppFlags += "  -DFT2_BUILD_LIBRARY";
+
+		BuildTarget linarm64 = BuildTarget.newDefaultTarget(TargetOs.Linux, true, true, "");
+		linarm64.headerDirs = headers;
+		linarm64.cIncludes = sources;
+		linarm64.cFlags += "  -DFT2_BUILD_LIBRARY";
+		linarm64.cppFlags += "  -DFT2_BUILD_LIBRARY";
+
 		BuildTarget mac64 = BuildTarget.newDefaultTarget(TargetOs.MacOsX, true);
 		mac64.headerDirs = headers;
 		mac64.cIncludes = sources;
@@ -104,8 +116,8 @@ public class FreetypeBuild {
 		ios.cppFlags += " -DFT2_BUILD_LIBRARY";
 
 		new NativeCodeGenerator().generate("src", "bin:../../gdx/bin", "jni");
-		new AntScriptGenerator().generate(new BuildConfig("gdx-freetype"), win32home, win32, win64, lin32, lin64, mac64,
-			android, ios);
+		new AntScriptGenerator().generate(new BuildConfig("gdx-freetype"), win32home, win32, win64, lin32, lin64, linarmgnueabihf, linarm64,
+			mac64, android, ios);
 // BuildExecutor.executeAnt("jni/build-windows32home.xml", "-v clean");
 // BuildExecutor.executeAnt("jni/build-windows32home.xml", "-v");
 // BuildExecutor.executeAnt("jni/build.xml", "pack-natives -v");

--- a/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/AntScriptGenerator.java
+++ b/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/AntScriptGenerator.java
@@ -247,7 +247,7 @@ public class AntScriptGenerator {
 		if (targetFolder == null) targetFolder = target.os.toString().toLowerCase() + (target.isARM ? "arm" : "") + (target.is64Bit ? "64" : "32");
 
 		// replace template vars with proper values
-		template = template.replace("%projectName%", config.sharedLibName + "-" + target.os + "-" + (target.isARM ? "arm" + "-" : "") + (target.is64Bit ? "64" : "32"));
+		template = template.replace("%projectName%", config.sharedLibName + "-" + target.os + "-" + (target.isARM ? "arm" : "") + (target.is64Bit ? "64" : "32"));
 		template = template.replace("%buildDir%", config.buildDir.child(targetFolder).path().replace('\\', '/'));
 		template = template.replace("%libsDir%", "../" + getLibsDirectory(config, target));
 		template = template.replace("%libName%", libName);

--- a/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/AntScriptGenerator.java
+++ b/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/AntScriptGenerator.java
@@ -91,10 +91,10 @@ public class AntScriptGenerator {
 				if (!libsDir.mkdirs()) throw new RuntimeException("Couldn't create libs directory '" + libsDir + "'");
 			}
 
-			String buildFileName = "build-" + target.os.toString().toLowerCase() + (target.isARM ? "arm" + target.abi : "") + (target.is64Bit ? "64" : "32") + ".xml";
+			String buildFileName = "build-" + target.os.toString().toLowerCase() + (target.isARM ? "arm" : "") + (target.is64Bit ? "64" : "32") + ".xml";
 			if (target.buildFileName != null) buildFileName = target.buildFileName;
 			config.jniDir.child(buildFileName).writeString(buildFile, false);
-			System.out.println("Wrote target '" + target.os + (target.isARM ? "Arm" + target.abi : "") + (target.is64Bit ? "64" : "32") + "' build script '"
+			System.out.println("Wrote target '" + target.os + (target.isARM ? "Arm" : "") + (target.is64Bit ? "64" : "32") + "' build script '"
 				+ config.jniDir.child(buildFileName) + "'");
 
 			if (!target.excludeFromMasterBuildFile) {
@@ -104,7 +104,7 @@ public class AntScriptGenerator {
 
 				String sharedLibFilename = target.libName;
 				if (sharedLibFilename == null)
-					sharedLibFilename = getSharedLibFilename(target.os, target.is64Bit, target.isARM, target.abi, config.sharedLibName);
+					sharedLibFilename = getSharedLibFilename(target.os, target.is64Bit, target.isARM, config.sharedLibName);
 				
 				sharedLibFiles.add(sharedLibFilename);
 				if (target.os != TargetOs.Android && target.os != TargetOs.IOS) {
@@ -156,7 +156,7 @@ public class AntScriptGenerator {
 		}
 	}
 
-	private String getSharedLibFilename (TargetOs os, boolean is64Bit, boolean isARM, String abi, String sharedLibName) {
+	private String getSharedLibFilename (TargetOs os, boolean is64Bit, boolean isARM, String sharedLibName) {
 		// generate shared lib prefix and suffix, determine jni platform headers directory
 		String libPrefix = "";
 		String libSuffix = "";
@@ -165,7 +165,7 @@ public class AntScriptGenerator {
 		}
 		if (os == TargetOs.Linux || os == TargetOs.Android) {
 			libPrefix = "lib";
-			libSuffix = (isARM ? "arm" + abi : "") + (is64Bit ? "64" : "") + ".so";
+			libSuffix = (isARM ? "arm" : "") + (is64Bit ? "64" : "") + ".so";
 		}
 		if (os == TargetOs.MacOsX) {
 			libPrefix = "lib";
@@ -187,7 +187,7 @@ public class AntScriptGenerator {
 
 	private String getLibsDirectory (BuildConfig config, BuildTarget target) {
 		String targetName = target.osFileName;
-		if (targetName == null) targetName = target.os.toString().toLowerCase() + (target.isARM ? "arm" + target.abi : "") + (target.is64Bit ? "64" : "32");
+		if (targetName == null) targetName = target.os.toString().toLowerCase() + (target.isARM ? "arm" : "") + (target.is64Bit ? "64" : "32");
 		return config.libsDir.child(targetName).path().replace('\\', '/');
 	}
 
@@ -214,7 +214,7 @@ public class AntScriptGenerator {
 
 		// generate shared lib filename and jni platform headers directory name
 		String libName = target.libName;
-		if (libName == null) libName = getSharedLibFilename(target.os, target.is64Bit, target.isARM, target.abi, config.sharedLibName);
+		if (libName == null) libName = getSharedLibFilename(target.os, target.is64Bit, target.isARM, config.sharedLibName);
 		String jniPlatform = getJniPlatform(target.os);
 
 		// generate include and exclude fileset Ant description for C/C++
@@ -244,10 +244,10 @@ public class AntScriptGenerator {
 		}
 
 		String targetFolder = target.osFileName;
-		if (targetFolder == null) targetFolder = target.os.toString().toLowerCase() + (target.isARM ? "arm" + target.abi : "") + (target.is64Bit ? "64" : "32");
+		if (targetFolder == null) targetFolder = target.os.toString().toLowerCase() + (target.isARM ? "arm" : "") + (target.is64Bit ? "64" : "32");
 
 		// replace template vars with proper values
-		template = template.replace("%projectName%", config.sharedLibName + "-" + target.os + "-" + (target.isARM ? "arm" + target.abi + "-" : "") + (target.is64Bit ? "64" : "32"));
+		template = template.replace("%projectName%", config.sharedLibName + "-" + target.os + "-" + (target.isARM ? "arm" + "-" : "") + (target.is64Bit ? "64" : "32"));
 		template = template.replace("%buildDir%", config.buildDir.child(targetFolder).path().replace('\\', '/'));
 		template = template.replace("%libsDir%", "../" + getLibsDirectory(config, target));
 		template = template.replace("%libName%", libName);

--- a/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/AntScriptGenerator.java
+++ b/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/AntScriptGenerator.java
@@ -91,10 +91,10 @@ public class AntScriptGenerator {
 				if (!libsDir.mkdirs()) throw new RuntimeException("Couldn't create libs directory '" + libsDir + "'");
 			}
 
-			String buildFileName = "build-" + target.os.toString().toLowerCase() + (target.is64Bit ? "64" : "32") + ".xml";
+			String buildFileName = "build-" + target.os.toString().toLowerCase() + (target.isARM ? "arm" + target.abi : "") + (target.is64Bit ? "64" : "32") + ".xml";
 			if (target.buildFileName != null) buildFileName = target.buildFileName;
 			config.jniDir.child(buildFileName).writeString(buildFile, false);
-			System.out.println("Wrote target '" + target.os + (target.is64Bit ? "64" : "") + "' build script '"
+			System.out.println("Wrote target '" + target.os + (target.isARM ? "Arm" + target.abi : "") + (target.is64Bit ? "64" : "32") + "' build script '"
 				+ config.jniDir.child(buildFileName) + "'");
 
 			if (!target.excludeFromMasterBuildFile) {
@@ -104,7 +104,7 @@ public class AntScriptGenerator {
 
 				String sharedLibFilename = target.libName;
 				if (sharedLibFilename == null)
-					sharedLibFilename = getSharedLibFilename(target.os, target.is64Bit, config.sharedLibName);
+					sharedLibFilename = getSharedLibFilename(target.os, target.is64Bit, target.isARM, target.abi, config.sharedLibName);
 				
 				sharedLibFiles.add(sharedLibFilename);
 				if (target.os != TargetOs.Android && target.os != TargetOs.IOS) {
@@ -156,7 +156,7 @@ public class AntScriptGenerator {
 		}
 	}
 
-	private String getSharedLibFilename (TargetOs os, boolean is64Bit, String sharedLibName) {
+	private String getSharedLibFilename (TargetOs os, boolean is64Bit, boolean isARM, String abi, String sharedLibName) {
 		// generate shared lib prefix and suffix, determine jni platform headers directory
 		String libPrefix = "";
 		String libSuffix = "";
@@ -165,7 +165,7 @@ public class AntScriptGenerator {
 		}
 		if (os == TargetOs.Linux || os == TargetOs.Android) {
 			libPrefix = "lib";
-			libSuffix = (is64Bit ? "64" : "") + ".so";
+			libSuffix = (isARM ? "arm" + abi : "") + (is64Bit ? "64" : "") + ".so";
 		}
 		if (os == TargetOs.MacOsX) {
 			libPrefix = "lib";
@@ -187,7 +187,7 @@ public class AntScriptGenerator {
 
 	private String getLibsDirectory (BuildConfig config, BuildTarget target) {
 		String targetName = target.osFileName;
-		if (targetName == null) targetName = target.os.toString().toLowerCase() + (target.is64Bit ? "64" : "32");
+		if (targetName == null) targetName = target.os.toString().toLowerCase() + (target.isARM ? "arm" + target.abi : "") + (target.is64Bit ? "64" : "32");
 		return config.libsDir.child(targetName).path().replace('\\', '/');
 	}
 
@@ -214,7 +214,7 @@ public class AntScriptGenerator {
 
 		// generate shared lib filename and jni platform headers directory name
 		String libName = target.libName;
-		if (libName == null) libName = getSharedLibFilename(target.os, target.is64Bit, config.sharedLibName);
+		if (libName == null) libName = getSharedLibFilename(target.os, target.is64Bit, target.isARM, target.abi, config.sharedLibName);
 		String jniPlatform = getJniPlatform(target.os);
 
 		// generate include and exclude fileset Ant description for C/C++
@@ -244,10 +244,10 @@ public class AntScriptGenerator {
 		}
 
 		String targetFolder = target.osFileName;
-		if (targetFolder == null) targetFolder = target.os.toString().toLowerCase() + (target.is64Bit ? "64" : "32");
+		if (targetFolder == null) targetFolder = target.os.toString().toLowerCase() + (target.isARM ? "arm" + target.abi : "") + (target.is64Bit ? "64" : "32");
 
 		// replace template vars with proper values
-		template = template.replace("%projectName%", config.sharedLibName + "-" + target.os + "-" + (target.is64Bit ? "64" : "32"));
+		template = template.replace("%projectName%", config.sharedLibName + "-" + target.os + "-" + (target.isARM ? "arm" + target.abi + "-" : "") + (target.is64Bit ? "64" : "32"));
 		template = template.replace("%buildDir%", config.buildDir.child(targetFolder).path().replace('\\', '/'));
 		template = template.replace("%libsDir%", "../" + getLibsDirectory(config, target));
 		template = template.replace("%libName%", libName);

--- a/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/BuildTarget.java
+++ b/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/BuildTarget.java
@@ -30,8 +30,6 @@ public class BuildTarget {
 	public boolean is64Bit;
 	/** whether this is an ARM build, not used for Android **/
 	public boolean isARM;
-	/** abi type used to differentiate different arm versions */
-	public String abi = "";
 	/** the C files and directories to be included in the build, accepts Ant path format, must not be null **/
 	public String[] cIncludes;
 	/** the C files and directories to be excluded from the build, accepts Ant path format, must not be null **/
@@ -96,19 +94,18 @@ public class BuildTarget {
 	}
 
 	/** Legacy compatible addition to specify ARM values */
-	public BuildTarget setARM (boolean isARM, String abi) {
+	public BuildTarget setARM (boolean isARM) {
 		this.isARM = isARM;
-		this.abi = abi;
 		return this;
 	}
 
 	/** Creates a new default BuildTarget for the given OS, using common default values. */
 	public static BuildTarget newDefaultTarget (BuildTarget.TargetOs type, boolean is64Bit) {
-		return newDefaultTarget(type, is64Bit, false, "");
+		return newDefaultTarget(type, is64Bit, false);
 	}
 
 	/** Creates a new default BuildTarget for the given OS, using common default values. */
-	public static BuildTarget newDefaultTarget (BuildTarget.TargetOs type, boolean is64Bit, boolean isARM, String abi) {
+	public static BuildTarget newDefaultTarget (BuildTarget.TargetOs type, boolean is64Bit, boolean isARM) {
 		if (type == TargetOs.Windows && !is64Bit) {
 			// Windows 32-Bit
 			return new BuildTarget(TargetOs.Windows, false, new String[] {"**/*.c"}, new String[0], new String[] {"**/*.cpp"},
@@ -125,25 +122,18 @@ public class BuildTarget {
 				"-Wl,--kill-at -shared -static -static-libgcc -static-libstdc++ -m64");
 		}
 
-		if (type == TargetOs.Linux && isARM && abi.equals("gnueabi") && !is64Bit) {
-			// Linux ARM 32-Bit softfloat
-			return new BuildTarget(TargetOs.Linux, false, new String[] {"**/*.c"}, new String[0], new String[] {"**/*.cpp"},
-				new String[0], new String[0], "arm-linux-gnueabi-", "-c -Wall -O2 -fmessage-length=0 -fPIC",
-				"-c -Wall -O2 -fmessage-length=0 -fPIC", "-shared").setARM(isARM, abi);
-		}
-
-		if (type == TargetOs.Linux && isARM && abi.equals("gnueabihf") && !is64Bit) {
+		if (type == TargetOs.Linux && isARM && !is64Bit) {
 			// Linux ARM 32-Bit hardfloat
 			return new BuildTarget(TargetOs.Linux, false, new String[] {"**/*.c"}, new String[0], new String[] {"**/*.cpp"},
 				new String[0], new String[0], "arm-linux-gnueabihf-", "-c -Wall -O2 -fmessage-length=0 -fPIC",
-				"-c -Wall -O2 -fmessage-length=0 -fPIC", "-shared").setARM(isARM, abi);
+				"-c -Wall -O2 -fmessage-length=0 -fPIC", "-shared").setARM(isARM);
 		}
 
-		if (type == TargetOs.Linux && isARM && abi.equals("") && is64Bit) {
+		if (type == TargetOs.Linux && isARM && is64Bit) {
 			// Linux ARM 64-Bit
 			return new BuildTarget(TargetOs.Linux, true, new String[] {"**/*.c"}, new String[0], new String[] {"**/*.cpp"},
 				new String[0], new String[0], "aarch64-linux-gnu-", "-c -Wall -O2 -fmessage-length=0 -fPIC",
-				"-c -Wall -O2 -fmessage-length=0 -fPIC", "-shared").setARM(isARM, abi);
+				"-c -Wall -O2 -fmessage-length=0 -fPIC", "-shared").setARM(isARM);
 		}
 
 		if (type == TargetOs.Linux && !is64Bit) {

--- a/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/BuildTarget.java
+++ b/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/BuildTarget.java
@@ -93,7 +93,7 @@ public class BuildTarget {
 		this.libraries = "";
 	}
 
-	/** Legacy compatible addition to specify ARM values */
+	/** Legacy compatible addition to specify isARM */
 	public BuildTarget setARM (boolean isARM) {
 		this.isARM = isARM;
 		return this;

--- a/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/BuildTarget.java
+++ b/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/BuildTarget.java
@@ -28,6 +28,10 @@ public class BuildTarget {
 	public BuildTarget.TargetOs os;
 	/** whether this is a 64-bit build, not used for Android **/
 	public boolean is64Bit;
+	/** whether this is an ARM build, not used for Android **/
+	public boolean isARM;
+	/** abi type used to differentiate different arm versions */
+	public String abi = "";
 	/** the C files and directories to be included in the build, accepts Ant path format, must not be null **/
 	public String[] cIncludes;
 	/** the C files and directories to be excluded from the build, accepts Ant path format, must not be null **/
@@ -91,8 +95,20 @@ public class BuildTarget {
 		this.libraries = "";
 	}
 
+	/** Legacy compatible addition to specify ARM values */
+	public BuildTarget setARM (boolean isARM, String abi) {
+		this.isARM = isARM;
+		this.abi = abi;
+		return this;
+	}
+
 	/** Creates a new default BuildTarget for the given OS, using common default values. */
 	public static BuildTarget newDefaultTarget (BuildTarget.TargetOs type, boolean is64Bit) {
+		return newDefaultTarget(type, is64Bit, false, "");
+	}
+
+	/** Creates a new default BuildTarget for the given OS, using common default values. */
+	public static BuildTarget newDefaultTarget (BuildTarget.TargetOs type, boolean is64Bit, boolean isARM, String abi) {
 		if (type == TargetOs.Windows && !is64Bit) {
 			// Windows 32-Bit
 			return new BuildTarget(TargetOs.Windows, false, new String[] {"**/*.c"}, new String[0], new String[] {"**/*.cpp"},
@@ -107,6 +123,27 @@ public class BuildTarget {
 				new String[0], new String[0], "x86_64-w64-mingw32-", "-c -Wall -O2 -mfpmath=sse -msse2 -fmessage-length=0 -m64",
 				"-c -Wall -O2 -mfpmath=sse -msse2 -fmessage-length=0 -m64",
 				"-Wl,--kill-at -shared -static -static-libgcc -static-libstdc++ -m64");
+		}
+
+		if (type == TargetOs.Linux && isARM && abi.equals("gnueabi") && !is64Bit) {
+			// Linux ARM 32-Bit softfloat
+			return new BuildTarget(TargetOs.Linux, false, new String[] {"**/*.c"}, new String[0], new String[] {"**/*.cpp"},
+				new String[0], new String[0], "arm-linux-gnueabi-", "-c -Wall -O2 -fmessage-length=0 -fPIC",
+				"-c -Wall -O2 -fmessage-length=0 -fPIC", "-shared").setARM(isARM, abi);
+		}
+
+		if (type == TargetOs.Linux && isARM && abi.equals("gnueabihf") && !is64Bit) {
+			// Linux ARM 32-Bit hardfloat
+			return new BuildTarget(TargetOs.Linux, false, new String[] {"**/*.c"}, new String[0], new String[] {"**/*.cpp"},
+				new String[0], new String[0], "arm-linux-gnueabihf-", "-c -Wall -O2 -fmessage-length=0 -fPIC",
+				"-c -Wall -O2 -fmessage-length=0 -fPIC", "-shared").setARM(isARM, abi);
+		}
+
+		if (type == TargetOs.Linux && isARM && abi.equals("") && is64Bit) {
+			// Linux ARM 64-Bit
+			return new BuildTarget(TargetOs.Linux, true, new String[] {"**/*.c"}, new String[0], new String[] {"**/*.cpp"},
+				new String[0], new String[0], "aarch64-linux-gnu-", "-c -Wall -O2 -fmessage-length=0 -fPIC",
+				"-c -Wall -O2 -fmessage-length=0 -fPIC", "-shared").setARM(isARM, abi);
 		}
 
 		if (type == TargetOs.Linux && !is64Bit) {

--- a/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/JniGenSharedLibraryLoader.java
+++ b/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/JniGenSharedLibraryLoader.java
@@ -174,8 +174,9 @@ public class JniGenSharedLibraryLoader {
 		boolean isLinux = System.getProperty("os.name").contains("Linux");
 		boolean isMac = System.getProperty("os.name").contains("Mac");
 		boolean isAndroid = false;
-		boolean is64Bit = System.getProperty("os.arch").equals("amd64") || System.getProperty("os.arch").equals("x86_64");
-		boolean isArm = System.getProperty("os.arch").equals("arm");
+		boolean is64Bit = System.getProperty("os.arch").equals("amd64") || System.getProperty("os.arch").equals("x86_64") || System.getProperty("os.arch").startsWith("aarch64") || System.getProperty("os.arch").startsWith("armv8") || System.getProperty("os.arch").startsWith("arm64");
+		boolean isArm = System.getProperty("os.arch").equals("arm") || System.getProperty("os.arch").startsWith("aarch64");
+		String abi = System.getProperty("sun.arch.abi", "");
 
 		String vm = System.getProperty("java.vm.name");
 		if (vm != null && vm.contains("Dalvik")) {
@@ -200,12 +201,12 @@ public class JniGenSharedLibraryLoader {
 				loaded = loadLibrary(libraryFinder.getSharedLibraryNameLinux(sharedLibName, is64Bit, isArm, nativesZip));
 			else if (!is64Bit) {
 				if (isArm)
-					loaded = loadLibrary("lib" + sharedLibName + "Arm.so");
+					loaded = loadLibrary("lib" + sharedLibName + "arm"+abi+".so");
 				else
 					loaded = loadLibrary("lib" + sharedLibName + ".so");
 			} else {
 				if (isArm)
-					loaded = loadLibrary("lib" + sharedLibName + "Arm64.so");
+					loaded = loadLibrary("lib" + sharedLibName + "arm"+abi+"64.so");
 				else
 					loaded = loadLibrary("lib" + sharedLibName + "64.so");
 			}

--- a/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/JniGenSharedLibraryLoader.java
+++ b/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/JniGenSharedLibraryLoader.java
@@ -200,12 +200,12 @@ public class JniGenSharedLibraryLoader {
 				loaded = loadLibrary(libraryFinder.getSharedLibraryNameLinux(sharedLibName, is64Bit, isArm, nativesZip));
 			else if (!is64Bit) {
 				if (isArm)
-					loaded = loadLibrary("lib" + sharedLibName + "arm" + ".so");
+					loaded = loadLibrary("lib" + sharedLibName + "arm.so");
 				else
 					loaded = loadLibrary("lib" + sharedLibName + ".so");
 			} else {
 				if (isArm)
-					loaded = loadLibrary("lib" + sharedLibName + "arm" + "64.so");
+					loaded = loadLibrary("lib" + sharedLibName + "arm64.so");
 				else
 					loaded = loadLibrary("lib" + sharedLibName + "64.so");
 			}

--- a/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/JniGenSharedLibraryLoader.java
+++ b/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/JniGenSharedLibraryLoader.java
@@ -176,7 +176,6 @@ public class JniGenSharedLibraryLoader {
 		boolean isAndroid = false;
 		boolean is64Bit = System.getProperty("os.arch").equals("amd64") || System.getProperty("os.arch").equals("x86_64") || System.getProperty("os.arch").startsWith("aarch64") || System.getProperty("os.arch").startsWith("armv8") || System.getProperty("os.arch").startsWith("arm64");
 		boolean isArm = System.getProperty("os.arch").equals("arm") || System.getProperty("os.arch").startsWith("aarch64");
-		String abi = System.getProperty("sun.arch.abi", "");
 
 		String vm = System.getProperty("java.vm.name");
 		if (vm != null && vm.contains("Dalvik")) {
@@ -201,12 +200,12 @@ public class JniGenSharedLibraryLoader {
 				loaded = loadLibrary(libraryFinder.getSharedLibraryNameLinux(sharedLibName, is64Bit, isArm, nativesZip));
 			else if (!is64Bit) {
 				if (isArm)
-					loaded = loadLibrary("lib" + sharedLibName + "arm" + abi + ".so");
+					loaded = loadLibrary("lib" + sharedLibName + "arm" + ".so");
 				else
 					loaded = loadLibrary("lib" + sharedLibName + ".so");
 			} else {
 				if (isArm)
-					loaded = loadLibrary("lib" + sharedLibName + "arm" + abi + "64.so");
+					loaded = loadLibrary("lib" + sharedLibName + "arm" + "64.so");
 				else
 					loaded = loadLibrary("lib" + sharedLibName + "64.so");
 			}

--- a/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/JniGenSharedLibraryLoader.java
+++ b/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/JniGenSharedLibraryLoader.java
@@ -201,12 +201,12 @@ public class JniGenSharedLibraryLoader {
 				loaded = loadLibrary(libraryFinder.getSharedLibraryNameLinux(sharedLibName, is64Bit, isArm, nativesZip));
 			else if (!is64Bit) {
 				if (isArm)
-					loaded = loadLibrary("lib" + sharedLibName + "arm"+abi+".so");
+					loaded = loadLibrary("lib" + sharedLibName + "arm" + abi + ".so");
 				else
 					loaded = loadLibrary("lib" + sharedLibName + ".so");
 			} else {
 				if (isArm)
-					loaded = loadLibrary("lib" + sharedLibName + "arm"+abi+"64.so");
+					loaded = loadLibrary("lib" + sharedLibName + "arm" + abi + "64.so");
 				else
 					loaded = loadLibrary("lib" + sharedLibName + "64.so");
 			}

--- a/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/JniGenSharedLibraryLoader.java
+++ b/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/JniGenSharedLibraryLoader.java
@@ -174,7 +174,7 @@ public class JniGenSharedLibraryLoader {
 		boolean isLinux = System.getProperty("os.name").contains("Linux");
 		boolean isMac = System.getProperty("os.name").contains("Mac");
 		boolean isAndroid = false;
-		boolean is64Bit = System.getProperty("os.arch").equals("amd64") || System.getProperty("os.arch").equals("x86_64") || System.getProperty("os.arch").startsWith("aarch64") || System.getProperty("os.arch").startsWith("armv8") || System.getProperty("os.arch").startsWith("arm64");
+		boolean is64Bit = System.getProperty("os.arch").contains("64") || System.getProperty("os.arch").startsWith("armv8");
 		boolean isArm = System.getProperty("os.arch").equals("arm") || System.getProperty("os.arch").startsWith("aarch64");
 
 		String vm = System.getProperty("java.vm.name");

--- a/gdx/jni/maven/pom.xml
+++ b/gdx/jni/maven/pom.xml
@@ -158,8 +158,8 @@
                             <resources>
                                 <resource><directory>${basedir}/../../libs/linux32</directory></resource>
                                 <resource><directory>${basedir}/../../libs/linux64</directory></resource>
+                                <resource><directory>${basedir}/../../libs/linuxarm32</directory></resource>
                                 <resource><directory>${basedir}/../../libs/linuxarm64</directory></resource>
-                                <resource><directory>${basedir}/../../libs/linuxarmgnueabihf32</directory></resource>
                                 <resource><directory>${basedir}/../../libs/macosx64</directory></resource>
                                 <resource><directory>${basedir}/../../libs/windows32</directory></resource>
                                 <resource><directory>${basedir}/../../libs/windows64</directory></resource>

--- a/gdx/jni/maven/pom.xml
+++ b/gdx/jni/maven/pom.xml
@@ -158,6 +158,8 @@
                             <resources>
                                 <resource><directory>${basedir}/../../libs/linux32</directory></resource>
                                 <resource><directory>${basedir}/../../libs/linux64</directory></resource>
+                                <resource><directory>${basedir}/../../libs/linuxarm64</directory></resource>
+                                <resource><directory>${basedir}/../../libs/linuxarmgnueabihf32</directory></resource>
                                 <resource><directory>${basedir}/../../libs/macosx64</directory></resource>
                                 <resource><directory>${basedir}/../../libs/windows32</directory></resource>
                                 <resource><directory>${basedir}/../../libs/windows64</directory></resource>

--- a/gdx/src/com/badlogic/gdx/utils/GdxBuild.java
+++ b/gdx/src/com/badlogic/gdx/utils/GdxBuild.java
@@ -18,7 +18,6 @@ package com.badlogic.gdx.utils;
 
 import com.badlogic.gdx.jnigen.AntScriptGenerator;
 import com.badlogic.gdx.jnigen.BuildConfig;
-import com.badlogic.gdx.jnigen.BuildExecutor;
 import com.badlogic.gdx.jnigen.BuildTarget;
 import com.badlogic.gdx.jnigen.BuildTarget.TargetOs;
 import com.badlogic.gdx.jnigen.NativeCodeGenerator;
@@ -50,6 +49,10 @@ public class GdxBuild {
 		lin32.cppExcludes = excludeCpp;
 		BuildTarget lin64 = BuildTarget.newDefaultTarget(TargetOs.Linux, true);
 		lin64.cppExcludes = excludeCpp;
+		BuildTarget linarmgnueabihf = BuildTarget.newDefaultTarget(TargetOs.Linux, false, true, "gnueabihf");
+		linarmgnueabihf.cppExcludes = excludeCpp;
+		BuildTarget linarm64 = BuildTarget.newDefaultTarget(TargetOs.Linux, true, true, "");
+		linarm64.cppExcludes = excludeCpp;
 		BuildTarget android = BuildTarget.newDefaultTarget(TargetOs.Android, false);
 		android.linkerFlags += " -llog";
 		android.cppExcludes = excludeCpp;
@@ -58,7 +61,7 @@ public class GdxBuild {
 		BuildTarget ios = BuildTarget.newDefaultTarget(TargetOs.IOS, false);
 		ios.headerDirs = new String[] {"iosgl"};
 		new AntScriptGenerator().generate(new BuildConfig("gdx", "../target/native", LIBS_DIR, JNI_DIR), mac64, win32home, win32,
-			win64, lin32, lin64, android, ios);
+			win64, lin32, lin64, linarmgnueabihf, linarm64, android, ios);
 
 		// build natives
 		// BuildExecutor.executeAnt("jni/build-windows32home.xml", "-v");

--- a/gdx/src/com/badlogic/gdx/utils/GdxBuild.java
+++ b/gdx/src/com/badlogic/gdx/utils/GdxBuild.java
@@ -49,9 +49,9 @@ public class GdxBuild {
 		lin32.cppExcludes = excludeCpp;
 		BuildTarget lin64 = BuildTarget.newDefaultTarget(TargetOs.Linux, true);
 		lin64.cppExcludes = excludeCpp;
-		BuildTarget linarmgnueabihf = BuildTarget.newDefaultTarget(TargetOs.Linux, false, true, "gnueabihf");
-		linarmgnueabihf.cppExcludes = excludeCpp;
-		BuildTarget linarm64 = BuildTarget.newDefaultTarget(TargetOs.Linux, true, true, "");
+		BuildTarget linarm32 = BuildTarget.newDefaultTarget(TargetOs.Linux, false, true);
+		linarm32.cppExcludes = excludeCpp;
+		BuildTarget linarm64 = BuildTarget.newDefaultTarget(TargetOs.Linux, true, true);
 		linarm64.cppExcludes = excludeCpp;
 		BuildTarget android = BuildTarget.newDefaultTarget(TargetOs.Android, false);
 		android.linkerFlags += " -llog";
@@ -61,7 +61,7 @@ public class GdxBuild {
 		BuildTarget ios = BuildTarget.newDefaultTarget(TargetOs.IOS, false);
 		ios.headerDirs = new String[] {"iosgl"};
 		new AntScriptGenerator().generate(new BuildConfig("gdx", "../target/native", LIBS_DIR, JNI_DIR), mac64, win32home, win32,
-			win64, lin32, lin64, linarmgnueabihf, linarm64, android, ios);
+			win64, lin32, lin64, linarm32, linarm64, android, ios);
 
 		// build natives
 		// BuildExecutor.executeAnt("jni/build-windows32home.xml", "-v");

--- a/gdx/src/com/badlogic/gdx/utils/SharedLibraryLoader.java
+++ b/gdx/src/com/badlogic/gdx/utils/SharedLibraryLoader.java
@@ -40,8 +40,7 @@ public class SharedLibraryLoader {
 	static public boolean isIos = false;
 	static public boolean isAndroid = false;
 	static public boolean isARM = System.getProperty("os.arch").startsWith("arm") || System.getProperty("os.arch").startsWith("aarch64");
-	static public boolean is64Bit = System.getProperty("os.arch").equals("amd64")
-		|| System.getProperty("os.arch").equals("x86_64") || System.getProperty("os.arch").startsWith("aarch64") || System.getProperty("os.arch").startsWith("armv8") || System.getProperty("os.arch").startsWith("arm64");
+	static public boolean is64Bit = System.getProperty("os.arch").contains("64") || System.getProperty("os.arch").startsWith("armv8");
 
 	static {
 		boolean isMOEiOS = "iOS".equals(System.getProperty("moe.platform.name"));

--- a/gdx/src/com/badlogic/gdx/utils/SharedLibraryLoader.java
+++ b/gdx/src/com/badlogic/gdx/utils/SharedLibraryLoader.java
@@ -43,9 +43,6 @@ public class SharedLibraryLoader {
 	static public boolean is64Bit = System.getProperty("os.arch").equals("amd64")
 		|| System.getProperty("os.arch").equals("x86_64") || System.getProperty("os.arch").startsWith("aarch64") || System.getProperty("os.arch").startsWith("armv8") || System.getProperty("os.arch").startsWith("arm64");
 
-	// JDK 8 only.
-	static public String abi = System.getProperty("sun.arch.abi", "");
-
 	static {
 		boolean isMOEiOS = "iOS".equals(System.getProperty("moe.platform.name"));
 		String vm = System.getProperty("java.runtime.name");
@@ -64,10 +61,6 @@ public class SharedLibraryLoader {
 			isMac = false;
 			is64Bit = false;
 		}
-
-		// Attempt to figure out abi if missing. see https://github.com/bytedeco/javacpp/blob/e51d34a230ad1e076d2158bd6810a6032d4b6d74/src/main/java/org/bytedeco/javacpp/Loader.java#L106
-		if (isARM && !is64Bit && abi.isEmpty() && System.getProperty("sun.boot.library.path", "").toLowerCase().contains("openjdk-armhf"))
-			abi = "gnueabihf";
 	}
 
 	static private final HashSet<String> loadedLibraries = new HashSet();
@@ -104,7 +97,7 @@ public class SharedLibraryLoader {
 	/** Maps a platform independent library name to a platform dependent name. */
 	public String mapLibraryName (String libraryName) {
 		if (isWindows) return libraryName + (is64Bit ? "64.dll" : ".dll");
-		if (isLinux) return "lib" + libraryName + (isARM ? "arm" + abi : "") + (is64Bit ? "64.so" : ".so");
+		if (isLinux) return "lib" + libraryName + (isARM ? "arm" : "") + (is64Bit ? "64.so" : ".so");
 		if (isMac) return "lib" + libraryName + (is64Bit ? "64.dylib" : ".dylib");
 		return libraryName;
 	}


### PR DESCRIPTION
- Added arm support to BuildTarget/AntScriptGenerator.
- Created default BuildTarget's for arm32(debian's armhf)/arm64
- Fixed aarch64 (arm64) not being detected correctly in SharedLibaryLoader.
- JniGenSharedLibraryLoader is now more consistent with SharedLibaryLoader.
- ~~SharedLibraryLoader#extractFile and SharedLibraryLoader#extractFileTo now have optional resultFileName parameter to support renaming during extraction.~~
- ~~Renamed private SharedLibraryLoader#extractFile to SharedLibraryLoader#extractFileIfRequired to differentiate method signature. (I'm open to better name suggestions)~~
- ~~LwjglNativesLoader will utilize renaming support to always use liblwjgl.so on disk to match expected library name.~~
- Kept as much backwards compatible as possible.

# Things to note: #
- If compiler is not on path, jnigen build scripts simply skip builds. See https://github.com/libgdx/libgdx/blob/a4805d6a017b80622d6bfdd3a791352257a3c539/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/resources/scripts/build-target.xml.template#L48-L67
- Ubuntu's multiarch env for ports ~~seems broken~~ is finicky but can be made to work. 
- armhf (gnueabihf) is not compatible with rpi 1/zero. Debian's armhf is armv7+ while the pi 1/zero is armv6+hf.
- "GL (Fake KMS) Desktop Driver" mode was sometimes required on raspbian to get decent performance.

# Rasperrypi custom arm-linux-gnueabihf-gXX: #
- Raspberry pi provides a custom toolchain that supports [armv6 hf](https://github.com/raspberrypi/tools/tree/master/arm-bcm2708/arm-rpi-4.9.3-linux-gnueabihf)
- Using this toolchain is required for rpi 1/zero support.
- Requires you to add custom arguments and or copy dependencies manually.
- `cp -r /usr/include/X11 $PATH_TOOL_TOOLS/arm-bcm2708/arm-rpi-4.9.3-linux-gnueabihf/arm-linux-gnueabihf/include/X11/`
- And the argument `-L/usr/lib/arm-linux-gnueabihf/` or recompile the toolchain to point to the proper location. See `$PATH_TOOL_TOOLS/arm-bcm2708/arm-linux-gnueabihf/bin/arm-linux-gnueabihf-ld --verbose | grep SEARCH_DIR`
  - This can be done in a ccache stub `ccache /home/ubuntu/rpitools/arm-bcm2708/arm-linux-gnueabihf/bin/arm-linux-gnueabihf-gcc -L/usr/lib/arm-linux-gnueabihf/ "$@"`
- Using as is will target armv6 for all libraries, which will run fine on armv7 but potentially slower.

# TODO: #
- [ ] decide if libgdx wants to move arm libs into arm specific package(s).
- [ ] decide if libgdx wants to use Rasperrypi's custom arm-linux-gnueabihf-gXX
- [x] add support for alternative fpu's? (neon)
  - Likely out of scope for this initial PR.
- [x] determine if default gcc flags should be tweaked.
  - Debian stretch's defaults seem sufficient.

# Running: #
No generated files are included in this PR for readability sake. The following snippet may be used to generate all automatically.

```
mvn install

cd gdx
mvn clean compile exec:java -Dexec.mainClass="com.badlogic.gdx.utils.GdxBuild"

cd ../extensions/gdx-controllers/gdx-controllers-desktop/
mvn clean compile exec:java -Dexec.mainClass="com.badlogic.gdx.controllers.desktop.DesktopControllersBuild"

cd ../../gdx-freetype/
mvn clean compile exec:java -Dexec.mainClass="com.badlogic.gdx.graphics.g2d.freetype.FreetypeBuild"

cd ../gdx-box2d/gdx-box2d
mvn clean compile exec:java -Dexec.mainClass="com.badlogic.gdx.physics.box2d.utils.Box2DBuild"

cd ../../gdx-bullet/
mvn clean compile exec:java -Dexec.mainClass="com.badlogic.gdx.physics.bullet.BulletBuild"
```

The following commands need run on the build server:
```
dpkg --add-architecture armhf
dpkg --add-architecture arm64
```

The following new packages need installed on the build server:

```
gcc-arm-linux-gnueabihf
g++-arm-linux-gnueabihf
gcc-aarch64-linux-gnu
g++-aarch64-linux-gnu
libx11-dev:armhf # Desktop controllers dependency
libx11-dev:arm64
```

References:
https://wiki.debian.org/RaspberryPi
https://wiki.debian.org/RaspberryPi3