### PR TITLE
Fixed pixmap blending.

### DIFF
--- a/gdx/jni/gdx2d/gdx2d.c
+++ b/gdx/jni/gdx2d/gdx2d.c
@@ -165,21 +165,23 @@ static inline set_pixel_func set_pixel_func_ptr(uint32_t format) {
 }
 
 static inline uint32_t blend(uint32_t src, uint32_t dst) {
-	int32_t src_r = (src & 0xff000000) >> 24;
-	int32_t src_g = (src & 0xff0000) >> 16;
-	int32_t src_b = (src & 0xff00) >> 8;
 	int32_t src_a = (src & 0xff);
-		
-	int32_t dst_r = (dst & 0xff000000) >> 24;
-	int32_t dst_g = (dst & 0xff0000) >> 16;
-	int32_t dst_b = (dst & 0xff00) >> 8;
+	if (src_a == 0) return dst;
+	int32_t src_b = (src & 0xff00) >> 8;
+	int32_t src_g = (src & 0xff0000) >> 16;
+	int32_t src_r = (src & 0xff000000) >> 24;
+
 	int32_t dst_a = (dst & 0xff);
-		
-	dst_r = dst_r + src_a * (src_r - dst_r) / 255;
-	dst_g = dst_g + src_a * (src_g - dst_g) / 255;
-	dst_b = dst_b + src_a * (src_b - dst_b) / 255;
-	dst_a = (int32_t)((1.0f - (1.0f - src_a / 255.0f) * (1.0f - dst_a / 255.0f)) * 255);
-	return (uint32_t)((dst_r << 24) | (dst_g << 16) | (dst_b << 8) | dst_a);
+	int32_t dst_b = (dst & 0xff00) >> 8;
+	int32_t dst_g = (dst & 0xff0000) >> 16;
+	int32_t dst_r = (dst & 0xff000000) >> 24;
+
+	dst_a -= (dst_a * src_a) / 255;
+	int32_t a = dst_a + src_a;
+	dst_r = (dst_r * dst_a + src_r * src_a) / a;
+	dst_g = (dst_g * dst_a + src_g * src_a) / a;
+	dst_b = (dst_b * dst_a + src_b * src_a) / a;
+	return (uint32_t)((dst_r << 24) | (dst_g << 16) | (dst_b << 8) | a);
 }
 
 static inline uint32_t get_pixel_alpha(unsigned char *pixel_addr) {


### PR DESCRIPTION
Pixmap blending is incorrect. Eg, if dst is `0,0,0,0` and src is `255,0,0,40` then the resulting pixel is `40,0,0,39` (alpha would be 40 instead of 39 if round was used instead of cast to int). The expected resulting pixel is `255,0,0,40`. The example code below shows (from bottom to top):

1. the source image
2. no blending
3. gdx2d "source over" blending
4. Java port of [gdx2d blend](https://github.com/libgdx/libgdx/blob/master/gdx/jni/gdx2d/gdx2d.c#L167-L183)
5. a proposed fix

Related: #4364, #3917

```java
import java.nio.IntBuffer;

import com.badlogic.gdx.ApplicationAdapter;
import com.badlogic.gdx.Gdx;
import com.badlogic.gdx.backends.lwjgl.LwjglApplication;
import com.badlogic.gdx.backends.lwjgl.LwjglApplicationConfiguration;
import com.badlogic.gdx.graphics.GL20;
import com.badlogic.gdx.graphics.Pixmap;
import com.badlogic.gdx.graphics.Pixmap.Blending;
import com.badlogic.gdx.graphics.Texture;
import com.badlogic.gdx.graphics.g2d.BitmapFont;
import com.badlogic.gdx.graphics.g2d.SpriteBatch;
import com.badlogic.gdx.utils.Align;

public class PixmapBlendingIssue extends ApplicationAdapter {
	SpriteBatch batch;
	BitmapFont font;
	Texture srcTexture, noneTexture, blendTexture, portTexture, nateTexture;

	public void create () {
		batch = new SpriteBatch();
		font = new BitmapFont();

		Pixmap src = new Pixmap(Gdx.files.internal("data/arial-32.png"));
		srcTexture = new Texture(src);

		Pixmap none = new Pixmap(src.getWidth(), src.getHeight(), src.getFormat());
		none.setBlending(Blending.None);
		none.drawPixmap(src, 0, 0);
		noneTexture = new Texture(none);

		Pixmap blend = new Pixmap(src.getWidth(), src.getHeight(), src.getFormat());
		blend.setBlending(Blending.SourceOver);
		blend.drawPixmap(src, 0, 0);
		blendTexture = new Texture(blend);

		Pixmap port = new Pixmap(src.getWidth(), src.getHeight(), src.getFormat());
		IntBuffer portPixels = port.getPixels().asIntBuffer();
		for (int x = 0, xn = src.getWidth(); x < xn; x++) {
			for (int y = 0, yn = src.getHeight(); y < yn; y++) {
				int s = src.getPixel(x, y);
				int d = port.getPixel(x, y);
				int src_r = (s & 0xff000000) >>> 24;
				int src_g = (s & 0xff0000) >>> 16;
				int src_b = (s & 0xff00) >>> 8;
				int src_a = (s & 0xff);

				int dst_r = (d & 0xff000000) >>> 24;
				int dst_g = (d & 0xff0000) >>> 16;
				int dst_b = (d & 0xff00) >>> 8;
				int dst_a = (d & 0xff);

				int r = dst_r + src_a * (src_r - dst_r) / 255;
				int g = dst_g + src_a * (src_g - dst_g) / 255;
				int b = dst_b + src_a * (src_b - dst_b) / 255;
				int a = (int)((1.0f - (1.0f - src_a / 255.0f) * (1.0f - dst_a / 255.0f)) * 255);

				portPixels.put(x + y * src.getWidth(), (r << 24) | (g << 16) | (b << 8) | a);
			}
		}
		portTexture = new Texture(port);

		Pixmap nate = new Pixmap(src.getWidth(), src.getHeight(), src.getFormat());
		// Optionally draw something to test when the destination pixmap is not empty.
		// nate.setBlending(Blending.None);
		// nate.drawPixmap(new Pixmap(Gdx.files.internal("data/badlogic.jpg")), 30, 0);
		IntBuffer natePixels = nate.getPixels().asIntBuffer();
		for (int x = 0, xn = src.getWidth(); x < xn; x++) {
			for (int y = 0, yn = src.getHeight(); y < yn; y++) {
				int s = src.getPixel(x, y);
				int src_a = (s & 0xff);
				if (src_a == 0) continue;
				int src_r = (s & 0xff000000) >>> 24;
				int src_g = (s & 0xff0000) >>> 16;
				int src_b = (s & 0xff00) >>> 8;

				int d = nate.getPixel(x, y);
				int dst_r = (d & 0xff000000) >>> 24;
				int dst_g = (d & 0xff0000) >>> 16;
				int dst_b = (d & 0xff00) >>> 8;
				int dst_a = (d & 0xff);

				// float src_af = src_a / 255f;
				// float dst_af = dst_a / 255f * (1 - src_af);
				// float af = src_af + dst_af;
				// int a = Math.round(af * 255);
				// int r = Math.round((src_r * src_af + dst_r * dst_af) / af);
				// int g = Math.round((src_g * src_af + dst_g * dst_af) / af);
				// int b = Math.round((src_b * src_af + dst_b * dst_af) / af);

				// Equivalent to above float code, except may be off by 1 (of 255).
				dst_a -= (dst_a * src_a) / 255;
				int a = dst_a + src_a;
				dst_r = (dst_r * dst_a + src_r * src_a) / a;
				dst_g = (dst_g * dst_a + src_g * src_a) / a;
				dst_b = (dst_b * dst_a + src_b * src_a) / a;

				natePixels.put(x + y * src.getWidth(), (dst_r << 24) | (dst_g << 16) | (dst_b << 8) | a);
			}
		}
		nateTexture = new Texture(nate);
	}

	public void render () {
		boolean showSrc = Gdx.graphics.getFrameId() % 120 < 60;

		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
		batch.begin();

		batch.draw(srcTexture, 100, 0);
		batch.draw(showSrc ? srcTexture : noneTexture, 100, 128);
		batch.draw(showSrc ? srcTexture : blendTexture, 100, 128 * 2);
		batch.draw(showSrc ? srcTexture : portTexture, 100, 128 * 3);
		batch.draw(showSrc ? srcTexture : nateTexture, 100, 128 * 4);

		font.draw(batch, "src", 0, 128, 90, Align.right, false);
		font.draw(batch, showSrc ? "src" : "none", 0, 128 * 2, 90, Align.right, false);
		font.draw(batch, showSrc ? "src" : "blend", 0, 128 * 3, 90, Align.right, false);
		font.draw(batch, showSrc ? "src" : "port", 0, 128 * 4, 90, Align.right, false);
		font.draw(batch, showSrc ? "src" : "nate", 0, 128 * 5, 90, Align.right, false);

		batch.end();
	}

	static public void main (String[] args) throws Exception {
		LwjglApplicationConfiguration config = new LwjglApplicationConfiguration();
		config.width = 612;
		config.height = 640;
		new LwjglApplication(new PixmapBlendingIssue(), config);
	}
}
```