### PR TITLE
Revert "Upgrade javaparser"

### DIFF
--- a/extensions/gdx-jnigen/pom.xml
+++ b/extensions/gdx-jnigen/pom.xml
@@ -16,7 +16,7 @@
     <dependency>
       <groupId>com.github.javaparser</groupId>
       <artifactId>javaparser-core</artifactId>
-      <version>3.10.0</version>
+      <version>2.3.0</version>
     </dependency>
   </dependencies>
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -35,7 +35,7 @@ versions.androidPlugin = "3.1.0"
 versions.androidSdk = 27
 versions.androidBuildTools = "27.0.3"
 versions.androidSupport = "25.+"
-versions.javaparser = "3.10.0"
+versions.javaparser = "2.3.0"
 
 libraries.lwjgl = [
         "org.lwjgl.lwjgl:lwjgl:${versions.lwjgl}",


### PR DESCRIPTION
Reverts libgdx/libgdx#5591

Sorry, I didn't see that it requires Java 8. Besides this, we don't have a strong need to move to Java 8 source. Discussion is here:
https://github.com/libgdx/libgdx/issues/5487