### PR TITLE
Don't draw on canvas if image dimensions are zero.

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/graphics/Pixmap.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/graphics/Pixmap.java
@@ -521,7 +521,9 @@ public class Pixmap implements Disposable {
 			context.setStrokeStyle(color);
 			context.setGlobalCompositeOperation(Composite.SOURCE_OVER);
 		}
-		context.drawImage(image, srcX, srcY, srcWidth, srcHeight, dstX, dstY, dstWidth, dstHeight);
+		if(srcWidth != 0 && srcHeight != 0 && dstWidth != 0 && dstHeight != 0) {
+			context.drawImage(image, srcX, srcY, srcWidth, srcHeight, dstX, dstY, dstWidth, dstHeight);
+		}		
 		pixels = null;
 	}
 	


### PR DESCRIPTION
https://html.spec.whatwg.org/multipage/canvas.html#drawing-images
States that:
1. Check usability. If either dstWidth or dstHeight is zero don't draw anything but return.
2. If either srcWidth or srcHeight is zero don't draw anything but return.

The spec doesn't mention any errors, but e.g. Chrome throws errors in this case, see https://github.com/intrigus/gdx-freetype-gwt/issues/7