### PR TITLE
custom shading preview in particle 2d editor

### DIFF
--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/CustomShading.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/CustomShading.java
@@ -1,0 +1,161 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogic.gdx.tools.particleeditor;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.files.FileHandle;
+import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.graphics.glutils.ShaderProgram;
+import com.badlogic.gdx.utils.Array;
+
+public class CustomShading {
+	private ShaderProgram shader;
+	Array<String> extraTexturePaths = new Array<String>();
+	Array<Texture> extraTextures = new Array<Texture>();
+	String defaultVertexShaderCode;
+	String defaultFragmentShaderCode;
+	String vertexShaderCode;
+	String fragmentShaderCode;
+	FileHandle lastVertexShaderFile;
+	FileHandle lastFragmentShaderFile;
+	boolean hasShaderErrors;
+	String shaderErrorMessage;
+	boolean hasMissingSamplers;
+	String missingSamplerMessage;
+
+	public CustomShading () {
+		shader = SpriteBatch.createDefaultShader();
+		vertexShaderCode = defaultVertexShaderCode = shader.getVertexShaderSource();
+		fragmentShaderCode = defaultFragmentShaderCode = shader.getFragmentShaderSource();
+	}
+
+	public void begin (SpriteBatch spriteBatch) {
+		spriteBatch.setShader(shader);
+		for (int i = 0; i < extraTextures.size; i++) {
+			extraTextures.get(i).bind(i + 1);
+		}
+		Gdx.gl.glActiveTexture(GL20.GL_TEXTURE0);
+	}
+
+	public void end (SpriteBatch spriteBatch) {
+		spriteBatch.setShader(null);
+		for (int i = 0; i < extraTextures.size; i++) {
+			Gdx.gl.glActiveTexture(GL20.GL_TEXTURE1 + i);
+			Gdx.gl.glBindTexture(extraTextures.get(i).glTarget, 0);
+		}
+		Gdx.gl.glActiveTexture(GL20.GL_TEXTURE0);
+	}
+
+	public void setVertexShaderFile (String absolutePath) {
+		if (absolutePath == null) {
+			lastVertexShaderFile = null;
+			vertexShaderCode = defaultVertexShaderCode;
+		} else {
+			lastVertexShaderFile = Gdx.files.absolute(absolutePath);
+			vertexShaderCode = lastVertexShaderFile.readString();
+		}
+		updateShader();
+	}
+
+	public void setFragmentShaderFile (String absolutePath) {
+		if (absolutePath == null) {
+			lastFragmentShaderFile = null;
+			fragmentShaderCode = defaultFragmentShaderCode;
+		} else {
+			lastFragmentShaderFile = Gdx.files.absolute(absolutePath);
+			fragmentShaderCode = lastFragmentShaderFile.readString();
+		}
+		updateShader();
+	}
+
+	public void reloadVertexShader () {
+		if (lastVertexShaderFile != null) {
+			vertexShaderCode = lastVertexShaderFile.readString();
+		}
+		updateShader();
+	}
+
+	public void reloadFragmentShader () {
+		if (lastFragmentShaderFile != null) {
+			fragmentShaderCode = lastFragmentShaderFile.readString();
+		}
+		updateShader();
+	}
+
+	private void updateShader () {
+		ShaderProgram shader = new ShaderProgram(vertexShaderCode, fragmentShaderCode);
+		if (shader.isCompiled()) {
+			hasShaderErrors = false;
+			shaderErrorMessage = null;
+			if (this.shader != null) {
+				this.shader.dispose();
+			}
+			this.shader = shader;
+			updateSamplers();
+		} else {
+			hasShaderErrors = true;
+			shaderErrorMessage = shader.getLog();
+			shader.dispose();
+		}
+	}
+
+	public void addTexture (String absolutePath) {
+		extraTexturePaths.add(absolutePath);
+		extraTextures.add(new Texture(Gdx.files.absolute(absolutePath)));
+		updateSamplers();
+	}
+
+	public void swapTexture (int indexA, int indexB) {
+		extraTexturePaths.swap(indexA, indexB);
+		extraTextures.swap(indexA, indexB);
+		updateSamplers();
+	}
+
+	public void removeTexture (int index) {
+		extraTexturePaths.removeIndex(index);
+		extraTextures.removeIndex(index).dispose();
+		updateSamplers();
+	}
+
+	public void reloadTexture (int index) {
+		Texture previousTexture = extraTextures.get(index);
+		String path = extraTexturePaths.get(index);
+		Texture texture = new Texture(Gdx.files.absolute(path));
+		previousTexture.dispose();
+		extraTextures.set(index, texture);
+	}
+
+	private void updateSamplers () {
+		hasMissingSamplers = false;
+		missingSamplerMessage = "";
+
+		shader.begin();
+		for (int i = 0; i < extraTextures.size; i++) {
+			int unit = i + 1;
+			int location = shader.fetchUniformLocation("u_texture" + unit, false);
+			if (location >= 0) {
+				shader.setUniformi(location, unit);
+			} else {
+				hasMissingSamplers = true;
+				missingSamplerMessage += "uniform sampler2D u_texture" + unit + " missing in shader program.\n";
+			}
+		}
+		shader.end();
+	}
+}

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/CustomShadingPanel.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/CustomShadingPanel.java
@@ -1,0 +1,265 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogic.gdx.tools.particleeditor;
+
+import java.awt.FileDialog;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.GridLayout;
+import java.awt.Insets;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.io.File;
+
+import javax.swing.DefaultListModel;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JList;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JTextArea;
+import javax.swing.ListSelectionModel;
+
+import com.badlogic.gdx.graphics.g2d.ParticleEmitter;
+
+public class CustomShadingPanel extends EditorPanel {
+	JPanel imagesPanel;
+	JList imageList;
+	DefaultListModel<String> imageListModel;
+	String lastDir;
+	final ParticleEditor editor;
+	final CustomShading shading;
+
+	public CustomShadingPanel (final ParticleEditor editor, String name, String description) {
+		super(null, name, description);
+		this.editor = editor;
+		this.shading = editor.renderer.customShading;
+
+		JPanel contentPanel = getContentPanel();
+
+		{
+			JPanel shaderStagePanel = createShaderStagePanel(editor, contentPanel, true);
+			contentPanel.add(shaderStagePanel, new GridBagConstraints(0, 0, 1, 1, 1, 0, GridBagConstraints.NORTHWEST,
+				GridBagConstraints.NONE, new Insets(0, 0, 0, 0), 0, 0));
+		}
+
+		{
+			JPanel shaderStagePanel = createShaderStagePanel(editor, contentPanel, false);
+			contentPanel.add(shaderStagePanel, new GridBagConstraints(1, 0, 1, 1, 1, 0, GridBagConstraints.NORTHWEST,
+				GridBagConstraints.NONE, new Insets(0, 0, 0, 0), 0, 0));
+		}
+
+		{
+			imagesPanel = new JPanel(new GridBagLayout());
+			contentPanel.add(imagesPanel, new GridBagConstraints(2, 0, 1, 1, 1, 0, GridBagConstraints.NORTHWEST,
+				GridBagConstraints.NONE, new Insets(0, 0, 0, 0), 0, 0));
+
+			imagesPanel.add(new JLabel("Extra Texture Units"));
+
+			imageListModel = new DefaultListModel<String>();
+			for (int i = 0; i < shading.extraTexturePaths.size; i++) {
+				String path = shading.extraTexturePaths.get(i);
+				imageListModel.addElement(textureDisplayName(i, path));
+			}
+
+			imageList = new JList<String>(imageListModel);
+			imageList.setFixedCellWidth(200);
+			imageList.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+			imagesPanel.add(imageList, new GridBagConstraints(0, 1, 1, 4, 0, 0, GridBagConstraints.NORTHWEST,
+				GridBagConstraints.NONE, new Insets(0, 0, 0, 0), 0, 0));
+
+			JButton addButton = new JButton("Add");
+			imagesPanel.add(addButton, new GridBagConstraints(1, 1, 1, 1, 0, 0, GridBagConstraints.NORTHWEST,
+				GridBagConstraints.NONE, new Insets(0, 0, 0, 0), 0, 0));
+			addButton.addActionListener(new ActionListener() {
+				public void actionPerformed (ActionEvent event) {
+					FileDialog dialog = new FileDialog(editor, "Open Image", FileDialog.LOAD);
+					if (lastDir != null) dialog.setDirectory(lastDir);
+					dialog.setVisible(true);
+					final String file = dialog.getFile();
+					final String dir = dialog.getDirectory();
+					if (dir == null || file == null || file.trim().length() == 0) return;
+					lastDir = dir;
+					addTexture(new File(dir, file).getAbsolutePath());
+				}
+			});
+
+			JButton upButton = new JButton("\u2191");
+			imagesPanel.add(upButton, new GridBagConstraints(1, 2, 1, 1, 0, 0, GridBagConstraints.NORTHWEST, GridBagConstraints.NONE,
+				new Insets(0, 0, 0, 0), 0, 0));
+			upButton.addActionListener(new ActionListener() {
+				@Override
+				public void actionPerformed (ActionEvent e) {
+					int index = imageList.getSelectedIndex();
+					if (index <= 0) return;
+					swapTexture(index, index - 1);
+					imageList.setSelectedIndex(index - 1);
+				}
+			});
+			JButton downButton = new JButton("\u2193");
+			imagesPanel.add(downButton, new GridBagConstraints(1, 3, 1, 1, 0, 0, GridBagConstraints.NORTHWEST,
+				GridBagConstraints.NONE, new Insets(0, 0, 0, 0), 0, 0));
+			downButton.addActionListener(new ActionListener() {
+				@Override
+				public void actionPerformed (ActionEvent e) {
+					int index = imageList.getSelectedIndex();
+					if (index < 0 || index >= imageList.getModel().getSize() - 1) return;
+					final ParticleEmitter emitter = editor.getEmitter();
+					swapTexture(index, index + 1);
+					imageList.setSelectedIndex(index + 1);
+				}
+			});
+			JButton removeButton = new JButton("X");
+			imagesPanel.add(removeButton, new GridBagConstraints(1, 4, 1, 1, 0, 0, GridBagConstraints.NORTHWEST,
+				GridBagConstraints.NONE, new Insets(0, 0, 0, 0), 0, 0));
+			removeButton.addActionListener(new ActionListener() {
+				@Override
+				public void actionPerformed (ActionEvent e) {
+					int index = imageList.getSelectedIndex();
+					if (index < 0) return;
+					removeTexture(index);
+				}
+			});
+			JButton reloadButton = new JButton("Reload");
+			imagesPanel.add(reloadButton, new GridBagConstraints(1, 5, 1, 1, 0, 0, GridBagConstraints.NORTHWEST,
+				GridBagConstraints.NONE, new Insets(0, 0, 0, 0), 0, 0));
+			reloadButton.addActionListener(new ActionListener() {
+				@Override
+				public void actionPerformed (ActionEvent e) {
+					int index = imageList.getSelectedIndex();
+					if (index < 0) return;
+					reloadTexture(index);
+				}
+			});
+		}
+	}
+
+	private JPanel createShaderStagePanel (final ParticleEditor editor, JPanel contentPanel, final boolean isVertexShader) {
+		JPanel buttonsPanel = new JPanel(new GridLayout(5, 1));
+
+		JLabel label = new JLabel(isVertexShader ? "Vertex Shader" : "Frag. Shader");
+		buttonsPanel.add(label);
+
+		JButton defaultButton = new JButton("Default");
+		buttonsPanel.add(defaultButton);
+		defaultButton.addActionListener(new ActionListener() {
+			public void actionPerformed (ActionEvent event) {
+				if (isVertexShader) {
+					shading.setVertexShaderFile(null);
+				} else {
+					shading.setFragmentShaderFile(null);
+				}
+				displayErrors();
+			}
+		});
+
+		JButton setButton = new JButton("Set");
+		buttonsPanel.add(setButton);
+		setButton.addActionListener(new ActionListener() {
+			public void actionPerformed (ActionEvent event) {
+				FileDialog dialog = new FileDialog(editor, isVertexShader ? "Open Vertex Shader File" : "Open Fragment Shader File",
+					FileDialog.LOAD);
+				if (lastDir != null) dialog.setDirectory(lastDir);
+				dialog.setVisible(true);
+				final String file = dialog.getFile();
+				final String dir = dialog.getDirectory();
+				if (dir == null || file == null || file.trim().length() == 0) return;
+				lastDir = dir;
+
+				String path = new File(dir, file).getAbsolutePath();
+
+				if (isVertexShader) {
+					shading.setVertexShaderFile(path);
+				} else {
+					shading.setFragmentShaderFile(path);
+				}
+
+				displayErrors();
+			}
+		});
+
+		JButton reloadButton = new JButton("Reload");
+		buttonsPanel.add(reloadButton);
+		reloadButton.addActionListener(new ActionListener() {
+			public void actionPerformed (ActionEvent event) {
+				if (isVertexShader) {
+					shading.reloadVertexShader();
+				} else {
+					shading.reloadFragmentShader();
+				}
+				displayErrors();
+			}
+		});
+
+		JButton showButton = new JButton("Show");
+		buttonsPanel.add(showButton);
+		showButton.addActionListener(new ActionListener() {
+			public void actionPerformed (ActionEvent event) {
+				JTextArea text = new JTextArea(isVertexShader ? shading.vertexShaderCode : shading.fragmentShaderCode);
+				text.setEditable(false);
+				JOptionPane.showMessageDialog(editor, text,
+					isVertexShader ? "Current vertex shader code" : "Current fragment shader code", JOptionPane.INFORMATION_MESSAGE);
+			}
+		});
+
+		return buttonsPanel;
+	}
+
+	protected void displayErrors () {
+		if (shading.hasShaderErrors) {
+			JOptionPane.showMessageDialog(editor, shading.shaderErrorMessage, "Shader Error", JOptionPane.ERROR_MESSAGE);
+		} else if (shading.hasMissingSamplers) {
+			JOptionPane.showMessageDialog(editor, shading.missingSamplerMessage, "Missing texture sampler",
+				JOptionPane.WARNING_MESSAGE);
+		}
+	}
+
+	private String textureDisplayName (int index, String path) {
+		int unit = index + 1;
+		return "u_texture" + unit + ": " + new File(path).getName();
+	}
+
+	protected void removeTexture (int index) {
+		imageListModel.remove(index);
+		shading.removeTexture(index);
+		revalidate();
+		displayErrors();
+	}
+
+	protected void swapTexture (int indexA, int indexB) {
+		shading.swapTexture(indexA, indexB);
+		String pathA = shading.extraTexturePaths.get(indexA);
+		String pathB = shading.extraTexturePaths.get(indexB);
+		imageListModel.set(indexA, textureDisplayName(indexA, pathA));
+		imageListModel.set(indexB, textureDisplayName(indexB, pathB));
+		revalidate();
+		displayErrors();
+	}
+
+	protected void addTexture (String absolutePath) {
+		imageListModel.addElement(textureDisplayName(imageListModel.getSize(), absolutePath));
+		shading.addTexture(absolutePath);
+		revalidate();
+		displayErrors();
+	}
+
+	protected void reloadTexture (int index) {
+		shading.reloadTexture(index);
+		displayErrors();
+	}
+
+}

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/ParticleEditor.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/ParticleEditor.java
@@ -120,6 +120,7 @@ public class ParticleEditor extends JFrame {
 				renderGridCheckBox = new JCheckBox("Render Grid", previousSelected);
 				gridPanel.add(renderGridCheckBox, new GridBagConstraints());
 				addEditorRow(gridPanel);
+				addEditorRow(new CustomShadingPanel(ParticleEditor.this, "Shading", "Custom shader and multi-texture preview."));
 
 				rowsPanel.removeAll();
 				ParticleEmitter emitter = getEmitter();
@@ -299,9 +300,12 @@ public class ParticleEditor extends JFrame {
 
 		public Sprite bgImage; // BOZO - Add setting background image to UI.
 
+		public CustomShading customShading;
+
 		public void create () {
 			if (spriteBatch != null) return;
 
+			customShading = new CustomShading();
 			spriteBatch = new SpriteBatch();
 			shapeRenderer = new ShapeRenderer();
 			lineColor = com.badlogic.gdx.graphics.Color.valueOf("636363");
@@ -460,6 +464,7 @@ public class ParticleEditor extends JFrame {
 
 			activeCount = 0;
 			boolean complete = true;
+			customShading.begin(spriteBatch);
 			for (ParticleEmitter emitter : effect.getEmitters()) {
 				if (emitter.getSprites().size == 0 && emitter.getImagePaths().size > 0) loadImages(emitter);
 				boolean enabled = isEnabled(emitter);
@@ -469,6 +474,7 @@ public class ParticleEditor extends JFrame {
 					if (!emitter.isComplete()) complete = false;
 				}
 			}
+			customShading.end(spriteBatch);
 			if (complete) effect.start();
 
 			maxActive = Math.max(maxActive, activeCount);


### PR DESCRIPTION
This change allows to use custom shader and additional texture units in particle 2d editor.

Shader code/path and additional textures are not saved within particle files. It's for preview purpose only.

A new GUI section is available in Editor properties panel : 

![screen](https://user-images.githubusercontent.com/8074238/55278359-87d2de00-530b-11e9-9ec2-7fedf9ad301f.png)

Features : 

* set/reload vertex and/or fragment shader
* display shaders source code (usefull to get initial boilerplate)
* reset shader to default (sprite batch default shader)
* add/remove/reorder/reload extra texture units (starting from texture unit 1)
* shader compilation error messages
* missing texture sampler error messages