### PR TITLE
Fix for box render has a triangle facing the wrong way.

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/glutils/ShapeRenderer.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/ShapeRenderer.java
@@ -745,11 +745,11 @@ public class ShapeRenderer implements Disposable {
 			renderer.vertex(x + width, y + height, z + depth);
 
 			renderer.color(colorBits);
-			renderer.vertex(x, y + height, z + depth);
+			renderer.vertex(x + width, y + height, z + depth);
 			renderer.color(colorBits);
 			renderer.vertex(x, y, z + depth);
 			renderer.color(colorBits);
-			renderer.vertex(x + width, y + height, z + depth);
+			renderer.vertex(x, y + height, z + depth);
 
 			// Left
 			renderer.color(colorBits);


### PR DESCRIPTION
Fixed the box render has a triangle facing the wrong way, by viewing with Gdx.gl.glEnable(GL20.GL_CULL_FACE) and Gdx.gl.glCullFace(GL20.GL_BACK) - one of the triangles facing incorrectly. It was discovered when tempting to make a 3D cloud rendering for my voxel engine similar to Minecraft Cloud.

Before and after the fix:
![ShapeRenderBug](https://user-images.githubusercontent.com/35620587/56785143-2aad4800-6837-11e9-9f1e-62fdfa48ba64.png)

This is my first time doing a pull request on Github. I'm well experienced with LibGDX API.