### PR TITLE
Add resources folder path

### DIFF
--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/core/build.gradle
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/core/build.gradle
@@ -4,6 +4,7 @@ sourceCompatibility = 1.6
 [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
 
 sourceSets.main.java.srcDirs = [ "src/" ]
+sourceSets.main.resources.srcDirs = [ "assets/" ]
 
 
 eclipse.project {


### PR DESCRIPTION
During starting the DesktopLauncher without this fix I get: Exception in thread "LWJGL Application" com.badlogic.gdx.utils.GdxRuntimeException: Couldn't load file: badlogic.jpg