### PR TITLE
Experimental travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 sudo: true
 git:
-  depth: 1
-branches:
-  only:
-    - master
+  depth: 3
+#branches:
+#  only:
+#    - master
 
 matrix:
   include:
@@ -13,12 +13,35 @@ matrix:
       before_install:
         - brew update
         - brew install ant
+        - brew install ccache
+        - export PATH="/usr/local/opt/ccache/libexec:$PATH"
       install:
         - true
       script:
         - ant -f build-mac-ios.xml
-    - name: "Unit Tests"
+      cache: ccache
+    - name: "Compile and Unit Tests"
       language: android
+      addons:
+        apt:
+          packages:
+          - ant
+          - maven
+          - unzip
+          - gcc
+          - g++
+          - g++-multilib
+          - gcc-mingw-w64-base
+          - gcc-mingw-w64-i686
+          - g++-mingw-w64-i686
+          - binutils-mingw-w64-i686
+          - gcc-mingw-w64-x86-64
+          - g++-mingw-w64-x86-64
+          - binutils-mingw-w64-x86-64
+          - ccache
+          - lib32z1
+          - libx11-dev
+          - libx11-dev:i386
       android:
         components:
           - build-tools-25.0.3
@@ -26,15 +49,30 @@ matrix:
         licenses:
           - 'android-sdk-license-.+'
       before_install:
+        - ccache --show-stats
+        - export PATH="/usr/lib/ccache:${PATH}"
+        - echo $PATH
         - yes | sdkmanager "platforms;android-27"
+        - pushd .
+        - mkdir -p /opt/ndk && cd /opt/ndk && wget -q https://dl.google.com/android/repository/android-ndk-r16b-linux-x86_64.zip -O ndk.zip && unzip -q ndk.zip && rm ndk.zip
+        - export NDK_HOME=/opt/ndk/android-ndk-r16b
+        - export PATH="/opt/ndk/android-ndk-r16b:${PATH}"
+        - export NDK_CCACHE=/usr/bin/ccache
+        - popd
       script:
+        - ant -f build.xml -Dbuild-natives=true -Dversion=nightly
+        - ls -l
         - ./gradlew fetchNatives
         - ./gradlew test
+        - ccache --show-stats
       before_cache:
         - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
         - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
       cache:
-        directories:
+        # How do we make ccache work in addition to directories? This doesn't seem to work
+        - ccache
+        - directories:
           - $HOME/.gradle/caches/
           - $HOME/.gradle/wrapper/
           - $HOME/.android/build-cache
+          - $HOME/.ccache

--- a/fetch.xml
+++ b/fetch.xml
@@ -86,8 +86,8 @@
         <mkdir dir="extensions/gdx-controllers/gdx-controllers-desktop/libs"/>
 
 		<!-- core -->		
-		<get src="https://search.maven.org/remotecontent?filepath=junit/junit/4.11/junit-4.11.jar" dest="gdx/libs/junit-4.11.jar"/>
-		<get src="https://search.maven.org/remotecontent?filepath=org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar" dest="gdx/libs/hamcrest-core-1.3.jar"/>
+		<get src="https://repo.maven.apache.org/maven2/junit/junit/4.11/junit-4.11.jar" dest="gdx/libs/junit-4.11.jar"/>
+		<get src="https://repo.maven.apache.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar" dest="gdx/libs/hamcrest-core-1.3.jar"/>
 		<get src="${domain}/gdx-natives.jar" dest="gdx/libs"/>
 		<get src="${domain}/armeabi/libgdx.so" dest="tmp/armeabi"/>
         <get src="${domain}/armeabi/libgdx.so" dest="gdx/libs/armeabi"/>


### PR DESCRIPTION
Jenkins hasn't reliably run builds in a while, so using a proper CI might be more ideal. This will also allow more easy changes for things like adding arm compilers for future arm builds.

This will allow users to more easily test their own changes by using their own travis instances.

Doesn't actually deploy anything anywhere atm, would need a maintainer to configure maven deploy to actually upload the resulting binaries.

Also replaced https://search.maven.org/ with direct links, since https://search.maven.org/ was failing during testing.