### PR TITLE
Add missing copyAndroidNatives task in gdx-tests-android

### DIFF
--- a/tests/gdx-tests-android/build.gradle
+++ b/tests/gdx-tests-android/build.gradle
@@ -23,6 +23,10 @@ buildscript {
 apply plugin: "com.android.application"
 apply from: "obb.gradle"
 
+configurations {
+	natives
+}
+
 dependencies {
 	compile project(":tests:gdx-tests")
 	compile project(":gdx")
@@ -60,3 +64,37 @@ android {
 	}
 }
 
+// called every time gradle gets executed, takes the native dependencies of
+// the natives configuration, and extracts them to the proper libs/ folders
+// so they get packed with the APK.
+task copyAndroidNatives {
+	doFirst {
+		file("libs/armeabi/").mkdirs()
+		file("libs/armeabi-v7a/").mkdirs()
+		file("libs/arm64-v8a/").mkdirs()
+		file("libs/x86_64/").mkdirs()
+		file("libs/x86/").mkdirs()
+
+		configurations.natives.files.each { jar ->
+			def outputDir = null
+			if (jar.name.endsWith("natives-arm64-v8a.jar")) outputDir = file("libs/arm64-v8a")
+			if (jar.name.endsWith("natives-armeabi-v7a.jar")) outputDir = file("libs/armeabi-v7a")
+			if(jar.name.endsWith("natives-armeabi.jar")) outputDir = file("libs/armeabi")
+			if(jar.name.endsWith("natives-x86_64.jar")) outputDir = file("libs/x86_64")
+			if(jar.name.endsWith("natives-x86.jar")) outputDir = file("libs/x86")
+			if(outputDir != null) {
+				copy {
+					from zipTree(jar)
+					into outputDir
+					include "*.so"
+				}
+			}
+		}
+	}
+}
+
+tasks.whenTaskAdded { packageTask ->
+	if (packageTask.name.contains("package")) {
+		packageTask.dependsOn 'copyAndroidNatives'
+	}
+}


### PR DESCRIPTION
Without this `./gradlew tests:gdx-tests-android:assembleDebug` on a clean project will not include natives in the generated apk.

Copied verbatim from https://github.com/libgdx/libgdx/blob/2a429a82463ed6dc2e24219f9ac67328789c8f43/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/android/build.gradle#L35-L68