### PR TITLE
Controllers not working on Chrome, closes #4982

### DIFF
--- a/extensions/gdx-controllers/gdx-controllers-gwt/src/com/badlogic/gdx/controllers/gwt/support/GamepadSupport.java
+++ b/extensions/gdx-controllers/gdx-controllers-gwt/src/com/badlogic/gdx/controllers/gwt/support/GamepadSupport.java
@@ -54,6 +54,8 @@ public class GamepadSupport {
 				if (gamepad != null) {
 					if (!gamepadsTemp.containsKey(gamepad.getIndex())) {
 						onGamepadConnect(gamepad);
+					} else {
+						gamepads.put(gamepad.getIndex(), gamepad);
 					}
 					gamepadsTemp.remove(gamepad.getIndex());
 				}				


### PR DESCRIPTION
Tested on Chrome Windows, Chrome Linux, Chrome Android, Firefox Windows, Firefox Linux