### PR TITLE
Speed up GWT build by excluding compatiblity for antique IE versions

### DIFF
--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/html/GdxDefinition
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/html/GdxDefinition
@@ -6,4 +6,6 @@
 	<entry-point class='%PACKAGE%.client.HtmlLauncher' />
 	<set-configuration-property name='xsiframe.failIfScriptTag' value='FALSE'/>
 	<set-configuration-property name="gdx.assetpath" value="../%ASSET_PATH%" />
+	<set-property name="user.agent" value="gecko1_8, safari"/>
+	<collapse-property name="user.agent" values="*" />
 </module>


### PR DESCRIPTION
Using this for the last 5 months without problems.