### PR TITLE
iOS RoboVM: Fix crash if getCurrentEventTime is called before first t…

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidInput.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidInput.java
@@ -144,7 +144,7 @@ public class AndroidInput implements Input, OnKeyListener, OnTouchListener {
 	private InputProcessor processor;
 	private final AndroidApplicationConfiguration config;
 	protected final Orientation nativeOrientation;
-	private long currentEventTimeStamp = System.nanoTime();
+	private long currentEventTimeStamp = 0;
 	private final AndroidOnscreenKeyboard onscreenKeyboard;
 
 	private SensorEventListener accelerometerListener;

--- a/backends/gdx-backend-moe/src/com/badlogic/gdx/backends/iosmoe/IOSInput.java
+++ b/backends/gdx-backend-moe/src/com/badlogic/gdx/backends/iosmoe/IOSInput.java
@@ -64,7 +64,7 @@ public class IOSInput implements Input {
 		}
 	};
 	Array<TouchEvent> touchEvents = new Array<TouchEvent>();
-	TouchEvent currentEvent = null;
+	private long currentEventTimeStamp = 0;
 	float[] acceleration = new float[3];
 	float[] rotation = new float[3];
 	float[] R = new float[9];
@@ -463,7 +463,7 @@ public class IOSInput implements Input {
 
 	@Override
 	public long getCurrentEventTime () {
-		return currentEvent.timestamp;
+		return currentEventTimeStamp;
 	}
 
 	@Override
@@ -556,7 +556,7 @@ public class IOSInput implements Input {
 		synchronized (touchEvents) {
 			justTouched = false;
 			for (TouchEvent event : touchEvents) {
-				currentEvent = event;
+				currentEventTimeStamp = event.timestamp;
 				if (event.phase == UITouchPhase.Began) {
 					if (inputProcessor != null) inputProcessor.touchDown(event.x, event.y, event.pointer, Buttons.LEFT);
 					if (numTouched == 1) justTouched = true;

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSInput.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSInput.java
@@ -86,7 +86,7 @@ public class IOSInput implements Input {
 		}
 	};
 	Array<TouchEvent> touchEvents = new Array<TouchEvent>();
-	TouchEvent currentEvent = null;
+	private long currentEventTimeStamp = 0;
 	float[] acceleration = new float[3];
 	float[] rotation = new float[3];
 	float[] R = new float[9];
@@ -528,7 +528,7 @@ public class IOSInput implements Input {
 
 	@Override
 	public long getCurrentEventTime () {
-		return currentEvent.timestamp;
+		return currentEventTimeStamp;
 	}
 
 	@Override
@@ -629,7 +629,7 @@ public class IOSInput implements Input {
 		synchronized (touchEvents) {
 			justTouched = false;
 			for (TouchEvent event : touchEvents) {
-				currentEvent = event;
+				currentEventTimeStamp = event.timestamp;
 				switch (event.phase) {
 				case Began:
 					if (inputProcessor != null) inputProcessor.touchDown(event.x, event.y, event.pointer, Buttons.LEFT);


### PR DESCRIPTION
…ouch was made

This can happen if the game is controlled without touches.