### PR TITLE
Fix - transforming the string into a float to avoid an exception when…

### DIFF
--- a/gdx/src/com/badlogic/gdx/maps/tiled/BaseTmxMapLoader.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/BaseTmxMapLoader.java
@@ -260,12 +260,12 @@ public abstract class BaseTmxMapLoader<P extends BaseTmxMapLoader.Parameters> ex
 			if (element.hasAttribute("offsetx")) {
 				x = Float.parseFloat(element.getAttribute("offsetx", "0"));
 			} else {
-				x = Integer.parseInt(element.getAttribute("x", "0"));
+				x = Float.parseFloat(element.getAttribute("x", "0"));
 			}
 			if (element.hasAttribute("offsety")) {
 				y = Float.parseFloat(element.getAttribute("offsety", "0"));
 			} else {
-				y = Integer.parseInt(element.getAttribute("y", "0"));
+				y = Float.parseFloat(element.getAttribute("y", "0"));
 			}
 			if (flipY) y = mapHeightInPixels - y;
 


### PR DESCRIPTION
… a floating point position is introduced in the TiledMap software

When loading an image layer from the Tiled software. An exception arises when the displacement values ​​x and y are not integers.

Tiled software allows positioning with float value.

The loadImageLayer method of the BaseTmxMapLoader class generates an exception "java.lang.NumberFormatException" because it tries to transform a string into an integer from possibly a string that can give a float value