### PR TITLE
Accelerometer implementation for gwt

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtAccelerometer.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtAccelerometer.java
@@ -1,0 +1,27 @@
+package com.badlogic.gdx.backends.gwt;
+
+public class GwtAccelerometer extends GwtSensor {
+
+	protected GwtAccelerometer() {
+	}
+
+	static native GwtAccelerometer getInstance() /*-{
+		return new $wnd.Accelerometer();
+	}-*/;
+
+	static native boolean isSupported() /*-{
+		return "Accelerometer" in $wnd;
+	}-*/;
+
+	final native double x() /*-{
+		return this.x;
+	}-*/;
+
+	final native double y() /*-{
+		return this.y;
+	}-*/;
+
+	final native double z() /*-{
+		return this.z;
+	}-*/;
+}

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtAccelerometer.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtAccelerometer.java
@@ -1,6 +1,33 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
 package com.badlogic.gdx.backends.gwt;
 
+/**
+ * Implementation of the <a href="https://www.w3.org/TR/accelerometer/#accelerometer-interface">Accelerometer Interface</a>
+ * <a href="https://developer.mozilla.org/en-US/docs/Web/API/Accelerometer#Browser_compatibility">Compatibility</a>
+ */
 public class GwtAccelerometer extends GwtSensor {
+
+	/**
+	 * Permission String to query the permission
+	 *
+	 * @see com.badlogic.gdx.backends.gwt.GwtPermissions
+	 */
+	public static final String PERMISSION = "accelerometer";
 
 	protected GwtAccelerometer() {
 	}
@@ -14,14 +41,14 @@ public class GwtAccelerometer extends GwtSensor {
 	}-*/;
 
 	final native double x() /*-{
-		return this.x;
+		return this.x ? this.x : 0;
 	}-*/;
 
 	final native double y() /*-{
-		return this.y;
+		return this.y ? this.y : 0;
 	}-*/;
 
 	final native double z() /*-{
-		return this.z;
+		return this.z ? this.z : 0;
 	}-*/;
 }

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplication.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplication.java
@@ -212,7 +212,7 @@ public abstract class GwtApplication implements EntryPoint, Application {
 		Gdx.gl20 = graphics.getGL20();
 		Gdx.gl = Gdx.gl20;
 		Gdx.files = new GwtFiles(preloader);
-		this.input = new GwtInput(graphics.canvas);
+		this.input = new GwtInput(graphics.canvas, this.config);
 		Gdx.input = this.input;
 		this.net = new GwtNet(config);
 		Gdx.net = this.net;

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplicationConfiguration.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplicationConfiguration.java
@@ -58,6 +58,8 @@ public class GwtApplicationConfiguration {
 	/* Whether openURI will open page in new tab. By default it will, however if may be blocked by popup blocker. */
 	/* To prevent the page from being blocked you can redirect to the new page. However this will exit your game.  */
 	public boolean openURLInNewWindow = true;
+	/** whether to use the accelerometer. default: true **/
+	public boolean useAccelerometer = true;
 
 	public GwtApplicationConfiguration (int width, int height) {
 		this.width = width;

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtClipboard.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtClipboard.java
@@ -36,7 +36,7 @@ public class GwtClipboard implements Clipboard {
 	@Override
 	public void setContents (String content) {
 		this.content = content;
-		if (requestedWritePermissions) {
+		if (requestedWritePermissions || GwtApplication.agentInfo().isFirefox()) {
 			if (hasWritePermissions)
 				setContentJSNI(content);
 		} else {

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtInput.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtInput.java
@@ -59,7 +59,7 @@ public class GwtInput implements Input {
 
 	public GwtInput (CanvasElement canvas) {
 		this.canvas = canvas;
-		GwtPermissions.queryPermission("accelerometer", new GwtPermissions.GwtPermissionResult() {
+		GwtPermissions.queryPermission(GwtAccelerometer.PERMISSION, new GwtPermissions.GwtPermissionResult() {
 			@Override
 			public void granted() {
 				setupAccelerometer();

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtInput.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtInput.java
@@ -50,30 +50,32 @@ public class GwtInput implements Input {
 	boolean[] justPressedKeys = new boolean[256];
 	boolean[] justPressedButtons = new boolean[5];
 	InputProcessor processor;
-	char lastKeyCharPressed;
-	float keyRepeatTimer;
 	long currentEventTimeStamp;
 	final CanvasElement canvas;
+	final GwtApplicationConfiguration config;
 	boolean hasFocus = true;
 	GwtAccelerometer accelerometer;
 
-	public GwtInput (CanvasElement canvas) {
+	public GwtInput (CanvasElement canvas, GwtApplicationConfiguration config) {
 		this.canvas = canvas;
-		GwtPermissions.queryPermission(GwtAccelerometer.PERMISSION, new GwtPermissions.GwtPermissionResult() {
-			@Override
-			public void granted() {
-				setupAccelerometer();
-			}
+		this.config = config;
+		if (config.useAccelerometer) {
+			GwtPermissions.queryPermission(GwtAccelerometer.PERMISSION, new GwtPermissions.GwtPermissionResult() {
+				@Override
+				public void granted() {
+					setupAccelerometer();
+				}
 
-			@Override
-			public void denied() {
-			}
+				@Override
+				public void denied() {
+				}
 
-			@Override
-			public void prompt() {
-				setupAccelerometer();
-			}
-		});
+				@Override
+				public void prompt() {
+					setupAccelerometer();
+				}
+			});
+		}
 		hookEvents();
 	}
 

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtInput.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtInput.java
@@ -60,21 +60,24 @@ public class GwtInput implements Input {
 		this.canvas = canvas;
 		this.config = config;
 		if (config.useAccelerometer) {
-			GwtPermissions.queryPermission(GwtAccelerometer.PERMISSION, new GwtPermissions.GwtPermissionResult() {
-				@Override
-				public void granted() {
-					setupAccelerometer();
-				}
+			if (GwtApplication.agentInfo().isFirefox())
+				setupAccelerometer();
+			else
+				GwtPermissions.queryPermission(GwtAccelerometer.PERMISSION, new GwtPermissions.GwtPermissionResult() {
+					@Override
+					public void granted() {
+						setupAccelerometer();
+					}
 
-				@Override
-				public void denied() {
-				}
+					@Override
+					public void denied() {
+					}
 
-				@Override
-				public void prompt() {
-					setupAccelerometer();
-				}
-			});
+					@Override
+					public void prompt() {
+						setupAccelerometer();
+					}
+				});
 		}
 		hookEvents();
 	}

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtInput.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtInput.java
@@ -59,9 +59,21 @@ public class GwtInput implements Input {
 
 	public GwtInput (CanvasElement canvas) {
 		this.canvas = canvas;
-		Gdx.app.log("GwtAccelerometer supported", String.valueOf(GwtAccelerometer.isSupported()));
-		this.accelerometer = GwtAccelerometer.getInstance();
-		this.accelerometer.start();
+		GwtPermissions.queryPermission("accelerometer", new GwtPermissions.GwtPermissionResult() {
+			@Override
+			public void granted() {
+				setupAccelerometer();
+			}
+
+			@Override
+			public void denied() {
+			}
+
+			@Override
+			public void prompt() {
+				setupAccelerometer();
+			}
+		});
 		hookEvents();
 	}
 
@@ -80,21 +92,28 @@ public class GwtInput implements Input {
 		}
 	}
 
+	void setupAccelerometer () {
+		if (GwtAccelerometer.isSupported()) {
+			if (accelerometer == null) accelerometer = GwtAccelerometer.getInstance();
+			if (!accelerometer.activated()) accelerometer.start();
+		}
+	}
+
 	@Override
 	public float getAccelerometerX () {
-		return (float) this.accelerometer.x();
+		return this.accelerometer != null ? (float) this.accelerometer.x() : 0;
 	}
 
 	@Override
 	public float getAccelerometerY () {
-		return (float) this.accelerometer.y();
+		return this.accelerometer != null ? (float) this.accelerometer.y() : 0;
 	}
 
 	@Override
 	public float getAccelerometerZ () {
-		return (float) this.accelerometer.z();
+		return this.accelerometer != null ? (float) this.accelerometer.z() : 0;
 	}
-	
+
 	@Override
 	public float getGyroscopeX () {
 		// TODO Auto-generated method stub
@@ -240,7 +259,7 @@ public class GwtInput implements Input {
 			}
 		});
 	}
-	
+
 	@Override
 	public void setOnscreenKeyboardVisible (boolean visible) {
 	}
@@ -321,7 +340,7 @@ public class GwtInput implements Input {
 
 	@Override
 	public boolean isPeripheralAvailable (Peripheral peripheral) {
-		if (peripheral == Peripheral.Accelerometer) return false;
+		if (peripheral == Peripheral.Accelerometer) return GwtAccelerometer.isSupported();
 		if (peripheral == Peripheral.Compass) return false;
 		if (peripheral == Peripheral.HardwareKeyboard) return !GwtApplication.isMobileDevice();
 		if (peripheral == Peripheral.MultitouchScreen) return isTouchScreen();
@@ -616,7 +635,7 @@ public class GwtInput implements Input {
 			this.currentEventTimeStamp = TimeUtils.nanoTime();
 			e.preventDefault();
 		}
-		
+
 		if (hasFocus && !e.getType().equals("blur")) {
 			if (e.getType().equals("keydown")) {
 				// Gdx.app.log("GwtInput", "keydown");
@@ -666,7 +685,7 @@ public class GwtInput implements Input {
 
 			while (iterator.hasNext) {
 				int code = iterator.next();
-				
+
 				if (pressedKeys[code]) {
 					pressedKeySet.remove(code);
 					pressedKeyCount--;
@@ -755,7 +774,7 @@ public class GwtInput implements Input {
 		}
 // if(hasFocus) e.preventDefault();
 	}
-	
+
 	private int getAvailablePointer () {
 		for (int i = 0; i < MAX_TOUCHES; i++) {
 			if (!touchMap.containsValue(i, false)) return i;

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtInput.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtInput.java
@@ -60,9 +60,9 @@ public class GwtInput implements Input {
 		this.canvas = canvas;
 		this.config = config;
 		if (config.useAccelerometer) {
-			if (GwtApplication.agentInfo().isFirefox())
+			if (GwtApplication.agentInfo().isFirefox()) {
 				setupAccelerometer();
-			else
+			} else {
 				GwtPermissions.queryPermission(GwtAccelerometer.PERMISSION, new GwtPermissions.GwtPermissionResult() {
 					@Override
 					public void granted() {
@@ -78,6 +78,7 @@ public class GwtInput implements Input {
 						setupAccelerometer();
 					}
 				});
+			}
 		}
 		hookEvents();
 	}

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtInput.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtInput.java
@@ -19,7 +19,6 @@ package com.badlogic.gdx.backends.gwt;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.InputProcessor;
-import com.badlogic.gdx.Input.Buttons;
 import com.badlogic.gdx.backends.gwt.widgets.TextInputDialogBox;
 import com.badlogic.gdx.backends.gwt.widgets.TextInputDialogBox.TextInputDialogListener;
 import com.badlogic.gdx.utils.IntMap;
@@ -30,11 +29,9 @@ import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.core.client.JsArray;
 import com.google.gwt.dom.client.CanvasElement;
 import com.google.gwt.dom.client.Document;
-import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.NativeEvent;
 import com.google.gwt.dom.client.Touch;
 import com.google.gwt.event.dom.client.KeyCodes;
-import com.google.gwt.logging.client.ConsoleLogHandler;
 
 public class GwtInput implements Input {
 	static final int MAX_TOUCHES = 20;
@@ -58,9 +55,13 @@ public class GwtInput implements Input {
 	long currentEventTimeStamp;
 	final CanvasElement canvas;
 	boolean hasFocus = true;
+	GwtAccelerometer accelerometer;
 
 	public GwtInput (CanvasElement canvas) {
 		this.canvas = canvas;
+		Gdx.app.log("GwtAccelerometer supported", String.valueOf(GwtAccelerometer.isSupported()));
+		this.accelerometer = GwtAccelerometer.getInstance();
+		this.accelerometer.start();
 		hookEvents();
 	}
 
@@ -81,17 +82,17 @@ public class GwtInput implements Input {
 
 	@Override
 	public float getAccelerometerX () {
-		return 0;
+		return (float) this.accelerometer.x();
 	}
 
 	@Override
 	public float getAccelerometerY () {
-		return 0;
+		return (float) this.accelerometer.y();
 	}
 
 	@Override
 	public float getAccelerometerZ () {
-		return 0;
+		return (float) this.accelerometer.z();
 	}
 	
 	@Override

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtSensor.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtSensor.java
@@ -1,7 +1,27 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
 package com.badlogic.gdx.backends.gwt;
 
 import com.google.gwt.core.client.JavaScriptObject;
 
+/**
+ * Implementation of the <a href="https://www.w3.org/TR/generic-sensor/#the-sensor-interface">Sensor Interface</a>
+ * <a href="https://developer.mozilla.org/en-US/docs/Web/API/Sensor#Browser_compatibility">Compatibility</a>
+ */
 public class GwtSensor extends JavaScriptObject {
 
 	protected GwtSensor() {

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtSensor.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtSensor.java
@@ -1,0 +1,54 @@
+package com.badlogic.gdx.backends.gwt;
+
+import com.google.gwt.core.client.JavaScriptObject;
+
+public class GwtSensor extends JavaScriptObject {
+
+	protected GwtSensor() {
+	}
+
+	final native boolean activated() /*-{
+		return this.activated;
+	}-*/;
+
+	final native boolean hasReading() /*-{
+		return this.hasReading;
+	}-*/;
+
+	final native double timestamp() /*-{
+		return this.timestamp;
+	}-*/;
+
+	final native void start() /*-{
+		this.start();
+	}-*/;
+
+	final native void stop() /*-{
+		this.stop();
+	}-*/;
+
+	final native void setReadingListener(SensorRead listener) /*-{
+		this.onreading = listener.@com.badlogic.gdx.backends.gwt.GwtSensor.SensorRead::onReading()();
+	}-*/;
+
+	final native void setErrorListener(SensorError listener) /*-{
+		this.onerror = listener.@com.badlogic.gdx.backends.gwt.GwtSensor.SensorError::onError()();
+	}-*/;
+
+	final native void setActivateListener(SensorActivate listener) /*-{
+		this.onactivate = listener.@com.badlogic.gdx.backends.gwt.GwtSensor.SensorActivate::onActivate()();
+	}-*/;
+
+	interface SensorRead {
+		void onReading();
+	}
+
+	interface SensorError {
+		void onError();
+	}
+
+	interface SensorActivate {
+		void onActivate();
+	}
+}
+


### PR DESCRIPTION
You must use https for using the Accelerometer API because it's only available in [Secure Context](https://heycam.github.io/webidl/#SecureContext). You can test it [here](https://libgdx.v22018086706171227.nicesrv.de/) on my Server running the test's or @MrStahlfelge 's [Lightblocks](https://www.golfgl.de/lightblocks/experimental). You have to play _Single Player_ -> _Marathon_ and use the mode _Gravity Control_.