### PR TITLE
GWT HttpResponse throw exceptions on unavailable operations

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtNet.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtNet.java
@@ -58,7 +58,8 @@ public class GwtNet implements Net {
 
 		@Override
 		public byte[] getResult () {
-			return null;
+			throw new GdxRuntimeException("HttpResponse.getResult() not available on GWT. " +
+					"Use getResultAsString() if possible, or make use of AssetDownloader class.");
 		}
 
 		@Override
@@ -68,7 +69,8 @@ public class GwtNet implements Net {
 
 		@Override
 		public InputStream getResultAsStream () {
-			return null;
+			throw new GdxRuntimeException("HttpResponse.getResultAsStream not available on GWT. " +
+					"Use getResultAsString() if possible, or make use of AssetDownloader class.");
 		}
 
 		@Override


### PR DESCRIPTION
Binary operations on HttpResponse are not available on GWT, unfortunately the implementation just returns null which can lead to confusion. This small change makes the implementation throw an Exception with a hint for the developer how to solve the problem.