### PR TITLE
Add FileHandle.read() support for audio

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/preloader/AssetDownloader.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/preloader/AssetDownloader.java
@@ -71,7 +71,7 @@ public class AssetDownloader {
 			loadBinary(url, (AssetLoaderListener<Blob>)listener);
 			break;
 		case Audio:
-			loadAudio(url, (AssetLoaderListener<Void>)listener);
+			loadAudio(url, (AssetLoaderListener<Blob>)listener);
 			break;
 		case Directory:
 			listener.onSuccess(null);
@@ -122,28 +122,24 @@ public class AssetDownloader {
 		request.send();
 	}
 
-	public void loadAudio (String url, final AssetLoaderListener<Void> listener) {
-		if (useBrowserCache) {
-			loadBinary(url, new AssetLoaderListener<Blob>() {
-				@Override
-				public void onProgress (double amount) {
-					listener.onProgress(amount);
-				}
+	public void loadAudio (String url, final AssetLoaderListener<Blob> listener) {
+		loadBinary(url, new AssetLoaderListener<Blob>() {
+			@Override
+			public void onProgress (double amount) {
+				listener.onProgress(amount);
+			}
 
-				@Override
-				public void onFailure () {
-					listener.onFailure();
-				}
+			@Override
+			public void onFailure () {
+				listener.onFailure();
+			}
 
-				@Override
-				public void onSuccess (Blob result) {
-					listener.onSuccess(null);
-				}
+			@Override
+			public void onSuccess (Blob result) {
+				listener.onSuccess(result);
+			}
 
-			});
-		} else {
-			listener.onSuccess(null);
-		}
+		});
 	}
 
 	public void loadImage (final String url, final String mimeType, final AssetLoaderListener<ImageElement> listener) {

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/preloader/Blob.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/preloader/Blob.java
@@ -80,6 +80,6 @@ public final class Blob {
 		return encoded.toString();
 	}
 
-	private final Int8Array data;
+	protected final Int8Array data;
 
 }

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/preloader/Preloader.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/preloader/Preloader.java
@@ -46,7 +46,7 @@ public class Preloader {
 
 	public ObjectMap<String, Void> directories = new ObjectMap<String, Void>();
 	public ObjectMap<String, ImageElement> images = new ObjectMap<String, ImageElement>();
-	public ObjectMap<String, Void> audio = new ObjectMap<String, Void>();
+	public ObjectMap<String, Blob> audio = new ObjectMap<String, Blob>();
 	public ObjectMap<String, String> texts = new ObjectMap<String, String>();
 	public ObjectMap<String, Blob> binaries = new ObjectMap<String, Blob>();
 
@@ -181,7 +181,7 @@ public class Preloader {
 								binaries.put(asset.url, (Blob) result);
 								break;
 							case Audio:
-								audio.put(asset.url, null);
+								audio.put(asset.url, (Blob) result);
 								break;
 							case Directory:
 								directories.put(asset.url, null);
@@ -212,7 +212,7 @@ public class Preloader {
 			return binaries.get(url).read();
 		}
 		if (audio.containsKey(url)) {
-			return new ByteArrayInputStream(new byte[1]); // FIXME, sensible?
+			return audio.get(url).read();
 		}
 		return null;
 	}
@@ -308,7 +308,7 @@ public class Preloader {
 			return binaries.get(url).length();
 		}
 		if (audio.containsKey(url)) {
-			return 1; // FIXME sensible?
+			return audio.get(url).length();
 		}
 		return 0;
 	}


### PR DESCRIPTION
Add FileHandel.read() support for audio. With the planned removal of
SoundManager 2 it is now needed to read() an audio file on GWT.
(So https://github.com/libgdx/libgdx/blob/7e661eb3cae9aba493b19a3f55226c3db66f1826/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/webaudio/WebAudioAPIManager.java#L166-L189 can be removed)
Previously SM 2 has been responsible for actually loading the file
and libgdx was only preloading it.