### PR TITLE
iOS RoboVM/MOE: set allowIpod default to true

### DIFF
--- a/backends/gdx-backend-moe/src/com/badlogic/gdx/backends/iosmoe/IOSApplicationConfiguration.java
+++ b/backends/gdx-backend-moe/src/com/badlogic/gdx/backends/iosmoe/IOSApplicationConfiguration.java
@@ -88,7 +88,7 @@ public class IOSApplicationConfiguration {
 	public boolean useCompass = true;
 
 	/** whether or not to allow background music from iPod **/
-	public boolean allowIpod = false;
+	public boolean allowIpod = true;
 	
 	/** whether or not the onScreenKeyboard should be closed on return key **/
 	public boolean keyboardCloseOnReturn = true;

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSApplicationConfiguration.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSApplicationConfiguration.java
@@ -89,7 +89,7 @@ public class IOSApplicationConfiguration {
 	public boolean useCompass = true;
 
 	/** whether or not to allow background music from iPod **/
-	public boolean allowIpod = false;
+	public boolean allowIpod = true;
 
 	/** whether or not the onScreenKeyboard should be closed on return key **/
 	public boolean keyboardCloseOnReturn = true;


### PR DESCRIPTION
The default setting of allowIpod to false has two disadvantages:

It accesses the audio hardware directly and reserves it for the game only, therefore suppresses other music even if the user deactivated playing sounds in game. Additionally, I experienced some problems with some sound files (stuttering). Both problems are gone since I've changed allowIpod to true. I suspect the flag made sense some years ago on older hardware, but for now I suggest to set the default to true.