### PR TITLE
iOS: Add possibility to add iOS device information in game projects

### DIFF
--- a/backends/gdx-backend-moe/src/com/badlogic/gdx/backends/iosmoe/IOSApplicationConfiguration.java
+++ b/backends/gdx-backend-moe/src/com/badlogic/gdx/backends/iosmoe/IOSApplicationConfiguration.java
@@ -16,6 +16,8 @@
 
 package com.badlogic.gdx.backends.iosmoe;
 
+import com.badlogic.gdx.utils.ObjectMap;
+
 import apple.glkit.enums.GLKViewDrawableColorFormat;
 import apple.glkit.enums.GLKViewDrawableDepthFormat;
 import apple.glkit.enums.GLKViewDrawableMultisample;
@@ -110,4 +112,15 @@ public class IOSApplicationConfiguration {
 	/** The maximum number of threads to use for network requests. Default is {@link Integer#MAX_VALUE}. */
 	public int maxNetThreads = Integer.MAX_VALUE;
 
+	ObjectMap<String, IOSDevice> knownDevices = IOSDevice.populateWithKnownDevices();
+
+	/**
+	 * adds device information for newer iOS devices, or overrides information for given ones
+	 * @param classifier human readable device classifier
+	 * @param machineString machine string returned by iOS
+	 * @param ppi device's pixel per inch value
+	 */
+	public void addIosDevice(String classifier, String machineString, int ppi) {
+		IOSDevice.addDeviceToMap(knownDevices, classifier, machineString, ppi);
+	}
 }

--- a/backends/gdx-backend-moe/src/com/badlogic/gdx/backends/iosmoe/IOSDevice.java
+++ b/backends/gdx-backend-moe/src/com/badlogic/gdx/backends/iosmoe/IOSDevice.java
@@ -16,114 +16,119 @@
 
 package com.badlogic.gdx.backends.iosmoe;
 
-public enum IOSDevice {
+import com.badlogic.gdx.utils.ObjectMap;
 
-	IPHONE_2G("iPhone1,1", 163),
-	IPHONE_3G("iPhone1,2", 163),
-	IPHONE_3GS("iPhone2,1", 163),
-	IPHONE_4("iPhone3,1", 326),
-	IPHONE_4V("iPhone3,2", 326),
-	IPHONE_4_CDMA("iPhone3,3", 326),
-	IPHONE_4S("iPhone4,1", 326),
-	IPHONE_5("iPhone5,1", 326),
-	IPHONE_5_CDMA_GSM("iPhone5,2", 326),
-	IPHONE_5C("iPhone5,3", 326),
-	IPHONE_5C_CDMA_GSM("iPhone5,4", 326),
-	IPHONE_5S("iPhone6,1", 326),
-	IPHONE_5S_CDMA_GSM("iPhone6,2", 326),
-	IPHONE_6_PLUS("iPhone7,1", 401),
-	IPHONE_6("iPhone7,2", 326),
-	IPHONE_6S("iPhone8,1", 326),
-	IPHONE_6S_PLUS("iPhone8,2", 401),
-	IPHONE_7_CDMA_GSM("iPhone9,1", 326),
-	IPHONE_7_PLUS_CDMA_GSM("iPhone9,2", 401),
-	IPHONE_7("iPhone9,3", 326),
-	IPHONE_7_PLUS("iPhone9,4", 401),
-	IPHONE_SE("iPhone8,4", 326),
-	IPHONE_8_CDMA_GSM("iPhone10,1", 326),
-	IPHONE_8_PLUS_CDMA_GSM("iPhone10,2",401),
-	IPHONE_X_CDMA_GSM("iPhone10,3", 458),
-	IPHONE_8("iPhone10,4", 326),
-    	IPHONE_8_PLUS("iPhone10,5", 401),
-	IPHONE_X("iPhone10,6", 458),
-	IPHONE_XR("iPhone11,8", 326),
-	IPHONE_XS("iPhone11,2", 458),
-	IPHONE_XS_MAX("iPhone11,4", 458),
-	IPHONE_XS_MAX_2_NANO_SIM("iPhone11,6", 458),
-	
-	IPOD_TOUCH_1G("iPod1,1", 163),
-	IPOD_TOUCH_2G("iPod2,1", 163),
-	IPOD_TOUCH_3G("iPod3,1", 163),
-	IPOD_TOUCH_4G("iPod4,1", 326),
-	IPOD_TOUCH_5G("iPod5,1", 326),
-	IPOD_TOUCH_6G("iPod7,1", 326),
+public class IOSDevice {
 
-	IPAD("iPad1,1", 132),
-	IPAD_3G("iPad1,2", 132),
-	IPAD_2_WIFI("iPad2,1", 132),
-	IPAD_2("iPad2,2", 132),
-	IPAD_2_CDMA("iPad2,3", 132),
-	IPAD_2V("iPad2,4", 132),
-	IPAD_MINI_WIFI("iPad2,5", 164),
-	IPAD_MINI("iPad2,6", 164),
-	IPAD_MINI_WIFI_CDMA("iPad2,7", 164),
-	IPAD_3_WIFI("iPad3,1", 264),
-	IPAD_3_WIFI_CDMA("iPad3,2", 264),
-	IPAD_3("iPad3,3", 264),
-	IPAD_4_WIFI("iPad3,4", 264),
-	IPAD_4("iPad3,5", 264),
-	IPAD_4_GSM_CDMA("iPad3,6", 264),
-	IPAD_AIR_WIFI("iPad4,1", 264),
-	IPAD_AIR_WIFI_GSM("iPad4,2", 264),
-	IPAD_AIR_WIFI_CDMA("iPad4,3", 264),
-	IPAD_MINI_RETINA_WIFI("iPad4,4", 326),
-	IPAD_MINI_RETINA_WIFI_CDMA("iPad4,5", 326),
-	IPAD_MINI_RETINA_WIFI_CELLULAR_CN("iPad4,6", 326),
-	IPAD_MINI_3_WIFI("iPad4,7", 326),
-	IPAD_MINI_3_WIFI_CELLULAR("iPad4,8", 326),
-	IPAD_MINI_3_WIFI_CELLULAR_CN("iPad4,9", 326),
-	IPAD_MINI_4_WIFI("iPad5,1", 326),
-	IPAD_MINI_4_WIFI_CELLULAR("iPad5,2", 326),
-	IPAD_MINI_AIR_2_WIFI("iPad5,3", 264),
-	IPAD_MINI_AIR_2_WIFI_CELLULAR("iPad5,4", 264),
-	IPAD_PRO_WIFI("iPad6,7", 264),
-	IPAD_PRO("iPad6,8", 264),
-	IPAD_PRO_97_WIFI("iPad6,3", 264),
-	IPAD_PRO_97("iPad6,4", 264),
-	IPAD_5_WIFI("iPad6,11", 264),
-	IPAD_5_WIFI_CELLULAR("iPad6,12", 264),
-	IPAD_PRO_2_WIFI("iPad7,1", 264),
-	IPAD_PRO_2_WIFI_CELLULAR("iPad7,2", 264),
-	IPAD_PRO_10_5_WIFI("iPad7,3", 264),
-	IPAD_PRO_10_5_WIFI_CELLULAR("iPad7,4", 264),
-	IPAD_6_WIFI("iPad7,5", 264),
-	IPAD_6_WIFI_CELLULAR("iPad7,6", 264),
-	IPAD_PRO_11_WIFI("iPad8,1", 264),
-	IPAD_PRO_11_WIFI_6GB("iPad8,2", 264),
-	IPAD_PRO_11_WIFI_CELLULAR("iPad8,3", 264),
-	IPAD_PRO_11_WIFI_CELLULAR_6GB("iPad8,4", 264),
-	IPAD_PRO_3_WIFI("iPad8,5", 264),
-	IPAD_PRO_3_WIFI_6GB("iPad8,6", 264),
-	IPAD_PRO_3_WIFI_CELLULAR("iPad8,7", 264),
-	IPAD_PRO_3_WIFI_CELLULAR_6GB("iPad8,8", 264),
-
-	SIMULATOR_32("i386", 264),
-	SIMULATOR_64("x86_64", 264);
-
+	final String classifier;
 	final String machineString;
 	final int ppi;
 
-	IOSDevice(String machineString, int ppi) {
+	public IOSDevice(String classifier, String machineString, int ppi) {
+		this.classifier = classifier;
 		this.machineString = machineString;
 		this.ppi = ppi;
 	}
 
-	public static IOSDevice getDevice (String machineString) {
-		for (IOSDevice device : values()) {
-			if (device.machineString.equalsIgnoreCase(machineString)) return device;
-		}
-		return null;
+	static ObjectMap<String, IOSDevice> populateWithKnownDevices() {
+		ObjectMap<String, IOSDevice> deviceMap = new ObjectMap<String, IOSDevice>();
+
+		addDeviceToMap(deviceMap, "IPHONE_2G", "iPhone1,1", 163);
+		addDeviceToMap(deviceMap, "IPHONE_3G", "iPhone1,2", 163);
+		addDeviceToMap(deviceMap, "IPHONE_3GS", "iPhone2,1", 163);
+		addDeviceToMap(deviceMap, "IPHONE_4", "iPhone3,1", 326);
+		addDeviceToMap(deviceMap, "IPHONE_4V", "iPhone3,2", 326);
+		addDeviceToMap(deviceMap, "IPHONE_4_CDMA", "iPhone3,3", 326);
+		addDeviceToMap(deviceMap, "IPHONE_4S", "iPhone4,1", 326);
+		addDeviceToMap(deviceMap, "IPHONE_5", "iPhone5,1", 326);
+		addDeviceToMap(deviceMap, "IPHONE_5_CDMA_GSM", "iPhone5,2", 326);
+		addDeviceToMap(deviceMap, "IPHONE_5C", "iPhone5,3", 326);
+		addDeviceToMap(deviceMap, "IPHONE_5C_CDMA_GSM", "iPhone5,4", 326);
+		addDeviceToMap(deviceMap, "IPHONE_5S", "iPhone6,1", 326);
+		addDeviceToMap(deviceMap, "IPHONE_5S_CDMA_GSM", "iPhone6,2", 326);
+		addDeviceToMap(deviceMap, "IPHONE_6_PLUS", "iPhone7,1", 401);
+		addDeviceToMap(deviceMap, "IPHONE_6", "iPhone7,2", 326);
+		addDeviceToMap(deviceMap, "IPHONE_6S", "iPhone8,1", 326);
+		addDeviceToMap(deviceMap, "IPHONE_6S_PLUS", "iPhone8,2", 401);
+		addDeviceToMap(deviceMap, "IPHONE_7_CDMA_GSM", "iPhone9,1", 326);
+		addDeviceToMap(deviceMap, "IPHONE_7_PLUS_CDMA_GSM", "iPhone9,2", 401);
+		addDeviceToMap(deviceMap, "IPHONE_7", "iPhone9,3", 326);
+		addDeviceToMap(deviceMap, "IPHONE_7_PLUS", "iPhone9,4", 401);
+		addDeviceToMap(deviceMap, "IPHONE_SE", "iPhone8,4", 326);
+		addDeviceToMap(deviceMap, "IPHONE_8_CDMA_GSM", "iPhone10,1", 326);
+		addDeviceToMap(deviceMap, "IPHONE_8_PLUS_CDMA_GSM", "iPhone10,2", 401);
+		addDeviceToMap(deviceMap, "IPHONE_X_CDMA_GSM", "iPhone10,3", 458);
+		addDeviceToMap(deviceMap, "IPHONE_8", "iPhone10,4", 326);
+		addDeviceToMap(deviceMap, "IPHONE_8_PLUS", "iPhone10,5", 401);
+		addDeviceToMap(deviceMap, "IPHONE_X", "iPhone10,6", 458);
+		addDeviceToMap(deviceMap, "IPHONE_XR", "iPhone11,8", 326);
+		addDeviceToMap(deviceMap, "IPHONE_XS", "iPhone11,2", 458);
+		addDeviceToMap(deviceMap, "IPHONE_XS_MAX", "iPhone11,4", 458);
+		addDeviceToMap(deviceMap, "IPHONE_XS_MAX_2_NANO_SIM", "iPhone11,6", 458);
+
+		addDeviceToMap(deviceMap, "IPOD_TOUCH_1G", "iPod1,1", 163);
+		addDeviceToMap(deviceMap, "IPOD_TOUCH_2G", "iPod2,1", 163);
+		addDeviceToMap(deviceMap, "IPOD_TOUCH_3G", "iPod3,1", 163);
+		addDeviceToMap(deviceMap, "IPOD_TOUCH_4G", "iPod4,1", 326);
+		addDeviceToMap(deviceMap, "IPOD_TOUCH_5G", "iPod5,1", 326);
+		addDeviceToMap(deviceMap, "IPOD_TOUCH_6G", "iPod7,1", 326);
+
+		addDeviceToMap(deviceMap, "IPAD", "iPad1,1", 132);
+		addDeviceToMap(deviceMap, "IPAD_3G", "iPad1,2", 132);
+		addDeviceToMap(deviceMap, "IPAD_2_WIFI", "iPad2,1", 132);
+		addDeviceToMap(deviceMap, "IPAD_2", "iPad2,2", 132);
+		addDeviceToMap(deviceMap, "IPAD_2_CDMA", "iPad2,3", 132);
+		addDeviceToMap(deviceMap, "IPAD_2V", "iPad2,4", 132);
+		addDeviceToMap(deviceMap, "IPAD_MINI_WIFI", "iPad2,5", 164);
+		addDeviceToMap(deviceMap, "IPAD_MINI", "iPad2,6", 164);
+		addDeviceToMap(deviceMap, "IPAD_MINI_WIFI_CDMA", "iPad2,7", 164);
+		addDeviceToMap(deviceMap, "IPAD_3_WIFI", "iPad3,1", 264);
+		addDeviceToMap(deviceMap, "IPAD_3_WIFI_CDMA", "iPad3,2", 264);
+		addDeviceToMap(deviceMap, "IPAD_3", "iPad3,3", 264);
+		addDeviceToMap(deviceMap, "IPAD_4_WIFI", "iPad3,4", 264);
+		addDeviceToMap(deviceMap, "IPAD_4", "iPad3,5", 264);
+		addDeviceToMap(deviceMap, "IPAD_4_GSM_CDMA", "iPad3,6", 264);
+		addDeviceToMap(deviceMap, "IPAD_AIR_WIFI", "iPad4,1", 264);
+		addDeviceToMap(deviceMap, "IPAD_AIR_WIFI_GSM", "iPad4,2", 264);
+		addDeviceToMap(deviceMap, "IPAD_AIR_WIFI_CDMA", "iPad4,3", 264);
+		addDeviceToMap(deviceMap, "IPAD_MINI_RETINA_WIFI", "iPad4,4", 326);
+		addDeviceToMap(deviceMap, "IPAD_MINI_RETINA_WIFI_CDMA", "iPad4,5", 326);
+		addDeviceToMap(deviceMap, "IPAD_MINI_RETINA_WIFI_CELLULAR_CN", "iPad4,6", 326);
+		addDeviceToMap(deviceMap, "IPAD_MINI_3_WIFI", "iPad4,7", 326);
+		addDeviceToMap(deviceMap, "IPAD_MINI_3_WIFI_CELLULAR", "iPad4,8", 326);
+		addDeviceToMap(deviceMap, "IPAD_MINI_3_WIFI_CELLULAR_CN", "iPad4,9", 326);
+		addDeviceToMap(deviceMap, "IPAD_MINI_4_WIFI", "iPad5,1", 326);
+		addDeviceToMap(deviceMap, "IPAD_MINI_4_WIFI_CELLULAR", "iPad5,2", 326);
+		addDeviceToMap(deviceMap, "IPAD_MINI_AIR_2_WIFI", "iPad5,3", 264);
+		addDeviceToMap(deviceMap, "IPAD_MINI_AIR_2_WIFI_CELLULAR", "iPad5,4", 264);
+		addDeviceToMap(deviceMap, "IPAD_PRO_WIFI", "iPad6,7", 264);
+		addDeviceToMap(deviceMap, "IPAD_PRO", "iPad6,8", 264);
+		addDeviceToMap(deviceMap, "IPAD_PRO_97_WIFI", "iPad6,3", 264);
+		addDeviceToMap(deviceMap, "IPAD_PRO_97", "iPad6,4", 264);
+		addDeviceToMap(deviceMap, "IPAD_5_WIFI", "iPad6,11", 264);
+		addDeviceToMap(deviceMap, "IPAD_5_WIFI_CELLULAR", "iPad6,12", 264);
+		addDeviceToMap(deviceMap, "IPAD_PRO_2_WIFI", "iPad7,1", 264);
+		addDeviceToMap(deviceMap, "IPAD_PRO_2_WIFI_CELLULAR", "iPad7,2", 264);
+		addDeviceToMap(deviceMap, "IPAD_PRO_10_5_WIFI", "iPad7,3", 264);
+		addDeviceToMap(deviceMap, "IPAD_PRO_10_5_WIFI_CELLULAR", "iPad7,4", 264);
+		addDeviceToMap(deviceMap, "IPAD_6_WIFI", "iPad7,5", 264);
+		addDeviceToMap(deviceMap, "IPAD_6_WIFI_CELLULAR", "iPad7,6", 264);
+		addDeviceToMap(deviceMap, "IPAD_PRO_11_WIFI", "iPad8,1", 264);
+		addDeviceToMap(deviceMap, "IPAD_PRO_11_WIFI_6GB", "iPad8,2", 264);
+		addDeviceToMap(deviceMap, "IPAD_PRO_11_WIFI_CELLULAR", "iPad8,3", 264);
+		addDeviceToMap(deviceMap, "IPAD_PRO_11_WIFI_CELLULAR_6GB", "iPad8,4", 264);
+		addDeviceToMap(deviceMap, "IPAD_PRO_3_WIFI", "iPad8,5", 264);
+		addDeviceToMap(deviceMap, "IPAD_PRO_3_WIFI_6GB", "iPad8,6", 264);
+		addDeviceToMap(deviceMap, "IPAD_PRO_3_WIFI_CELLULAR", "iPad8,7", 264);
+		addDeviceToMap(deviceMap, "IPAD_PRO_3_WIFI_CELLULAR_6GB", "iPad8,8", 264);
+
+		addDeviceToMap(deviceMap, "SIMULATOR_32", "i386", 264);
+		addDeviceToMap(deviceMap, "SIMULATOR_64", "x86_64", 264);
+
+		return deviceMap;
 	}
 
-
+	static void addDeviceToMap(ObjectMap<String, IOSDevice> deviceMap, String classifier, String machineString, int ppi) {
+		deviceMap.put(machineString, new IOSDevice(classifier, machineString, ppi));
+	}
 }

--- a/backends/gdx-backend-moe/src/com/badlogic/gdx/backends/iosmoe/IOSGraphics.java
+++ b/backends/gdx-backend-moe/src/com/badlogic/gdx/backends/iosmoe/IOSGraphics.java
@@ -169,7 +169,7 @@ public class IOSGraphics extends NSObject implements Graphics, GLKViewDelegate, 
 		bufferFormat = new BufferFormat(r, g, b, a, depth, stencil, samples, false);
 
 		String machineString = HWMachine.getMachineString();
-		IOSDevice device = IOSDevice.getDevice(machineString);
+		IOSDevice device = config.knownDevices.get(machineString);
 		if (device == null) app.error(tag, "Machine ID: " + machineString + " not found, please report to LibGDX");
 		int ppi = device != null ? device.ppi : 163;
 		density = device != null ? device.ppi / 160f : scale;

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSApplicationConfiguration.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSApplicationConfiguration.java
@@ -16,6 +16,8 @@
 
 package com.badlogic.gdx.backends.iosrobovm;
 
+import com.badlogic.gdx.utils.ObjectMap;
+
 import org.robovm.apple.glkit.GLKViewDrawableColorFormat;
 import org.robovm.apple.glkit.GLKViewDrawableDepthFormat;
 import org.robovm.apple.glkit.GLKViewDrawableMultisample;
@@ -115,4 +117,15 @@ public class IOSApplicationConfiguration {
 	/** whether to use audio or not. Default is <code>true</code> **/
 	public boolean useAudio = true;
 
+	ObjectMap<String, IOSDevice> knownDevices = IOSDevice.populateWithKnownDevices();
+
+	/**
+	 * adds device information for newer iOS devices, or overrides information for given ones
+	 * @param classifier human readable device classifier
+	 * @param machineString machine string returned by iOS
+	 * @param ppi device's pixel per inch value
+	 */
+	public void addIosDevice(String classifier, String machineString, int ppi) {
+		IOSDevice.addDeviceToMap(knownDevices, classifier, machineString, ppi);
+	}
 }

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSDevice.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSDevice.java
@@ -16,114 +16,119 @@
 
 package com.badlogic.gdx.backends.iosrobovm;
 
-public enum IOSDevice {
+import com.badlogic.gdx.utils.ObjectMap;
 
-	IPHONE_2G("iPhone1,1", 163),
-	IPHONE_3G("iPhone1,2", 163),
-	IPHONE_3GS("iPhone2,1", 163),
-	IPHONE_4("iPhone3,1", 326),
-	IPHONE_4V("iPhone3,2", 326),
-	IPHONE_4_CDMA("iPhone3,3", 326),
-	IPHONE_4S("iPhone4,1", 326),
-	IPHONE_5("iPhone5,1", 326),
-	IPHONE_5_CDMA_GSM("iPhone5,2", 326),
-	IPHONE_5C("iPhone5,3", 326),
-	IPHONE_5C_CDMA_GSM("iPhone5,4", 326),
-	IPHONE_5S("iPhone6,1", 326),
-	IPHONE_5S_CDMA_GSM("iPhone6,2", 326),
-	IPHONE_6_PLUS("iPhone7,1", 401),
-	IPHONE_6("iPhone7,2", 326),
-	IPHONE_6S("iPhone8,1", 326),
-	IPHONE_6S_PLUS("iPhone8,2", 401),
-	IPHONE_7_CDMA_GSM("iPhone9,1", 326),
-	IPHONE_7_PLUS_CDMA_GSM("iPhone9,2", 401),
-	IPHONE_7("iPhone9,3", 326),
-	IPHONE_7_PLUS("iPhone9,4", 401),
-	IPHONE_SE("iPhone8,4", 326),
-	IPHONE_8_CDMA_GSM("iPhone10,1", 326),
-	IPHONE_8_PLUS_CDMA_GSM("iPhone10,2",401),
-	IPHONE_X_CDMA_GSM("iPhone10,3", 458),
-	IPHONE_8("iPhone10,4", 326),
-    	IPHONE_8_PLUS("iPhone10,5", 401),
-	IPHONE_X("iPhone10,6", 458),
-	IPHONE_XR("iPhone11,8", 326),
-	IPHONE_XS("iPhone11,2", 458),
-	IPHONE_XS_MAX("iPhone11,4", 458),
-	IPHONE_XS_MAX_2_NANO_SIM("iPhone11,6", 458),
+public class IOSDevice {
 
-	IPOD_TOUCH_1G("iPod1,1", 163),
-	IPOD_TOUCH_2G("iPod2,1", 163),
-	IPOD_TOUCH_3G("iPod3,1", 163),
-	IPOD_TOUCH_4G("iPod4,1", 326),
-	IPOD_TOUCH_5G("iPod5,1", 326),
-	IPOD_TOUCH_6G("iPod7,1", 326),
-
-	IPAD("iPad1,1", 132),
-	IPAD_3G("iPad1,2", 132),
-	IPAD_2_WIFI("iPad2,1", 132),
-	IPAD_2("iPad2,2", 132),
-	IPAD_2_CDMA("iPad2,3", 132),
-	IPAD_2V("iPad2,4", 132),
-	IPAD_MINI_WIFI("iPad2,5", 164),
-	IPAD_MINI("iPad2,6", 164),
-	IPAD_MINI_WIFI_CDMA("iPad2,7", 164),
-	IPAD_3_WIFI("iPad3,1", 264),
-	IPAD_3_WIFI_CDMA("iPad3,2", 264),
-	IPAD_3("iPad3,3", 264),
-	IPAD_4_WIFI("iPad3,4", 264),
-	IPAD_4("iPad3,5", 264),
-	IPAD_4_GSM_CDMA("iPad3,6", 264),
-	IPAD_AIR_WIFI("iPad4,1", 264),
-	IPAD_AIR_WIFI_GSM("iPad4,2", 264),
-	IPAD_AIR_WIFI_CDMA("iPad4,3", 264),
-	IPAD_MINI_RETINA_WIFI("iPad4,4", 326),
-	IPAD_MINI_RETINA_WIFI_CDMA("iPad4,5", 326),
-	IPAD_MINI_RETINA_WIFI_CELLULAR_CN("iPad4,6", 326),
-	IPAD_MINI_3_WIFI("iPad4,7", 326),
-	IPAD_MINI_3_WIFI_CELLULAR("iPad4,8", 326),
-	IPAD_MINI_3_WIFI_CELLULAR_CN("iPad4,9", 326),
-	IPAD_MINI_4_WIFI("iPad5,1", 326),
-	IPAD_MINI_4_WIFI_CELLULAR("iPad5,2", 326),
-	IPAD_MINI_AIR_2_WIFI("iPad5,3", 264),
-	IPAD_MINI_AIR_2_WIFI_CELLULAR("iPad5,4", 264),
-	IPAD_PRO_WIFI("iPad6,7", 264),
-	IPAD_PRO("iPad6,8", 264),
-	IPAD_PRO_97_WIFI("iPad6,3", 264),
-	IPAD_PRO_97("iPad6,4", 264),
-	IPAD_5_WIFI("iPad6,11", 264),
-	IPAD_5_WIFI_CELLULAR("iPad6,12", 264),
-	IPAD_PRO_2_WIFI("iPad7,1", 264),
-	IPAD_PRO_2_WIFI_CELLULAR("iPad7,2", 264),
-	IPAD_PRO_10_5_WIFI("iPad7,3", 264),
-	IPAD_PRO_10_5_WIFI_CELLULAR("iPad7,4", 264),
-	IPAD_6_WIFI("iPad7,5", 264),
-	IPAD_6_WIFI_CELLULAR("iPad7,6", 264),
-	IPAD_PRO_11_WIFI("iPad8,1", 264),
-	IPAD_PRO_11_WIFI_6GB("iPad8,2", 264),
-	IPAD_PRO_11_WIFI_CELLULAR("iPad8,3", 264),
-	IPAD_PRO_11_WIFI_CELLULAR_6GB("iPad8,4", 264),
-	IPAD_PRO_3_WIFI("iPad8,5", 264),
-	IPAD_PRO_3_WIFI_6GB("iPad8,6", 264),
-	IPAD_PRO_3_WIFI_CELLULAR("iPad8,7", 264),
-	IPAD_PRO_3_WIFI_CELLULAR_6GB("iPad8,8", 264),
-
-	SIMULATOR_32("i386", 264),
-	SIMULATOR_64("x86_64", 264);
-
+	final String classifier;
 	final String machineString;
 	final int ppi;
 
-	IOSDevice(String machineString, int ppi) {
+	public IOSDevice(String classifier, String machineString, int ppi) {
+		this.classifier = classifier;
 		this.machineString = machineString;
 		this.ppi = ppi;
 	}
 
-	public static IOSDevice getDevice (String machineString) {
-		for (IOSDevice device : values()) {
-			if (device.machineString.equalsIgnoreCase(machineString)) return device;
-		}
-		return null;
+	static ObjectMap<String, IOSDevice> populateWithKnownDevices() {
+		ObjectMap<String, IOSDevice> deviceMap = new ObjectMap<String, IOSDevice>();
+
+		addDeviceToMap(deviceMap, "IPHONE_2G", "iPhone1,1", 163);
+		addDeviceToMap(deviceMap, "IPHONE_3G", "iPhone1,2", 163);
+		addDeviceToMap(deviceMap, "IPHONE_3GS", "iPhone2,1", 163);
+		addDeviceToMap(deviceMap, "IPHONE_4", "iPhone3,1", 326);
+		addDeviceToMap(deviceMap, "IPHONE_4V", "iPhone3,2", 326);
+		addDeviceToMap(deviceMap, "IPHONE_4_CDMA", "iPhone3,3", 326);
+		addDeviceToMap(deviceMap, "IPHONE_4S", "iPhone4,1", 326);
+		addDeviceToMap(deviceMap, "IPHONE_5", "iPhone5,1", 326);
+		addDeviceToMap(deviceMap, "IPHONE_5_CDMA_GSM", "iPhone5,2", 326);
+		addDeviceToMap(deviceMap, "IPHONE_5C", "iPhone5,3", 326);
+		addDeviceToMap(deviceMap, "IPHONE_5C_CDMA_GSM", "iPhone5,4", 326);
+		addDeviceToMap(deviceMap, "IPHONE_5S", "iPhone6,1", 326);
+		addDeviceToMap(deviceMap, "IPHONE_5S_CDMA_GSM", "iPhone6,2", 326);
+		addDeviceToMap(deviceMap, "IPHONE_6_PLUS", "iPhone7,1", 401);
+		addDeviceToMap(deviceMap, "IPHONE_6", "iPhone7,2", 326);
+		addDeviceToMap(deviceMap, "IPHONE_6S", "iPhone8,1", 326);
+		addDeviceToMap(deviceMap, "IPHONE_6S_PLUS", "iPhone8,2", 401);
+		addDeviceToMap(deviceMap, "IPHONE_7_CDMA_GSM", "iPhone9,1", 326);
+		addDeviceToMap(deviceMap, "IPHONE_7_PLUS_CDMA_GSM", "iPhone9,2", 401);
+		addDeviceToMap(deviceMap, "IPHONE_7", "iPhone9,3", 326);
+		addDeviceToMap(deviceMap, "IPHONE_7_PLUS", "iPhone9,4", 401);
+		addDeviceToMap(deviceMap, "IPHONE_SE", "iPhone8,4", 326);
+		addDeviceToMap(deviceMap, "IPHONE_8_CDMA_GSM", "iPhone10,1", 326);
+		addDeviceToMap(deviceMap, "IPHONE_8_PLUS_CDMA_GSM", "iPhone10,2", 401);
+		addDeviceToMap(deviceMap, "IPHONE_X_CDMA_GSM", "iPhone10,3", 458);
+		addDeviceToMap(deviceMap, "IPHONE_8", "iPhone10,4", 326);
+		addDeviceToMap(deviceMap, "IPHONE_8_PLUS", "iPhone10,5", 401);
+		addDeviceToMap(deviceMap, "IPHONE_X", "iPhone10,6", 458);
+		addDeviceToMap(deviceMap, "IPHONE_XR", "iPhone11,8", 326);
+		addDeviceToMap(deviceMap, "IPHONE_XS", "iPhone11,2", 458);
+		addDeviceToMap(deviceMap, "IPHONE_XS_MAX", "iPhone11,4", 458);
+		addDeviceToMap(deviceMap, "IPHONE_XS_MAX_2_NANO_SIM", "iPhone11,6", 458);
+
+		addDeviceToMap(deviceMap, "IPOD_TOUCH_1G", "iPod1,1", 163);
+		addDeviceToMap(deviceMap, "IPOD_TOUCH_2G", "iPod2,1", 163);
+		addDeviceToMap(deviceMap, "IPOD_TOUCH_3G", "iPod3,1", 163);
+		addDeviceToMap(deviceMap, "IPOD_TOUCH_4G", "iPod4,1", 326);
+		addDeviceToMap(deviceMap, "IPOD_TOUCH_5G", "iPod5,1", 326);
+		addDeviceToMap(deviceMap, "IPOD_TOUCH_6G", "iPod7,1", 326);
+
+		addDeviceToMap(deviceMap, "IPAD", "iPad1,1", 132);
+		addDeviceToMap(deviceMap, "IPAD_3G", "iPad1,2", 132);
+		addDeviceToMap(deviceMap, "IPAD_2_WIFI", "iPad2,1", 132);
+		addDeviceToMap(deviceMap, "IPAD_2", "iPad2,2", 132);
+		addDeviceToMap(deviceMap, "IPAD_2_CDMA", "iPad2,3", 132);
+		addDeviceToMap(deviceMap, "IPAD_2V", "iPad2,4", 132);
+		addDeviceToMap(deviceMap, "IPAD_MINI_WIFI", "iPad2,5", 164);
+		addDeviceToMap(deviceMap, "IPAD_MINI", "iPad2,6", 164);
+		addDeviceToMap(deviceMap, "IPAD_MINI_WIFI_CDMA", "iPad2,7", 164);
+		addDeviceToMap(deviceMap, "IPAD_3_WIFI", "iPad3,1", 264);
+		addDeviceToMap(deviceMap, "IPAD_3_WIFI_CDMA", "iPad3,2", 264);
+		addDeviceToMap(deviceMap, "IPAD_3", "iPad3,3", 264);
+		addDeviceToMap(deviceMap, "IPAD_4_WIFI", "iPad3,4", 264);
+		addDeviceToMap(deviceMap, "IPAD_4", "iPad3,5", 264);
+		addDeviceToMap(deviceMap, "IPAD_4_GSM_CDMA", "iPad3,6", 264);
+		addDeviceToMap(deviceMap, "IPAD_AIR_WIFI", "iPad4,1", 264);
+		addDeviceToMap(deviceMap, "IPAD_AIR_WIFI_GSM", "iPad4,2", 264);
+		addDeviceToMap(deviceMap, "IPAD_AIR_WIFI_CDMA", "iPad4,3", 264);
+		addDeviceToMap(deviceMap, "IPAD_MINI_RETINA_WIFI", "iPad4,4", 326);
+		addDeviceToMap(deviceMap, "IPAD_MINI_RETINA_WIFI_CDMA", "iPad4,5", 326);
+		addDeviceToMap(deviceMap, "IPAD_MINI_RETINA_WIFI_CELLULAR_CN", "iPad4,6", 326);
+		addDeviceToMap(deviceMap, "IPAD_MINI_3_WIFI", "iPad4,7", 326);
+		addDeviceToMap(deviceMap, "IPAD_MINI_3_WIFI_CELLULAR", "iPad4,8", 326);
+		addDeviceToMap(deviceMap, "IPAD_MINI_3_WIFI_CELLULAR_CN", "iPad4,9", 326);
+		addDeviceToMap(deviceMap, "IPAD_MINI_4_WIFI", "iPad5,1", 326);
+		addDeviceToMap(deviceMap, "IPAD_MINI_4_WIFI_CELLULAR", "iPad5,2", 326);
+		addDeviceToMap(deviceMap, "IPAD_MINI_AIR_2_WIFI", "iPad5,3", 264);
+		addDeviceToMap(deviceMap, "IPAD_MINI_AIR_2_WIFI_CELLULAR", "iPad5,4", 264);
+		addDeviceToMap(deviceMap, "IPAD_PRO_WIFI", "iPad6,7", 264);
+		addDeviceToMap(deviceMap, "IPAD_PRO", "iPad6,8", 264);
+		addDeviceToMap(deviceMap, "IPAD_PRO_97_WIFI", "iPad6,3", 264);
+		addDeviceToMap(deviceMap, "IPAD_PRO_97", "iPad6,4", 264);
+		addDeviceToMap(deviceMap, "IPAD_5_WIFI", "iPad6,11", 264);
+		addDeviceToMap(deviceMap, "IPAD_5_WIFI_CELLULAR", "iPad6,12", 264);
+		addDeviceToMap(deviceMap, "IPAD_PRO_2_WIFI", "iPad7,1", 264);
+		addDeviceToMap(deviceMap, "IPAD_PRO_2_WIFI_CELLULAR", "iPad7,2", 264);
+		addDeviceToMap(deviceMap, "IPAD_PRO_10_5_WIFI", "iPad7,3", 264);
+		addDeviceToMap(deviceMap, "IPAD_PRO_10_5_WIFI_CELLULAR", "iPad7,4", 264);
+		addDeviceToMap(deviceMap, "IPAD_6_WIFI", "iPad7,5", 264);
+		addDeviceToMap(deviceMap, "IPAD_6_WIFI_CELLULAR", "iPad7,6", 264);
+		addDeviceToMap(deviceMap, "IPAD_PRO_11_WIFI", "iPad8,1", 264);
+		addDeviceToMap(deviceMap, "IPAD_PRO_11_WIFI_6GB", "iPad8,2", 264);
+		addDeviceToMap(deviceMap, "IPAD_PRO_11_WIFI_CELLULAR", "iPad8,3", 264);
+		addDeviceToMap(deviceMap, "IPAD_PRO_11_WIFI_CELLULAR_6GB", "iPad8,4", 264);
+		addDeviceToMap(deviceMap, "IPAD_PRO_3_WIFI", "iPad8,5", 264);
+		addDeviceToMap(deviceMap, "IPAD_PRO_3_WIFI_6GB", "iPad8,6", 264);
+		addDeviceToMap(deviceMap, "IPAD_PRO_3_WIFI_CELLULAR", "iPad8,7", 264);
+		addDeviceToMap(deviceMap, "IPAD_PRO_3_WIFI_CELLULAR_6GB", "iPad8,8", 264);
+
+		addDeviceToMap(deviceMap, "SIMULATOR_32", "i386", 264);
+		addDeviceToMap(deviceMap, "SIMULATOR_64", "x86_64", 264);
+
+		return deviceMap;
 	}
 
-
+	static void addDeviceToMap(ObjectMap<String, IOSDevice> deviceMap, String classifier, String machineString, int ppi) {
+		deviceMap.put(machineString, new IOSDevice(classifier, machineString, ppi));
+	}
 }

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
@@ -265,7 +265,7 @@ public class IOSGraphics extends NSObject implements Graphics, GLKViewDelegate, 
 		bufferFormat = new BufferFormat(r, g, b, a, depth, stencil, samples, false);
 
 		String machineString = HWMachine.getMachineString();
-		IOSDevice device = IOSDevice.getDevice(machineString);
+		IOSDevice device = config.knownDevices.get(machineString);
 		if (device == null) app.error(tag, "Machine ID: " + machineString + " not found, please report to LibGDX");
 		int ppi = device != null ? device.ppi : 163;
 		density = device != null ? device.ppi/160f : scale;


### PR DESCRIPTION
New iOS devices pop up regularly, but existing games can't always be updated to the latest libGDX version. This PR makes the device list accessible to the game code. You can add new iOS device information via `IOSApplicationConfiguration.addIosDevice()`.