### PR TITLE
jnigen: Fix double quote issue in BuildExecutor.

### DIFF
--- a/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/AntScriptGenerator.java
+++ b/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/AntScriptGenerator.java
@@ -42,7 +42,7 @@ import com.badlogic.gdx.jnigen.FileDescriptor.FileType;
  * BuildConfig config = new BuildConfig("mysharedlibrary");
  * 
  * new AntScriptGenerator().generate(config, win32, win64, linux32, linux64, mac, android);
- * BuildExecutor.executeAnt("jni/build.xml", "clean all -v");
+ * BuildExecutor.executeAnt("jni/build.xml", "clean", "all", "-v");
  * 
  * // assuming the natives jar is on the classpath of the application 
  * new SharedLibraryLoader().load("mysharedlibrary)

--- a/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/BuildExecutor.java
+++ b/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/BuildExecutor.java
@@ -20,6 +20,9 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -30,12 +33,19 @@ public class BuildExecutor {
 	 * @param buildFile
 	 * @param params
 	 * @return whether the Ant succeeded */
-	public static boolean executeAnt (String buildFile, String params) {
+	public static boolean executeAnt (String buildFile, String... params) {
 		FileDescriptor build = new FileDescriptor(buildFile);
 		String ant = System.getProperty("os.name").contains("Windows") ? "ant.bat" : "ant";
-		String command = ant + " -f \"" + build.file().getAbsolutePath() + "\" " + params;
+
+		List<String> command = new ArrayList<>();
+		command.add(ant);
+		command.add("-f");
+		command.add(build.file.getAbsolutePath());
+		command.addAll(Arrays.asList(params));
+
+		String[] args = command.toArray(new String[0]);
 		System.out.println("Executing '" + command + "'");
-		return startProcess(command, build.parent().file());
+		return startProcess(build.parent().file(), args);
 	}
 
 	/** Execute ndk-build in the given directory
@@ -43,12 +53,15 @@ public class BuildExecutor {
 	public static void executeNdk (String directory) {
 		FileDescriptor build = new FileDescriptor(directory);
 		String command = "ndk-build";
-		startProcess(command, build.file());
+		startProcess(build.file(), command);
 	}
 
-	private static boolean startProcess (String command, File directory) {
+	private static boolean startProcess (File directory, String... command) {
 		try {
-			final Process process = new ProcessBuilder(command.split(" ")).redirectErrorStream(true).start();
+			final Process process = new ProcessBuilder(command)
+					.redirectErrorStream(true)
+					.directory(directory)
+					.start();
 
 			Thread t = new Thread(new Runnable() {
 				@Override

--- a/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/test/MyJniClass.java
+++ b/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/test/MyJniClass.java
@@ -75,8 +75,8 @@ public class MyJniClass {
 		new AntScriptGenerator().generate(buildConfig, win32, lin64);
 		
 		// build natives
-		BuildExecutor.executeAnt("jni/build-linux64.xml", "-v -Dhas-compiler=true clean postcompile");
-		BuildExecutor.executeAnt("jni/build.xml", "-v pack-natives");
+		BuildExecutor.executeAnt("jni/build-linux64.xml", "-v", "-Dhas-compiler=true", "clean", "postcompile");
+		BuildExecutor.executeAnt("jni/build.xml", "-v", "pack-natives");
 		
 		// load the test-natives.jar and from it the shared library, then execute the test. 
 		new JniGenSharedLibraryLoader("libs/test-natives.jar").load("test");


### PR DESCRIPTION
* Added missing working directory change in BuildExecutor#startProcess

Original changes were originally in https://github.com/libgdx/libgdx/pull/5556 but includes additional changes from https://github.com/MobiDevelop/gdx-jnigen