### PR TITLE
iOS RoboVM make UIViewController customizable

### DIFF
--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSApplication.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSApplication.java
@@ -178,6 +178,10 @@ public class IOSApplication implements Application {
 		 return new IOSGraphics(scale, this, config, input, config.useGL30);
 	}
 
+	protected IOSGraphics.IOSUIViewController createUIViewController(IOSGraphics graphics) {
+		return new IOSGraphics.IOSUIViewController(this, graphics);
+	}
+
 	protected IOSInput createInput() {
 		 return new IOSInput(this);
 	}

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
@@ -55,12 +55,12 @@ public class IOSGraphics extends NSObject implements Graphics, GLKViewDelegate, 
 
 	private static final String tag = "IOSGraphics";
 
-	static class IOSUIViewController extends GLKViewController {
+	public static class IOSUIViewController extends GLKViewController {
 		final IOSApplication app;
 		final IOSGraphics graphics;
 		boolean created = false;
 
-		IOSUIViewController (IOSApplication app, IOSGraphics graphics) {
+		protected IOSUIViewController (IOSApplication app, IOSGraphics graphics) {
 			this.app = app;
 			this.graphics = graphics;
 		}
@@ -237,7 +237,7 @@ public class IOSGraphics extends NSObject implements Graphics, GLKViewDelegate, 
 		view.setDrawableMultisample(config.multisample);
 		view.setMultipleTouchEnabled(true);
 
-		viewController = new IOSUIViewController(app, this);
+		viewController = app.createUIViewController(this);
 		viewController.setView(view);
 		viewController.setDelegate(this);
 		viewController.setPreferredFramesPerSecond(config.preferredFramesPerSecond);


### PR DESCRIPTION
On iOS, the appearance of the app is controlled by the UIViewController. In order to change some system behaviour, some methods of it must be overriden. 

The UIViewController used in the RoboVM backend was not exposed to the game project, thus not changeable if the default behaviour was not suitable. This commit changes it. 

I tested it to make sure it works by adding a selector/binding that I need in my project for supporting iCade controllers.

I looked into MOE, but it is solved in another way there and so I didn't change anything for the MOE backend.