### PR TITLE
Moved allocateIterators config to new Collections class

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -33,7 +33,7 @@
 - API Addition: new InstanceBufferObject and InstanceBufferObjectSubData classes to enable instanced rendering.
 - API Addition: Support for InstancedRendering via Mesh
 - API Change: Cell#setLayout renamed to setTable.
-- API Addition: Added Array.allocateIterators. When true, iterators are allocated. When false (default), iterators cannot be used nested.
+- API Addition: Added Collections#allocateIterators. When true, iterators are allocated. When false (default), iterators cannot be used nested.
 
 [1.9.9]
 - API Addition: Add support for stripping whitespace in PixmapPacker

--- a/gdx/src/com/badlogic/gdx/graphics/VertexAttributes.java
+++ b/gdx/src/com/badlogic/gdx/graphics/VertexAttributes.java
@@ -188,7 +188,7 @@ public final class VertexAttributes implements Iterable<VertexAttribute>, Compar
 		return 0;
 	}
 
-	/** @see Collections#setAllocateIterators(boolean) */
+	/** @see Collections#allocateIterators */
 	@Override
 	public Iterator<VertexAttribute> iterator () {
 		if (iterable == null) iterable = new ReadonlyIterable<VertexAttribute>(attributes);
@@ -242,7 +242,7 @@ public final class VertexAttributes implements Iterable<VertexAttribute>, Compar
 
 		@Override
 		public Iterator<T> iterator () {
-			if (Collections.isAllocateIterators()) return new ReadonlyIterator(array);
+			if (Collections.allocateIterators) return new ReadonlyIterator(array);
 			if (iterator1 == null) {
 				iterator1 = new ReadonlyIterator(array);
 				iterator2 = new ReadonlyIterator(array);

--- a/gdx/src/com/badlogic/gdx/graphics/VertexAttributes.java
+++ b/gdx/src/com/badlogic/gdx/graphics/VertexAttributes.java
@@ -20,6 +20,7 @@ import java.util.Iterator;
 import java.util.NoSuchElementException;
 
 import com.badlogic.gdx.utils.Array;
+import com.badlogic.gdx.utils.Collections;
 import com.badlogic.gdx.utils.GdxRuntimeException;
 
 /** Instances of this class specify the vertex attributes of a mesh. VertexAttributes are used by {@link Mesh} instances to define
@@ -187,7 +188,7 @@ public final class VertexAttributes implements Iterable<VertexAttribute>, Compar
 		return 0;
 	}
 
-	/** @see Array#allocateIterators */
+	/** @see Collections#setAllocateIterators(boolean) */
 	@Override
 	public Iterator<VertexAttribute> iterator () {
 		if (iterable == null) iterable = new ReadonlyIterable<VertexAttribute>(attributes);
@@ -241,7 +242,7 @@ public final class VertexAttributes implements Iterable<VertexAttribute>, Compar
 
 		@Override
 		public Iterator<T> iterator () {
-			if (Array.allocateIterators) return new ReadonlyIterator(array);
+			if (Collections.isAllocateIterators()) return new ReadonlyIterator(array);
 			if (iterator1 == null) {
 				iterator1 = new ReadonlyIterator(array);
 				iterator2 = new ReadonlyIterator(array);

--- a/gdx/src/com/badlogic/gdx/utils/Array.java
+++ b/gdx/src/com/badlogic/gdx/utils/Array.java
@@ -23,8 +23,6 @@ import java.util.NoSuchElementException;
 import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.utils.reflect.ArrayReflection;
 
-import static com.badlogic.gdx.utils.Collections.isAllocateIterators;
-
 /** A resizable, ordered or unordered array of objects. If unordered, this class avoids a memory copy when removing elements (the
  * last element is moved to the removed element's position).
  * @author Nathan Sweet */
@@ -475,20 +473,20 @@ public class Array<T> implements Iterable<T> {
 
 	/** Returns an iterator for the items in the array. Remove is supported.
 	 * <p>
-	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link ArrayIterator} constructor for nested or multithreaded iteration. */
 	public Iterator<T> iterator () {
-		if (isAllocateIterators()) return new ArrayIterator(this, true);
+		if (Collections.allocateIterators) return new ArrayIterator(this, true);
 		if (iterable == null) iterable = new ArrayIterable(this);
 		return iterable.iterator();
 	}
 
 	/** Returns an iterable for the selected items in the array. Remove is supported, but not between hasNext() and next().
 	 * <p>
-	 * If {@link Collections#isAllocateIterators()} is false, the same iterable instance is returned each time this method is called. Use the
+	 * If {@link Collections#allocateIterators} is false, the same iterable instance is returned each time this method is called. Use the
 	 * {@link Predicate.PredicateIterable} constructor for nested or multithreaded iteration. */
 	public Iterable<T> select (Predicate<T> predicate) {
-		if (isAllocateIterators()) new Predicate.PredicateIterable<T>(this, predicate);
+		if (Collections.allocateIterators) new Predicate.PredicateIterable<T>(this, predicate);
 		if (predicateIterable == null)
 			predicateIterable = new Predicate.PredicateIterable<T>(this, predicate);
 		else
@@ -674,9 +672,9 @@ public class Array<T> implements Iterable<T> {
 			this.allowRemove = allowRemove;
 		}
 
-		/** @see Collections#isAllocateIterators() */
+		/** @see Collections#allocateIterators */
 		public Iterator<T> iterator () {
-			if (isAllocateIterators()) return new ArrayIterator(array, allowRemove);
+			if (Collections.allocateIterators) return new ArrayIterator(array, allowRemove);
 // lastAcquire.getBuffer().setLength(0);
 // new Throwable().printStackTrace(new java.io.PrintWriter(lastAcquire));
 			if (iterator1 == null) {

--- a/gdx/src/com/badlogic/gdx/utils/Array.java
+++ b/gdx/src/com/badlogic/gdx/utils/Array.java
@@ -27,7 +27,6 @@ import com.badlogic.gdx.utils.reflect.ArrayReflection;
  * last element is moved to the removed element's position).
  * @author Nathan Sweet */
 public class Array<T> implements Iterable<T> {
-
 	/** Provides direct access to the underlying array. If the Array's generic type is not Object, this field may only be accessed
 	 * if the {@link Array#Array(boolean, int, Class)} constructor was used. */
 	public T[] items;

--- a/gdx/src/com/badlogic/gdx/utils/Array.java
+++ b/gdx/src/com/badlogic/gdx/utils/Array.java
@@ -23,13 +23,12 @@ import java.util.NoSuchElementException;
 import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.utils.reflect.ArrayReflection;
 
+import static com.badlogic.gdx.utils.Collections.isAllocateIterators;
+
 /** A resizable, ordered or unordered array of objects. If unordered, this class avoids a memory copy when removing elements (the
  * last element is moved to the removed element's position).
  * @author Nathan Sweet */
 public class Array<T> implements Iterable<T> {
-	/** When true, {@link Iterable#iterator()} in this class and others will allocate a new iterator for each invocation. When
-	 * false, the iterator is reused and nested use will throw an exception. Default is false. */
-	static public boolean allocateIterators;
 
 	/** Provides direct access to the underlying array. If the Array's generic type is not Object, this field may only be accessed
 	 * if the {@link Array#Array(boolean, int, Class)} constructor was used. */
@@ -476,20 +475,20 @@ public class Array<T> implements Iterable<T> {
 
 	/** Returns an iterator for the items in the array. Remove is supported.
 	 * <p>
-	 * If {@link #allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link ArrayIterator} constructor for nested or multithreaded iteration. */
 	public Iterator<T> iterator () {
-		if (Array.allocateIterators) return new ArrayIterator(this, true);
+		if (isAllocateIterators()) return new ArrayIterator(this, true);
 		if (iterable == null) iterable = new ArrayIterable(this);
 		return iterable.iterator();
 	}
 
 	/** Returns an iterable for the selected items in the array. Remove is supported, but not between hasNext() and next().
 	 * <p>
-	 * If {@link Array#allocateIterators} is false, the same iterable instance is returned each time this method is called. Use the
+	 * If {@link Collections#isAllocateIterators()} is false, the same iterable instance is returned each time this method is called. Use the
 	 * {@link Predicate.PredicateIterable} constructor for nested or multithreaded iteration. */
 	public Iterable<T> select (Predicate<T> predicate) {
-		if (Array.allocateIterators) new Predicate.PredicateIterable<T>(this, predicate);
+		if (isAllocateIterators()) new Predicate.PredicateIterable<T>(this, predicate);
 		if (predicateIterable == null)
 			predicateIterable = new Predicate.PredicateIterable<T>(this, predicate);
 		else
@@ -675,9 +674,9 @@ public class Array<T> implements Iterable<T> {
 			this.allowRemove = allowRemove;
 		}
 
-		/** @see Array#allocateIterators */
+		/** @see Collections#isAllocateIterators() */
 		public Iterator<T> iterator () {
-			if (allocateIterators) return new ArrayIterator(array, allowRemove);
+			if (isAllocateIterators()) return new ArrayIterator(array, allowRemove);
 // lastAcquire.getBuffer().setLength(0);
 // new Throwable().printStackTrace(new java.io.PrintWriter(lastAcquire));
 			if (iterator1 == null) {

--- a/gdx/src/com/badlogic/gdx/utils/ArrayMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/ArrayMap.java
@@ -23,6 +23,8 @@ import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.utils.ObjectMap.Entry;
 import com.badlogic.gdx.utils.reflect.ArrayReflection;
 
+import static com.badlogic.gdx.utils.Collections.isAllocateIterators;
+
 /** An ordered or unordered map of objects. This implementation uses arrays to store the keys and values, which means
  * {@link #getKey(Object, boolean) gets} do a comparison for each key in the map. This is slower than a typical hash map
  * implementation, but may be acceptable for small maps and has the benefits that keys and values can be accessed by index, which
@@ -485,11 +487,11 @@ public class ArrayMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 
 	/** Returns an iterator for the entries in the map. Remove is supported.
 	 * <p>
-	 * If {@link Array#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link Entries} constructor for nested or multithreaded iteration.
-	 * @see Array#allocateIterators */
+	 * @see Collections#isAllocateIterators() */
 	public Entries<K, V> entries () {
-		if (Array.allocateIterators) return new Entries(this);
+		if (isAllocateIterators()) return new Entries(this);
 		if (entries1 == null) {
 			entries1 = new Entries(this);
 			entries2 = new Entries(this);
@@ -508,11 +510,11 @@ public class ArrayMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 
 	/** Returns an iterator for the values in the map. Remove is supported.
 	 * <p>
-	 * If {@link Array#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link Entries} constructor for nested or multithreaded iteration.
-	 * @see Array#allocateIterators */
+	 * @see Collections#isAllocateIterators()  */
 	public Values<V> values () {
-		if (Array.allocateIterators) return new Values(this);
+		if (isAllocateIterators()) return new Values(this);
 		if (values1 == null) {
 			values1 = new Values(this);
 			values2 = new Values(this);
@@ -531,11 +533,11 @@ public class ArrayMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 
 	/** Returns an iterator for the keys in the map. Remove is supported.
 	 * <p>
-	 * If {@link Array#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link Entries} constructor for nested or multithreaded iteration.
-	 * @see Array#allocateIterators */
+	 * @see Collections#isAllocateIterators() */
 	public Keys<K> keys () {
-		if (Array.allocateIterators) return new Keys(this);
+		if (isAllocateIterators()) return new Keys(this);
 		if (keys1 == null) {
 			keys1 = new Keys(this);
 			keys2 = new Keys(this);

--- a/gdx/src/com/badlogic/gdx/utils/ArrayMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/ArrayMap.java
@@ -23,8 +23,6 @@ import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.utils.ObjectMap.Entry;
 import com.badlogic.gdx.utils.reflect.ArrayReflection;
 
-import static com.badlogic.gdx.utils.Collections.isAllocateIterators;
-
 /** An ordered or unordered map of objects. This implementation uses arrays to store the keys and values, which means
  * {@link #getKey(Object, boolean) gets} do a comparison for each key in the map. This is slower than a typical hash map
  * implementation, but may be acceptable for small maps and has the benefits that keys and values can be accessed by index, which
@@ -487,11 +485,11 @@ public class ArrayMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 
 	/** Returns an iterator for the entries in the map. Remove is supported.
 	 * <p>
-	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link Entries} constructor for nested or multithreaded iteration.
-	 * @see Collections#isAllocateIterators() */
+	 * @see Collections#allocateIterators */
 	public Entries<K, V> entries () {
-		if (isAllocateIterators()) return new Entries(this);
+		if (Collections.allocateIterators) return new Entries(this);
 		if (entries1 == null) {
 			entries1 = new Entries(this);
 			entries2 = new Entries(this);
@@ -510,11 +508,11 @@ public class ArrayMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 
 	/** Returns an iterator for the values in the map. Remove is supported.
 	 * <p>
-	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link Entries} constructor for nested or multithreaded iteration.
-	 * @see Collections#isAllocateIterators()  */
+	 * @see Collections#allocateIterators  */
 	public Values<V> values () {
-		if (isAllocateIterators()) return new Values(this);
+		if (Collections.allocateIterators) return new Values(this);
 		if (values1 == null) {
 			values1 = new Values(this);
 			values2 = new Values(this);
@@ -533,11 +531,11 @@ public class ArrayMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 
 	/** Returns an iterator for the keys in the map. Remove is supported.
 	 * <p>
-	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link Entries} constructor for nested or multithreaded iteration.
-	 * @see Collections#isAllocateIterators() */
+	 * @see Collections#allocateIterators */
 	public Keys<K> keys () {
-		if (isAllocateIterators()) return new Keys(this);
+		if (Collections.allocateIterators) return new Keys(this);
 		if (keys1 == null) {
 			keys1 = new Keys(this);
 			keys2 = new Keys(this);

--- a/gdx/src/com/badlogic/gdx/utils/Collections.java
+++ b/gdx/src/com/badlogic/gdx/utils/Collections.java
@@ -1,0 +1,19 @@
+package com.badlogic.gdx.utils;
+
+public class Collections {
+
+	private static boolean allocateIterators;
+
+	public static boolean isAllocateIterators() {
+		return allocateIterators;
+	}
+
+	/**
+	 * AllocateIterators determines whether {@link Iterable#iterator()} in collection classes have to allocate a new iterator for each invocation or not. When
+	 * true, a new iterator is created per invocation, when false, the iterator is reused and nested use will throw an exception. Default is false.
+	 * @param allocateIterators the allocateIterators value to set
+	 */
+	public static void setAllocateIterators(boolean allocateIterators) {
+		Collections.allocateIterators = allocateIterators;
+	}
+}

--- a/gdx/src/com/badlogic/gdx/utils/Collections.java
+++ b/gdx/src/com/badlogic/gdx/utils/Collections.java
@@ -2,18 +2,8 @@ package com.badlogic.gdx.utils;
 
 public class Collections {
 
-	private static boolean allocateIterators;
+	/** When true, {@link Iterable#iterator()} in this class and others will allocate a new iterator for each invocation. When
+	 * false, the iterator is reused and nested use will throw an exception. Default is false. */
+	public static boolean allocateIterators;
 
-	public static boolean isAllocateIterators() {
-		return allocateIterators;
-	}
-
-	/**
-	 * AllocateIterators determines whether {@link Iterable#iterator()} in collection classes have to allocate a new iterator for each invocation or not. When
-	 * true, a new iterator is created per invocation, when false, the iterator is reused and nested use will throw an exception. Default is false.
-	 * @param allocateIterators the allocateIterators value to set
-	 */
-	public static void setAllocateIterators(boolean allocateIterators) {
-		Collections.allocateIterators = allocateIterators;
-	}
 }

--- a/gdx/src/com/badlogic/gdx/utils/Collections.java
+++ b/gdx/src/com/badlogic/gdx/utils/Collections.java
@@ -2,8 +2,9 @@ package com.badlogic.gdx.utils;
 
 public class Collections {
 
-	/** When true, {@link Iterable#iterator()} in this class and others will allocate a new iterator for each invocation. When
-	 * false, the iterator is reused and nested use will throw an exception. Default is false. */
+	/** When true, {@link Iterable#iterator()} for {@link Array}, {@link ObjectMap}, and other collections will allocate a new
+	 * iterator for each invocation. When false, the iterator is reused and nested use will throw an exception. Default is
+	 * false. */
 	public static boolean allocateIterators;
 
 }

--- a/gdx/src/com/badlogic/gdx/utils/IdentityMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/IdentityMap.java
@@ -22,6 +22,8 @@ import java.util.NoSuchElementException;
 import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.utils.ObjectMap.Entry;
 
+import static com.badlogic.gdx.utils.Collections.isAllocateIterators;
+
 /** An unordered map that uses identity comparison for keys. This implementation is a cuckoo hash map using 3 hashes, random
  * walking, and a small stash for problematic keys. Null keys are not allowed. Null values are allowed. No allocation is done
  * except when growing the table size. <br>
@@ -600,10 +602,10 @@ public class IdentityMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 
 	/** Returns an iterator for the entries in the map. Remove is supported.
 	 * <p>
-	 * If {@link Array#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link Entries} constructor for nested or multithreaded iteration. */
 	public Entries<K, V> entries () {
-		if (Array.allocateIterators) return new Entries(this);
+		if (isAllocateIterators()) return new Entries(this);
 		if (entries1 == null) {
 			entries1 = new Entries(this);
 			entries2 = new Entries(this);
@@ -622,10 +624,10 @@ public class IdentityMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 
 	/** Returns an iterator for the values in the map. Remove is supported.
 	 * <p>
-	 * If {@link Array#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link Entries} constructor for nested or multithreaded iteration. */
 	public Values<V> values () {
-		if (Array.allocateIterators) return new Values(this);
+		if (isAllocateIterators()) return new Values(this);
 		if (values1 == null) {
 			values1 = new Values(this);
 			values2 = new Values(this);
@@ -644,10 +646,10 @@ public class IdentityMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 
 	/** Returns an iterator for the keys in the map. Remove is supported.
 	 * <p>
-	 * If {@link Array#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link Entries} constructor for nested or multithreaded iteration. */
 	public Keys<K> keys () {
-		if (Array.allocateIterators) return new Keys(this);
+		if (isAllocateIterators()) return new Keys(this);
 		if (keys1 == null) {
 			keys1 = new Keys(this);
 			keys2 = new Keys(this);

--- a/gdx/src/com/badlogic/gdx/utils/IdentityMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/IdentityMap.java
@@ -22,8 +22,6 @@ import java.util.NoSuchElementException;
 import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.utils.ObjectMap.Entry;
 
-import static com.badlogic.gdx.utils.Collections.isAllocateIterators;
-
 /** An unordered map that uses identity comparison for keys. This implementation is a cuckoo hash map using 3 hashes, random
  * walking, and a small stash for problematic keys. Null keys are not allowed. Null values are allowed. No allocation is done
  * except when growing the table size. <br>
@@ -602,10 +600,10 @@ public class IdentityMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 
 	/** Returns an iterator for the entries in the map. Remove is supported.
 	 * <p>
-	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link Entries} constructor for nested or multithreaded iteration. */
 	public Entries<K, V> entries () {
-		if (isAllocateIterators()) return new Entries(this);
+		if (Collections.allocateIterators) return new Entries(this);
 		if (entries1 == null) {
 			entries1 = new Entries(this);
 			entries2 = new Entries(this);
@@ -624,10 +622,10 @@ public class IdentityMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 
 	/** Returns an iterator for the values in the map. Remove is supported.
 	 * <p>
-	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link Entries} constructor for nested or multithreaded iteration. */
 	public Values<V> values () {
-		if (isAllocateIterators()) return new Values(this);
+		if (Collections.allocateIterators) return new Values(this);
 		if (values1 == null) {
 			values1 = new Values(this);
 			values2 = new Values(this);
@@ -646,10 +644,10 @@ public class IdentityMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 
 	/** Returns an iterator for the keys in the map. Remove is supported.
 	 * <p>
-	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link Entries} constructor for nested or multithreaded iteration. */
 	public Keys<K> keys () {
-		if (isAllocateIterators()) return new Keys(this);
+		if (Collections.allocateIterators) return new Keys(this);
 		if (keys1 == null) {
 			keys1 = new Keys(this);
 			keys2 = new Keys(this);

--- a/gdx/src/com/badlogic/gdx/utils/IntFloatMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/IntFloatMap.java
@@ -21,8 +21,6 @@ import java.util.NoSuchElementException;
 
 import com.badlogic.gdx.math.MathUtils;
 
-import static com.badlogic.gdx.utils.Collections.isAllocateIterators;
-
 /** An unordered map where the keys are ints and values are floats. This implementation is a cuckoo hash map using 3 hashes,
  * random walking, and a small stash for problematic keys. Null keys are not allowed. No allocation is done except when growing
  * the table size. <br>
@@ -633,10 +631,10 @@ public class IntFloatMap implements Iterable<IntFloatMap.Entry> {
 
 	/** Returns an iterator for the entries in the map. Remove is supported.
 	 * <p>
-	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link Entries} constructor for nested or multithreaded iteration. */
 	public Entries entries () {
-		if (isAllocateIterators()) return new Entries(this);
+		if (Collections.allocateIterators) return new Entries(this);
 		if (entries1 == null) {
 			entries1 = new Entries(this);
 			entries2 = new Entries(this);
@@ -655,10 +653,10 @@ public class IntFloatMap implements Iterable<IntFloatMap.Entry> {
 
 	/** Returns an iterator for the values in the map. Remove is supported.
 	 * <p>
-	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link Entries} constructor for nested or multithreaded iteration. */
 	public Values values () {
-		if (isAllocateIterators()) return new Values(this);
+		if (Collections.allocateIterators) return new Values(this);
 		if (values1 == null) {
 			values1 = new Values(this);
 			values2 = new Values(this);
@@ -677,10 +675,10 @@ public class IntFloatMap implements Iterable<IntFloatMap.Entry> {
 
 	/** Returns an iterator for the keys in the map. Remove is supported.
 	 * <p>
-	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link Entries} constructor for nested or multithreaded iteration. */
 	public Keys keys () {
-		if (isAllocateIterators()) return new Keys(this);
+		if (Collections.allocateIterators) return new Keys(this);
 		if (keys1 == null) {
 			keys1 = new Keys(this);
 			keys2 = new Keys(this);

--- a/gdx/src/com/badlogic/gdx/utils/IntFloatMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/IntFloatMap.java
@@ -21,6 +21,8 @@ import java.util.NoSuchElementException;
 
 import com.badlogic.gdx.math.MathUtils;
 
+import static com.badlogic.gdx.utils.Collections.isAllocateIterators;
+
 /** An unordered map where the keys are ints and values are floats. This implementation is a cuckoo hash map using 3 hashes,
  * random walking, and a small stash for problematic keys. Null keys are not allowed. No allocation is done except when growing
  * the table size. <br>
@@ -631,10 +633,10 @@ public class IntFloatMap implements Iterable<IntFloatMap.Entry> {
 
 	/** Returns an iterator for the entries in the map. Remove is supported.
 	 * <p>
-	 * If {@link Array#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link Entries} constructor for nested or multithreaded iteration. */
 	public Entries entries () {
-		if (Array.allocateIterators) return new Entries(this);
+		if (isAllocateIterators()) return new Entries(this);
 		if (entries1 == null) {
 			entries1 = new Entries(this);
 			entries2 = new Entries(this);
@@ -653,10 +655,10 @@ public class IntFloatMap implements Iterable<IntFloatMap.Entry> {
 
 	/** Returns an iterator for the values in the map. Remove is supported.
 	 * <p>
-	 * If {@link Array#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link Entries} constructor for nested or multithreaded iteration. */
 	public Values values () {
-		if (Array.allocateIterators) return new Values(this);
+		if (isAllocateIterators()) return new Values(this);
 		if (values1 == null) {
 			values1 = new Values(this);
 			values2 = new Values(this);
@@ -675,10 +677,10 @@ public class IntFloatMap implements Iterable<IntFloatMap.Entry> {
 
 	/** Returns an iterator for the keys in the map. Remove is supported.
 	 * <p>
-	 * If {@link Array#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link Entries} constructor for nested or multithreaded iteration. */
 	public Keys keys () {
-		if (Array.allocateIterators) return new Keys(this);
+		if (isAllocateIterators()) return new Keys(this);
 		if (keys1 == null) {
 			keys1 = new Keys(this);
 			keys2 = new Keys(this);

--- a/gdx/src/com/badlogic/gdx/utils/IntIntMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/IntIntMap.java
@@ -21,6 +21,8 @@ import java.util.NoSuchElementException;
 
 import com.badlogic.gdx.math.MathUtils;
 
+import static com.badlogic.gdx.utils.Collections.isAllocateIterators;
+
 /** An unordered map where the keys and values are ints. This implementation is a cuckoo hash map using 3 hashes, random walking,
  * and a small stash for problematic keys. No allocation is done except when growing the table size. <br>
  * <br>
@@ -617,10 +619,10 @@ public class IntIntMap implements Iterable<IntIntMap.Entry> {
 
 	/** Returns an iterator for the entries in the map. Remove is supported.
 	 * <p>
-	 * If {@link Array#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link Entries} constructor for nested or multithreaded iteration. */
 	public Entries entries () {
-		if (Array.allocateIterators) return new Entries(this);
+		if (isAllocateIterators()) return new Entries(this);
 		if (entries1 == null) {
 			entries1 = new Entries(this);
 			entries2 = new Entries(this);
@@ -639,10 +641,10 @@ public class IntIntMap implements Iterable<IntIntMap.Entry> {
 
 	/** Returns an iterator for the values in the map. Remove is supported.
 	 * <p>
-	 * If {@link Array#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link Entries} constructor for nested or multithreaded iteration. */
 	public Values values () {
-		if (Array.allocateIterators) return new Values(this);
+		if (isAllocateIterators()) return new Values(this);
 		if (values1 == null) {
 			values1 = new Values(this);
 			values2 = new Values(this);
@@ -661,10 +663,10 @@ public class IntIntMap implements Iterable<IntIntMap.Entry> {
 
 	/** Returns an iterator for the keys in the map. Remove is supported.
 	 * <p>
-	 * If {@link Array#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link Entries} constructor for nested or multithreaded iteration. */
 	public Keys keys () {
-		if (Array.allocateIterators) return new Keys(this);
+		if (isAllocateIterators()) return new Keys(this);
 		if (keys1 == null) {
 			keys1 = new Keys(this);
 			keys2 = new Keys(this);

--- a/gdx/src/com/badlogic/gdx/utils/IntIntMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/IntIntMap.java
@@ -21,8 +21,6 @@ import java.util.NoSuchElementException;
 
 import com.badlogic.gdx.math.MathUtils;
 
-import static com.badlogic.gdx.utils.Collections.isAllocateIterators;
-
 /** An unordered map where the keys and values are ints. This implementation is a cuckoo hash map using 3 hashes, random walking,
  * and a small stash for problematic keys. No allocation is done except when growing the table size. <br>
  * <br>
@@ -619,10 +617,10 @@ public class IntIntMap implements Iterable<IntIntMap.Entry> {
 
 	/** Returns an iterator for the entries in the map. Remove is supported.
 	 * <p>
-	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link Entries} constructor for nested or multithreaded iteration. */
 	public Entries entries () {
-		if (isAllocateIterators()) return new Entries(this);
+		if (Collections.allocateIterators) return new Entries(this);
 		if (entries1 == null) {
 			entries1 = new Entries(this);
 			entries2 = new Entries(this);
@@ -641,10 +639,10 @@ public class IntIntMap implements Iterable<IntIntMap.Entry> {
 
 	/** Returns an iterator for the values in the map. Remove is supported.
 	 * <p>
-	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link Entries} constructor for nested or multithreaded iteration. */
 	public Values values () {
-		if (isAllocateIterators()) return new Values(this);
+		if (Collections.allocateIterators) return new Values(this);
 		if (values1 == null) {
 			values1 = new Values(this);
 			values2 = new Values(this);
@@ -663,10 +661,10 @@ public class IntIntMap implements Iterable<IntIntMap.Entry> {
 
 	/** Returns an iterator for the keys in the map. Remove is supported.
 	 * <p>
-	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link Entries} constructor for nested or multithreaded iteration. */
 	public Keys keys () {
-		if (isAllocateIterators()) return new Keys(this);
+		if (Collections.allocateIterators) return new Keys(this);
 		if (keys1 == null) {
 			keys1 = new Keys(this);
 			keys2 = new Keys(this);

--- a/gdx/src/com/badlogic/gdx/utils/IntMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/IntMap.java
@@ -21,8 +21,6 @@ import java.util.NoSuchElementException;
 
 import com.badlogic.gdx.math.MathUtils;
 
-import static com.badlogic.gdx.utils.Collections.isAllocateIterators;
-
 /** An unordered map that uses int keys. This implementation is a cuckoo hash map using 3 hashes, random walking, and a small
  * stash for problematic keys. Null values are allowed. No allocation is done except when growing the table size. <br>
  * <br>
@@ -665,10 +663,10 @@ public class IntMap<V> implements Iterable<IntMap.Entry<V>> {
 
 	/** Returns an iterator for the entries in the map. Remove is supported.
 	 * <p>
-	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link Entries} constructor for nested or multithreaded iteration. */
 	public Entries<V> entries () {
-		if (isAllocateIterators()) return new Entries(this);
+		if (Collections.allocateIterators) return new Entries(this);
 		if (entries1 == null) {
 			entries1 = new Entries(this);
 			entries2 = new Entries(this);
@@ -687,10 +685,10 @@ public class IntMap<V> implements Iterable<IntMap.Entry<V>> {
 
 	/** Returns an iterator for the values in the map. Remove is supported.
 	 * <p>
-	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link Entries} constructor for nested or multithreaded iteration. */
 	public Values<V> values () {
-		if (isAllocateIterators()) return new Values(this);
+		if (Collections.allocateIterators) return new Values(this);
 		if (values1 == null) {
 			values1 = new Values(this);
 			values2 = new Values(this);
@@ -709,10 +707,10 @@ public class IntMap<V> implements Iterable<IntMap.Entry<V>> {
 
 	/** Returns an iterator for the keys in the map. Remove is supported.
 	 * <p>
-	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link Entries} constructor for nested or multithreaded iteration. */
 	public Keys keys () {
-		if (isAllocateIterators()) return new Keys(this);
+		if (Collections.allocateIterators) return new Keys(this);
 		if (keys1 == null) {
 			keys1 = new Keys(this);
 			keys2 = new Keys(this);

--- a/gdx/src/com/badlogic/gdx/utils/IntMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/IntMap.java
@@ -21,6 +21,8 @@ import java.util.NoSuchElementException;
 
 import com.badlogic.gdx.math.MathUtils;
 
+import static com.badlogic.gdx.utils.Collections.isAllocateIterators;
+
 /** An unordered map that uses int keys. This implementation is a cuckoo hash map using 3 hashes, random walking, and a small
  * stash for problematic keys. Null values are allowed. No allocation is done except when growing the table size. <br>
  * <br>
@@ -663,10 +665,10 @@ public class IntMap<V> implements Iterable<IntMap.Entry<V>> {
 
 	/** Returns an iterator for the entries in the map. Remove is supported.
 	 * <p>
-	 * If {@link Array#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link Entries} constructor for nested or multithreaded iteration. */
 	public Entries<V> entries () {
-		if (Array.allocateIterators) return new Entries(this);
+		if (isAllocateIterators()) return new Entries(this);
 		if (entries1 == null) {
 			entries1 = new Entries(this);
 			entries2 = new Entries(this);
@@ -685,10 +687,10 @@ public class IntMap<V> implements Iterable<IntMap.Entry<V>> {
 
 	/** Returns an iterator for the values in the map. Remove is supported.
 	 * <p>
-	 * If {@link Array#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link Entries} constructor for nested or multithreaded iteration. */
 	public Values<V> values () {
-		if (Array.allocateIterators) return new Values(this);
+		if (isAllocateIterators()) return new Values(this);
 		if (values1 == null) {
 			values1 = new Values(this);
 			values2 = new Values(this);
@@ -707,10 +709,10 @@ public class IntMap<V> implements Iterable<IntMap.Entry<V>> {
 
 	/** Returns an iterator for the keys in the map. Remove is supported.
 	 * <p>
-	 * If {@link Array#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link Entries} constructor for nested or multithreaded iteration. */
 	public Keys keys () {
-		if (Array.allocateIterators) return new Keys(this);
+		if (isAllocateIterators()) return new Keys(this);
 		if (keys1 == null) {
 			keys1 = new Keys(this);
 			keys2 = new Keys(this);

--- a/gdx/src/com/badlogic/gdx/utils/IntSet.java
+++ b/gdx/src/com/badlogic/gdx/utils/IntSet.java
@@ -482,10 +482,10 @@ public class IntSet {
 
 	/** Returns an iterator for the keys in the set. Remove is supported.
 	 * <p>
-	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link IntSetIterator} constructor for nested or multithreaded iteration. */
 	public IntSetIterator iterator () {
-		if (Collections.isAllocateIterators()) return new IntSetIterator(this);
+		if (Collections.allocateIterators) return new IntSetIterator(this);
 		if (iterator1 == null) {
 			iterator1 = new IntSetIterator(this);
 			iterator2 = new IntSetIterator(this);

--- a/gdx/src/com/badlogic/gdx/utils/IntSet.java
+++ b/gdx/src/com/badlogic/gdx/utils/IntSet.java
@@ -482,10 +482,10 @@ public class IntSet {
 
 	/** Returns an iterator for the keys in the set. Remove is supported.
 	 * <p>
-	 * If {@link Array#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link IntSetIterator} constructor for nested or multithreaded iteration. */
 	public IntSetIterator iterator () {
-		if (Array.allocateIterators) return new IntSetIterator(this);
+		if (Collections.isAllocateIterators()) return new IntSetIterator(this);
 		if (iterator1 == null) {
 			iterator1 = new IntSetIterator(this);
 			iterator2 = new IntSetIterator(this);

--- a/gdx/src/com/badlogic/gdx/utils/LongMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/LongMap.java
@@ -21,6 +21,8 @@ import java.util.NoSuchElementException;
 
 import com.badlogic.gdx.math.MathUtils;
 
+import static com.badlogic.gdx.utils.Collections.isAllocateIterators;
+
 /** An unordered map that uses long keys. This implementation is a cuckoo hash map using 3 hashes, random walking, and a small
  * stash for problematic keys. Null values are allowed. No allocation is done except when growing the table size. <br>
  * <br>
@@ -655,10 +657,10 @@ public class LongMap<V> implements Iterable<LongMap.Entry<V>> {
 
 	/** Returns an iterator for the entries in the map. Remove is supported.
 	 * <p>
-	 * If {@link Array#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link Entries} constructor for nested or multithreaded iteration. */
 	public Entries<V> entries () {
-		if (Array.allocateIterators) return new Entries(this);
+		if (isAllocateIterators()) return new Entries(this);
 		if (entries1 == null) {
 			entries1 = new Entries(this);
 			entries2 = new Entries(this);
@@ -677,10 +679,10 @@ public class LongMap<V> implements Iterable<LongMap.Entry<V>> {
 
 	/** Returns an iterator for the values in the map. Remove is supported.
 	 * <p>
-	 * If {@link Array#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link Entries} constructor for nested or multithreaded iteration. */
 	public Values<V> values () {
-		if (Array.allocateIterators) return new Values(this);
+		if (isAllocateIterators()) return new Values(this);
 		if (values1 == null) {
 			values1 = new Values(this);
 			values2 = new Values(this);
@@ -699,10 +701,10 @@ public class LongMap<V> implements Iterable<LongMap.Entry<V>> {
 
 	/** Returns an iterator for the keys in the map. Remove is supported.
 	 * <p>
-	 * If {@link Array#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link Entries} constructor for nested or multithreaded iteration. */
 	public Keys keys () {
-		if (Array.allocateIterators) return new Keys(this);
+		if (isAllocateIterators()) return new Keys(this);
 		if (keys1 == null) {
 			keys1 = new Keys(this);
 			keys2 = new Keys(this);

--- a/gdx/src/com/badlogic/gdx/utils/LongMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/LongMap.java
@@ -21,8 +21,6 @@ import java.util.NoSuchElementException;
 
 import com.badlogic.gdx.math.MathUtils;
 
-import static com.badlogic.gdx.utils.Collections.isAllocateIterators;
-
 /** An unordered map that uses long keys. This implementation is a cuckoo hash map using 3 hashes, random walking, and a small
  * stash for problematic keys. Null values are allowed. No allocation is done except when growing the table size. <br>
  * <br>
@@ -657,10 +655,10 @@ public class LongMap<V> implements Iterable<LongMap.Entry<V>> {
 
 	/** Returns an iterator for the entries in the map. Remove is supported.
 	 * <p>
-	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link Entries} constructor for nested or multithreaded iteration. */
 	public Entries<V> entries () {
-		if (isAllocateIterators()) return new Entries(this);
+		if (Collections.allocateIterators) return new Entries(this);
 		if (entries1 == null) {
 			entries1 = new Entries(this);
 			entries2 = new Entries(this);
@@ -679,10 +677,10 @@ public class LongMap<V> implements Iterable<LongMap.Entry<V>> {
 
 	/** Returns an iterator for the values in the map. Remove is supported.
 	 * <p>
-	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link Entries} constructor for nested or multithreaded iteration. */
 	public Values<V> values () {
-		if (isAllocateIterators()) return new Values(this);
+		if (Collections.allocateIterators) return new Values(this);
 		if (values1 == null) {
 			values1 = new Values(this);
 			values2 = new Values(this);
@@ -701,10 +699,10 @@ public class LongMap<V> implements Iterable<LongMap.Entry<V>> {
 
 	/** Returns an iterator for the keys in the map. Remove is supported.
 	 * <p>
-	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link Entries} constructor for nested or multithreaded iteration. */
 	public Keys keys () {
-		if (isAllocateIterators()) return new Keys(this);
+		if (Collections.allocateIterators) return new Keys(this);
 		if (keys1 == null) {
 			keys1 = new Keys(this);
 			keys2 = new Keys(this);

--- a/gdx/src/com/badlogic/gdx/utils/ObjectFloatMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/ObjectFloatMap.java
@@ -21,6 +21,8 @@ import java.util.NoSuchElementException;
 
 import com.badlogic.gdx.math.MathUtils;
 
+import static com.badlogic.gdx.utils.Collections.isAllocateIterators;
+
 /** An unordered map where the values are floats. This implementation is a cuckoo hash map using 3 hashes, random walking, and a
  * small stash for problematic keys. Null keys are not allowed. No allocation is done except when growing the table size. <br>
  * <br>
@@ -569,10 +571,10 @@ public class ObjectFloatMap<K> implements Iterable<ObjectFloatMap.Entry<K>> {
 
 	/** Returns an iterator for the entries in the map. Remove is supported.
 	 * <p>
-	 * If {@link Array#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link Entries} constructor for nested or multithreaded iteration. */
 	public Entries<K> entries () {
-		if (Array.allocateIterators) return new Entries(this);
+		if (isAllocateIterators()) return new Entries(this);
 		if (entries1 == null) {
 			entries1 = new Entries(this);
 			entries2 = new Entries(this);
@@ -591,10 +593,10 @@ public class ObjectFloatMap<K> implements Iterable<ObjectFloatMap.Entry<K>> {
 
 	/** Returns an iterator for the values in the map. Remove is supported.
 	 * <p>
-	 * If {@link Array#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link Entries} constructor for nested or multithreaded iteration. */
 	public Values values () {
-		if (Array.allocateIterators) return new Values(this);
+		if (isAllocateIterators()) return new Values(this);
 		if (values1 == null) {
 			values1 = new Values(this);
 			values2 = new Values(this);
@@ -613,10 +615,10 @@ public class ObjectFloatMap<K> implements Iterable<ObjectFloatMap.Entry<K>> {
 
 	/** Returns an iterator for the keys in the map. Remove is supported.
 	 * <p>
-	 * If {@link Array#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link Entries} constructor for nested or multithreaded iteration. */
 	public Keys<K> keys () {
-		if (Array.allocateIterators) return new Keys(this);
+		if (isAllocateIterators()) return new Keys(this);
 		if (keys1 == null) {
 			keys1 = new Keys(this);
 			keys2 = new Keys(this);

--- a/gdx/src/com/badlogic/gdx/utils/ObjectFloatMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/ObjectFloatMap.java
@@ -21,8 +21,6 @@ import java.util.NoSuchElementException;
 
 import com.badlogic.gdx.math.MathUtils;
 
-import static com.badlogic.gdx.utils.Collections.isAllocateIterators;
-
 /** An unordered map where the values are floats. This implementation is a cuckoo hash map using 3 hashes, random walking, and a
  * small stash for problematic keys. Null keys are not allowed. No allocation is done except when growing the table size. <br>
  * <br>
@@ -571,10 +569,10 @@ public class ObjectFloatMap<K> implements Iterable<ObjectFloatMap.Entry<K>> {
 
 	/** Returns an iterator for the entries in the map. Remove is supported.
 	 * <p>
-	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link Entries} constructor for nested or multithreaded iteration. */
 	public Entries<K> entries () {
-		if (isAllocateIterators()) return new Entries(this);
+		if (Collections.allocateIterators) return new Entries(this);
 		if (entries1 == null) {
 			entries1 = new Entries(this);
 			entries2 = new Entries(this);
@@ -593,10 +591,10 @@ public class ObjectFloatMap<K> implements Iterable<ObjectFloatMap.Entry<K>> {
 
 	/** Returns an iterator for the values in the map. Remove is supported.
 	 * <p>
-	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link Entries} constructor for nested or multithreaded iteration. */
 	public Values values () {
-		if (isAllocateIterators()) return new Values(this);
+		if (Collections.allocateIterators) return new Values(this);
 		if (values1 == null) {
 			values1 = new Values(this);
 			values2 = new Values(this);
@@ -615,10 +613,10 @@ public class ObjectFloatMap<K> implements Iterable<ObjectFloatMap.Entry<K>> {
 
 	/** Returns an iterator for the keys in the map. Remove is supported.
 	 * <p>
-	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link Entries} constructor for nested or multithreaded iteration. */
 	public Keys<K> keys () {
-		if (isAllocateIterators()) return new Keys(this);
+		if (Collections.allocateIterators) return new Keys(this);
 		if (keys1 == null) {
 			keys1 = new Keys(this);
 			keys2 = new Keys(this);

--- a/gdx/src/com/badlogic/gdx/utils/ObjectIntMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/ObjectIntMap.java
@@ -21,6 +21,8 @@ import java.util.NoSuchElementException;
 
 import com.badlogic.gdx.math.MathUtils;
 
+import static com.badlogic.gdx.utils.Collections.isAllocateIterators;
+
 /** An unordered map where the values are ints. This implementation is a cuckoo hash map using 3 hashes, random walking, and a
  * small stash for problematic keys. Null keys are not allowed. No allocation is done except when growing the table size. <br>
  * <br>
@@ -570,10 +572,10 @@ public class ObjectIntMap<K> implements Iterable<ObjectIntMap.Entry<K>> {
 
 	/** Returns an iterator for the entries in the map. Remove is supported.
 	 * <p>
-	 * If {@link Array#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link Entries} constructor for nested or multithreaded iteration. */
 	public Entries<K> entries () {
-		if (Array.allocateIterators) return new Entries(this);
+		if (isAllocateIterators()) return new Entries(this);
 		if (entries1 == null) {
 			entries1 = new Entries(this);
 			entries2 = new Entries(this);
@@ -592,10 +594,10 @@ public class ObjectIntMap<K> implements Iterable<ObjectIntMap.Entry<K>> {
 
 	/** Returns an iterator for the values in the map. Remove is supported.
 	 * <p>
-	 * If {@link Array#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link Entries} constructor for nested or multithreaded iteration. */
 	public Values values () {
-		if (Array.allocateIterators) return new Values(this);
+		if (isAllocateIterators()) return new Values(this);
 		if (values1 == null) {
 			values1 = new Values(this);
 			values2 = new Values(this);
@@ -614,10 +616,10 @@ public class ObjectIntMap<K> implements Iterable<ObjectIntMap.Entry<K>> {
 
 	/** Returns an iterator for the keys in the map. Remove is supported.
 	 * <p>
-	 * If {@link Array#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link Entries} constructor for nested or multithreaded iteration. */
 	public Keys<K> keys () {
-		if (Array.allocateIterators) return new Keys(this);
+		if (isAllocateIterators()) return new Keys(this);
 		if (keys1 == null) {
 			keys1 = new Keys(this);
 			keys2 = new Keys(this);

--- a/gdx/src/com/badlogic/gdx/utils/ObjectIntMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/ObjectIntMap.java
@@ -21,8 +21,6 @@ import java.util.NoSuchElementException;
 
 import com.badlogic.gdx.math.MathUtils;
 
-import static com.badlogic.gdx.utils.Collections.isAllocateIterators;
-
 /** An unordered map where the values are ints. This implementation is a cuckoo hash map using 3 hashes, random walking, and a
  * small stash for problematic keys. Null keys are not allowed. No allocation is done except when growing the table size. <br>
  * <br>
@@ -572,10 +570,10 @@ public class ObjectIntMap<K> implements Iterable<ObjectIntMap.Entry<K>> {
 
 	/** Returns an iterator for the entries in the map. Remove is supported.
 	 * <p>
-	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link Entries} constructor for nested or multithreaded iteration. */
 	public Entries<K> entries () {
-		if (isAllocateIterators()) return new Entries(this);
+		if (Collections.allocateIterators) return new Entries(this);
 		if (entries1 == null) {
 			entries1 = new Entries(this);
 			entries2 = new Entries(this);
@@ -594,10 +592,10 @@ public class ObjectIntMap<K> implements Iterable<ObjectIntMap.Entry<K>> {
 
 	/** Returns an iterator for the values in the map. Remove is supported.
 	 * <p>
-	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link Entries} constructor for nested or multithreaded iteration. */
 	public Values values () {
-		if (isAllocateIterators()) return new Values(this);
+		if (Collections.allocateIterators) return new Values(this);
 		if (values1 == null) {
 			values1 = new Values(this);
 			values2 = new Values(this);
@@ -616,10 +614,10 @@ public class ObjectIntMap<K> implements Iterable<ObjectIntMap.Entry<K>> {
 
 	/** Returns an iterator for the keys in the map. Remove is supported.
 	 * <p>
-	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link Entries} constructor for nested or multithreaded iteration. */
 	public Keys<K> keys () {
-		if (isAllocateIterators()) return new Keys(this);
+		if (Collections.allocateIterators) return new Keys(this);
 		if (keys1 == null) {
 			keys1 = new Keys(this);
 			keys2 = new Keys(this);

--- a/gdx/src/com/badlogic/gdx/utils/ObjectMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/ObjectMap.java
@@ -21,8 +21,6 @@ import java.util.NoSuchElementException;
 
 import com.badlogic.gdx.math.MathUtils;
 
-import static com.badlogic.gdx.utils.Collections.isAllocateIterators;
-
 /** An unordered map. This implementation is a cuckoo hash map using 3 hashes, random walking, and a small stash for problematic
  * keys. Null keys are not allowed. Null values are allowed. No allocation is done except when growing the table size. <br>
  * <br>
@@ -628,10 +626,10 @@ public class ObjectMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 
 	/** Returns an iterator for the entries in the map. Remove is supported.
 	 * <p>
-	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link Entries} constructor for nested or multithreaded iteration. */
 	public Entries<K, V> entries () {
-		if (isAllocateIterators()) return new Entries(this);
+		if (Collections.allocateIterators) return new Entries(this);
 		if (entries1 == null) {
 			entries1 = new Entries(this);
 			entries2 = new Entries(this);
@@ -650,10 +648,10 @@ public class ObjectMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 
 	/** Returns an iterator for the values in the map. Remove is supported.
 	 * <p>
-	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link Values} constructor for nested or multithreaded iteration. */
 	public Values<V> values () {
-		if (isAllocateIterators()) return new Values(this);
+		if (Collections.allocateIterators) return new Values(this);
 		if (values1 == null) {
 			values1 = new Values(this);
 			values2 = new Values(this);
@@ -672,10 +670,10 @@ public class ObjectMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 
 	/** Returns an iterator for the keys in the map. Remove is supported.
 	 * <p>
-	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link Keys} constructor for nested or multithreaded iteration. */
 	public Keys<K> keys () {
-		if (isAllocateIterators()) return new Keys(this);
+		if (Collections.allocateIterators) return new Keys(this);
 		if (keys1 == null) {
 			keys1 = new Keys(this);
 			keys2 = new Keys(this);

--- a/gdx/src/com/badlogic/gdx/utils/ObjectMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/ObjectMap.java
@@ -21,6 +21,8 @@ import java.util.NoSuchElementException;
 
 import com.badlogic.gdx.math.MathUtils;
 
+import static com.badlogic.gdx.utils.Collections.isAllocateIterators;
+
 /** An unordered map. This implementation is a cuckoo hash map using 3 hashes, random walking, and a small stash for problematic
  * keys. Null keys are not allowed. Null values are allowed. No allocation is done except when growing the table size. <br>
  * <br>
@@ -626,10 +628,10 @@ public class ObjectMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 
 	/** Returns an iterator for the entries in the map. Remove is supported.
 	 * <p>
-	 * If {@link Array#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link Entries} constructor for nested or multithreaded iteration. */
 	public Entries<K, V> entries () {
-		if (Array.allocateIterators) return new Entries(this);
+		if (isAllocateIterators()) return new Entries(this);
 		if (entries1 == null) {
 			entries1 = new Entries(this);
 			entries2 = new Entries(this);
@@ -648,10 +650,10 @@ public class ObjectMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 
 	/** Returns an iterator for the values in the map. Remove is supported.
 	 * <p>
-	 * If {@link Array#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link Values} constructor for nested or multithreaded iteration. */
 	public Values<V> values () {
-		if (Array.allocateIterators) return new Values(this);
+		if (isAllocateIterators()) return new Values(this);
 		if (values1 == null) {
 			values1 = new Values(this);
 			values2 = new Values(this);
@@ -670,10 +672,10 @@ public class ObjectMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 
 	/** Returns an iterator for the keys in the map. Remove is supported.
 	 * <p>
-	 * If {@link Array#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link Keys} constructor for nested or multithreaded iteration. */
 	public Keys<K> keys () {
-		if (Array.allocateIterators) return new Keys(this);
+		if (isAllocateIterators()) return new Keys(this);
 		if (keys1 == null) {
 			keys1 = new Keys(this);
 			keys2 = new Keys(this);

--- a/gdx/src/com/badlogic/gdx/utils/ObjectSet.java
+++ b/gdx/src/com/badlogic/gdx/utils/ObjectSet.java
@@ -485,10 +485,10 @@ public class ObjectSet<T> implements Iterable<T> {
 
 	/** Returns an iterator for the keys in the set. Remove is supported.
 	 * <p>
-	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link ObjectSetIterator} constructor for nested or multithreaded iteration. */
 	public ObjectSetIterator<T> iterator () {
-		if (Collections.isAllocateIterators()) return new ObjectSetIterator(this);
+		if (Collections.allocateIterators) return new ObjectSetIterator(this);
 		if (iterator1 == null) {
 			iterator1 = new ObjectSetIterator(this);
 			iterator2 = new ObjectSetIterator(this);

--- a/gdx/src/com/badlogic/gdx/utils/ObjectSet.java
+++ b/gdx/src/com/badlogic/gdx/utils/ObjectSet.java
@@ -485,10 +485,10 @@ public class ObjectSet<T> implements Iterable<T> {
 
 	/** Returns an iterator for the keys in the set. Remove is supported.
 	 * <p>
-	 * If {@link Array#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link ObjectSetIterator} constructor for nested or multithreaded iteration. */
 	public ObjectSetIterator<T> iterator () {
-		if (Array.allocateIterators) return new ObjectSetIterator(this);
+		if (Collections.isAllocateIterators()) return new ObjectSetIterator(this);
 		if (iterator1 == null) {
 			iterator1 = new ObjectSetIterator(this);
 			iterator2 = new ObjectSetIterator(this);

--- a/gdx/src/com/badlogic/gdx/utils/OrderedMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/OrderedMap.java
@@ -18,6 +18,8 @@ package com.badlogic.gdx.utils;
 
 import java.util.NoSuchElementException;
 
+import static com.badlogic.gdx.utils.Collections.isAllocateIterators;
+
 /** An {@link ObjectMap} that also stores keys in an {@link Array} using the insertion order. Iteration over the
  * {@link #entries()}, {@link #keys()}, and {@link #values()} is ordered and faster than an unordered map. Keys can also be
  * accessed and the order changed using {@link #orderedKeys()}. There is some additional overhead for put and remove. When used
@@ -80,10 +82,10 @@ public class OrderedMap<K, V> extends ObjectMap<K, V> {
 
 	/** Returns an iterator for the entries in the map. Remove is supported.
 	 * <p>
-	 * If {@link Array#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link OrderedMapEntries} constructor for nested or multithreaded iteration. */
 	public Entries<K, V> entries () {
-		if (Array.allocateIterators) return new Entries(this);
+		if (isAllocateIterators()) return new Entries(this);
 		if (entries1 == null) {
 			entries1 = new OrderedMapEntries(this);
 			entries2 = new OrderedMapEntries(this);
@@ -102,10 +104,10 @@ public class OrderedMap<K, V> extends ObjectMap<K, V> {
 
 	/** Returns an iterator for the values in the map. Remove is supported.
 	 * <p>
-	 * If {@link Array#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link OrderedMapValues} constructor for nested or multithreaded iteration. */
 	public Values<V> values () {
-		if (Array.allocateIterators) return new Values(this);
+		if (isAllocateIterators()) return new Values(this);
 		if (values1 == null) {
 			values1 = new OrderedMapValues(this);
 			values2 = new OrderedMapValues(this);
@@ -124,10 +126,10 @@ public class OrderedMap<K, V> extends ObjectMap<K, V> {
 
 	/** Returns an iterator for the keys in the map. Remove is supported.
 	 * <p>
-	 * If {@link Array#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link OrderedMapKeys} constructor for nested or multithreaded iteration. */
 	public Keys<K> keys () {
-		if (Array.allocateIterators) return new Keys(this);
+		if (isAllocateIterators()) return new Keys(this);
 		if (keys1 == null) {
 			keys1 = new OrderedMapKeys(this);
 			keys2 = new OrderedMapKeys(this);

--- a/gdx/src/com/badlogic/gdx/utils/OrderedMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/OrderedMap.java
@@ -18,8 +18,6 @@ package com.badlogic.gdx.utils;
 
 import java.util.NoSuchElementException;
 
-import static com.badlogic.gdx.utils.Collections.isAllocateIterators;
-
 /** An {@link ObjectMap} that also stores keys in an {@link Array} using the insertion order. Iteration over the
  * {@link #entries()}, {@link #keys()}, and {@link #values()} is ordered and faster than an unordered map. Keys can also be
  * accessed and the order changed using {@link #orderedKeys()}. There is some additional overhead for put and remove. When used
@@ -82,10 +80,10 @@ public class OrderedMap<K, V> extends ObjectMap<K, V> {
 
 	/** Returns an iterator for the entries in the map. Remove is supported.
 	 * <p>
-	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link OrderedMapEntries} constructor for nested or multithreaded iteration. */
 	public Entries<K, V> entries () {
-		if (isAllocateIterators()) return new Entries(this);
+		if (Collections.allocateIterators) return new Entries(this);
 		if (entries1 == null) {
 			entries1 = new OrderedMapEntries(this);
 			entries2 = new OrderedMapEntries(this);
@@ -104,10 +102,10 @@ public class OrderedMap<K, V> extends ObjectMap<K, V> {
 
 	/** Returns an iterator for the values in the map. Remove is supported.
 	 * <p>
-	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link OrderedMapValues} constructor for nested or multithreaded iteration. */
 	public Values<V> values () {
-		if (isAllocateIterators()) return new Values(this);
+		if (Collections.allocateIterators) return new Values(this);
 		if (values1 == null) {
 			values1 = new OrderedMapValues(this);
 			values2 = new OrderedMapValues(this);
@@ -126,10 +124,10 @@ public class OrderedMap<K, V> extends ObjectMap<K, V> {
 
 	/** Returns an iterator for the keys in the map. Remove is supported.
 	 * <p>
-	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link OrderedMapKeys} constructor for nested or multithreaded iteration. */
 	public Keys<K> keys () {
-		if (isAllocateIterators()) return new Keys(this);
+		if (Collections.allocateIterators) return new Keys(this);
 		if (keys1 == null) {
 			keys1 = new OrderedMapKeys(this);
 			keys2 = new OrderedMapKeys(this);

--- a/gdx/src/com/badlogic/gdx/utils/OrderedSet.java
+++ b/gdx/src/com/badlogic/gdx/utils/OrderedSet.java
@@ -91,7 +91,7 @@ public class OrderedSet<T> extends ObjectSet<T> {
 	}
 
 	public OrderedSetIterator<T> iterator () {
-		if (Collections.isAllocateIterators()) return new OrderedSetIterator(this);
+		if (Collections.allocateIterators) return new OrderedSetIterator(this);
 		if (iterator1 == null) {
 			iterator1 = new OrderedSetIterator(this);
 			iterator2 = new OrderedSetIterator(this);

--- a/gdx/src/com/badlogic/gdx/utils/OrderedSet.java
+++ b/gdx/src/com/badlogic/gdx/utils/OrderedSet.java
@@ -91,7 +91,7 @@ public class OrderedSet<T> extends ObjectSet<T> {
 	}
 
 	public OrderedSetIterator<T> iterator () {
-		if (Array.allocateIterators) return new OrderedSetIterator(this);
+		if (Collections.isAllocateIterators()) return new OrderedSetIterator(this);
 		if (iterator1 == null) {
 			iterator1 = new OrderedSetIterator(this);
 			iterator2 = new OrderedSetIterator(this);

--- a/gdx/src/com/badlogic/gdx/utils/Predicate.java
+++ b/gdx/src/com/badlogic/gdx/utils/Predicate.java
@@ -99,11 +99,11 @@ public interface Predicate<T> {
 
 		/** Returns an iterator. Remove is supported.
 		 * <p>
-		 * If {@link Array#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use
+		 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use
 		 * the {@link Predicate.PredicateIterator} constructor for nested or multithreaded iteration. */
 		@Override
 		public Iterator<T> iterator () {
-			if (Array.allocateIterators) return new PredicateIterator<T>(iterable.iterator(), predicate);
+			if (Collections.isAllocateIterators()) return new PredicateIterator<T>(iterable.iterator(), predicate);
 			if (iterator == null)
 				iterator = new PredicateIterator<T>(iterable.iterator(), predicate);
 			else

--- a/gdx/src/com/badlogic/gdx/utils/Predicate.java
+++ b/gdx/src/com/badlogic/gdx/utils/Predicate.java
@@ -99,11 +99,11 @@ public interface Predicate<T> {
 
 		/** Returns an iterator. Remove is supported.
 		 * <p>
-		 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use
+		 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use
 		 * the {@link Predicate.PredicateIterator} constructor for nested or multithreaded iteration. */
 		@Override
 		public Iterator<T> iterator () {
-			if (Collections.isAllocateIterators()) return new PredicateIterator<T>(iterable.iterator(), predicate);
+			if (Collections.allocateIterators) return new PredicateIterator<T>(iterable.iterator(), predicate);
 			if (iterator == null)
 				iterator = new PredicateIterator<T>(iterable.iterator(), predicate);
 			else

--- a/gdx/src/com/badlogic/gdx/utils/Queue.java
+++ b/gdx/src/com/badlogic/gdx/utils/Queue.java
@@ -21,8 +21,6 @@ import java.util.NoSuchElementException;
 
 import com.badlogic.gdx.utils.reflect.ArrayReflection;
 
-import static com.badlogic.gdx.utils.Collections.isAllocateIterators;
-
 /** A resizable, ordered array of objects with efficient add and remove at the beginning and end. Values in the backing array may
  * wrap back to the beginning, making add and remove at the beginning and end O(1) (unless the backing array needs to resize when
  * adding). Deque functionality is provided via {@link #removeLast()} and {@link #addFirst(Object)}. */
@@ -332,10 +330,10 @@ public class Queue<T> implements Iterable<T> {
 
 	/** Returns an iterator for the items in the queue. Remove is supported.
 	 * <p>
-	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link QueueIterator} constructor for nested or multithreaded iteration. */
 	public Iterator<T> iterator () {
-		if (isAllocateIterators()) return new QueueIterator(this, true);
+		if (Collections.allocateIterators) return new QueueIterator(this, true);
 		if (iterable == null) iterable = new QueueIterable(this);
 		return iterable.iterator();
 	}
@@ -499,9 +497,9 @@ public class Queue<T> implements Iterable<T> {
 			this.allowRemove = allowRemove;
 		}
 
-		/** @see Collections#setAllocateIterators(boolean) */
+		/** @see Collections#allocateIterators */
 		public Iterator<T> iterator () {
-			if (isAllocateIterators()) return new QueueIterator(queue, allowRemove);
+			if (Collections.allocateIterators) return new QueueIterator(queue, allowRemove);
 // lastAcquire.getBuffer().setLength(0);
 // new Throwable().printStackTrace(new java.io.PrintWriter(lastAcquire));
 			if (iterator1 == null) {

--- a/gdx/src/com/badlogic/gdx/utils/Queue.java
+++ b/gdx/src/com/badlogic/gdx/utils/Queue.java
@@ -21,6 +21,8 @@ import java.util.NoSuchElementException;
 
 import com.badlogic.gdx.utils.reflect.ArrayReflection;
 
+import static com.badlogic.gdx.utils.Collections.isAllocateIterators;
+
 /** A resizable, ordered array of objects with efficient add and remove at the beginning and end. Values in the backing array may
  * wrap back to the beginning, making add and remove at the beginning and end O(1) (unless the backing array needs to resize when
  * adding). Deque functionality is provided via {@link #removeLast()} and {@link #addFirst(Object)}. */
@@ -330,10 +332,10 @@ public class Queue<T> implements Iterable<T> {
 
 	/** Returns an iterator for the items in the queue. Remove is supported.
 	 * <p>
-	 * If {@link Array#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
+	 * If {@link Collections#isAllocateIterators()} is false, the same iterator instance is returned each time this method is called. Use the
 	 * {@link QueueIterator} constructor for nested or multithreaded iteration. */
 	public Iterator<T> iterator () {
-		if (Array.allocateIterators) return new QueueIterator(this, true);
+		if (isAllocateIterators()) return new QueueIterator(this, true);
 		if (iterable == null) iterable = new QueueIterable(this);
 		return iterable.iterator();
 	}
@@ -497,9 +499,9 @@ public class Queue<T> implements Iterable<T> {
 			this.allowRemove = allowRemove;
 		}
 
-		/** @see Array#allocateIterators */
+		/** @see Collections#setAllocateIterators(boolean) */
 		public Iterator<T> iterator () {
-			if (Array.allocateIterators) return new QueueIterator(queue, allowRemove);
+			if (isAllocateIterators()) return new QueueIterator(queue, allowRemove);
 // lastAcquire.getBuffer().setLength(0);
 // new Throwable().printStackTrace(new java.io.PrintWriter(lastAcquire));
 			if (iterator1 == null) {


### PR DESCRIPTION
Created a new Collections class to hold common configuration/utility methods for all collection classes. Moved allocationIterators from Array class to Collections.

I've made a getter/setter for the property, can change to public as it's not that great anyway.