### PR TITLE
removed a line disabling autoBind when passing Renderable to ModelBat…

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g3d/ModelBatch.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/ModelBatch.java
@@ -225,7 +225,6 @@ public class ModelBatch implements Disposable {
 	 * @param renderable The {@link Renderable} to be added. */
 	public void render (final Renderable renderable) {
 		renderable.shader = shaderProvider.getShader(renderable);
-		renderable.meshPart.mesh.setAutoBind(false);
 		renderables.add(renderable);
 	}
 


### PR DESCRIPTION
before this change, ModelBatch.render behaves differently depending on whether a Renderable or a RenderableProvider is passed as the argument. If a RenderableProvider is passed, autoBind is not disabled. However, if a Renderable is passed, autoBind is disabled, which causes an exception unless the custom Shader takes steps to force autoBind to be used. 

I tested this by creating https://gist.github.com/ryanastout/ec842b8ce63342834909c07ff37c66f8 and verifying that I don't see the exception with this change, but I do without the change from this commit