### PR TITLE
Android: Hardware keyboard not detected when connected before app launched

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidDaydream.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidDaydream.java
@@ -169,6 +169,10 @@ public class AndroidDaydream extends DreamService implements AndroidApplicationB
 
 		createWakeLock(config.useWakelock);
 		hideStatusBar(config);
+
+		// detect an already connected bluetooth keyboardAvailable
+		if (getResources().getConfiguration().keyboard != Configuration.KEYBOARD_NOKEYS)
+			this.getInput().keyboardAvailable = true;
 	}
 
 	protected FrameLayout.LayoutParams createLayoutParams () {

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidFragmentApplication.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidFragmentApplication.java
@@ -202,6 +202,10 @@ public class AndroidFragmentApplication extends Fragment implements AndroidAppli
 				log("AndroidApplication", "Failed to create AndroidVisibilityListener", e);
 			}
 		}
+
+		// detect an already connected bluetooth keyboardAvailable
+		if (getResources().getConfiguration().keyboard != Configuration.KEYBOARD_NOKEYS)
+			this.getInput().keyboardAvailable = true;
 		return graphics.getView();
 	}
 


### PR DESCRIPTION
Followup to PR #5081 / commit dfaa35111, which fixed this issue for AndroidApplication, but not for Daydream and Fragment.