### PR TITLE
Fixed GLES20 NoSuchMethodError on Android API < 17

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGL20.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGL20.java
@@ -25,7 +25,8 @@ import com.badlogic.gdx.graphics.GL20;
 import android.opengl.GLES20;
 
 public class AndroidGL20 implements GL20 {
-	private int[] ints = new int[1];
+	private int[] ints = new int[1], ints2 = new int[1], ints3 = new int[1];
+	private byte[] buffer = new byte[512];
 	
 	public void glActiveTexture (int texture) {
 		GLES20.glActiveTexture (texture);
@@ -287,13 +288,31 @@ public class AndroidGL20 implements GL20 {
 		return ints[0];
 	}
 
-	public String glGetActiveAttrib (int program, int index, IntBuffer size, Buffer type) {
-		return GLES20.glGetActiveAttrib (program, index, size, (IntBuffer)type);
+	public String glGetActiveAttrib(int program, int index, IntBuffer size, Buffer type) {
+		//it is assumed that size and type are both int buffers of length 1 with a single integer at position 0
+		
+		//length
+		ints[0] = 0;
+		//size
+		ints2[0] = size.get(0);
+		//type
+		ints3[0] = ((IntBuffer)type).get(0);
+
+		GLES20.glGetActiveAttrib(program, index, buffer.length, ints, 0, ints2, 0, ints3, 0, buffer, 0);
+		return new String(buffer, 0, ints[0]);
 	}
 
-	public String glGetActiveUniform (int program, int index, IntBuffer size, Buffer type) {
-		return GLES20.glGetActiveUniform (program, index, size, (IntBuffer)type);
-	}
+    	public String glGetActiveUniform(int program, int index, IntBuffer size, Buffer type) {
+        	//length
+        	ints[0] = 0;
+        	//size
+        	ints2[0] = size.get(0);
+        	//type
+        	ints3[0] = ((IntBuffer)type).get(0);
+
+        	GLES20.glGetActiveUniform(program, index, buffer.length, ints, 0, ints2, 0, ints3, 0, buffer, 0);
+        	return new String(buffer, 0, ints[0]);
+    	}
 
 	public void glGetAttachedShaders (int program, int maxcount, Buffer count, IntBuffer shaders) {
 		GLES20.glGetAttachedShaders (program, maxcount, (IntBuffer)count, shaders);


### PR DESCRIPTION
The new GLES20 code used some convenience methods that were added in API 17, causing instant crashes on older devices. This PR swaps out these methods for older ones that should be compatible with all API levels supported by libGDX.

*If someone has a device with API < 17, please test this to make sure it fixes the problem. This does not seem to cause any regressions on my 7.0 device.*