### PR TITLE
ignore temporary folders of roboVM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,8 @@ x86_64/
 robovm-build/
 ipch/
 /dist
+/ios/IOSLauncher.app
+/ios/IOSLauncher.app.dSYM
 
 *.a
 *.a.tvos


### PR DESCRIPTION
these folders are generated by roboVM and should not go to Git