### PR TITLE
Fixed order of getting elements in loadTileSet

### DIFF
--- a/gdx/src/com/badlogic/gdx/maps/tiled/BaseTmxMapLoader.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/BaseTmxMapLoader.java
@@ -543,6 +543,21 @@ public abstract class BaseTmxMapLoader<P extends BaseTmxMapLoader.Parameters> ex
 
 	protected void loadTileSet (Element element, FileHandle tmxFile, ImageResolver imageResolver) {
 		if (element.getName().equals("tileset")) {
+			String name = element.get("name", null);
+			int firstgid = element.getIntAttribute("firstgid", 1);
+			int tilewidth = element.getIntAttribute("tilewidth", 0);
+			int tileheight = element.getIntAttribute("tileheight", 0);
+			int spacing = element.getIntAttribute("spacing", 0);
+			int margin = element.getIntAttribute("margin", 0);
+
+			Element offset = element.getChildByName("tileoffset");
+			int offsetX = 0;
+			int offsetY = 0;
+			if (offset != null) {
+				offsetX = offset.getIntAttribute("x", 0);
+				offsetY = offset.getIntAttribute("y", 0);
+			}
+
 			String imageSource = "";
 			int imageWidth = 0;
 			int imageHeight = 0;
@@ -571,21 +586,6 @@ public abstract class BaseTmxMapLoader<P extends BaseTmxMapLoader.Parameters> ex
 					imageHeight = imageElement.getIntAttribute("height", 0);
 					image = getRelativeFileHandle(tmxFile, imageSource);
 				}
-			}
-
-			String name = element.get("name", null);
-			int firstgid = element.getIntAttribute("firstgid", 1);
-			int tilewidth = element.getIntAttribute("tilewidth", 0);
-			int tileheight = element.getIntAttribute("tileheight", 0);
-			int spacing = element.getIntAttribute("spacing", 0);
-			int margin = element.getIntAttribute("margin", 0);
-
-			Element offset = element.getChildByName("tileoffset");
-			int offsetX = 0;
-			int offsetY = 0;
-			if (offset != null) {
-				offsetX = offset.getIntAttribute("x", 0);
-				offsetY = offset.getIntAttribute("y", 0);
 			}
 
 			TiledMapTileSet tileSet = new TiledMapTileSet();


### PR DESCRIPTION
Fix for https://github.com/libgdx/libgdx/issues/5709

(Base)TmxLoader was refactored (by me) a few weeks ago.
This bug occured because a code block moved without noticing that a variable gets assigned a new value inbetween.
"Element element" (line 544) gets replaced further down in the code (line 570 before change).
To get the correct element to retrieve the attributes the appropriate code block is moved to the top again, as it was before the BaseTmxMapLoader refactor.

In my test this fixed https://github.com/libgdx/libgdx/issues/5709. Please verify.