### PR TITLE
Android/iOS: Added methods to get safe area insets

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphics.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphics.java
@@ -16,9 +16,6 @@
 
 package com.badlogic.gdx.backends.android;
 
-import java.text.NumberFormat;
-import java.text.ParseException;
-
 import javax.microedition.khronos.egl.EGL10;
 import javax.microedition.khronos.egl.EGLConfig;
 import javax.microedition.khronos.egl.EGLContext;
@@ -28,8 +25,10 @@ import javax.microedition.khronos.opengles.GL10;
 import android.opengl.GLSurfaceView;
 import android.opengl.GLSurfaceView.EGLConfigChooser;
 import android.opengl.GLSurfaceView.Renderer;
+import android.os.Build;
 import android.util.DisplayMetrics;
 import android.view.Display;
+import android.view.DisplayCutout;
 import android.view.View;
 import android.view.WindowManager.LayoutParams;
 
@@ -55,7 +54,6 @@ import com.badlogic.gdx.graphics.glutils.FrameBuffer;
 import com.badlogic.gdx.graphics.glutils.GLVersion;
 import com.badlogic.gdx.graphics.glutils.ShaderProgram;
 import com.badlogic.gdx.math.WindowedMean;
-import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.GdxRuntimeException;
 import com.badlogic.gdx.utils.SnapshotArray;
 
@@ -76,6 +74,7 @@ public class AndroidGraphics implements Graphics, Renderer {
 	final View view;
 	int width;
 	int height;
+	int safeInsetLeft, safeInsetTop, safeInsetBottom, safeInsetRight;
 	AndroidApplicationBase app;
 	GL20 gl20;
 	GL30 gl30;
@@ -305,6 +304,7 @@ public class AndroidGraphics implements Graphics, Renderer {
 		this.width = width;
 		this.height = height;
 		updatePpi();
+		updateSafeAreaInsets();
 		gl.glViewport(0, 0, this.width, this.height);
 		if (created == false) {
 			app.getApplicationListener().create();
@@ -322,6 +322,7 @@ public class AndroidGraphics implements Graphics, Renderer {
 		setupGL(gl);
 		logConfig(config);
 		updatePpi();
+		updateSafeAreaInsets();
 
 		Mesh.invalidateAllMeshes(app);
 		Texture.invalidateAllTextures(app);
@@ -646,6 +647,43 @@ public class AndroidGraphics implements Graphics, Renderer {
 	@Override
 	public DisplayMode[] getDisplayModes () {
 		return new DisplayMode[] {getDisplayMode()};
+	}
+
+	protected void updateSafeAreaInsets() {
+		safeInsetLeft = 0;
+		safeInsetTop = 0;
+		safeInsetRight = 0;
+		safeInsetBottom = 0;
+
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+			DisplayCutout displayCutout = app.getApplicationWindow().getDecorView().getRootWindowInsets().getDisplayCutout();
+			if (displayCutout != null) {
+				safeInsetRight = displayCutout.getSafeInsetRight();
+				safeInsetBottom = displayCutout.getSafeInsetBottom();
+				safeInsetTop = displayCutout.getSafeInsetTop();
+				safeInsetLeft = displayCutout.getSafeInsetLeft();
+			}
+		}
+	}
+
+	@Override
+	public int getSafeInsetLeft() {
+		return safeInsetLeft;
+	}
+
+	@Override
+	public int getSafeInsetTop() {
+		return safeInsetTop;
+	}
+
+	@Override
+	public int getSafeInsetBottom() {
+		return safeInsetBottom;
+	}
+
+	@Override
+	public int getSafeInsetRight() {
+		return safeInsetRight;
 	}
 
 	@Override

--- a/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/mock/graphics/MockGraphics.java
+++ b/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/mock/graphics/MockGraphics.java
@@ -152,6 +152,26 @@ public class MockGraphics implements Graphics {
 	}
 
 	@Override
+	public int getSafeInsetLeft() {
+		return 0;
+	}
+
+	@Override
+	public int getSafeInsetTop() {
+		return 0;
+	}
+
+	@Override
+	public int getSafeInsetBottom() {
+		return 0;
+	}
+
+	@Override
+	public int getSafeInsetRight() {
+		return 0;
+	}
+
+	@Override
 	public boolean setFullscreenMode(DisplayMode displayMode) {
 		return false;
 	}

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGraphics.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGraphics.java
@@ -447,6 +447,26 @@ public class LwjglGraphics implements Graphics {
 	}
 
 	@Override
+	public int getSafeInsetLeft() {
+		return 0;
+	}
+
+	@Override
+	public int getSafeInsetTop() {
+		return 0;
+	}
+
+	@Override
+	public int getSafeInsetBottom() {
+		return 0;
+	}
+
+	@Override
+	public int getSafeInsetRight() {
+		return 0;
+	}
+
+	@Override
 	public boolean setFullscreenMode (DisplayMode displayMode) {
 		org.lwjgl.opengl.DisplayMode mode = ((LwjglDisplayMode)displayMode).mode;
 		try {

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Graphics.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Graphics.java
@@ -323,6 +323,26 @@ public class Lwjgl3Graphics implements Graphics, Disposable {
 	}
 
 	@Override
+	public int getSafeInsetLeft() {
+		return 0;
+	}
+
+	@Override
+	public int getSafeInsetTop() {
+		return 0;
+	}
+
+	@Override
+	public int getSafeInsetBottom() {
+		return 0;
+	}
+
+	@Override
+	public int getSafeInsetRight() {
+		return 0;
+	}
+
+	@Override
 	public boolean setFullscreenMode(DisplayMode displayMode) {
 		window.getInput().resetPollingStates();
 		Lwjgl3DisplayMode newMode = (Lwjgl3DisplayMode) displayMode;

--- a/backends/gdx-backend-moe/src/com/badlogic/gdx/backends/iosmoe/IOSGraphics.java
+++ b/backends/gdx-backend-moe/src/com/badlogic/gdx/backends/iosmoe/IOSGraphics.java
@@ -431,6 +431,26 @@ public class IOSGraphics extends NSObject implements Graphics, GLKViewDelegate, 
 	}
 
 	@Override
+	public int getSafeInsetLeft() {
+		return 0;
+	}
+
+	@Override
+	public int getSafeInsetTop() {
+		return 0;
+	}
+
+	@Override
+	public int getSafeInsetBottom() {
+		return 0;
+	}
+
+	@Override
+	public int getSafeInsetRight() {
+		return 0;
+	}
+
+	@Override
 	public boolean setFullscreenMode (DisplayMode displayMode) {
 		return false;
 	}

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtGraphics.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtGraphics.java
@@ -331,6 +331,26 @@ public class GwtGraphics implements Graphics {
 	}
 
 	@Override
+	public int getSafeInsetLeft() {
+		return 0;
+	}
+
+	@Override
+	public int getSafeInsetTop() {
+		return 0;
+	}
+
+	@Override
+	public int getSafeInsetBottom() {
+		return 0;
+	}
+
+	@Override
+	public int getSafeInsetRight() {
+		return 0;
+	}
+
+	@Override
 	public boolean setFullscreenMode (DisplayMode displayMode) {
 		if (displayMode.width != getScreenWidthJSNI() && displayMode.height != getScreenHeightJSNI()) return false;
 		return setFullscreenJSNI(this, canvas);

--- a/gdx/src/com/badlogic/gdx/Graphics.java
+++ b/gdx/src/com/badlogic/gdx/Graphics.java
@@ -153,6 +153,26 @@ public interface Graphics {
 	/** @return the height of the framebuffer in physical pixels */
 	public int getBackBufferHeight ();
 
+	/**
+	 * @return the inset from the left which avoids display cutouts in pixels
+	 */
+	int getSafeInsetLeft();
+
+	/**
+	 * @return the inset from the top which avoids display cutouts in pixels
+	 */
+	int getSafeInsetTop();
+
+	/**
+	 * @return the inset from the bottom which avoids display cutouts or floating gesture bars, in pixels
+	 */
+	int getSafeInsetBottom();
+
+	/**
+	 * @return the inset from the right which avoids display cutouts in pixels
+	 */
+	int getSafeInsetRight();
+
 	/** Returns the id of the current frame. The general contract of this method is that the id is incremented only when the
 	 * application is in the running state right before calling the {@link ApplicationListener#render()} method. Also, the id of
 	 * the first frame is 0; the id of subsequent frames is guaranteed to take increasing values for 2<sup>63</sup>-1 rendering

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -33,8 +33,8 @@ versions.junit = "4.11"
 versions.appleExtension = "1.4"
 versions.androidPlugin = "3.1.0"
 versions.multiDex = "1.0.3"
-versions.androidSdk = 27
-versions.androidBuildTools = "27.0.3"
+versions.androidSdk = 28
+versions.androidBuildTools = "28.0.3"
 versions.androidSupport = "25.+"
 versions.javaparser = "2.3.0"
 

--- a/tests/gdx-tests-android/src/com/badlogic/gdx/tests/android/GdxTestActivity.java
+++ b/tests/gdx-tests-android/src/com/badlogic/gdx/tests/android/GdxTestActivity.java
@@ -16,7 +16,10 @@
 
 package com.badlogic.gdx.tests.android;
 
+import android.os.Build;
 import android.os.Bundle;
+import android.view.Window;
+import android.view.WindowManager;
 
 import com.badlogic.gdx.backends.android.AndroidApplication;
 import com.badlogic.gdx.backends.android.AndroidApplicationConfiguration;
@@ -27,6 +30,13 @@ public class GdxTestActivity extends AndroidApplication {
 
 	public void onCreate (Bundle bundle) {
 		super.onCreate(bundle);
+
+		// use the full display, even if we have a device with a notch
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+			Window applicationWindow = getApplicationWindow();
+			WindowManager.LayoutParams attrib = applicationWindow.getAttributes();
+			attrib.layoutInDisplayCutoutMode = WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES;
+		}
 
 		// obtain the test info
 		Bundle extras = getIntent().getExtras();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/FullscreenTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/FullscreenTest.java
@@ -18,6 +18,7 @@ package com.badlogic.gdx.tests;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Graphics.DisplayMode;
+import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
@@ -53,6 +54,9 @@ public class FullscreenTest extends GdxTest {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		
 		batch.begin();
+		batch.setColor(Gdx.input.getX() < Gdx.graphics.getSafeInsetLeft() ||
+				Gdx.input.getX() + tex.getWidth() > Gdx.graphics.getWidth() - Gdx.graphics.getSafeInsetRight()
+				? Color.RED : Color.WHITE);
 		batch.draw(tex, Gdx.input.getX(), Gdx.graphics.getHeight() - Gdx.input.getY());
 		font.draw(batch, "" + Gdx.graphics.getWidth() + ", " + Gdx.graphics.getHeight(), 0, 20);
 		batch.end();
@@ -86,6 +90,8 @@ public class FullscreenTest extends GdxTest {
 	@Override
 	public void resize (int width, int height) {
 		Gdx.app.log("FullscreenTest", "resized: " + width + ", " + height);
+		Gdx.app.log("FullscreenTest", "safe insets: " + Gdx.graphics.getSafeInsetLeft() +
+				"/" + Gdx.graphics.getSafeInsetRight());
 		batch.getProjectionMatrix().setToOrtho2D(0, 0, width, height);
 	}
 


### PR DESCRIPTION
We have display cutouts on iPhone X and now after updating on Android API 28 we can also have some on Android (although Android's default behaviour avoids that you have to deal with them).

This PR adds support for iOS RoboVM and Android backend to return the safe area insets. The changed `GdxTestActivity` demonstrates how to expand the game under the Notch on Android. A further change to apply this automatically if immersive mode is set might be useful, but this can be discussed.

This is tested on Android 4.2 and Android 9 and iOS 12.1 with RoboVM. The FullScreenTest tints the badlogic logo red if the logo is outside of the safe display area.