### PR TITLE
fix wrong firstgid when load external tileset

### DIFF
--- a/gdx/src/com/badlogic/gdx/maps/tiled/BaseTmxMapLoader.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/BaseTmxMapLoader.java
@@ -543,21 +543,7 @@ public abstract class BaseTmxMapLoader<P extends BaseTmxMapLoader.Parameters> ex
 
 	protected void loadTileSet (Element element, FileHandle tmxFile, ImageResolver imageResolver) {
 		if (element.getName().equals("tileset")) {
-			String name = element.get("name", null);
-			int firstgid = element.getIntAttribute("firstgid", 1);
-			int tilewidth = element.getIntAttribute("tilewidth", 0);
-			int tileheight = element.getIntAttribute("tileheight", 0);
-			int spacing = element.getIntAttribute("spacing", 0);
-			int margin = element.getIntAttribute("margin", 0);
-
-			Element offset = element.getChildByName("tileoffset");
-			int offsetX = 0;
-			int offsetY = 0;
-			if (offset != null) {
-				offsetX = offset.getIntAttribute("x", 0);
-				offsetY = offset.getIntAttribute("y", 0);
-			}
-
+            int firstgid = element.getIntAttribute("firstgid", 1);
 			String imageSource = "";
 			int imageWidth = 0;
 			int imageHeight = 0;
@@ -587,7 +573,19 @@ public abstract class BaseTmxMapLoader<P extends BaseTmxMapLoader.Parameters> ex
 					image = getRelativeFileHandle(tmxFile, imageSource);
 				}
 			}
+            String name = element.get("name", null);
+            int tilewidth = element.getIntAttribute("tilewidth", 0);
+            int tileheight = element.getIntAttribute("tileheight", 0);
+            int spacing = element.getIntAttribute("spacing", 0);
+            int margin = element.getIntAttribute("margin", 0);
 
+            Element offset = element.getChildByName("tileoffset");
+            int offsetX = 0;
+            int offsetY = 0;
+            if (offset != null) {
+                offsetX = offset.getIntAttribute("x", 0);
+                offsetY = offset.getIntAttribute("y", 0);
+            }
 			TiledMapTileSet tileSet = new TiledMapTileSet();
 
 			// TileSet

--- a/gdx/src/com/badlogic/gdx/maps/tiled/BaseTmxMapLoader.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/BaseTmxMapLoader.java
@@ -543,7 +543,7 @@ public abstract class BaseTmxMapLoader<P extends BaseTmxMapLoader.Parameters> ex
 
 	protected void loadTileSet (Element element, FileHandle tmxFile, ImageResolver imageResolver) {
 		if (element.getName().equals("tileset")) {
-            int firstgid = element.getIntAttribute("firstgid", 1);
+			int firstgid = element.getIntAttribute("firstgid", 1);
 			String imageSource = "";
 			int imageWidth = 0;
 			int imageHeight = 0;
@@ -573,19 +573,19 @@ public abstract class BaseTmxMapLoader<P extends BaseTmxMapLoader.Parameters> ex
 					image = getRelativeFileHandle(tmxFile, imageSource);
 				}
 			}
-            String name = element.get("name", null);
-            int tilewidth = element.getIntAttribute("tilewidth", 0);
-            int tileheight = element.getIntAttribute("tileheight", 0);
-            int spacing = element.getIntAttribute("spacing", 0);
-            int margin = element.getIntAttribute("margin", 0);
+			String name = element.get("name", null);
+			int tilewidth = element.getIntAttribute("tilewidth", 0);
+			int tileheight = element.getIntAttribute("tileheight", 0);
+			int spacing = element.getIntAttribute("spacing", 0);
+			int margin = element.getIntAttribute("margin", 0);
 
-            Element offset = element.getChildByName("tileoffset");
-            int offsetX = 0;
-            int offsetY = 0;
-            if (offset != null) {
-                offsetX = offset.getIntAttribute("x", 0);
-                offsetY = offset.getIntAttribute("y", 0);
-            }
+			Element offset = element.getChildByName("tileoffset");
+			int offsetX = 0;
+			int offsetY = 0;
+			if (offset != null) {
+				offsetX = offset.getIntAttribute("x", 0);
+				offsetY = offset.getIntAttribute("y", 0);
+			}
 			TiledMapTileSet tileSet = new TiledMapTileSet();
 
 			// TileSet


### PR DESCRIPTION
#5710 didn't really fix the issue #5709 if map uses external tsx tileset. In this case the tileset element in tmx file only has two attributes firstgid and the source to the tsx. All tileset attributes like name,tilewidth,tileheight,... are defined in tsx file.