### PR TITLE
jnigen: Support specifying `APP_ABI` in `Application.mk`

### DIFF
--- a/extensions/gdx-box2d/gdx-box2d/jni/Application.mk
+++ b/extensions/gdx-box2d/gdx-box2d/jni/Application.mk
@@ -1,2 +1,2 @@
-APP_ABI := armeabi armeabi-v7a x86 x86_64 arm64-v8a
+APP_ABI := all
 APP_PLATFORM := android-9

--- a/extensions/gdx-bullet/jni/Application.mk
+++ b/extensions/gdx-bullet/jni/Application.mk
@@ -1,4 +1,4 @@
-APP_ABI := armeabi armeabi-v7a x86 x86_64 arm64-v8a
+APP_ABI := all
 APP_PLATFORM := android-9
 
 APP_STL := stlport_static

--- a/extensions/gdx-freetype/jni/Application.mk
+++ b/extensions/gdx-freetype/jni/Application.mk
@@ -1,2 +1,2 @@
-APP_ABI := armeabi armeabi-v7a x86 x86_64 arm64-v8a
+APP_ABI := all
 APP_PLATFORM := android-9

--- a/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/AndroidNdkScriptGenerator.java
+++ b/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/AndroidNdkScriptGenerator.java
@@ -55,12 +55,15 @@ public class AndroidNdkScriptGenerator {
 		gatherSourceFiles(config.jniDir, includes, excludes, files);
 
 		// create Application.mk file
-		FileDescriptor application = config.jniDir.child("Application.mk");
-		application.writeString(new FileDescriptor("com/badlogic/gdx/jnigen/resources/scripts/Application.mk.template",
-			FileType.Classpath).readString(), false);
+		String template = new FileDescriptor("com/badlogic/gdx/jnigen/resources/scripts/Application.mk.template",
+			FileType.Classpath).readString();
+
+		template = template.replace("%androidABIs%", target.androidABIs);
+
+		config.jniDir.child("Application.mk").writeString(template, false);
 
 		// create Android.mk file
-		String template = new FileDescriptor("com/badlogic/gdx/jnigen/resources/scripts/Android.mk.template", FileType.Classpath)
+		template = new FileDescriptor("com/badlogic/gdx/jnigen/resources/scripts/Android.mk.template", FileType.Classpath)
 			.readString();
 
 		StringBuilder srcFiles = new StringBuilder();

--- a/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/BuildTarget.java
+++ b/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/BuildTarget.java
@@ -61,6 +61,9 @@ public class BuildTarget {
 	/** The name used for the library file. This is a full file name, including file extension. Default is platform specific.
 	 *  E.g. "lib{sharedLibName}64.so" **/
 	public String libName; 
+	/** Space delimited list of ABIs we wish to build for Android. Defaults to all available in current NDK.
+	 * {@link "https://developer.android.com/ndk/guides/application_mk#app_abi"} **/
+	public String androidABIs = "all";
 
 	/** Creates a new build target. See members of this class for a description of the parameters. */
 	public BuildTarget (BuildTarget.TargetOs targetType, boolean is64Bit, String[] cIncludes, String[] cExcludes,

--- a/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/resources/scripts/Application.mk.template
+++ b/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/resources/scripts/Application.mk.template
@@ -1,2 +1,2 @@
-APP_ABI := armeabi armeabi-v7a x86 x86_64 arm64-v8a
+APP_ABI := %androidABIs%
 APP_PLATFORM := android-9

--- a/gdx/jni/Application.mk
+++ b/gdx/jni/Application.mk
@@ -1,2 +1,2 @@
-APP_ABI := armeabi armeabi-v7a x86 x86_64 arm64-v8a
+APP_ABI := all
 APP_PLATFORM := android-9


### PR DESCRIPTION
* Default changed to "all". 
* "all" will allow building on more recent NDK's, omitting armeabi builds.
* Updated generated Application.mk included for all libgdx projects.
* See https://developer.android.com/ndk/guides/application_mk#app_abi for more information.

This is step 1 on removing support for armeabi.