### PR TITLE
SoundManager2: Changed mp3 required to false

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/soundmanager2/SoundManager.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/soundmanager2/SoundManager.java
@@ -16,8 +16,6 @@
 
 package com.badlogic.gdx.backends.gwt.soundmanager2;
 
-import com.google.gwt.core.client.JavaScriptObject;
-
 public class SoundManager {
 	
 	public interface SoundManagerCallback {
@@ -75,6 +73,7 @@ public class SoundManager {
 
 	public static native void init (String moduleBaseURL, int flashVersion, boolean preferFlash, SoundManagerCallback callback) /*-{
 		$wnd.soundManager = new $wnd.SoundManager();
+		$wnd.soundManager.audioFormats.mp3.required = false;
 		$wnd.soundManager.setup({
 			url: moduleBaseURL,
 			flashVersion: flashVersion,


### PR DESCRIPTION
My game was blocked from running on an older version of Chromium, because the browser didn't support mp3. Changing required:!0 to required:!1 for mp3 inside SoundManager2 fixed my game and it runs now. The game uses ogg by the way.

When I say the game was blocked I mean the loading bar doesn't appear. I got this in the console.

SoundManager 2: No Flash detected. Trying HTML5-only mode.
SoundManager V2.97a.20150601 (AS3/Flash 9) + HTML5 audio
SoundManager 2: soundManager: Fatal error: Flash is needed to play some required formats, but is not available.
SoundManager 2 HTML5 support: mp3 = false (using flash), mp4 = false (using flash), ogg = true, opus = true, wav = true