### PR TITLE
Android controller vibration

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,5 @@
+[1.9.11]
+- API Addition: added controller vibration for Android
 [1.9.10]
 - API Addition: Allow target display for maximization LWJGL3 backend
 - API Addition: Accelerometer support on GWT

--- a/extensions/gdx-controllers/gdx-controllers-desktop/src/com/badlogic/gdx/controllers/desktop/OisControllers.java
+++ b/extensions/gdx-controllers/gdx-controllers-desktop/src/com/badlogic/gdx/controllers/desktop/OisControllers.java
@@ -239,6 +239,24 @@ public class OisControllers {
 		public String toString () {
 			return joystick.getName();
 		}
+
+		@Override
+		public boolean hasVibrator () {
+			return false;
+		}
+
+		@Override
+		public void setVibration (long milliseconds, float amplitude) {
+		}
+
+		@Override
+		public void stopVibration () {
+		}
+
+		@Override
+		public boolean supportsVibrationAmplitude () {
+			return false;
+		}
 	}
 
 	/** Returns the window handle from LWJGL needed by OIS. */

--- a/extensions/gdx-controllers/gdx-controllers-gwt/src/com/badlogic/gdx/controllers/gwt/GwtController.java
+++ b/extensions/gdx-controllers/gdx-controllers-gwt/src/com/badlogic/gdx/controllers/gwt/GwtController.java
@@ -133,4 +133,22 @@ public class GwtController implements Controller {
 	public Array<ControllerListener> getListeners() {
 		return listeners;
 	}
+
+	@Override
+	public boolean hasVibrator () {
+		return false;
+	}
+
+	@Override
+	public void setVibration (long milliseconds, float amplitude) {
+	}
+
+	@Override
+	public void stopVibration () {
+	}
+
+	@Override
+	public boolean supportsVibrationAmplitude () {
+		return false;
+	}
 }

--- a/extensions/gdx-controllers/gdx-controllers-lwjgl3/src/com/badlogic/gdx/controllers/lwjgl3/Lwjgl3Controller.java
+++ b/extensions/gdx-controllers/gdx-controllers-lwjgl3/src/com/badlogic/gdx/controllers/lwjgl3/Lwjgl3Controller.java
@@ -1,15 +1,15 @@
 package com.badlogic.gdx.controllers.lwjgl3;
 
-import java.nio.ByteBuffer;
-import java.nio.FloatBuffer;
-
-import org.lwjgl.glfw.GLFW;
-
 import com.badlogic.gdx.controllers.Controller;
 import com.badlogic.gdx.controllers.ControllerListener;
 import com.badlogic.gdx.controllers.PovDirection;
 import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.utils.Array;
+
+import org.lwjgl.glfw.GLFW;
+
+import java.nio.ByteBuffer;
+import java.nio.FloatBuffer;
 
 public class Lwjgl3Controller implements Controller {
 	final Lwjgl3ControllerManager manager;
@@ -161,5 +161,23 @@ public class Lwjgl3Controller implements Controller {
 	@Override
 	public String getName () {
 		return name;
-	}	
+	}
+
+	@Override
+	public boolean hasVibrator () {
+		return false;
+	}
+
+	@Override
+	public void setVibration (long milliseconds, float amplitude) {
+	}
+
+	@Override
+	public void stopVibration () {
+	}
+
+	@Override
+	public boolean supportsVibrationAmplitude () {
+		return false;
+	}
 }

--- a/extensions/gdx-controllers/gdx-controllers/src/com/badlogic/gdx/controllers/Controller.java
+++ b/extensions/gdx-controllers/gdx-controllers/src/com/badlogic/gdx/controllers/Controller.java
@@ -62,4 +62,16 @@ public interface Controller {
 	/** Removes the given {@link ControllerListener}
 	 * @param listener */
 	public void removeListener (ControllerListener listener);
+
+	/** @return if the controller supports vibration (only for Android) */
+	boolean hasVibrator ();
+
+	/** Make the controller vibrate if it supports vibration (only for Android) */
+	void setVibration (long milliseconds, float amplitude);
+
+	/** Make the controller stop vibrating (only for Android) */
+	void stopVibration ();
+
+	/** @return if the controller supports different amplitudes when vibrating (only for Android) */
+	boolean supportsVibrationAmplitude ();
 }

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/extensions/ControllersTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/extensions/ControllersTest.java
@@ -100,7 +100,8 @@ public class ControllersTest extends GdxTest {
 		print("Controllers: " + Controllers.getControllers().size);
 		int i = 0;
 		for (Controller controller : Controllers.getControllers()) {
-			print("#" + i++ + ": " + controller.getName());
+			print("#" + i + ": " + controller.getName());
+			print("#" + i++ + ", Has Vibrator: " + controller.hasVibrator() + ", Has Amplitude: " + controller.supportsVibrationAmplitude());
 		}
 		if (Controllers.getControllers().size == 0) print("No controllers attached");
 
@@ -115,7 +116,8 @@ public class ControllersTest extends GdxTest {
 				print("connected " + controller.getName());
 				int i = 0;
 				for (Controller c : Controllers.getControllers()) {
-					print("#" + i++ + ": " + c.getName());
+					print("#" + i + ": " + c.getName());
+					print("#" + i++ + ", Has Vibrator: " + c.hasVibrator() + ", Has Amplitude: " + c.supportsVibrationAmplitude());
 				}
 			}
 
@@ -138,6 +140,7 @@ public class ControllersTest extends GdxTest {
 			@Override
 			public boolean buttonUp (Controller controller, int buttonIndex) {
 				print("#" + indexOf(controller) + ", button " + buttonIndex + " up");
+				controller.setVibration(100,.5f);
 				return false;
 			}
 


### PR DESCRIPTION
Tested on Android 4.4 and 8.1. The only controllers I have that support vibration on the Android devices are Xbox 360 and Xbox original (with USB adapter.) Those controllers only had vibration on the Android 8.1 device, but the Android APIs for it go back to Android 4.1. The amplitude control wasn't supported on either of the controllers, so the vibration was always at max. The Android APIs do support special patterns, but I didn't incorporate that.

It seems LWJGL doesn't support rumble.

JavaScript doesn't have rumble support yet:
https://github.com/w3c/gamepad/issues/19
https://www.chromestatus.com/feature/5705158763741184

I'm not sure if you want to add this to the APIs since it's so limited, but I figured I'd share it anyways.