### PR TITLE
Get game controller id/index assigned by backend

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,5 @@
+[1.9.11]
+- API Addition: get ID for game controllers assigned by backend
 [1.9.10]
 - API Addition: Allow target display for maximization LWJGL3 backend
 - API Addition: Accelerometer support on GWT

--- a/extensions/gdx-controllers/gdx-controllers-android/src/com/badlogic/gdx/controllers/android/AndroidController.java
+++ b/extensions/gdx-controllers/gdx-controllers-android/src/com/badlogic/gdx/controllers/android/AndroidController.java
@@ -157,4 +157,9 @@ public class AndroidController implements Controller {
 	public String getName () {
 		return name;
 	}
+
+	@Override
+	public long getSystemId () {
+		return deviceId;
+	}
 }

--- a/extensions/gdx-controllers/gdx-controllers-desktop/src/com/badlogic/gdx/controllers/desktop/OisControllers.java
+++ b/extensions/gdx-controllers/gdx-controllers-desktop/src/com/badlogic/gdx/controllers/desktop/OisControllers.java
@@ -239,6 +239,11 @@ public class OisControllers {
 		public String toString () {
 			return joystick.getName();
 		}
+
+		@Override
+		public long getSystemId () {
+			return joystick.getPointer();
+		}
 	}
 
 	/** Returns the window handle from LWJGL needed by OIS. */

--- a/extensions/gdx-controllers/gdx-controllers-desktop/src/com/badlogic/gdx/controllers/desktop/ois/OisJoystick.java
+++ b/extensions/gdx-controllers/gdx-controllers-desktop/src/com/badlogic/gdx/controllers/desktop/ois/OisJoystick.java
@@ -154,6 +154,10 @@ public class OisJoystick {
 		return name;
 	}
 
+	public long getPointer () {
+		return joystickPtr;
+	}
+
 	// @off
 	/*JNI
 	#include <OISJoyStick.h>

--- a/extensions/gdx-controllers/gdx-controllers-gwt/src/com/badlogic/gdx/controllers/gwt/GwtController.java
+++ b/extensions/gdx-controllers/gdx-controllers-gwt/src/com/badlogic/gdx/controllers/gwt/GwtController.java
@@ -129,8 +129,13 @@ public class GwtController implements Controller {
 	public void removeListener(ControllerListener listener) {
 		this.listeners.removeValue(listener, true);
 	}
-	
+
 	public Array<ControllerListener> getListeners() {
 		return listeners;
+	}
+
+	@Override
+	public long getSystemId() {
+		return index;
 	}
 }

--- a/extensions/gdx-controllers/gdx-controllers-lwjgl3/src/com/badlogic/gdx/controllers/lwjgl3/Lwjgl3Controller.java
+++ b/extensions/gdx-controllers/gdx-controllers-lwjgl3/src/com/badlogic/gdx/controllers/lwjgl3/Lwjgl3Controller.java
@@ -1,15 +1,15 @@
 package com.badlogic.gdx.controllers.lwjgl3;
 
-import java.nio.ByteBuffer;
-import java.nio.FloatBuffer;
-
-import org.lwjgl.glfw.GLFW;
-
 import com.badlogic.gdx.controllers.Controller;
 import com.badlogic.gdx.controllers.ControllerListener;
 import com.badlogic.gdx.controllers.PovDirection;
 import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.utils.Array;
+
+import org.lwjgl.glfw.GLFW;
+
+import java.nio.ByteBuffer;
+import java.nio.FloatBuffer;
 
 public class Lwjgl3Controller implements Controller {
 	final Lwjgl3ControllerManager manager;
@@ -97,7 +97,7 @@ public class Lwjgl3Controller implements Controller {
 	public void removeListener (ControllerListener listener) {
 		listeners.removeValue(listener, true);
 	}
-	
+
 	@Override
 	public boolean getButton (int buttonCode) {
 		if(buttonCode < 0 || buttonCode >= buttonState.length) {
@@ -161,5 +161,10 @@ public class Lwjgl3Controller implements Controller {
 	@Override
 	public String getName () {
 		return name;
-	}	
+	}
+
+	@Override
+	public long getSystemId () {
+		return index;
+	}
 }

--- a/extensions/gdx-controllers/gdx-controllers/src/com/badlogic/gdx/controllers/Controller.java
+++ b/extensions/gdx-controllers/gdx-controllers/src/com/badlogic/gdx/controllers/Controller.java
@@ -62,4 +62,11 @@ public interface Controller {
 	/** Removes the given {@link ControllerListener}
 	 * @param listener */
 	public void removeListener (ControllerListener listener);
+
+	/** The ID of the controller assigned by the backend.
+	 * Javascript returns value of Gamepad.index
+	 * Android returns value of InputDevice.getId()
+	 * Lwjgl2 & Lwjgl3 return an index
+	 * @return the ID of the controller assigned by the backend. */
+	public long getSystemId();
 }

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/extensions/ControllersTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/extensions/ControllersTest.java
@@ -100,7 +100,8 @@ public class ControllersTest extends GdxTest {
 		print("Controllers: " + Controllers.getControllers().size);
 		int i = 0;
 		for (Controller controller : Controllers.getControllers()) {
-			print("#" + i++ + ": " + controller.getName());
+			print("#" + i + ": " + controller.getName());
+			print("#" + i++ + ": System ID " + controller.getSystemId());
 		}
 		if (Controllers.getControllers().size == 0) print("No controllers attached");
 
@@ -115,7 +116,8 @@ public class ControllersTest extends GdxTest {
 				print("connected " + controller.getName());
 				int i = 0;
 				for (Controller c : Controllers.getControllers()) {
-					print("#" + i++ + ": " + c.getName());
+					print("#" + i + ": " + c.getName());
+					print("#" + i++ + ": System ID " + c.getSystemId());
 				}
 			}
 


### PR DESCRIPTION
This is a new method that returns an id or index number generated for a game controller by the backend. They are assigned differently by each backend when the controller is connected.

Javascript returns the value of Gamepad.index
Android returns the value of InputDevice.getId()
Lwjgl2 & Lwjgl3 return an index

This is mostly useful if you need to interface with code on a specific backend. This would let you expand the controller functions without having to edit libGDX.