### PR TITLE
 jnigen: Allow changing the c/cpp compiler from gcc to clang.

### DIFF
--- a/extensions/gdx-bullet/jni/src/bullet/LinearMath/btVector3.h
+++ b/extensions/gdx-bullet/jni/src/bullet/LinearMath/btVector3.h
@@ -39,7 +39,7 @@ subject to the following restrictions:
 #endif
 
 
-#define BT_SHUFFLE(x,y,z,w) ((w)<<6 | (z)<<4 | (y)<<2 | (x))
+#define BT_SHUFFLE(x, y, z, w) (((w) << 6 | (z) << 4 | (y) << 2 | (x)) & 0xff)
 //#define bt_pshufd_ps( _a, _mask ) (__m128) _mm_shuffle_epi32((__m128i)(_a), (_mask) )
 #define bt_pshufd_ps( _a, _mask ) _mm_shuffle_ps((_a), (_a), (_mask) )
 #define bt_splat3_ps( _a, _i ) bt_pshufd_ps((_a), BT_SHUFFLE(_i,_i,_i, 3) )

--- a/extensions/gdx-bullet/jni/src/custom/gdx/common/jniHelpers.h
+++ b/extensions/gdx-bullet/jni/src/custom/gdx/common/jniHelpers.h
@@ -63,7 +63,7 @@ struct GdxPool {
 };
 
 struct GdxPooledObject {
-	GdxPool * const &pool;
+	GdxPool * const pool;
 	jobject obj;
 	const bool autoFree;
 

--- a/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/AntScriptGenerator.java
+++ b/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/AntScriptGenerator.java
@@ -252,6 +252,8 @@ public class AntScriptGenerator {
 		template = template.replace("%libsDir%", "../" + getLibsDirectory(config, target));
 		template = template.replace("%libName%", libName);
 		template = template.replace("%jniPlatform%", jniPlatform);
+		template = template.replace("%cCompiler%", target.cCompiler);
+		template = template.replace("%cppCompiler%", target.cppCompiler);
 		template = template.replace("%compilerPrefix%", target.compilerPrefix);
 		template = template.replace("%cFlags%", target.cFlags);
 		template = template.replace("%cppFlags%", target.cppFlags);

--- a/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/BuildTarget.java
+++ b/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/BuildTarget.java
@@ -38,6 +38,10 @@ public class BuildTarget {
 	public String[] cppExcludes;
 	/** the directories containing headers for the build, must not be null **/
 	public String[] headerDirs;
+	/** the compiler to use when compiling c files. Usually gcc or clang, must not be null */
+	public String cCompiler = "gcc";
+	/** the compiler to use when compiling c++ files. Usually g++ or clang++, must not be null */
+	public String cppCompiler = "g++";
 	/** prefix for the compiler (g++, gcc), useful for cross compilation, must not be null **/
 	public String compilerPrefix;
 	/** the flags passed to the C compiler, must not be null **/

--- a/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/resources/scripts/build-target.xml.template
+++ b/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/resources/scripts/build-target.xml.template
@@ -9,13 +9,17 @@
 	<property name="libName" value="%libName%"/>
 	<!-- the jni header jniPlatform to use -->
 	<property name="jniPlatform" value="%jniPlatform%"/>
+	<!-- the compiler to use when compiling c files -->
+	<property name="cCompiler" value="%cCompiler%"/>
+	<!--  the compiler to use when compiling c++ files -->
+	<property name="cppCompiler" value="%cppCompiler%"/>
 	<!-- the compilerPrefix for the C & C++ compilers -->
 	<property name="compilerPrefix" value="%compilerPrefix%"/>
 	<!--  the compilerSuffix for the C & C++ compilers -->	
 	<property name="compilerSuffix" value="" />	
 	
 	<!-- define gcc compiler, options and files to compile -->
-	<property name="gcc" value="${compilerPrefix}gcc${compilerSuffix}"/>	
+	<property name="gcc" value="${compilerPrefix}${cCompiler}${compilerSuffix}"/>
 	<property name="gcc-opts" value="%cFlags%"/>
 	<fileset id="gcc-files" dir="./">
 		<exclude name="target/"/>		
@@ -24,7 +28,7 @@
 	</fileset>
 	
 	<!-- define g++ compiler, options and files to compile -->
-	<property name="g++" value="${compilerPrefix}g++${compilerSuffix}"/>
+	<property name="g++" value="${compilerPrefix}${cppCompiler}${compilerSuffix}"/>
 	<property name="g++-opts" value="%cppFlags%"/>
 	<fileset id="g++-files" dir="./">
 		<exclude name="target/"/>
@@ -33,7 +37,7 @@
 	</fileset>
 
 	<!-- define linker and options -->
-	<property name="linker" value="${compilerPrefix}g++${compilerSuffix}"/>
+	<property name="linker" value="${compilerPrefix}${cppCompiler}${compilerSuffix}"/>
 	<property name="linker-opts" value="%linkerFlags%"/>
 	<property name="libraries" value="%libraries%"/>
 


### PR DESCRIPTION
Also includes two compiler issues to allow compiling with clang.

Backported https://github.com/bulletphysics/bullet3/pull/2232
And a fix for a fix for a "binds to a temporary object whose lifetime would be shorter than the lifetime of the constructed object" error.