### PR TITLE
GWT Accelerometer: report availability only if sensor is present

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtInput.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtInput.java
@@ -120,6 +120,10 @@ public class GwtInput implements Input {
 		return this.accelerometer != null ? (float) this.accelerometer.z() : 0;
 	}
 
+	private boolean isAccelerometerPresent() {
+		return getAccelerometerX() != 0 || getAccelerometerY() != 0 || getAccelerometerZ() != 0;
+	}
+
 	@Override
 	public float getGyroscopeX () {
 		// TODO Auto-generated method stub
@@ -346,7 +350,7 @@ public class GwtInput implements Input {
 
 	@Override
 	public boolean isPeripheralAvailable (Peripheral peripheral) {
-		if (peripheral == Peripheral.Accelerometer) return GwtAccelerometer.isSupported();
+		if (peripheral == Peripheral.Accelerometer) return GwtAccelerometer.isSupported() && isAccelerometerPresent();
 		if (peripheral == Peripheral.Compass) return false;
 		if (peripheral == Peripheral.HardwareKeyboard) return !GwtApplication.isMobileDevice();
 		if (peripheral == Peripheral.MultitouchScreen) return isTouchScreen();


### PR DESCRIPTION
GWT Accelerometer is reported as present if the web browser supports it even if there is no accelerometer. This is not correct, using Chrome on Desktop reports an available accelerometer.

This commit changes getPeriphalAvailable in a way that accelerometer availability is only returned if real sensor data is present, this matches the behaviour of the other platforms.

Note: At first I wanted to use the onError callback of the sensor, but it was called on my mobile device too. I was not able to find out why, because the callback provides no error message.


Sorry for the diff. GwtInput had CRLF line endings which I was not able to commit. I think this is okay because (most) libGDX sources have LF line endings in general.