### PR TITLE
Fix FileHandle#map compatibility with GWT

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/files/FileHandle.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/files/FileHandle.java
@@ -335,6 +335,18 @@ public class FileHandle {
 	public long lastModified () {
 		throw new GdxRuntimeException("Stub");
 	}
+	
+	/** Attempts to memory map this file in READ_ONLY mode. Android files must not be compressed.
+	 * @throws GdxRuntimeException if this file handle represents a directory, doesn't exist, or could not be read, or memory mapping fails, or is a {@link FileType#Classpath} file. */
+	public ByteBuffer map () {
+		throw new GdxRuntimeException("Stub");
+	}
+
+	/** Attempts to memory map this file. Android files must not be compressed.
+	 * @throws GdxRuntimeException if this file handle represents a directory, doesn't exist, or could not be read, or memory mapping fails, or is a {@link FileType#Classpath} file. */
+	public ByteBuffer map (FileChannel.MapMode mode) {
+		throw new GdxRuntimeException("Stub");
+	}
 
 	public String toString () {
 		throw new GdxRuntimeException("Stub");


### PR DESCRIPTION
https://github.com/libgdx/libgdx/pull/5259 doesn't work for me.
When compiling gdx-freetype-gwt I had to comment the part that used FileHandle.map() (https://github.com/intrigus/gdx-freetype-gwt/commit/93221646a8f56c37b6a3362558a8392189dec5ad#diff-11ed83df84f87aedd79b6b30b2c85b2aR93)