### PR TITLE
backend-lwjgl3: expose setter for maxNetThreads

### DIFF
--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3ApplicationConfiguration.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3ApplicationConfiguration.java
@@ -114,6 +114,13 @@ public class Lwjgl3ApplicationConfiguration extends Lwjgl3WindowConfiguration {
 	}
 
 	/**
+	 * Sets the maximum number of threads to use for network requests.
+	 */
+	public void setMaxNetThreads(int maxNetThreads) {
+		this.maxNetThreads = maxNetThreads;
+	}
+
+	/**
 	 * Sets the audio device configuration.
 	 * 
 	 * @param simultaniousSources


### PR DESCRIPTION
This adds a setter to allow someone to set this without having to use reflection, or be in the protected scope. Tested with the NetAPITest setting reasonable/unreasonable values in the lwjgl3 application configuration.