### PR TITLE
Fixed BaseDrawable#setMinSize()

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/BaseDrawable.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/BaseDrawable.java
@@ -99,7 +99,7 @@ public class BaseDrawable implements Drawable {
 
 	public void setMinSize (float minWidth, float minHeight) {
 		setMinWidth(minWidth);
-		setMinHeight(minWidth);
+		setMinHeight(minHeight);
 	}
 
 	public String getName () {


### PR DESCRIPTION
setMinSize() incorrectly passes minWidth to setMinHeight().