### PR TITLE
Added cache packed color for later uses.

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g3d/utils/MeshBuilder.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/utils/MeshBuilder.java
@@ -564,13 +564,11 @@ public class MeshBuilder implements MeshPartBuilder {
 				vertex[cpOffset] = Color.WHITE_FLOAT_BITS;
 			} else {
 				final int colIntBits = col.toIntBits();
-				if (colIntBits == lastColIntBits) {
-					vertex[cpOffset] = cacheFloatBits;
-				} else {
+				if (colIntBits != lastColIntBits) {
 					lastColIntBits = colIntBits;
 					cacheFloatBits = NumberUtils.intToFloatColor(colIntBits);
-					vertex[cpOffset] = cacheFloatBits;
 				}
+				vertex[cpOffset] = cacheFloatBits;
 			}
 		}
 

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/utils/MeshBuilder.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/utils/MeshBuilder.java
@@ -534,6 +534,9 @@ public class MeshBuilder implements MeshPartBuilder {
 	}
 
 	private final Vector3 tmpNormal = new Vector3();
+	
+	private float cacheFloatBits = Color.WHITE_FLOAT_BITS;
+	private int lastColIntBits = Color.WHITE.toIntBits();
 
 	@Override
 	public short vertex (Vector3 pos, Vector3 nor, Color col, Vector2 uv) {
@@ -557,8 +560,18 @@ public class MeshBuilder implements MeshPartBuilder {
 			vertex[colOffset + 2] = col.b;
 			if (colSize > 3) vertex[colOffset + 3] = col.a;
 		} else if (cpOffset > 0) {
-			if (col == null) col = Color.WHITE;
-			vertex[cpOffset] = col.toFloatBits(); // FIXME cache packed color?
+			if (col == null) {
+				vertex[cpOffset] = Color.WHITE_FLOAT_BITS;
+			} else {
+				final int colIntBits = col.toIntBits();
+				if (colIntBits == lastColIntBits) {
+					vertex[cpOffset] = cacheFloatBits;
+				} else {
+					lastColIntBits = colIntBits;
+					cacheFloatBits = NumberUtils.intToFloatColor(colIntBits);
+					vertex[cpOffset] = cacheFloatBits;
+				}
+			}
 		}
 
 		if (uv != null && uvOffset >= 0) {


### PR DESCRIPTION
Added cache packed color by storing last color Intbits and compare the current color Intbits and if equals, then use previous cached FloatBits to avoid uses of Float.intBitsToFloat(value) inside col.toFloatBits().

The rundown:
If the color is null, then use "packed float white float bits" in vertex[cpOffset], else convert the color into Int bits (to avoid uses of Float.intBitsToFloat(value) inside NumberUtils) and store in local variable; colIntBits, than compare colIntBits to lastColIntBits, if equals, use cashed float bits ("tmpColFloatBits") from previous runs and put in vertex[cpOffset], else store colIntBits in lastColIntBits and convert colIntBits to cacheFloatBits (for later uses) and put in vertex[cpOffset].