### PR TITLE
Better error message when fetching Uniform from uncompiled shader.

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/glutils/ShaderProgram.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/ShaderProgram.java
@@ -305,7 +305,10 @@ public class ShaderProgram implements Disposable {
 		int location;
 		if ((location = uniforms.get(name, -2)) == -2) {
 			location = gl.glGetUniformLocation(program, name);
-			if (location == -1 && pedantic) throw new IllegalArgumentException("no uniform with name '" + name + "' in shader");
+			if (location == -1 && pedantic) {
+				if (isCompiled) throw new IllegalArgumentException("no uniform with name '" + name + "' in shader");
+				else throw new GdxRuntimeException("An attempted fetch uniform from uncompiled shader \n" + getLog());
+			}
 			uniforms.put(name, location);
 		}
 		return location;

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/ShaderProgram.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/ShaderProgram.java
@@ -35,6 +35,7 @@ import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.BufferUtils;
 import com.badlogic.gdx.utils.Disposable;
+import com.badlogic.gdx.utils.GdxRuntimeException;
 import com.badlogic.gdx.utils.ObjectIntMap;
 import com.badlogic.gdx.utils.ObjectMap;
 

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/ShaderProgram.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/ShaderProgram.java
@@ -35,7 +35,6 @@ import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.BufferUtils;
 import com.badlogic.gdx.utils.Disposable;
-import com.badlogic.gdx.utils.GdxRuntimeException;
 import com.badlogic.gdx.utils.ObjectIntMap;
 import com.badlogic.gdx.utils.ObjectMap;
 
@@ -308,7 +307,7 @@ public class ShaderProgram implements Disposable {
 			location = gl.glGetUniformLocation(program, name);
 			if (location == -1 && pedantic) {
 				if (isCompiled) throw new IllegalArgumentException("no uniform with name '" + name + "' in shader");
-				else throw new GdxRuntimeException("An attempted fetch uniform from uncompiled shader \n" + getLog());
+				throw new IllegalStateException("An attempted fetch uniform from uncompiled shader \n" + getLog());
 			}
 			uniforms.put(name, location);
 		}


### PR DESCRIPTION
Better error message in ShaderProgam class.

When programming shaders, I use visual code studio to program shaders. The issue with visual code studio it doesn't have OpenGL ES error checking or "Code language not supported or defined". When saving the shader file to asset folder with a typo or syntax error, then run the game and a misleading exception "no uniform with the name" show on console log and close the game - this creates confusing from programmer checking the variable is correct without realizing there is an error when compiling the shader, it happens to me once and with a new exception would prevent from happening who using a text editor like visual code studio.