### PR TITLE
Minor changes to MeshBuilder and Color and interfaces.

### DIFF
--- a/gdx/src/com/badlogic/gdx/Screen.java
+++ b/gdx/src/com/badlogic/gdx/Screen.java
@@ -16,8 +16,6 @@
 
 package com.badlogic.gdx;
 
-import com.badlogic.gdx.utils.Disposable;
-
 /** <p>
  * Represents one of many application screens, such as a main menu, a settings menu, the game screen and so on.
  * </p>
@@ -25,7 +23,7 @@ import com.badlogic.gdx.utils.Disposable;
  * Note that {@link #dispose()} is not called automatically.
  * </p>
  * @see Game */
-public interface Screen extends Disposable {
+public interface Screen {
 	
 	/** Called when this screen becomes the current screen for a {@link Game}. */
 	public void show ();
@@ -47,6 +45,5 @@ public interface Screen extends Disposable {
 	public void hide ();
 
 	/** Called when this screen should release all resources. */
-	@Override
 	public void dispose ();
 }

--- a/gdx/src/com/badlogic/gdx/Screen.java
+++ b/gdx/src/com/badlogic/gdx/Screen.java
@@ -16,6 +16,8 @@
 
 package com.badlogic.gdx;
 
+import com.badlogic.gdx.utils.Disposable;
+
 /** <p>
  * Represents one of many application screens, such as a main menu, a settings menu, the game screen and so on.
  * </p>
@@ -23,7 +25,7 @@ package com.badlogic.gdx;
  * Note that {@link #dispose()} is not called automatically.
  * </p>
  * @see Game */
-public interface Screen {
+public interface Screen extends Disposable {
 	
 	/** Called when this screen becomes the current screen for a {@link Game}. */
 	public void show ();
@@ -45,5 +47,6 @@ public interface Screen {
 	public void hide ();
 
 	/** Called when this screen should release all resources. */
+	@Override
 	public void dispose ();
 }

--- a/gdx/src/com/badlogic/gdx/graphics/Color.java
+++ b/gdx/src/com/badlogic/gdx/graphics/Color.java
@@ -312,8 +312,7 @@ public class Color {
 	 * from 0-255 to 0-254 to avoid using float bits in the NaN range (see {@link NumberUtils#intToFloatColor(int)}).
 	 * @return the packed color as a 32-bit float */
 	public float toFloatBits () {
-		int color = ((int)(255 * a) << 24) | ((int)(255 * b) << 16) | ((int)(255 * g) << 8) | ((int)(255 * r));
-		return NumberUtils.intToFloatColor(color);
+		return NumberUtils.intToFloatColor(toIntBits());
 	}
 
 	/** Packs the color components into a 32-bit integer with the format ABGR.
@@ -324,8 +323,7 @@ public class Color {
 
 	/** Returns the color encoded as hex string with the format RRGGBBAA. */
 	public String toString () {
-		String value = Integer
-			.toHexString(((int)(255 * r) << 24) | ((int)(255 * g) << 16) | ((int)(255 * b) << 8) | ((int)(255 * a)));
+		String value = Integer.toHexString(toIntBits());
 		while (value.length() < 8)
 			value = "0" + value;
 		return value;
@@ -352,8 +350,7 @@ public class Color {
 	 * @see NumberUtils#intToFloatColor(int) */
 	public static float toFloatBits (int r, int g, int b, int a) {
 		int color = (a << 24) | (b << 16) | (g << 8) | r;
-		float floatColor = NumberUtils.intToFloatColor(color);
-		return floatColor;
+		return NumberUtils.intToFloatColor(color);
 	}
 
 	/** Packs the color components into a 32-bit integer with the format ABGR and then converts it to a float.

--- a/gdx/src/com/badlogic/gdx/graphics/Color.java
+++ b/gdx/src/com/badlogic/gdx/graphics/Color.java
@@ -323,7 +323,8 @@ public class Color {
 
 	/** Returns the color encoded as hex string with the format RRGGBBAA. */
 	public String toString () {
-		String value = Integer.toHexString(toIntBits());
+		String value = Integer
+			.toHexString(((int)(255 * r) << 24) | ((int)(255 * g) << 16) | ((int)(255 * b) << 8) | ((int)(255 * a)));
 		while (value.length() < 8)
 			value = "0" + value;
 		return value;

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/utils/MeshBuilder.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/utils/MeshBuilder.java
@@ -43,8 +43,6 @@ import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.FloatArray;
 import com.badlogic.gdx.utils.GdxRuntimeException;
 import com.badlogic.gdx.utils.IntIntMap;
-import com.badlogic.gdx.utils.NumberUtils;
-import com.badlogic.gdx.utils.Pool;
 import com.badlogic.gdx.utils.ShortArray;
 
 /** Class to construct a mesh, optionally splitting it into one or more mesh parts. Before you can call any other method you must
@@ -557,8 +555,8 @@ public class MeshBuilder implements MeshPartBuilder {
 			vertex[colOffset + 2] = col.b;
 			if (colSize > 3) vertex[colOffset + 3] = col.a;
 		} else if (cpOffset > 0) {
-			if (col == null) col = Color.WHITE;
-			vertex[cpOffset] = col.toFloatBits(); // FIXME cache packed color?
+			if (col == null) vertex[cpOffset] = Color.WHITE_FLOAT_BITS;
+			else vertex[cpOffset] = col.toFloatBits();
 		}
 
 		if (uv != null && uvOffset >= 0) {

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/ImmediateModeRenderer.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/ImmediateModeRenderer.java
@@ -18,8 +18,9 @@ package com.badlogic.gdx.graphics.glutils;
 
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.math.Matrix4;
+import com.badlogic.gdx.utils.Disposable;
 
-public interface ImmediateModeRenderer {
+public interface ImmediateModeRenderer extends Disposable {
 	public void begin (Matrix4 projModelView, int primitiveType);
 
 	public void flush ();
@@ -41,6 +42,4 @@ public interface ImmediateModeRenderer {
 	public int getNumVertices ();
 
 	public int getMaxVertices ();
-
-	public void dispose ();
 }

--- a/gdx/src/com/badlogic/gdx/math/GridPoint3.java
+++ b/gdx/src/com/badlogic/gdx/math/GridPoint3.java
@@ -18,7 +18,7 @@ package com.badlogic.gdx.math;
 
 import java.io.Serializable;
 
-/** A point in a 3D grid, with integer x and y coordinates
+/** A point in a 3D grid, with integer x, y and z coordinates
  * 
  * @author badlogic */
 public class GridPoint3 implements Serializable {


### PR DESCRIPTION
Added extended Disposable in ImmediateModeRenderer and Screen interface; for reason. - I found out how useful the Disposable interface is. 

Added missing Z-Axis in the comment. And removed 2 unused imports and FIXME comment, for FIXME comment "cache packed color?" - no, these are no efficient way to cache packed color in MeshBuilder, according to from my closed pull request (the second and last reply): #5772. And also a minor change in the vertex method.

Minor changes to Color class for readability.