### PR TITLE
Removed "evt.target.style.cursor" lines from default index.html

### DIFF
--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/html/war/index
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/html/war/index
@@ -22,14 +22,12 @@
               function handleMouseDown(evt) {
                 evt.preventDefault();
                 evt.stopPropagation();
-                evt.target.style.cursor = 'default';
                 window.focus();
               }
 
               function handleMouseUp(evt) {
                 evt.preventDefault();
                 evt.stopPropagation();
-                evt.target.style.cursor = '';
               }
               document.getElementById('embed-html').addEventListener('mousedown', handleMouseDown, false);
               document.getElementById('embed-html').addEventListener('mouseup', handleMouseUp, false);


### PR DESCRIPTION
Removed "evt.target.style.cursor" lines from default index.html because they are unnecessary. These lines interfere with custom cursors set during runtime (the default arrow always comes back when the user clicks the game).