### PR TITLE
Have Flame store 3d particle texture atlas into save file

### DIFF
--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/FlameMain.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/FlameMain.java
@@ -198,7 +198,7 @@ public class FlameMain extends JFrame implements AssetErrorListener {
 	AppRenderer renderer;
 	AssetManager assetManager;
 	JComboBox influencerBox;
-	String atlasFilename;
+	TextureAtlas textureAtlas;
 
 	private ParticleEffect effect;
 	/** READ only */
@@ -895,9 +895,8 @@ public class FlameMain extends JFrame implements AssetErrorListener {
 	public ModelInstanceParticleBatch getModelInstanceParticleBatch () {
 		return renderer.modelInstanceParticleBatch;
 	}
-	public void setAtlas(TextureAtlas atlas, String atlasFilename) {
-                this.atlasFilename = atlasFilename;
-		//currentAtlas = atlas;
+	public void setAtlas(TextureAtlas atlas) {
+		this.textureAtlas = atlas;
 		setTexture(atlas.getTextures().first());
 	}
 	
@@ -923,9 +922,12 @@ public class FlameMain extends JFrame implements AssetErrorListener {
 		return getAtlas(renderer.billboardBatch.getTexture());
 	}
 
-        public String getAtlasFilename() {
-            return atlasFilename;
-        }
+	public String getAtlasFilename() {
+		if (textureAtlas == null) {
+			return null;
+		}
+		return assetManager.getAssetFileName(textureAtlas);
+	}
 	
 	public boolean isUsingDefaultTexture () {
 		return renderer.billboardBatch.getTexture() == assetManager.get(DEFAULT_BILLBOARD_PARTICLE, Texture.class);

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/FlameMain.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/FlameMain.java
@@ -198,7 +198,8 @@ public class FlameMain extends JFrame implements AssetErrorListener {
 	AppRenderer renderer;
 	AssetManager assetManager;
 	JComboBox influencerBox;
-	
+	String atlasFilename;
+
 	private ParticleEffect effect;
 	/** READ only */
 	public Array<ControllerData> controllersData;
@@ -894,8 +895,8 @@ public class FlameMain extends JFrame implements AssetErrorListener {
 	public ModelInstanceParticleBatch getModelInstanceParticleBatch () {
 		return renderer.modelInstanceParticleBatch;
 	}
-	
-	public void setAtlas(TextureAtlas atlas){
+	public void setAtlas(TextureAtlas atlas, String atlasFilename) {
+                this.atlasFilename = atlasFilename;
 		//currentAtlas = atlas;
 		setTexture(atlas.getTextures().first());
 	}
@@ -921,6 +922,10 @@ public class FlameMain extends JFrame implements AssetErrorListener {
 	public TextureAtlas getAtlas(){
 		return getAtlas(renderer.billboardBatch.getTexture());
 	}
+
+        public String getAtlasFilename() {
+            return atlasFilename;
+        }
 	
 	public boolean isUsingDefaultTexture () {
 		return renderer.billboardBatch.getTexture() == assetManager.get(DEFAULT_BILLBOARD_PARTICLE, Texture.class);

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/RegionInfluencerPanel.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/RegionInfluencerPanel.java
@@ -68,7 +68,8 @@ public class RegionInfluencerPanel extends InfluencerPanel<RegionInfluencer> imp
 		regionSelectDialog.setVisible(false);
 		if(regions.size == 0) return;
 		value.clear();
-		value.add(atlasName, (TextureRegion[])regions.toArray(TextureRegion.class));
+		value.setAtlasName(atlasName);
+		value.add((TextureRegion[])regions.toArray(TextureRegion.class));
 		editor.setTexture(regions.get(0).getTexture());
 		editor.restart();
 	}

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/RegionInfluencerPanel.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/RegionInfluencerPanel.java
@@ -47,8 +47,9 @@ public class RegionInfluencerPanel extends InfluencerPanel<RegionInfluencer> imp
 				}
 				
 				TextureAtlas atlas = editor.getAtlas();
+				String atlasFilename = editor.getAtlasFilename();
 				if(atlas != null)
-					regionPickerPanel.setAtlas(atlas);
+					regionPickerPanel.setAtlas(atlas, atlasFilename);
 				else 
 					regionPickerPanel.setTexture(editor.getTexture());
 				
@@ -63,11 +64,11 @@ public class RegionInfluencerPanel extends InfluencerPanel<RegionInfluencer> imp
 	}
 
 	@Override
-	public void onRegionsSelected (Array<TextureRegion> regions) {
+	public void onRegionsSelected (Array<TextureRegion> regions, String atlasName) {
 		regionSelectDialog.setVisible(false);
 		if(regions.size == 0) return;
 		value.clear();
-		value.add((TextureRegion[])regions.toArray(TextureRegion.class));
+		value.add(atlasName, (TextureRegion[])regions.toArray(TextureRegion.class));
 		editor.setTexture(regions.get(0).getTexture());
 		editor.restart();
 	}

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/RegionPickerPanel.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/RegionPickerPanel.java
@@ -35,7 +35,7 @@ public class RegionPickerPanel extends JPanel{
 	}
 	
 	public interface Listener{
-		void onRegionsSelected(Array<TextureRegion> regions);
+		void onRegionsSelected(Array<TextureRegion> regions, String atlasFilename);
 	}
 	
 	TextureAtlasPanel atlasPanel;
@@ -109,7 +109,8 @@ public class RegionPickerPanel extends JPanel{
 			public void actionPerformed (ActionEvent arg0) {
 				JPanel panel = ((CustomCardLayout)content.getLayout()).getCurrentCard(content);
 				TexturePanel currentTexturePanel = panel == atlasPanel ? atlasPanel.getCurrentRegionPanel() : texturePanel;
-				listener.onRegionsSelected(currentTexturePanel.selectedRegions);
+				String atlasName = panel == atlasPanel ? atlasPanel.getAtlasName() : null;
+				listener.onRegionsSelected(currentTexturePanel.selectedRegions, atlasName);
 			}
 		});
 		
@@ -178,9 +179,9 @@ public class RegionPickerPanel extends JPanel{
 		}
 	}
 
-	public void setAtlas (TextureAtlas atlas) {
+	public void setAtlas(TextureAtlas atlas, String atlasFilename) {
 		atlasPanel.clearSelection();
-		atlasPanel.setAtlas(atlas);
+		atlasPanel.setAtlas(atlas, atlasFilename);
 		CustomCardLayout cardLayout = (CustomCardLayout)content.getLayout();
 		cardLayout.show(content, "atlas");
 		showGenerationPanel(false);

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/TextureAtlasPanel.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/TextureAtlasPanel.java
@@ -21,6 +21,7 @@ import com.badlogic.gdx.utils.Array;
 public class TextureAtlasPanel extends JPanel {
 	JPanel regionsPanel;
 	TextureAtlas atlas;
+	String atlasFilename;
 	
 	public TextureAtlasPanel(){
 		initializeComponents();
@@ -58,7 +59,7 @@ public class TextureAtlasPanel extends JPanel {
 		});	
 	}
 	
-	public void setAtlas(TextureAtlas atlas){
+       public void setAtlas(TextureAtlas atlas, String atlasFilename){
 		if(atlas == this.atlas) return;
 		regionsPanel.removeAll();
 		 Array<AtlasRegion> atlasRegions = atlas.getRegions();
@@ -70,6 +71,10 @@ public class TextureAtlasPanel extends JPanel {
 		}
 		layout.first(regionsPanel);
 		this.atlas = atlas;
+		this.atlasFilename = atlasFilename;
+	}
+	public String getAtlasName() {
+		return atlasFilename;
 	}
 	
 	protected Array<TextureRegion> getRegions (Texture texture, Array<AtlasRegion> atlasRegions, Array<TextureRegion> out) {

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/TextureLoaderPanel.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/TextureLoaderPanel.java
@@ -53,7 +53,7 @@ public class TextureLoaderPanel extends EditorPanel {
 				if(file != null){
 					TextureAtlas atlas = editor.load(file.getAbsolutePath(), TextureAtlas.class, null,  null);
 					if(atlas != null){
-						editor.setAtlas(atlas, file.getName());
+						editor.setAtlas(atlas, file.getAbsolutePath());
 					}
 				}
 			}

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/TextureLoaderPanel.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/TextureLoaderPanel.java
@@ -53,7 +53,7 @@ public class TextureLoaderPanel extends EditorPanel {
 				if(file != null){
 					TextureAtlas atlas = editor.load(file.getAbsolutePath(), TextureAtlas.class, null,  null);
 					if(atlas != null){
-						editor.setAtlas(atlas, file.getAbsolutePath());
+						editor.setAtlas(atlas);
 					}
 				}
 			}

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/TextureLoaderPanel.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/TextureLoaderPanel.java
@@ -53,7 +53,7 @@ public class TextureLoaderPanel extends EditorPanel {
 				if(file != null){
 					TextureAtlas atlas = editor.load(file.getAbsolutePath(), TextureAtlas.class, null,  null);
 					if(atlas != null){
-						editor.setAtlas(atlas);
+						editor.setAtlas(atlas, file.getName());
 					}
 				}
 			}

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/particles/influencers/RegionInfluencer.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/particles/influencers/RegionInfluencer.java
@@ -217,9 +217,9 @@ public abstract class RegionInfluencer extends Influencer {
 
 	/** All the regions must be defined on the same Texture */
 	public RegionInfluencer (TextureRegion... regions) {
+		setAtlasName(null);
 		this.regions = new Array<AspectTextureRegion>(false, regions.length, AspectTextureRegion.class);
-		String atlasName = null;
-		add(atlasName, regions);
+		add(regions);
 	}
 
 	public RegionInfluencer (Texture texture) {
@@ -233,9 +233,10 @@ public abstract class RegionInfluencer extends Influencer {
 			regions.add(new AspectTextureRegion((AspectTextureRegion)regionInfluencer.regions.get(i)));
 		}
 	}
-
-	public void add (String atlasName, TextureRegion... regions) {
+	public void setAtlasName (String atlasName) {
 		this.atlasName = atlasName;
+	}
+	public void add (TextureRegion... regions) {
 		this.regions.ensureCapacity(regions.length);
 		for (TextureRegion region : regions) {
 			this.regions.add(new AspectTextureRegion(region));
@@ -243,12 +244,13 @@ public abstract class RegionInfluencer extends Influencer {
 	}
 
 	public void clear () {
+		atlasName = null;
 		regions.clear();
 	}
-
+	private final static String ASSET_DATA = "atlasAssetData";
 	@Override
 	public void load (AssetManager manager, ResourceData resources) {
-		SaveData data = resources.getSaveData("atlasAssetData");
+		SaveData data = resources.getSaveData(ASSET_DATA);
 		if (data == null) {
 			return;
 		}
@@ -262,9 +264,9 @@ public abstract class RegionInfluencer extends Influencer {
 	@Override
 	public void save (AssetManager manager, ResourceData resources) {
 		if (atlasName != null) {
-			SaveData data = resources.getSaveData("atlasAssetData");
+			SaveData data = resources.getSaveData(ASSET_DATA);
 			if (data == null) {
-				data = resources.createSaveData("atlasAssetData");
+				data = resources.createSaveData(ASSET_DATA);
                         }
 			data.saveAsset(atlasName, TextureAtlas.class);
 		}

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/particles/influencers/RegionInfluencer.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/particles/influencers/RegionInfluencer.java
@@ -262,7 +262,10 @@ public abstract class RegionInfluencer extends Influencer {
 	@Override
 	public void save (AssetManager manager, ResourceData resources) {
 		if (atlasName != null) {
-			SaveData data = resources.createSaveData("atlasAssetData");
+			SaveData data = resources.getSaveData("atlasAssetData");
+			if (data == null) {
+				data = resources.createSaveData("atlasAssetData");
+                        }
 			data.saveAsset(atlasName, TextureAtlas.class);
 		}
 		super.save(manager, resources);

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/particles/influencers/RegionInfluencer.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/particles/influencers/RegionInfluencer.java
@@ -250,6 +250,7 @@ public abstract class RegionInfluencer extends Influencer {
 	private final static String ASSET_DATA = "atlasAssetData";
 	@Override
 	public void load (AssetManager manager, ResourceData resources) {
+		super.load(manager, resources);
 		SaveData data = resources.getSaveData(ASSET_DATA);
 		if (data == null) {
 			return;
@@ -259,10 +260,10 @@ public abstract class RegionInfluencer extends Influencer {
 		for (AspectTextureRegion atr : regions) {
 			atr.updateUV(atlas);
 		}
-		super.load(manager, resources);
 	}
 	@Override
 	public void save (AssetManager manager, ResourceData resources) {
+		super.save(manager, resources);
 		if (atlasName != null) {
 			SaveData data = resources.getSaveData(ASSET_DATA);
 			if (data == null) {
@@ -270,7 +271,6 @@ public abstract class RegionInfluencer extends Influencer {
                         }
 			data.saveAsset(atlasName, TextureAtlas.class);
 		}
-		super.save(manager, resources);
 	}
 	@Override
 	public void allocateChannels () {


### PR DESCRIPTION
make it so that in the 3d particle effect editor (Flame), if a texture region

is used, the name of the sub-image (region) is stored. This makes it so that if a texture atlas is updated, the uv-coordinates of the region can be read from the atlas rather than having the uv coordinates stored in the particle effect save file.