### PR TITLE
Update LWJGL3 backend to 3.2.3.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+[1.9.11]
+- Update to LWJGL 3.2.3
+
 [1.9.10]
 - API Addition: Allow target display for maximization LWJGL3 backend
 - API Addition: Accelerometer support on GWT

--- a/backends/gdx-backend-lwjgl3/.classpath
+++ b/backends/gdx-backend-lwjgl3/.classpath
@@ -11,29 +11,47 @@
 	<classpathentry exported="true" kind="lib" path="libs/jorbis.jar"/>
 	<classpathentry exported="true" kind="lib" path="libs/lwjgl.jar"/>
 	<classpathentry exported="true" kind="lib" path="libs/lwjgl-natives-linux.jar"/>
+	<classpathentry exported="true" kind="lib" path="libs/lwjgl-natives-linux-arm32.jar"/>
+	<classpathentry exported="true" kind="lib" path="libs/lwjgl-natives-linux-arm64.jar"/>
 	<classpathentry exported="true" kind="lib" path="libs/lwjgl-natives-macos.jar"/>
 	<classpathentry exported="true" kind="lib" path="libs/lwjgl-natives-windows.jar"/>
+	<classpathentry exported="true" kind="lib" path="libs/lwjgl-natives-windows-x86.jar"/>
 	<classpathentry exported="true" kind="lib" path="libs/lwjgl-glfw.jar"/>
 	<classpathentry exported="true" kind="lib" path="libs/lwjgl-glfw-natives-linux.jar"/>
+	<classpathentry exported="true" kind="lib" path="libs/lwjgl-glfw-natives-linux-arm32.jar"/>
+	<classpathentry exported="true" kind="lib" path="libs/lwjgl-glfw-natives-linux-arm64.jar"/>
 	<classpathentry exported="true" kind="lib" path="libs/lwjgl-glfw-natives-macos.jar"/>
 	<classpathentry exported="true" kind="lib" path="libs/lwjgl-glfw-natives-windows.jar"/>
+	<classpathentry exported="true" kind="lib" path="libs/lwjgl-glfw-natives-windows-x86.jar"/>
 	<classpathentry exported="true" kind="lib" path="libs/lwjgl-jemalloc.jar"/>
 	<classpathentry exported="true" kind="lib" path="libs/lwjgl-jemalloc-natives-linux.jar"/>
+	<classpathentry exported="true" kind="lib" path="libs/lwjgl-jemalloc-natives-linux-arm32.jar"/>
+	<classpathentry exported="true" kind="lib" path="libs/lwjgl-jemalloc-natives-linux-arm64.jar"/>
 	<classpathentry exported="true" kind="lib" path="libs/lwjgl-jemalloc-natives-macos.jar"/>
 	<classpathentry exported="true" kind="lib" path="libs/lwjgl-jemalloc-natives-windows.jar"/>
+	<classpathentry exported="true" kind="lib" path="libs/lwjgl-jemalloc-natives-windows-x86.jar"/>
 	<classpathentry exported="true" kind="lib" path="libs/lwjgl-openal.jar"/>
 	<classpathentry exported="true" kind="lib" path="libs/lwjgl-openal-natives-linux.jar"/>
+	<classpathentry exported="true" kind="lib" path="libs/lwjgl-openal-natives-linux-arm32.jar"/>
+	<classpathentry exported="true" kind="lib" path="libs/lwjgl-openal-natives-linux-arm64.jar"/>
 	<classpathentry exported="true" kind="lib" path="libs/lwjgl-openal-natives-macos.jar"/>
 	<classpathentry exported="true" kind="lib" path="libs/lwjgl-openal-natives-windows.jar"/>
+	<classpathentry exported="true" kind="lib" path="libs/lwjgl-openal-natives-windows-x86.jar"/>
 	<classpathentry exported="true" kind="lib" path="libs/lwjgl-opengl.jar"/>
 	<classpathentry exported="true" kind="lib" path="libs/lwjgl-opengl-natives-linux.jar"/>
+	<classpathentry exported="true" kind="lib" path="libs/lwjgl-opengl-natives-linux-arm32.jar"/>
+	<classpathentry exported="true" kind="lib" path="libs/lwjgl-opengl-natives-linux-arm64.jar"/>
 	<classpathentry exported="true" kind="lib" path="libs/lwjgl-opengl-natives-macos.jar"/>
 	<classpathentry exported="true" kind="lib" path="libs/lwjgl-opengl-natives-windows.jar"/>
+	<classpathentry exported="true" kind="lib" path="libs/lwjgl-opengl-natives-windows-x86.jar"/>
 	<classpathentry exported="true" kind="lib" path="libs/lwjgl-stb.jar"/>
 	<classpathentry exported="true" kind="lib" path="libs/lwjgl-stb-natives-linux.jar"/>
+	<classpathentry exported="true" kind="lib" path="libs/lwjgl-stb-natives-linux-arm32.jar"/>
+	<classpathentry exported="true" kind="lib" path="libs/lwjgl-stb-natives-linux-arm64.jar"/>
 	<classpathentry exported="true" kind="lib" path="libs/lwjgl-stb-natives-macos.jar"/>
 	<classpathentry combineaccessrules="false" exported="true" kind="src" path="/gdx"/>
 	<classpathentry exported="true" kind="lib" path="libs/AppleJavaExtensions-1.4.jar"/>
 	<classpathentry exported="true" kind="lib" path="libs/lwjgl-stb-natives-windows.jar"/>
+	<classpathentry exported="true" kind="lib" path="libs/lwjgl-stb-natives-windows-x86.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/backends/gdx-backend-lwjgl3/pom.xml
+++ b/backends/gdx-backend-lwjgl3/pom.xml
@@ -36,7 +36,28 @@
       <groupId>org.lwjgl</groupId>
       <artifactId>lwjgl</artifactId>
       <version>${lwjgl3.version}</version>
+      <classifier>natives-windows-x86</classifier>
+    </dependency>
+
+    <dependency>
+      <groupId>org.lwjgl</groupId>
+      <artifactId>lwjgl</artifactId>
+      <version>${lwjgl3.version}</version>
       <classifier>natives-linux</classifier>
+    </dependency>
+
+    <dependency>
+      <groupId>org.lwjgl</groupId>
+      <artifactId>lwjgl</artifactId>
+      <version>${lwjgl3.version}</version>
+      <classifier>natives-linux-arm32</classifier>
+    </dependency>
+
+    <dependency>
+      <groupId>org.lwjgl</groupId>
+      <artifactId>lwjgl</artifactId>
+      <version>${lwjgl3.version}</version>
+      <classifier>natives-linux-arm64</classifier>
     </dependency>
 
     <dependency>
@@ -63,7 +84,28 @@
       <groupId>org.lwjgl</groupId>
       <artifactId>lwjgl-glfw</artifactId>
       <version>${lwjgl3.version}</version>
+      <classifier>natives-windows-x86</classifier>
+    </dependency>
+
+    <dependency>
+      <groupId>org.lwjgl</groupId>
+      <artifactId>lwjgl-glfw</artifactId>
+      <version>${lwjgl3.version}</version>
       <classifier>natives-linux</classifier>
+    </dependency>
+
+    <dependency>
+      <groupId>org.lwjgl</groupId>
+      <artifactId>lwjgl-glfw</artifactId>
+      <version>${lwjgl3.version}</version>
+      <classifier>natives-linux-arm32</classifier>
+    </dependency>
+
+    <dependency>
+      <groupId>org.lwjgl</groupId>
+      <artifactId>lwjgl-glfw</artifactId>
+      <version>${lwjgl3.version}</version>
+      <classifier>natives-linux-arm64</classifier>
     </dependency>
 
     <dependency>
@@ -90,7 +132,28 @@
       <groupId>org.lwjgl</groupId>
       <artifactId>lwjgl-jemalloc</artifactId>
       <version>${lwjgl3.version}</version>
+      <classifier>natives-windows-x86</classifier>
+    </dependency>
+
+    <dependency>
+      <groupId>org.lwjgl</groupId>
+      <artifactId>lwjgl-jemalloc</artifactId>
+      <version>${lwjgl3.version}</version>
       <classifier>natives-linux</classifier>
+    </dependency>
+
+    <dependency>
+      <groupId>org.lwjgl</groupId>
+      <artifactId>lwjgl-jemalloc</artifactId>
+      <version>${lwjgl3.version}</version>
+      <classifier>natives-linux-arm32</classifier>
+    </dependency>
+
+    <dependency>
+      <groupId>org.lwjgl</groupId>
+      <artifactId>lwjgl-jemalloc</artifactId>
+      <version>${lwjgl3.version}</version>
+      <classifier>natives-linux-arm64</classifier>
     </dependency>
 
     <dependency>
@@ -117,7 +180,28 @@
       <groupId>org.lwjgl</groupId>
       <artifactId>lwjgl-opengl</artifactId>
       <version>${lwjgl3.version}</version>
+      <classifier>natives-windows-x86</classifier>
+    </dependency>
+
+    <dependency>
+      <groupId>org.lwjgl</groupId>
+      <artifactId>lwjgl-opengl</artifactId>
+      <version>${lwjgl3.version}</version>
       <classifier>natives-linux</classifier>
+    </dependency>
+
+    <dependency>
+      <groupId>org.lwjgl</groupId>
+      <artifactId>lwjgl-opengl</artifactId>
+      <version>${lwjgl3.version}</version>
+      <classifier>natives-linux-arm32</classifier>
+    </dependency>
+
+    <dependency>
+      <groupId>org.lwjgl</groupId>
+      <artifactId>lwjgl-opengl</artifactId>
+      <version>${lwjgl3.version}</version>
+      <classifier>natives-linux-arm64</classifier>
     </dependency>
 
     <dependency>
@@ -144,7 +228,28 @@
       <groupId>org.lwjgl</groupId>
       <artifactId>lwjgl-openal</artifactId>
       <version>${lwjgl3.version}</version>
+      <classifier>natives-windows-x86</classifier>
+    </dependency>
+
+    <dependency>
+      <groupId>org.lwjgl</groupId>
+      <artifactId>lwjgl-openal</artifactId>
+      <version>${lwjgl3.version}</version>
       <classifier>natives-linux</classifier>
+    </dependency>
+
+    <dependency>
+      <groupId>org.lwjgl</groupId>
+      <artifactId>lwjgl-openal</artifactId>
+      <version>${lwjgl3.version}</version>
+      <classifier>natives-linux-arm32</classifier>
+    </dependency>
+
+    <dependency>
+      <groupId>org.lwjgl</groupId>
+      <artifactId>lwjgl-openal</artifactId>
+      <version>${lwjgl3.version}</version>
+      <classifier>natives-linux-arm64</classifier>
     </dependency>
 
     <dependency>

--- a/fetch.xml
+++ b/fetch.xml
@@ -19,33 +19,51 @@
         <!-- lwjgl -->
         <get src="${lwjgl}/lwjgl/${lwjgl-version}/lwjgl-${lwjgl-version}.jar" dest="backends/gdx-backend-lwjgl3/libs/lwjgl.jar"/>
         <get src="${lwjgl}/lwjgl/${lwjgl-version}/lwjgl-${lwjgl-version}-natives-linux.jar" dest="backends/gdx-backend-lwjgl3/libs/lwjgl-natives-linux.jar"/>
+        <get src="${lwjgl}/lwjgl/${lwjgl-version}/lwjgl-${lwjgl-version}-natives-linux-arm32.jar" dest="backends/gdx-backend-lwjgl3/libs/lwjgl-natives-linux-arm32.jar"/>
+        <get src="${lwjgl}/lwjgl/${lwjgl-version}/lwjgl-${lwjgl-version}-natives-linux-arm64.jar" dest="backends/gdx-backend-lwjgl3/libs/lwjgl-natives-linux-arm64.jar"/>
         <get src="${lwjgl}/lwjgl/${lwjgl-version}/lwjgl-${lwjgl-version}-natives-macos.jar" dest="backends/gdx-backend-lwjgl3/libs/lwjgl-natives-macos.jar"/>
         <get src="${lwjgl}/lwjgl/${lwjgl-version}/lwjgl-${lwjgl-version}-natives-windows.jar" dest="backends/gdx-backend-lwjgl3/libs/lwjgl-natives-windows.jar"/>
+        <get src="${lwjgl}/lwjgl/${lwjgl-version}/lwjgl-${lwjgl-version}-natives-windows-x86.jar" dest="backends/gdx-backend-lwjgl3/libs/lwjgl-natives-windows-x86.jar"/>
         <!-- lwjgl-glfw -->
         <get src="${lwjgl}/lwjgl-glfw/${lwjgl-version}/lwjgl-glfw-${lwjgl-version}.jar" dest="backends/gdx-backend-lwjgl3/libs/lwjgl-glfw.jar"/>
         <get src="${lwjgl}/lwjgl-glfw/${lwjgl-version}/lwjgl-glfw-${lwjgl-version}-natives-linux.jar" dest="backends/gdx-backend-lwjgl3/libs/lwjgl-glfw-natives-linux.jar"/>
+        <get src="${lwjgl}/lwjgl-glfw/${lwjgl-version}/lwjgl-glfw-${lwjgl-version}-natives-linux-arm32.jar" dest="backends/gdx-backend-lwjgl3/libs/lwjgl-glfw-natives-linux-arm32.jar"/>
+        <get src="${lwjgl}/lwjgl-glfw/${lwjgl-version}/lwjgl-glfw-${lwjgl-version}-natives-linux-arm64.jar" dest="backends/gdx-backend-lwjgl3/libs/lwjgl-glfw-natives-linux-arm64.jar"/>
         <get src="${lwjgl}/lwjgl-glfw/${lwjgl-version}/lwjgl-glfw-${lwjgl-version}-natives-macos.jar" dest="backends/gdx-backend-lwjgl3/libs/lwjgl-glfw-natives-macos.jar"/>
         <get src="${lwjgl}/lwjgl-glfw/${lwjgl-version}/lwjgl-glfw-${lwjgl-version}-natives-windows.jar" dest="backends/gdx-backend-lwjgl3/libs/lwjgl-glfw-natives-windows.jar"/>
+        <get src="${lwjgl}/lwjgl-glfw/${lwjgl-version}/lwjgl-glfw-${lwjgl-version}-natives-windows-x86.jar" dest="backends/gdx-backend-lwjgl3/libs/lwjgl-glfw-natives-windows-x86.jar"/>
         <!-- lwjgl-jemalloc -->
         <get src="${lwjgl}/lwjgl-jemalloc/${lwjgl-version}/lwjgl-jemalloc-${lwjgl-version}.jar" dest="backends/gdx-backend-lwjgl3/libs/lwjgl-jemalloc.jar"/>
         <get src="${lwjgl}/lwjgl-jemalloc/${lwjgl-version}/lwjgl-jemalloc-${lwjgl-version}-natives-linux.jar" dest="backends/gdx-backend-lwjgl3/libs/lwjgl-jemalloc-natives-linux.jar"/>
+        <get src="${lwjgl}/lwjgl-jemalloc/${lwjgl-version}/lwjgl-jemalloc-${lwjgl-version}-natives-linux-arm32.jar" dest="backends/gdx-backend-lwjgl3/libs/lwjgl-jemalloc-natives-linux-arm32.jar"/>
+        <get src="${lwjgl}/lwjgl-jemalloc/${lwjgl-version}/lwjgl-jemalloc-${lwjgl-version}-natives-linux-arm64.jar" dest="backends/gdx-backend-lwjgl3/libs/lwjgl-jemalloc-natives-linux-arm64.jar"/>
         <get src="${lwjgl}/lwjgl-jemalloc/${lwjgl-version}/lwjgl-jemalloc-${lwjgl-version}-natives-macos.jar" dest="backends/gdx-backend-lwjgl3/libs/lwjgl-jemalloc-natives-macos.jar"/>
         <get src="${lwjgl}/lwjgl-jemalloc/${lwjgl-version}/lwjgl-jemalloc-${lwjgl-version}-natives-windows.jar" dest="backends/gdx-backend-lwjgl3/libs/lwjgl-jemalloc-natives-windows.jar"/>
+        <get src="${lwjgl}/lwjgl-jemalloc/${lwjgl-version}/lwjgl-jemalloc-${lwjgl-version}-natives-windows-x86.jar" dest="backends/gdx-backend-lwjgl3/libs/lwjgl-jemalloc-natives-windows-x86.jar"/>
         <!-- lwjgl-openal -->
         <get src="${lwjgl}/lwjgl-openal/${lwjgl-version}/lwjgl-openal-${lwjgl-version}.jar" dest="backends/gdx-backend-lwjgl3/libs/lwjgl-openal.jar"/>
         <get src="${lwjgl}/lwjgl-openal/${lwjgl-version}/lwjgl-openal-${lwjgl-version}-natives-linux.jar" dest="backends/gdx-backend-lwjgl3/libs/lwjgl-openal-natives-linux.jar"/>
+        <get src="${lwjgl}/lwjgl-openal/${lwjgl-version}/lwjgl-openal-${lwjgl-version}-natives-linux-arm32.jar" dest="backends/gdx-backend-lwjgl3/libs/lwjgl-openal-natives-linux-arm32.jar"/>
+        <get src="${lwjgl}/lwjgl-openal/${lwjgl-version}/lwjgl-openal-${lwjgl-version}-natives-linux-arm64.jar" dest="backends/gdx-backend-lwjgl3/libs/lwjgl-openal-natives-linux-arm64.jar"/>
         <get src="${lwjgl}/lwjgl-openal/${lwjgl-version}/lwjgl-openal-${lwjgl-version}-natives-macos.jar" dest="backends/gdx-backend-lwjgl3/libs/lwjgl-openal-natives-macos.jar"/>
         <get src="${lwjgl}/lwjgl-openal/${lwjgl-version}/lwjgl-openal-${lwjgl-version}-natives-windows.jar" dest="backends/gdx-backend-lwjgl3/libs/lwjgl-openal-natives-windows.jar"/>
+        <get src="${lwjgl}/lwjgl-openal/${lwjgl-version}/lwjgl-openal-${lwjgl-version}-natives-windows-x86.jar" dest="backends/gdx-backend-lwjgl3/libs/lwjgl-openal-natives-windows-x86.jar"/>
         <!-- lwjgl-opengl -->
         <get src="${lwjgl}/lwjgl-opengl/${lwjgl-version}/lwjgl-opengl-${lwjgl-version}.jar" dest="backends/gdx-backend-lwjgl3/libs/lwjgl-opengl.jar"/>
         <get src="${lwjgl}/lwjgl-opengl/${lwjgl-version}/lwjgl-opengl-${lwjgl-version}-natives-linux.jar" dest="backends/gdx-backend-lwjgl3/libs/lwjgl-opengl-natives-linux.jar"/>
+        <get src="${lwjgl}/lwjgl-opengl/${lwjgl-version}/lwjgl-opengl-${lwjgl-version}-natives-linux-arm32.jar" dest="backends/gdx-backend-lwjgl3/libs/lwjgl-opengl-natives-linux-arm32.jar"/>
+        <get src="${lwjgl}/lwjgl-opengl/${lwjgl-version}/lwjgl-opengl-${lwjgl-version}-natives-linux-arm64.jar" dest="backends/gdx-backend-lwjgl3/libs/lwjgl-opengl-natives-linux-arm64.jar"/>
         <get src="${lwjgl}/lwjgl-opengl/${lwjgl-version}/lwjgl-opengl-${lwjgl-version}-natives-macos.jar" dest="backends/gdx-backend-lwjgl3/libs/lwjgl-opengl-natives-macos.jar"/>
         <get src="${lwjgl}/lwjgl-opengl/${lwjgl-version}/lwjgl-opengl-${lwjgl-version}-natives-windows.jar" dest="backends/gdx-backend-lwjgl3/libs/lwjgl-opengl-natives-windows.jar"/>
+        <get src="${lwjgl}/lwjgl-opengl/${lwjgl-version}/lwjgl-opengl-${lwjgl-version}-natives-windows-x86.jar" dest="backends/gdx-backend-lwjgl3/libs/lwjgl-opengl-natives-windows-x86.jar"/>
         <!-- lwjgl-stb -->
         <get src="${lwjgl}/lwjgl-stb/${lwjgl-version}/lwjgl-stb-${lwjgl-version}.jar" dest="backends/gdx-backend-lwjgl3/libs/lwjgl-stb.jar"/>
         <get src="${lwjgl}/lwjgl-stb/${lwjgl-version}/lwjgl-stb-${lwjgl-version}-natives-linux.jar" dest="backends/gdx-backend-lwjgl3/libs/lwjgl-stb-natives-linux.jar"/>
+        <get src="${lwjgl}/lwjgl-stb/${lwjgl-version}/lwjgl-stb-${lwjgl-version}-natives-linux-arm32.jar" dest="backends/gdx-backend-lwjgl3/libs/lwjgl-stb-natives-linux-arm32.jar"/>
+        <get src="${lwjgl}/lwjgl-stb/${lwjgl-version}/lwjgl-stb-${lwjgl-version}-natives-linux-arm64.jar" dest="backends/gdx-backend-lwjgl3/libs/lwjgl-stb-natives-linux-arm64.jar"/>
         <get src="${lwjgl}/lwjgl-stb/${lwjgl-version}/lwjgl-stb-${lwjgl-version}-natives-macos.jar" dest="backends/gdx-backend-lwjgl3/libs/lwjgl-stb-natives-macos.jar"/>
         <get src="${lwjgl}/lwjgl-stb/${lwjgl-version}/lwjgl-stb-${lwjgl-version}-natives-windows.jar" dest="backends/gdx-backend-lwjgl3/libs/lwjgl-stb-natives-windows.jar"/>
+        <get src="${lwjgl}/lwjgl-stb/${lwjgl-version}/lwjgl-stb-${lwjgl-version}-natives-windows-x86.jar" dest="backends/gdx-backend-lwjgl3/libs/lwjgl-stb-natives-windows-x86.jar"/>
     </target>
 
     <target name="fetch">

--- a/fetch.xml
+++ b/fetch.xml
@@ -5,7 +5,7 @@
     <property name="robovm-version" value="2.3.6"/>
 
     <property name="lwjgl" value="https://oss.sonatype.org/content/repositories/releases/org/lwjgl"/>
-    <property name="lwjgl-version" value="3.2.1"/>
+    <property name="lwjgl-version" value="3.2.3"/>
 
     <target name="fetch-robovm">
         <mkdir dir="backends/gdx-backend-robovm/libs/"/>

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -26,7 +26,7 @@ versions.gwt = "2.8.2"
 versions.gwtPlugin = "1.0.9"
 versions.jglwf = "1.1"
 versions.lwjgl = "2.9.3"
-versions.lwjgl3 = "3.2.1"
+versions.lwjgl3 = "3.2.3"
 versions.jlayer = "1.0.1-gdx"
 versions.jorbis = "0.0.17"
 versions.junit = "4.11"
@@ -48,28 +48,46 @@ libraries.lwjgl = [
 libraries.lwjgl3 = [
         "org.lwjgl:lwjgl:${versions.lwjgl3}",
         "org.lwjgl:lwjgl:${versions.lwjgl3}:natives-linux",
+        "org.lwjgl:lwjgl:${versions.lwjgl3}:natives-linux-arm32",
+        "org.lwjgl:lwjgl:${versions.lwjgl3}:natives-linux-arm64",
         "org.lwjgl:lwjgl:${versions.lwjgl3}:natives-macos",
         "org.lwjgl:lwjgl:${versions.lwjgl3}:natives-windows",
+        "org.lwjgl:lwjgl:${versions.lwjgl3}:natives-windows-x86",
         "org.lwjgl:lwjgl-glfw:${versions.lwjgl3}",
         "org.lwjgl:lwjgl-glfw:${versions.lwjgl3}:natives-linux",
+        "org.lwjgl:lwjgl-glfw:${versions.lwjgl3}:natives-linux-arm32",
+        "org.lwjgl:lwjgl-glfw:${versions.lwjgl3}:natives-linux-arm64",
         "org.lwjgl:lwjgl-glfw:${versions.lwjgl3}:natives-macos",
         "org.lwjgl:lwjgl-glfw:${versions.lwjgl3}:natives-windows",
+        "org.lwjgl:lwjgl-glfw:${versions.lwjgl3}:natives-windows-x86",
         "org.lwjgl:lwjgl-jemalloc:${versions.lwjgl3}",
         "org.lwjgl:lwjgl-jemalloc:${versions.lwjgl3}:natives-linux",
+        "org.lwjgl:lwjgl-jemalloc:${versions.lwjgl3}:natives-linux-arm32",
+        "org.lwjgl:lwjgl-jemalloc:${versions.lwjgl3}:natives-linux-arm64",
         "org.lwjgl:lwjgl-jemalloc:${versions.lwjgl3}:natives-macos",
         "org.lwjgl:lwjgl-jemalloc:${versions.lwjgl3}:natives-windows",
+        "org.lwjgl:lwjgl-jemalloc:${versions.lwjgl3}:natives-windows-x86",
         "org.lwjgl:lwjgl-openal:${versions.lwjgl3}",
         "org.lwjgl:lwjgl-openal:${versions.lwjgl3}:natives-linux",
+        "org.lwjgl:lwjgl-openal:${versions.lwjgl3}:natives-linux-arm32",
+        "org.lwjgl:lwjgl-openal:${versions.lwjgl3}:natives-linux-arm64",
         "org.lwjgl:lwjgl-openal:${versions.lwjgl3}:natives-macos",
         "org.lwjgl:lwjgl-openal:${versions.lwjgl3}:natives-windows",
+        "org.lwjgl:lwjgl-openal:${versions.lwjgl3}:natives-windows-x86",
         "org.lwjgl:lwjgl-opengl:${versions.lwjgl3}",
         "org.lwjgl:lwjgl-opengl:${versions.lwjgl3}:natives-linux",
+        "org.lwjgl:lwjgl-opengl:${versions.lwjgl3}:natives-linux-arm32",
+        "org.lwjgl:lwjgl-opengl:${versions.lwjgl3}:natives-linux-arm64",
         "org.lwjgl:lwjgl-opengl:${versions.lwjgl3}:natives-macos",
         "org.lwjgl:lwjgl-opengl:${versions.lwjgl3}:natives-windows",
+        "org.lwjgl:lwjgl-opengl:${versions.lwjgl3}:natives-windows-x86",
         "org.lwjgl:lwjgl-stb:${versions.lwjgl3}",
         "org.lwjgl:lwjgl-stb:${versions.lwjgl3}:natives-linux",
+        "org.lwjgl:lwjgl-stb:${versions.lwjgl3}:natives-linux-arm32",
+        "org.lwjgl:lwjgl-stb:${versions.lwjgl3}:natives-linux-arm64",
         "org.lwjgl:lwjgl-stb:${versions.lwjgl3}:natives-macos",
         "org.lwjgl:lwjgl-stb:${versions.lwjgl3}:natives-windows",
+        "org.lwjgl:lwjgl-stb:${versions.lwjgl3}:natives-windows-x86",
         "com.apple:AppleJavaExtensions:${versions.appleExtension}",
         "com.badlogicgames.jlayer:jlayer:${versions.jlayer}",
         "org.jcraft:jorbis:${versions.jorbis}"

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <android.version>7.1</android.version>
     <gwt.version>2.8.2</gwt.version>
     <lwjgl.version>2.9.3</lwjgl.version>
-    <lwjgl3.version>3.2.1</lwjgl3.version>
+    <lwjgl3.version>3.2.3</lwjgl3.version>
     <robovm.version>2.3.6</robovm.version>
     <moe.version>1.4.0</moe.version>
   </properties>


### PR DESCRIPTION
Includes new `windows-x86`, `linux-arm32`, and `linux-arm64` classifiers as dependencies.