### PR TITLE
fix #5791 Fixing `AtlasRegion.name` documentation

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g2d/TextureAtlas.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/TextureAtlas.java
@@ -473,8 +473,9 @@ public class TextureAtlas implements Disposable {
 		 * @see TextureAtlas#findRegions(String) */
 		public int index;
 
-		/** The name of the original image file, up to the first underscore. Underscores denote special instructions to the texture
-		 * packer. */
+		/** The name of the original image file, without the file's extension.<br>
+		 * If the name ends with an underscore followed by only numbers, that part is excluded: 
+		 * underscores denote special instructions to the texture packer. */
 		public String name;
 
 		/** The offset from the left of the original image to the left of the packed image, after whitespace was removed for packing. */


### PR DESCRIPTION
The documentation currently says `The name of the original image file, up to the first underscore. Underscores denote special instructions to the texture packer.`.

However, for example, if you pack an image called `bob_walking.png`, the returned String will be `bob_walking`.

The JavaDoc is now accurate as of the content of that variable.