### PR TITLE
LWGLJ3: Request rendering on resize rather then directly resizing

### DIFF
--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Graphics.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Graphics.java
@@ -69,8 +69,7 @@ public class Lwjgl3Graphics implements Graphics, Disposable {
 			window.makeCurrent();
 			gl20.glViewport(0, 0, width, height);
 			window.getListener().resize(getWidth(), getHeight());
-			window.getListener().render();
-			GLFW.glfwSwapBuffers(windowHandle);
+			window.requestRendering();
 		}
 	};
 


### PR DESCRIPTION
I've been having a problem when resizing windows with LWJGL3 under both Windows and Linux that while dragging the window around triggers a lot of resize events. That's fine by itself however this can (and does) form a very tight loop which prevents runnables from being run. If you're rendering thread posts a runnable for any reason this will just be queued, which can lead to a very large set of runnables pending which can then take a surprising amount of time to clear. It leads to a weird problem where the window is relatively current, but once you stop resizing it it freezes.

I'm not fully sold on this being the correct fix. In my case the behavior that lead to this was an intermediate state and the current behavior that can post all the runnables will be changing either way. The patch as PR'd resolves the problem for me, but I'm not fully sure that this is really the correct fix (and possibly has a more significant impact on projects other then my own).

Anyways thought I'd throw it up since I'd investigated it,and it fixes it for me. If it's out of scope I'm not fussed if it's closed :)