### PR TITLE
fix broken isButtonJustPressed in GWT backend, fixes #5805

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtInput.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtInput.java
@@ -588,8 +588,9 @@ public class GwtInput implements Input {
 			hasFocus = true;
 			this.justTouched = true;
 			this.touched[0] = true;
-			this.pressedButtons.add(getButton(e.getButton()));
-			justPressedButtons[e.getButton()] = true;
+			final int button = getButton(e.getButton());
+			this.pressedButtons.add(button);
+			justPressedButtons[button] = true;
 			this.deltaX[0] = 0;
 			this.deltaY[0] = 0;
 			if (isCursorCatched()) {

--- a/gdx/src/com/badlogic/gdx/Input.java
+++ b/gdx/src/com/badlogic/gdx/Input.java
@@ -653,7 +653,7 @@ public interface Input {
 	public boolean isButtonPressed (int button);
 
 	/** Returns whether a given button has just been pressed. Button constants can be found in {@link Buttons}. On Android only the Buttons#LEFT
-	 * constant is meaningful before version 4.0.
+	 * constant is meaningful before version 4.0. On WebGL (GWT), only LEFT, RIGHT and MIDDLE buttons are supported.
 	 *
 	 * @param button the button to check.
 	 * @return true or false. */

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtInputTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtInputTest.java
@@ -19,6 +19,7 @@ package com.badlogic.gdx.tests.gwt;
 import com.badlogic.gdx.Application;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Graphics;
+import com.badlogic.gdx.Input;
 import com.badlogic.gdx.InputProcessor;
 import com.badlogic.gdx.Input.Keys;
 import com.badlogic.gdx.graphics.Color;
@@ -73,6 +74,15 @@ public class GwtInputTest extends GdxTest {
 
 		if (Gdx.input.isKeyPressed(Keys.DOWN)) {
 			y -= 1;
+		}
+		if (Gdx.input.isButtonJustPressed(Input.Buttons.LEFT)){
+			Gdx.app.log("GwtInputTest", "button pressed: LEFT");
+		}
+		if (Gdx.input.isButtonJustPressed(Input.Buttons.MIDDLE)){
+			Gdx.app.log("GwtInputTest", "button pressed: MIDDLE");
+		}
+		if (Gdx.input.isButtonJustPressed(Input.Buttons.RIGHT)){
+			Gdx.app.log("GwtInputTest", "button pressed: RIGHT");
 		}
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtTestWrapper.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtTestWrapper.java
@@ -359,7 +359,7 @@ public class GwtTestWrapper extends GdxTest {
 
 		@Override
 		public boolean isButtonJustPressed (int button) {
-			return false;
+			return input.isButtonJustPressed(button);
 		}
 
 		@Override


### PR DESCRIPTION
note that BACK and FORWARD buttons could be implemented but : 
* [Gwt NativeEvent](http://www.gwtproject.org/javadoc/latest/com/google/gwt/dom/client/NativeEvent.html) doesn't support/provide codes for them.
* Real javascript native codes are not the same as GWT codes.

so i didn't want to mess with these cases.