### PR TITLE
improved doc for MathUtils sin lookup table

### DIFF
--- a/gdx/src/com/badlogic/gdx/math/MathUtils.java
+++ b/gdx/src/com/badlogic/gdx/math/MathUtils.java
@@ -59,22 +59,26 @@ public final class MathUtils {
 		}
 	}
 
-	/** Returns the sine in radians from a lookup table. */
+	/** Returns the sine in radians from a lookup table. For optimal precision, use radians that are not drastically more positive
+	 * or negative than {@link #PI2} */
 	static public float sin (float radians) {
 		return Sin.table[(int)(radians * radToIndex) & SIN_MASK];
 	}
 
-	/** Returns the cosine in radians from a lookup table. */
+	/** Returns the cosine in radians from a lookup table. For optimal precision, use radians that are not drastically more
+	 * positive or negative than {@link #PI2} */
 	static public float cos (float radians) {
 		return Sin.table[(int)((radians + PI / 2) * radToIndex) & SIN_MASK];
 	}
 
-	/** Returns the sine in degrees from a lookup table. */
+	/** Returns the sine in degrees from a lookup table. For optimal precision, use degrees that are not drastically more positive
+	 * or negative than 360 */
 	static public float sinDeg (float degrees) {
 		return Sin.table[(int)(degrees * degToIndex) & SIN_MASK];
 	}
 
-	/** Returns the cosine in degrees from a lookup table. */
+	/** Returns the cosine in degrees from a lookup table. For optimal precision, use degrees that are not drastically more
+	 * positive or negative than 360 */
 	static public float cosDeg (float degrees) {
 		return Sin.table[(int)((degrees + 90) * degToIndex) & SIN_MASK];
 	}


### PR DESCRIPTION
As you can see in graphs below, using large angle values can give bad precisions :

This one is using high values unbounded (360000 to 360360)
![](https://i.imgur.com/m5L4hek.png)

This one is using same values but bounded (using % 360 before lookup table) which is the same as (0 to 360) range.
![](https://i.imgur.com/nGPoZNk.png)

Thanks to @tommyettinger for these graphs and his help.