### PR TITLE
Access to  BitmapFont for extends It on RTL language support

### DIFF
--- a/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGenerator.java
+++ b/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGenerator.java
@@ -166,8 +166,9 @@ public class FreeTypeFontGenerator implements Disposable {
 		return font;
 	}
 	
+	/** Create a new {@link BitmapFont} instance for inject customized {@link BitmapFont} (ex. support RTL fonts). */
 	protected BitmapFont newBitmapFont(BitmapFont.BitmapFontData data, Array<TextureRegion> pageRegions, boolean integer) {
-		return new BitmapFont(data, pageRegions, true);
+		return new BitmapFont(data, pageRegions, integer);
 	}
 	
 	/** Uses ascender and descender of font to calculate real height that makes all glyphs to fit in given pixel size. Source:

--- a/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGenerator.java
+++ b/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGenerator.java
@@ -161,11 +161,15 @@ public class FreeTypeFontGenerator implements Disposable {
 		if (updateTextureRegions)
 			parameter.packer.updateTextureRegions(data.regions, parameter.minFilter, parameter.magFilter, parameter.genMipMaps);
 		if (data.regions.isEmpty()) throw new GdxRuntimeException("Unable to create a font with no texture regions.");
-		BitmapFont font = new BitmapFont(data, data.regions, true);
+		BitmapFont font = newBitmapFont(data, data.regions, true);
 		font.setOwnsTexture(parameter.packer == null);
 		return font;
 	}
-
+	
+	protected BitmapFont newBitmapFont(BitmapFont.BitmapFontData data, Array<TextureRegion> pageRegions, boolean integer) {
+		return new BitmapFont(data, pageRegions, true);
+	}
+	
 	/** Uses ascender and descender of font to calculate real height that makes all glyphs to fit in given pixel size. Source:
 	 * http://nothings.org/stb/stb_truetype.h / stbtt_ScaleForPixelHeight */
 	public int scaleForPixelHeight (int height) {


### PR DESCRIPTION
For supporting another languages (like RTL language) we need to customize the BitmapFont... So,for doing this approach I need to change (override) some methods on BitmapFont that generated glyphs using FreeTypeFontGenerator.