### PR TITLE
Java 8

### DIFF
--- a/backends/build.gradle
+++ b/backends/build.gradle
@@ -17,8 +17,8 @@
 subprojects {
     apply plugin: "java"
 
-    sourceCompatibility = 1.6
-    targetCompatibility = 1.6
+    sourceCompatibility = 1.8
+    targetCompatibility = 1.8
     sourceSets.main.java.srcDirs = ["src"]
     sourceSets.main.resources.srcDirs = ["src"]
 

--- a/extensions/build.gradle
+++ b/extensions/build.gradle
@@ -17,8 +17,8 @@
 subprojects {
     apply plugin: "java"
 
-    sourceCompatibility = 1.6
-    targetCompatibility = 1.6
+    sourceCompatibility = 1.8
+    targetCompatibility = 1.8
 
     compileJava.options.encoding = 'UTF-8'
 

--- a/gdx/build.gradle
+++ b/gdx/build.gradle
@@ -16,8 +16,8 @@
 
 apply plugin: "java"
 
-sourceCompatibility = 1.6
-targetCompatibility = 1.6
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 sourceSets.main.java.srcDirs = ["src"]
 sourceSets.main.resources.srcDirs = ["src"]

--- a/pom.xml
+++ b/pom.xml
@@ -78,8 +78,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.3.2</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.8</source>
+          <target>1.8</target>
           <fork>true</fork>
           <showWarnings>true</showWarnings>
         </configuration>

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -17,8 +17,8 @@
 configure(subprojects - project(":tests:gdx-tests-android")) {
     apply plugin: "java"
 
-    sourceCompatibility = 1.6
-    targetCompatibility = 1.6
+    sourceCompatibility = 1.8
+    targetCompatibility = 1.8
     sourceSets.main.java.srcDirs = ["src"]
     sourceSets.main.resources.srcDirs = ["src"]
 

--- a/tests/gdx-tests-iosrobovm/build.gradle
+++ b/tests/gdx-tests-iosrobovm/build.gradle
@@ -22,8 +22,8 @@ buildscript {
 
 apply plugin: "robovm"
 
-sourceCompatibility = '1.7'
-targetCompatibility = '1.7'
+sourceCompatibility = '1.8'
+targetCompatibility = '1.8'
 
 dependencies {
     compile project(":tests:gdx-tests")


### PR DESCRIPTION
Moves the Maven and Gradle build process and source version to 1.8.
Fixes the no longer working ```mvn install``` since Maven no longer supports Java version 6 and below.