### PR TITLE
Ensure BitmapFontCache.setColors(float, int, int) stays in-bounds

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFontCache.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFontCache.java
@@ -187,7 +187,7 @@ public class BitmapFontCache {
 	public void setColors (float color, int start, int end) {
 		if (pageVertices.length == 1) { // One page.
 			float[] vertices = pageVertices[0];
-			for (int i = start * 20 + 2, n = end * 20; i < n; i += 5)
+			for (int i = start * 20 + 2, n = Math.min(end * 20, idx[0]); i < n; i += 5)
 				vertices[i] = color;
 			return;
 		}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/BitmapFontTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/BitmapFontTest.java
@@ -42,6 +42,7 @@ public class BitmapFontTest extends GdxTest {
 	private BitmapFont font;
 	private ShapeRenderer renderer;
 	private BitmapFont multiPageFont;
+	private BitmapFont smallFont;
 	private GlyphLayout layout;
 	private Label label;
 
@@ -50,6 +51,7 @@ public class BitmapFontTest extends GdxTest {
 		spriteBatch = new SpriteBatch();
 		// font = new BitmapFont(Gdx.files.internal("data/verdana39.fnt"), false);
 		font = new BitmapFont(Gdx.files.internal("data/arial-32-pad.fnt"), false);
+		smallFont = new BitmapFont(); // uses Arial 15, the default
 		// font = new FreeTypeFontGenerator(Gdx.files.internal("data/arial.ttf")).generateFont(new FreeTypeFontParameter());
 		font.getData().markupEnabled = true;
 		font.getData().breakChars = new char[] {'-'};
@@ -93,7 +95,7 @@ public class BitmapFontTest extends GdxTest {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 
 		// Test wrapping or truncation with the font directly.
-		if (true) {
+		if (false) {
 			// BitmapFont font = label.getStyle().font;
 			BitmapFont font = this.font;
 			font.getRegion().getTexture().setFilter(TextureFilter.Nearest, TextureFilter.Nearest);
@@ -204,6 +206,14 @@ public class BitmapFontTest extends GdxTest {
 			// tinting
 			cache.tint(new Color(1f, 1f, 1f, 0.3f));
 			cache.translate(0f, 40f);
+			cache.draw(spriteBatch);
+
+			cache = smallFont.getCache();
+			// String neeeds to be pretty long to trigger the crash described in #5834; fixed now
+			final String trogdor = "TROGDOR! TROGDOR! Trogdor was a man! Or maybe he was a... Dragon-Man!";
+			cache.clear();
+			cache.addText(trogdor, 24, 37, 500, Align.center, true);
+			cache.setColors(Color.FOREST, 0, trogdor.length());
 			cache.draw(spriteBatch);
 
 			spriteBatch.end();


### PR DESCRIPTION
This fixes #5834 . It only needs a single `Math.min(int, int)` call to be added per call to `setColors(float, int, int)`, checking to make sure that the calculated end index is no greater than what other parts of the class use (`idx[page]`, where page is always 0 in the broken case). It also technically permits arbitrarily high end values to be given as long as end is greater than start; if too high of an end was supplied to a single-page font before, it would have crashed. I added the reproduction code from #5834 to BitmapFontTest, which needed an if/else block to be changed to actually run the tests on most of the features.

I'm pretty sure the formatting is correct, but the automatic eclipse-formatter was inserting a space after every indent in IntelliJ, so I just manually made sure the tab count was the same on each line.