### PR TITLE
Log the exception inside flush and fix NullPointerException if LocalStorage is not supported

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtFiles.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtFiles.java
@@ -24,7 +24,7 @@ import com.google.gwt.storage.client.Storage;
 
 public class GwtFiles implements Files {
 	
-	public static final Storage LocalStorage = Storage.getLocalStorageIfSupported();
+	public static final Storage LocalStorage = Storage.getLocalStorageIfSupported(); // Can be null if cookies are disabled or blocked by the browser with "block third-party cookies"
 	
 	final Preloader preloader;
 	

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtPreferences.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtPreferences.java
@@ -30,16 +30,18 @@ public class GwtPreferences implements Preferences {
 	GwtPreferences (String prefix) {
 		this.prefix = prefix + ":";
 		int prefixLength = this.prefix.length();
-		try {
-			for (int i = 0; i < GwtFiles.LocalStorage.getLength(); i++) {
-				String key = GwtFiles.LocalStorage.key(i);
-				if (key.startsWith(prefix)) {
-					String value = GwtFiles.LocalStorage.getItem(key);
-					values.put(key.substring(prefixLength, key.length() - 1), toObject(key, value));
+		if (GwtFiles.LocalStorage != null) {
+			try {
+				for (int i = 0; i < GwtFiles.LocalStorage.getLength(); i++) {
+					String key = GwtFiles.LocalStorage.key(i);
+					if (key.startsWith(prefix)) {
+						String value = GwtFiles.LocalStorage.getItem(key);
+						values.put(key.substring(prefixLength, key.length() - 1), toObject(key, value));
+					}
 				}
+			} catch (Exception e) {
+				values.clear();
 			}
-		} catch (Exception e) {
-			values.clear();
 		}
 	}
 
@@ -61,22 +63,24 @@ public class GwtPreferences implements Preferences {
 
 	@Override
 	public void flush () {
-		try {
-			// remove all old values
-			for (int i = 0; i < GwtFiles.LocalStorage.getLength(); i++) {
-				String key = GwtFiles.LocalStorage.key(i);
-				if (key.startsWith(prefix)) GwtFiles.LocalStorage.removeItem(key);
-			}
+		if (GwtFiles.LocalStorage != null) {
+			try {
+				// remove all old values
+				for (int i = 0; i < GwtFiles.LocalStorage.getLength(); i++) {
+					String key = GwtFiles.LocalStorage.key(i);
+					if (key.startsWith(prefix)) GwtFiles.LocalStorage.removeItem(key);
+				}
 
-			// push new values to LocalStorage
-			for (String key : values.keys()) {
-				String storageKey = toStorageKey(key, values.get(key));
-				String storageValue = "" + values.get(key).toString();
-				GwtFiles.LocalStorage.setItem(storageKey, storageValue);
-			}
+				// push new values to LocalStorage
+				for (String key : values.keys()) {
+					String storageKey = toStorageKey(key, values.get(key));
+					String storageValue = "" + values.get(key).toString();
+					GwtFiles.LocalStorage.setItem(storageKey, storageValue);
+				}
 
-		} catch (Exception e) {
-			throw new GdxRuntimeException("Couldn't flush preferences", e);
+			} catch (Exception e) {
+				throw new GdxRuntimeException("Couldn't flush preferences", e);
+			}
 		}
 	}
 

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtPreferences.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtPreferences.java
@@ -44,10 +44,10 @@ public class GwtPreferences implements Preferences {
 	}
 
 	private Object toObject (String key, String value) {
-		if (key.endsWith("b")) return new Boolean(Boolean.parseBoolean(value));
-		if (key.endsWith("i")) return new Integer(Integer.parseInt(value));
-		if (key.endsWith("l")) return new Long(Long.parseLong(value));
-		if (key.endsWith("f")) return new Float(Float.parseFloat(value));
+		if (key.endsWith("b")) return Boolean.parseBoolean(value);
+		if (key.endsWith("i")) return Integer.parseInt(value);
+		if (key.endsWith("l")) return Long.parseLong(value);
+		if (key.endsWith("f")) return Float.parseFloat(value);
 		return value;
 	}
 
@@ -76,7 +76,7 @@ public class GwtPreferences implements Preferences {
 			}
 
 		} catch (Exception e) {
-			throw new GdxRuntimeException("Couldn't flush preferences");
+			throw new GdxRuntimeException("Couldn't flush preferences", e);
 		}
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtTestWrapper.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtTestWrapper.java
@@ -85,6 +85,7 @@ import com.badlogic.gdx.tests.ParallaxTest;
 import com.badlogic.gdx.tests.ParticleEmitterTest;
 import com.badlogic.gdx.tests.PixelsPerInchTest;
 import com.badlogic.gdx.tests.PixmapPackerTest;
+import com.badlogic.gdx.tests.PreferencesTest;
 import com.badlogic.gdx.tests.ProjectiveTextureTest;
 import com.badlogic.gdx.tests.ReflectionCorrectnessTest;
 import com.badlogic.gdx.tests.ReflectionTest;
@@ -722,6 +723,10 @@ public class GwtTestWrapper extends GdxTest {
 		},
 		// new Instancer() {public GdxTest instance(){return new PixmapBlendingTest();}}, // FIXME no idea why this doesn't work
 		new Instancer() {
+			public GdxTest instance () {
+				return new PreferencesTest();
+			}
+		}, new Instancer() {
 			public GdxTest instance () {
 				return new ProjectiveTextureTest();
 			}


### PR DESCRIPTION
We experienced some "Couldn't flush preferences" erros. The cause seem to be that `getLocalStorageIfSupported` can return null if the browser doesn't support it or "block third-party cookies" is enabled. Then in `flush`, GwtPreferences tries to access to LocalStorage but it's null.
Logging the original exception is helpful to get causes of problems.
Also removed the unnecessary creation of objects from the same type in toObject (the constructors are deprecated since java 9)