### PR TITLE
Add assertions to prove that scene2d code is on the GL thread

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphics.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphics.java
@@ -105,6 +105,7 @@ public class AndroidGraphics implements Graphics, Renderer {
 	protected final AndroidApplicationConfiguration config;
 	private BufferFormat bufferFormat = new BufferFormat(5, 6, 5, 0, 16, 0, 0, false);
 	private boolean isContinuous = true;
+	private Thread glThread;
 
 	public AndroidGraphics (AndroidApplicationBase application, AndroidApplicationConfiguration config,
 		ResolutionStrategy resolutionStrategy) {
@@ -113,6 +114,7 @@ public class AndroidGraphics implements Graphics, Renderer {
 
 	public AndroidGraphics (AndroidApplicationBase application, AndroidApplicationConfiguration config,
 		ResolutionStrategy resolutionStrategy, boolean focusableView) {
+    this.glThread = Thread.currentThread();
 		this.config = config;
 		this.app = application;
 		view = createGLSurfaceView(application, resolutionStrategy);
@@ -776,6 +778,11 @@ public class AndroidGraphics implements Graphics, Renderer {
 
 	@Override
 	public void setSystemCursor (SystemCursor systemCursor) {
+	}
+
+	@Override
+	public boolean isGLThread () {
+		return glThread == Thread.currentThread();
 	}
 
 	private class AndroidDisplayMode extends DisplayMode {

--- a/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/mock/graphics/MockGraphics.java
+++ b/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/mock/graphics/MockGraphics.java
@@ -252,6 +252,11 @@ public class MockGraphics implements Graphics {
 	}
 
 	@Override
+	public boolean isGLThread () {
+		return true;
+	}
+
+	@Override
 	public Monitor getPrimaryMonitor() {
 		return null;
 	}

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGraphics.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGraphics.java
@@ -67,6 +67,7 @@ public class LwjglGraphics implements Graphics {
 	volatile boolean requestRendering = false;
 	boolean softwareMode;
 	boolean usingGL30;
+	Thread glThread;
 
 	LwjglGraphics (LwjglApplicationConfiguration config) {
 		this.config = config;
@@ -186,6 +187,7 @@ public class LwjglGraphics implements Graphics {
 	}
 
 	void setupDisplay () throws LWJGLException {
+		this.glThread = Thread.currentThread();
 		if (config.useHDPI) {
 			System.setProperty("org.lwjgl.opengl.Display.enableHighDPI", "true");
 		}
@@ -687,6 +689,11 @@ public class LwjglGraphics implements Graphics {
 		} catch (LWJGLException e) {
 			throw new GdxRuntimeException("Couldn't set system cursor");
 		}
+	}
+
+	@Override
+	public boolean isGLThread () {
+		return glThread == Thread.currentThread();
 	}
 
 	private class LwjglDisplayMode extends DisplayMode {

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Graphics.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Graphics.java
@@ -55,6 +55,7 @@ public class Lwjgl3Graphics implements Graphics, Disposable {
 	private int windowPosXBeforeFullscreen;
 	private int windowPosYBeforeFullscreen;
 	private DisplayMode displayModeBeforeFullscreen = null;
+	private Thread glThread;
 
 	IntBuffer tmpBuffer = BufferUtils.createIntBuffer(1);
 	IntBuffer tmpBuffer2 = BufferUtils.createIntBuffer(1);
@@ -75,6 +76,7 @@ public class Lwjgl3Graphics implements Graphics, Disposable {
 	};
 
 	public Lwjgl3Graphics(Lwjgl3Window window) {
+		this.glThread = Thread.currentThread();
 		this.window = window;
 		if (window.getConfig().useGL30) {
 			this.gl30 = new Lwjgl3GL30();
@@ -462,6 +464,11 @@ public class Lwjgl3Graphics implements Graphics, Disposable {
 	@Override
 	public void setSystemCursor(SystemCursor systemCursor) {
 		Lwjgl3Cursor.setSystemCursor(getWindow().getWindowHandle(), systemCursor);
+	}
+
+	@Override
+	public boolean isGLThread () {
+		return glThread == Thread.currentThread();
 	}
 
 	@Override

--- a/backends/gdx-backend-moe/src/com/badlogic/gdx/backends/iosmoe/IOSGraphics.java
+++ b/backends/gdx-backend-moe/src/com/badlogic/gdx/backends/iosmoe/IOSGraphics.java
@@ -90,6 +90,8 @@ public class IOSGraphics extends NSObject implements Graphics, GLKViewDelegate, 
 	IOSGLKView view;
 	IOSUIViewController viewController;
 
+	private Thread glThread;
+
 	@Selector("alloc")
 	public static native IOSGraphics alloc ();
 
@@ -102,6 +104,7 @@ public class IOSGraphics extends NSObject implements Graphics, GLKViewDelegate, 
 
 	public IOSGraphics init (float scale, IOSApplication app, IOSApplicationConfiguration config, IOSInput input,
 		boolean useGLES30, IOSGLKView view) {
+    this.glThread = Thread.currentThread();
 		this.view = view;
 
 		init();
@@ -522,6 +525,11 @@ public class IOSGraphics extends NSObject implements Graphics, GLKViewDelegate, 
 
 	@Override
 	public void setSystemCursor (SystemCursor systemCursor) {
+	}
+
+	@Override
+	public boolean isGLThread () {
+		return glThread == Thread.currentThread();
 	}
 
 	@Override

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
@@ -181,6 +181,7 @@ public class IOSGraphics extends NSObject implements Graphics, GLKViewDelegate, 
 	private long frameId = -1;
 	private boolean isContinuous = true;
 	private boolean isFrameRequested = true;
+	private Thread glThread;
 
 	IOSApplicationConfiguration config;
 	EAGLContext context;
@@ -189,6 +190,7 @@ public class IOSGraphics extends NSObject implements Graphics, GLKViewDelegate, 
 	IOSUIViewController viewController;
 
 	public IOSGraphics (float scale, IOSApplication app, IOSApplicationConfiguration config, IOSInput input, boolean useGLES30) {
+		this.glThread = Thread.currentThread();
 		this.config = config;
 
 		final CGRect bounds = app.getBounds();
@@ -652,6 +654,11 @@ public class IOSGraphics extends NSObject implements Graphics, GLKViewDelegate, 
 	@Override
 	public void setSystemCursor (SystemCursor systemCursor) {
 	}
+
+	@Override
+	public boolean isGLThread () {
+		return glThread == Thread.currentThread();
+  }
 
 	private class IOSDisplayMode extends DisplayMode {
 		protected IOSDisplayMode (int width, int height, int refreshRate, int bitsPerPixel) {

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtGraphics.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtGraphics.java
@@ -531,6 +531,11 @@ public class GwtGraphics implements Graphics {
 		((GwtApplication)Gdx.app).graphics.canvas.getStyle().setProperty("cursor", GwtCursor.getNameForSystemCursor(systemCursor));
 	}
 
+	@Override
+	public boolean isGLThread () {
+		return true;
+	}
+
 	static class GwtMonitor extends Monitor {
 		protected GwtMonitor (int virtualX, int virtualY, String name) {
 			super(virtualX, virtualY, name);

--- a/gdx/src/com/badlogic/gdx/Graphics.java
+++ b/gdx/src/com/badlogic/gdx/Graphics.java
@@ -343,4 +343,10 @@ public interface Graphics {
 	 * Sets one of the predefined {@link SystemCursor}s
 	 */
 	public void setSystemCursor(SystemCursor systemCursor);
+
+	/**
+	 * Returns true if the current thread is the GL thread
+	 */
+	public boolean isGLThread ();
+
 }

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Label.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Label.java
@@ -16,6 +16,7 @@
 
 package com.badlogic.gdx.scenes.scene2d.ui;
 
+import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.g2d.Batch;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
@@ -70,12 +71,14 @@ public class Label extends Widget {
 	}
 
 	public Label (CharSequence text, LabelStyle style) {
+		assert Gdx.graphics.isGLThread() : "Not on the GL thread";
 		if (text != null) this.text.append(text);
 		setStyle(style);
 		if (text != null && text.length() > 0) setSize(getPrefWidth(), getPrefHeight());
 	}
 
 	public void setStyle (LabelStyle style) {
+		assert Gdx.graphics.isGLThread() : "Not on the GL thread";
 		if (style == null) throw new IllegalArgumentException("style cannot be null.");
 		if (style.font == null) throw new IllegalArgumentException("Missing LabelStyle font.");
 		this.style = style;
@@ -93,6 +96,7 @@ public class Label extends Widget {
 	 * allocated.
 	 * @return true if the text was changed. */
 	public boolean setText (int value) {
+		assert Gdx.graphics.isGLThread() : "Not on the GL thread";
 		if (this.intValue == value) return false;
 		setText(Integer.toString(value));
 		intValue = value;
@@ -101,6 +105,7 @@ public class Label extends Widget {
 
 	/** @param newText May be null, "" will be used. */
 	public void setText (CharSequence newText) {
+		assert Gdx.graphics.isGLThread() : "Not on the GL thread";
 		if (newText == null) newText = "";
 		if (newText instanceof StringBuilder) {
 			if (text.equals(newText)) return;
@@ -134,6 +139,7 @@ public class Label extends Widget {
 	}
 
 	private void scaleAndComputePrefSize () {
+		assert Gdx.graphics.isGLThread() : "Not on the GL thread";
 		BitmapFont font = cache.getFont();
 		float oldScaleX = font.getScaleX();
 		float oldScaleY = font.getScaleY();
@@ -145,6 +151,7 @@ public class Label extends Widget {
 	}
 
 	private void computePrefSize () {
+		assert Gdx.graphics.isGLThread() : "Not on the GL thread";
 		prefSizeInvalid = false;
 		GlyphLayout prefSizeLayout = Label.prefSizeLayout;
 		if (wrap && ellipsis == null) {
@@ -160,6 +167,7 @@ public class Label extends Widget {
 	}
 
 	public void layout () {
+		assert Gdx.graphics.isGLThread() : "Not on the GL thread";
 		BitmapFont font = cache.getFont();
 		float oldScaleX = font.getScaleX();
 		float oldScaleY = font.getScaleY();
@@ -221,6 +229,7 @@ public class Label extends Widget {
 	}
 
 	public void draw (Batch batch, float parentAlpha) {
+		assert Gdx.graphics.isGLThread() : "Not on the GL thread";
 		validate();
 		Color color = tempColor.set(getColor());
 		color.a *= parentAlpha;
@@ -235,6 +244,7 @@ public class Label extends Widget {
 	}
 
 	public float getPrefWidth () {
+		assert Gdx.graphics.isGLThread() : "Not on the GL thread";
 		if (wrap) return 0;
 		if (prefSizeInvalid) scaleAndComputePrefSize();
 		float width = prefSize.x;
@@ -245,6 +255,7 @@ public class Label extends Widget {
 	}
 
 	public float getPrefHeight () {
+		assert Gdx.graphics.isGLThread() : "Not on the GL thread";
 		if (prefSizeInvalid) scaleAndComputePrefSize();
 		float descentScaleCorrection = 1;
 		if (fontScaleChanged) descentScaleCorrection = fontScaleY / style.font.getScaleY();
@@ -267,6 +278,7 @@ public class Label extends Widget {
 	 * will need to layout twice: once to set the width of the label and a second time to adjust to the label's new preferred
 	 * height. */
 	public void setWrap (boolean wrap) {
+		assert Gdx.graphics.isGLThread() : "Not on the GL thread";
 		this.wrap = wrap;
 		invalidateHierarchy();
 	}
@@ -283,6 +295,7 @@ public class Label extends Widget {
 	 *           left).
 	 * @see Align */
 	public void setAlignment (int alignment) {
+		assert Gdx.graphics.isGLThread() : "Not on the GL thread";
 		setAlignment(alignment, alignment);
 	}
 
@@ -290,6 +303,7 @@ public class Label extends Widget {
 	 * @param lineAlign Aligns each line of text horizontally (default left).
 	 * @see Align */
 	public void setAlignment (int labelAlign, int lineAlign) {
+		assert Gdx.graphics.isGLThread() : "Not on the GL thread";
 		this.labelAlign = labelAlign;
 
 		if ((lineAlign & Align.left) != 0)
@@ -303,10 +317,12 @@ public class Label extends Widget {
 	}
 
 	public void setFontScale (float fontScale) {
+		assert Gdx.graphics.isGLThread() : "Not on the GL thread";
 		setFontScale(fontScale, fontScale);
 	}
 
 	public void setFontScale (float fontScaleX, float fontScaleY) {
+		assert Gdx.graphics.isGLThread() : "Not on the GL thread";
 		fontScaleChanged = true;
 		this.fontScaleX = fontScaleX;
 		this.fontScaleY = fontScaleY;
@@ -318,6 +334,7 @@ public class Label extends Widget {
 	}
 
 	public void setFontScaleX (float fontScaleX) {
+		assert Gdx.graphics.isGLThread() : "Not on the GL thread";
 		setFontScale(fontScaleX, fontScaleY);
 	}
 
@@ -326,6 +343,7 @@ public class Label extends Widget {
 	}
 
 	public void setFontScaleY (float fontScaleY) {
+		assert Gdx.graphics.isGLThread() : "Not on the GL thread";
 		setFontScale(fontScaleX, fontScaleY);
 	}
 

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextField.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextField.java
@@ -134,6 +134,7 @@ public class TextField extends Widget implements Disableable {
 	}
 
 	public TextField (String text, TextFieldStyle style) {
+		assert Gdx.graphics.isGLThread() : "Not on the GL thread";
 		setStyle(style);
 		clipboard = Gdx.app.getClipboard();
 		initialize();
@@ -150,6 +151,7 @@ public class TextField extends Widget implements Disableable {
 	}
 
 	protected int letterUnderCursor (float x) {
+		assert Gdx.graphics.isGLThread() : "Not on the GL thread";
 		x -= textOffset + fontOffset - style.font.getData().cursorX - glyphPositions.get(visibleTextStart);
 		Drawable background = getBackgroundDrawable();
 		if (background != null) x -= style.background.getLeftWidth();
@@ -169,6 +171,7 @@ public class TextField extends Widget implements Disableable {
 	}
 
 	protected int[] wordUnderCursor (int at) {
+		assert Gdx.graphics.isGLThread() : "Not on the GL thread";
 		String text = this.text;
 		int start = at, right = text.length(), left = 0, index = start;
 		if (at >= text.length()) {
@@ -215,6 +218,7 @@ public class TextField extends Widget implements Disableable {
 	}
 
 	public void setStyle (TextFieldStyle style) {
+		assert Gdx.graphics.isGLThread() : "Not on the GL thread";
 		if (style == null) throw new IllegalArgumentException("style cannot be null.");
 		this.style = style;
 		textHeight = style.font.getCapHeight() - style.font.getDescent() * 2;
@@ -228,6 +232,7 @@ public class TextField extends Widget implements Disableable {
 	}
 
 	protected void calculateOffsets () {
+		assert Gdx.graphics.isGLThread() : "Not on the GL thread";
 		float visibleWidth = getWidth();
 		Drawable background = getBackgroundDrawable();
 		if (background != null) visibleWidth -= background.getLeftWidth() + background.getRightWidth();
@@ -297,6 +302,7 @@ public class TextField extends Widget implements Disableable {
 	}
 
 	public void draw (Batch batch, float parentAlpha) {
+		assert Gdx.graphics.isGLThread() : "Not on the GL thread";
 		boolean focused = hasKeyboardFocus();
 		if (focused != this.focused) {
 			this.focused = focused;
@@ -358,6 +364,7 @@ public class TextField extends Widget implements Disableable {
 	}
 
 	protected float getTextY (BitmapFont font, Drawable background) {
+		assert Gdx.graphics.isGLThread() : "Not on the GL thread";
 		float height = getHeight();
 		float textY = textHeight / 2 + font.getDescent();
 		if (background != null) {
@@ -372,25 +379,30 @@ public class TextField extends Widget implements Disableable {
 
 	/** Draws selection rectangle **/
 	protected void drawSelection (Drawable selection, Batch batch, BitmapFont font, float x, float y) {
+		assert Gdx.graphics.isGLThread() : "Not on the GL thread";
 		selection.draw(batch, x + textOffset + selectionX + fontOffset, y - textHeight - font.getDescent(), selectionWidth,
 			textHeight);
 	}
 
 	protected void drawText (Batch batch, BitmapFont font, float x, float y) {
+		assert Gdx.graphics.isGLThread() : "Not on the GL thread";
 		font.draw(batch, displayText, x + textOffset, y, visibleTextStart, visibleTextEnd, 0, Align.left, false);
 	}
 
 	protected void drawMessageText (Batch batch, BitmapFont font, float x, float y, float maxWidth) {
+		assert Gdx.graphics.isGLThread() : "Not on the GL thread";
 		font.draw(batch, messageText, x, y, 0, messageText.length(), maxWidth, textHAlign, false, "...");
 	}
 
 	protected void drawCursor (Drawable cursorPatch, Batch batch, BitmapFont font, float x, float y) {
+		assert Gdx.graphics.isGLThread() : "Not on the GL thread";
 		cursorPatch.draw(batch,
 			x + textOffset + glyphPositions.get(cursor) - glyphPositions.get(visibleTextStart) + fontOffset + font.getData().cursorX,
 			y - textHeight - font.getDescent(), cursorPatch.getMinWidth(), textHeight);
 	}
 
 	void updateDisplayText () {
+		assert Gdx.graphics.isGLThread() : "Not on the GL thread";
 		BitmapFont font = style.font;
 		BitmapFontData data = font.getData();
 		String text = this.text;
@@ -438,6 +450,7 @@ public class TextField extends Widget implements Disableable {
 
 	/** Copies the contents of this TextField to the {@link Clipboard} implementation set on this TextField. */
 	public void copy () {
+		assert Gdx.graphics.isGLThread() : "Not on the GL thread";
 		if (hasSelection && !passwordMode) {
 			clipboard.setContents(text.substring(Math.min(cursor, selectionStart), Math.max(cursor, selectionStart)));
 		}
@@ -446,10 +459,12 @@ public class TextField extends Widget implements Disableable {
 	/** Copies the selected contents of this TextField to the {@link Clipboard} implementation set on this TextField, then removes
 	 * it. */
 	public void cut () {
+		assert Gdx.graphics.isGLThread() : "Not on the GL thread";
 		cut(programmaticChangeEvents);
 	}
 
 	void cut (boolean fireChangeEvent) {
+		assert Gdx.graphics.isGLThread() : "Not on the GL thread";
 		if (hasSelection && !passwordMode) {
 			copy();
 			cursor = delete(fireChangeEvent);
@@ -458,6 +473,7 @@ public class TextField extends Widget implements Disableable {
 	}
 
 	void paste (String content, boolean fireChangeEvent) {
+		assert Gdx.graphics.isGLThread() : "Not on the GL thread";
 		if (content == null) return;
 		StringBuilder buffer = new StringBuilder();
 		int textLength = text.length();
@@ -485,11 +501,13 @@ public class TextField extends Widget implements Disableable {
 	}
 
 	String insert (int position, CharSequence text, String to) {
+		assert Gdx.graphics.isGLThread() : "Not on the GL thread";
 		if (to.length() == 0) return text.toString();
 		return to.substring(0, position) + text + to.substring(position, to.length());
 	}
 
 	int delete (boolean fireChangeEvent) {
+		assert Gdx.graphics.isGLThread() : "Not on the GL thread";
 		int from = selectionStart;
 		int to = cursor;
 		int minIndex = Math.min(from, to);
@@ -507,6 +525,7 @@ public class TextField extends Widget implements Disableable {
 	/** Focuses the next TextField. If none is found, the keyboard is hidden. Does nothing if the text field is not in a stage.
 	 * @param up If true, the TextField with the same or next smallest y coordinate is found, else the next highest. */
 	public void next (boolean up) {
+		assert Gdx.graphics.isGLThread() : "Not on the GL thread";
 		Stage stage = getStage();
 		if (stage == null) return;
 		TextField current = this;
@@ -537,6 +556,7 @@ public class TextField extends Widget implements Disableable {
 	/** @return May be null. */
 	private TextField findNextTextField (Array<Actor> actors, TextField best, Vector2 bestCoords, Vector2 currentCoords,
 		boolean up) {
+		assert Gdx.graphics.isGLThread() : "Not on the GL thread";
 		for (int i = 0, n = actors.size; i < n; i++) {
 			Actor actor = actors.get(i);
 			if (actor instanceof TextField) {
@@ -565,11 +585,13 @@ public class TextField extends Widget implements Disableable {
 
 	/** @param listener May be null. */
 	public void setTextFieldListener (TextFieldListener listener) {
+		assert Gdx.graphics.isGLThread() : "Not on the GL thread";
 		this.listener = listener;
 	}
 
 	/** @param filter May be null. */
 	public void setTextFieldFilter (TextFieldFilter filter) {
+		assert Gdx.graphics.isGLThread() : "Not on the GL thread";
 		this.filter = filter;
 	}
 
@@ -579,6 +601,7 @@ public class TextField extends Widget implements Disableable {
 
 	/** If true (the default), tab/shift+tab will move to the next text field. */
 	public void setFocusTraversal (boolean focusTraversal) {
+		assert Gdx.graphics.isGLThread() : "Not on the GL thread";
 		this.focusTraversal = focusTraversal;
 	}
 
@@ -590,11 +613,13 @@ public class TextField extends Widget implements Disableable {
 	/** Sets the text that will be drawn in the text field if no text has been entered.
 	 * @param messageText may be null. */
 	public void setMessageText (String messageText) {
+		assert Gdx.graphics.isGLThread() : "Not on the GL thread";
 		this.messageText = messageText;
 	}
 
 	/** @param str If null, "" is used. */
 	public void appendText (String str) {
+		assert Gdx.graphics.isGLThread() : "Not on the GL thread";
 		if (str == null) str = "";
 
 		clearSelection();
@@ -604,6 +629,7 @@ public class TextField extends Widget implements Disableable {
 
 	/** @param str If null, "" is used. */
 	public void setText (String str) {
+		assert Gdx.graphics.isGLThread() : "Not on the GL thread";
 		if (str == null) str = "";
 		if (str.equals(text)) return;
 
@@ -623,6 +649,7 @@ public class TextField extends Widget implements Disableable {
 	/** @param oldText May be null.
 	 * @return True if the text was changed. */
 	boolean changeText (String oldText, String newText) {
+		assert Gdx.graphics.isGLThread() : "Not on the GL thread";
 		if (newText.equals(oldText)) return false;
 		text = newText;
 		ChangeEvent changeEvent = Pools.obtain(ChangeEvent.class);
@@ -647,11 +674,13 @@ public class TextField extends Widget implements Disableable {
 	}
 
 	public String getSelection () {
+		assert Gdx.graphics.isGLThread() : "Not on the GL thread";
 		return hasSelection ? text.substring(Math.min(selectionStart, cursor), Math.max(selectionStart, cursor)) : "";
 	}
 
 	/** Sets the selected text. */
 	public void setSelection (int selectionStart, int selectionEnd) {
+		assert Gdx.graphics.isGLThread() : "Not on the GL thread";
 		if (selectionStart < 0) throw new IllegalArgumentException("selectionStart must be >= 0");
 		if (selectionEnd < 0) throw new IllegalArgumentException("selectionEnd must be >= 0");
 		selectionStart = Math.min(text.length(), selectionStart);
@@ -672,15 +701,18 @@ public class TextField extends Widget implements Disableable {
 	}
 
 	public void selectAll () {
+		assert Gdx.graphics.isGLThread() : "Not on the GL thread";
 		setSelection(0, text.length());
 	}
 
 	public void clearSelection () {
+		assert Gdx.graphics.isGLThread() : "Not on the GL thread";
 		hasSelection = false;
 	}
 
 	/** Sets the cursor position and clears any selection. */
 	public void setCursorPosition (int cursorPosition) {
+		assert Gdx.graphics.isGLThread() : "Not on the GL thread";
 		if (cursorPosition < 0) throw new IllegalArgumentException("cursorPosition must be >= 0");
 		clearSelection();
 		cursor = Math.min(cursorPosition, text.length());
@@ -696,10 +728,12 @@ public class TextField extends Widget implements Disableable {
 	}
 
 	public void setOnscreenKeyboard (OnscreenKeyboard keyboard) {
+		assert Gdx.graphics.isGLThread() : "Not on the GL thread";
 		this.keyboard = keyboard;
 	}
 
 	public void setClipboard (Clipboard clipboard) {
+		assert Gdx.graphics.isGLThread() : "Not on the GL thread";
 		this.clipboard = clipboard;
 	}
 
@@ -708,6 +742,7 @@ public class TextField extends Widget implements Disableable {
 	}
 
 	public float getPrefHeight () {
+		assert Gdx.graphics.isGLThread() : "Not on the GL thread";
 		float topAndBottom = 0, minHeight = 0;
 		if (style.background != null) {
 			topAndBottom = Math.max(topAndBottom, style.background.getBottomHeight() + style.background.getTopHeight());
@@ -729,6 +764,7 @@ public class TextField extends Widget implements Disableable {
 	/** Sets text horizontal alignment (left, center or right).
 	 * @see Align */
 	public void setAlignment (int alignment) {
+		assert Gdx.graphics.isGLThread() : "Not on the GL thread";
 		this.textHAlign = alignment;
 	}
 
@@ -739,6 +775,7 @@ public class TextField extends Widget implements Disableable {
 	/** If true, the text in this text field will be shown as bullet characters.
 	 * @see #setPasswordCharacter(char) */
 	public void setPasswordMode (boolean passwordMode) {
+		assert Gdx.graphics.isGLThread() : "Not on the GL thread";
 		this.passwordMode = passwordMode;
 		updateDisplayText();
 	}
@@ -750,6 +787,7 @@ public class TextField extends Widget implements Disableable {
 	/** Sets the password character for the text field. The character must be present in the {@link BitmapFont}. Default is 149
 	 * (bullet). */
 	public void setPasswordCharacter (char passwordCharacter) {
+		assert Gdx.graphics.isGLThread() : "Not on the GL thread";
 		this.passwordCharacter = passwordCharacter;
 		if (passwordMode) updateDisplayText();
 	}
@@ -767,6 +805,7 @@ public class TextField extends Widget implements Disableable {
 	}
 
 	protected void moveCursor (boolean forward, boolean jump) {
+		assert Gdx.graphics.isGLThread() : "Not on the GL thread";
 		int limit = forward ? text.length() : 0;
 		int charOffset = forward ? 0 : -1;
 		while ((forward ? ++cursor < limit : --cursor > limit) && jump) {
@@ -775,6 +814,7 @@ public class TextField extends Widget implements Disableable {
 	}
 
 	protected boolean continueCursor (int index, int offset) {
+		assert Gdx.graphics.isGLThread() : "Not on the GL thread";
 		char c = text.charAt(index + offset);
 		return isWordCharacter(c);
 	}

--- a/tests/gdx-tests-lwjgl/build.gradle
+++ b/tests/gdx-tests-lwjgl/build.gradle
@@ -26,6 +26,7 @@ dependencies {
 }
 
 task launchTestsLwjgl (dependsOn: classes, type: JavaExec) {
+    enableAssertions = true
     main = mainTestClass
     classpath = sourceSets.main.runtimeClasspath
     standardInput = System.in

--- a/tests/gdx-tests-lwjgl3/build.gradle
+++ b/tests/gdx-tests-lwjgl3/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 }
 
 task launchTestsLwjgl3 (dependsOn: classes, type: JavaExec) {
+    enableAssertions = true
     main = mainTestClass
     classpath = sourceSets.main.runtimeClasspath
     standardInput = System.in


### PR DESCRIPTION
This was something I've been wanting to do for a bit now. A lot of code in LibGDX is unsafe to be called anywhere other then the GL thread, which generally is quite manageable, but when you have enough callbacks/helpers it's quite easy to start calling things from threads other then the GL thread, which can lead to race conditions causing crashing within the GL thread. This adds assertions (that you would have to enable when launching the JVM), that would catch the call to manipulate an object from somewhere other then the GL thread. Because they are completely ignored if they aren't enabled on JVM launch there should be no performance penalty during normal usage, but would make it much easier to track down this class of error when needed.

As an example of what of these assertions would look like when tripped:
``` java
Exception in thread "Thread-31" java.lang.AssertionError: Not on the GL thread
        at com.badlogic.gdx.scenes.scene2d.ui.Label.setText(Label.java:108)
        at com.badlogic.gdx.tests.LabelTest$1.run(LabelTest.java:141)
```

To do this I added a `isGLThread()` helper on the Graphics object that the asserts can use. I've only been able to test the Lwjgl and Lwjgl3 backends thus far, and will need help with the iOS and GWT backends. (I can test the Android one, but haven't gotten to it yet).

I'd like to extend this to a lot more of the scene2d code at a minimum, but before going further wanted to send in this prototype to get people's opinion.