### PR TITLE
Add badges for readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Forum](https://img.shields.io/badge/community-forum-green.svg)](https://www.badlogicgames.com/forum/)
 [![Forum](https://img.shields.io/badge/website-start-green.svg)](https://libgdx.badlogicgames.com/)
 
-[![PayPal](https://img.shields.io/badge/paypal-donate-yellow.svg)](https://www.paypal.com/donate/?token=-L6zcRVjpBngDd8OXVud6GVfmLw5J7rCWQN5FYIGpKMhQhhpoRCVDrZURRF6lHTTZIRMd0&country.x=US&locale.x=US)
+[![PayPal](https://img.shields.io/badge/paypal-donate-yellow.svg)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=AB7YCDCVWWABC)
 [![Patreon](https://img.shields.io/badge/patreon-support-yellow.svg)](https://www.patreon.com/libgdx)
 
 libGDX is a cross-platform Java game development framework based on 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,17 @@
 ![logo](http://libgdx.badlogicgames.com/img/logo.png)
-
+  
 [![Jenkins build status](https://libgdx.badlogicgames.com/jenkins/buildStatus/icon?job=libgdx&.png)](https://libgdx.badlogicgames.com/jenkins/job/libgdx/) (Jenkins)
-
 [![Travis build status](https://travis-ci.org/libgdx/libgdx.svg?branch=master)](https://travis-ci.org/libgdx/libgdx) (Travis)
+
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/libgdx/libgdx/blob/master/LICENSE)
+[![Downloads](https://img.shields.io/github/downloads/libgdx/libgdx/total.svg)](https://github.com/libgdx/libgdx/releases)
+
+[![Discord Chat](https://img.shields.io/discord/348229412858101762?logo=discord)](https://discord.gg/7c6Wg8H)
+[![Forum](https://img.shields.io/badge/community-forum-green.svg)](https://www.badlogicgames.com/forum/)
+[![Forum](https://img.shields.io/badge/website-start-green.svg)](https://libgdx.badlogicgames.com/)
+
+[![PayPal](https://img.shields.io/badge/paypal-donate-yellow.svg)](https://www.paypal.com/donate/?token=-L6zcRVjpBngDd8OXVud6GVfmLw5J7rCWQN5FYIGpKMhQhhpoRCVDrZURRF6lHTTZIRMd0&country.x=US&locale.x=US)
+[![Patreon](https://img.shields.io/badge/patreon-support-yellow.svg)](https://www.patreon.com/libgdx)
 
 libGDX is a cross-platform Java game development framework based on 
 OpenGL (ES) that works on Windows, Linux, Mac OS X, Android, your


### PR DESCRIPTION
Hey all.
I want to contribute to gdx, 
For learn github pull request i start with readme.

 i add badge on readme (licence/downloads/forums/website/discord/patreon)
and group on line by style (build, community, supports)
For look result : https://github.com/fabiitch/libgdx/tree/readme-badge

I just got a problem with discord , see https://img.shields.io/discord/348229412858101762?logo=discord   widget are disabled, so if someone can enabled widget it can be cool (i gonna ask on discord too). or i can remove this badge.

Thanks for reading.