### PR TITLE
#5858 Ray normalise origin vector after set methods

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,7 +3,9 @@
 - Update to LWJGL 3.2.3
 - API Change: Table#getRow now returns -1 when over the table but not over a row (used to return the last row).
 - API Change: Tree#addToTree and #removeFromTree now have an "int actorIndex" parameter.
-- API Change: Ray#set(float x, float y, float z, float dx, float dy, float dz) normalize direction vector after set.
+- API Change: Ray#Ray(Vector3, Vector3) not normalize direction vector.
+- API addition: Ray#Ray(Vector3, Vector3, boolean) for get a constructor who normalize the direction vector. 
+- API addition: Ray#setAndNormalizeDirection(Vector3, Vector3) and Ray#setAndNormalizeDirection(float, float, float, float, float, float) for set ray and normalize the direction vector. 
 
 [1.9.10]
 - API Addition: Allow target display for maximization LWJGL3 backend

--- a/CHANGES
+++ b/CHANGES
@@ -5,7 +5,7 @@
 - API Change: Tree#addToTree and #removeFromTree now have an "int actorIndex" parameter.
 - API Change: Ray#Ray(Vector3, Vector3) not normalize direction vector.
 - API addition: Ray#Ray(Vector3, Vector3, boolean) for get a constructor who normalize the direction vector. 
-- API addition: Ray#setAndNormalizeDirection(Vector3, Vector3) and Ray#setAndNormalizeDirection(float, float, float, float, float, float) for set ray and normalize the direction vector. 
+- API addition: Ray#setNormalize(Vector3, Vector3) and Ray#setNormalize(float, float, float, float, float, float) for set ray and normalize the direction vector.
 
 [1.9.10]
 - API Addition: Allow target display for maximization LWJGL3 backend

--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,7 @@
 - Update to LWJGL 3.2.3
 - API Change: Table#getRow now returns -1 when over the table but not over a row (used to return the last row).
 - API Change: Tree#addToTree and #removeFromTree now have an "int actorIndex" parameter.
+- API Change: Ray#set(float x, float y, float z, float dx, float dy, float dz) normalize direction vector after set.
 
 [1.9.10]
 - API Addition: Allow target display for maximization LWJGL3 backend

--- a/gdx/src/com/badlogic/gdx/math/collision/Ray.java
+++ b/gdx/src/com/badlogic/gdx/math/collision/Ray.java
@@ -34,10 +34,15 @@ public class Ray implements Serializable {
 	/** Constructor, sets the starting position of the ray and the direction.
 	 * 
 	 * @param origin The starting position
-	 * @param direction The direction */
+	 * @param direction The direction(must be normalized before) */
 	public Ray (Vector3 origin, Vector3 direction) {
 		this.origin.set(origin);
-		this.direction.set(direction).nor();
+		this.direction.set(direction);
+	}
+
+	/** Constructor, sets the starting position of the ray and the direction. */
+	public Ray (Vector3 origin, Vector3 direction, boolean normalize) {
+		this(origin, normalize ? direction.nor() : direction);
 	}
 
 	/** @return a copy of this ray. */
@@ -73,9 +78,9 @@ public class Ray implements Serializable {
 	}
 
 	/** Sets the starting position and the direction of this ray.
-	 * 
 	 * @param origin The starting position
-	 * @param direction The direction
+	 * @param direction The direction (Vector must be normalized before, use vector.nor() or
+	 *           {@link Ray#setAndNormalizeDirection(Vector3, Vector3)})
 	 * @return this ray for chaining */
 	public Ray set (Vector3 origin, Vector3 direction) {
 		this.origin.set(origin);
@@ -83,8 +88,19 @@ public class Ray implements Serializable {
 		return this;
 	}
 
-	/** Sets this ray from the given starting position and direction.
+	/** Sets the starting position and the direction of this ray.
 	 * 
+	 * @param origin The starting position
+	 * @param direction The direction
+	 * @return this ray for chaining */
+	public Ray setAndNormalizeDirection (Vector3 origin, Vector3 direction) {
+		set(origin, direction.nor());
+		return this;
+	}
+
+	/** Sets this ray from the given starting position and direction.
+	 * dx, dy, dz must give a Vector3 normalized (instead use
+	 * {@link Ray#setAndNormalizeDirection(float, float, float, float, float, float)})
 	 * @param x The x-component of the starting position
 	 * @param y The y-component of the starting position
 	 * @param z The z-component of the starting position
@@ -95,6 +111,20 @@ public class Ray implements Serializable {
 	public Ray set (float x, float y, float z, float dx, float dy, float dz) {
 		this.origin.set(x, y, z);
 		this.direction.set(dx, dy, dz);
+		return this;
+	}
+
+	/** Sets this ray from the given starting position and direction.
+	 * @param x The x-component of the starting position
+	 * @param y The y-component of the starting position
+	 * @param z The z-component of the starting position
+	 * @param dx The x-component of the direction
+	 * @param dy The y-component of the direction
+	 * @param dz The z-component of the direction
+	 * @return this ray for chaining */
+	public Ray setAndNormalizeDirection (float x, float y, float z, float dx, float dy, float dz) {
+		set(x, y, z, dx, dy, dz);
+		direction.set(direction.nor());
 		return this;
 	}
 

--- a/gdx/src/com/badlogic/gdx/math/collision/Ray.java
+++ b/gdx/src/com/badlogic/gdx/math/collision/Ray.java
@@ -82,7 +82,7 @@ public class Ray implements Serializable {
 	 * 
 	 * @param origin The starting position
 	 * @param direction The direction (Vector must be normalized before, use vector.nor() or
-	 *           {@link Ray#setAndNormalizeDirection(Vector3, Vector3)})
+	 *           {@link Ray#setNormalize(Vector3, Vector3)})
 	 * @return this ray for chaining */
 	public Ray set (Vector3 origin, Vector3 direction) {
 		this.origin.set(origin);
@@ -91,18 +91,18 @@ public class Ray implements Serializable {
 	}
 
 	/** Sets the starting position and the direction of this ray.
-	 * 
+	 * The direction vector will be normalized
 	 * @param origin The starting position
 	 * @param direction The direction
 	 * @return this ray for chaining */
-	public Ray setAndNormalizeDirection (Vector3 origin, Vector3 direction) {
+	public Ray setNormalize (Vector3 origin, Vector3 direction) {
 		this.set(origin, direction.nor());
 		return this;
 	}
 
 	/** Sets this ray from the given starting position and direction.
 	 * dx, dy, dz must give a Vector3 normalized (instead use
-	 * {@link Ray#setAndNormalizeDirection(float, float, float, float, float, float)})
+	 * {@link Ray#setNormalize(float, float, float, float, float, float)})
 	 * @param x The x-component of the starting position
 	 * @param y The y-component of the starting position
 	 * @param z The z-component of the starting position
@@ -117,6 +117,7 @@ public class Ray implements Serializable {
 	}
 
 	/** Sets this ray from the given starting position and direction.
+	 * the direction vector will be normalized
 	 * @param x The x-component of the starting position
 	 * @param y The y-component of the starting position
 	 * @param z The z-component of the starting position
@@ -124,9 +125,9 @@ public class Ray implements Serializable {
 	 * @param dy The y-component of the direction
 	 * @param dz The z-component of the direction
 	 * @return this ray for chaining */
-	public Ray setAndNormalizeDirection (float x, float y, float z, float dx, float dy, float dz) {
-		this.set(x, y, z, dx, dy, dz);
-		this.direction.set(direction.nor());
+	public Ray setNormalize (float x, float y, float z, float dx, float dy, float dz) {
+		this.origin.set(x, y, z);
+		this.direction.set(dx, dy, dz).nor();
 		return this;
 	}
 

--- a/gdx/src/com/badlogic/gdx/math/collision/Ray.java
+++ b/gdx/src/com/badlogic/gdx/math/collision/Ray.java
@@ -43,7 +43,8 @@ public class Ray implements Serializable {
 
 	/** Constructor, sets the starting position of the ray and the direction. */
 	public Ray (Vector3 origin, Vector3 direction, boolean normalizeDirection) {
-		this(origin, normalizeDirection ? direction.nor() : direction);
+		this(origin, direction);
+		if (normalizeDirection) this.direction.nor();
 	}
 
 	/** @return a copy of this ray. */
@@ -96,7 +97,8 @@ public class Ray implements Serializable {
 	 * @param direction The direction
 	 * @return this ray for chaining */
 	public Ray setNormalize (Vector3 origin, Vector3 direction) {
-		this.set(origin, direction.nor());
+		this.set(origin, direction);
+		this.direction.nor();
 		return this;
 	}
 

--- a/gdx/src/com/badlogic/gdx/math/collision/Ray.java
+++ b/gdx/src/com/badlogic/gdx/math/collision/Ray.java
@@ -21,7 +21,8 @@ import java.io.Serializable;
 import com.badlogic.gdx.math.Matrix4;
 import com.badlogic.gdx.math.Vector3;
 
-/** Encapsulates a ray having a starting position and a unit length direction.
+/** Encapsulates a ray having a starting position and a unit length direction
+ * The direction vector must be a normalized vector for the proper functioning of this object.
  * 
  * @author badlogicgames@gmail.com */
 public class Ray implements Serializable {


### PR DESCRIPTION
create a new pr after closing https://github.com/libgdx/libgdx/pull/5859 with push force on my fork.

So :
- Add javadocs for direction vector must be normalized
	public Ray set (Vector3 origin, Vector3 direction)

- Add nor on direction vector3 in method public Ray set (float x, float y, float z, float dx, float dy, float dz)

thx for reading.