### PR TITLE
[lwjgl3 backend] fix an empty title and NullPointerException.

### DIFF
--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
@@ -87,8 +87,8 @@ public class Lwjgl3Application implements Application {
 	public Lwjgl3Application(ApplicationListener listener, Lwjgl3ApplicationConfiguration config) {
 		initializeGlfw();
 		setApplicationLogger(new Lwjgl3ApplicationLogger());
+		if (config.title == null) config.title = listener.getClass().getSimpleName();
 		this.config = Lwjgl3ApplicationConfiguration.copy(config);
-		if (this.config.title == null) this.config.title = listener.getClass().getSimpleName();
 		Gdx.app = this;
 		if (!config.disableAudio) {
 			try {

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
@@ -88,7 +88,7 @@ public class Lwjgl3Application implements Application {
 		initializeGlfw();
 		setApplicationLogger(new Lwjgl3ApplicationLogger());
 		if (config.title == null) config.title = listener.getClass().getSimpleName();
-		this.config = Lwjgl3ApplicationConfiguration.copy(config);
+		this.config = config = Lwjgl3ApplicationConfiguration.copy(config);
 		Gdx.app = this;
 		if (!config.disableAudio) {
 			try {

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3WindowConfiguration.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3WindowConfiguration.java
@@ -39,7 +39,7 @@ public class Lwjgl3WindowConfiguration {
 	String[] windowIconPaths;
 	Lwjgl3WindowListener windowListener;
 	Lwjgl3DisplayMode fullscreenMode;
-	String title = "";
+	String title;
 	Color initialBackgroundColor = Color.BLACK;
 	boolean initialVisible = true;
 	boolean vSyncEnabled = true;


### PR DESCRIPTION
In the code Lwjgl3Application.java, when constructing a new lwjgl3 application, it clones config instance, then it checks the **cloned** config's title if it is null than replace it with the class's name. The problem within construct initialization, it uses the local config (non-clone) which hasn't check if the title is null, hence when creating a new application with the title set to null will crash when initialization.

With these changes, it will fixes when the title is null, preventing the crash. And will behave similarly to lwjgl2 backend (if the title is null, then replace it with the listener's class name).