### PR TITLE
#5858 Ray.java normalize direction vector in set() methods

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,7 @@
 - Update to LWJGL 3.2.3
 - API Change: Table#getRow now returns -1 when over the table but not over a row (used to return the last row).
 - API Change: Tree#addToTree and #removeFromTree now have an "int actorIndex" parameter.
+- API Change: Ray#set methods and Ray#mul(Matrix4) normalize direction vector.Use public field to set and avoid nor()
 
 [1.9.10]
 - API Addition: Allow target display for maximization LWJGL3 backend

--- a/gdx/src/com/badlogic/gdx/math/collision/Ray.java
+++ b/gdx/src/com/badlogic/gdx/math/collision/Ray.java
@@ -63,7 +63,7 @@ public class Ray implements Serializable {
 		tmp.set(origin).add(direction);
 		tmp.mul(matrix);
 		origin.mul(matrix);
-		direction.set(tmp.sub(origin));
+		direction.set(tmp.sub(origin)).nor();
 		return this;
 	}
 
@@ -79,7 +79,7 @@ public class Ray implements Serializable {
 	 * @return this ray for chaining */
 	public Ray set (Vector3 origin, Vector3 direction) {
 		this.origin.set(origin);
-		this.direction.set(direction);
+		this.direction.set(direction).nor();
 		return this;
 	}
 
@@ -94,7 +94,7 @@ public class Ray implements Serializable {
 	 * @return this ray for chaining */
 	public Ray set (float x, float y, float z, float dx, float dy, float dz) {
 		this.origin.set(x, y, z);
-		this.direction.set(dx, dy, dz);
+		this.direction.set(dx, dy, dz).nor();
 		return this;
 	}
 
@@ -104,7 +104,7 @@ public class Ray implements Serializable {
 	 * @return This ray for chaining */
 	public Ray set (Ray ray) {
 		this.origin.set(ray.origin);
-		this.direction.set(ray.direction);
+		this.direction.set(ray.direction).nor();
 		return this;
 	}
 


### PR DESCRIPTION
finnally ! 

nor() direction vector everytime.
Cause Math.sqrt avoid if vector is already normalized in Vector2#nor().
If you want to avoid the call of nor() , use the public field direction.

thx for reading.