### PR TITLE
Update ExtendViewport.java

### DIFF
--- a/gdx/src/com/badlogic/gdx/utils/viewport/ExtendViewport.java
+++ b/gdx/src/com/badlogic/gdx/utils/viewport/ExtendViewport.java
@@ -54,6 +54,15 @@ public class ExtendViewport extends Viewport {
 		this.maxWorldWidth = maxWorldWidth;
 		this.maxWorldHeight = maxWorldHeight;
 		setCamera(camera);
+		
+		//This fixes the Viewport re-sizing issue from 1.9.10 and before, concerning ExtendViewport 
+		//      and OrthographicCamera.
+        	if ( super.getCamera() instanceof OrthographicCamera ) {
+            		( ( OrthographicCamera ) super.getCamera() ).setToOrtho(
+                    		false,
+                    		super.getWorldWidth(),
+                    		super.getWorldHeight() );
+        	}
 	}
 
 	public void update (int screenWidth, int screenHeight, boolean centerCamera) {


### PR DESCRIPTION
Lines 60 through 65 fix the Viewport re-sizing issue from 1.9.10 and before, concerning ExtendViewport and OrthographicCamera.  In certain situations where an ExtendViewport object was quickly removed and created anew, it would double the values of the OrthographicCamera reacting to the parent Viewport class variables of worldWidth and worldHeight.  The OrthographicCamera would effectively act as if zoomed in by 200%.

Lines 60 through 65 verify if the Camera type is truly an OrthographicCamera and reacts accordingly with the fix.  This may carry a benefit for future 3D endeavors with non-Orthographic Camera types, such as PerspectiveCamera.

I have tested this with my own code, relying upon my own version of ExtendViewport only.  Thank you for reading.