### PR TITLE
Link to open list of apps/games built with LibGDX/RoboVM.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,5 @@ libGDX is supported by helpful 3rd parties via code contributions, free licenses
 </table>
 
 Intel and the Intel logo are trademarks of Intel Corporation in the U.S. and/or other countries.
+
+[Open list of apps and games built with LibGDX/RoboVM](https://github.com/vminc/made-with-robovm-libgdx)


### PR DESCRIPTION
This repository is an open list of apps that is made by libGDX and/or RoboVM. The benefits of having this list is

- It improves the credentials of libGDX/RoboVM as a technology stack as new users can discover how they have been succesfully applied.

The list is open to any developers. All apps made with libGDX are welcomed to be included in the list.

A few reasons why we think listing links to apps/organization in github is better:
- Github has much more visibility than the libgdx gallery website (https://libgdx.badlogicgames.com/gallery.html)
- libgdx gallery page is not optimized. An app page there does not even have the right title name (the title is just libgdx) and it is not indexed by Google.


