### PR TITLE
performance improvements for Matrix4 operations

### DIFF
--- a/gdx/src/com/badlogic/gdx/math/Matrix4.java
+++ b/gdx/src/com/badlogic/gdx/math/Matrix4.java
@@ -1197,75 +1197,6 @@ public class Matrix4 implements Serializable {
 		memcpy(mata, tmp, sizeof(float) *  16);
 	}
 	
-	static inline float matrix4_det(float* val) {
-		return val[M30] * val[M21] * val[M12] * val[M03] - val[M20] * val[M31] * val[M12] * val[M03] - val[M30] * val[M11]
-				* val[M22] * val[M03] + val[M10] * val[M31] * val[M22] * val[M03] + val[M20] * val[M11] * val[M32] * val[M03] - val[M10]
-				* val[M21] * val[M32] * val[M03] - val[M30] * val[M21] * val[M02] * val[M13] + val[M20] * val[M31] * val[M02] * val[M13]
-				+ val[M30] * val[M01] * val[M22] * val[M13] - val[M00] * val[M31] * val[M22] * val[M13] - val[M20] * val[M01] * val[M32]
-				* val[M13] + val[M00] * val[M21] * val[M32] * val[M13] + val[M30] * val[M11] * val[M02] * val[M23] - val[M10] * val[M31]
-				* val[M02] * val[M23] - val[M30] * val[M01] * val[M12] * val[M23] + val[M00] * val[M31] * val[M12] * val[M23] + val[M10]
-				* val[M01] * val[M32] * val[M23] - val[M00] * val[M11] * val[M32] * val[M23] - val[M20] * val[M11] * val[M02] * val[M33]
-				+ val[M10] * val[M21] * val[M02] * val[M33] + val[M20] * val[M01] * val[M12] * val[M33] - val[M00] * val[M21] * val[M12]
-				* val[M33] - val[M10] * val[M01] * val[M22] * val[M33] + val[M00] * val[M11] * val[M22] * val[M33];
-	}
-	
-	static inline bool matrix4_inv(float* val) {
-		float tmp[16];
-		float l_det = matrix4_det(val);
-		if (l_det == 0) return false;
-		tmp[M00] = val[M12] * val[M23] * val[M31] - val[M13] * val[M22] * val[M31] + val[M13] * val[M21] * val[M32] - val[M11]
-			* val[M23] * val[M32] - val[M12] * val[M21] * val[M33] + val[M11] * val[M22] * val[M33];
-		tmp[M01] = val[M03] * val[M22] * val[M31] - val[M02] * val[M23] * val[M31] - val[M03] * val[M21] * val[M32] + val[M01]
-			* val[M23] * val[M32] + val[M02] * val[M21] * val[M33] - val[M01] * val[M22] * val[M33];
-		tmp[M02] = val[M02] * val[M13] * val[M31] - val[M03] * val[M12] * val[M31] + val[M03] * val[M11] * val[M32] - val[M01]
-			* val[M13] * val[M32] - val[M02] * val[M11] * val[M33] + val[M01] * val[M12] * val[M33];
-		tmp[M03] = val[M03] * val[M12] * val[M21] - val[M02] * val[M13] * val[M21] - val[M03] * val[M11] * val[M22] + val[M01]
-			* val[M13] * val[M22] + val[M02] * val[M11] * val[M23] - val[M01] * val[M12] * val[M23];
-		tmp[M10] = val[M13] * val[M22] * val[M30] - val[M12] * val[M23] * val[M30] - val[M13] * val[M20] * val[M32] + val[M10]
-			* val[M23] * val[M32] + val[M12] * val[M20] * val[M33] - val[M10] * val[M22] * val[M33];
-		tmp[M11] = val[M02] * val[M23] * val[M30] - val[M03] * val[M22] * val[M30] + val[M03] * val[M20] * val[M32] - val[M00]
-			* val[M23] * val[M32] - val[M02] * val[M20] * val[M33] + val[M00] * val[M22] * val[M33];
-		tmp[M12] = val[M03] * val[M12] * val[M30] - val[M02] * val[M13] * val[M30] - val[M03] * val[M10] * val[M32] + val[M00]
-			* val[M13] * val[M32] + val[M02] * val[M10] * val[M33] - val[M00] * val[M12] * val[M33];
-		tmp[M13] = val[M02] * val[M13] * val[M20] - val[M03] * val[M12] * val[M20] + val[M03] * val[M10] * val[M22] - val[M00]
-			* val[M13] * val[M22] - val[M02] * val[M10] * val[M23] + val[M00] * val[M12] * val[M23];
-		tmp[M20] = val[M11] * val[M23] * val[M30] - val[M13] * val[M21] * val[M30] + val[M13] * val[M20] * val[M31] - val[M10]
-			* val[M23] * val[M31] - val[M11] * val[M20] * val[M33] + val[M10] * val[M21] * val[M33];
-		tmp[M21] = val[M03] * val[M21] * val[M30] - val[M01] * val[M23] * val[M30] - val[M03] * val[M20] * val[M31] + val[M00]
-			* val[M23] * val[M31] + val[M01] * val[M20] * val[M33] - val[M00] * val[M21] * val[M33];
-		tmp[M22] = val[M01] * val[M13] * val[M30] - val[M03] * val[M11] * val[M30] + val[M03] * val[M10] * val[M31] - val[M00]
-			* val[M13] * val[M31] - val[M01] * val[M10] * val[M33] + val[M00] * val[M11] * val[M33];
-		tmp[M23] = val[M03] * val[M11] * val[M20] - val[M01] * val[M13] * val[M20] - val[M03] * val[M10] * val[M21] + val[M00]
-			* val[M13] * val[M21] + val[M01] * val[M10] * val[M23] - val[M00] * val[M11] * val[M23];
-		tmp[M30] = val[M12] * val[M21] * val[M30] - val[M11] * val[M22] * val[M30] - val[M12] * val[M20] * val[M31] + val[M10]
-			* val[M22] * val[M31] + val[M11] * val[M20] * val[M32] - val[M10] * val[M21] * val[M32];
-		tmp[M31] = val[M01] * val[M22] * val[M30] - val[M02] * val[M21] * val[M30] + val[M02] * val[M20] * val[M31] - val[M00]
-			* val[M22] * val[M31] - val[M01] * val[M20] * val[M32] + val[M00] * val[M21] * val[M32];
-		tmp[M32] = val[M02] * val[M11] * val[M30] - val[M01] * val[M12] * val[M30] - val[M02] * val[M10] * val[M31] + val[M00]
-			* val[M12] * val[M31] + val[M01] * val[M10] * val[M32] - val[M00] * val[M11] * val[M32];
-		tmp[M33] = val[M01] * val[M12] * val[M20] - val[M02] * val[M11] * val[M20] + val[M02] * val[M10] * val[M21] - val[M00]
-			* val[M12] * val[M21] - val[M01] * val[M10] * val[M22] + val[M00] * val[M11] * val[M22];
-
-		float inv_det = 1.0f / l_det;
-		val[M00] = tmp[M00] * inv_det;
-		val[M01] = tmp[M01] * inv_det;
-		val[M02] = tmp[M02] * inv_det;
-		val[M03] = tmp[M03] * inv_det;
-		val[M10] = tmp[M10] * inv_det;
-		val[M11] = tmp[M11] * inv_det;
-		val[M12] = tmp[M12] * inv_det;
-		val[M13] = tmp[M13] * inv_det;
-		val[M20] = tmp[M20] * inv_det;
-		val[M21] = tmp[M21] * inv_det;
-		val[M22] = tmp[M22] * inv_det;
-		val[M23] = tmp[M23] * inv_det;
-		val[M30] = tmp[M30] * inv_det;
-		val[M31] = tmp[M31] * inv_det;
-		val[M32] = tmp[M32] * inv_det;
-		val[M33] = tmp[M33] * inv_det;
-		return true;
-	}
-
 	static inline void matrix4_mulVec(float* mat, float* vec) {
 		float x = vec[0] * mat[M00] + vec[1] * mat[M01] + vec[2] * mat[M02] + mat[M03];
 		float y = vec[0] * mat[M10] + vec[1] * mat[M11] + vec[2] * mat[M12] + mat[M13];
@@ -1300,9 +1231,25 @@ public class Matrix4 implements Serializable {
 	 *
 	 * @param mata the first matrix.
 	 * @param matb the second matrix. */
-	public static native void mul (float[] mata, float[] matb) /*-{ }-*/; /*
-		matrix4_mul(mata, matb);
-	*/
+	public static void mul (float[] mata, float[] matb) {
+		tmp[M00] = mata[M00] * matb[M00] + mata[M01] * matb[M10] + mata[M02] * matb[M20] + mata[M03] * matb[M30];
+		tmp[M01] = mata[M00] * matb[M01] + mata[M01] * matb[M11] + mata[M02] * matb[M21] + mata[M03] * matb[M31];
+		tmp[M02] = mata[M00] * matb[M02] + mata[M01] * matb[M12] + mata[M02] * matb[M22] + mata[M03] * matb[M32];
+		tmp[M03] = mata[M00] * matb[M03] + mata[M01] * matb[M13] + mata[M02] * matb[M23] + mata[M03] * matb[M33];
+		tmp[M10] = mata[M10] * matb[M00] + mata[M11] * matb[M10] + mata[M12] * matb[M20] + mata[M13] * matb[M30];
+		tmp[M11] = mata[M10] * matb[M01] + mata[M11] * matb[M11] + mata[M12] * matb[M21] + mata[M13] * matb[M31];
+		tmp[M12] = mata[M10] * matb[M02] + mata[M11] * matb[M12] + mata[M12] * matb[M22] + mata[M13] * matb[M32];
+		tmp[M13] = mata[M10] * matb[M03] + mata[M11] * matb[M13] + mata[M12] * matb[M23] + mata[M13] * matb[M33];
+		tmp[M20] = mata[M20] * matb[M00] + mata[M21] * matb[M10] + mata[M22] * matb[M20] + mata[M23] * matb[M30];
+		tmp[M21] = mata[M20] * matb[M01] + mata[M21] * matb[M11] + mata[M22] * matb[M21] + mata[M23] * matb[M31];
+		tmp[M22] = mata[M20] * matb[M02] + mata[M21] * matb[M12] + mata[M22] * matb[M22] + mata[M23] * matb[M32];
+		tmp[M23] = mata[M20] * matb[M03] + mata[M21] * matb[M13] + mata[M22] * matb[M23] + mata[M23] * matb[M33];
+		tmp[M30] = mata[M30] * matb[M00] + mata[M31] * matb[M10] + mata[M32] * matb[M20] + mata[M33] * matb[M30];
+		tmp[M31] = mata[M30] * matb[M01] + mata[M31] * matb[M11] + mata[M32] * matb[M21] + mata[M33] * matb[M31];
+		tmp[M32] = mata[M30] * matb[M02] + mata[M31] * matb[M12] + mata[M32] * matb[M22] + mata[M33] * matb[M32];
+		tmp[M33] = mata[M30] * matb[M03] + mata[M31] * matb[M13] + mata[M32] * matb[M23] + mata[M33] * matb[M33];
+		System.arraycopy(tmp, 0, mata, 0, 16);
+	}
 
 	/** Multiplies the vector with the given matrix. The matrix array is assumed to hold a 4x4 column major matrix as you can get
 	 * from {@link Matrix4#val}. The vector array is assumed to hold a 3-component vector, with x being the first element, y being
@@ -1310,9 +1257,14 @@ public class Matrix4 implements Serializable {
 	 * {@link Vector3#mul(Matrix4)}.
 	 * @param mat the matrix
 	 * @param vec the vector. */
-	public static native void mulVec (float[] mat, float[] vec) /*-{ }-*/; /*
-		matrix4_mulVec(mat, vec);
-	*/
+	public static void mulVec (float[] mat, float[] vec) {
+		float x = vec[0] * mat[M00] + vec[1] * mat[M01] + vec[2] * mat[M02] + mat[M03];
+		float y = vec[0] * mat[M10] + vec[1] * mat[M11] + vec[2] * mat[M12] + mat[M13];
+		float z = vec[0] * mat[M20] + vec[1] * mat[M21] + vec[2] * mat[M22] + mat[M23];
+		vec[0] = x;
+		vec[1] = y;
+		vec[2] = z;
+	}
 
 	/** Multiplies the vectors with the given matrix. The matrix array is assumed to hold a 4x4 column major matrix as you can get
 	 * from {@link Matrix4#val}. The vectors array is assumed to hold 3-component vectors. Offset specifies the offset into the
@@ -1339,9 +1291,15 @@ public class Matrix4 implements Serializable {
 	 * same as {@link Vector3#prj(Matrix4)}.
 	 * @param mat the matrix
 	 * @param vec the vector. */
-	public static native void prj (float[] mat, float[] vec) /*-{ }-*/; /*
-		matrix4_proj(mat, vec);
-	*/
+	public static void prj (float[] mat, float[] vec) {
+		float inv_w = 1.0f / (vec[0] * mat[M30] + vec[1] * mat[M31] + vec[2] * mat[M32] + mat[M33]);
+		float x = (vec[0] * mat[M00] + vec[1] * mat[M01] + vec[2] * mat[M02] + mat[M03]) * inv_w;
+		float y = (vec[0] * mat[M10] + vec[1] * mat[M11] + vec[2] * mat[M12] + mat[M13]) * inv_w;
+		float z = (vec[0] * mat[M20] + vec[1] * mat[M21] + vec[2] * mat[M22] + mat[M23]) * inv_w;
+		vec[0] = x;
+		vec[1] = y;
+		vec[2] = z;
+	}
 
 	/** Multiplies the vectors with the given matrix, , performing a division by w. The matrix array is assumed to hold a 4x4 column
 	 * major matrix as you can get from {@link Matrix4#val}. The vectors array is assumed to hold 3-component vectors. Offset
@@ -1368,9 +1326,14 @@ public class Matrix4 implements Serializable {
 	 * same as {@link Vector3#rot(Matrix4)}.
 	 * @param mat the matrix
 	 * @param vec the vector. */
-	public static native void rot (float[] mat, float[] vec) /*-{ }-*/; /*
-		matrix4_rot(mat, vec);
-	*/
+	public static void rot (float[] mat, float[] vec) {
+		float x = vec[0] * mat[M00] + vec[1] * mat[M01] + vec[2] * mat[M02];
+		float y = vec[0] * mat[M10] + vec[1] * mat[M11] + vec[2] * mat[M12];
+		float z = vec[0] * mat[M20] + vec[1] * mat[M21] + vec[2] * mat[M22];
+		vec[0] = x;
+		vec[1] = y;
+		vec[2] = z;
+	}
 
 	/** Multiplies the vectors with the top most 3x3 sub-matrix of the given matrix. The matrix array is assumed to hold a 4x4
 	 * column major matrix as you can get from {@link Matrix4#val}. The vectors array is assumed to hold 3-component vectors.
@@ -1395,17 +1358,79 @@ public class Matrix4 implements Serializable {
 	 * {@link Matrix4#val}.
 	 * @param values the matrix values.
 	 * @return false in case the inverse could not be calculated, true otherwise. */
-	public static native boolean inv (float[] values) /*-{ }-*/; /*
-		return matrix4_inv(values);
-	*/
+	public static boolean inv (float[] values) {
+		float tmp[] = new float[16];
+		float l_det = det(values);
+		if (l_det == 0) return false;
+		tmp[M00] = values[M12] * values[M23] * values[M31] - values[M13] * values[M22] * values[M31] + values[M13] * values[M21] * values[M32] - values[M11]
+			* values[M23] * values[M32] - values[M12] * values[M21] * values[M33] + values[M11] * values[M22] * values[M33];
+		tmp[M01] = values[M03] * values[M22] * values[M31] - values[M02] * values[M23] * values[M31] - values[M03] * values[M21] * values[M32] + values[M01]
+			* values[M23] * values[M32] + values[M02] * values[M21] * values[M33] - values[M01] * values[M22] * values[M33];
+		tmp[M02] = values[M02] * values[M13] * values[M31] - values[M03] * values[M12] * values[M31] + values[M03] * values[M11] * values[M32] - values[M01]
+			* values[M13] * values[M32] - values[M02] * values[M11] * values[M33] + values[M01] * values[M12] * values[M33];
+		tmp[M03] = values[M03] * values[M12] * values[M21] - values[M02] * values[M13] * values[M21] - values[M03] * values[M11] * values[M22] + values[M01]
+			* values[M13] * values[M22] + values[M02] * values[M11] * values[M23] - values[M01] * values[M12] * values[M23];
+		tmp[M10] = values[M13] * values[M22] * values[M30] - values[M12] * values[M23] * values[M30] - values[M13] * values[M20] * values[M32] + values[M10]
+			* values[M23] * values[M32] + values[M12] * values[M20] * values[M33] - values[M10] * values[M22] * values[M33];
+		tmp[M11] = values[M02] * values[M23] * values[M30] - values[M03] * values[M22] * values[M30] + values[M03] * values[M20] * values[M32] - values[M00]
+			* values[M23] * values[M32] - values[M02] * values[M20] * values[M33] + values[M00] * values[M22] * values[M33];
+		tmp[M12] = values[M03] * values[M12] * values[M30] - values[M02] * values[M13] * values[M30] - values[M03] * values[M10] * values[M32] + values[M00]
+			* values[M13] * values[M32] + values[M02] * values[M10] * values[M33] - values[M00] * values[M12] * values[M33];
+		tmp[M13] = values[M02] * values[M13] * values[M20] - values[M03] * values[M12] * values[M20] + values[M03] * values[M10] * values[M22] - values[M00]
+			* values[M13] * values[M22] - values[M02] * values[M10] * values[M23] + values[M00] * values[M12] * values[M23];
+		tmp[M20] = values[M11] * values[M23] * values[M30] - values[M13] * values[M21] * values[M30] + values[M13] * values[M20] * values[M31] - values[M10]
+			* values[M23] * values[M31] - values[M11] * values[M20] * values[M33] + values[M10] * values[M21] * values[M33];
+		tmp[M21] = values[M03] * values[M21] * values[M30] - values[M01] * values[M23] * values[M30] - values[M03] * values[M20] * values[M31] + values[M00]
+			* values[M23] * values[M31] + values[M01] * values[M20] * values[M33] - values[M00] * values[M21] * values[M33];
+		tmp[M22] = values[M01] * values[M13] * values[M30] - values[M03] * values[M11] * values[M30] + values[M03] * values[M10] * values[M31] - values[M00]
+			* values[M13] * values[M31] - values[M01] * values[M10] * values[M33] + values[M00] * values[M11] * values[M33];
+		tmp[M23] = values[M03] * values[M11] * values[M20] - values[M01] * values[M13] * values[M20] - values[M03] * values[M10] * values[M21] + values[M00]
+			* values[M13] * values[M21] + values[M01] * values[M10] * values[M23] - values[M00] * values[M11] * values[M23];
+		tmp[M30] = values[M12] * values[M21] * values[M30] - values[M11] * values[M22] * values[M30] - values[M12] * values[M20] * values[M31] + values[M10]
+			* values[M22] * values[M31] + values[M11] * values[M20] * values[M32] - values[M10] * values[M21] * values[M32];
+		tmp[M31] = values[M01] * values[M22] * values[M30] - values[M02] * values[M21] * values[M30] + values[M02] * values[M20] * values[M31] - values[M00]
+			* values[M22] * values[M31] - values[M01] * values[M20] * values[M32] + values[M00] * values[M21] * values[M32];
+		tmp[M32] = values[M02] * values[M11] * values[M30] - values[M01] * values[M12] * values[M30] - values[M02] * values[M10] * values[M31] + values[M00]
+			* values[M12] * values[M31] + values[M01] * values[M10] * values[M32] - values[M00] * values[M11] * values[M32];
+		tmp[M33] = values[M01] * values[M12] * values[M20] - values[M02] * values[M11] * values[M20] + values[M02] * values[M10] * values[M21] - values[M00]
+			* values[M12] * values[M21] - values[M01] * values[M10] * values[M22] + values[M00] * values[M11] * values[M22];
+
+		float inv_det = 1.0f / l_det;
+		values[M00] = tmp[M00] * inv_det;
+		values[M01] = tmp[M01] * inv_det;
+		values[M02] = tmp[M02] * inv_det;
+		values[M03] = tmp[M03] * inv_det;
+		values[M10] = tmp[M10] * inv_det;
+		values[M11] = tmp[M11] * inv_det;
+		values[M12] = tmp[M12] * inv_det;
+		values[M13] = tmp[M13] * inv_det;
+		values[M20] = tmp[M20] * inv_det;
+		values[M21] = tmp[M21] * inv_det;
+		values[M22] = tmp[M22] * inv_det;
+		values[M23] = tmp[M23] * inv_det;
+		values[M30] = tmp[M30] * inv_det;
+		values[M31] = tmp[M31] * inv_det;
+		values[M32] = tmp[M32] * inv_det;
+		values[M33] = tmp[M33] * inv_det;
+		return true;
+	}
 
 	/** Computes the determinante of the given matrix. The matrix array is assumed to hold a 4x4 column major matrix as you can get
 	 * from {@link Matrix4#val}.
 	 * @param values the matrix values.
 	 * @return the determinante. */
-	public static native float det (float[] values) /*-{ }-*/; /*
-		return matrix4_det(values);
-	*/
+	public static float det (float[] values) {
+		return values[M30] * values[M21] * values[M12] * values[M03] - values[M20] * values[M31] * values[M12] * values[M03] - values[M30] * values[M11]
+			* values[M22] * values[M03] + values[M10] * values[M31] * values[M22] * values[M03] + values[M20] * values[M11] * values[M32] * values[M03] - values[M10]
+			* values[M21] * values[M32] * values[M03] - values[M30] * values[M21] * values[M02] * values[M13] + values[M20] * values[M31] * values[M02] * values[M13]
+			+ values[M30] * values[M01] * values[M22] * values[M13] - values[M00] * values[M31] * values[M22] * values[M13] - values[M20] * values[M01] * values[M32]
+			* values[M13] + values[M00] * values[M21] * values[M32] * values[M13] + values[M30] * values[M11] * values[M02] * values[M23] - values[M10] * values[M31]
+			* values[M02] * values[M23] - values[M30] * values[M01] * values[M12] * values[M23] + values[M00] * values[M31] * values[M12] * values[M23] + values[M10]
+			* values[M01] * values[M32] * values[M23] - values[M00] * values[M11] * values[M32] * values[M23] - values[M20] * values[M11] * values[M02] * values[M33]
+			+ values[M10] * values[M21] * values[M02] * values[M33] + values[M20] * values[M01] * values[M12] * values[M33] - values[M00] * values[M21] * values[M12]
+			* values[M33] - values[M10] * values[M01] * values[M22] * values[M33] + values[M00] * values[M11] * values[M22] * values[M33];
+		
+	}
 
 	// @on
 	/** Postmultiplies this matrix by a translation matrix. Postmultiplication is also used by OpenGL ES'

--- a/gdx/src/com/badlogic/gdx/math/Matrix4.java
+++ b/gdx/src/com/badlogic/gdx/math/Matrix4.java
@@ -1226,6 +1226,64 @@ public class Matrix4 implements Serializable {
 	}
 	 */
 
+	/** Multiplies the vectors with the given matrix. The matrix array is assumed to hold a 4x4 column major matrix as you can get
+	 * from {@link Matrix4#val}. The vectors array is assumed to hold 3-component vectors. Offset specifies the offset into the
+	 * array where the x-component of the first vector is located. The numVecs parameter specifies the number of vectors stored in
+	 * the vectors array. The stride parameter specifies the number of floats between subsequent vectors and must be >= 3. This is
+	 * the same as {@link Vector3#mul(Matrix4)} applied to multiple vectors.
+	 * 
+	 * @param mat the matrix
+	 * @param vecs the vectors
+	 * @param offset the offset into the vectors array
+	 * @param numVecs the number of vectors
+	 * @param stride the stride between vectors in floats */
+	public static native void mulVec (float[] mat, float[] vecs, int offset, int numVecs, int stride) /*-{ }-*/; /*
+		float* vecPtr = vecs + offset;
+		for(int i = 0; i < numVecs; i++) {
+			matrix4_mulVec(mat, vecPtr);
+			vecPtr += stride;
+		}
+	*/
+
+	/** Multiplies the vectors with the given matrix, , performing a division by w. The matrix array is assumed to hold a 4x4 column
+	 * major matrix as you can get from {@link Matrix4#val}. The vectors array is assumed to hold 3-component vectors. Offset
+	 * specifies the offset into the array where the x-component of the first vector is located. The numVecs parameter specifies
+	 * the number of vectors stored in the vectors array. The stride parameter specifies the number of floats between subsequent
+	 * vectors and must be >= 3. This is the same as {@link Vector3#prj(Matrix4)} applied to multiple vectors.
+	 * 
+	 * @param mat the matrix
+	 * @param vecs the vectors
+	 * @param offset the offset into the vectors array
+	 * @param numVecs the number of vectors
+	 * @param stride the stride between vectors in floats */
+	public static native void prj (float[] mat, float[] vecs, int offset, int numVecs, int stride) /*-{ }-*/; /*
+		float* vecPtr = vecs + offset;
+		for(int i = 0; i < numVecs; i++) {
+			matrix4_proj(mat, vecPtr);
+			vecPtr += stride;
+		}
+	*/
+
+	/** Multiplies the vectors with the top most 3x3 sub-matrix of the given matrix. The matrix array is assumed to hold a 4x4
+	 * column major matrix as you can get from {@link Matrix4#val}. The vectors array is assumed to hold 3-component vectors.
+	 * Offset specifies the offset into the array where the x-component of the first vector is located. The numVecs parameter
+	 * specifies the number of vectors stored in the vectors array. The stride parameter specifies the number of floats between
+	 * subsequent vectors and must be >= 3. This is the same as {@link Vector3#rot(Matrix4)} applied to multiple vectors.
+	 * 
+	 * @param mat the matrix
+	 * @param vecs the vectors
+	 * @param offset the offset into the vectors array
+	 * @param numVecs the number of vectors
+	 * @param stride the stride between vectors in floats */
+	public static native void rot (float[] mat, float[] vecs, int offset, int numVecs, int stride) /*-{ }-*/; /*
+		float* vecPtr = vecs + offset;
+		for(int i = 0; i < numVecs; i++) {
+			matrix4_rot(mat, vecPtr);
+			vecPtr += stride;
+		}
+	*/
+	// @on
+
 	/** Multiplies the matrix mata with matrix matb, storing the result in mata. The arrays are assumed to hold 4x4 column major
 	 * matrices as you can get from {@link Matrix4#val}. This is the same as {@link Matrix4#mul(Matrix4)}.
 	 *
@@ -1266,25 +1324,6 @@ public class Matrix4 implements Serializable {
 		vec[2] = z;
 	}
 
-	/** Multiplies the vectors with the given matrix. The matrix array is assumed to hold a 4x4 column major matrix as you can get
-	 * from {@link Matrix4#val}. The vectors array is assumed to hold 3-component vectors. Offset specifies the offset into the
-	 * array where the x-component of the first vector is located. The numVecs parameter specifies the number of vectors stored in
-	 * the vectors array. The stride parameter specifies the number of floats between subsequent vectors and must be >= 3. This is
-	 * the same as {@link Vector3#mul(Matrix4)} applied to multiple vectors.
-	 * 
-	 * @param mat the matrix
-	 * @param vecs the vectors
-	 * @param offset the offset into the vectors array
-	 * @param numVecs the number of vectors
-	 * @param stride the stride between vectors in floats */
-	public static native void mulVec (float[] mat, float[] vecs, int offset, int numVecs, int stride) /*-{ }-*/; /*
-		float* vecPtr = vecs + offset;
-		for(int i = 0; i < numVecs; i++) {
-			matrix4_mulVec(mat, vecPtr);
-			vecPtr += stride;
-		}
-	*/
-
 	/** Multiplies the vector with the given matrix, performing a division by w. The matrix array is assumed to hold a 4x4 column
 	 * major matrix as you can get from {@link Matrix4#val}. The vector array is assumed to hold a 3-component vector, with x being
 	 * the first element, y being the second and z being the last component. The result is stored in the vector array. This is the
@@ -1301,25 +1340,6 @@ public class Matrix4 implements Serializable {
 		vec[2] = z;
 	}
 
-	/** Multiplies the vectors with the given matrix, , performing a division by w. The matrix array is assumed to hold a 4x4 column
-	 * major matrix as you can get from {@link Matrix4#val}. The vectors array is assumed to hold 3-component vectors. Offset
-	 * specifies the offset into the array where the x-component of the first vector is located. The numVecs parameter specifies
-	 * the number of vectors stored in the vectors array. The stride parameter specifies the number of floats between subsequent
-	 * vectors and must be >= 3. This is the same as {@link Vector3#prj(Matrix4)} applied to multiple vectors.
-	 * 
-	 * @param mat the matrix
-	 * @param vecs the vectors
-	 * @param offset the offset into the vectors array
-	 * @param numVecs the number of vectors
-	 * @param stride the stride between vectors in floats */
-	public static native void prj (float[] mat, float[] vecs, int offset, int numVecs, int stride) /*-{ }-*/; /*
-		float* vecPtr = vecs + offset;
-		for(int i = 0; i < numVecs; i++) {
-			matrix4_proj(mat, vecPtr);
-			vecPtr += stride;
-		}
-	*/
-
 	/** Multiplies the vector with the top most 3x3 sub-matrix of the given matrix. The matrix array is assumed to hold a 4x4 column
 	 * major matrix as you can get from {@link Matrix4#val}. The vector array is assumed to hold a 3-component vector, with x being
 	 * the first element, y being the second and z being the last component. The result is stored in the vector array. This is the
@@ -1334,25 +1354,6 @@ public class Matrix4 implements Serializable {
 		vec[1] = y;
 		vec[2] = z;
 	}
-
-	/** Multiplies the vectors with the top most 3x3 sub-matrix of the given matrix. The matrix array is assumed to hold a 4x4
-	 * column major matrix as you can get from {@link Matrix4#val}. The vectors array is assumed to hold 3-component vectors.
-	 * Offset specifies the offset into the array where the x-component of the first vector is located. The numVecs parameter
-	 * specifies the number of vectors stored in the vectors array. The stride parameter specifies the number of floats between
-	 * subsequent vectors and must be >= 3. This is the same as {@link Vector3#rot(Matrix4)} applied to multiple vectors.
-	 * 
-	 * @param mat the matrix
-	 * @param vecs the vectors
-	 * @param offset the offset into the vectors array
-	 * @param numVecs the number of vectors
-	 * @param stride the stride between vectors in floats */
-	public static native void rot (float[] mat, float[] vecs, int offset, int numVecs, int stride) /*-{ }-*/; /*
-		float* vecPtr = vecs + offset;
-		for(int i = 0; i < numVecs; i++) {
-			matrix4_rot(mat, vecPtr);
-			vecPtr += stride;
-		}
-	*/
 
 	/** Computes the inverse of the given matrix. The matrix array is assumed to hold a 4x4 column major matrix as you can get from
 	 * {@link Matrix4#val}.
@@ -1432,7 +1433,6 @@ public class Matrix4 implements Serializable {
 		
 	}
 
-	// @on
 	/** Postmultiplies this matrix by a translation matrix. Postmultiplication is also used by OpenGL ES'
 	 * glTranslate/glRotate/glScale
 	 * @param translation

--- a/gdx/src/com/badlogic/gdx/math/Matrix4.java
+++ b/gdx/src/com/badlogic/gdx/math/Matrix4.java
@@ -1360,7 +1360,6 @@ public class Matrix4 implements Serializable {
 	 * @param values the matrix values.
 	 * @return false in case the inverse could not be calculated, true otherwise. */
 	public static boolean inv (float[] values) {
-		float tmp[] = new float[16];
 		float l_det = det(values);
 		if (l_det == 0) return false;
 		tmp[M00] = values[M12] * values[M23] * values[M31] - values[M13] * values[M22] * values[M31] + values[M13] * values[M21] * values[M32] - values[M11]


### PR DESCRIPTION
Some Matrix4 native methods give significant improvements when replacing them by java code (probably because of JNI overhead). .

I made few tests on a real scenario, gain is around 16% FPS : 320 FPS before, 373 after. 
Context: 1000 model instance, 4000 Matrix4.mul.

Matrix4.mul is heavily used, especially for 3D node tree 
Matrix4.inv is only used by cameras.
others are not used by framework code.

Thanks @Anuken to brought this up and @tommyettinger for the [Matrix4 Comparative Benchmark](https://github.com/tommyettinger/assorted-benchmarks/blob/master/src/main/java/net/adoptopenjdk/bumblebench/examples/Matrix4Benchmarks.md)

Notes: 
* java code was directly copied from GWT emulation implementation.
* my second commit might be questionnable, i made choice of mouving methods instead of adding a bunch of On/Off formatting tags. Tell me if i should reconsider. 
* few C functions become unused, so i removed it. I thing it's fine.