### PR TITLE
Polyline contains implemented and mini opti on Polygon/Polyline

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,8 @@
 - Update to LWJGL 3.2.3
 - API Change: Table#getRow now returns -1 when over the table but not over a row (used to return the last row).
 - API Change: Tree#addToTree and #removeFromTree now have an "int actorIndex" parameter.
+- API Change: Polyline#contains implemented (return true if point on one segment)
+- API Addition: Polyline#contains with approximation (return true if point is nearnest of approximation on one segment
 
 [1.9.10]
 - API Addition: Allow target display for maximization LWJGL3 backend

--- a/gdx/src/com/badlogic/gdx/math/Polygon.java
+++ b/gdx/src/com/badlogic/gdx/math/Polygon.java
@@ -68,8 +68,8 @@ public class Polygon implements Shape2D {
 		final float scaleY = this.scaleY;
 		final boolean scale = scaleX != 1 || scaleY != 1;
 		final float rotation = this.rotation;
-		final float cos = MathUtils.cosDeg(rotation);
-		final float sin = MathUtils.sinDeg(rotation);
+		final float cos = (rotation != 0) ? MathUtils.cosDeg(rotation) : 0;
+		final float sin = (rotation != 0) ? MathUtils.sinDeg(rotation) : 0;
 
 		for (int i = 0, n = localVertices.length; i < n; i += 2) {
 			float x = localVertices[i] - originX;

--- a/gdx/src/com/badlogic/gdx/math/Polyline.java
+++ b/gdx/src/com/badlogic/gdx/math/Polyline.java
@@ -204,9 +204,10 @@ public class Polyline implements Shape2D {
 		dirty = true;
 	}
 
+	/** check if the point is on one segment */
 	@Override
 	public boolean contains (Vector2 point) {
-		return false;
+		return contains(point.x, point.y);
 	}
 
 	/** check if the point is on one segment */

--- a/gdx/src/com/badlogic/gdx/math/Polyline.java
+++ b/gdx/src/com/badlogic/gdx/math/Polyline.java
@@ -60,8 +60,8 @@ public class Polyline implements Shape2D {
 		final float scaleY = this.scaleY;
 		final boolean scale = scaleX != 1 || scaleY != 1;
 		final float rotation = this.rotation;
-		final float cos = MathUtils.cosDeg(rotation);
-		final float sin = MathUtils.sinDeg(rotation);
+		final float cos = (rotation != 0) ? MathUtils.cosDeg(rotation) : 0;
+		final float sin = (rotation != 0) ? MathUtils.sinDeg(rotation) : 0;
 
 		for (int i = 0, n = localVertices.length; i < n; i += 2) {
 			float x = localVertices[i] - originX;
@@ -209,8 +209,28 @@ public class Polyline implements Shape2D {
 		return false;
 	}
 
+	/** check if the point is on one segment */
 	@Override
 	public boolean contains (float x, float y) {
+		final float[] vertices = getTransformedVertices();
+		for (int i = 0, n = vertices.length; i < n - 2; i += 2) {
+			if (Vector2.dst(vertices[i], vertices[i + 1], x, y) + Vector2.dst(vertices[i + 2], vertices[i + 3], x, y) == Vector2
+				.dst(vertices[i], vertices[i + 1], vertices[i + 2], vertices[i + 3])) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/** check if point is nearnest than approximation on one segment */
+	public boolean contains (float x, float y, float approximation) {
+		final float[] vertices = getTransformedVertices();
+		for (int i = 0, n = vertices.length; i < n - 2; i += 2) {
+			if (Intersector.distanceSegmentPoint(vertices[i], vertices[i + 1], vertices[i + 2], vertices[i + 3], x,
+				y) <= approximation) {
+				return true;
+			}
+		}
 		return false;
 	}
 }


### PR DESCRIPTION
Hello, i see Polyline contains method (from Shape interface) wasnt implemented.

So the contains method check if the point is on one segment of polyline.
And another method to check if a point is nearest of one segment.

I do a mini "opti" on getTransformedVertices , cos and sin arent used if rotation =0.

i know a polyline is not really a shape, but i think contains method can be util.

thanks for reading.
