### PR TITLE
Fix documentation (Fixes #5868)

### DIFF
--- a/gdx/src/com/badlogic/gdx/Net.java
+++ b/gdx/src/com/badlogic/gdx/Net.java
@@ -361,7 +361,7 @@ public interface Net {
 	 * @param port the port
 	 * @param hints additional {@link SocketHints} used to create the socket. Input null to use the default setting provided by the
 	 *           system.
-	 * @return GdxRuntimeException in case the socket couldn't be opened */
+	 * @throws GdxRuntimeException in case the socket couldn't be opened */
 	public Socket newClientSocket (Protocol protocol, String host, int port, SocketHints hints);
 
 	/** Launches the default browser to display a URI. If the default browser is not able to handle the specified URI, the


### PR DESCRIPTION
This pull request fixes the issue outlined in #5868 
However, now that the documentation has been changed to throw GdxRuntimeException instead of returning it, the method documentation for the method that was changed no longer contains a returns attribute.
I am not very experienced with the source code behind this framework, so I did not take the liberty of writing that documentation.