### PR TITLE
Add warning about setLooping method in Sound interface

### DIFF
--- a/gdx/src/com/badlogic/gdx/audio/Sound.java
+++ b/gdx/src/com/badlogic/gdx/audio/Sound.java
@@ -102,7 +102,7 @@ public interface Sound extends Disposable {
 	public void resume (long soundId);
 
 	/** Sets the sound instance with the given id to be looping. If the sound is no longer playing this has no effect.
-	 * <p><b>Note: </b>Due to a bug in SoundPool, the sound will not loop if this method is called after play(). The sound can be still looped using the loop() method.</p>
+	 * <p><b>Note: </b>Due to a bug in SoundPool, the sound will not loop if this method is called after {@link #play()}. The sound can be still looped using the {@link #loop()} method.</p>
 	 * @param soundId the sound id
 	 * @param looping whether to loop or not. */
 	public void setLooping (long soundId, boolean looping);

--- a/gdx/src/com/badlogic/gdx/audio/Sound.java
+++ b/gdx/src/com/badlogic/gdx/audio/Sound.java
@@ -102,7 +102,7 @@ public interface Sound extends Disposable {
 	public void resume (long soundId);
 
 	/** Sets the sound instance with the given id to be looping. If the sound is no longer playing this has no effect.
-	 * <p><b>Note: </b>Due to a bug in SoundPool, the sound will not loop if this method is called after {@link #play()}. The sound can be still looped using the {@link #loop()} method.</p>
+	 * <p><b>Note: </b>In the Android backend, due to a bug in SoundPool the sound will not loop if this method is called after {@link #play()}. The sound can be still looped using the {@link #loop()} method.</p>
 	 * @param soundId the sound id
 	 * @param looping whether to loop or not. */
 	public void setLooping (long soundId, boolean looping);

--- a/gdx/src/com/badlogic/gdx/audio/Sound.java
+++ b/gdx/src/com/badlogic/gdx/audio/Sound.java
@@ -101,7 +101,8 @@ public interface Sound extends Disposable {
 	 * @param soundId the sound id */
 	public void resume (long soundId);
 
-	/** Sets the sound instance with the given id to be looping. If the sound is no longer playing this has no effect.s
+	/** Sets the sound instance with the given id to be looping. If the sound is no longer playing this has no effect.
+	 * <p><b>Note: </b>Due to a bug in SoundPool, the sound will not loop if this method is called after play(). The sound can be still looped using the loop() method.</p>
 	 * @param soundId the sound id
 	 * @param looping whether to loop or not. */
 	public void setLooping (long soundId, boolean looping);


### PR DESCRIPTION
As mentioned in issue #5822 , sounds on Android do not loop when the setLooping method is called after the play method because of a SoundPool bug. This commit adds a notice to the java documentation on the setLooping method of interface Sound.