### PR TITLE
Gradle: Proper runtimeClasspath usage for desktop uber jar

### DIFF
--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/desktop/build.gradle
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/desktop/build.gradle
@@ -28,8 +28,9 @@ task dist(type: Jar) {
     manifest {
         attributes 'Main-Class': project.mainClassName
     }
+    dependsOn configurations.runtimeClasspath
     from {
-        configurations.compileClasspath.collect { it.isDirectory() ? it : zipTree(it) }
+        configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
     }
     with jar
 }


### PR DESCRIPTION
* See https://docs.gradle.org/current/userguide/working_with_files.html
* For project dependencies `compileClasspath` points to class file directories, but does not contain resources.
* For project dependencies `runtimeClasspath` points to fully built jar files.
* `configurations.runtimeClasspath.collect` does not build these jars, so we have to manually add it via `dependsOn`
* Actually actually fix #5716