### PR TITLE
Setup: removed obsolete options and fix eclipse import

### DIFF
--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/BuildScriptHelper.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/BuildScriptHelper.java
@@ -61,6 +61,7 @@ public class BuildScriptHelper {
 
 	public static void addAllProjects(BufferedWriter wr) throws IOException {
 		write(wr, "allprojects {");
+		write(wr, "apply plugin: \"eclipse\"");
 		space(wr);
 		write(wr, "version = '1.0'");
 		write(wr, "ext {");

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetup.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetup.java
@@ -621,7 +621,6 @@ public class GdxSetup {
 		String argString = "";
 		if (args == null) return argString;
 		for (String argument : args) {
-			if (argument.equals("afterEclipseImport") && !modules.contains(ProjectType.DESKTOP)) continue;
 			argString += " " + argument;
 		}
 		return argString;

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetupUI.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetupUI.java
@@ -268,14 +268,9 @@ public class GdxSetupUI extends JFrame {
 					}
 				}, ui.settings.getGradleArgs());
 				log("Done!");
-				if (ui.settings.getGradleArgs().contains("eclipse") || ui.settings.getGradleArgs().contains("idea")) {
-					log("To import in Eclipse: File -> Import -> General -> Existing Projects into Workspace");
-					log("To import to Intellij IDEA: File -> Open -> YourProject.ipr");
-				} else {
-					log("To import in Eclipse: File -> Import -> Gradle -> Gradle Project");
-					log("To import to Intellij IDEA: File -> Open -> build.gradle");
-					log("To import to NetBeans: File -> Open Project...");
-				}
+				log("To import in Eclipse: File -> Import -> Gradle -> Gradle Project");
+				log("To import to Intellij IDEA: File -> Open -> build.gradle");
+				log("To import to NetBeans: File -> Open Project...");
 				SwingUtilities.invokeLater(new Runnable() {
 					@Override
 					public void run() {

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/SettingsDialog.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/SettingsDialog.java
@@ -66,13 +66,9 @@ public class SettingsDialog extends JDialog {
 	private JPanel buttonPanel;
 
 	private JTextField mavenTextField;
-	private SetupCheckBox ideaBox;
-	private SetupCheckBox eclipseBox;
 	SetupCheckBox offlineBox;
 	SetupCheckBox kotlinBox;
 	private String mavenSnapshot;
-	private boolean ideaSnapshot;
-	private boolean eclipseSnapshot;
 	private boolean offlineSnapshot;
 	private boolean kotlinSnapshot;
 
@@ -162,18 +158,6 @@ public class SettingsDialog extends JDialog {
 		mavenTextField.setMinimumSize(mavenTextField.getPreferredSize());
 		mavenLabel.setForeground(new Color(170, 170, 170));
 		mavenDesc.setForeground(new Color(170, 170, 170));
-		JLabel ideaLabel = new JLabel("IDEA");
-		JLabel ideaDesc = new JLabel("Generates Intellij IDEA project files");
-		ideaBox = new SetupCheckBox();
-		ideaLabel.setForeground(new Color(170, 170, 170));
-		ideaDesc.setForeground(new Color(170, 170, 170));
-		ideaBox.setBackground(new Color(36, 36, 36));
-		JLabel eclipseLabel = new JLabel("Eclipse");
-		JLabel eclipseDesc = new JLabel("Generates Eclipse project files");
-		eclipseBox = new SetupCheckBox();
-		eclipseLabel.setForeground(new Color(170, 170, 170));
-		eclipseDesc.setForeground(new Color(170, 170, 170));
-		eclipseBox.setBackground(new Color(36, 36, 36));
 		JLabel offlineLabel = new JLabel("Offline Mode");
 		JLabel offlineDesc = new JLabel("Don't force download dependencies");
 		JLabel kotlinLabel = new JLabel("Use Kotlin");
@@ -210,21 +194,13 @@ public class SettingsDialog extends JDialog {
 		content.add(mavenTextField, new GridBagConstraints(1, 2, 2, 1, 1, 1, NORTH, HORIZONTAL, new Insets(0, 15, 0, 0), 0, 0));
 		content.add(mavenDesc, new GridBagConstraints(3, 2, 1, 1, 1, 1, NORTH, HORIZONTAL, new Insets(0, 15, 0, 0), 0, 0));
 
-		content.add(ideaLabel, new GridBagConstraints(0, 3, 1, 1, 1, 1, NORTH, HORIZONTAL, new Insets(0, 0, 0, 0), 0, 0));
-		content.add(ideaBox, new GridBagConstraints(1, 3, 2, 1, 1, 1, NORTH, HORIZONTAL, new Insets(0, 15, 0, 0), 0, 0));
-		content.add(ideaDesc, new GridBagConstraints(3, 3, 2, 1, 1, 1, NORTH, HORIZONTAL, new Insets(0, 15, 0, 0), 0, 0));
-
-		content.add(eclipseLabel, new GridBagConstraints(0, 4, 1, 1, 1, 1, NORTH, HORIZONTAL, new Insets(0, 0, 0, 0), 0, 0));
-		content.add(eclipseBox, new GridBagConstraints(1, 4, 2, 1, 1, 1, NORTH, HORIZONTAL, new Insets(0, 15, 0, 0), 0, 0));
-		content.add(eclipseDesc, new GridBagConstraints(3, 4, 1, 1, 1, 1, NORTH, HORIZONTAL, new Insets(0, 15, 0, 0), 0, 0));
+		content.add(offlineLabel, new GridBagConstraints(0, 3, 1, 1, 1, 1, NORTH, HORIZONTAL, new Insets(0, 0, 0, 0), 0, 0));
+		content.add(offlineBox, new GridBagConstraints(1, 3, 2, 1, 1, 1, NORTH, HORIZONTAL, new Insets(0, 15, 0, 0), 0, 0));
+		content.add(offlineDesc, new GridBagConstraints(3, 3, 1, 1, 1, 1, NORTH, HORIZONTAL, new Insets(0, 15, 0, 0), 0, 0));
 		
-		content.add(offlineLabel, new GridBagConstraints(0, 5, 1, 1, 1, 1, NORTH, HORIZONTAL, new Insets(0, 0, 0, 0), 0, 0));
-		content.add(offlineBox, new GridBagConstraints(1, 5, 2, 1, 1, 1, NORTH, HORIZONTAL, new Insets(0, 15, 0, 0), 0, 0));
-		content.add(offlineDesc, new GridBagConstraints(3, 5, 1, 1, 1, 1, NORTH, HORIZONTAL, new Insets(0, 15, 0, 0), 0, 0));
-		
-		content.add(kotlinLabel, new GridBagConstraints(0, 6, 1, 1, 1, 1, NORTH, HORIZONTAL, new Insets(0, 0, 0, 0), 0, 0));
-		content.add(kotlinBox, new GridBagConstraints(1, 6, 2, 1, 1, 1, NORTH, HORIZONTAL, new Insets(0, 15, 0, 0), 0, 0));
-		content.add(kotlinDesc, new GridBagConstraints(3, 6, 1, 1, 1, 1, NORTH, HORIZONTAL, new Insets(0, 15, 0, 0), 0, 0));
+		content.add(kotlinLabel, new GridBagConstraints(0, 4, 1, 1, 1, 1, NORTH, HORIZONTAL, new Insets(0, 0, 0, 0), 0, 0));
+		content.add(kotlinBox, new GridBagConstraints(1, 4, 2, 1, 1, 1, NORTH, HORIZONTAL, new Insets(0, 15, 0, 0), 0, 0));
+		content.add(kotlinDesc, new GridBagConstraints(3, 4, 1, 1, 1, 1, NORTH, HORIZONTAL, new Insets(0, 15, 0, 0), 0, 0));
 
 
 		String text = "<p style=\"font-size:10\">Click for more info on using Gradle without IDE integration</p>";
@@ -271,13 +247,6 @@ public class SettingsDialog extends JDialog {
 		if (offlineBox.isSelected()) {
 			list.add("--offline");	
 		}
-		if (eclipseBox.isSelected()) {
-			list.add("eclipse");
-			list.add("afterEclipseImport");
-		}
-		if (ideaBox.isSelected()) {
-			list.add("idea");
-		}
 		return list;
 	}
 
@@ -297,16 +266,12 @@ public class SettingsDialog extends JDialog {
 
 	private void takeSnapshot () {
 		mavenSnapshot = mavenTextField.getText();
-		ideaSnapshot = ideaBox.isSelected();
-		eclipseSnapshot = eclipseBox.isSelected();
 		offlineSnapshot = offlineBox.isSelected();
 		kotlinSnapshot = kotlinBox.isSelected();
 	}
 
 	private void restore () {
 		mavenTextField.setText(mavenSnapshot);
-		ideaBox.setSelected(ideaSnapshot);
-		eclipseBox.setSelected(eclipseSnapshot);
 		offlineBox.setSelected(offlineSnapshot);
 		kotlinBox.setSelected(kotlinSnapshot);
 	}

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/android/build.gradle
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/android/build.gradle
@@ -88,3 +88,5 @@ task run(type: Exec) {
     def adb = path + "/platform-tools/adb"
     commandLine "$adb", 'shell', 'am', 'start', '-n', '%PACKAGE%/%PACKAGE%.AndroidLauncher'
 }
+
+eclipse.project.name = appName + "-android"

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/core/build.gradle
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/core/build.gradle
@@ -4,3 +4,5 @@ sourceCompatibility = 1.7
 [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
 
 sourceSets.main.java.srcDirs = [ "src/" ]
+
+eclipse.project.name = appName + "-core"

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/desktop/build.gradle
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/desktop/build.gradle
@@ -37,3 +37,5 @@ task dist(type: Jar) {
 
 
 dist.dependsOn classes
+
+eclipse.project.name = appName + "-desktop"

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/html/build.gradle
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/html/build.gradle
@@ -78,3 +78,5 @@ tasks.draftCompileGwt.dependsOn(addSource)
 
 sourceCompatibility = 1.7
 sourceSets.main.java.srcDirs = [ "src/" ]
+
+eclipse.project.name = appName + "-html"

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/ios/build.gradle
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/ios/build.gradle
@@ -15,3 +15,5 @@ createIPA.dependsOn build
 robovm {
 	archs = "thumbv7:arm64"
 }
+
+eclipse.project.name = appName + "-ios"


### PR DESCRIPTION
These changes are related to #5700 changes : 

* IDE options in setup dialog (Eclipse and Intellij) are no longer necessary. 
* afterEclipseImport task doesn't exists anymore and was generating errors when Eclipse option was checked.
* Eclipse plugin still necessary for project naming (prevent confliting names in Eclipse workspace)

For the last one there was 2 way to do it, see [Buildship issue](https://github.com/eclipse/buildship/issues/629#issuecomment-354762915) : either by changing projects names in settings.gradle or by using eclipse plugin.

Chaging names in settings.gradle would impact all IDE and is a bit ugly IMO. So i chosed to bring back Eclipse plugin which will only impact Eclipse.