### PR TITLE
Fix for OutOfMemoryError, slow remove(), high RAM usage in most maps and sets

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,9 @@
 - API Change: Tree#addToTree and #removeFromTree now have an "int actorIndex" parameter.
 - Fixed AndroidInput crashes due to missing array resize (pressure array).
 - API Change: Ray#set methods and Ray#mul(Matrix4) normalize direction vector. Use public field to set and avoid nor()
+- Changed the internal implementation of all Map and Set classes (except ArrayMap) to avoid OutOfMemoryErrors when too many keys collide; this helps resistance against malicious users who can choose problematic names
+- API Addition: OrderedMap#alter(Object,Object) and OrderedMap#alterIndex(int,Object) allow swapping out a key in-place without changing its value; OrderedSet also has this
+- More of the LibGDX data structures can now be passed to Json, to read and write things like a LongMap or an IntIntMap
 
 [1.9.10]
 - API Addition: Allow target display for maximization LWJGL3 backend

--- a/gdx/src/com/badlogic/gdx/utils/IdentityMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/IdentityMap.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,794 +16,89 @@
 
 package com.badlogic.gdx.utils;
 
-import java.util.Iterator;
-import java.util.NoSuchElementException;
-
-import com.badlogic.gdx.math.MathUtils;
-import com.badlogic.gdx.utils.ObjectMap.Entry;
-
-/** An unordered map that uses identity comparison for keys. This implementation is a cuckoo hash map using 3 hashes, random
- * walking, and a small stash for problematic keys. Null keys are not allowed. Null values are allowed. No allocation is done
- * except when growing the table size. <br>
+/**
+ * An unordered map that uses identity comparison for its object keys. This implementation uses linear probing with the backward-shift
+ * algorithm for removal, and finds space for keys using Fibonacci hashing instead of the more-common power-of-two mask.
+ * Null keys are not allowed. Null values are allowed. No allocation is done except when growing the table size. It uses
+ * {@link System#identityHashCode(Object)} to hash keys, which may be slower than the hashCode() on some types that have it
+ * already computed, like String; for String keys in particular, identity comparison is a challenge and some other map should be
+ * used instead. This class implements {@link Json.Serializable}, but the behavior of Json serialization
+ * with identity equality is uncertain at best. You may want to get separate key and value Arrays with {@link ObjectMap.Keys#toArray()} and
+ * {@link ObjectMap.Values#toArray()} and serialize those, though even that technique may fail with some key types ({@code int[]} and other
+ * primitive arrays can be used as keys here, but not serialized).
  * <br>
- * This map performs very fast get, containsKey, and remove (typically O(1), worst case O(log(n))). Put may be a bit slower,
- * depending on hash collisions. Load factors greater than 0.91 greatly increase the chances the map will have to rehash to the
- * next higher POT size.
- * @author Nathan Sweet */
-public class IdentityMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
-	private static final int PRIME1 = 0xbe1f14b1;
-	private static final int PRIME2 = 0xb4b82e39;
-	private static final int PRIME3 = 0xced1c241;
+ * This map uses Fibonacci hashing to help distribute what may be very bad hashCode() results across the
+ * whole capacity. See <a href="https://probablydance.com/2018/06/16/fibonacci-hashing-the-optimization-that-the-world-forgot-or-a-better-alternative-to-integer-modulo/">Malte Skarupke's blog post</a>
+ * for more information on Fibonacci hashing. It uses linear probing to resolve collisions, which is far from the academically
+ * optimal algorithm, but performs considerably better in practice than most alternatives, and combined with Fibonacci hashing, it
+ * can handle "normal" generated hashCode() implementations, and not just theoretically optimal hashing functions. Even if all
+ * hashCode()s this is given collide, it will still work, just slowly; the older libGDX implementation using cuckoo hashing would
+ * crash with an OutOfMemoryError with under 50 collisions.
+ * <br>
+ * This map performs very fast contains and remove (typically O(1), worst case O(n) due to occasional probing, but still very
+ * fast). Add may be a bit slower, depending on hash collisions, but this data structure is somewhat collision-resistant.
+ * Load factors greater than 0.91 greatly increase the chances the map will have to rehash to the next higher POT size.
+ * Memory usage is excellent, and the aforementioned collision-resistance helps avoid too much capacity resizing.
+ * <br>
+ * The <a href="http://codecapsule.com/2013/11/17/robin-hood-hashing-backward-shift-deletion/">backward-shift algorithm</a>
+ * used during removal apparently is key to the good performance of this implementation, even though this doesn't use Robin Hood
+ * hashing; the performance of {@link #remove(Object)} has improved considerably over the previous libGDX version.
+ * <br>
+ * Iteration should be fast with OrderedSet and OrderedMap, whereas ObjectSet and ObjectMap aren't designed to provide especially
+ * quick iteration.
+ *
+ * @author Tommy Ettinger
+ * @author Nathan Sweet
+ */
+public class IdentityMap<K, V> extends ObjectMap<K, V> {
 
-	public int size;
-
-	K[] keyTable;
-	V[] valueTable;
-	int capacity, stashSize;
-
-	private float loadFactor;
-	private int hashShift, mask, threshold;
-	private int stashCapacity;
-	private int pushIterations;
-
-	private Entries entries1, entries2;
-	private Values values1, values2;
-	private Keys keys1, keys2;
-
-	/** Creates a new map with an initial capacity of 51 and a load factor of 0.8. */
+	/**
+	 * Creates a new map with an initial capacity of 51 and a load factor of 0.8.
+	 */
 	public IdentityMap () {
-		this(51, 0.8f);
+		super();
 	}
 
-	/** Creates a new map with a load factor of 0.8.
-	 * @param initialCapacity If not a power of two, it is increased to the next nearest power of two. */
+	/**
+	 * Creates a new map with a load factor of 0.8.
+	 *
+	 * @param initialCapacity If not a power of two, it is increased to the next nearest power of two.
+	 */
 	public IdentityMap (int initialCapacity) {
-		this(initialCapacity, 0.8f);
+		super(initialCapacity);
 	}
 
-	/** Creates a new map with the specified initial capacity and load factor. This map will hold initialCapacity items before
+	/**
+	 * Creates a new map with the specified initial capacity and load factor. This map will hold initialCapacity items before
 	 * growing the backing table.
-	 * @param initialCapacity If not a power of two, it is increased to the next nearest power of two. */
+	 *
+	 * @param initialCapacity If not a power of two, it is increased to the next nearest power of two.
+	 */
 	public IdentityMap (int initialCapacity, float loadFactor) {
-		if (loadFactor <= 0) throw new IllegalArgumentException("loadFactor must be > 0: " + loadFactor);
-		this.loadFactor = loadFactor;
-
-		if (initialCapacity < 0) throw new IllegalArgumentException("initialCapacity must be >= 0: " + initialCapacity);
-		initialCapacity = MathUtils.nextPowerOfTwo((int)Math.ceil(initialCapacity / loadFactor));
-		if (initialCapacity > 1 << 30) throw new IllegalArgumentException("initialCapacity is too large: " + initialCapacity);
-		capacity = initialCapacity;
-
-		threshold = (int)(capacity * loadFactor);
-		mask = capacity - 1;
-		hashShift = 31 - Integer.numberOfTrailingZeros(capacity);
-		stashCapacity = Math.max(3, (int)Math.ceil(Math.log(capacity)) * 2);
-		pushIterations = Math.max(Math.min(capacity, 8), (int)Math.sqrt(capacity) / 8);
-
-		keyTable = (K[])new Object[capacity + stashCapacity];
-		valueTable = (V[])new Object[keyTable.length];
+		super(initialCapacity, loadFactor);
 	}
 
-	/** Creates a new map identical to the specified map. */
-	public IdentityMap (IdentityMap map) {
-		this((int)Math.floor(map.capacity * map.loadFactor), map.loadFactor);
-		stashSize = map.stashSize;
-		System.arraycopy(map.keyTable, 0, keyTable, 0, map.keyTable.length);
-		System.arraycopy(map.valueTable, 0, valueTable, 0, map.valueTable.length);
-		size = map.size;
+	/**
+	 * Creates a new map identical to the specified map.
+	 */
+	public IdentityMap (IdentityMap<? extends K, ? extends V> map) {
+		super(map);
 	}
 
-	public V put (K key, V value) {
-		if (key == null) throw new IllegalArgumentException("key cannot be null.");
-		K[] keyTable = this.keyTable;
+	@Override protected int place (K item) {
+		return (int)(System.identityHashCode(item) * 0x9E3779B97F4A7C15L >>> shift);
+		//return (System.identityHashCode(item) & mask);
+	}
 
-		// Check for existing keys.
-		int hashCode = System.identityHashCode(key);
-		int index1 = hashCode & mask;
-		K key1 = keyTable[index1];
-		if (key1 == key) {
-			V oldValue = valueTable[index1];
-			valueTable[index1] = value;
-			return oldValue;
-		}
-
-		int index2 = hash2(hashCode);
-		K key2 = keyTable[index2];
-		if (key2 == key) {
-			V oldValue = valueTable[index2];
-			valueTable[index2] = value;
-			return oldValue;
-		}
-
-		int index3 = hash3(hashCode);
-		K key3 = keyTable[index3];
-		if (key3 == key) {
-			V oldValue = valueTable[index3];
-			valueTable[index3] = value;
-			return oldValue;
-		}
-
-		// Update key in the stash.
-		for (int i = capacity, n = i + stashSize; i < n; i++) {
-			if (keyTable[i] == key) {
-				V oldValue = valueTable[i];
-				valueTable[i] = value;
-				return oldValue;
+	@Override int locateKey (K key, int placement) {
+		for (int i = placement; ; i = i + 1 & mask) {
+			// empty space is available
+			if (keyTable[i] == null) {
+				return -1;
 			}
-		}
-
-		// Check for empty buckets.
-		if (key1 == null) {
-			keyTable[index1] = key;
-			valueTable[index1] = value;
-			if (size++ >= threshold) resize(capacity << 1);
-			return null;
-		}
-
-		if (key2 == null) {
-			keyTable[index2] = key;
-			valueTable[index2] = value;
-			if (size++ >= threshold) resize(capacity << 1);
-			return null;
-		}
-
-		if (key3 == null) {
-			keyTable[index3] = key;
-			valueTable[index3] = value;
-			if (size++ >= threshold) resize(capacity << 1);
-			return null;
-		}
-
-		push(key, value, index1, key1, index2, key2, index3, key3);
-		return null;
-	}
-
-	/** Skips checks for existing keys. */
-	private void putResize (K key, V value) {
-		// Check for empty buckets.
-		int hashCode = System.identityHashCode(key);
-		int index1 = hashCode & mask;
-		K key1 = keyTable[index1];
-		if (key1 == null) {
-			keyTable[index1] = key;
-			valueTable[index1] = value;
-			if (size++ >= threshold) resize(capacity << 1);
-			return;
-		}
-
-		int index2 = hash2(hashCode);
-		K key2 = keyTable[index2];
-		if (key2 == null) {
-			keyTable[index2] = key;
-			valueTable[index2] = value;
-			if (size++ >= threshold) resize(capacity << 1);
-			return;
-		}
-
-		int index3 = hash3(hashCode);
-		K key3 = keyTable[index3];
-		if (key3 == null) {
-			keyTable[index3] = key;
-			valueTable[index3] = value;
-			if (size++ >= threshold) resize(capacity << 1);
-			return;
-		}
-
-		push(key, value, index1, key1, index2, key2, index3, key3);
-	}
-
-	private void push (K insertKey, V insertValue, int index1, K key1, int index2, K key2, int index3, K key3) {
-		K[] keyTable = this.keyTable;
-		V[] valueTable = this.valueTable;
-		int mask = this.mask;
-
-		// Push keys until an empty bucket is found.
-		K evictedKey;
-		V evictedValue;
-		int i = 0, pushIterations = this.pushIterations;
-		do {
-			// Replace the key and value for one of the hashes.
-			switch (MathUtils.random(2)) {
-			case 0:
-				evictedKey = key1;
-				evictedValue = valueTable[index1];
-				keyTable[index1] = insertKey;
-				valueTable[index1] = insertValue;
-				break;
-			case 1:
-				evictedKey = key2;
-				evictedValue = valueTable[index2];
-				keyTable[index2] = insertKey;
-				valueTable[index2] = insertValue;
-				break;
-			default:
-				evictedKey = key3;
-				evictedValue = valueTable[index3];
-				keyTable[index3] = insertKey;
-				valueTable[index3] = insertValue;
-				break;
+			if (key == (keyTable[i])) {
+				return i;
 			}
-
-			// If the evicted key hashes to an empty bucket, put it there and stop.
-			int hashCode = System.identityHashCode(evictedKey);
-			index1 = hashCode & mask;
-			key1 = keyTable[index1];
-			if (key1 == null) {
-				keyTable[index1] = evictedKey;
-				valueTable[index1] = evictedValue;
-				if (size++ >= threshold) resize(capacity << 1);
-				return;
-			}
-
-			index2 = hash2(hashCode);
-			key2 = keyTable[index2];
-			if (key2 == null) {
-				keyTable[index2] = evictedKey;
-				valueTable[index2] = evictedValue;
-				if (size++ >= threshold) resize(capacity << 1);
-				return;
-			}
-
-			index3 = hash3(hashCode);
-			key3 = keyTable[index3];
-			if (key3 == null) {
-				keyTable[index3] = evictedKey;
-				valueTable[index3] = evictedValue;
-				if (size++ >= threshold) resize(capacity << 1);
-				return;
-			}
-
-			if (++i == pushIterations) break;
-
-			insertKey = evictedKey;
-			insertValue = evictedValue;
-		} while (true);
-
-		putStash(evictedKey, evictedValue);
-	}
-
-	private void putStash (K key, V value) {
-		if (stashSize == stashCapacity) {
-			// Too many pushes occurred and the stash is full, increase the table size.
-			resize(capacity << 1);
-			putResize(key, value);
-			return;
-		}
-		// Store key in the stash.
-		int index = capacity + stashSize;
-		keyTable[index] = key;
-		valueTable[index] = value;
-		stashSize++;
-		size++;
-	}
-
-	public V get (K key) {
-		int hashCode = System.identityHashCode(key);
-		int index = hashCode & mask;
-		if (key != keyTable[index]) {
-			index = hash2(hashCode);
-			if (key != keyTable[index]) {
-				index = hash3(hashCode);
-				if (key != keyTable[index]) return getStash(key, null);
-			}
-		}
-		return valueTable[index];
-	}
-
-	public V get (K key, V defaultValue) {
-		int hashCode = System.identityHashCode(key);
-		int index = hashCode & mask;
-		if (key != keyTable[index]) {
-			index = hash2(hashCode);
-			if (key != keyTable[index]) {
-				index = hash3(hashCode);
-				if (key != keyTable[index]) return getStash(key, defaultValue);
-			}
-		}
-		return valueTable[index];
-	}
-
-	private V getStash (K key, V defaultValue) {
-		K[] keyTable = this.keyTable;
-		for (int i = capacity, n = i + stashSize; i < n; i++)
-			if (keyTable[i] == key) return valueTable[i];
-		return defaultValue;
-	}
-
-	public V remove (K key) {
-		int hashCode = System.identityHashCode(key);
-		int index = hashCode & mask;
-		if (keyTable[index] == key) {
-			keyTable[index] = null;
-			V oldValue = valueTable[index];
-			valueTable[index] = null;
-			size--;
-			return oldValue;
-		}
-
-		index = hash2(hashCode);
-		if (keyTable[index] == key) {
-			keyTable[index] = null;
-			V oldValue = valueTable[index];
-			valueTable[index] = null;
-			size--;
-			return oldValue;
-		}
-
-		index = hash3(hashCode);
-		if (keyTable[index] == key) {
-			keyTable[index] = null;
-			V oldValue = valueTable[index];
-			valueTable[index] = null;
-			size--;
-			return oldValue;
-		}
-
-		return removeStash(key);
-	}
-
-	V removeStash (K key) {
-		K[] keyTable = this.keyTable;
-		for (int i = capacity, n = i + stashSize; i < n; i++) {
-			if (keyTable[i] == key) {
-				V oldValue = valueTable[i];
-				removeStashIndex(i);
-				size--;
-				return oldValue;
-			}
-		}
-		return null;
-	}
-
-	void removeStashIndex (int index) {
-		// If the removed location was not last, move the last tuple to the removed location.
-		stashSize--;
-		int lastIndex = capacity + stashSize;
-		if (index < lastIndex) {
-			keyTable[index] = keyTable[lastIndex];
-			valueTable[index] = valueTable[lastIndex];
-			valueTable[lastIndex] = null;
-		} else
-			valueTable[index] = null;
-	}
-
-	/** Returns true if the map has one or more items. */
-	public boolean notEmpty () {
-		return size > 0;
-	}
-
-	/** Returns true if the map is empty. */
-	public boolean isEmpty () {
-		return size == 0;
-	}
-
-	/** Reduces the size of the backing arrays to be the specified capacity or less. If the capacity is already less, nothing is
-	 * done. If the map contains more items than the specified capacity, the next highest power of two capacity is used instead. */
-	public void shrink (int maximumCapacity) {
-		if (maximumCapacity < 0) throw new IllegalArgumentException("maximumCapacity must be >= 0: " + maximumCapacity);
-		if (size > maximumCapacity) maximumCapacity = size;
-		if (capacity <= maximumCapacity) return;
-		maximumCapacity = MathUtils.nextPowerOfTwo(maximumCapacity);
-		resize(maximumCapacity);
-	}
-
-	/** Clears the map and reduces the size of the backing arrays to be the specified capacity if they are larger. */
-	public void clear (int maximumCapacity) {
-		if (capacity <= maximumCapacity) {
-			clear();
-			return;
-		}
-		size = 0;
-		resize(maximumCapacity);
-	}
-
-	public void clear () {
-		if (size == 0) return;
-		K[] keyTable = this.keyTable;
-		V[] valueTable = this.valueTable;
-		for (int i = capacity + stashSize; i-- > 0;) {
-			keyTable[i] = null;
-			valueTable[i] = null;
-		}
-		size = 0;
-		stashSize = 0;
-	}
-
-	/** Returns true if the specified value is in the map. Note this traverses the entire map and compares every value, which may
-	 * be an expensive operation.
-	 * @param identity If true, uses == to compare the specified value with values in the map. If false, uses
-	 *           {@link #equals(Object)}. */
-	public boolean containsValue (Object value, boolean identity) {
-		V[] valueTable = this.valueTable;
-		if (value == null) {
-			K[] keyTable = this.keyTable;
-			for (int i = capacity + stashSize; i-- > 0;)
-				if (keyTable[i] != null && valueTable[i] == null) return true;
-		} else if (identity) {
-			for (int i = capacity + stashSize; i-- > 0;)
-				if (valueTable[i] == value) return true;
-		} else {
-			for (int i = capacity + stashSize; i-- > 0;)
-				if (value.equals(valueTable[i])) return true;
-		}
-		return false;
-	}
-
-	public boolean containsKey (K key) {
-		int hashCode = System.identityHashCode(key);
-		int index = hashCode & mask;
-		if (key != keyTable[index]) {
-			index = hash2(hashCode);
-			if (key != keyTable[index]) {
-				index = hash3(hashCode);
-				if (key != keyTable[index]) return containsKeyStash(key);
-			}
-		}
-		return true;
-	}
-
-	private boolean containsKeyStash (K key) {
-		K[] keyTable = this.keyTable;
-		for (int i = capacity, n = i + stashSize; i < n; i++)
-			if (keyTable[i] == key) return true;
-		return false;
-	}
-
-	/** Returns the key for the specified value, or null if it is not in the map. Note this traverses the entire map and compares
-	 * every value, which may be an expensive operation.
-	 * @param identity If true, uses == to compare the specified value with values in the map. If false, uses
-	 *           {@link #equals(Object)}. */
-	public K findKey (Object value, boolean identity) {
-		V[] valueTable = this.valueTable;
-		if (value == null) {
-			K[] keyTable = this.keyTable;
-			for (int i = capacity + stashSize; i-- > 0;)
-				if (keyTable[i] != null && valueTable[i] == null) return keyTable[i];
-		} else if (identity) {
-			for (int i = capacity + stashSize; i-- > 0;)
-				if (valueTable[i] == value) return keyTable[i];
-		} else {
-			for (int i = capacity + stashSize; i-- > 0;)
-				if (value.equals(valueTable[i])) return keyTable[i];
-		}
-		return null;
-	}
-
-	/** Increases the size of the backing array to accommodate the specified number of additional items. Useful before adding many
-	 * items to avoid multiple backing array resizes. */
-	public void ensureCapacity (int additionalCapacity) {
-		if (additionalCapacity < 0) throw new IllegalArgumentException("additionalCapacity must be >= 0: " + additionalCapacity);
-		int sizeNeeded = size + additionalCapacity;
-		if (sizeNeeded >= threshold) resize(MathUtils.nextPowerOfTwo((int)Math.ceil(sizeNeeded / loadFactor)));
-	}
-
-	private void resize (int newSize) {
-		int oldEndIndex = capacity + stashSize;
-
-		capacity = newSize;
-		threshold = (int)(newSize * loadFactor);
-		mask = newSize - 1;
-		hashShift = 31 - Integer.numberOfTrailingZeros(newSize);
-		stashCapacity = Math.max(3, (int)Math.ceil(Math.log(newSize)) * 2);
-		pushIterations = Math.max(Math.min(newSize, 8), (int)Math.sqrt(newSize) / 8);
-
-		K[] oldKeyTable = keyTable;
-		V[] oldValueTable = valueTable;
-
-		keyTable = (K[])new Object[newSize + stashCapacity];
-		valueTable = (V[])new Object[newSize + stashCapacity];
-
-		int oldSize = size;
-		size = 0;
-		stashSize = 0;
-		if (oldSize > 0) {
-			for (int i = 0; i < oldEndIndex; i++) {
-				K key = oldKeyTable[i];
-				if (key != null) putResize(key, oldValueTable[i]);
-			}
-		}
-	}
-
-	private int hash2 (int h) {
-		h *= PRIME2;
-		return (h ^ h >>> hashShift) & mask;
-	}
-
-	private int hash3 (int h) {
-		h *= PRIME3;
-		return (h ^ h >>> hashShift) & mask;
-	}
-
-	public int hashCode () {
-		int h = 0;
-		K[] keyTable = this.keyTable;
-		V[] valueTable = this.valueTable;
-		for (int i = 0, n = capacity + stashSize; i < n; i++) {
-			K key = keyTable[i];
-			if (key != null) {
-				h += key.hashCode() * 31;
-
-				V value = valueTable[i];
-				if (value != null) {
-					h += value.hashCode();
-				}
-			}
-		}
-		return h;
-	}
-
-	public boolean equals (Object obj) {
-		if (obj == this) return true;
-		if (!(obj instanceof IdentityMap)) return false;
-		IdentityMap other = (IdentityMap)obj;
-		if (other.size != size) return false;
-		K[] keyTable = this.keyTable;
-		V[] valueTable = this.valueTable;
-		for (int i = 0, n = capacity + stashSize; i < n; i++) {
-			K key = keyTable[i];
-			if (key != null) {
-				V value = valueTable[i];
-				if (value == null) {
-					if (other.get(key, ObjectMap.dummy) != null) return false;
-				} else {
-					if (!value.equals(other.get(key))) return false;
-				}
-			}
-		}
-		return true;
-	}
-
-	/** Uses == for comparison of each value. */
-	public boolean equalsIdentity (Object obj) {
-		if (obj == this) return true;
-		if (!(obj instanceof IdentityMap)) return false;
-		IdentityMap other = (IdentityMap)obj;
-		if (other.size != size) return false;
-		K[] keyTable = this.keyTable;
-		V[] valueTable = this.valueTable;
-		for (int i = 0, n = capacity + stashSize; i < n; i++) {
-			K key = keyTable[i];
-			if (key != null && valueTable[i] != other.get(key, ObjectMap.dummy)) return false;
-		}
-		return true;
-	}
-
-	public String toString () {
-		if (size == 0) return "[]";
-		StringBuilder buffer = new StringBuilder(32);
-		buffer.append('[');
-		K[] keyTable = this.keyTable;
-		V[] valueTable = this.valueTable;
-		int i = keyTable.length;
-		while (i-- > 0) {
-			K key = keyTable[i];
-			if (key == null) continue;
-			buffer.append(key);
-			buffer.append('=');
-			buffer.append(valueTable[i]);
-			break;
-		}
-		while (i-- > 0) {
-			K key = keyTable[i];
-			if (key == null) continue;
-			buffer.append(", ");
-			buffer.append(key);
-			buffer.append('=');
-			buffer.append(valueTable[i]);
-		}
-		buffer.append(']');
-		return buffer.toString();
-	}
-
-	public Iterator<Entry<K, V>> iterator () {
-		return entries();
-	}
-
-	/** Returns an iterator for the entries in the map. Remove is supported.
-	 * <p>
-	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called.
-	 * Use the {@link Entries} constructor for nested or multithreaded iteration. */
-	public Entries<K, V> entries () {
-		if (Collections.allocateIterators) return new Entries(this);
-		if (entries1 == null) {
-			entries1 = new Entries(this);
-			entries2 = new Entries(this);
-		}
-		if (!entries1.valid) {
-			entries1.reset();
-			entries1.valid = true;
-			entries2.valid = false;
-			return entries1;
-		}
-		entries2.reset();
-		entries2.valid = true;
-		entries1.valid = false;
-		return entries2;
-	}
-
-	/** Returns an iterator for the values in the map. Remove is supported.
-	 * <p>
-	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called.
-	 * Use the {@link Entries} constructor for nested or multithreaded iteration. */
-	public Values<V> values () {
-		if (Collections.allocateIterators) return new Values(this);
-		if (values1 == null) {
-			values1 = new Values(this);
-			values2 = new Values(this);
-		}
-		if (!values1.valid) {
-			values1.reset();
-			values1.valid = true;
-			values2.valid = false;
-			return values1;
-		}
-		values2.reset();
-		values2.valid = true;
-		values1.valid = false;
-		return values2;
-	}
-
-	/** Returns an iterator for the keys in the map. Remove is supported.
-	 * <p>
-	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called.
-	 * Use the {@link Entries} constructor for nested or multithreaded iteration. */
-	public Keys<K> keys () {
-		if (Collections.allocateIterators) return new Keys(this);
-		if (keys1 == null) {
-			keys1 = new Keys(this);
-			keys2 = new Keys(this);
-		}
-		if (!keys1.valid) {
-			keys1.reset();
-			keys1.valid = true;
-			keys2.valid = false;
-			return keys1;
-		}
-		keys2.reset();
-		keys2.valid = true;
-		keys1.valid = false;
-		return keys2;
-	}
-
-	static private abstract class MapIterator<K, V, I> implements Iterable<I>, Iterator<I> {
-		public boolean hasNext;
-
-		final IdentityMap<K, V> map;
-		int nextIndex, currentIndex;
-		boolean valid = true;
-
-		public MapIterator (IdentityMap<K, V> map) {
-			this.map = map;
-			reset();
-		}
-
-		public void reset () {
-			currentIndex = -1;
-			nextIndex = -1;
-			findNextIndex();
-		}
-
-		void findNextIndex () {
-			hasNext = false;
-			K[] keyTable = map.keyTable;
-			for (int n = map.capacity + map.stashSize; ++nextIndex < n;) {
-				if (keyTable[nextIndex] != null) {
-					hasNext = true;
-					break;
-				}
-			}
-		}
-
-		public void remove () {
-			if (currentIndex < 0) throw new IllegalStateException("next must be called before remove.");
-			if (currentIndex >= map.capacity) {
-				map.removeStashIndex(currentIndex);
-				nextIndex = currentIndex - 1;
-				findNextIndex();
-			} else {
-				map.keyTable[currentIndex] = null;
-				map.valueTable[currentIndex] = null;
-			}
-			currentIndex = -1;
-			map.size--;
-		}
-	}
-
-	static public class Entries<K, V> extends MapIterator<K, V, Entry<K, V>> {
-		private Entry<K, V> entry = new Entry();
-
-		public Entries (IdentityMap<K, V> map) {
-			super(map);
-		}
-
-		/** Note the same entry instance is returned each time this method is called. */
-		public Entry<K, V> next () {
-			if (!hasNext) throw new NoSuchElementException();
-			if (!valid) throw new GdxRuntimeException("#iterator() cannot be used nested.");
-			K[] keyTable = map.keyTable;
-			entry.key = keyTable[nextIndex];
-			entry.value = map.valueTable[nextIndex];
-			currentIndex = nextIndex;
-			findNextIndex();
-			return entry;
-		}
-
-		public boolean hasNext () {
-			if (!valid) throw new GdxRuntimeException("#iterator() cannot be used nested.");
-			return hasNext;
-		}
-
-		public Iterator<Entry<K, V>> iterator () {
-			return this;
-		}
-	}
-
-	static public class Values<V> extends MapIterator<Object, V, V> {
-		public Values (IdentityMap<?, V> map) {
-			super((IdentityMap<Object, V>)map);
-		}
-
-		public boolean hasNext () {
-			if (!valid) throw new GdxRuntimeException("#iterator() cannot be used nested.");
-			return hasNext;
-		}
-
-		public V next () {
-			if (!hasNext) throw new NoSuchElementException();
-			if (!valid) throw new GdxRuntimeException("#iterator() cannot be used nested.");
-			V value = map.valueTable[nextIndex];
-			currentIndex = nextIndex;
-			findNextIndex();
-			return value;
-		}
-
-		public Iterator<V> iterator () {
-			return this;
-		}
-
-		/** Returns a new array containing the remaining values. */
-		public Array<V> toArray () {
-			Array array = new Array(true, map.size);
-			while (hasNext)
-				array.add(next());
-			return array;
-		}
-
-		/** Adds the remaining values to the specified array. */
-		public void toArray (Array<V> array) {
-			while (hasNext)
-				array.add(next());
-		}
-	}
-
-	static public class Keys<K> extends MapIterator<K, Object, K> {
-		public Keys (IdentityMap<K, ?> map) {
-			super((IdentityMap<K, Object>)map);
-		}
-
-		public boolean hasNext () {
-			if (!valid) throw new GdxRuntimeException("#iterator() cannot be used nested.");
-			return hasNext;
-		}
-
-		public K next () {
-			if (!hasNext) throw new NoSuchElementException();
-			if (!valid) throw new GdxRuntimeException("#iterator() cannot be used nested.");
-			K key = map.keyTable[nextIndex];
-			currentIndex = nextIndex;
-			findNextIndex();
-			return key;
-		}
-
-		public Iterator<K> iterator () {
-			return this;
-		}
-
-		/** Returns a new array containing the remaining keys. */
-		public Array<K> toArray () {
-			Array array = new Array(true, map.size);
-			while (hasNext)
-				array.add(next());
-			return array;
 		}
 	}
 }

--- a/gdx/src/com/badlogic/gdx/utils/IdentityMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/IdentityMap.java
@@ -37,12 +37,7 @@ package com.badlogic.gdx.utils;
  * Load factors greater than 0.91 greatly increase the chances the map will have to rehash to the next higher POT size.
  * Memory usage is excellent, and the aforementioned collision-resistance helps avoid too much capacity resizing.
  * <br>
- * The <a href="http://codecapsule.com/2013/11/17/robin-hood-hashing-backward-shift-deletion/">backward-shift algorithm</a>
- * used during removal apparently is key to the good performance of this implementation, even though this doesn't use Robin Hood
- * hashing; the performance of {@link #remove(Object)} has improved considerably over the previous libGDX version.
- * <br>
- * Iteration should be fast with OrderedSet and OrderedMap, whereas ObjectSet and ObjectMap aren't designed to provide especially
- * quick iteration.
+* Iteration won't be as fast here as with OrderedSet and OrderedMap.
  *
  * @author Tommy Ettinger
  * @author Nathan Sweet

--- a/gdx/src/com/badlogic/gdx/utils/IdentityMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/IdentityMap.java
@@ -22,10 +22,7 @@ package com.badlogic.gdx.utils;
  * Null keys are not allowed. Null values are allowed. No allocation is done except when growing the table size. It uses
  * {@link System#identityHashCode(Object)} to hash keys, which may be slower than the hashCode() on some types that have it
  * already computed, like String; for String keys in particular, identity comparison is a challenge and some other map should be
- * used instead. This class implements {@link Json.Serializable}, but the behavior of Json serialization
- * with identity equality is uncertain at best. You may want to get separate key and value Arrays with {@link ObjectMap.Keys#toArray()} and
- * {@link ObjectMap.Values#toArray()} and serialize those, though even that technique may fail with some key types ({@code int[]} and other
- * primitive arrays can be used as keys here, but not serialized).
+ * used instead.
  * <br>
  * This map uses Fibonacci hashing to help distribute what may be very bad hashCode() results across the
  * whole capacity. See <a href="https://probablydance.com/2018/06/16/fibonacci-hashing-the-optimization-that-the-world-forgot-or-a-better-alternative-to-integer-modulo/">Malte Skarupke's blog post</a>

--- a/gdx/src/com/badlogic/gdx/utils/IntFloatMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/IntFloatMap.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,79 +16,118 @@
 
 package com.badlogic.gdx.utils;
 
+import com.badlogic.gdx.math.MathUtils;
+
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
-import com.badlogic.gdx.math.MathUtils;
-
-/** An unordered map where the keys are ints and values are floats. This implementation is a cuckoo hash map using 3 hashes,
- * random walking, and a small stash for problematic keys. Null keys are not allowed. No allocation is done except when growing
- * the table size. <br>
+/**
+ * An unordered map where the keys are unboxed ints and values are unboxed floats. This implementation uses linear probing with
+ * the backward-shift algorithm for removal, and finds space for keys using Fibonacci hashing instead of the more-common
+ * power-of-two mask. Null keys are not allowed. No allocation is done except when growing the table size.
  * <br>
- * This map performs very fast get, containsKey, and remove (typically O(1), worst case O(log(n))). Put may be a bit slower,
- * depending on hash collisions. Load factors greater than 0.91 greatly increase the chances the map will have to rehash to the
- * next higher POT size.
- * @author Nathan Sweet */
-public class IntFloatMap implements Iterable<IntFloatMap.Entry> {
-	private static final int PRIME1 = 0xbe1f14b1;
-	private static final int PRIME2 = 0xb4b82e39;
-	private static final int PRIME3 = 0xced1c241;
-	private static final int EMPTY = 0;
-
+ * This map uses Fibonacci hashing to help distribute what may be very bad hashCode() results across the
+ * whole capacity. See <a href="https://probablydance.com/2018/06/16/fibonacci-hashing-the-optimization-that-the-world-forgot-or-a-better-alternative-to-integer-modulo/">Malte Skarupke's blog post</a>
+ * for more information on Fibonacci hashing. It uses linear probing to resolve collisions, which is far from the academically
+ * optimal algorithm, but performs considerably better in practice than most alternatives, and combined with Fibonacci hashing, it
+ * can handle "normal" generated hashCode() implementations, and not just theoretically optimal hashing functions. Even if all
+ * hashCode()s this is given collide, it will still work, just slowly; the older libGDX implementation using cuckoo hashing would
+ * crash with an OutOfMemoryError with under 50 collisions.
+ * <br>
+ * This map performs very fast contains and remove (typically O(1), worst case O(n) due to occasional probing, but still very
+ * fast). Add may be a bit slower, depending on hash collisions, but this data structure is somewhat collision-resistant.
+ * Load factors greater than 0.91 greatly increase the chances the map will have to rehash to the next higher POT size.
+ * Memory usage is excellent, and the aforementioned collision-resistance helps avoid too much capacity resizing.
+ * <br>
+ * The <a href="http://codecapsule.com/2013/11/17/robin-hood-hashing-backward-shift-deletion/">backward-shift algorithm</a>
+ * used during removal apparently is key to the good performance of this implementation, even though this doesn't use Robin Hood
+ * hashing; the performance of {@link #remove(int, float)} has improved considerably over the previous libGDX version.
+ * <br>
+ * Iteration won't be as fast here as with OrderedSet and OrderedMap.
+ *
+ * @author Tommy Ettinger
+ * @author Nathan Sweet
+ */
+public class IntFloatMap implements Json.Serializable, Iterable<IntFloatMap.Entry> {
 	public int size;
 
-	int[] keyTable;
-	float[] valueTable;
-	int capacity, stashSize;
-	float zeroValue;
-	boolean hasZeroValue;
+	private int[] keyTable;
+	private float[] valueTable;
+
+	private float zeroValue;
+	private boolean hasZeroValue;
 
 	private float loadFactor;
-	private int hashShift, mask, threshold;
-	private int stashCapacity;
-	private int pushIterations;
+	private int threshold;
+	/**
+	 * Used by {@link #place(int)} to bit-shift the upper bits of a {@code long} into a usable range (less than or
+	 * equal to {@link #mask}, greater than or equal to 0). If you're setting it in a subclass, this shift can be
+	 * negative, which is a convenient way to match the number of bits in mask; if mask is a 7-bit number, then a shift
+	 * of -7 will correctly shift the upper 7 bits into the lowest 7 positions. If using what this class sets, shift
+	 * will be greater than 32 and less than 64; if you use this shift with an int, it will still correctly move the
+	 * upper bits of an int to the lower bits, thanks to Java's implicit modulus on shifts.
+	 * <br>
+	 * You can also use {@link #mask} to mask the low bits of a number, which may be faster for some hashCode()s, if you
+	 * reimplement {@link #place(int)}.
+	 */
+	private int shift;
+	/**
+	 * The bitmask used to contain hashCode()s to the indices that can be fit into the key array this uses. This should
+	 * always be all-1-bits in its low positions; that is, it must be a power of two minus 1. If you subclass and change
+	 * {@link #place(int)}, you may want to use this instead of {@link #shift} to isolate usable bits of a hash.
+	 */
+	private int mask;
 
 	private Entries entries1, entries2;
 	private Values values1, values2;
 	private Keys keys1, keys2;
 
-	/** Creates a new map with an initial capacity of 51 and a load factor of 0.8. */
+	/**
+	 * Creates a new map with an initial capacity of 51 and a load factor of 0.8.
+	 */
 	public IntFloatMap () {
 		this(51, 0.8f);
 	}
 
-	/** Creates a new map with a load factor of 0.8.
-	 * @param initialCapacity If not a power of two, it is increased to the next nearest power of two. */
+	/**
+	 * Creates a new map with a load factor of 0.8.
+	 *
+	 * @param initialCapacity If not a power of two, it is increased to the next nearest power of two.
+	 */
 	public IntFloatMap (int initialCapacity) {
 		this(initialCapacity, 0.8f);
 	}
 
-	/** Creates a new map with the specified initial capacity and load factor. This map will hold initialCapacity items before
+	/**
+	 * Creates a new map with the specified initial capacity and load factor. This map will hold initialCapacity items before
 	 * growing the backing table.
-	 * @param initialCapacity If not a power of two, it is increased to the next nearest power of two. */
+	 *
+	 * @param initialCapacity If not a power of two, it is increased to the next nearest power of two.
+	 */
 	public IntFloatMap (int initialCapacity, float loadFactor) {
-		if (loadFactor <= 0) throw new IllegalArgumentException("loadFactor must be > 0: " + loadFactor);
+		if (initialCapacity < 0)
+			throw new IllegalArgumentException("initialCapacity must be >= 0: " + initialCapacity);
+		if (loadFactor <= 0f || loadFactor >= 1f)
+			throw new IllegalArgumentException("loadFactor must be > 0 and < 1: " + loadFactor);
+		initialCapacity = MathUtils.nextPowerOfTwo((int)Math.ceil(initialCapacity / loadFactor));
+		if (initialCapacity > 1 << 30)
+			throw new IllegalArgumentException("initialCapacity is too large: " + initialCapacity);
+
 		this.loadFactor = loadFactor;
 
-		if (initialCapacity < 0) throw new IllegalArgumentException("initialCapacity must be >= 0: " + initialCapacity);
-		initialCapacity = MathUtils.nextPowerOfTwo((int)Math.ceil(initialCapacity / loadFactor));
-		if (initialCapacity > 1 << 30) throw new IllegalArgumentException("initialCapacity is too large: " + initialCapacity);
-		capacity = initialCapacity;
+		threshold = (int)(initialCapacity * loadFactor);
+		mask = initialCapacity - 1;
+		shift = Long.numberOfLeadingZeros(mask);
 
-		threshold = (int)(capacity * loadFactor);
-		mask = capacity - 1;
-		hashShift = 31 - Integer.numberOfTrailingZeros(capacity);
-		stashCapacity = Math.max(3, (int)Math.ceil(Math.log(capacity)) * 2);
-		pushIterations = Math.max(Math.min(capacity, 8), (int)Math.sqrt(capacity) / 8);
-
-		keyTable = new int[capacity + stashCapacity];
-		valueTable = new float[keyTable.length];
+		keyTable = new int[initialCapacity];
+		valueTable = new float[initialCapacity];
 	}
 
-	/** Creates a new map identical to the specified map. */
+	/**
+	 * Creates a new map identical to the specified map.
+	 */
 	public IntFloatMap (IntFloatMap map) {
-		this((int)Math.floor(map.capacity * map.loadFactor), map.loadFactor);
-		stashSize = map.stashSize;
+		this((int)(map.keyTable.length * map.loadFactor), map.loadFactor);
 		System.arraycopy(map.keyTable, 0, keyTable, 0, map.keyTable.length);
 		System.arraycopy(map.valueTable, 0, valueTable, 0, map.valueTable.length);
 		size = map.size;
@@ -96,6 +135,61 @@ public class IntFloatMap implements Iterable<IntFloatMap.Entry> {
 		hasZeroValue = map.hasZeroValue;
 	}
 
+	/**
+	 * Finds an array index between 0 and {@link #mask}, both inclusive, corresponding to the hash code of {@code item}.
+	 * By default, this uses "Fibonacci Hashing" on the int {@code item} directly; this multiplies
+	 * {@code item} by a long constant (2 to the 64, divided by the golden ratio) and shifts the high-quality
+	 * uppermost bits into the lowest positions so they can be used as array indices. The multiplication by a long may
+	 * be somewhat slow on GWT, but it will be correct across all platforms and won't lose precision. Using Fibonacci
+	 * Hashing allows even very poor hashCode() implementations, such as those that only differ in their upper bits, to
+	 * work in a hash table without heavy collision rates. It has known problems when all or most hashCode()s are
+	 * multiples of larger Fibonacci numbers; see <a href="https://probablydance.com/2018/06/16/fibonacci-hashing-the-optimization-that-the-world-forgot-or-a-better-alternative-to-integer-modulo/">this blog post by Malte Skarupke</a>
+	 * for more details. In the unlikely event that most of your hashCode()s are Fibonacci numbers, you can subclass
+	 * this to change this method, which is a one-liner in this form:
+	 * {@code return (int) (item * 0x9E3779B97F4A7C15L >>> shift);}
+	 * <br>
+	 * This can be overridden by subclasses, which you may want to do if your key type needs special consideration for
+	 * its hash (such as if you use arrays as keys, which still requires that the arrays are not modified). Subclasses
+	 * that don't need the collision decrease of Fibonacci Hashing (assuming the keys are well-distributed) may do
+	 * fine with a simple implementation:
+	 * {@code return (item & mask);}
+	 *
+	 * @param item a key that this method will use to get a hashed position
+	 * @return an int between 0 and {@link #mask}, both inclusive
+	 */
+	private int place (final int item) {
+		// shift is always greater than 32, less than 64
+		return (int)(item * 0x9E3779B97F4A7C15L >>> shift);
+	}
+
+	private int locateKey (final int key) {
+		return locateKey(key, place(key));
+	}
+
+	/**
+	 * Given a key and its initial placement to try in an array, this finds the actual location of the key in the array
+	 * if it is present, or -1 if the key is not present. This can be overridden if a subclass needs to compare for
+	 * equality differently than just by using == with int keys, but only within the same package.
+	 *
+	 * @param key       a K key that will be checked for equality if a similar-seeming key is found
+	 * @param placement as calculated by {@link #place(int)}, almost always with {@code place(key)}
+	 * @return the location in the key array of key, if found, or -1 if it was not found.
+	 */
+	private int locateKey (final int key, final int placement) {
+		for (int i = placement; ; i = i + 1 & mask) {
+			// empty space is available
+			if (keyTable[i] == 0) {
+				return -1;
+			}
+			if (key == (keyTable[i])) {
+				return i;
+			}
+		}
+	}
+
+	/**
+	 * Doesn't return a value, unlike other maps.
+	 */
 	public void put (int key, float value) {
 		if (key == 0) {
 			zeroValue = value;
@@ -106,336 +200,172 @@ public class IntFloatMap implements Iterable<IntFloatMap.Entry> {
 			return;
 		}
 
-		int[] keyTable = this.keyTable;
-
-		// Check for existing keys.
-		int index1 = key & mask;
-		int key1 = keyTable[index1];
-		if (key == key1) {
-			valueTable[index1] = value;
+		int b = place(key);
+		int loc = locateKey(key, b);
+		// an identical key already exists
+		if (loc != -1) {
+			valueTable[loc] = value;
 			return;
 		}
+		final int[] keyTable = this.keyTable;
+		final float[] valueTable = this.valueTable;
 
-		int index2 = hash2(key);
-		int key2 = keyTable[index2];
-		if (key == key2) {
-			valueTable[index2] = value;
-			return;
-		}
-
-		int index3 = hash3(key);
-		int key3 = keyTable[index3];
-		if (key == key3) {
-			valueTable[index3] = value;
-			return;
-		}
-
-		// Update key in the stash.
-		for (int i = capacity, n = i + stashSize; i < n; i++) {
-			if (key == keyTable[i]) {
+		for (int i = b; ; i = (i + 1) & mask) {
+			// space is available so we insert and break
+			if (keyTable[i] == 0) {
+				keyTable[i] = key;
 				valueTable[i] = value;
+
+				if (++size >= threshold) {
+					resize(keyTable.length << 1);
+				}
 				return;
 			}
 		}
-
-		// Check for empty buckets.
-		if (key1 == EMPTY) {
-			keyTable[index1] = key;
-			valueTable[index1] = value;
-			if (size++ >= threshold) resize(capacity << 1);
-			return;
-		}
-
-		if (key2 == EMPTY) {
-			keyTable[index2] = key;
-			valueTable[index2] = value;
-			if (size++ >= threshold) resize(capacity << 1);
-			return;
-		}
-
-		if (key3 == EMPTY) {
-			keyTable[index3] = key;
-			valueTable[index3] = value;
-			if (size++ >= threshold) resize(capacity << 1);
-			return;
-		}
-
-		push(key, value, index1, key1, index2, key2, index3, key3);
+		// never reached
 	}
 
 	public void putAll (IntFloatMap map) {
-		for (Entry entry : map.entries())
-			put(entry.key, entry.value);
+		ensureCapacity(map.size);
+		if (map.hasZeroValue)
+			put(0, map.zeroValue);
+		final int[] keyTable = map.keyTable;
+		final float[] valueTable = map.valueTable;
+		int k;
+		for (int i = 0, n = keyTable.length; i < n; i++) {
+			if ((k = keyTable[i]) != 0)
+				put(k, valueTable[i]);
+		}
 	}
+	// the old version; I think the new way avoids a little work
+//	   ensureCapacity(map.size);
+//		for (Entry entry : map.entries())
+//			put(entry.key, entry.value);
 
-	/** Skips checks for existing keys. */
+	/**
+	 * Skips checks for existing keys.
+	 */
 	private void putResize (int key, float value) {
 		if (key == 0) {
 			zeroValue = value;
-			hasZeroValue = true;
-			return;
-		}
-
-		// Check for empty buckets.
-		int index1 = key & mask;
-		int key1 = keyTable[index1];
-		if (key1 == EMPTY) {
-			keyTable[index1] = key;
-			valueTable[index1] = value;
-			if (size++ >= threshold) resize(capacity << 1);
-			return;
-		}
-
-		int index2 = hash2(key);
-		int key2 = keyTable[index2];
-		if (key2 == EMPTY) {
-			keyTable[index2] = key;
-			valueTable[index2] = value;
-			if (size++ >= threshold) resize(capacity << 1);
-			return;
-		}
-
-		int index3 = hash3(key);
-		int key3 = keyTable[index3];
-		if (key3 == EMPTY) {
-			keyTable[index3] = key;
-			valueTable[index3] = value;
-			if (size++ >= threshold) resize(capacity << 1);
-			return;
-		}
-
-		push(key, value, index1, key1, index2, key2, index3, key3);
-	}
-
-	private void push (int insertKey, float insertValue, int index1, int key1, int index2, int key2, int index3, int key3) {
-		int[] keyTable = this.keyTable;
-		float[] valueTable = this.valueTable;
-		int mask = this.mask;
-
-		// Push keys until an empty bucket is found.
-		int evictedKey;
-		float evictedValue;
-		int i = 0, pushIterations = this.pushIterations;
-		do {
-			// Replace the key and value for one of the hashes.
-			switch (MathUtils.random(2)) {
-			case 0:
-				evictedKey = key1;
-				evictedValue = valueTable[index1];
-				keyTable[index1] = insertKey;
-				valueTable[index1] = insertValue;
-				break;
-			case 1:
-				evictedKey = key2;
-				evictedValue = valueTable[index2];
-				keyTable[index2] = insertKey;
-				valueTable[index2] = insertValue;
-				break;
-			default:
-				evictedKey = key3;
-				evictedValue = valueTable[index3];
-				keyTable[index3] = insertKey;
-				valueTable[index3] = insertValue;
-				break;
+			if (!hasZeroValue) {
+				hasZeroValue = true;
+				size++;
 			}
-
-			// If the evicted key hashes to an empty bucket, put it there and stop.
-			index1 = evictedKey & mask;
-			key1 = keyTable[index1];
-			if (key1 == EMPTY) {
-				keyTable[index1] = evictedKey;
-				valueTable[index1] = evictedValue;
-				if (size++ >= threshold) resize(capacity << 1);
+			return;
+		}
+		final int[] keyTable = this.keyTable;
+		final float[] valueTable = this.valueTable;
+		
+		int b = place(key);
+		for (int i = b; ; i = (i + 1) & mask) {
+			// space is available so we insert and break (resize is later)
+			if (keyTable[i] == 0) {
+				keyTable[i] = key;
+				valueTable[i] = value;
+				
+				if (++size >= threshold) {
+					resize(keyTable.length << 1);
+				}
 				return;
 			}
-
-			index2 = hash2(evictedKey);
-			key2 = keyTable[index2];
-			if (key2 == EMPTY) {
-				keyTable[index2] = evictedKey;
-				valueTable[index2] = evictedValue;
-				if (size++ >= threshold) resize(capacity << 1);
-				return;
-			}
-
-			index3 = hash3(evictedKey);
-			key3 = keyTable[index3];
-			if (key3 == EMPTY) {
-				keyTable[index3] = evictedKey;
-				valueTable[index3] = evictedValue;
-				if (size++ >= threshold) resize(capacity << 1);
-				return;
-			}
-
-			if (++i == pushIterations) break;
-
-			insertKey = evictedKey;
-			insertValue = evictedValue;
-		} while (true);
-
-		putStash(evictedKey, evictedValue);
-	}
-
-	private void putStash (int key, float value) {
-		if (stashSize == stashCapacity) {
-			// Too many pushes occurred and the stash is full, increase the table size.
-			resize(capacity << 1);
-			putResize(key, value);
-			return;
 		}
-		// Store key in the stash.
-		int index = capacity + stashSize;
-		keyTable[index] = key;
-		valueTable[index] = value;
-		stashSize++;
-		size++;
 	}
 
-	/** @param defaultValue Returned if the key was not associated with a value. */
 	public float get (int key, float defaultValue) {
 		if (key == 0) {
-			if (!hasZeroValue) return defaultValue;
+			if (!hasZeroValue)
+				return defaultValue;
 			return zeroValue;
 		}
-		int index = key & mask;
-		if (keyTable[index] != key) {
-			index = hash2(key);
-			if (keyTable[index] != key) {
-				index = hash3(key);
-				if (keyTable[index] != key) return getStash(key, defaultValue);
-			}
-		}
-		return valueTable[index];
-	}
-
-	private float getStash (int key, float defaultValue) {
-		int[] keyTable = this.keyTable;
-		for (int i = capacity, n = i + stashSize; i < n; i++)
-			if (key == keyTable[i]) return valueTable[i];
-		return defaultValue;
-	}
-
-	/** Returns the key's current value and increments the stored value. If the key is not in the map, defaultValue + increment is
-	 * put into the map. */
-	public float getAndIncrement (int key, float defaultValue, float increment) {
-		if (key == 0) {
-			if (hasZeroValue) {
-				float value = zeroValue;
-				zeroValue += increment;
-				return value;
-			} else {
-				hasZeroValue = true;
-				zeroValue = defaultValue + increment;
-				++size;
+		final int placement = place(key);
+		for (int i = placement; ; i = i + 1 & mask) {
+			// empty space is available
+			if (keyTable[i] == 0) {
 				return defaultValue;
 			}
-		}
-		int index = key & mask;
-		if (key != keyTable[index]) {
-			index = hash2(key);
-			if (key != keyTable[index]) {
-				index = hash3(key);
-				if (key != keyTable[index]) return getAndIncrementStash(key, defaultValue, increment);
+			if (key == (keyTable[i])) {
+				return valueTable[i];
 			}
 		}
-		float value = valueTable[index];
-		valueTable[index] = value + increment;
-		return value;
 	}
 
-	private float getAndIncrementStash (int key, float defaultValue, float increment) {
-		int[] keyTable = this.keyTable;
-		for (int i = capacity, n = i + stashSize; i < n; i++)
-			if (key == keyTable[i]) {
-				float value = valueTable[i];
-				valueTable[i] = value + increment;
-				return value;
-			}
-		put(key, defaultValue + increment);
-		return defaultValue;
+	/**
+	 * Returns the key's current value and increments the stored value. If the key is not in the map, defaultValue + increment is
+	 * put into the map.
+	 */
+	public float getAndIncrement (int key, int defaultValue, int increment) {
+		final int loc = locateKey(key);
+		// key was not found
+		if (loc == -1) {
+			// because we know there's no existing duplicate key, we can use putResize().
+			putResize(key, defaultValue + increment);
+			return defaultValue;
+		}
+		final float oldValue = valueTable[loc];
+		valueTable[loc] += increment;
+		return oldValue;
 	}
 
 	public float remove (int key, float defaultValue) {
 		if (key == 0) {
-			if (!hasZeroValue) return defaultValue;
+			if (!hasZeroValue)
+				return defaultValue;
+			float oldValue = zeroValue;
 			hasZeroValue = false;
 			size--;
-			return zeroValue;
-		}
-
-		int index = key & mask;
-		if (key == keyTable[index]) {
-			keyTable[index] = EMPTY;
-			float oldValue = valueTable[index];
-			size--;
 			return oldValue;
 		}
 
-		index = hash2(key);
-		if (key == keyTable[index]) {
-			keyTable[index] = EMPTY;
-			float oldValue = valueTable[index];
-			size--;
-			return oldValue;
+		int loc = locateKey(key);
+		if (loc == -1) {
+			return defaultValue;
 		}
-
-		index = hash3(key);
-		if (key == keyTable[index]) {
-			keyTable[index] = EMPTY;
-			float oldValue = valueTable[index];
-			size--;
-			return oldValue;
+		final int[] keyTable = this.keyTable;
+		final float[] valueTable = this.valueTable;
+		final float oldValue = valueTable[loc];
+		while ((key = keyTable[loc + 1 & mask]) != 0 && (loc + 1 & mask) != place(key)) {
+			keyTable[loc] = key;
+			valueTable[loc] = valueTable[++loc & mask];
 		}
-
-		return removeStash(key, defaultValue);
+		keyTable[loc] = 0;
+		--size;
+		return oldValue;
 	}
 
-	float removeStash (int key, float defaultValue) {
-		int[] keyTable = this.keyTable;
-		for (int i = capacity, n = i + stashSize; i < n; i++) {
-			if (key == keyTable[i]) {
-				float oldValue = valueTable[i];
-				removeStashIndex(i);
-				size--;
-				return oldValue;
-			}
-		}
-		return defaultValue;
-	}
-
-	void removeStashIndex (int index) {
-		// If the removed location was not last, move the last tuple to the removed location.
-		stashSize--;
-		int lastIndex = capacity + stashSize;
-		if (index < lastIndex) {
-			keyTable[index] = keyTable[lastIndex];
-			valueTable[index] = valueTable[lastIndex];
-		}
-	}
-
-	/** Returns true if the map has one or more items. */
+	/**
+	 * Returns true if the map has one or more items.
+	 */
 	public boolean notEmpty () {
 		return size > 0;
 	}
 
-	/** Returns true if the map is empty. */
+	/**
+	 * Returns true if the map is empty.
+	 */
 	public boolean isEmpty () {
 		return size == 0;
 	}
 
-	/** Reduces the size of the backing arrays to be the specified capacity or less. If the capacity is already less, nothing is
-	 * done. If the map contains more items than the specified capacity, the next highest power of two capacity is used instead. */
+	/**
+	 * Reduces the size of the backing arrays to be the specified capacity or less. If the capacity is already less, nothing is
+	 * done. If the map contains more items than the specified capacity, the next highest power of two capacity is used instead.
+	 */
 	public void shrink (int maximumCapacity) {
-		if (maximumCapacity < 0) throw new IllegalArgumentException("maximumCapacity must be >= 0: " + maximumCapacity);
-		if (size > maximumCapacity) maximumCapacity = size;
-		if (capacity <= maximumCapacity) return;
-		maximumCapacity = MathUtils.nextPowerOfTwo(maximumCapacity);
-		resize(maximumCapacity);
+		if (maximumCapacity < 0)
+			throw new IllegalArgumentException("maximumCapacity must be >= 0: " + maximumCapacity);
+		if (size > maximumCapacity)
+			maximumCapacity = size;
+		if (keyTable.length <= maximumCapacity)
+			return;
+		resize(MathUtils.nextPowerOfTwo(maximumCapacity));
 	}
 
-	/** Clears the map and reduces the size of the backing arrays to be the specified capacity if they are larger. */
+	/**
+	 * Clears the map and reduces the size of the backing arrays to be the specified capacity if they are larger.
+	 */
 	public void clear (int maximumCapacity) {
-		if (capacity <= maximumCapacity) {
+		if (keyTable.length <= maximumCapacity) {
 			clear();
 			return;
 		}
@@ -445,160 +375,143 @@ public class IntFloatMap implements Iterable<IntFloatMap.Entry> {
 	}
 
 	public void clear () {
-		if (size == 0) return;
-		int[] keyTable = this.keyTable;
-		for (int i = capacity + stashSize; i-- > 0;)
-			keyTable[i] = EMPTY;
-		hasZeroValue = false;
+		if (size == 0)
+			return;
+		final int[] keyTable = this.keyTable;
+		for (int i = keyTable.length; i > 0; ) {
+			keyTable[--i] = 0;
+		}
 		size = 0;
-		stashSize = 0;
+		hasZeroValue = false;
 	}
 
-	/** Returns true if the specified value is in the map. Note this traverses the entire map and compares every value, which may
-	 * be an expensive operation. */
-	public boolean containsValue (float value) {
-		if (hasZeroValue && zeroValue == value) return true;
-		int[] keyTable = this.keyTable;
-		float[] valueTable = this.valueTable;
-		for (int i = capacity + stashSize; i-- > 0;)
-			if (keyTable[i] != 0 && valueTable[i] == value) return true;
-		return false;
-	}
-
-	/** Returns true if the specified value is in the map. Note this traverses the entire map and compares every value, which may
-	 * be an expensive operation. */
-	public boolean containsValue (float value, float epsilon) {
-		if (hasZeroValue && Math.abs(zeroValue - value) <= epsilon) return true;
-		float[] valueTable = this.valueTable;
-		for (int i = capacity + stashSize; i-- > 0;)
-			if (Math.abs(valueTable[i] - value) <= epsilon) return true;
+	/**
+	 * Returns true if the specified value is in the map. Note this traverses the entire map and compares every value, which may
+	 * be an expensive operation.
+	 */
+	public boolean containsValue (int value) {
+		if (hasZeroValue && zeroValue == value)
+			return true;
+		final int[] keyTable = this.keyTable;
+		final float[] valueTable = this.valueTable;
+		for (int i = valueTable.length; i-- > 0; )
+			if (keyTable[i] != 0 && valueTable[i] == value)
+				return true;
 		return false;
 	}
 
 	public boolean containsKey (int key) {
-		if (key == 0) return hasZeroValue;
-		int index = key & mask;
-		if (keyTable[index] != key) {
-			index = hash2(key);
-			if (keyTable[index] != key) {
-				index = hash3(key);
-				if (keyTable[index] != key) return containsKeyStash(key);
-			}
+		if (key == 0)
+			return hasZeroValue;
+		return locateKey(key) != -1;
+	}
+
+	/**
+	 * Returns the key for the specified value, or null if it is not in the map. Note this traverses the entire map and compares
+	 * every value, which may be an expensive operation.
+	 */
+	public int findKey (int value, int notFound) {
+		if (hasZeroValue && zeroValue == value)
+			return 0;
+		final int[] keyTable = this.keyTable;
+		final float[] valueTable = this.valueTable;
+		for (int i = valueTable.length; i-- > 0; ) {
+			int key = keyTable[i];
+			if (key != 0 && valueTable[i] == value)
+				return key;
 		}
-		return true;
-	}
-
-	private boolean containsKeyStash (int key) {
-		int[] keyTable = this.keyTable;
-		for (int i = capacity, n = i + stashSize; i < n; i++)
-			if (key == keyTable[i]) return true;
-		return false;
-	}
-
-	/** Returns the key for the specified value, or null if it is not in the map. Note this traverses the entire map and compares
-	 * every value, which may be an expensive operation. */
-	public int findKey (float value, int notFound) {
-		if (hasZeroValue && zeroValue == value) return 0;
-		int[] keyTable = this.keyTable;
-		float[] valueTable = this.valueTable;
-		for (int i = capacity + stashSize; i-- > 0;)
-			if (keyTable[i] != 0 && valueTable[i] == value) return keyTable[i];
 		return notFound;
 	}
 
-	/** Increases the size of the backing array to accommodate the specified number of additional items. Useful before adding many
-	 * items to avoid multiple backing array resizes. */
+	/**
+	 * Increases the size of the backing array to accommodate the specified number of additional items. Useful before adding many
+	 * items to avoid multiple backing array resizes.
+	 */
 	public void ensureCapacity (int additionalCapacity) {
-		if (additionalCapacity < 0) throw new IllegalArgumentException("additionalCapacity must be >= 0: " + additionalCapacity);
+		if (additionalCapacity < 0)
+			throw new IllegalArgumentException("additionalCapacity must be >= 0: " + additionalCapacity);
 		int sizeNeeded = size + additionalCapacity;
-		if (sizeNeeded >= threshold) resize(MathUtils.nextPowerOfTwo((int)Math.ceil(sizeNeeded / loadFactor)));
+		if (sizeNeeded >= threshold)
+			resize(MathUtils.nextPowerOfTwo((int)Math.ceil(sizeNeeded / loadFactor)));
 	}
 
 	private void resize (int newSize) {
-		int oldEndIndex = capacity + stashSize;
-
-		capacity = newSize;
+		int oldCapacity = keyTable.length;
 		threshold = (int)(newSize * loadFactor);
 		mask = newSize - 1;
-		hashShift = 31 - Integer.numberOfTrailingZeros(newSize);
-		stashCapacity = Math.max(3, (int)Math.ceil(Math.log(newSize)) * 2);
-		pushIterations = Math.max(Math.min(newSize, 8), (int)Math.sqrt(newSize) / 8);
+		shift = Long.numberOfLeadingZeros(mask);
 
-		int[] oldKeyTable = keyTable;
-		float[] oldValueTable = valueTable;
+		final int[] oldKeyTable = keyTable;
+		final float[] oldValueTable = valueTable;
 
-		keyTable = new int[newSize + stashCapacity];
-		valueTable = new float[newSize + stashCapacity];
+		keyTable = new int[newSize];
+		valueTable = new float[newSize];
 
 		int oldSize = size;
-		size = hasZeroValue ? 1 : 0;
-		stashSize = 0;
+		size = 0;
 		if (oldSize > 0) {
-			for (int i = 0; i < oldEndIndex; i++) {
+			for (int i = 0; i < oldCapacity; i++) {
 				int key = oldKeyTable[i];
-				if (key != EMPTY) putResize(key, oldValueTable[i]);
+				if (key != 0)
+					putResize(key, oldValueTable[i]);
 			}
 		}
 	}
 
-	private int hash2 (int h) {
-		h *= PRIME2;
-		return (h ^ h >>> hashShift) & mask;
-	}
-
-	private int hash3 (int h) {
-		h *= PRIME3;
-		return (h ^ h >>> hashShift) & mask;
-	}
-
 	public int hashCode () {
-		int h = 0;
+		int h = size;
 		if (hasZeroValue) {
-			h += Float.floatToIntBits(zeroValue);
+			h += NumberUtils.floatToRawIntBits(zeroValue);
 		}
 		int[] keyTable = this.keyTable;
 		float[] valueTable = this.valueTable;
-		for (int i = 0, n = capacity + stashSize; i < n; i++) {
+		for (int i = 0, n = keyTable.length; i < n; i++) {
 			int key = keyTable[i];
-			if (key != EMPTY) {
-				h += key * 31;
-
-				float value = valueTable[i];
-				h += Float.floatToIntBits(value);
+			if (key != 0) {
+				h ^= key;
+				key = NumberUtils.floatToRawIntBits(valueTable[i]);
+				h += key ^ key >>> 16 ^ key >>> 21;
 			}
 		}
 		return h;
 	}
 
 	public boolean equals (Object obj) {
-		if (obj == this) return true;
-		if (!(obj instanceof IntFloatMap)) return false;
-		IntFloatMap other = (IntFloatMap)obj;
-		if (other.size != size) return false;
-		if (other.hasZeroValue != hasZeroValue) return false;
-		if (hasZeroValue && other.zeroValue != zeroValue) {
+		if (obj == this)
+			return true;
+		if (!(obj instanceof IntFloatMap))
 			return false;
+		IntFloatMap other = (IntFloatMap)obj;
+		if (other.size != size)
+			return false;
+		if (other.hasZeroValue != hasZeroValue)
+			return false;
+		if (hasZeroValue) {
+			if (other.zeroValue != zeroValue)
+				return false;
 		}
-		int[] keyTable = this.keyTable;
-		float[] valueTable = this.valueTable;
-		for (int i = 0, n = capacity + stashSize; i < n; i++) {
+		final int[] keyTable = this.keyTable;
+		final float[] valueTable = this.valueTable;
+		for (int i = 0, n = keyTable.length; i < n; i++) {
 			int key = keyTable[i];
-			if (key != EMPTY) {
+			if (key != 0) {
 				float otherValue = other.get(key, 0f);
-				if (otherValue == 0f && !other.containsKey(key)) return false;
-				float value = valueTable[i];
-				if (otherValue != value) return false;
+				if (otherValue == 0f && !other.containsKey(key))
+					return false;
+				if (otherValue != valueTable[i])
+					return false;
 			}
 		}
 		return true;
 	}
 
 	public String toString () {
-		if (size == 0) return "{}";
-		StringBuilder buffer = new StringBuilder(32);
-		buffer.append('{');
-		int[] keyTable = this.keyTable;
-		float[] valueTable = this.valueTable;
+		if (size == 0)
+			return "[]";
+		java.lang.StringBuilder buffer = new java.lang.StringBuilder(32);
+		buffer.append('[');
+		final int[] keyTable = this.keyTable;
+		final float[] valueTable = this.valueTable;
 		int i = keyTable.length;
 		if (hasZeroValue) {
 			buffer.append("0=");
@@ -606,7 +519,8 @@ public class IntFloatMap implements Iterable<IntFloatMap.Entry> {
 		} else {
 			while (i-- > 0) {
 				int key = keyTable[i];
-				if (key == EMPTY) continue;
+				if (key == 0)
+					continue;
 				buffer.append(key);
 				buffer.append('=');
 				buffer.append(valueTable[i]);
@@ -615,13 +529,14 @@ public class IntFloatMap implements Iterable<IntFloatMap.Entry> {
 		}
 		while (i-- > 0) {
 			int key = keyTable[i];
-			if (key == EMPTY) continue;
+			if (key == 0)
+				continue;
 			buffer.append(", ");
 			buffer.append(key);
 			buffer.append('=');
 			buffer.append(valueTable[i]);
 		}
-		buffer.append('}');
+		buffer.append(']');
 		return buffer.toString();
 	}
 
@@ -629,12 +544,15 @@ public class IntFloatMap implements Iterable<IntFloatMap.Entry> {
 		return entries();
 	}
 
-	/** Returns an iterator for the entries in the map. Remove is supported.
+	/**
+	 * Returns an iterator for the entries in the map. Remove is supported.
 	 * <p>
 	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called.
-	 * Use the {@link Entries} constructor for nested or multithreaded iteration. */
+	 * Use the {@link Entries} constructor for nested or multithreaded iteration.
+	 */
 	public Entries entries () {
-		if (Collections.allocateIterators) return new Entries(this);
+		if (Collections.allocateIterators)
+			return new Entries(this);
 		if (entries1 == null) {
 			entries1 = new Entries(this);
 			entries2 = new Entries(this);
@@ -651,12 +569,15 @@ public class IntFloatMap implements Iterable<IntFloatMap.Entry> {
 		return entries2;
 	}
 
-	/** Returns an iterator for the values in the map. Remove is supported.
+	/**
+	 * Returns an iterator for the values in the map. Remove is supported.
 	 * <p>
 	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called.
-	 * Use the {@link Entries} constructor for nested or multithreaded iteration. */
+	 * Use the {@link Entries} constructor for nested or multithreaded iteration.
+	 */
 	public Values values () {
-		if (Collections.allocateIterators) return new Values(this);
+		if (Collections.allocateIterators)
+			return new Values(this);
 		if (values1 == null) {
 			values1 = new Values(this);
 			values2 = new Values(this);
@@ -673,12 +594,15 @@ public class IntFloatMap implements Iterable<IntFloatMap.Entry> {
 		return values2;
 	}
 
-	/** Returns an iterator for the keys in the map. Remove is supported.
+	/**
+	 * Returns an iterator for the keys in the map. Remove is supported.
 	 * <p>
 	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called.
-	 * Use the {@link Entries} constructor for nested or multithreaded iteration. */
+	 * Use the {@link Entries} constructor for nested or multithreaded iteration.
+	 */
 	public Keys keys () {
-		if (Collections.allocateIterators) return new Keys(this);
+		if (Collections.allocateIterators)
+			return new Keys(this);
 		if (keys1 == null) {
 			keys1 = new Keys(this);
 			keys2 = new Keys(this);
@@ -693,6 +617,23 @@ public class IntFloatMap implements Iterable<IntFloatMap.Entry> {
 		keys2.valid = true;
 		keys1.valid = false;
 		return keys2;
+	}
+
+	public void write (Json json) {
+		json.writeArrayStart("entries");
+		for (Entry entry : entries()) {
+			json.writeValue(entry.key, Integer.class);
+			json.writeValue(entry.value, Float.class);
+		}
+		json.writeArrayEnd();
+	}
+
+	public void read (Json json, JsonValue jsonData) {
+		for (JsonValue child = jsonData.get("entries").child; child != null; child = child.next) {
+			int key = child.asInt();
+			float value = (child = child.next).asFloat();
+			put(key, value);
+		}
 	}
 
 	static public class Entry {
@@ -731,8 +672,8 @@ public class IntFloatMap implements Iterable<IntFloatMap.Entry> {
 		void findNextIndex () {
 			hasNext = false;
 			int[] keyTable = map.keyTable;
-			for (int n = map.capacity + map.stashSize; ++nextIndex < n;) {
-				if (keyTable[nextIndex] != EMPTY) {
+			for (int n = keyTable.length; ++nextIndex < n; ) {
+				if (keyTable[nextIndex] != 0) {
 					hasNext = true;
 					break;
 				}
@@ -744,12 +685,18 @@ public class IntFloatMap implements Iterable<IntFloatMap.Entry> {
 				map.hasZeroValue = false;
 			} else if (currentIndex < 0) {
 				throw new IllegalStateException("next must be called before remove.");
-			} else if (currentIndex >= map.capacity) {
-				map.removeStashIndex(currentIndex);
-				nextIndex = currentIndex - 1;
-				findNextIndex();
 			} else {
-				map.keyTable[currentIndex] = EMPTY;
+				int[] keyTable = map.keyTable;
+				float[] valueTable = map.valueTable;
+				int loc = currentIndex, key;
+				final int mask = map.mask;
+				while ((key = keyTable[loc + 1 & mask]) != 0 && (loc + 1 & mask) != map.place(key)) {
+					keyTable[loc] = key;
+					valueTable[loc] = valueTable[loc + 1 & mask];
+					++loc;
+				}
+				if(loc != currentIndex) --nextIndex;
+				keyTable[loc] = 0;
 			}
 			currentIndex = INDEX_ILLEGAL;
 			map.size--;
@@ -763,10 +710,14 @@ public class IntFloatMap implements Iterable<IntFloatMap.Entry> {
 			super(map);
 		}
 
-		/** Note the same entry instance is returned each time this method is called. */
+		/**
+		 * Note the same entry instance is returned each time this method is called.
+		 */
 		public Entry next () {
-			if (!hasNext) throw new NoSuchElementException();
-			if (!valid) throw new GdxRuntimeException("#iterator() cannot be used nested.");
+			if (!hasNext)
+				throw new NoSuchElementException();
+			if (!valid)
+				throw new GdxRuntimeException("#iterator() cannot be used nested.");
 			int[] keyTable = map.keyTable;
 			if (nextIndex == INDEX_ZERO) {
 				entry.key = 0;
@@ -781,7 +732,8 @@ public class IntFloatMap implements Iterable<IntFloatMap.Entry> {
 		}
 
 		public boolean hasNext () {
-			if (!valid) throw new GdxRuntimeException("#iterator() cannot be used nested.");
+			if (!valid)
+				throw new GdxRuntimeException("#iterator() cannot be used nested.");
 			return hasNext;
 		}
 
@@ -800,26 +752,40 @@ public class IntFloatMap implements Iterable<IntFloatMap.Entry> {
 		}
 
 		public boolean hasNext () {
-			if (!valid) throw new GdxRuntimeException("#iterator() cannot be used nested.");
+			if (!valid)
+				throw new GdxRuntimeException("#iterator() cannot be used nested.");
 			return hasNext;
 		}
 
 		public float next () {
-			if (!hasNext) throw new NoSuchElementException();
-			if (!valid) throw new GdxRuntimeException("#iterator() cannot be used nested.");
-			float value;
-			if (nextIndex == INDEX_ZERO)
-				value = map.zeroValue;
-			else
-				value = map.valueTable[nextIndex];
+			if (!hasNext)
+				throw new NoSuchElementException();
+			if (!valid)
+				throw new GdxRuntimeException("#iterator() cannot be used nested.");
+			float value = map.valueTable[nextIndex];
 			currentIndex = nextIndex;
 			findNextIndex();
 			return value;
 		}
 
-		/** Returns a new array containing the remaining values. */
+		public Values iterator () {
+			return this;
+		}
+
+		/**
+		 * Returns a new array containing the remaining values.
+		 */
 		public FloatArray toArray () {
 			FloatArray array = new FloatArray(true, map.size);
+			while (hasNext)
+				array.add(next());
+			return array;
+		}
+
+		/**
+		 * Adds the remaining values to the specified array.
+		 */
+		public FloatArray toArray (FloatArray array) {
 			while (hasNext)
 				array.add(next());
 			return array;
@@ -831,23 +797,31 @@ public class IntFloatMap implements Iterable<IntFloatMap.Entry> {
 			super(map);
 		}
 
-		public boolean hasNext () {
-			if (!valid) throw new GdxRuntimeException("#iterator() cannot be used nested.");
-			return hasNext;
-		}
-
 		public int next () {
-			if (!hasNext) throw new NoSuchElementException();
-			if (!valid) throw new GdxRuntimeException("#iterator() cannot be used nested.");
+			if (!hasNext)
+				throw new NoSuchElementException();
+			if (!valid)
+				throw new GdxRuntimeException("#iterator() cannot be used nested.");
 			int key = nextIndex == INDEX_ZERO ? 0 : map.keyTable[nextIndex];
 			currentIndex = nextIndex;
 			findNextIndex();
 			return key;
 		}
 
-		/** Returns a new array containing the remaining keys. */
+		/**
+		 * Returns a new array containing the remaining keys.
+		 */
 		public IntArray toArray () {
 			IntArray array = new IntArray(true, map.size);
+			while (hasNext)
+				array.add(next());
+			return array;
+		}
+
+		/**
+		 * Adds the remaining values to the specified array.
+		 */
+		public IntArray toArray (IntArray array) {
 			while (hasNext)
 				array.add(next());
 			return array;

--- a/gdx/src/com/badlogic/gdx/utils/IntFloatMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/IntFloatMap.java
@@ -320,9 +320,12 @@ public class IntFloatMap implements Json.Serializable, Iterable<IntFloatMap.Entr
 		final int[] keyTable = this.keyTable;
 		final float[] valueTable = this.valueTable;
 		final float oldValue = valueTable[loc];
-		while ((key = keyTable[loc + 1 & mask]) != 0 && (loc + 1 & mask) != place(key)) {
+		int nl = (loc + 1 & mask);
+		while ((key = keyTable[nl]) != 0 && nl != place(key)) {
 			keyTable[loc] = key;
-			valueTable[loc] = valueTable[++loc & mask];
+			valueTable[loc] = valueTable[nl];
+			loc = nl;
+			nl = loc + 1 & mask;
 		}
 		keyTable[loc] = 0;
 		--size;
@@ -684,12 +687,13 @@ public class IntFloatMap implements Json.Serializable, Iterable<IntFloatMap.Entr
 			} else {
 				int[] keyTable = map.keyTable;
 				float[] valueTable = map.valueTable;
-				int loc = currentIndex, key;
 				final int mask = map.mask;
-				while ((key = keyTable[loc + 1 & mask]) != 0 && (loc + 1 & mask) != map.place(key)) {
+				int loc = currentIndex, nl = (loc + 1 & mask), key;
+				while ((key = keyTable[nl]) != 0 && nl != map.place(key)) {
 					keyTable[loc] = key;
-					valueTable[loc] = valueTable[loc + 1 & mask];
-					++loc;
+					valueTable[loc] = valueTable[nl];
+					loc = nl;
+					nl = loc + 1 & mask;
 				}
 				if(loc != currentIndex) --nextIndex;
 				keyTable[loc] = 0;

--- a/gdx/src/com/badlogic/gdx/utils/IntFloatMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/IntFloatMap.java
@@ -53,7 +53,7 @@ public class IntFloatMap implements Json.Serializable, Iterable<IntFloatMap.Entr
 	private float zeroValue;
 	private boolean hasZeroValue;
 
-	private float loadFactor;
+	private final float loadFactor;
 	private int threshold;
 	/**
 	 * Used by {@link #place(int)} to bit-shift the upper bits of a {@code long} into a usable range (less than or
@@ -248,16 +248,14 @@ public class IntFloatMap implements Json.Serializable, Iterable<IntFloatMap.Entr
 		}
 		final int[] keyTable = this.keyTable;
 		final float[] valueTable = this.valueTable;
-		
+
 		for (int i = place(key); ; i = (i + 1) & mask) {
-			// space is available so we insert and break (resize is later)
+			// space is available so we insert and break
 			if (keyTable[i] == 0) {
 				keyTable[i] = key;
 				valueTable[i] = value;
-				
-				if (++size >= threshold) {
-					resize(keyTable.length << 1);
-				}
+
+				++size;
 				return;
 			}
 		}
@@ -690,7 +688,8 @@ public class IntFloatMap implements Json.Serializable, Iterable<IntFloatMap.Entr
 					loc = nl;
 					nl = loc + 1 & mask;
 				}
-				if(loc != currentIndex) --nextIndex;
+				if (loc != currentIndex)
+					--nextIndex;
 				keyTable[loc] = 0;
 			}
 			currentIndex = INDEX_ILLEGAL;
@@ -699,7 +698,7 @@ public class IntFloatMap implements Json.Serializable, Iterable<IntFloatMap.Entr
 	}
 
 	static public class Entries extends MapIterator implements Iterable<Entry>, Iterator<Entry> {
-		private Entry entry = new Entry();
+		private final Entry entry = new Entry();
 
 		public Entries (IntFloatMap map) {
 			super(map);

--- a/gdx/src/com/badlogic/gdx/utils/IntFloatMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/IntFloatMap.java
@@ -253,8 +253,7 @@ public class IntFloatMap implements Json.Serializable, Iterable<IntFloatMap.Entr
 		final int[] keyTable = this.keyTable;
 		final float[] valueTable = this.valueTable;
 		
-		int b = place(key);
-		for (int i = b; ; i = (i + 1) & mask) {
+		for (int i = place(key); ; i = (i + 1) & mask) {
 			// space is available so we insert and break (resize is later)
 			if (keyTable[i] == 0) {
 				keyTable[i] = key;

--- a/gdx/src/com/badlogic/gdx/utils/IntFloatMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/IntFloatMap.java
@@ -233,10 +233,6 @@ public class IntFloatMap implements Json.Serializable, Iterable<IntFloatMap.Entr
 				put(k, valueTable[i]);
 		}
 	}
-	// the old version; I think the new way avoids a little work
-//	   ensureCapacity(map.size);
-//		for (Entry entry : map.entries())
-//			put(entry.key, entry.value);
 
 	/**
 	 * Skips checks for existing keys.

--- a/gdx/src/com/badlogic/gdx/utils/IntFloatMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/IntFloatMap.java
@@ -105,7 +105,7 @@ public class IntFloatMap implements Json.Serializable, Iterable<IntFloatMap.Entr
 			throw new IllegalArgumentException("initialCapacity must be >= 0: " + initialCapacity);
 		if (loadFactor <= 0f || loadFactor >= 1f)
 			throw new IllegalArgumentException("loadFactor must be > 0 and < 1: " + loadFactor);
-		initialCapacity = MathUtils.nextPowerOfTwo((int)Math.ceil(initialCapacity / loadFactor));
+		initialCapacity = MathUtils.nextPowerOfTwo((int)Math.ceil(Math.max(1, initialCapacity) / loadFactor));
 		if (initialCapacity > 1 << 30)
 			throw new IllegalArgumentException("initialCapacity is too large: " + initialCapacity);
 
@@ -446,7 +446,7 @@ public class IntFloatMap implements Json.Serializable, Iterable<IntFloatMap.Entr
 		valueTable = new float[newSize];
 
 		int oldSize = size;
-		size = 0;
+		size = hasZeroValue ? 1 : 0;
 		if (oldSize > 0) {
 			for (int i = 0; i < oldCapacity; i++) {
 				int key = oldKeyTable[i];

--- a/gdx/src/com/badlogic/gdx/utils/IntFloatMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/IntFloatMap.java
@@ -39,10 +39,6 @@ import java.util.NoSuchElementException;
  * Load factors greater than 0.91 greatly increase the chances the map will have to rehash to the next higher POT size.
  * Memory usage is excellent, and the aforementioned collision-resistance helps avoid too much capacity resizing.
  * <br>
- * The <a href="http://codecapsule.com/2013/11/17/robin-hood-hashing-backward-shift-deletion/">backward-shift algorithm</a>
- * used during removal apparently is key to the good performance of this implementation, even though this doesn't use Robin Hood
- * hashing; the performance of {@link #remove(int, float)} has improved considerably over the previous libGDX version.
- * <br>
  * Iteration won't be as fast here as with OrderedSet and OrderedMap.
  *
  * @author Tommy Ettinger
@@ -149,7 +145,7 @@ public class IntFloatMap implements Json.Serializable, Iterable<IntFloatMap.Entr
 	 * {@code return (int) (item * 0x9E3779B97F4A7C15L >>> shift);}
 	 * <br>
 	 * This can be overridden by subclasses, which you may want to do if your key type needs special consideration for
-	 * its hash (such as if you use arrays as keys, which still requires that the arrays are not modified). Subclasses
+	 * its hash (such as if you can't modify or extend a particular class that has an incorrect hashCode()). Subclasses
 	 * that don't need the collision decrease of Fibonacci Hashing (assuming the keys are well-distributed) may do
 	 * fine with a simple implementation:
 	 * {@code return (item & mask);}

--- a/gdx/src/com/badlogic/gdx/utils/IntIntMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/IntIntMap.java
@@ -39,10 +39,6 @@ import java.util.NoSuchElementException;
  * Load factors greater than 0.91 greatly increase the chances the map will have to rehash to the next higher POT size.
  * Memory usage is excellent, and the aforementioned collision-resistance helps avoid too much capacity resizing.
  * <br>
- * The <a href="http://codecapsule.com/2013/11/17/robin-hood-hashing-backward-shift-deletion/">backward-shift algorithm</a>
- * used during removal apparently is key to the good performance of this implementation, even though this doesn't use Robin Hood
- * hashing; the performance of {@link #remove(int, int)} has improved considerably over the previous libGDX version.
- * <br>
  * Iteration won't be as fast here as with OrderedSet and OrderedMap.
  *
  * @author Tommy Ettinger
@@ -149,7 +145,7 @@ public class IntIntMap implements Json.Serializable, Iterable<IntIntMap.Entry> {
 	 * {@code return (int) (item * 0x9E3779B97F4A7C15L >>> shift);}
 	 * <br>
 	 * This can be overridden by subclasses, which you may want to do if your key type needs special consideration for
-	 * its hash (such as if you use arrays as keys, which still requires that the arrays are not modified). Subclasses
+	 * its hash (such as if you can't modify or extend a particular class that has an incorrect hashCode()). Subclasses
 	 * that don't need the collision decrease of Fibonacci Hashing (assuming the keys are well-distributed) may do
 	 * fine with a simple implementation:
 	 * {@code return (item & mask);}

--- a/gdx/src/com/badlogic/gdx/utils/IntIntMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/IntIntMap.java
@@ -105,7 +105,7 @@ public class IntIntMap implements Json.Serializable, Iterable<IntIntMap.Entry> {
 			throw new IllegalArgumentException("initialCapacity must be >= 0: " + initialCapacity);
 		if (loadFactor <= 0f || loadFactor >= 1f)
 			throw new IllegalArgumentException("loadFactor must be > 0 and < 1: " + loadFactor);
-		initialCapacity = MathUtils.nextPowerOfTwo((int)Math.ceil(initialCapacity / loadFactor));
+		initialCapacity = MathUtils.nextPowerOfTwo((int)Math.ceil(Math.max(1, initialCapacity) / loadFactor));
 		if (initialCapacity > 1 << 30)
 			throw new IllegalArgumentException("initialCapacity is too large: " + initialCapacity);
 
@@ -443,7 +443,7 @@ public class IntIntMap implements Json.Serializable, Iterable<IntIntMap.Entry> {
 		valueTable = new int[newSize];
 		
 		int oldSize = size;
-		size = 0;
+		size = hasZeroValue ? 1 : 0;
 		if (oldSize > 0) {
 			for (int i = 0; i < oldCapacity; i++) {
 				int key = oldKeyTable[i];

--- a/gdx/src/com/badlogic/gdx/utils/IntIntMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/IntIntMap.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,77 +16,118 @@
 
 package com.badlogic.gdx.utils;
 
+import com.badlogic.gdx.math.MathUtils;
+
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
-import com.badlogic.gdx.math.MathUtils;
-
-/** An unordered map where the keys and values are ints. This implementation is a cuckoo hash map using 3 hashes, random walking,
- * and a small stash for problematic keys. No allocation is done except when growing the table size. <br>
+/**
+ * An unordered map where the keys and values are unboxed ints. This implementation uses linear probing with the
+ * backward-shift algorithm for removal, and finds space for keys using Fibonacci hashing instead of the more-common power-of-two
+ * mask. Null keys are not allowed. No allocation is done except when growing the table size.
  * <br>
- * This map performs very fast get, containsKey, and remove (typically O(1), worst case O(log(n))). Put may be a bit slower,
- * depending on hash collisions. Load factors greater than 0.91 greatly increase the chances the map will have to rehash to the
- * next higher POT size.
- * @author Nathan Sweet */
-public class IntIntMap implements Iterable<IntIntMap.Entry> {
-	private static final int PRIME1 = 0xbe1f14b1;
-	private static final int PRIME2 = 0xb4b82e39;
-	private static final int PRIME3 = 0xced1c241;
-	private static final int EMPTY = 0;
-
+ * This map uses Fibonacci hashing to help distribute what may be very bad hashCode() results across the
+ * whole capacity. See <a href="https://probablydance.com/2018/06/16/fibonacci-hashing-the-optimization-that-the-world-forgot-or-a-better-alternative-to-integer-modulo/">Malte Skarupke's blog post</a>
+ * for more information on Fibonacci hashing. It uses linear probing to resolve collisions, which is far from the academically
+ * optimal algorithm, but performs considerably better in practice than most alternatives, and combined with Fibonacci hashing, it
+ * can handle "normal" generated hashCode() implementations, and not just theoretically optimal hashing functions. Even if all
+ * hashCode()s this is given collide, it will still work, just slowly; the older libGDX implementation using cuckoo hashing would
+ * crash with an OutOfMemoryError with under 50 collisions.
+ * <br>
+ * This map performs very fast contains and remove (typically O(1), worst case O(n) due to occasional probing, but still very
+ * fast). Add may be a bit slower, depending on hash collisions, but this data structure is somewhat collision-resistant.
+ * Load factors greater than 0.91 greatly increase the chances the map will have to rehash to the next higher POT size.
+ * Memory usage is excellent, and the aforementioned collision-resistance helps avoid too much capacity resizing.
+ * <br>
+ * The <a href="http://codecapsule.com/2013/11/17/robin-hood-hashing-backward-shift-deletion/">backward-shift algorithm</a>
+ * used during removal apparently is key to the good performance of this implementation, even though this doesn't use Robin Hood
+ * hashing; the performance of {@link #remove(int, int)} has improved considerably over the previous libGDX version.
+ * <br>
+ * Iteration won't be as fast here as with OrderedSet and OrderedMap.
+ *
+ * @author Tommy Ettinger
+ * @author Nathan Sweet
+ */
+public class IntIntMap implements Json.Serializable, Iterable<IntIntMap.Entry> {
 	public int size;
 
-	int[] keyTable, valueTable;
-	int capacity, stashSize;
-	int zeroValue;
-	boolean hasZeroValue;
+	private int[] keyTable;
+	private int[] valueTable;
+
+	private int zeroValue;
+	private boolean hasZeroValue;
 
 	private float loadFactor;
-	private int hashShift, mask, threshold;
-	private int stashCapacity;
-	private int pushIterations;
+	private int threshold;
+	/**
+	 * Used by {@link #place(int)} to bit-shift the upper bits of a {@code long} into a usable range (less than or
+	 * equal to {@link #mask}, greater than or equal to 0). If you're setting it in a subclass, this shift can be
+	 * negative, which is a convenient way to match the number of bits in mask; if mask is a 7-bit number, then a shift
+	 * of -7 will correctly shift the upper 7 bits into the lowest 7 positions. If using what this class sets, shift
+	 * will be greater than 32 and less than 64; if you use this shift with an int, it will still correctly move the
+	 * upper bits of an int to the lower bits, thanks to Java's implicit modulus on shifts.
+	 * <br>
+	 * You can also use {@link #mask} to mask the low bits of a number, which may be faster for some hashCode()s, if you
+	 * reimplement {@link #place(int)}.
+	 */
+	private int shift;
+	/**
+	 * The bitmask used to contain hashCode()s to the indices that can be fit into the key array this uses. This should
+	 * always be all-1-bits in its low positions; that is, it must be a power of two minus 1. If you subclass and change
+	 * {@link #place(int)}, you may want to use this instead of {@link #shift} to isolate usable bits of a hash.
+	 */
+	private int mask;
 
 	private Entries entries1, entries2;
 	private Values values1, values2;
 	private Keys keys1, keys2;
 
-	/** Creates a new map with an initial capacity of 51 and a load factor of 0.8. */
+	/**
+	 * Creates a new map with an initial capacity of 51 and a load factor of 0.8.
+	 */
 	public IntIntMap () {
 		this(51, 0.8f);
 	}
 
-	/** Creates a new map with a load factor of 0.8.
-	 * @param initialCapacity If not a power of two, it is increased to the next nearest power of two. */
+	/**
+	 * Creates a new map with a load factor of 0.8.
+	 *
+	 * @param initialCapacity If not a power of two, it is increased to the next nearest power of two.
+	 */
 	public IntIntMap (int initialCapacity) {
 		this(initialCapacity, 0.8f);
 	}
 
-	/** Creates a new map with the specified initial capacity and load factor. This map will hold initialCapacity items before
+	/**
+	 * Creates a new map with the specified initial capacity and load factor. This map will hold initialCapacity items before
 	 * growing the backing table.
-	 * @param initialCapacity If not a power of two, it is increased to the next nearest power of two. */
+	 *
+	 * @param initialCapacity If not a power of two, it is increased to the next nearest power of two.
+	 */
 	public IntIntMap (int initialCapacity, float loadFactor) {
-		if (loadFactor <= 0) throw new IllegalArgumentException("loadFactor must be > 0: " + loadFactor);
+		if (initialCapacity < 0)
+			throw new IllegalArgumentException("initialCapacity must be >= 0: " + initialCapacity);
+		if (loadFactor <= 0f || loadFactor >= 1f)
+			throw new IllegalArgumentException("loadFactor must be > 0 and < 1: " + loadFactor);
+		initialCapacity = MathUtils.nextPowerOfTwo((int)Math.ceil(initialCapacity / loadFactor));
+		if (initialCapacity > 1 << 30)
+			throw new IllegalArgumentException("initialCapacity is too large: " + initialCapacity);
+
 		this.loadFactor = loadFactor;
 
-		if (initialCapacity < 0) throw new IllegalArgumentException("initialCapacity must be >= 0: " + initialCapacity);
-		initialCapacity = MathUtils.nextPowerOfTwo((int)Math.ceil(initialCapacity / loadFactor));
-		if (initialCapacity > 1 << 30) throw new IllegalArgumentException("initialCapacity is too large: " + initialCapacity);
-		capacity = initialCapacity;
+		threshold = (int)(initialCapacity * loadFactor);
+		mask = initialCapacity - 1;
+		shift = Long.numberOfLeadingZeros(mask);
 
-		threshold = (int)(capacity * loadFactor);
-		mask = capacity - 1;
-		hashShift = 31 - Integer.numberOfTrailingZeros(capacity);
-		stashCapacity = Math.max(3, (int)Math.ceil(Math.log(capacity)) * 2);
-		pushIterations = Math.max(Math.min(capacity, 8), (int)Math.sqrt(capacity) / 8);
-
-		keyTable = new int[capacity + stashCapacity];
-		valueTable = new int[keyTable.length];
+		keyTable = new int[initialCapacity];
+		valueTable = new int[initialCapacity];
 	}
 
-	/** Creates a new map identical to the specified map. */
+	/**
+	 * Creates a new map identical to the specified map.
+	 */
 	public IntIntMap (IntIntMap map) {
-		this((int)Math.floor(map.capacity * map.loadFactor), map.loadFactor);
-		stashSize = map.stashSize;
+		this((int)(map.keyTable.length * map.loadFactor), map.loadFactor);
 		System.arraycopy(map.keyTable, 0, keyTable, 0, map.keyTable.length);
 		System.arraycopy(map.valueTable, 0, valueTable, 0, map.valueTable.length);
 		size = map.size;
@@ -94,6 +135,61 @@ public class IntIntMap implements Iterable<IntIntMap.Entry> {
 		hasZeroValue = map.hasZeroValue;
 	}
 
+	/**
+	 * Finds an array index between 0 and {@link #mask}, both inclusive, corresponding to the hash code of {@code item}.
+	 * By default, this uses "Fibonacci Hashing" on the int {@code item} directly; this multiplies
+	 * {@code item} by a long constant (2 to the 64, divided by the golden ratio) and shifts the high-quality
+	 * uppermost bits into the lowest positions so they can be used as array indices. The multiplication by a long may
+	 * be somewhat slow on GWT, but it will be correct across all platforms and won't lose precision. Using Fibonacci
+	 * Hashing allows even very poor hashCode() implementations, such as those that only differ in their upper bits, to
+	 * work in a hash table without heavy collision rates. It has known problems when all or most hashCode()s are
+	 * multiples of larger Fibonacci numbers; see <a href="https://probablydance.com/2018/06/16/fibonacci-hashing-the-optimization-that-the-world-forgot-or-a-better-alternative-to-integer-modulo/">this blog post by Malte Skarupke</a>
+	 * for more details. In the unlikely event that most of your hashCode()s are Fibonacci numbers, you can subclass
+	 * this to change this method, which is a one-liner in this form:
+	 * {@code return (int) (item * 0x9E3779B97F4A7C15L >>> shift);}
+	 * <br>
+	 * This can be overridden by subclasses, which you may want to do if your key type needs special consideration for
+	 * its hash (such as if you use arrays as keys, which still requires that the arrays are not modified). Subclasses
+	 * that don't need the collision decrease of Fibonacci Hashing (assuming the keys are well-distributed) may do
+	 * fine with a simple implementation:
+	 * {@code return (item & mask);}
+	 *
+	 * @param item a key that this method will use to get a hashed position
+	 * @return an int between 0 and {@link #mask}, both inclusive
+	 */
+	private int place (final int item) {
+		// shift is always greater than 32, less than 64
+		return (int)(item * 0x9E3779B97F4A7C15L >>> shift);
+	}
+
+	private int locateKey (final int key) {
+		return locateKey(key, place(key));
+	}
+
+	/**
+	 * Given a key and its initial placement to try in an array, this finds the actual location of the key in the array
+	 * if it is present, or -1 if the key is not present. This can be overridden if a subclass needs to compare for
+	 * equality differently than just by using == with int keys, but only within the same package.
+	 *
+	 * @param key       a K key that will be checked for equality if a similar-seeming key is found
+	 * @param placement as calculated by {@link #place(int)}, almost always with {@code place(key)}
+	 * @return the location in the key array of key, if found, or -1 if it was not found.
+	 */
+	private int locateKey (final int key, final int placement) {
+		for (int i = placement; ; i = i + 1 & mask) {
+			// empty space is available
+			if (keyTable[i] == 0) {
+				return -1;
+			}
+			if (key == (keyTable[i])) {
+				return i;
+			}
+		}
+	}
+
+	/**
+	 * Doesn't return a value, unlike other maps.
+	 */
 	public void put (int key, int value) {
 		if (key == 0) {
 			zeroValue = value;
@@ -104,336 +200,169 @@ public class IntIntMap implements Iterable<IntIntMap.Entry> {
 			return;
 		}
 
-		int[] keyTable = this.keyTable;
-
-		// Check for existing keys.
-		int index1 = key & mask;
-		int key1 = keyTable[index1];
-		if (key == key1) {
-			valueTable[index1] = value;
+		int b = place(key);
+		int loc = locateKey(key, b);
+		// an identical key already exists
+		if (loc != -1) {
+			valueTable[loc] = value;
 			return;
 		}
-
-		int index2 = hash2(key);
-		int key2 = keyTable[index2];
-		if (key == key2) {
-			valueTable[index2] = value;
-			return;
-		}
-
-		int index3 = hash3(key);
-		int key3 = keyTable[index3];
-		if (key == key3) {
-			valueTable[index3] = value;
-			return;
-		}
-
-		// Update key in the stash.
-		for (int i = capacity, n = i + stashSize; i < n; i++) {
-			if (key == keyTable[i]) {
+		final int[] keyTable = this.keyTable;
+		final int[] valueTable = this.valueTable;
+		for (int i = b; ; i = (i + 1) & mask) {
+			// space is available so we insert and break
+			if (keyTable[i] == 0) {
+				keyTable[i] = key;
 				valueTable[i] = value;
+
+				if (++size >= threshold) {
+					resize(keyTable.length << 1);
+				}
 				return;
 			}
 		}
-
-		// Check for empty buckets.
-		if (key1 == EMPTY) {
-			keyTable[index1] = key;
-			valueTable[index1] = value;
-			if (size++ >= threshold) resize(capacity << 1);
-			return;
-		}
-
-		if (key2 == EMPTY) {
-			keyTable[index2] = key;
-			valueTable[index2] = value;
-			if (size++ >= threshold) resize(capacity << 1);
-			return;
-		}
-
-		if (key3 == EMPTY) {
-			keyTable[index3] = key;
-			valueTable[index3] = value;
-			if (size++ >= threshold) resize(capacity << 1);
-			return;
-		}
-
-		push(key, value, index1, key1, index2, key2, index3, key3);
+		// never reached
 	}
 
 	public void putAll (IntIntMap map) {
-		for (Entry entry : map.entries())
-			put(entry.key, entry.value);
+		ensureCapacity(map.size);
+		if (map.hasZeroValue)
+			put(0, map.zeroValue);
+		final int[] keyTable = map.keyTable;
+		final int[] valueTable = map.valueTable;
+		int k;
+		for (int i = 0, n = keyTable.length; i < n; i++) {
+			if ((k = keyTable[i]) != 0)
+				put(k, valueTable[i]);
+		}
 	}
+	// the old version; I think the new way avoids a little work
+//	   ensureCapacity(map.size);
+//		for (Entry entry : map.entries())
+//			put(entry.key, entry.value);
 
-	/** Skips checks for existing keys. */
+	/**
+	 * Skips checks for existing keys.
+	 */
 	private void putResize (int key, int value) {
 		if (key == 0) {
 			zeroValue = value;
-			hasZeroValue = true;
-			return;
-		}
-
-		// Check for empty buckets.
-		int index1 = key & mask;
-		int key1 = keyTable[index1];
-		if (key1 == EMPTY) {
-			keyTable[index1] = key;
-			valueTable[index1] = value;
-			if (size++ >= threshold) resize(capacity << 1);
-			return;
-		}
-
-		int index2 = hash2(key);
-		int key2 = keyTable[index2];
-		if (key2 == EMPTY) {
-			keyTable[index2] = key;
-			valueTable[index2] = value;
-			if (size++ >= threshold) resize(capacity << 1);
-			return;
-		}
-
-		int index3 = hash3(key);
-		int key3 = keyTable[index3];
-		if (key3 == EMPTY) {
-			keyTable[index3] = key;
-			valueTable[index3] = value;
-			if (size++ >= threshold) resize(capacity << 1);
-			return;
-		}
-
-		push(key, value, index1, key1, index2, key2, index3, key3);
-	}
-
-	private void push (int insertKey, int insertValue, int index1, int key1, int index2, int key2, int index3, int key3) {
-		int[] keyTable = this.keyTable;
-		int[] valueTable = this.valueTable;
-		int mask = this.mask;
-
-		// Push keys until an empty bucket is found.
-		int evictedKey;
-		int evictedValue;
-		int i = 0, pushIterations = this.pushIterations;
-		do {
-			// Replace the key and value for one of the hashes.
-			switch (MathUtils.random(2)) {
-			case 0:
-				evictedKey = key1;
-				evictedValue = valueTable[index1];
-				keyTable[index1] = insertKey;
-				valueTable[index1] = insertValue;
-				break;
-			case 1:
-				evictedKey = key2;
-				evictedValue = valueTable[index2];
-				keyTable[index2] = insertKey;
-				valueTable[index2] = insertValue;
-				break;
-			default:
-				evictedKey = key3;
-				evictedValue = valueTable[index3];
-				keyTable[index3] = insertKey;
-				valueTable[index3] = insertValue;
-				break;
+			if (!hasZeroValue) {
+				hasZeroValue = true;
+				size++;
 			}
+			return;
+		}
+		final int[] keyTable = this.keyTable;
+		final int[] valueTable = this.valueTable;
+		int b = place(key);
+		for (int i = b; ; i = (i + 1) & mask) {
+			// space is available so we insert and break (resize is later)
+			if (keyTable[i] == 0) {
+				keyTable[i] = key;
+				valueTable[i] = value;
 
-			// If the evicted key hashes to an empty bucket, put it there and stop.
-			index1 = evictedKey & mask;
-			key1 = keyTable[index1];
-			if (key1 == EMPTY) {
-				keyTable[index1] = evictedKey;
-				valueTable[index1] = evictedValue;
-				if (size++ >= threshold) resize(capacity << 1);
+				if (++size >= threshold) {
+					resize(keyTable.length << 1);
+				}
 				return;
 			}
-
-			index2 = hash2(evictedKey);
-			key2 = keyTable[index2];
-			if (key2 == EMPTY) {
-				keyTable[index2] = evictedKey;
-				valueTable[index2] = evictedValue;
-				if (size++ >= threshold) resize(capacity << 1);
-				return;
-			}
-
-			index3 = hash3(evictedKey);
-			key3 = keyTable[index3];
-			if (key3 == EMPTY) {
-				keyTable[index3] = evictedKey;
-				valueTable[index3] = evictedValue;
-				if (size++ >= threshold) resize(capacity << 1);
-				return;
-			}
-
-			if (++i == pushIterations) break;
-
-			insertKey = evictedKey;
-			insertValue = evictedValue;
-		} while (true);
-
-		putStash(evictedKey, evictedValue);
-	}
-
-	private void putStash (int key, int value) {
-		if (stashSize == stashCapacity) {
-			// Too many pushes occurred and the stash is full, increase the table size.
-			resize(capacity << 1);
-			putResize(key, value);
-			return;
 		}
-		// Store key in the stash.
-		int index = capacity + stashSize;
-		keyTable[index] = key;
-		valueTable[index] = value;
-		stashSize++;
-		size++;
 	}
 
-	/** @param defaultValue Returned if the key was not associated with a value. */
 	public int get (int key, int defaultValue) {
 		if (key == 0) {
-			if (!hasZeroValue) return defaultValue;
+			if (!hasZeroValue)
+				return defaultValue;
 			return zeroValue;
 		}
-		int index = key & mask;
-		if (keyTable[index] != key) {
-			index = hash2(key);
-			if (keyTable[index] != key) {
-				index = hash3(key);
-				if (keyTable[index] != key) return getStash(key, defaultValue);
-			}
-		}
-		return valueTable[index];
-	}
-
-	private int getStash (int key, int defaultValue) {
-		int[] keyTable = this.keyTable;
-		for (int i = capacity, n = i + stashSize; i < n; i++)
-			if (key == keyTable[i]) return valueTable[i];
-		return defaultValue;
-	}
-
-	/** Returns the key's current value and increments the stored value. If the key is not in the map, defaultValue + increment is
-	 * put into the map. */
-	public int getAndIncrement (int key, int defaultValue, int increment) {
-		if (key == 0) {
-			if (hasZeroValue) {
-				int value = zeroValue;
-				zeroValue += increment;
-				return value;
-			} else {
-				hasZeroValue = true;
-				zeroValue = defaultValue + increment;
-				++size;
+		final int placement = place(key);
+		for (int i = placement; ; i = i + 1 & mask) {
+			// empty space is available
+			if (keyTable[i] == 0) {
 				return defaultValue;
 			}
-		}
-		int index = key & mask;
-		if (key != keyTable[index]) {
-			index = hash2(key);
-			if (key != keyTable[index]) {
-				index = hash3(key);
-				if (key != keyTable[index]) return getAndIncrementStash(key, defaultValue, increment);
+			if (key == (keyTable[i])) {
+				return valueTable[i];
 			}
 		}
-		int value = valueTable[index];
-		valueTable[index] = value + increment;
-		return value;
 	}
 
-	private int getAndIncrementStash (int key, int defaultValue, int increment) {
-		int[] keyTable = this.keyTable;
-		for (int i = capacity, n = i + stashSize; i < n; i++)
-			if (key == keyTable[i]) {
-				int value = valueTable[i];
-				valueTable[i] = value + increment;
-				return value;
-			}
-		put(key, defaultValue + increment);
-		return defaultValue;
+	/**
+	 * Returns the key's current value and increments the stored value. If the key is not in the map, defaultValue + increment is
+	 * put into the map.
+	 */
+	public int getAndIncrement (int key, int defaultValue, int increment) {
+		final int loc = locateKey(key);
+		// key was not found
+		if (loc == -1) {
+			// because we know there's no existing duplicate key, we can use putResize().
+			putResize(key, defaultValue + increment);
+			return defaultValue;
+		}
+		final int oldValue = valueTable[loc];
+		valueTable[loc] += increment;
+		return oldValue;
 	}
 
 	public int remove (int key, int defaultValue) {
 		if (key == 0) {
-			if (!hasZeroValue) return defaultValue;
+			if (!hasZeroValue)
+				return defaultValue;
+			int oldValue = zeroValue;
 			hasZeroValue = false;
 			size--;
-			return zeroValue;
-		}
-
-		int index = key & mask;
-		if (key == keyTable[index]) {
-			keyTable[index] = EMPTY;
-			int oldValue = valueTable[index];
-			size--;
 			return oldValue;
 		}
 
-		index = hash2(key);
-		if (key == keyTable[index]) {
-			keyTable[index] = EMPTY;
-			int oldValue = valueTable[index];
-			size--;
-			return oldValue;
+		int loc = locateKey(key);
+		if (loc == -1) {
+			return defaultValue;
 		}
 
-		index = hash3(key);
-		if (key == keyTable[index]) {
-			keyTable[index] = EMPTY;
-			int oldValue = valueTable[index];
-			size--;
-			return oldValue;
+		final int oldValue = valueTable[loc];
+		while ((key = keyTable[loc + 1 & mask]) != 0 && (loc + 1 & mask) != place(key)) {
+			keyTable[loc] = key;
+			valueTable[loc] = valueTable[++loc & mask];
 		}
-
-		return removeStash(key, defaultValue);
+		keyTable[loc] = 0;
+		--size;
+		return oldValue;
 	}
 
-	int removeStash (int key, int defaultValue) {
-		int[] keyTable = this.keyTable;
-		for (int i = capacity, n = i + stashSize; i < n; i++) {
-			if (key == keyTable[i]) {
-				int oldValue = valueTable[i];
-				removeStashIndex(i);
-				size--;
-				return oldValue;
-			}
-		}
-		return defaultValue;
-	}
-
-	void removeStashIndex (int index) {
-		// If the removed location was not last, move the last tuple to the removed location.
-		stashSize--;
-		int lastIndex = capacity + stashSize;
-		if (index < lastIndex) {
-			keyTable[index] = keyTable[lastIndex];
-			valueTable[index] = valueTable[lastIndex];
-		}
-	}
-
-	/** Returns true if the map has one or more items. */
+	/**
+	 * Returns true if the map has one or more items.
+	 */
 	public boolean notEmpty () {
 		return size > 0;
 	}
 
-	/** Returns true if the map is empty. */
+	/**
+	 * Returns true if the map is empty.
+	 */
 	public boolean isEmpty () {
 		return size == 0;
 	}
 
-	/** Reduces the size of the backing arrays to be the specified capacity or less. If the capacity is already less, nothing is
-	 * done. If the map contains more items than the specified capacity, the next highest power of two capacity is used instead. */
+	/**
+	 * Reduces the size of the backing arrays to be the specified capacity or less. If the capacity is already less, nothing is
+	 * done. If the map contains more items than the specified capacity, the next highest power of two capacity is used instead.
+	 */
 	public void shrink (int maximumCapacity) {
-		if (maximumCapacity < 0) throw new IllegalArgumentException("maximumCapacity must be >= 0: " + maximumCapacity);
-		if (size > maximumCapacity) maximumCapacity = size;
-		if (capacity <= maximumCapacity) return;
-		maximumCapacity = MathUtils.nextPowerOfTwo(maximumCapacity);
-		resize(maximumCapacity);
+		if (maximumCapacity < 0)
+			throw new IllegalArgumentException("maximumCapacity must be >= 0: " + maximumCapacity);
+		if (size > maximumCapacity)
+			maximumCapacity = size;
+		if (keyTable.length <= maximumCapacity)
+			return;
+		resize(MathUtils.nextPowerOfTwo(maximumCapacity));
 	}
 
-	/** Clears the map and reduces the size of the backing arrays to be the specified capacity if they are larger. */
+	/**
+	 * Clears the map and reduces the size of the backing arrays to be the specified capacity if they are larger.
+	 */
 	public void clear (int maximumCapacity) {
-		if (capacity <= maximumCapacity) {
+		if (keyTable.length <= maximumCapacity) {
 			clear();
 			return;
 		}
@@ -443,148 +372,142 @@ public class IntIntMap implements Iterable<IntIntMap.Entry> {
 	}
 
 	public void clear () {
-		if (size == 0) return;
-		int[] keyTable = this.keyTable;
-		for (int i = capacity + stashSize; i-- > 0;)
-			keyTable[i] = EMPTY;
+		if (size == 0)
+			return;
+		final int[] keyTable = this.keyTable;
+		for (int i = keyTable.length; i > 0; ) {
+			keyTable[--i] = 0;
+		}
 		size = 0;
-		stashSize = 0;
 		hasZeroValue = false;
 	}
 
-	/** Returns true if the specified value is in the map. Note this traverses the entire map and compares every value, which may
-	 * be an expensive operation. */
+	/**
+	 * Returns true if the specified value is in the map. Note this traverses the entire map and compares every value, which may
+	 * be an expensive operation.
+	 */
 	public boolean containsValue (int value) {
-		if (hasZeroValue && zeroValue == value) return true;
-		int[] keyTable = this.keyTable, valueTable = this.valueTable;
-		for (int i = capacity + stashSize; i-- > 0;)
-			if (keyTable[i] != 0 && valueTable[i] == value) return true;
+		if (hasZeroValue && zeroValue == value)
+			return true;
+		final int[] keyTable = this.keyTable;
+		final int[] valueTable = this.valueTable;
+		for (int i = valueTable.length; i-- > 0; )
+			if (keyTable[i] != 0 && valueTable[i] == value)
+				return true;
 		return false;
 	}
 
 	public boolean containsKey (int key) {
-		if (key == 0) return hasZeroValue;
-		int index = key & mask;
-		if (keyTable[index] != key) {
-			index = hash2(key);
-			if (keyTable[index] != key) {
-				index = hash3(key);
-				if (keyTable[index] != key) return containsKeyStash(key);
-			}
-		}
-		return true;
+		if (key == 0)
+			return hasZeroValue;
+		return locateKey(key) != -1;
 	}
 
-	private boolean containsKeyStash (int key) {
-		int[] keyTable = this.keyTable;
-		for (int i = capacity, n = i + stashSize; i < n; i++)
-			if (key == keyTable[i]) return true;
-		return false;
-	}
-
-	/** Returns the key for the specified value, or null if it is not in the map. Note this traverses the entire map and compares
-	 * every value, which may be an expensive operation. */
+	/**
+	 * Returns the key for the specified value, or null if it is not in the map. Note this traverses the entire map and compares
+	 * every value, which may be an expensive operation.
+	 */
 	public int findKey (int value, int notFound) {
-		if (hasZeroValue && zeroValue == value) return 0;
-		int[] keyTable = this.keyTable, valueTable = this.valueTable;
-		for (int i = capacity + stashSize; i-- > 0;)
-			if (keyTable[i] != 0 && valueTable[i] == value) return keyTable[i];
+		if (hasZeroValue && zeroValue == value)
+			return 0;
+		final int[] keyTable = this.keyTable;
+		final int[] valueTable = this.valueTable;
+		for (int i = valueTable.length; i-- > 0; ) {
+			int key = keyTable[i];
+			if (key != 0 && valueTable[i] == value)
+				return key;
+		}
 		return notFound;
 	}
 
-	/** Increases the size of the backing array to accommodate the specified number of additional items. Useful before adding many
-	 * items to avoid multiple backing array resizes. */
+	/**
+	 * Increases the size of the backing array to accommodate the specified number of additional items. Useful before adding many
+	 * items to avoid multiple backing array resizes.
+	 */
 	public void ensureCapacity (int additionalCapacity) {
-		if (additionalCapacity < 0) throw new IllegalArgumentException("additionalCapacity must be >= 0: " + additionalCapacity);
+		if (additionalCapacity < 0)
+			throw new IllegalArgumentException("additionalCapacity must be >= 0: " + additionalCapacity);
 		int sizeNeeded = size + additionalCapacity;
-		if (sizeNeeded >= threshold) resize(MathUtils.nextPowerOfTwo((int)Math.ceil(sizeNeeded / loadFactor)));
+		if (sizeNeeded >= threshold)
+			resize(MathUtils.nextPowerOfTwo((int)Math.ceil(sizeNeeded / loadFactor)));
 	}
 
 	private void resize (int newSize) {
-		int oldEndIndex = capacity + stashSize;
-
-		capacity = newSize;
+		int oldCapacity = keyTable.length;
 		threshold = (int)(newSize * loadFactor);
 		mask = newSize - 1;
-		hashShift = 31 - Integer.numberOfTrailingZeros(newSize);
-		stashCapacity = Math.max(3, (int)Math.ceil(Math.log(newSize)) * 2);
-		pushIterations = Math.max(Math.min(newSize, 8), (int)Math.sqrt(newSize) / 8);
+		shift = Long.numberOfLeadingZeros(mask);
 
-		int[] oldKeyTable = keyTable;
-		int[] oldValueTable = valueTable;
+		final int[] oldKeyTable = keyTable;
+		final int[] oldValueTable = valueTable;
 
-		keyTable = new int[newSize + stashCapacity];
-		valueTable = new int[newSize + stashCapacity];
-
+		keyTable = new int[newSize];
+		valueTable = new int[newSize];
+		
 		int oldSize = size;
-		size = hasZeroValue ? 1 : 0;
-		stashSize = 0;
+		size = 0;
 		if (oldSize > 0) {
-			for (int i = 0; i < oldEndIndex; i++) {
+			for (int i = 0; i < oldCapacity; i++) {
 				int key = oldKeyTable[i];
-				if (key != EMPTY) putResize(key, oldValueTable[i]);
+				if (key != 0)
+					putResize(key, oldValueTable[i]);
 			}
 		}
 	}
 
-	private int hash2 (int h) {
-		h *= PRIME2;
-		return (h ^ h >>> hashShift) & mask;
-	}
-
-	private int hash3 (int h) {
-		h *= PRIME3;
-		return (h ^ h >>> hashShift) & mask;
-	}
-
 	public int hashCode () {
-		int h = 0;
+		int h = size;
 		if (hasZeroValue) {
-			h += Float.floatToIntBits(zeroValue);
+			h += zeroValue;
 		}
 		int[] keyTable = this.keyTable;
 		int[] valueTable = this.valueTable;
-		for (int i = 0, n = capacity + stashSize; i < n; i++) {
+		for (int i = 0, n = keyTable.length; i < n; i++) {
 			int key = keyTable[i];
-			if (key != EMPTY) {
-				h += key * 31;
-
-				int value = valueTable[i];
-				h += value;
+			if (key != 0) {
+				h ^= key;
+				h += valueTable[i];
 			}
 		}
 		return h;
 	}
 
 	public boolean equals (Object obj) {
-		if (obj == this) return true;
-		if (!(obj instanceof IntIntMap)) return false;
-		IntIntMap other = (IntIntMap)obj;
-		if (other.size != size) return false;
-		if (other.hasZeroValue != hasZeroValue) return false;
-		if (hasZeroValue && other.zeroValue != zeroValue) {
+		if (obj == this)
+			return true;
+		if (!(obj instanceof IntIntMap))
 			return false;
+		IntIntMap other = (IntIntMap)obj;
+		if (other.size != size)
+			return false;
+		if (other.hasZeroValue != hasZeroValue)
+			return false;
+		if (hasZeroValue) {
+			if (other.zeroValue != zeroValue)
+				return false;
 		}
-		int[] keyTable = this.keyTable;
-		int[] valueTable = this.valueTable;
-		for (int i = 0, n = capacity + stashSize; i < n; i++) {
+		final int[] keyTable = this.keyTable;
+		final int[] valueTable = this.valueTable;
+		for (int i = 0, n = keyTable.length; i < n; i++) {
 			int key = keyTable[i];
-			if (key != EMPTY) {
+			if (key != 0) {
 				int otherValue = other.get(key, 0);
-				if (otherValue == 0 && !other.containsKey(key)) return false;
-				int value = valueTable[i];
-				if (otherValue != value) return false;
+				if (otherValue == 0 && !other.containsKey(key))
+					return false;
+				if (otherValue != valueTable[i])
+					return false;
 			}
 		}
 		return true;
 	}
 
 	public String toString () {
-		if (size == 0) return "{}";
-		StringBuilder buffer = new StringBuilder(32);
-		buffer.append('{');
-		int[] keyTable = this.keyTable;
-		int[] valueTable = this.valueTable;
+		if (size == 0)
+			return "[]";
+		java.lang.StringBuilder buffer = new java.lang.StringBuilder(32);
+		buffer.append('[');
+		final int[] keyTable = this.keyTable;
+		final int[] valueTable = this.valueTable;
 		int i = keyTable.length;
 		if (hasZeroValue) {
 			buffer.append("0=");
@@ -592,7 +515,8 @@ public class IntIntMap implements Iterable<IntIntMap.Entry> {
 		} else {
 			while (i-- > 0) {
 				int key = keyTable[i];
-				if (key == EMPTY) continue;
+				if (key == 0)
+					continue;
 				buffer.append(key);
 				buffer.append('=');
 				buffer.append(valueTable[i]);
@@ -601,13 +525,14 @@ public class IntIntMap implements Iterable<IntIntMap.Entry> {
 		}
 		while (i-- > 0) {
 			int key = keyTable[i];
-			if (key == EMPTY) continue;
+			if (key == 0)
+				continue;
 			buffer.append(", ");
 			buffer.append(key);
 			buffer.append('=');
 			buffer.append(valueTable[i]);
 		}
-		buffer.append('}');
+		buffer.append(']');
 		return buffer.toString();
 	}
 
@@ -615,12 +540,15 @@ public class IntIntMap implements Iterable<IntIntMap.Entry> {
 		return entries();
 	}
 
-	/** Returns an iterator for the entries in the map. Remove is supported.
+	/**
+	 * Returns an iterator for the entries in the map. Remove is supported.
 	 * <p>
 	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called.
-	 * Use the {@link Entries} constructor for nested or multithreaded iteration. */
+	 * Use the {@link Entries} constructor for nested or multithreaded iteration.
+	 */
 	public Entries entries () {
-		if (Collections.allocateIterators) return new Entries(this);
+		if (Collections.allocateIterators)
+			return new Entries(this);
 		if (entries1 == null) {
 			entries1 = new Entries(this);
 			entries2 = new Entries(this);
@@ -637,12 +565,15 @@ public class IntIntMap implements Iterable<IntIntMap.Entry> {
 		return entries2;
 	}
 
-	/** Returns an iterator for the values in the map. Remove is supported.
+	/**
+	 * Returns an iterator for the values in the map. Remove is supported.
 	 * <p>
 	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called.
-	 * Use the {@link Entries} constructor for nested or multithreaded iteration. */
+	 * Use the {@link Entries} constructor for nested or multithreaded iteration.
+	 */
 	public Values values () {
-		if (Collections.allocateIterators) return new Values(this);
+		if (Collections.allocateIterators)
+			return new Values(this);
 		if (values1 == null) {
 			values1 = new Values(this);
 			values2 = new Values(this);
@@ -659,12 +590,15 @@ public class IntIntMap implements Iterable<IntIntMap.Entry> {
 		return values2;
 	}
 
-	/** Returns an iterator for the keys in the map. Remove is supported.
+	/**
+	 * Returns an iterator for the keys in the map. Remove is supported.
 	 * <p>
 	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called.
-	 * Use the {@link Entries} constructor for nested or multithreaded iteration. */
+	 * Use the {@link Entries} constructor for nested or multithreaded iteration.
+	 */
 	public Keys keys () {
-		if (Collections.allocateIterators) return new Keys(this);
+		if (Collections.allocateIterators)
+			return new Keys(this);
 		if (keys1 == null) {
 			keys1 = new Keys(this);
 			keys2 = new Keys(this);
@@ -679,6 +613,23 @@ public class IntIntMap implements Iterable<IntIntMap.Entry> {
 		keys2.valid = true;
 		keys1.valid = false;
 		return keys2;
+	}
+
+	public void write (Json json) {
+		json.writeArrayStart("entries");
+		for (Entry entry : entries()) {
+			json.writeValue(entry.key, Integer.class);
+			json.writeValue(entry.value, Integer.class);
+		}
+		json.writeArrayEnd();
+	}
+
+	public void read (Json json, JsonValue jsonData) {
+		for (JsonValue child = jsonData.get("entries").child; child != null; child = child.next) {
+			int key = child.asInt();
+			int value = (child = child.next).asInt();
+			put(key, value);
+		}
 	}
 
 	static public class Entry {
@@ -717,8 +668,8 @@ public class IntIntMap implements Iterable<IntIntMap.Entry> {
 		void findNextIndex () {
 			hasNext = false;
 			int[] keyTable = map.keyTable;
-			for (int n = map.capacity + map.stashSize; ++nextIndex < n;) {
-				if (keyTable[nextIndex] != EMPTY) {
+			for (int n = keyTable.length; ++nextIndex < n; ) {
+				if (keyTable[nextIndex] != 0) {
 					hasNext = true;
 					break;
 				}
@@ -730,12 +681,18 @@ public class IntIntMap implements Iterable<IntIntMap.Entry> {
 				map.hasZeroValue = false;
 			} else if (currentIndex < 0) {
 				throw new IllegalStateException("next must be called before remove.");
-			} else if (currentIndex >= map.capacity) {
-				map.removeStashIndex(currentIndex);
-				nextIndex = currentIndex - 1;
-				findNextIndex();
 			} else {
-				map.keyTable[currentIndex] = EMPTY;
+				final int[] keyTable = map.keyTable;
+				final int[] valueTable = map.valueTable;
+				int loc = currentIndex, key;
+				final int mask = map.mask;
+				while ((key = keyTable[loc + 1 & mask]) != 0 && (loc + 1 & mask) != map.place(key)) {
+					keyTable[loc] = key;
+					valueTable[loc] = valueTable[loc + 1 & mask];
+					++loc;
+				}
+				if(loc != currentIndex) --nextIndex;
+				keyTable[loc] = 0;
 			}
 			currentIndex = INDEX_ILLEGAL;
 			map.size--;
@@ -749,10 +706,14 @@ public class IntIntMap implements Iterable<IntIntMap.Entry> {
 			super(map);
 		}
 
-		/** Note the same entry instance is returned each time this method is called. */
+		/**
+		 * Note the same entry instance is returned each time this method is called.
+		 */
 		public Entry next () {
-			if (!hasNext) throw new NoSuchElementException();
-			if (!valid) throw new GdxRuntimeException("#iterator() cannot be used nested.");
+			if (!hasNext)
+				throw new NoSuchElementException();
+			if (!valid)
+				throw new GdxRuntimeException("#iterator() cannot be used nested.");
 			int[] keyTable = map.keyTable;
 			if (nextIndex == INDEX_ZERO) {
 				entry.key = 0;
@@ -767,7 +728,8 @@ public class IntIntMap implements Iterable<IntIntMap.Entry> {
 		}
 
 		public boolean hasNext () {
-			if (!valid) throw new GdxRuntimeException("#iterator() cannot be used nested.");
+			if (!valid)
+				throw new GdxRuntimeException("#iterator() cannot be used nested.");
 			return hasNext;
 		}
 
@@ -786,26 +748,40 @@ public class IntIntMap implements Iterable<IntIntMap.Entry> {
 		}
 
 		public boolean hasNext () {
-			if (!valid) throw new GdxRuntimeException("#iterator() cannot be used nested.");
+			if (!valid)
+				throw new GdxRuntimeException("#iterator() cannot be used nested.");
 			return hasNext;
 		}
 
 		public int next () {
-			if (!hasNext) throw new NoSuchElementException();
-			if (!valid) throw new GdxRuntimeException("#iterator() cannot be used nested.");
-			int value;
-			if (nextIndex == INDEX_ZERO)
-				value = map.zeroValue;
-			else
-				value = map.valueTable[nextIndex];
+			if (!hasNext)
+				throw new NoSuchElementException();
+			if (!valid)
+				throw new GdxRuntimeException("#iterator() cannot be used nested.");
+			int value = map.valueTable[nextIndex];
 			currentIndex = nextIndex;
 			findNextIndex();
 			return value;
 		}
 
-		/** Returns a new array containing the remaining values. */
+		public Values iterator () {
+			return this;
+		}
+
+		/**
+		 * Returns a new array containing the remaining values.
+		 */
 		public IntArray toArray () {
 			IntArray array = new IntArray(true, map.size);
+			while (hasNext)
+				array.add(next());
+			return array;
+		}
+
+		/**
+		 * Adds the remaining values to the specified array.
+		 */
+		public IntArray toArray (IntArray array) {
 			while (hasNext)
 				array.add(next());
 			return array;
@@ -817,23 +793,31 @@ public class IntIntMap implements Iterable<IntIntMap.Entry> {
 			super(map);
 		}
 
-		public boolean hasNext () {
-			if (!valid) throw new GdxRuntimeException("#iterator() cannot be used nested.");
-			return hasNext;
-		}
-
 		public int next () {
-			if (!hasNext) throw new NoSuchElementException();
-			if (!valid) throw new GdxRuntimeException("#iterator() cannot be used nested.");
+			if (!hasNext)
+				throw new NoSuchElementException();
+			if (!valid)
+				throw new GdxRuntimeException("#iterator() cannot be used nested.");
 			int key = nextIndex == INDEX_ZERO ? 0 : map.keyTable[nextIndex];
 			currentIndex = nextIndex;
 			findNextIndex();
 			return key;
 		}
 
-		/** Returns a new array containing the remaining keys. */
+		/**
+		 * Returns a new array containing the remaining keys.
+		 */
 		public IntArray toArray () {
 			IntArray array = new IntArray(true, map.size);
+			while (hasNext)
+				array.add(next());
+			return array;
+		}
+
+		/**
+		 * Adds the remaining values to the specified array.
+		 */
+		public IntArray toArray (IntArray array) {
 			while (hasNext)
 				array.add(next());
 			return array;

--- a/gdx/src/com/badlogic/gdx/utils/IntIntMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/IntIntMap.java
@@ -53,7 +53,7 @@ public class IntIntMap implements Json.Serializable, Iterable<IntIntMap.Entry> {
 	private int zeroValue;
 	private boolean hasZeroValue;
 
-	private float loadFactor;
+	private final float loadFactor;
 	private int threshold;
 	/**
 	 * Used by {@link #place(int)} to bit-shift the upper bits of a {@code long} into a usable range (less than or
@@ -232,7 +232,7 @@ public class IntIntMap implements Json.Serializable, Iterable<IntIntMap.Entry> {
 				put(k, valueTable[i]);
 		}
 	}
-	
+
 	/**
 	 * Skips checks for existing keys.
 	 */
@@ -248,14 +248,12 @@ public class IntIntMap implements Json.Serializable, Iterable<IntIntMap.Entry> {
 		final int[] keyTable = this.keyTable;
 		final int[] valueTable = this.valueTable;
 		for (int i = place(key); ; i = (i + 1) & mask) {
-			// space is available so we insert and break (resize is later)
+			// space is available so we insert and break
 			if (keyTable[i] == 0) {
 				keyTable[i] = key;
 				valueTable[i] = value;
 
-				if (++size >= threshold) {
-					resize(keyTable.length << 1);
-				}
+				++size;
 				return;
 			}
 		}
@@ -437,7 +435,7 @@ public class IntIntMap implements Json.Serializable, Iterable<IntIntMap.Entry> {
 
 		keyTable = new int[newSize];
 		valueTable = new int[newSize];
-		
+
 		int oldSize = size;
 		size = hasZeroValue ? 1 : 0;
 		if (oldSize > 0) {
@@ -686,7 +684,8 @@ public class IntIntMap implements Json.Serializable, Iterable<IntIntMap.Entry> {
 					loc = nl;
 					nl = loc + 1 & mask;
 				}
-				if(loc != currentIndex) --nextIndex;
+				if (loc != currentIndex)
+					--nextIndex;
 				keyTable[loc] = 0;
 			}
 			currentIndex = INDEX_ILLEGAL;
@@ -695,7 +694,7 @@ public class IntIntMap implements Json.Serializable, Iterable<IntIntMap.Entry> {
 	}
 
 	static public class Entries extends MapIterator implements Iterable<Entry>, Iterator<Entry> {
-		private Entry entry = new Entry();
+		private final Entry entry = new Entry();
 
 		public Entries (IntIntMap map) {
 			super(map);

--- a/gdx/src/com/badlogic/gdx/utils/IntIntMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/IntIntMap.java
@@ -251,8 +251,7 @@ public class IntIntMap implements Json.Serializable, Iterable<IntIntMap.Entry> {
 		}
 		final int[] keyTable = this.keyTable;
 		final int[] valueTable = this.valueTable;
-		int b = place(key);
-		for (int i = b; ; i = (i + 1) & mask) {
+		for (int i = place(key); ; i = (i + 1) & mask) {
 			// space is available so we insert and break (resize is later)
 			if (keyTable[i] == 0) {
 				keyTable[i] = key;

--- a/gdx/src/com/badlogic/gdx/utils/IntIntMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/IntIntMap.java
@@ -317,9 +317,12 @@ public class IntIntMap implements Json.Serializable, Iterable<IntIntMap.Entry> {
 		}
 
 		final int oldValue = valueTable[loc];
-		while ((key = keyTable[loc + 1 & mask]) != 0 && (loc + 1 & mask) != place(key)) {
+		int nl = (loc + 1 & mask);
+		while ((key = keyTable[nl]) != 0 && nl != place(key)) {
 			keyTable[loc] = key;
-			valueTable[loc] = valueTable[++loc & mask];
+			valueTable[loc] = valueTable[nl];
+			loc = nl;
+			nl = loc + 1 & mask;
 		}
 		keyTable[loc] = 0;
 		--size;
@@ -680,12 +683,13 @@ public class IntIntMap implements Json.Serializable, Iterable<IntIntMap.Entry> {
 			} else {
 				final int[] keyTable = map.keyTable;
 				final int[] valueTable = map.valueTable;
-				int loc = currentIndex, key;
 				final int mask = map.mask;
-				while ((key = keyTable[loc + 1 & mask]) != 0 && (loc + 1 & mask) != map.place(key)) {
+				int loc = currentIndex, nl = (loc + 1 & mask), key;
+				while ((key = keyTable[nl]) != 0 && nl != map.place(key)) {
 					keyTable[loc] = key;
-					valueTable[loc] = valueTable[loc + 1 & mask];
-					++loc;
+					valueTable[loc] = valueTable[nl];
+					loc = nl;
+					nl = loc + 1 & mask;
 				}
 				if(loc != currentIndex) --nextIndex;
 				keyTable[loc] = 0;

--- a/gdx/src/com/badlogic/gdx/utils/IntIntMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/IntIntMap.java
@@ -232,11 +232,7 @@ public class IntIntMap implements Json.Serializable, Iterable<IntIntMap.Entry> {
 				put(k, valueTable[i]);
 		}
 	}
-	// the old version; I think the new way avoids a little work
-//	   ensureCapacity(map.size);
-//		for (Entry entry : map.entries())
-//			put(entry.key, entry.value);
-
+	
 	/**
 	 * Skips checks for existing keys.
 	 */

--- a/gdx/src/com/badlogic/gdx/utils/IntMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/IntMap.java
@@ -232,10 +232,6 @@ public class IntMap<V> implements Iterable<IntMap.Entry<V>> {
 				put(k, valueTable[i]);
 		}
 	}
-	// the old version; I think the new way avoids a little work
-//	   ensureCapacity(map.size);
-//		for (Entry<? extends V> entry : map.entries())
-//			put(entry.key, entry.value);
 
 	/**
 	 * Skips checks for existing keys.

--- a/gdx/src/com/badlogic/gdx/utils/IntMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/IntMap.java
@@ -48,7 +48,7 @@ import java.util.NoSuchElementException;
  * @author Tommy Ettinger
  * @author Nathan Sweet
  */
-public class IntMap<V> implements Json.Serializable, Iterable<IntMap.Entry<V>> {
+public class IntMap<V> implements Iterable<IntMap.Entry<V>> {
 	public int size;
 
 	private int[] keyTable;
@@ -687,23 +687,6 @@ public class IntMap<V> implements Json.Serializable, Iterable<IntMap.Entry<V>> {
 		keys2.valid = true;
 		keys1.valid = false;
 		return keys2;
-	}
-
-	public void write (Json json) {
-		json.writeArrayStart("entries");
-		for (Entry<V> entry : entries()) {
-			json.writeValue(entry.key, Integer.class);
-			json.writeValue(entry.value, null);
-		}
-		json.writeArrayEnd();
-	}
-
-	public void read (Json json, JsonValue jsonData) {
-		for (JsonValue child = jsonData.get("entries").child; child != null; child = child.next) {
-			int key = child.asInt();
-			V value = json.readValue(null, child = child.next);
-			put(key, value);
-		}
 	}
 
 	static public class Entry<V> {

--- a/gdx/src/com/badlogic/gdx/utils/IntMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/IntMap.java
@@ -251,8 +251,7 @@ public class IntMap<V> implements Iterable<IntMap.Entry<V>> {
 		}
 		final int[] keyTable = this.keyTable;
 		final V[] valueTable = this.valueTable;
-		int b = place(key);
-		for (int i = b; ; i = (i + 1) & mask) {
+		for (int i = place(key); ; i = (i + 1) & mask) {
 			// space is available so we insert and break (resize is later)
 			if (keyTable[i] == 0) {
 				keyTable[i] = key;

--- a/gdx/src/com/badlogic/gdx/utils/IntMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/IntMap.java
@@ -39,10 +39,6 @@ import java.util.NoSuchElementException;
  * Load factors greater than 0.91 greatly increase the chances the map will have to rehash to the next higher POT size.
  * Memory usage is excellent, and the aforementioned collision-resistance helps avoid too much capacity resizing.
  * <br>
- * The <a href="http://codecapsule.com/2013/11/17/robin-hood-hashing-backward-shift-deletion/">backward-shift algorithm</a>
- * used during removal apparently is key to the good performance of this implementation, even though this doesn't use Robin Hood
- * hashing; the performance of {@link #remove(int)} has improved considerably over the previous libGDX version.
- * <br>
  * Iteration won't be as fast here as with OrderedSet and OrderedMap.
  *
  * @author Tommy Ettinger
@@ -149,7 +145,7 @@ public class IntMap<V> implements Iterable<IntMap.Entry<V>> {
 	 * {@code return (int) (item * 0x9E3779B97F4A7C15L >>> shift);}
 	 * <br>
 	 * This can be overridden by subclasses, which you may want to do if your key type needs special consideration for
-	 * its hash (such as if you use arrays as keys, which still requires that the arrays are not modified). Subclasses
+	 * its hash (such as if you can't modify or extend a particular class that has an incorrect hashCode()). Subclasses
 	 * that don't need the collision decrease of Fibonacci Hashing (assuming the keys are well-distributed) may do
 	 * fine with a simple implementation:
 	 * {@code return (item & mask);}

--- a/gdx/src/com/badlogic/gdx/utils/IntMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/IntMap.java
@@ -317,9 +317,12 @@ public class IntMap<V> implements Iterable<IntMap.Entry<V>> {
 			return null;
 		}
 		V oldValue = valueTable[loc];
-		while ((key = keyTable[loc + 1 & mask]) != 0 && (loc + 1 & mask) != place(key)) {
+		int nl = (loc + 1 & mask);
+		while ((key = keyTable[nl]) != 0 && nl != place(key)) {
 			keyTable[loc] = key;
-			valueTable[loc] = valueTable[++loc & mask];
+			valueTable[loc] = valueTable[nl];
+			loc = nl;
+			nl = loc + 1 & mask;
 		}
 		keyTable[loc] = 0;
 		valueTable[loc] = null;
@@ -738,12 +741,13 @@ public class IntMap<V> implements Iterable<IntMap.Entry<V>> {
 			} else {
 				int[] keyTable = map.keyTable;
 				V[] valueTable = map.valueTable;
-				int loc = currentIndex, key;
 				final int mask = map.mask;
-				while ((key = keyTable[loc + 1 & mask]) != 0 && (loc + 1 & mask) != map.place(key)) {
+				int loc = currentIndex, nl = (loc + 1 & mask), key;
+				while ((key = keyTable[nl]) != 0 && nl != map.place(key)) {
 					keyTable[loc] = key;
-					valueTable[loc] = valueTable[loc + 1 & mask];
-					++loc;
+					valueTable[loc] = valueTable[nl];
+					loc = nl;
+					nl = loc + 1 & mask;
 				}
 				if(loc != currentIndex) --nextIndex;
 				keyTable[loc] = 0;

--- a/gdx/src/com/badlogic/gdx/utils/IntMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/IntMap.java
@@ -53,7 +53,7 @@ public class IntMap<V> implements Iterable<IntMap.Entry<V>> {
 	private V zeroValue;
 	private boolean hasZeroValue;
 
-	private float loadFactor;
+	private final float loadFactor;
 	private int threshold;
 	/**
 	 * Used by {@link #place(int)} to bit-shift the upper bits of a {@code long} into a usable range (less than or
@@ -248,14 +248,12 @@ public class IntMap<V> implements Iterable<IntMap.Entry<V>> {
 		final int[] keyTable = this.keyTable;
 		final V[] valueTable = this.valueTable;
 		for (int i = place(key); ; i = (i + 1) & mask) {
-			// space is available so we insert and break (resize is later)
+			// space is available so we insert and break
 			if (keyTable[i] == 0) {
 				keyTable[i] = key;
 				valueTable[i] = value;
 
-				if (++size >= threshold) {
-					resize(keyTable.length << 1);
-				}
+				++size;
 				return;
 			}
 		}
@@ -744,7 +742,8 @@ public class IntMap<V> implements Iterable<IntMap.Entry<V>> {
 					loc = nl;
 					nl = loc + 1 & mask;
 				}
-				if(loc != currentIndex) --nextIndex;
+				if (loc != currentIndex)
+					--nextIndex;
 				keyTable[loc] = 0;
 				valueTable[loc] = null;
 			}
@@ -754,7 +753,7 @@ public class IntMap<V> implements Iterable<IntMap.Entry<V>> {
 	}
 
 	static public class Entries<V> extends MapIterator<V> implements Iterable<Entry<V>>, Iterator<Entry<V>> {
-		private Entry<V> entry = new Entry();
+		private final Entry<V> entry = new Entry();
 
 		public Entries (IntMap map) {
 			super(map);

--- a/gdx/src/com/badlogic/gdx/utils/IntMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/IntMap.java
@@ -105,7 +105,7 @@ public class IntMap<V> implements Iterable<IntMap.Entry<V>> {
 			throw new IllegalArgumentException("initialCapacity must be >= 0: " + initialCapacity);
 		if (loadFactor <= 0f || loadFactor >= 1f)
 			throw new IllegalArgumentException("loadFactor must be > 0 and < 1: " + loadFactor);
-		initialCapacity = MathUtils.nextPowerOfTwo((int)Math.ceil(initialCapacity / loadFactor));
+		initialCapacity = MathUtils.nextPowerOfTwo((int)Math.ceil(Math.max(1, initialCapacity) / loadFactor));
 		if (initialCapacity > 1 << 30)
 			throw new IllegalArgumentException("initialCapacity is too large: " + initialCapacity);
 
@@ -481,7 +481,7 @@ public class IntMap<V> implements Iterable<IntMap.Entry<V>> {
 		valueTable = (V[])new Object[newSize];
 
 		int oldSize = size;
-		size = 0;
+		size = hasZeroValue ? 1 : 0;
 		if (oldSize > 0) {
 			for (int i = 0; i < oldCapacity; i++) {
 				int key = oldKeyTable[i];

--- a/gdx/src/com/badlogic/gdx/utils/IntMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/IntMap.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,83 +16,175 @@
 
 package com.badlogic.gdx.utils;
 
+import com.badlogic.gdx.math.MathUtils;
+
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
-import com.badlogic.gdx.math.MathUtils;
-
-/** An unordered map that uses int keys. This implementation is a cuckoo hash map using 3 hashes, random walking, and a small
- * stash for problematic keys. Null values are allowed. No allocation is done except when growing the table size. <br>
+/**
+ * An unordered map where the keys are unboxed ints and values are objects. This implementation uses linear probing with the
+ * backward-shift algorithm for removal, and finds space for keys using Fibonacci hashing instead of the more-common power-of-two
+ * mask. Null keys are not allowed. No allocation is done except when growing the table size.
  * <br>
- * This map performs very fast get, containsKey, and remove (typically O(1), worst case O(log(n))). Put may be a bit slower,
- * depending on hash collisions. Load factors greater than 0.91 greatly increase the chances the map will have to rehash to the
- * next higher POT size.
- * @author Nathan Sweet */
-public class IntMap<V> implements Iterable<IntMap.Entry<V>> {
-	private static final int PRIME1 = 0xbe1f14b1;
-	private static final int PRIME2 = 0xb4b82e39;
-	private static final int PRIME3 = 0xced1c241;
-	private static final int EMPTY = 0;
-
+ * This map uses Fibonacci hashing to help distribute what may be very bad hashCode() results across the
+ * whole capacity. See <a href="https://probablydance.com/2018/06/16/fibonacci-hashing-the-optimization-that-the-world-forgot-or-a-better-alternative-to-integer-modulo/">Malte Skarupke's blog post</a>
+ * for more information on Fibonacci hashing. It uses linear probing to resolve collisions, which is far from the academically
+ * optimal algorithm, but performs considerably better in practice than most alternatives, and combined with Fibonacci hashing, it
+ * can handle "normal" generated hashCode() implementations, and not just theoretically optimal hashing functions. Even if all
+ * hashCode()s this is given collide, it will still work, just slowly; the older libGDX implementation using cuckoo hashing would
+ * crash with an OutOfMemoryError with under 50 collisions.
+ * <br>
+ * This map performs very fast contains and remove (typically O(1), worst case O(n) due to occasional probing, but still very
+ * fast). Add may be a bit slower, depending on hash collisions, but this data structure is somewhat collision-resistant.
+ * Load factors greater than 0.91 greatly increase the chances the map will have to rehash to the next higher POT size.
+ * Memory usage is excellent, and the aforementioned collision-resistance helps avoid too much capacity resizing.
+ * <br>
+ * The <a href="http://codecapsule.com/2013/11/17/robin-hood-hashing-backward-shift-deletion/">backward-shift algorithm</a>
+ * used during removal apparently is key to the good performance of this implementation, even though this doesn't use Robin Hood
+ * hashing; the performance of {@link #remove(int)} has improved considerably over the previous libGDX version.
+ * <br>
+ * Iteration won't be as fast here as with OrderedSet and OrderedMap.
+ *
+ * @author Tommy Ettinger
+ * @author Nathan Sweet
+ */
+public class IntMap<V> implements Json.Serializable, Iterable<IntMap.Entry<V>> {
 	public int size;
 
-	int[] keyTable;
-	V[] valueTable;
-	int capacity, stashSize;
-	V zeroValue;
-	boolean hasZeroValue;
+	private int[] keyTable;
+	private V[] valueTable;
+
+	private V zeroValue;
+	private boolean hasZeroValue;
 
 	private float loadFactor;
-	private int hashShift, mask, threshold;
-	private int stashCapacity;
-	private int pushIterations;
+	private int threshold;
+	/**
+	 * Used by {@link #place(int)} to bit-shift the upper bits of a {@code long} into a usable range (less than or
+	 * equal to {@link #mask}, greater than or equal to 0). If you're setting it in a subclass, this shift can be
+	 * negative, which is a convenient way to match the number of bits in mask; if mask is a 7-bit number, then a shift
+	 * of -7 will correctly shift the upper 7 bits into the lowest 7 positions. If using what this class sets, shift
+	 * will be greater than 32 and less than 64; if you use this shift with an int, it will still correctly move the
+	 * upper bits of an int to the lower bits, thanks to Java's implicit modulus on shifts.
+	 * <br>
+	 * You can also use {@link #mask} to mask the low bits of a number, which may be faster for some hashCode()s, if you
+	 * reimplement {@link #place(int)}.
+	 */
+	private int shift;
+	/**
+	 * The bitmask used to contain hashCode()s to the indices that can be fit into the key array this uses. This should
+	 * always be all-1-bits in its low positions; that is, it must be a power of two minus 1. If you subclass and change
+	 * {@link #place(int)}, you may want to use this instead of {@link #shift} to isolate usable bits of a hash.
+	 */
+	private int mask;
 
 	private Entries entries1, entries2;
 	private Values values1, values2;
 	private Keys keys1, keys2;
 
-	/** Creates a new map with an initial capacity of 51 and a load factor of 0.8. */
+	/**
+	 * Creates a new map with an initial capacity of 51 and a load factor of 0.8.
+	 */
 	public IntMap () {
 		this(51, 0.8f);
 	}
 
-	/** Creates a new map with a load factor of 0.8.
-	 * @param initialCapacity If not a power of two, it is increased to the next nearest power of two. */
+	/**
+	 * Creates a new map with a load factor of 0.8.
+	 *
+	 * @param initialCapacity If not a power of two, it is increased to the next nearest power of two.
+	 */
 	public IntMap (int initialCapacity) {
 		this(initialCapacity, 0.8f);
 	}
 
-	/** Creates a new map with the specified initial capacity and load factor. This map will hold initialCapacity items before
+	/**
+	 * Creates a new map with the specified initial capacity and load factor. This map will hold initialCapacity items before
 	 * growing the backing table.
-	 * @param initialCapacity If not a power of two, it is increased to the next nearest power of two. */
+	 *
+	 * @param initialCapacity If not a power of two, it is increased to the next nearest power of two.
+	 */
 	public IntMap (int initialCapacity, float loadFactor) {
-		if (loadFactor <= 0) throw new IllegalArgumentException("loadFactor must be > 0: " + loadFactor);
+		if (initialCapacity < 0)
+			throw new IllegalArgumentException("initialCapacity must be >= 0: " + initialCapacity);
+		if (loadFactor <= 0f || loadFactor >= 1f)
+			throw new IllegalArgumentException("loadFactor must be > 0 and < 1: " + loadFactor);
+		initialCapacity = MathUtils.nextPowerOfTwo((int)Math.ceil(initialCapacity / loadFactor));
+		if (initialCapacity > 1 << 30)
+			throw new IllegalArgumentException("initialCapacity is too large: " + initialCapacity);
+
 		this.loadFactor = loadFactor;
 
-		if (initialCapacity < 0) throw new IllegalArgumentException("initialCapacity must be >= 0: " + initialCapacity);
-		initialCapacity = MathUtils.nextPowerOfTwo((int)Math.ceil(initialCapacity / loadFactor));
-		if (initialCapacity > 1 << 30) throw new IllegalArgumentException("initialCapacity is too large: " + initialCapacity);
-		capacity = initialCapacity;
+		threshold = (int)(initialCapacity * loadFactor);
+		mask = initialCapacity - 1;
+		shift = Long.numberOfLeadingZeros(mask);
 
-		threshold = (int)(capacity * loadFactor);
-		mask = capacity - 1;
-		hashShift = 31 - Integer.numberOfTrailingZeros(capacity);
-		stashCapacity = Math.max(3, (int)Math.ceil(Math.log(capacity)) * 2);
-		pushIterations = Math.max(Math.min(capacity, 8), (int)Math.sqrt(capacity) / 8);
-
-		keyTable = new int[capacity + stashCapacity];
-		valueTable = (V[])new Object[keyTable.length];
+		keyTable = new int[initialCapacity];
+		valueTable = (V[])new Object[initialCapacity];
 	}
 
-	/** Creates a new map identical to the specified map. */
+	/**
+	 * Creates a new map identical to the specified map.
+	 */
 	public IntMap (IntMap<? extends V> map) {
-		this((int)Math.floor(map.capacity * map.loadFactor), map.loadFactor);
-		stashSize = map.stashSize;
+		this((int)(map.keyTable.length * map.loadFactor), map.loadFactor);
 		System.arraycopy(map.keyTable, 0, keyTable, 0, map.keyTable.length);
 		System.arraycopy(map.valueTable, 0, valueTable, 0, map.valueTable.length);
 		size = map.size;
 		zeroValue = map.zeroValue;
 		hasZeroValue = map.hasZeroValue;
+	}
+
+	/**
+	 * Finds an array index between 0 and {@link #mask}, both inclusive, corresponding to the hash code of {@code item}.
+	 * By default, this uses "Fibonacci Hashing" on the int {@code item} directly; this multiplies
+	 * {@code item} by a long constant (2 to the 64, divided by the golden ratio) and shifts the high-quality
+	 * uppermost bits into the lowest positions so they can be used as array indices. The multiplication by a long may
+	 * be somewhat slow on GWT, but it will be correct across all platforms and won't lose precision. Using Fibonacci
+	 * Hashing allows even very poor hashCode() implementations, such as those that only differ in their upper bits, to
+	 * work in a hash table without heavy collision rates. It has known problems when all or most hashCode()s are
+	 * multiples of larger Fibonacci numbers; see <a href="https://probablydance.com/2018/06/16/fibonacci-hashing-the-optimization-that-the-world-forgot-or-a-better-alternative-to-integer-modulo/">this blog post by Malte Skarupke</a>
+	 * for more details. In the unlikely event that most of your hashCode()s are Fibonacci numbers, you can subclass
+	 * this to change this method, which is a one-liner in this form:
+	 * {@code return (int) (item * 0x9E3779B97F4A7C15L >>> shift);}
+	 * <br>
+	 * This can be overridden by subclasses, which you may want to do if your key type needs special consideration for
+	 * its hash (such as if you use arrays as keys, which still requires that the arrays are not modified). Subclasses
+	 * that don't need the collision decrease of Fibonacci Hashing (assuming the keys are well-distributed) may do
+	 * fine with a simple implementation:
+	 * {@code return (item & mask);}
+	 *
+	 * @param item a key that this method will use to get a hashed position
+	 * @return an int between 0 and {@link #mask}, both inclusive
+	 */
+	private int place (final int item) {
+		// shift is always greater than 32, less than 64
+		return (int)(item * 0x9E3779B97F4A7C15L >>> shift);
+	}
+
+	private int locateKey (final int key) {
+		return locateKey(key, place(key));
+	}
+
+	/**
+	 * Given a key and its initial placement to try in an array, this finds the actual location of the key in the array
+	 * if it is present, or -1 if the key is not present. This can be overridden if a subclass needs to compare for
+	 * equality differently than just by using == with int keys, but only within the same package.
+	 *
+	 * @param key       a K key that will be checked for equality if a similar-seeming key is found
+	 * @param placement as calculated by {@link #place(int)}, almost always with {@code place(key)}
+	 * @return the location in the key array of key, if found, or -1 if it was not found.
+	 */
+	private int locateKey (final int key, final int placement) {
+		for (int i = placement; ; i = i + 1 & mask) {
+			// empty space is available
+			if (keyTable[i] == 0) {
+				return -1;
+			}
+			if (key == (keyTable[i])) {
+				return i;
+			}
+		}
 	}
 
 	public V put (int key, V value) {
@@ -106,324 +198,172 @@ public class IntMap<V> implements Iterable<IntMap.Entry<V>> {
 			return oldValue;
 		}
 
-		int[] keyTable = this.keyTable;
-
-		// Check for existing keys.
-		int index1 = key & mask;
-		int key1 = keyTable[index1];
-		if (key1 == key) {
-			V oldValue = valueTable[index1];
-			valueTable[index1] = value;
-			return oldValue;
+		int b = place(key);
+		int loc = locateKey(key, b);
+		// an identical key already exists
+		if (loc != -1) {
+			V tv = valueTable[loc];
+			valueTable[loc] = value;
+			return tv;
 		}
+		final int[] keyTable = this.keyTable;
+		final V[] valueTable = this.valueTable;
 
-		int index2 = hash2(key);
-		int key2 = keyTable[index2];
-		if (key2 == key) {
-			V oldValue = valueTable[index2];
-			valueTable[index2] = value;
-			return oldValue;
-		}
-
-		int index3 = hash3(key);
-		int key3 = keyTable[index3];
-		if (key3 == key) {
-			V oldValue = valueTable[index3];
-			valueTable[index3] = value;
-			return oldValue;
-		}
-
-		// Update key in the stash.
-		for (int i = capacity, n = i + stashSize; i < n; i++) {
-			if (keyTable[i] == key) {
-				V oldValue = valueTable[i];
+		for (int i = b; ; i = (i + 1) & mask) {
+			// space is available so we insert and break
+			if (keyTable[i] == 0) {
+				keyTable[i] = key;
 				valueTable[i] = value;
-				return oldValue;
+
+				if (++size >= threshold) {
+					resize(keyTable.length << 1);
+				}
+				return null;
 			}
 		}
-
-		// Check for empty buckets.
-		if (key1 == EMPTY) {
-			keyTable[index1] = key;
-			valueTable[index1] = value;
-			if (size++ >= threshold) resize(capacity << 1);
-			return null;
-		}
-
-		if (key2 == EMPTY) {
-			keyTable[index2] = key;
-			valueTable[index2] = value;
-			if (size++ >= threshold) resize(capacity << 1);
-			return null;
-		}
-
-		if (key3 == EMPTY) {
-			keyTable[index3] = key;
-			valueTable[index3] = value;
-			if (size++ >= threshold) resize(capacity << 1);
-			return null;
-		}
-
-		push(key, value, index1, key1, index2, key2, index3, key3);
-		return null;
+		// never reached
 	}
 
 	public void putAll (IntMap<? extends V> map) {
-		for (Entry<? extends V> entry : map.entries())
-			put(entry.key, entry.value);
+		ensureCapacity(map.size);
+		if (map.hasZeroValue)
+			put(0, map.zeroValue);
+		final int[] keyTable = map.keyTable;
+		final V[] valueTable = map.valueTable;
+		int k;
+		for (int i = 0, n = keyTable.length; i < n; i++) {
+			if ((k = keyTable[i]) != 0)
+				put(k, valueTable[i]);
+		}
 	}
+	// the old version; I think the new way avoids a little work
+//	   ensureCapacity(map.size);
+//		for (Entry<? extends V> entry : map.entries())
+//			put(entry.key, entry.value);
 
-	/** Skips checks for existing keys. */
+	/**
+	 * Skips checks for existing keys.
+	 */
 	private void putResize (int key, V value) {
 		if (key == 0) {
 			zeroValue = value;
-			hasZeroValue = true;
-			return;
-		}
-
-		// Check for empty buckets.
-		int index1 = key & mask;
-		int key1 = keyTable[index1];
-		if (key1 == EMPTY) {
-			keyTable[index1] = key;
-			valueTable[index1] = value;
-			if (size++ >= threshold) resize(capacity << 1);
-			return;
-		}
-
-		int index2 = hash2(key);
-		int key2 = keyTable[index2];
-		if (key2 == EMPTY) {
-			keyTable[index2] = key;
-			valueTable[index2] = value;
-			if (size++ >= threshold) resize(capacity << 1);
-			return;
-		}
-
-		int index3 = hash3(key);
-		int key3 = keyTable[index3];
-		if (key3 == EMPTY) {
-			keyTable[index3] = key;
-			valueTable[index3] = value;
-			if (size++ >= threshold) resize(capacity << 1);
-			return;
-		}
-
-		push(key, value, index1, key1, index2, key2, index3, key3);
-	}
-
-	private void push (int insertKey, V insertValue, int index1, int key1, int index2, int key2, int index3, int key3) {
-		int[] keyTable = this.keyTable;
-
-		V[] valueTable = this.valueTable;
-		int mask = this.mask;
-
-		// Push keys until an empty bucket is found.
-		int evictedKey;
-		V evictedValue;
-		int i = 0, pushIterations = this.pushIterations;
-		do {
-			// Replace the key and value for one of the hashes.
-			switch (MathUtils.random(2)) {
-			case 0:
-				evictedKey = key1;
-				evictedValue = valueTable[index1];
-				keyTable[index1] = insertKey;
-				valueTable[index1] = insertValue;
-				break;
-			case 1:
-				evictedKey = key2;
-				evictedValue = valueTable[index2];
-				keyTable[index2] = insertKey;
-				valueTable[index2] = insertValue;
-				break;
-			default:
-				evictedKey = key3;
-				evictedValue = valueTable[index3];
-				keyTable[index3] = insertKey;
-				valueTable[index3] = insertValue;
-				break;
+			if (!hasZeroValue) {
+				hasZeroValue = true;
+				size++;
 			}
+			return;
+		}
+		final int[] keyTable = this.keyTable;
+		final V[] valueTable = this.valueTable;
+		int b = place(key);
+		for (int i = b; ; i = (i + 1) & mask) {
+			// space is available so we insert and break (resize is later)
+			if (keyTable[i] == 0) {
+				keyTable[i] = key;
+				valueTable[i] = value;
 
-			// If the evicted key hashes to an empty bucket, put it there and stop.
-			index1 = evictedKey & mask;
-			key1 = keyTable[index1];
-			if (key1 == EMPTY) {
-				keyTable[index1] = evictedKey;
-				valueTable[index1] = evictedValue;
-				if (size++ >= threshold) resize(capacity << 1);
+				if (++size >= threshold) {
+					resize(keyTable.length << 1);
+				}
 				return;
 			}
-
-			index2 = hash2(evictedKey);
-			key2 = keyTable[index2];
-			if (key2 == EMPTY) {
-				keyTable[index2] = evictedKey;
-				valueTable[index2] = evictedValue;
-				if (size++ >= threshold) resize(capacity << 1);
-				return;
-			}
-
-			index3 = hash3(evictedKey);
-			key3 = keyTable[index3];
-			if (key3 == EMPTY) {
-				keyTable[index3] = evictedKey;
-				valueTable[index3] = evictedValue;
-				if (size++ >= threshold) resize(capacity << 1);
-				return;
-			}
-
-			if (++i == pushIterations) break;
-
-			insertKey = evictedKey;
-			insertValue = evictedValue;
-		} while (true);
-
-		putStash(evictedKey, evictedValue);
-	}
-
-	private void putStash (int key, V value) {
-		if (stashSize == stashCapacity) {
-			// Too many pushes occurred and the stash is full, increase the table size.
-			resize(capacity << 1);
-			putResize(key, value);
-			return;
 		}
-		// Store key in the stash.
-		int index = capacity + stashSize;
-		keyTable[index] = key;
-		valueTable[index] = value;
-		stashSize++;
-		size++;
 	}
 
 	public V get (int key) {
 		if (key == 0) {
-			if (!hasZeroValue) return null;
+			if (!hasZeroValue)
+				return null;
 			return zeroValue;
 		}
-		int index = key & mask;
-		if (keyTable[index] != key) {
-			index = hash2(key);
-			if (keyTable[index] != key) {
-				index = hash3(key);
-				if (keyTable[index] != key) return getStash(key, null);
+		final int placement = place(key);
+		for (int i = placement; ; i = i + 1 & mask) {
+			// empty space is available
+			if (keyTable[i] == 0) {
+				return null;
+			}
+			if (key == (keyTable[i])) {
+				return valueTable[i];
 			}
 		}
-		return valueTable[index];
 	}
 
 	public V get (int key, V defaultValue) {
 		if (key == 0) {
-			if (!hasZeroValue) return defaultValue;
+			if (!hasZeroValue)
+				return defaultValue;
 			return zeroValue;
 		}
-		int index = key & mask;
-		if (keyTable[index] != key) {
-			index = hash2(key);
-			if (keyTable[index] != key) {
-				index = hash3(key);
-				if (keyTable[index] != key) return getStash(key, defaultValue);
+		final int placement = place(key);
+		for (int i = placement; ; i = i + 1 & mask) {
+			// empty space is available
+			if (keyTable[i] == 0) {
+				return defaultValue;
+			}
+			if (key == (keyTable[i])) {
+				return valueTable[i];
 			}
 		}
-		return valueTable[index];
-	}
-
-	private V getStash (int key, V defaultValue) {
-		int[] keyTable = this.keyTable;
-		for (int i = capacity, n = i + stashSize; i < n; i++)
-			if (keyTable[i] == key) return valueTable[i];
-		return defaultValue;
 	}
 
 	public V remove (int key) {
 		if (key == 0) {
-			if (!hasZeroValue) return null;
+			if (!hasZeroValue)
+				return null;
 			V oldValue = zeroValue;
 			zeroValue = null;
 			hasZeroValue = false;
 			size--;
 			return oldValue;
 		}
-
-		int index = key & mask;
-		if (keyTable[index] == key) {
-			keyTable[index] = EMPTY;
-			V oldValue = valueTable[index];
-			valueTable[index] = null;
-			size--;
-			return oldValue;
+		int loc = locateKey(key);
+		if (loc == -1) {
+			return null;
 		}
-
-		index = hash2(key);
-		if (keyTable[index] == key) {
-			keyTable[index] = EMPTY;
-			V oldValue = valueTable[index];
-			valueTable[index] = null;
-			size--;
-			return oldValue;
+		V oldValue = valueTable[loc];
+		while ((key = keyTable[loc + 1 & mask]) != 0 && (loc + 1 & mask) != place(key)) {
+			keyTable[loc] = key;
+			valueTable[loc] = valueTable[++loc & mask];
 		}
-
-		index = hash3(key);
-		if (keyTable[index] == key) {
-			keyTable[index] = EMPTY;
-			V oldValue = valueTable[index];
-			valueTable[index] = null;
-			size--;
-			return oldValue;
-		}
-
-		return removeStash(key);
+		keyTable[loc] = 0;
+		valueTable[loc] = null;
+		--size;
+		return oldValue;
 	}
 
-	V removeStash (int key) {
-		int[] keyTable = this.keyTable;
-		for (int i = capacity, n = i + stashSize; i < n; i++) {
-			if (keyTable[i] == key) {
-				V oldValue = valueTable[i];
-				removeStashIndex(i);
-				size--;
-				return oldValue;
-			}
-		}
-		return null;
-	}
-
-	void removeStashIndex (int index) {
-		// If the removed location was not last, move the last tuple to the removed location.
-		stashSize--;
-		int lastIndex = capacity + stashSize;
-		if (index < lastIndex) {
-			keyTable[index] = keyTable[lastIndex];
-			valueTable[index] = valueTable[lastIndex];
-			valueTable[lastIndex] = null;
-		} else
-			valueTable[index] = null;
-	}
-
-	/** Returns true if the map has one or more items. */
+	/**
+	 * Returns true if the map has one or more items.
+	 */
 	public boolean notEmpty () {
 		return size > 0;
 	}
 
-	/** Returns true if the map is empty. */
+	/**
+	 * Returns true if the map is empty.
+	 */
 	public boolean isEmpty () {
 		return size == 0;
 	}
 
-	/** Reduces the size of the backing arrays to be the specified capacity or less. If the capacity is already less, nothing is
-	 * done. If the map contains more items than the specified capacity, the next highest power of two capacity is used instead. */
+	/**
+	 * Reduces the size of the backing arrays to be the specified capacity or less. If the capacity is already less, nothing is
+	 * done. If the map contains more items than the specified capacity, the next highest power of two capacity is used instead.
+	 */
 	public void shrink (int maximumCapacity) {
-		if (maximumCapacity < 0) throw new IllegalArgumentException("maximumCapacity must be >= 0: " + maximumCapacity);
-		if (size > maximumCapacity) maximumCapacity = size;
-		if (capacity <= maximumCapacity) return;
-		maximumCapacity = MathUtils.nextPowerOfTwo(maximumCapacity);
-		resize(maximumCapacity);
+		if (maximumCapacity < 0)
+			throw new IllegalArgumentException("maximumCapacity must be >= 0: " + maximumCapacity);
+		if (size > maximumCapacity)
+			maximumCapacity = size;
+		if (keyTable.length <= maximumCapacity)
+			return;
+		resize(MathUtils.nextPowerOfTwo(maximumCapacity));
 	}
 
-	/** Clears the map and reduces the size of the backing arrays to be the specified capacity if they are larger. */
+	/**
+	 * Clears the map and reduces the size of the backing arrays to be the specified capacity if they are larger.
+	 */
 	public void clear (int maximumCapacity) {
-		if (capacity <= maximumCapacity) {
+		if (keyTable.length <= maximumCapacity) {
 			clear();
 			return;
 		}
@@ -434,142 +374,136 @@ public class IntMap<V> implements Iterable<IntMap.Entry<V>> {
 	}
 
 	public void clear () {
-		if (size == 0) return;
-		int[] keyTable = this.keyTable;
-		V[] valueTable = this.valueTable;
-		for (int i = capacity + stashSize; i-- > 0;) {
-			keyTable[i] = EMPTY;
+		if (size == 0)
+			return;
+		final int[] keyTable = this.keyTable;
+		final V[] valueTable = this.valueTable;
+		for (int i = keyTable.length; i > 0; ) {
+			keyTable[--i] = 0;
 			valueTable[i] = null;
 		}
 		size = 0;
-		stashSize = 0;
 		zeroValue = null;
 		hasZeroValue = false;
 	}
 
-	/** Returns true if the specified value is in the map. Note this traverses the entire map and compares every value, which may
+	/**
+	 * Returns true if the specified value is in the map. Note this traverses the entire map and compares every value, which may
 	 * be an expensive operation.
+	 *
 	 * @param identity If true, uses == to compare the specified value with values in the map. If false, uses
-	 *           {@link #equals(Object)}. */
+	 *                 {@link #equals(Object)}.
+	 */
 	public boolean containsValue (Object value, boolean identity) {
-		V[] valueTable = this.valueTable;
+		final V[] valueTable = this.valueTable;
 		if (value == null) {
-			if (hasZeroValue && zeroValue == null) return true;
+			if (hasZeroValue && zeroValue == null)
+				return true;
 			int[] keyTable = this.keyTable;
-			for (int i = capacity + stashSize; i-- > 0;)
-				if (keyTable[i] != EMPTY && valueTable[i] == null) return true;
+			for (int i = valueTable.length; i-- > 0; )
+				if (keyTable[i] != 0 && valueTable[i] == null)
+					return true;
 		} else if (identity) {
-			if (value == zeroValue) return true;
-			for (int i = capacity + stashSize; i-- > 0;)
-				if (valueTable[i] == value) return true;
+			if (value == zeroValue)
+				return true;
+			for (int i = valueTable.length; i-- > 0; )
+				if (valueTable[i] == value)
+					return true;
 		} else {
-			if (hasZeroValue && value.equals(zeroValue)) return true;
-			for (int i = capacity + stashSize; i-- > 0;)
-				if (value.equals(valueTable[i])) return true;
+			if (hasZeroValue && value.equals(zeroValue))
+				return true;
+			for (int i = valueTable.length; i-- > 0; )
+				if (value.equals(valueTable[i]))
+					return true;
 		}
 		return false;
+
 	}
 
 	public boolean containsKey (int key) {
-		if (key == 0) return hasZeroValue;
-		int index = key & mask;
-		if (keyTable[index] != key) {
-			index = hash2(key);
-			if (keyTable[index] != key) {
-				index = hash3(key);
-				if (keyTable[index] != key) return containsKeyStash(key);
-			}
-		}
-		return true;
+		if (key == 0)
+			return hasZeroValue;
+		return locateKey(key) != -1;
 	}
 
-	private boolean containsKeyStash (int key) {
-		int[] keyTable = this.keyTable;
-		for (int i = capacity, n = i + stashSize; i < n; i++)
-			if (keyTable[i] == key) return true;
-		return false;
-	}
-
-	/** Returns the key for the specified value, or <tt>notFound</tt> if it is not in the map. Note this traverses the entire map
+	/**
+	 * Returns the key for the specified value, or <tt>notFound</tt> if it is not in the map. Note this traverses the entire map
 	 * and compares every value, which may be an expensive operation.
+	 *
 	 * @param identity If true, uses == to compare the specified value with values in the map. If false, uses
-	 *           {@link #equals(Object)}. */
+	 *                 {@link #equals(Object)}.
+	 */
 	public int findKey (Object value, boolean identity, int notFound) {
-		V[] valueTable = this.valueTable;
+		final V[] valueTable = this.valueTable;
 		if (value == null) {
-			if (hasZeroValue && zeroValue == null) return 0;
+			if (hasZeroValue && zeroValue == null)
+				return 0;
 			int[] keyTable = this.keyTable;
-			for (int i = capacity + stashSize; i-- > 0;)
-				if (keyTable[i] != EMPTY && valueTable[i] == null) return keyTable[i];
+			for (int i = valueTable.length; i-- > 0; )
+				if (keyTable[i] != 0 && valueTable[i] == null)
+					return keyTable[i];
 		} else if (identity) {
-			if (value == zeroValue) return 0;
-			for (int i = capacity + stashSize; i-- > 0;)
-				if (valueTable[i] == value) return keyTable[i];
+			if (value == zeroValue)
+				return 0;
+			for (int i = valueTable.length; i-- > 0; )
+				if (valueTable[i] == value)
+					return keyTable[i];
 		} else {
-			if (hasZeroValue && value.equals(zeroValue)) return 0;
-			for (int i = capacity + stashSize; i-- > 0;)
-				if (value.equals(valueTable[i])) return keyTable[i];
+			if (hasZeroValue && value.equals(zeroValue))
+				return 0;
+			for (int i = valueTable.length; i-- > 0; )
+				if (value.equals(valueTable[i]))
+					return keyTable[i];
 		}
 		return notFound;
 	}
 
-	/** Increases the size of the backing array to accommodate the specified number of additional items. Useful before adding many
-	 * items to avoid multiple backing array resizes. */
+	/**
+	 * Increases the size of the backing array to accommodate the specified number of additional items. Useful before adding many
+	 * items to avoid multiple backing array resizes.
+	 */
 	public void ensureCapacity (int additionalCapacity) {
-		if (additionalCapacity < 0) throw new IllegalArgumentException("additionalCapacity must be >= 0: " + additionalCapacity);
+		if (additionalCapacity < 0)
+			throw new IllegalArgumentException("additionalCapacity must be >= 0: " + additionalCapacity);
 		int sizeNeeded = size + additionalCapacity;
-		if (sizeNeeded >= threshold) resize(MathUtils.nextPowerOfTwo((int)Math.ceil(sizeNeeded / loadFactor)));
+		if (sizeNeeded >= threshold)
+			resize(MathUtils.nextPowerOfTwo((int)Math.ceil(sizeNeeded / loadFactor)));
 	}
 
 	private void resize (int newSize) {
-		int oldEndIndex = capacity + stashSize;
-
-		capacity = newSize;
+		int oldCapacity = keyTable.length;
 		threshold = (int)(newSize * loadFactor);
 		mask = newSize - 1;
-		hashShift = 31 - Integer.numberOfTrailingZeros(newSize);
-		stashCapacity = Math.max(3, (int)Math.ceil(Math.log(newSize)) * 2);
-		pushIterations = Math.max(Math.min(newSize, 8), (int)Math.sqrt(newSize) / 8);
+		shift = Long.numberOfLeadingZeros(mask);
 
-		int[] oldKeyTable = keyTable;
-		V[] oldValueTable = valueTable;
+		final int[] oldKeyTable = keyTable;
+		final V[] oldValueTable = valueTable;
 
-		keyTable = new int[newSize + stashCapacity];
-		valueTable = (V[])new Object[newSize + stashCapacity];
+		keyTable = new int[newSize];
+		valueTable = (V[])new Object[newSize];
 
 		int oldSize = size;
-		size = hasZeroValue ? 1 : 0;
-		stashSize = 0;
+		size = 0;
 		if (oldSize > 0) {
-			for (int i = 0; i < oldEndIndex; i++) {
+			for (int i = 0; i < oldCapacity; i++) {
 				int key = oldKeyTable[i];
-				if (key != EMPTY) putResize(key, oldValueTable[i]);
+				if (key != 0)
+					putResize(key, oldValueTable[i]);
 			}
 		}
 	}
 
-	private int hash2 (int h) {
-		h *= PRIME2;
-		return (h ^ h >>> hashShift) & mask;
-	}
-
-	private int hash3 (int h) {
-		h *= PRIME3;
-		return (h ^ h >>> hashShift) & mask;
-	}
-
 	public int hashCode () {
-		int h = 0;
+		int h = size;
 		if (hasZeroValue && zeroValue != null) {
-			h += zeroValue.hashCode();
+			h = zeroValue.hashCode();
 		}
 		int[] keyTable = this.keyTable;
 		V[] valueTable = this.valueTable;
-		for (int i = 0, n = capacity + stashSize; i < n; i++) {
+		for (int i = 0, n = keyTable.length; i < n; i++) {
 			int key = keyTable[i];
-			if (key != EMPTY) {
-				h += key * 31;
-
+			if (key != 0) {
+				h ^= key;
 				V value = valueTable[i];
 				if (value != null) {
 					h += value.hashCode();
@@ -580,57 +514,74 @@ public class IntMap<V> implements Iterable<IntMap.Entry<V>> {
 	}
 
 	public boolean equals (Object obj) {
-		if (obj == this) return true;
-		if (!(obj instanceof IntMap)) return false;
+		if (obj == this)
+			return true;
+		if (!(obj instanceof IntMap))
+			return false;
 		IntMap other = (IntMap)obj;
-		if (other.size != size) return false;
-		if (other.hasZeroValue != hasZeroValue) return false;
+		if (other.size != size)
+			return false;
+		if (other.hasZeroValue != hasZeroValue)
+			return false;
 		if (hasZeroValue) {
 			if (other.zeroValue == null) {
-				if (zeroValue != null) return false;
+				if (zeroValue != null)
+					return false;
 			} else {
-				if (!other.zeroValue.equals(zeroValue)) return false;
+				if (!other.zeroValue.equals(zeroValue))
+					return false;
 			}
 		}
-		int[] keyTable = this.keyTable;
-		V[] valueTable = this.valueTable;
-		for (int i = 0, n = capacity + stashSize; i < n; i++) {
+		final int[] keyTable = this.keyTable;
+		final V[] valueTable = this.valueTable;
+		for (int i = 0, n = keyTable.length; i < n; i++) {
 			int key = keyTable[i];
-			if (key != EMPTY) {
+			if (key != 0) {
 				V value = valueTable[i];
 				if (value == null) {
-					if (other.get(key, ObjectMap.dummy) != null) return false;
+					if (other.get(key, ObjectMap.dummy) != null)
+						return false;
 				} else {
-					if (!value.equals(other.get(key))) return false;
+					if (!value.equals(other.get(key)))
+						return false;
 				}
 			}
 		}
 		return true;
 	}
 
-	/** Uses == for comparison of each value. */
+	/**
+	 * Uses == for comparison of each value.
+	 */
 	public boolean equalsIdentity (Object obj) {
-		if (obj == this) return true;
-		if (!(obj instanceof IntMap)) return false;
+		if (obj == this)
+			return true;
+		if (!(obj instanceof IntMap))
+			return false;
 		IntMap other = (IntMap)obj;
-		if (other.size != size) return false;
-		if (other.hasZeroValue != hasZeroValue) return false;
-		if (hasZeroValue && zeroValue != other.zeroValue) return false;
-		int[] keyTable = this.keyTable;
-		V[] valueTable = this.valueTable;
-		for (int i = 0, n = capacity + stashSize; i < n; i++) {
+		if (other.size != size)
+			return false;
+		if (other.hasZeroValue != hasZeroValue)
+			return false;
+		if (hasZeroValue && zeroValue != other.zeroValue)
+			return false;
+		final int[] keyTable = this.keyTable;
+		final V[] valueTable = this.valueTable;
+		for (int i = 0, n = keyTable.length; i < n; i++) {
 			int key = keyTable[i];
-			if (key != EMPTY && valueTable[i] != other.get(key, ObjectMap.dummy)) return false;
+			if (key != 0 && valueTable[i] != other.get(key, ObjectMap.dummy))
+				return false;
 		}
 		return true;
 	}
 
 	public String toString () {
-		if (size == 0) return "[]";
-		StringBuilder buffer = new StringBuilder(32);
+		if (size == 0)
+			return "[]";
+		java.lang.StringBuilder buffer = new java.lang.StringBuilder(32);
 		buffer.append('[');
-		int[] keyTable = this.keyTable;
-		V[] valueTable = this.valueTable;
+		final int[] keyTable = this.keyTable;
+		final V[] valueTable = this.valueTable;
 		int i = keyTable.length;
 		if (hasZeroValue) {
 			buffer.append("0=");
@@ -638,7 +589,8 @@ public class IntMap<V> implements Iterable<IntMap.Entry<V>> {
 		} else {
 			while (i-- > 0) {
 				int key = keyTable[i];
-				if (key == EMPTY) continue;
+				if (key == 0)
+					continue;
 				buffer.append(key);
 				buffer.append('=');
 				buffer.append(valueTable[i]);
@@ -647,7 +599,8 @@ public class IntMap<V> implements Iterable<IntMap.Entry<V>> {
 		}
 		while (i-- > 0) {
 			int key = keyTable[i];
-			if (key == EMPTY) continue;
+			if (key == 0)
+				continue;
 			buffer.append(", ");
 			buffer.append(key);
 			buffer.append('=');
@@ -661,12 +614,15 @@ public class IntMap<V> implements Iterable<IntMap.Entry<V>> {
 		return entries();
 	}
 
-	/** Returns an iterator for the entries in the map. Remove is supported.
+	/**
+	 * Returns an iterator for the entries in the map. Remove is supported.
 	 * <p>
 	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called.
-	 * Use the {@link Entries} constructor for nested or multithreaded iteration. */
+	 * Use the {@link Entries} constructor for nested or multithreaded iteration.
+	 */
 	public Entries<V> entries () {
-		if (Collections.allocateIterators) return new Entries(this);
+		if (Collections.allocateIterators)
+			return new Entries(this);
 		if (entries1 == null) {
 			entries1 = new Entries(this);
 			entries2 = new Entries(this);
@@ -683,12 +639,15 @@ public class IntMap<V> implements Iterable<IntMap.Entry<V>> {
 		return entries2;
 	}
 
-	/** Returns an iterator for the values in the map. Remove is supported.
+	/**
+	 * Returns an iterator for the values in the map. Remove is supported.
 	 * <p>
 	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called.
-	 * Use the {@link Entries} constructor for nested or multithreaded iteration. */
+	 * Use the {@link Entries} constructor for nested or multithreaded iteration.
+	 */
 	public Values<V> values () {
-		if (Collections.allocateIterators) return new Values(this);
+		if (Collections.allocateIterators)
+			return new Values(this);
 		if (values1 == null) {
 			values1 = new Values(this);
 			values2 = new Values(this);
@@ -705,12 +664,15 @@ public class IntMap<V> implements Iterable<IntMap.Entry<V>> {
 		return values2;
 	}
 
-	/** Returns an iterator for the keys in the map. Remove is supported.
+	/**
+	 * Returns an iterator for the keys in the map. Remove is supported.
 	 * <p>
 	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called.
-	 * Use the {@link Entries} constructor for nested or multithreaded iteration. */
+	 * Use the {@link Entries} constructor for nested or multithreaded iteration.
+	 */
 	public Keys keys () {
-		if (Collections.allocateIterators) return new Keys(this);
+		if (Collections.allocateIterators)
+			return new Keys(this);
 		if (keys1 == null) {
 			keys1 = new Keys(this);
 			keys2 = new Keys(this);
@@ -725,6 +687,23 @@ public class IntMap<V> implements Iterable<IntMap.Entry<V>> {
 		keys2.valid = true;
 		keys1.valid = false;
 		return keys2;
+	}
+
+	public void write (Json json) {
+		json.writeArrayStart("entries");
+		for (Entry<V> entry : entries()) {
+			json.writeValue(entry.key, Integer.class);
+			json.writeValue(entry.value, null);
+		}
+		json.writeArrayEnd();
+	}
+
+	public void read (Json json, JsonValue jsonData) {
+		for (JsonValue child = jsonData.get("entries").child; child != null; child = child.next) {
+			int key = child.asInt();
+			V value = json.readValue(null, child = child.next);
+			put(key, value);
+		}
 	}
 
 	static public class Entry<V> {
@@ -763,8 +742,8 @@ public class IntMap<V> implements Iterable<IntMap.Entry<V>> {
 		void findNextIndex () {
 			hasNext = false;
 			int[] keyTable = map.keyTable;
-			for (int n = map.capacity + map.stashSize; ++nextIndex < n;) {
-				if (keyTable[nextIndex] != EMPTY) {
+			for (int n = keyTable.length; ++nextIndex < n; ) {
+				if (keyTable[nextIndex] != 0) {
 					hasNext = true;
 					break;
 				}
@@ -777,13 +756,19 @@ public class IntMap<V> implements Iterable<IntMap.Entry<V>> {
 				map.hasZeroValue = false;
 			} else if (currentIndex < 0) {
 				throw new IllegalStateException("next must be called before remove.");
-			} else if (currentIndex >= map.capacity) {
-				map.removeStashIndex(currentIndex);
-				nextIndex = currentIndex - 1;
-				findNextIndex();
 			} else {
-				map.keyTable[currentIndex] = EMPTY;
-				map.valueTable[currentIndex] = null;
+				int[] keyTable = map.keyTable;
+				V[] valueTable = map.valueTable;
+				int loc = currentIndex, key;
+				final int mask = map.mask;
+				while ((key = keyTable[loc + 1 & mask]) != 0 && (loc + 1 & mask) != map.place(key)) {
+					keyTable[loc] = key;
+					valueTable[loc] = valueTable[loc + 1 & mask];
+					++loc;
+				}
+				if(loc != currentIndex) --nextIndex;
+				keyTable[loc] = 0;
+				valueTable[loc] = null;
 			}
 			currentIndex = INDEX_ILLEGAL;
 			map.size--;
@@ -797,10 +782,14 @@ public class IntMap<V> implements Iterable<IntMap.Entry<V>> {
 			super(map);
 		}
 
-		/** Note the same entry instance is returned each time this method is called. */
+		/**
+		 * Note the same entry instance is returned each time this method is called.
+		 */
 		public Entry<V> next () {
-			if (!hasNext) throw new NoSuchElementException();
-			if (!valid) throw new GdxRuntimeException("#iterator() cannot be used nested.");
+			if (!hasNext)
+				throw new NoSuchElementException();
+			if (!valid)
+				throw new GdxRuntimeException("#iterator() cannot be used nested.");
 			int[] keyTable = map.keyTable;
 			if (nextIndex == INDEX_ZERO) {
 				entry.key = 0;
@@ -815,7 +804,8 @@ public class IntMap<V> implements Iterable<IntMap.Entry<V>> {
 		}
 
 		public boolean hasNext () {
-			if (!valid) throw new GdxRuntimeException("#iterator() cannot be used nested.");
+			if (!valid)
+				throw new GdxRuntimeException("#iterator() cannot be used nested.");
 			return hasNext;
 		}
 
@@ -834,13 +824,16 @@ public class IntMap<V> implements Iterable<IntMap.Entry<V>> {
 		}
 
 		public boolean hasNext () {
-			if (!valid) throw new GdxRuntimeException("#iterator() cannot be used nested.");
+			if (!valid)
+				throw new GdxRuntimeException("#iterator() cannot be used nested.");
 			return hasNext;
 		}
 
 		public V next () {
-			if (!hasNext) throw new NoSuchElementException();
-			if (!valid) throw new GdxRuntimeException("#iterator() cannot be used nested.");
+			if (!hasNext)
+				throw new NoSuchElementException();
+			if (!valid)
+				throw new GdxRuntimeException("#iterator() cannot be used nested.");
 			V value;
 			if (nextIndex == INDEX_ZERO)
 				value = map.zeroValue;
@@ -855,16 +848,14 @@ public class IntMap<V> implements Iterable<IntMap.Entry<V>> {
 			return this;
 		}
 
-		/** Returns a new array containing the remaining values. */
+		/**
+		 * Returns a new array containing the remaining values.
+		 */
 		public Array<V> toArray () {
 			Array array = new Array(true, map.size);
 			while (hasNext)
 				array.add(next());
 			return array;
-		}
-
-		public void remove () {
-			super.remove();
 		}
 	}
 
@@ -874,17 +865,30 @@ public class IntMap<V> implements Iterable<IntMap.Entry<V>> {
 		}
 
 		public int next () {
-			if (!hasNext) throw new NoSuchElementException();
-			if (!valid) throw new GdxRuntimeException("#iterator() cannot be used nested.");
+			if (!hasNext)
+				throw new NoSuchElementException();
+			if (!valid)
+				throw new GdxRuntimeException("#iterator() cannot be used nested.");
 			int key = nextIndex == INDEX_ZERO ? 0 : map.keyTable[nextIndex];
 			currentIndex = nextIndex;
 			findNextIndex();
 			return key;
 		}
 
-		/** Returns a new array containing the remaining keys. */
+		/**
+		 * Returns a new array containing the remaining keys.
+		 */
 		public IntArray toArray () {
 			IntArray array = new IntArray(true, map.size);
+			while (hasNext)
+				array.add(next());
+			return array;
+		}
+
+		/**
+		 * Adds the remaining values to the specified array.
+		 */
+		public IntArray toArray (IntArray array) {
 			while (hasNext)
 				array.add(next());
 			return array;

--- a/gdx/src/com/badlogic/gdx/utils/IntSet.java
+++ b/gdx/src/com/badlogic/gdx/utils/IntSet.java
@@ -49,7 +49,7 @@ public class IntSet {
 	private int[] keyTable;
 	boolean hasZeroValue;
 
-	private float loadFactor;
+	private final float loadFactor;
 	private int shift, mask, threshold;
 
 	private IntSetIterator iterator1, iterator2;
@@ -149,7 +149,7 @@ public class IntSet {
 			// space is available so we insert and break
 			if (keyTable[i] == 0) {
 				keyTable[i] = key;
-				
+
 				if (++size >= threshold) {
 					resize(keyTable.length << 1);
 				}
@@ -205,13 +205,11 @@ public class IntSet {
 
 		final int[] keyTable = this.keyTable;
 		for (int i = place(key); ; i = (i + 1) & mask) {
-			// space is available so we insert and break (resize is later)
+			// space is available so we insert and break
 			if (keyTable[i] == 0) {
 				keyTable[i] = key;
 
-				if (++size >= threshold) {
-					resize(keyTable.length << 1);
-				}
+				++size;
 				return;
 			}
 		}
@@ -342,7 +340,7 @@ public class IntSet {
 		final int[] oldKeyTable = keyTable;
 
 		keyTable = new int[newSize];
-		
+
 		int oldSize = size;
 		size = hasZeroValue ? 1 : 0;
 		if (oldSize > 0) {
@@ -488,7 +486,8 @@ public class IntSet {
 					loc = nl;
 					nl = loc + 1 & mask;
 				}
-				if(loc != currentIndex) --nextIndex;
+				if (loc != currentIndex)
+					--nextIndex;
 				keyTable[loc] = 0;
 			}
 			currentIndex = INDEX_ILLEGAL;

--- a/gdx/src/com/badlogic/gdx/utils/IntSet.java
+++ b/gdx/src/com/badlogic/gdx/utils/IntSet.java
@@ -47,7 +47,7 @@ import java.util.NoSuchElementException;
  * @author Tommy Ettinger
  * @author Nathan Sweet
  */
-public class IntSet implements Json.Serializable {
+public class IntSet {
 	public int size;
 
 	private int[] keyTable;
@@ -444,19 +444,6 @@ public class IntSet implements Json.Serializable {
 		IntSet set = new IntSet();
 		set.addAll(array);
 		return set;
-	}
-
-	public void write (Json json) {
-		json.writeArrayStart("items");
-		IntSetIterator it = iterator();
-		while (it.hasNext) {
-			json.writeValue(it.next(), Integer.class);
-		}
-		json.writeArrayEnd();
-	}
-
-	public void read (Json json, JsonValue jsonData) {
-		addAll(jsonData.get("items").asIntArray());
 	}
 
 	static public class IntSetIterator {

--- a/gdx/src/com/badlogic/gdx/utils/IntSet.java
+++ b/gdx/src/com/badlogic/gdx/utils/IntSet.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,126 +16,150 @@
 
 package com.badlogic.gdx.utils;
 
-import java.util.NoSuchElementException;
-
 import com.badlogic.gdx.math.MathUtils;
 
-/** An unordered set that uses int keys. This implementation uses cuckoo hashing using 3 hashes, random walking, and a small stash
- * for problematic keys. No allocation is done except when growing the table size. <br>
- * <br>
- * This set performs very fast contains and remove (typically O(1), worst case O(log(n))). Add may be a bit slower, depending on
- * hash collisions. Load factors greater than 0.91 greatly increase the chances the set will have to rehash to the next higher POT
- * size.
- * @author Nathan Sweet */
-public class IntSet {
-	private static final int PRIME1 = 0xbe1f14b1;
-	private static final int PRIME2 = 0xb4b82e39;
-	private static final int PRIME3 = 0xced1c241;
-	private static final int EMPTY = 0;
+import java.util.NoSuchElementException;
 
+/**
+ * An unordered set where the items are unboxed ints. This implementation uses linear probing with th backward-shift algorithm for
+ * removal, and finds space for keys using Fibonacci hashing instead of the more-common power-of-two mask.
+ * Null keys are not allowed. No allocation is done except when growing the table size.
+ * <br>
+ * This set uses Fibonacci hashing to help distribute what may be very bad hashCode() results across the
+ * whole capacity. See <a href="https://probablydance.com/2018/06/16/fibonacci-hashing-the-optimization-that-the-world-forgot-or-a-better-alternative-to-integer-modulo/">Malte Skarupke's blog post</a>
+ * for more information on Fibonacci hashing. It uses linear probing to resolve collisions, which is far from the academically
+ * optimal algorithm, but performs considerably better in practice than most alternatives, and combined with Fibonacci hashing, it
+ * can handle "normal" generated hashCode() implementations, and not just theoretically optimal hashing functions. Even if all
+ * hashCode()s this is given collide, it will still work, just slowly; the older libGDX implementation using cuckoo hashing would
+ * crash with an OutOfMemoryError with under 50 collisions.
+ * <br>
+ * This set performs very fast contains and remove (typically O(1), worst case O(n) due to occasional probing, but still very
+ * fast). Add may be a bit slower, depending on hash collisions, but this data structure is somewhat collision-resistant.
+ * Load factors greater than 0.91 greatly increase the chances the set will have to rehash to the next higher POT size.
+ * Memory usage is excellent, and the aforementioned collision-resistance helps avoid too much capacity resizing.
+ * <br>
+ * The <a href="http://codecapsule.com/2013/11/17/robin-hood-hashing-backward-shift-deletion/">backward-shift algorithm</a>
+ * used during removal apparently is key to the good performance of this implementation, even though this doesn't use Robin Hood
+ * hashing; the performance of {@link #remove(int)} has improved considerably over the previous libGDX version.
+ * <br>
+ * Iteration won't be as fast here as with OrderedSet and OrderedMap.
+ *
+ * @author Tommy Ettinger
+ * @author Nathan Sweet
+ */
+public class IntSet implements Json.Serializable {
 	public int size;
 
-	int[] keyTable;
-	int capacity, stashSize;
+	private int[] keyTable;
 	boolean hasZeroValue;
 
 	private float loadFactor;
-	private int hashShift, mask, threshold;
-	private int stashCapacity;
-	private int pushIterations;
+	private int shift, mask, threshold;
 
 	private IntSetIterator iterator1, iterator2;
 
-	/** Creates a new set with an initial capacity of 51 and a load factor of 0.8. */
+	/**
+	 * Creates a new set with an initial capacity of 51 and a load factor of 0.8.
+	 */
 	public IntSet () {
 		this(51, 0.8f);
 	}
 
-	/** Creates a new set with a load factor of 0.8.
-	 * @param initialCapacity If not a power of two, it is increased to the next nearest power of two. */
+	/**
+	 * Creates a new set with a load factor of 0.8.
+	 *
+	 * @param initialCapacity If not a power of two, it is increased to the next nearest power of two.
+	 */
 	public IntSet (int initialCapacity) {
 		this(initialCapacity, 0.8f);
 	}
 
-	/** Creates a new set with the specified initial capacity and load factor. This set will hold initialCapacity items before
+	/**
+	 * Creates a new set with the specified initial capacity and load factor. This set will hold initialCapacity items before
 	 * growing the backing table.
-	 * @param initialCapacity If not a power of two, it is increased to the next nearest power of two. */
+	 *
+	 * @param initialCapacity If not a power of two, it is increased to the next nearest power of two.
+	 */
 	public IntSet (int initialCapacity, float loadFactor) {
-		if (loadFactor <= 0) throw new IllegalArgumentException("loadFactor must be > 0: " + loadFactor);
+		if (initialCapacity < 0)
+			throw new IllegalArgumentException("initialCapacity must be >= 0: " + initialCapacity);
+		if (loadFactor <= 0f || loadFactor >= 1f)
+			throw new IllegalArgumentException("loadFactor must be > 0 and < 1: " + loadFactor);
+		initialCapacity = MathUtils.nextPowerOfTwo((int)Math.ceil(initialCapacity / loadFactor));
+		if (initialCapacity > 1 << 30)
+			throw new IllegalArgumentException("initialCapacity is too large: " + initialCapacity);
+
 		this.loadFactor = loadFactor;
 
-		if (initialCapacity < 0) throw new IllegalArgumentException("initialCapacity must be >= 0: " + initialCapacity);
-		initialCapacity = MathUtils.nextPowerOfTwo((int)Math.ceil(initialCapacity / loadFactor));
-		if (initialCapacity > 1 << 30) throw new IllegalArgumentException("initialCapacity is too large: " + initialCapacity);
-		capacity = initialCapacity;
+		threshold = (int)(initialCapacity * loadFactor);
+		mask = initialCapacity - 1;
+		shift = Long.numberOfLeadingZeros(mask);
 
-		threshold = (int)(capacity * loadFactor);
-		mask = capacity - 1;
-		hashShift = 31 - Integer.numberOfTrailingZeros(capacity);
-		stashCapacity = Math.max(3, (int)Math.ceil(Math.log(capacity)) * 2);
-		pushIterations = Math.max(Math.min(capacity, 8), (int)Math.sqrt(capacity) / 8);
-
-		keyTable = new int[capacity + stashCapacity];
+		keyTable = new int[initialCapacity];
 	}
 
-	/** Creates a new set identical to the specified set. */
+	/**
+	 * Creates a new set identical to the specified set.
+	 */
 	public IntSet (IntSet set) {
-		this((int)Math.floor(set.capacity * set.loadFactor), set.loadFactor);
-		stashSize = set.stashSize;
+		this((int)(set.keyTable.length * set.loadFactor), set.loadFactor);
 		System.arraycopy(set.keyTable, 0, keyTable, 0, set.keyTable.length);
 		size = set.size;
 		hasZeroValue = set.hasZeroValue;
 	}
 
-	/** Returns true if the key was not already in the set. */
+	private int place (final int item) {
+		// shift is always greater than 32, less than 64
+		return (int)(item * 0x9E3779B97F4A7C15L >>> shift);
+	}
+
+	private int locateKey (final int key) {
+		return locateKey(key, place(key));
+	}
+
+	private int locateKey (final int key, final int placement) {
+		for (int i = placement; ; i = i + 1 & mask) {
+			// empty space is available
+			if (keyTable[i] == 0) {
+				return -1;
+			}
+			if (key == (keyTable[i])) {
+				return i;
+			}
+		}
+	}
+
+	/**
+	 * Returns true if the key was not already in the set.
+	 */
 	public boolean add (int key) {
 		if (key == 0) {
-			if (hasZeroValue) return false;
+			if (hasZeroValue)
+				return false;
 			hasZeroValue = true;
 			size++;
 			return true;
 		}
 
-		int[] keyTable = this.keyTable;
-
-		// Check for existing keys.
-		int index1 = key & mask;
-		int key1 = keyTable[index1];
-		if (key1 == key) return false;
-
-		int index2 = hash2(key);
-		int key2 = keyTable[index2];
-		if (key2 == key) return false;
-
-		int index3 = hash3(key);
-		int key3 = keyTable[index3];
-		if (key3 == key) return false;
-
-		// Find key in the stash.
-		for (int i = capacity, n = i + stashSize; i < n; i++)
-			if (keyTable[i] == key) return false;
-
-		// Check for empty buckets.
-		if (key1 == EMPTY) {
-			keyTable[index1] = key;
-			if (size++ >= threshold) resize(capacity << 1);
-			return true;
+		int b = place(key);
+		int loc = locateKey(key, b);
+		// an identical key already exists
+		if (loc != -1) {
+			return false;
 		}
+		final int[] keyTable = this.keyTable;
 
-		if (key2 == EMPTY) {
-			keyTable[index2] = key;
-			if (size++ >= threshold) resize(capacity << 1);
-			return true;
+		for (int i = b; ; i = (i + 1) & mask) {
+			// space is available so we insert and break
+			if (keyTable[i] == 0) {
+				keyTable[i] = key;
+				
+				if (++size >= threshold) {
+					resize(keyTable.length << 1);
+				}
+				return true;
+			}
 		}
-
-		if (key3 == EMPTY) {
-			keyTable[index3] = key;
-			if (size++ >= threshold) resize(capacity << 1);
-			return true;
-		}
-
-		push(key, index1, key1, index2, key2, index3, key3);
-		return true;
 	}
 
 	public void addAll (IntArray array) {
@@ -144,7 +168,8 @@ public class IntSet {
 
 	public void addAll (IntArray array, int offset, int length) {
 		if (offset + length > array.size)
-			throw new IllegalArgumentException("offset + length must be <= size: " + offset + " + " + length + " <= " + array.size);
+			throw new IllegalArgumentException(
+				"offset + length must be <= size: " + offset + " + " + length + " <= " + array.size);
 		addAll(array.items, offset, length);
 	}
 
@@ -160,193 +185,105 @@ public class IntSet {
 
 	public void addAll (IntSet set) {
 		ensureCapacity(set.size);
-		IntSetIterator iterator = set.iterator();
-		while (iterator.hasNext)
-			add(iterator.next());
+		if (set.hasZeroValue)
+			add(0);
+		final int[] keyTable = set.keyTable;
+		int k;
+		for (int i = 0, n = keyTable.length; i < n; i++) {
+			if ((k = keyTable[i]) != 0)
+				add(k);
+		}
+
+//		ensureCapacity(set.size);
+//		IntSetIterator iterator = set.iterator();
+//		while (iterator.hasNext)
+//			add(iterator.next());
 	}
 
-	/** Skips checks for existing keys. */
+	/**
+	 * Skips checks for existing keys.
+	 */
 	private void addResize (int key) {
 		if (key == 0) {
+			if (!hasZeroValue && size++ >= threshold)
+				resize(keyTable.length << 1);
 			hasZeroValue = true;
 			return;
 		}
 
-		// Check for empty buckets.
-		int index1 = key & mask;
-		int key1 = keyTable[index1];
-		if (key1 == EMPTY) {
-			keyTable[index1] = key;
-			if (size++ >= threshold) resize(capacity << 1);
-			return;
-		}
+		final int[] keyTable = this.keyTable;
+		int b = place(key);
+		for (int i = b; ; i = (i + 1) & mask) {
+			// space is available so we insert and break (resize is later)
+			if (keyTable[i] == 0) {
+				keyTable[i] = key;
 
-		int index2 = hash2(key);
-		int key2 = keyTable[index2];
-		if (key2 == EMPTY) {
-			keyTable[index2] = key;
-			if (size++ >= threshold) resize(capacity << 1);
-			return;
-		}
-
-		int index3 = hash3(key);
-		int key3 = keyTable[index3];
-		if (key3 == EMPTY) {
-			keyTable[index3] = key;
-			if (size++ >= threshold) resize(capacity << 1);
-			return;
-		}
-
-		push(key, index1, key1, index2, key2, index3, key3);
-	}
-
-	private void push (int insertKey, int index1, int key1, int index2, int key2, int index3, int key3) {
-		int[] keyTable = this.keyTable;
-
-		int mask = this.mask;
-
-		// Push keys until an empty bucket is found.
-		int evictedKey;
-		int i = 0, pushIterations = this.pushIterations;
-		do {
-			// Replace the key and value for one of the hashes.
-			switch (MathUtils.random(2)) {
-			case 0:
-				evictedKey = key1;
-				keyTable[index1] = insertKey;
-				break;
-			case 1:
-				evictedKey = key2;
-				keyTable[index2] = insertKey;
-				break;
-			default:
-				evictedKey = key3;
-				keyTable[index3] = insertKey;
-				break;
-			}
-
-			// If the evicted key hashes to an empty bucket, put it there and stop.
-			index1 = evictedKey & mask;
-			key1 = keyTable[index1];
-			if (key1 == EMPTY) {
-				keyTable[index1] = evictedKey;
-				if (size++ >= threshold) resize(capacity << 1);
+				if (++size >= threshold) {
+					resize(keyTable.length << 1);
+				}
 				return;
 			}
-
-			index2 = hash2(evictedKey);
-			key2 = keyTable[index2];
-			if (key2 == EMPTY) {
-				keyTable[index2] = evictedKey;
-				if (size++ >= threshold) resize(capacity << 1);
-				return;
-			}
-
-			index3 = hash3(evictedKey);
-			key3 = keyTable[index3];
-			if (key3 == EMPTY) {
-				keyTable[index3] = evictedKey;
-				if (size++ >= threshold) resize(capacity << 1);
-				return;
-			}
-
-			if (++i == pushIterations) break;
-
-			insertKey = evictedKey;
-		} while (true);
-
-		addStash(evictedKey);
-	}
-
-	private void addStash (int key) {
-		if (stashSize == stashCapacity) {
-			// Too many pushes occurred and the stash is full, increase the table size.
-			resize(capacity << 1);
-			addResize(key);
-			return;
 		}
-		// Store key in the stash.
-		int index = capacity + stashSize;
-		keyTable[index] = key;
-		stashSize++;
-		size++;
 	}
 
-	/** Returns true if the key was removed. */
+	/**
+	 * Returns true if the key was removed.
+	 */
 	public boolean remove (int key) {
 		if (key == 0) {
-			if (!hasZeroValue) return false;
+			if (!hasZeroValue)
+				return false;
 			hasZeroValue = false;
 			size--;
 			return true;
 		}
 
-		int index = key & mask;
-		if (keyTable[index] == key) {
-			keyTable[index] = EMPTY;
-			size--;
-			return true;
+		int loc = locateKey(key);
+		if (loc == -1) {
+			return false;
 		}
-
-		index = hash2(key);
-		if (keyTable[index] == key) {
-			keyTable[index] = EMPTY;
-			size--;
-			return true;
+		while ((key = keyTable[loc + 1 & mask]) != 0 && (loc + 1 & mask) != place(key)) {
+			keyTable[loc] = key;
+			++loc;
 		}
-
-		index = hash3(key);
-		if (keyTable[index] == key) {
-			keyTable[index] = EMPTY;
-			size--;
-			return true;
-		}
-
-		return removeStash(key);
+		keyTable[loc] = 0;
+		--size;
+		return true;
 	}
 
-	boolean removeStash (int key) {
-		int[] keyTable = this.keyTable;
-		for (int i = capacity, n = i + stashSize; i < n; i++) {
-			if (keyTable[i] == key) {
-				removeStashIndex(i);
-				size--;
-				return true;
-			}
-		}
-		return false;
-	}
-
-	void removeStashIndex (int index) {
-		// If the removed location was not last, move the last tuple to the removed location.
-		stashSize--;
-		int lastIndex = capacity + stashSize;
-		if (index < lastIndex) keyTable[index] = keyTable[lastIndex];
-	}
-
-	/** Returns true if the set has one or more items. */
+	/**
+	 * Returns true if the set has one or more items.
+	 */
 	public boolean notEmpty () {
 		return size > 0;
 	}
 
-	/** Returns true if the set is empty. */
+	/**
+	 * Returns true if the set is empty.
+	 */
 	public boolean isEmpty () {
 		return size == 0;
 	}
 
-	/** Reduces the size of the backing arrays to be the specified capacity or less. If the capacity is already less, nothing is
-	 * done. If the set contains more items than the specified capacity, the next highest power of two capacity is used instead. */
+	/**
+	 * Reduces the size of the backing arrays to be the specified capacity or less. If the capacity is already less, nothing is
+	 * done. If the set contains more items than the specified capacity, the next highest power of two capacity is used instead.
+	 */
 	public void shrink (int maximumCapacity) {
-		if (maximumCapacity < 0) throw new IllegalArgumentException("maximumCapacity must be >= 0: " + maximumCapacity);
-		if (size > maximumCapacity) maximumCapacity = size;
-		if (capacity <= maximumCapacity) return;
-		maximumCapacity = MathUtils.nextPowerOfTwo(maximumCapacity);
-		resize(maximumCapacity);
+		if (maximumCapacity < 0)
+			throw new IllegalArgumentException("maximumCapacity must be >= 0: " + maximumCapacity);
+		if (size > maximumCapacity)
+			maximumCapacity = size;
+		if (keyTable.length <= maximumCapacity)
+			return;
+		resize(MathUtils.nextPowerOfTwo(maximumCapacity));
 	}
 
-	/** Clears the set and reduces the size of the backing arrays to be the specified capacity if they are larger. */
+	/**
+	 * Clears the set and reduces the size of the backing arrays to be the specified capacity if they are larger.
+	 */
 	public void clear (int maximumCapacity) {
-		if (capacity <= maximumCapacity) {
+		if (keyTable.length <= maximumCapacity) {
 			clear();
 			return;
 		}
@@ -356,107 +293,103 @@ public class IntSet {
 	}
 
 	public void clear () {
-		if (size == 0) return;
-		int[] keyTable = this.keyTable;
-		for (int i = capacity + stashSize; i-- > 0;)
-			keyTable[i] = EMPTY;
+		if (size == 0)
+			return;
+		final int[] keyTable = this.keyTable;
+		for (int i = keyTable.length; i > 0; ) {
+			keyTable[--i] = 0;
+		}
 		size = 0;
-		stashSize = 0;
 		hasZeroValue = false;
 	}
 
 	public boolean contains (int key) {
-		if (key == 0) return hasZeroValue;
-		int index = key & mask;
-		if (keyTable[index] != key) {
-			index = hash2(key);
-			if (keyTable[index] != key) {
-				index = hash3(key);
-				if (keyTable[index] != key) return containsKeyStash(key);
+		if (key == 0)
+			return hasZeroValue;
+		// inlined locateKey()
+		for (int i = (int)(key * 0x9E3779B97F4A7C15L >>> shift); ; i = i + 1 & mask) {
+			// empty space is available
+			if (keyTable[i] == 0) {
+				return false;
+			}
+			if (key == (keyTable[i])) {
+				return true;
 			}
 		}
-		return true;
-	}
-
-	private boolean containsKeyStash (int key) {
-		int[] keyTable = this.keyTable;
-		for (int i = capacity, n = i + stashSize; i < n; i++)
-			if (keyTable[i] == key) return true;
-		return false;
 	}
 
 	public int first () {
-		if (hasZeroValue) return 0;
+		if (hasZeroValue)
+			return 0;
 		int[] keyTable = this.keyTable;
-		for (int i = 0, n = capacity + stashSize; i < n; i++)
-			if (keyTable[i] != EMPTY) return keyTable[i];
+		for (int i = 0, n = keyTable.length; i < n; i++)
+			if (keyTable[i] != 0)
+				return keyTable[i];
 		throw new IllegalStateException("IntSet is empty.");
 	}
 
-	/** Increases the size of the backing array to accommodate the specified number of additional items. Useful before adding many
-	 * items to avoid multiple backing array resizes. */
+	/**
+	 * Increases the size of the backing array to accommodate the specified number of additional items. Useful before adding many
+	 * items to avoid multiple backing array resizes.
+	 */
 	public void ensureCapacity (int additionalCapacity) {
-		if (additionalCapacity < 0) throw new IllegalArgumentException("additionalCapacity must be >= 0: " + additionalCapacity);
+		if (additionalCapacity < 0)
+			throw new IllegalArgumentException("additionalCapacity must be >= 0: " + additionalCapacity);
 		int sizeNeeded = size + additionalCapacity;
-		if (sizeNeeded >= threshold) resize(MathUtils.nextPowerOfTwo((int)Math.ceil(sizeNeeded / loadFactor)));
+		if (sizeNeeded >= threshold)
+			resize(MathUtils.nextPowerOfTwo((int)Math.ceil(sizeNeeded / loadFactor)));
 	}
 
 	private void resize (int newSize) {
-		int oldEndIndex = capacity + stashSize;
-
-		capacity = newSize;
+		int oldCapacity = keyTable.length;
 		threshold = (int)(newSize * loadFactor);
 		mask = newSize - 1;
-		hashShift = 31 - Integer.numberOfTrailingZeros(newSize);
-		stashCapacity = Math.max(3, (int)Math.ceil(Math.log(newSize)) * 2);
-		pushIterations = Math.max(Math.min(newSize, 8), (int)Math.sqrt(newSize) / 8);
+		shift = Long.numberOfLeadingZeros(mask);
 
-		int[] oldKeyTable = keyTable;
+		final int[] oldKeyTable = keyTable;
 
-		keyTable = new int[newSize + stashCapacity];
-
+		keyTable = new int[newSize];
+		
 		int oldSize = size;
-		size = hasZeroValue ? 1 : 0;
-		stashSize = 0;
+		size = 0;
 		if (oldSize > 0) {
-			for (int i = 0; i < oldEndIndex; i++) {
+			for (int i = 0; i < oldCapacity; i++) {
 				int key = oldKeyTable[i];
-				if (key != EMPTY) addResize(key);
+				if (key != 0)
+					addResize(key);
 			}
 		}
 	}
 
-	private int hash2 (int h) {
-		h *= PRIME2;
-		return (h ^ h >>> hashShift) & mask;
-	}
-
-	private int hash3 (int h) {
-		h *= PRIME3;
-		return (h ^ h >>> hashShift) & mask;
-	}
-
 	public int hashCode () {
-		int h = 0;
-		for (int i = 0, n = capacity + stashSize; i < n; i++)
-			if (keyTable[i] != EMPTY) h += keyTable[i];
+		int h = size;
+		for (int i = 0, n = keyTable.length; i < n; i++) {
+			if (keyTable[i] != 0) {
+				h += keyTable[i];
+			}
+		}
 		return h;
 	}
 
 	public boolean equals (Object obj) {
-		if (!(obj instanceof IntSet)) return false;
+		if (!(obj instanceof IntSet))
+			return false;
 		IntSet other = (IntSet)obj;
-		if (other.size != size) return false;
-		if (other.hasZeroValue != hasZeroValue) return false;
+		if (other.size != size)
+			return false;
+		if (other.hasZeroValue != hasZeroValue)
+			return false;
 		int[] keyTable = this.keyTable;
-		for (int i = 0, n = capacity + stashSize; i < n; i++)
-			if (keyTable[i] != EMPTY && !other.contains(keyTable[i])) return false;
+		for (int i = 0, n = keyTable.length; i < n; i++)
+			if (keyTable[i] != 0 && !other.contains(keyTable[i]))
+				return false;
 		return true;
 	}
 
 	public String toString () {
-		if (size == 0) return "[]";
-		StringBuilder buffer = new StringBuilder(32);
+		if (size == 0)
+			return "[]";
+		java.lang.StringBuilder buffer = new java.lang.StringBuilder(32);
 		buffer.append('[');
 		int[] keyTable = this.keyTable;
 		int i = keyTable.length;
@@ -465,14 +398,16 @@ public class IntSet {
 		else {
 			while (i-- > 0) {
 				int key = keyTable[i];
-				if (key == EMPTY) continue;
+				if (key == 0)
+					continue;
 				buffer.append(key);
 				break;
 			}
 		}
 		while (i-- > 0) {
 			int key = keyTable[i];
-			if (key == EMPTY) continue;
+			if (key == 0)
+				continue;
 			buffer.append(", ");
 			buffer.append(key);
 		}
@@ -480,12 +415,15 @@ public class IntSet {
 		return buffer.toString();
 	}
 
-	/** Returns an iterator for the keys in the set. Remove is supported.
+	/**
+	 * Returns an iterator for the keys in the set. Remove is supported.
 	 * <p>
 	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called.
-	 * Use the {@link IntSetIterator} constructor for nested or multithreaded iteration. */
+	 * Use the {@link IntSetIterator} constructor for nested or multithreaded iteration.
+	 */
 	public IntSetIterator iterator () {
-		if (Collections.allocateIterators) return new IntSetIterator(this);
+		if (Collections.allocateIterators)
+			return new IntSetIterator(this);
 		if (iterator1 == null) {
 			iterator1 = new IntSetIterator(this);
 			iterator2 = new IntSetIterator(this);
@@ -506,6 +444,19 @@ public class IntSet {
 		IntSet set = new IntSet();
 		set.addAll(array);
 		return set;
+	}
+
+	public void write (Json json) {
+		json.writeArrayStart("items");
+		IntSetIterator it = iterator();
+		while (it.hasNext) {
+			json.writeValue(it.next(), Integer.class);
+		}
+		json.writeArrayEnd();
+	}
+
+	public void read (Json json, JsonValue jsonData) {
+		addAll(jsonData.get("items").asIntArray());
 	}
 
 	static public class IntSetIterator {
@@ -535,8 +486,8 @@ public class IntSet {
 		void findNextIndex () {
 			hasNext = false;
 			int[] keyTable = set.keyTable;
-			for (int n = set.capacity + set.stashSize; ++nextIndex < n;) {
-				if (keyTable[nextIndex] != EMPTY) {
+			for (int n = keyTable.length; ++nextIndex < n; ) {
+				if (keyTable[nextIndex] != 0) {
 					hasNext = true;
 					break;
 				}
@@ -548,27 +499,38 @@ public class IntSet {
 				set.hasZeroValue = false;
 			} else if (currentIndex < 0) {
 				throw new IllegalStateException("next must be called before remove.");
-			} else if (currentIndex >= set.capacity) {
-				set.removeStashIndex(currentIndex);
-				nextIndex = currentIndex - 1;
-				findNextIndex();
 			} else {
-				set.keyTable[currentIndex] = EMPTY;
+				set.keyTable[currentIndex] = 0;
+
+				int[] keyTable = set.keyTable;
+				final int mask = set.mask;
+				int loc = currentIndex;
+				int key;
+				while ((key = keyTable[loc + 1 & mask]) != 0 && (loc + 1 & mask) != set.place(key)) {
+					keyTable[loc] = key;
+					++loc;
+				}
+				if(loc != currentIndex) --nextIndex;
+				keyTable[loc] = 0;
 			}
 			currentIndex = INDEX_ILLEGAL;
 			set.size--;
 		}
 
 		public int next () {
-			if (!hasNext) throw new NoSuchElementException();
-			if (!valid) throw new GdxRuntimeException("#iterator() cannot be used nested.");
+			if (!hasNext)
+				throw new NoSuchElementException();
+			if (!valid)
+				throw new GdxRuntimeException("#iterator() cannot be used nested.");
 			int key = nextIndex == INDEX_ZERO ? 0 : set.keyTable[nextIndex];
 			currentIndex = nextIndex;
 			findNextIndex();
 			return key;
 		}
 
-		/** Returns a new array containing the remaining keys. */
+		/**
+		 * Returns a new array containing the remaining keys.
+		 */
 		public IntArray toArray () {
 			IntArray array = new IntArray(true, set.size);
 			while (hasNext)

--- a/gdx/src/com/badlogic/gdx/utils/IntSet.java
+++ b/gdx/src/com/badlogic/gdx/utils/IntSet.java
@@ -38,10 +38,6 @@ import java.util.NoSuchElementException;
  * Load factors greater than 0.91 greatly increase the chances the set will have to rehash to the next higher POT size.
  * Memory usage is excellent, and the aforementioned collision-resistance helps avoid too much capacity resizing.
  * <br>
- * The <a href="http://codecapsule.com/2013/11/17/robin-hood-hashing-backward-shift-deletion/">backward-shift algorithm</a>
- * used during removal apparently is key to the good performance of this implementation, even though this doesn't use Robin Hood
- * hashing; the performance of {@link #remove(int)} has improved considerably over the previous libGDX version.
- * <br>
  * Iteration won't be as fast here as with OrderedSet and OrderedMap.
  *
  * @author Tommy Ettinger

--- a/gdx/src/com/badlogic/gdx/utils/IntSet.java
+++ b/gdx/src/com/badlogic/gdx/utils/IntSet.java
@@ -238,9 +238,11 @@ public class IntSet {
 		if (loc == -1) {
 			return false;
 		}
-		while ((key = keyTable[loc + 1 & mask]) != 0 && (loc + 1 & mask) != place(key)) {
+		int nl = (loc + 1 & mask);
+		while ((key = keyTable[nl]) != 0 && nl != place(key)) {
 			keyTable[loc] = key;
-			++loc;
+			loc = nl;
+			nl = loc + 1 & mask;
 		}
 		keyTable[loc] = 0;
 		--size;
@@ -483,15 +485,13 @@ public class IntSet {
 			} else if (currentIndex < 0) {
 				throw new IllegalStateException("next must be called before remove.");
 			} else {
-				set.keyTable[currentIndex] = 0;
-
 				int[] keyTable = set.keyTable;
 				final int mask = set.mask;
-				int loc = currentIndex;
-				int key;
-				while ((key = keyTable[loc + 1 & mask]) != 0 && (loc + 1 & mask) != set.place(key)) {
+				int loc = currentIndex, nl = (loc + 1 & mask), key;
+				while ((key = keyTable[nl]) != 0 && nl != set.place(key)) {
 					keyTable[loc] = key;
-					++loc;
+					loc = nl;
+					nl = loc + 1 & mask;
 				}
 				if(loc != currentIndex) --nextIndex;
 				keyTable[loc] = 0;

--- a/gdx/src/com/badlogic/gdx/utils/IntSet.java
+++ b/gdx/src/com/badlogic/gdx/utils/IntSet.java
@@ -81,7 +81,7 @@ public class IntSet {
 			throw new IllegalArgumentException("initialCapacity must be >= 0: " + initialCapacity);
 		if (loadFactor <= 0f || loadFactor >= 1f)
 			throw new IllegalArgumentException("loadFactor must be > 0 and < 1: " + loadFactor);
-		initialCapacity = MathUtils.nextPowerOfTwo((int)Math.ceil(initialCapacity / loadFactor));
+		initialCapacity = MathUtils.nextPowerOfTwo((int)Math.ceil(Math.max(1, initialCapacity) / loadFactor));
 		if (initialCapacity > 1 << 30)
 			throw new IllegalArgumentException("initialCapacity is too large: " + initialCapacity);
 
@@ -348,7 +348,7 @@ public class IntSet {
 		keyTable = new int[newSize];
 		
 		int oldSize = size;
-		size = 0;
+		size = hasZeroValue ? 1 : 0;
 		if (oldSize > 0) {
 			for (int i = 0; i < oldCapacity; i++) {
 				int key = oldKeyTable[i];

--- a/gdx/src/com/badlogic/gdx/utils/IntSet.java
+++ b/gdx/src/com/badlogic/gdx/utils/IntSet.java
@@ -208,8 +208,7 @@ public class IntSet {
 		}
 
 		final int[] keyTable = this.keyTable;
-		int b = place(key);
-		for (int i = b; ; i = (i + 1) & mask) {
+		for (int i = place(key); ; i = (i + 1) & mask) {
 			// space is available so we insert and break (resize is later)
 			if (keyTable[i] == 0) {
 				keyTable[i] = key;

--- a/gdx/src/com/badlogic/gdx/utils/IntSet.java
+++ b/gdx/src/com/badlogic/gdx/utils/IntSet.java
@@ -190,10 +190,6 @@ public class IntSet {
 				add(k);
 		}
 
-//		ensureCapacity(set.size);
-//		IntSetIterator iterator = set.iterator();
-//		while (iterator.hasNext)
-//			add(iterator.next());
 	}
 
 	/**

--- a/gdx/src/com/badlogic/gdx/utils/LongMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/LongMap.java
@@ -48,7 +48,7 @@ import java.util.NoSuchElementException;
  * @author Tommy Ettinger
  * @author Nathan Sweet
  */
-public class LongMap<V> implements Json.Serializable, Iterable<LongMap.Entry<V>> {
+public class LongMap<V> implements Iterable<LongMap.Entry<V>> {
 	public int size;
 
 	private long[] keyTable;
@@ -690,26 +690,6 @@ public class LongMap<V> implements Json.Serializable, Iterable<LongMap.Entry<V>>
 		keys2.valid = true;
 		keys1.valid = false;
 		return keys2;
-	}
-
-	public void write (Json json) {
-		json.writeArrayStart("entries");
-		for (Entry<V> entry : entries()) {
-			// we're working around the lack of precise 64-bit integers in JSON here
-			json.writeValue((int)(entry.key >>> 32), Integer.class);
-			json.writeValue((int)entry.key, Integer.class);
-			json.writeValue(entry.value, null);
-		}
-		json.writeArrayEnd();
-	}
-
-	public void read (Json json, JsonValue jsonData) {
-		for (JsonValue child = jsonData.get("entries").child; child != null; child = child.next) {
-			long key = (child.asInt() & 0xFFFFFFFFL) << 32;
-			key |= (child = child.next).asInt() & 0xFFFFFFFFL;
-			V value = json.readValue(null, child = child.next);
-			put(key, value);
-		}
 	}
 
 	static public class Entry<V> {

--- a/gdx/src/com/badlogic/gdx/utils/LongMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/LongMap.java
@@ -232,10 +232,6 @@ public class LongMap<V> implements Iterable<LongMap.Entry<V>> {
 				put(k, valueTable[i]);
 		}
 	}
-	// the old version; I think the new way avoids a little work
-//	   ensureCapacity(map.size);
-//		for (Entry<? extends V> entry : map.entries())
-//			put(entry.key, entry.value);
 
 	/**
 	 * Skips checks for existing keys.

--- a/gdx/src/com/badlogic/gdx/utils/LongMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/LongMap.java
@@ -105,7 +105,7 @@ public class LongMap<V> implements Iterable<LongMap.Entry<V>> {
 			throw new IllegalArgumentException("initialCapacity must be >= 0: " + initialCapacity);
 		if (loadFactor <= 0f || loadFactor >= 1f)
 			throw new IllegalArgumentException("loadFactor must be > 0 and < 1: " + loadFactor);
-		initialCapacity = MathUtils.nextPowerOfTwo((int)Math.ceil(initialCapacity / loadFactor));
+		initialCapacity = MathUtils.nextPowerOfTwo((int)Math.ceil(Math.max(1, initialCapacity) / loadFactor));
 		if (initialCapacity > 1 << 30)
 			throw new IllegalArgumentException("initialCapacity is too large: " + initialCapacity);
 
@@ -484,7 +484,7 @@ public class LongMap<V> implements Iterable<LongMap.Entry<V>> {
 		valueTable = (V[])new Object[newSize];
 
 		int oldSize = size;
-		size = 0;
+		size = hasZeroValue ? 1 : 0;
 		if (oldSize > 0) {
 			for (int i = 0; i < oldCapacity; i++) {
 				long key = oldKeyTable[i];

--- a/gdx/src/com/badlogic/gdx/utils/LongMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/LongMap.java
@@ -320,11 +320,14 @@ public class LongMap<V> implements Iterable<LongMap.Entry<V>> {
 		final long[] keyTable = this.keyTable;
 		final V[] valueTable = this.valueTable;
 		V oldValue = valueTable[loc];
-		while ((key = keyTable[loc + 1 & mask]) != 0L && (loc + 1 & mask) != place(key)) {
+		int nl = (loc + 1 & mask);
+		while ((key = keyTable[nl]) != 0L && nl != place(key)) {
 			keyTable[loc] = key;
-			valueTable[loc] = valueTable[++loc & mask];
+			valueTable[loc] = valueTable[nl];
+			loc = nl;
+			nl = loc + 1 & mask;
 		}
-		keyTable[loc] = 0;
+		keyTable[loc] = 0L;
 		valueTable[loc] = null;
 		--size;
 		return oldValue;
@@ -741,13 +744,14 @@ public class LongMap<V> implements Iterable<LongMap.Entry<V>> {
 			} else {
 				final long[] keyTable = map.keyTable;
 				final V[] valueTable = map.valueTable;
-				int loc = currentIndex;
-				long key;
 				final int mask = map.mask;
-				while ((key = keyTable[loc + 1 & mask]) != 0 && (loc + 1 & mask) != map.place(key)) {
+				int loc = currentIndex, nl = (loc + 1 & mask);
+				long key;
+				while ((key = keyTable[nl]) != 0 && nl != map.place(key)) {
 					keyTable[loc] = key;
-					valueTable[loc] = valueTable[loc + 1 & mask];
-					++loc;
+					valueTable[loc] = valueTable[nl];
+					loc = nl;
+					nl = loc + 1 & mask;
 				}
 				if(loc != currentIndex) --nextIndex;
 				keyTable[loc] = 0;

--- a/gdx/src/com/badlogic/gdx/utils/LongMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/LongMap.java
@@ -39,10 +39,6 @@ import java.util.NoSuchElementException;
  * Load factors greater than 0.91 greatly increase the chances the map will have to rehash to the next higher POT size.
  * Memory usage is excellent, and the aforementioned collision-resistance helps avoid too much capacity resizing.
  * <br>
- * The <a href="http://codecapsule.com/2013/11/17/robin-hood-hashing-backward-shift-deletion/">backward-shift algorithm</a>
- * used during removal apparently is key to the good performance of this implementation, even though this doesn't use Robin Hood
- * hashing; the performance of {@link #remove(long)} has improved considerably over the previous libGDX version.
- * <br>
  * Iteration won't be as fast here as with OrderedSet and OrderedMap.
  *
  * @author Tommy Ettinger
@@ -149,7 +145,7 @@ public class LongMap<V> implements Iterable<LongMap.Entry<V>> {
 	 * {@code return (int) ((item ^ item >>> 32) * 0x9E3779B97F4A7C15L >>> shift);}
 	 * <br>
 	 * This can be overridden by subclasses, which you may want to do if your key type needs special consideration for
-	 * its hash (such as if you use arrays as keys, which still requires that the arrays are not modified). Subclasses
+	 * its hash (such as if you can't modify or extend a particular class that has an incorrect hashCode()). Subclasses
 	 * that don't need the collision decrease of Fibonacci Hashing (assuming the keys are well-distributed) may do
 	 * fine with a simple implementation:
 	 * {@code return ((int)(item ^ item >>> 32) & mask);}

--- a/gdx/src/com/badlogic/gdx/utils/LongMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/LongMap.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,83 +16,175 @@
 
 package com.badlogic.gdx.utils;
 
+import com.badlogic.gdx.math.MathUtils;
+
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
-import com.badlogic.gdx.math.MathUtils;
-
-/** An unordered map that uses long keys. This implementation is a cuckoo hash map using 3 hashes, random walking, and a small
- * stash for problematic keys. Null values are allowed. No allocation is done except when growing the table size. <br>
+/**
+ * An unordered map where the keys are unboxed longs and values are objects. This implementation uses linear probing with the
+ * backward-shift algorithm for removal, and finds space for keys using Fibonacci hashing instead of the more-common power-of-two
+ * mask. Null keys are not allowed. No allocation is done except when growing the table size.
  * <br>
- * This map performs very fast get, containsKey, and remove (typically O(1), worst case O(log(n))). Put may be a bit slower,
- * depending on hash collisions. Load factors greater than 0.91 greatly increase the chances the map will have to rehash to the
- * next higher POT size.
- * @author Nathan Sweet */
-public class LongMap<V> implements Iterable<LongMap.Entry<V>> {
-	private static final int PRIME1 = 0xbe1f14b1;
-	private static final int PRIME2 = 0xb4b82e39;
-	private static final int PRIME3 = 0xced1c241;
-	private static final int EMPTY = 0;
-
+ * This map uses Fibonacci hashing to help distribute what may be very bad hashCode() results across the
+ * whole capacity. See <a href="https://probablydance.com/2018/06/16/fibonacci-hashing-the-optimization-that-the-world-forgot-or-a-better-alternative-to-integer-modulo/">Malte Skarupke's blog post</a>
+ * for more information on Fibonacci hashing. It uses linear probing to resolve collisions, which is far from the academically
+ * optimal algorithm, but performs considerably better in practice than most alternatives, and combined with Fibonacci hashing, it
+ * can handle "normal" generated hashCode() implementations, and not just theoretically optimal hashing functions. Even if all
+ * hashCode()s this is given collide, it will still work, just slowly; the older libGDX implementation using cuckoo hashing would
+ * crash with an OutOfMemoryError with under 50 collisions.
+ * <br>
+ * This map performs very fast contains and remove (typically O(1), worst case O(n) due to occasional probing, but still very
+ * fast). Add may be a bit slower, depending on hash collisions, but this data structure is somewhat collision-resistant.
+ * Load factors greater than 0.91 greatly increase the chances the map will have to rehash to the next higher POT size.
+ * Memory usage is excellent, and the aforementioned collision-resistance helps avoid too much capacity resizing.
+ * <br>
+ * The <a href="http://codecapsule.com/2013/11/17/robin-hood-hashing-backward-shift-deletion/">backward-shift algorithm</a>
+ * used during removal apparently is key to the good performance of this implementation, even though this doesn't use Robin Hood
+ * hashing; the performance of {@link #remove(long)} has improved considerably over the previous libGDX version.
+ * <br>
+ * Iteration won't be as fast here as with OrderedSet and OrderedMap.
+ *
+ * @author Tommy Ettinger
+ * @author Nathan Sweet
+ */
+public class LongMap<V> implements Json.Serializable, Iterable<LongMap.Entry<V>> {
 	public int size;
 
-	long[] keyTable;
-	V[] valueTable;
-	int capacity, stashSize;
-	V zeroValue;
-	boolean hasZeroValue;
+	private long[] keyTable;
+	private V[] valueTable;
+
+	private V zeroValue;
+	private boolean hasZeroValue;
 
 	private float loadFactor;
-	private int hashShift, mask, threshold;
-	private int stashCapacity;
-	private int pushIterations;
+	private int threshold;
+	/**
+	 * Used by {@link #place(long)} to bit-shift the upper bits of a {@code long} into a usable range (less than or
+	 * equal to {@link #mask}, greater than or equal to 0). If you're setting it in a subclass, this shift can be
+	 * negative, which is a convenient way to match the number of bits in mask; if mask is a 7-bit number, then a shift
+	 * of -7 will correctly shift the upper 7 bits into the lowest 7 positions. If using what this class sets, shift
+	 * will be greater than 32 and less than 64; if you use this shift with an int, it will still correctly move the
+	 * upper bits of an int to the lower bits, thanks to Java's implicit modulus on shifts.
+	 * <br>
+	 * You can also use {@link #mask} to mask the low bits of a number, which may be faster for some hashCode()s, if you
+	 * reimplement {@link #place(long)}.
+	 */
+	private int shift;
+	/**
+	 * The bitmask used to contain hashCode()s to the indices that can be fit into the key array this uses. This should
+	 * always be all-1-bits in its low positions; that is, it must be a power of two minus 1. If you subclass and change
+	 * {@link #place(long)}, you may want to use this instead of {@link #shift} to isolate usable bits of a hash.
+	 */
+	private int mask;
 
 	private Entries entries1, entries2;
 	private Values values1, values2;
 	private Keys keys1, keys2;
 
-	/** Creates a new map with an initial capacity of 51 and a load factor of 0.8. */
+	/**
+	 * Creates a new map with an initial capacity of 51 and a load factor of 0.8.
+	 */
 	public LongMap () {
 		this(51, 0.8f);
 	}
 
-	/** Creates a new map with a load factor of 0.8.
-	 * @param initialCapacity If not a power of two, it is increased to the next nearest power of two. */
+	/**
+	 * Creates a new map with a load factor of 0.8.
+	 *
+	 * @param initialCapacity If not a power of two, it is increased to the next nearest power of two.
+	 */
 	public LongMap (int initialCapacity) {
 		this(initialCapacity, 0.8f);
 	}
 
-	/** Creates a new map with the specified initial capacity and load factor. This map will hold initialCapacity items before
+	/**
+	 * Creates a new map with the specified initial capacity and load factor. This map will hold initialCapacity items before
 	 * growing the backing table.
-	 * @param initialCapacity If not a power of two, it is increased to the next nearest power of two. */
+	 *
+	 * @param initialCapacity If not a power of two, it is increased to the next nearest power of two.
+	 */
 	public LongMap (int initialCapacity, float loadFactor) {
-		if (loadFactor <= 0) throw new IllegalArgumentException("loadFactor must be > 0: " + loadFactor);
+		if (initialCapacity < 0)
+			throw new IllegalArgumentException("initialCapacity must be >= 0: " + initialCapacity);
+		if (loadFactor <= 0f || loadFactor >= 1f)
+			throw new IllegalArgumentException("loadFactor must be > 0 and < 1: " + loadFactor);
+		initialCapacity = MathUtils.nextPowerOfTwo((int)Math.ceil(initialCapacity / loadFactor));
+		if (initialCapacity > 1 << 30)
+			throw new IllegalArgumentException("initialCapacity is too large: " + initialCapacity);
+
 		this.loadFactor = loadFactor;
 
-		if (initialCapacity < 0) throw new IllegalArgumentException("initialCapacity must be >= 0: " + initialCapacity);
-		initialCapacity = MathUtils.nextPowerOfTwo((int)Math.ceil(initialCapacity / loadFactor));
-		if (initialCapacity > 1 << 30) throw new IllegalArgumentException("initialCapacity is too large: " + initialCapacity);
-		capacity = initialCapacity;
+		threshold = (int)(initialCapacity * loadFactor);
+		mask = initialCapacity - 1;
+		shift = Long.numberOfLeadingZeros(mask);
 
-		threshold = (int)(capacity * loadFactor);
-		mask = capacity - 1;
-		hashShift = 63 - Long.numberOfTrailingZeros(capacity);
-		stashCapacity = Math.max(3, (int)Math.ceil(Math.log(capacity)) * 2);
-		pushIterations = Math.max(Math.min(capacity, 8), (int)Math.sqrt(capacity) / 8);
-
-		keyTable = new long[capacity + stashCapacity];
-		valueTable = (V[])new Object[keyTable.length];
+		keyTable = new long[initialCapacity];
+		valueTable = (V[])new Object[initialCapacity];
 	}
 
-	/** Creates a new map identical to the specified map. */
+	/**
+	 * Creates a new map identical to the specified map.
+	 */
 	public LongMap (LongMap<? extends V> map) {
-		this((int)Math.floor(map.capacity * map.loadFactor), map.loadFactor);
-		stashSize = map.stashSize;
+		this((int)(map.keyTable.length * map.loadFactor), map.loadFactor);
 		System.arraycopy(map.keyTable, 0, keyTable, 0, map.keyTable.length);
 		System.arraycopy(map.valueTable, 0, valueTable, 0, map.valueTable.length);
 		size = map.size;
 		zeroValue = map.zeroValue;
 		hasZeroValue = map.hasZeroValue;
+	}
+
+	/**
+	 * Finds an array index between 0 and {@link #mask}, both inclusive, corresponding to the hash code of {@code item}.
+	 * By default, this uses "Fibonacci Hashing" on the long {@code item} with mixed upper and lower bits; this multiplies
+	 * {@code item} by a long constant (2 to the 64, divided by the golden ratio) and shifts the high-quality
+	 * uppermost bits into the lowest positions so they can be used as array indices. The multiplication by a long may
+	 * be somewhat slow on GWT, but it will be correct across all platforms and won't lose precision. Using Fibonacci
+	 * Hashing allows even very poor hashCode() implementations, such as those that only differ in their upper bits, to
+	 * work in a hash table without heavy collision rates. It has known problems when all or most hashCode()s are
+	 * multiples of larger Fibonacci numbers; see <a href="https://probablydance.com/2018/06/16/fibonacci-hashing-the-optimization-that-the-world-forgot-or-a-better-alternative-to-integer-modulo/">this blog post by Malte Skarupke</a>
+	 * for more details. In the unlikely event that most of your hashCode()s are Fibonacci numbers, you can subclass
+	 * this to change this method, which is a one-liner in this form:
+	 * {@code return (int) ((item ^ item >>> 32) * 0x9E3779B97F4A7C15L >>> shift);}
+	 * <br>
+	 * This can be overridden by subclasses, which you may want to do if your key type needs special consideration for
+	 * its hash (such as if you use arrays as keys, which still requires that the arrays are not modified). Subclasses
+	 * that don't need the collision decrease of Fibonacci Hashing (assuming the keys are well-distributed) may do
+	 * fine with a simple implementation:
+	 * {@code return ((int)(item ^ item >>> 32) & mask);}
+	 *
+	 * @param item a key that this method will use to get a hashed position
+	 * @return an int between 0 and {@link #mask}, both inclusive
+	 */
+	private int place (final long item) {
+		// shift is always greater than 32, less than 64
+		return (int)((item ^ item >>> 32) * 0x9E3779B97F4A7C15L >>> shift);
+	}
+
+	private int locateKey (final long key) {
+		return locateKey(key, place(key));
+	}
+
+	/**
+	 * Given a key and its initial placement to try in an array, this finds the actual location of the key in the array
+	 * if it is present, or -1 if the key is not present. This can be overridden if a subclass needs to compare for
+	 * equality differently than just by using == with int keys, but only within the same package.
+	 *
+	 * @param key       a K key that will be checked for equality if a similar-seeming key is found
+	 * @param placement as calculated by {@link #place(long)}, almost always with {@code place(key)}
+	 * @return the location in the key array of key, if found, or -1 if it was not found.
+	 */
+	private int locateKey (final long key, final int placement) {
+		for (int i = placement; ; i = i + 1 & mask) {
+			// empty space is available
+			if (keyTable[i] == 0) {
+				return -1;
+			}
+			if (key == (keyTable[i])) {
+				return i;
+			}
+		}
 	}
 
 	public V put (long key, V value) {
@@ -106,238 +198,118 @@ public class LongMap<V> implements Iterable<LongMap.Entry<V>> {
 			return oldValue;
 		}
 
-		long[] keyTable = this.keyTable;
-
-		// Check for existing keys.
-		int index1 = (int)(key & mask);
-		long key1 = keyTable[index1];
-		if (key1 == key) {
-			V oldValue = valueTable[index1];
-			valueTable[index1] = value;
-			return oldValue;
+		int b = place(key);
+		int loc = locateKey(key, b);
+		// an identical key already exists
+		if (loc != -1) {
+			V tv = valueTable[loc];
+			valueTable[loc] = value;
+			return tv;
 		}
+		final long[] keyTable = this.keyTable;
+		final V[] valueTable = this.valueTable;
 
-		int index2 = hash2(key);
-		long key2 = keyTable[index2];
-		if (key2 == key) {
-			V oldValue = valueTable[index2];
-			valueTable[index2] = value;
-			return oldValue;
-		}
-
-		int index3 = hash3(key);
-		long key3 = keyTable[index3];
-		if (key3 == key) {
-			V oldValue = valueTable[index3];
-			valueTable[index3] = value;
-			return oldValue;
-		}
-
-		// Update key in the stash.
-		for (int i = capacity, n = i + stashSize; i < n; i++) {
-			if (keyTable[i] == key) {
-				V oldValue = valueTable[i];
+		for (int i = b; ; i = (i + 1) & mask) {
+			// space is available so we insert and break
+			if (keyTable[i] == 0) {
+				keyTable[i] = key;
 				valueTable[i] = value;
-				return oldValue;
+
+				if (++size >= threshold) {
+					resize(keyTable.length << 1);
+				}
+				return null;
 			}
 		}
-
-		// Check for empty buckets.
-		if (key1 == EMPTY) {
-			keyTable[index1] = key;
-			valueTable[index1] = value;
-			if (size++ >= threshold) resize(capacity << 1);
-			return null;
-		}
-
-		if (key2 == EMPTY) {
-			keyTable[index2] = key;
-			valueTable[index2] = value;
-			if (size++ >= threshold) resize(capacity << 1);
-			return null;
-		}
-
-		if (key3 == EMPTY) {
-			keyTable[index3] = key;
-			valueTable[index3] = value;
-			if (size++ >= threshold) resize(capacity << 1);
-			return null;
-		}
-
-		push(key, value, index1, key1, index2, key2, index3, key3);
-		return null;
+		// never reached
 	}
 
 	public void putAll (LongMap<? extends V> map) {
-		for (Entry<? extends V> entry : map.entries())
-			put(entry.key, entry.value);
+		ensureCapacity(map.size);
+		if (map.hasZeroValue)
+			put(0, map.zeroValue);
+		final long[] keyTable = map.keyTable;
+		final V[] valueTable = map.valueTable;
+		long k;
+		for (int i = 0, n = keyTable.length; i < n; i++) {
+			if ((k = keyTable[i]) != 0)
+				put(k, valueTable[i]);
+		}
 	}
+	// the old version; I think the new way avoids a little work
+//	   ensureCapacity(map.size);
+//		for (Entry<? extends V> entry : map.entries())
+//			put(entry.key, entry.value);
 
-	/** Skips checks for existing keys. */
+	/**
+	 * Skips checks for existing keys.
+	 */
 	private void putResize (long key, V value) {
 		if (key == 0) {
 			zeroValue = value;
-			hasZeroValue = true;
-			return;
-		}
-
-		// Check for empty buckets.
-		int index1 = (int)(key & mask);
-		long key1 = keyTable[index1];
-		if (key1 == EMPTY) {
-			keyTable[index1] = key;
-			valueTable[index1] = value;
-			if (size++ >= threshold) resize(capacity << 1);
-			return;
-		}
-
-		int index2 = hash2(key);
-		long key2 = keyTable[index2];
-		if (key2 == EMPTY) {
-			keyTable[index2] = key;
-			valueTable[index2] = value;
-			if (size++ >= threshold) resize(capacity << 1);
-			return;
-		}
-
-		int index3 = hash3(key);
-		long key3 = keyTable[index3];
-		if (key3 == EMPTY) {
-			keyTable[index3] = key;
-			valueTable[index3] = value;
-			if (size++ >= threshold) resize(capacity << 1);
-			return;
-		}
-
-		push(key, value, index1, key1, index2, key2, index3, key3);
-	}
-
-	private void push (long insertKey, V insertValue, int index1, long key1, int index2, long key2, int index3, long key3) {
-		long[] keyTable = this.keyTable;
-		V[] valueTable = this.valueTable;
-		int mask = this.mask;
-
-		// Push keys until an empty bucket is found.
-		long evictedKey;
-		V evictedValue;
-		int i = 0, pushIterations = this.pushIterations;
-		do {
-			// Replace the key and value for one of the hashes.
-			switch (MathUtils.random(2)) {
-			case 0:
-				evictedKey = key1;
-				evictedValue = valueTable[index1];
-				keyTable[index1] = insertKey;
-				valueTable[index1] = insertValue;
-				break;
-			case 1:
-				evictedKey = key2;
-				evictedValue = valueTable[index2];
-				keyTable[index2] = insertKey;
-				valueTable[index2] = insertValue;
-				break;
-			default:
-				evictedKey = key3;
-				evictedValue = valueTable[index3];
-				keyTable[index3] = insertKey;
-				valueTable[index3] = insertValue;
-				break;
+			if (!hasZeroValue) {
+				hasZeroValue = true;
+				size++;
 			}
+			return;
+		}
+		final long[] keyTable = this.keyTable;
+		final V[] valueTable = this.valueTable;
+		int b = place(key);
+		for (int i = b; ; i = (i + 1) & mask) {
+			// space is available so we insert and break (resize is later)
+			if (keyTable[i] == 0) {
+				keyTable[i] = key;
+				valueTable[i] = value;
 
-			// If the evicted key hashes to an empty bucket, put it there and stop.
-			index1 = (int)(evictedKey & mask);
-			key1 = keyTable[index1];
-			if (key1 == EMPTY) {
-				keyTable[index1] = evictedKey;
-				valueTable[index1] = evictedValue;
-				if (size++ >= threshold) resize(capacity << 1);
+				if (++size >= threshold) {
+					resize(keyTable.length << 1);
+				}
 				return;
 			}
-
-			index2 = hash2(evictedKey);
-			key2 = keyTable[index2];
-			if (key2 == EMPTY) {
-				keyTable[index2] = evictedKey;
-				valueTable[index2] = evictedValue;
-				if (size++ >= threshold) resize(capacity << 1);
-				return;
-			}
-
-			index3 = hash3(evictedKey);
-			key3 = keyTable[index3];
-			if (key3 == EMPTY) {
-				keyTable[index3] = evictedKey;
-				valueTable[index3] = evictedValue;
-				if (size++ >= threshold) resize(capacity << 1);
-				return;
-			}
-
-			if (++i == pushIterations) break;
-
-			insertKey = evictedKey;
-			insertValue = evictedValue;
-		} while (true);
-
-		putStash(evictedKey, evictedValue);
-	}
-
-	private void putStash (long key, V value) {
-		if (stashSize == stashCapacity) {
-			// Too many pushes occurred and the stash is full, increase the table size.
-			resize(capacity << 1);
-			putResize(key, value);
-			return;
 		}
-		// Store key in the stash.
-		int index = capacity + stashSize;
-		keyTable[index] = key;
-		valueTable[index] = value;
-		stashSize++;
-		size++;
 	}
 
 	public V get (long key) {
 		if (key == 0) {
-			if (!hasZeroValue) return null;
+			if (!hasZeroValue)
+				return null;
 			return zeroValue;
 		}
-		int index = (int)(key & mask);
-		if (keyTable[index] != key) {
-			index = hash2(key);
-			if (keyTable[index] != key) {
-				index = hash3(key);
-				if (keyTable[index] != key) return getStash(key, null);
+		final int placement = place(key);
+		for (int i = placement; ; i = i + 1 & mask) {
+			// empty space is available
+			if (keyTable[i] == 0) {
+				return null;
+			}
+			if (key == (keyTable[i])) {
+				return valueTable[i];
 			}
 		}
-		return valueTable[index];
 	}
 
 	public V get (long key, V defaultValue) {
 		if (key == 0) {
-			if (!hasZeroValue) return defaultValue;
+			if (!hasZeroValue)
+				return defaultValue;
 			return zeroValue;
 		}
-		int index = (int)(key & mask);
-		if (keyTable[index] != key) {
-			index = hash2(key);
-			if (keyTable[index] != key) {
-				index = hash3(key);
-				if (keyTable[index] != key) return getStash(key, defaultValue);
+		final int placement = place(key);
+		for (int i = placement; ; i = i + 1 & mask) {
+			// empty space is available
+			if (keyTable[i] == 0) {
+				return defaultValue;
+			}
+			if (key == (keyTable[i])) {
+				return valueTable[i];
 			}
 		}
-		return valueTable[index];
-	}
-
-	private V getStash (long key, V defaultValue) {
-		long[] keyTable = this.keyTable;
-		for (int i = capacity, n = i + stashSize; i < n; i++)
-			if (keyTable[i] == key) return valueTable[i];
-		return defaultValue;
 	}
 
 	public V remove (long key) {
 		if (key == 0) {
-			if (!hasZeroValue) return null;
+			if (!hasZeroValue)
+				return null;
 			V oldValue = zeroValue;
 			zeroValue = null;
 			hasZeroValue = false;
@@ -345,84 +317,56 @@ public class LongMap<V> implements Iterable<LongMap.Entry<V>> {
 			return oldValue;
 		}
 
-		int index = (int)(key & mask);
-		if (keyTable[index] == key) {
-			keyTable[index] = EMPTY;
-			V oldValue = valueTable[index];
-			valueTable[index] = null;
-			size--;
-			return oldValue;
+		int loc = locateKey(key);
+		if (loc == -1) {
+			return null;
 		}
-
-		index = hash2(key);
-		if (keyTable[index] == key) {
-			keyTable[index] = EMPTY;
-			V oldValue = valueTable[index];
-			valueTable[index] = null;
-			size--;
-			return oldValue;
+		final long[] keyTable = this.keyTable;
+		final V[] valueTable = this.valueTable;
+		V oldValue = valueTable[loc];
+		while ((key = keyTable[loc + 1 & mask]) != 0L && (loc + 1 & mask) != place(key)) {
+			keyTable[loc] = key;
+			valueTable[loc] = valueTable[++loc & mask];
 		}
-
-		index = hash3(key);
-		if (keyTable[index] == key) {
-			keyTable[index] = EMPTY;
-			V oldValue = valueTable[index];
-			valueTable[index] = null;
-			size--;
-			return oldValue;
-		}
-
-		return removeStash(key);
+		keyTable[loc] = 0;
+		valueTable[loc] = null;
+		--size;
+		return oldValue;
 	}
 
-	V removeStash (long key) {
-		long[] keyTable = this.keyTable;
-		for (int i = capacity, n = i + stashSize; i < n; i++) {
-			if (keyTable[i] == key) {
-				V oldValue = valueTable[i];
-				removeStashIndex(i);
-				size--;
-				return oldValue;
-			}
-		}
-		return null;
-	}
-
-	void removeStashIndex (int index) {
-		// If the removed location was not last, move the last tuple to the removed location.
-		stashSize--;
-		int lastIndex = capacity + stashSize;
-		if (index < lastIndex) {
-			keyTable[index] = keyTable[lastIndex];
-			valueTable[index] = valueTable[lastIndex];
-			valueTable[lastIndex] = null;
-		} else
-			valueTable[index] = null;
-	}
-
-	/** Returns true if the map has one or more items. */
+	/**
+	 * Returns true if the map has one or more items.
+	 */
 	public boolean notEmpty () {
 		return size > 0;
 	}
 
-	/** Returns true if the map is empty. */
+	/**
+	 * Returns true if the map is empty.
+	 */
 	public boolean isEmpty () {
 		return size == 0;
 	}
 
-	/** Reduces the size of the backing arrays to be the specified capacity or less. If the capacity is already less, nothing is
-	 * done. If the map contains more items than the specified capacity, the next highest power of two capacity is used instead. */
+	/**
+	 * Reduces the size of the backing arrays to be the specified capacity or less. If the capacity is already less, nothing is
+	 * done. If the map contains more items than the specified capacity, the next highest power of two capacity is used instead.
+	 */
 	public void shrink (int maximumCapacity) {
-		if (maximumCapacity < 0) throw new IllegalArgumentException("maximumCapacity must be >= 0: " + maximumCapacity);
-		if (size > maximumCapacity) maximumCapacity = size;
-		if (capacity <= maximumCapacity) return;
-		maximumCapacity = MathUtils.nextPowerOfTwo(maximumCapacity);
-		resize(maximumCapacity);
+		if (maximumCapacity < 0)
+			throw new IllegalArgumentException("maximumCapacity must be >= 0: " + maximumCapacity);
+		if (size > maximumCapacity)
+			maximumCapacity = size;
+		if (keyTable.length <= maximumCapacity)
+			return;
+		resize(MathUtils.nextPowerOfTwo(maximumCapacity));
 	}
 
-	/** Clears the map and reduces the size of the backing arrays to be the specified capacity if they are larger. */
+	/**
+	 * Clears the map and reduces the size of the backing arrays to be the specified capacity if they are larger.
+	 */
 	public void clear (int maximumCapacity) {
-		if (capacity <= maximumCapacity) {
+		if (keyTable.length <= maximumCapacity) {
 			clear();
 			return;
 		}
@@ -433,140 +377,136 @@ public class LongMap<V> implements Iterable<LongMap.Entry<V>> {
 	}
 
 	public void clear () {
-		if (size == 0) return;
-		long[] keyTable = this.keyTable;
-		V[] valueTable = this.valueTable;
-		for (int i = capacity + stashSize; i-- > 0;) {
-			keyTable[i] = EMPTY;
+		if (size == 0)
+			return;
+		final long[] keyTable = this.keyTable;
+		final V[] valueTable = this.valueTable;
+		for (int i = keyTable.length; i > 0; ) {
+			keyTable[--i] = 0;
 			valueTable[i] = null;
 		}
 		size = 0;
-		stashSize = 0;
 		zeroValue = null;
 		hasZeroValue = false;
 	}
 
-	/** Returns true if the specified value is in the map. Note this traverses the entire map and compares every value, which may
-	 * be an expensive operation. */
+	/**
+	 * Returns true if the specified value is in the map. Note this traverses the entire map and compares every value, which may
+	 * be an expensive operation.
+	 *
+	 * @param identity If true, uses == to compare the specified value with values in the map. If false, uses
+	 *                 {@link #equals(Object)}.
+	 */
 	public boolean containsValue (Object value, boolean identity) {
-		V[] valueTable = this.valueTable;
+		final V[] valueTable = this.valueTable;
 		if (value == null) {
-			if (hasZeroValue && zeroValue == null) return true;
+			if (hasZeroValue && zeroValue == null)
+				return true;
 			long[] keyTable = this.keyTable;
-			for (int i = capacity + stashSize; i-- > 0;)
-				if (keyTable[i] != EMPTY && valueTable[i] == null) return true;
+			for (int i = valueTable.length; i-- > 0; )
+				if (keyTable[i] != 0 && valueTable[i] == null)
+					return true;
 		} else if (identity) {
-			if (value == zeroValue) return true;
-			for (int i = capacity + stashSize; i-- > 0;)
-				if (valueTable[i] == value) return true;
+			if (value == zeroValue)
+				return true;
+			for (int i = valueTable.length; i-- > 0; )
+				if (valueTable[i] == value)
+					return true;
 		} else {
-			if (hasZeroValue && value.equals(zeroValue)) return true;
-			for (int i = capacity + stashSize; i-- > 0;)
-				if (value.equals(valueTable[i])) return true;
+			if (hasZeroValue && value.equals(zeroValue))
+				return true;
+			for (int i = valueTable.length; i-- > 0; )
+				if (value.equals(valueTable[i]))
+					return true;
 		}
 		return false;
+
 	}
 
 	public boolean containsKey (long key) {
-		if (key == 0) return hasZeroValue;
-		int index = (int)(key & mask);
-		if (keyTable[index] != key) {
-			index = hash2(key);
-			if (keyTable[index] != key) {
-				index = hash3(key);
-				if (keyTable[index] != key) return containsKeyStash(key);
-			}
-		}
-		return true;
+		if (key == 0)
+			return hasZeroValue;
+		return locateKey(key) != -1;
 	}
 
-	private boolean containsKeyStash (long key) {
-		long[] keyTable = this.keyTable;
-		for (int i = capacity, n = i + stashSize; i < n; i++)
-			if (keyTable[i] == key) return true;
-		return false;
-	}
-
-	/** Returns the key for the specified value, or <tt>notFound</tt> if it is not in the map. Note this traverses the entire map
+	/**
+	 * Returns the key for the specified value, or <tt>notFound</tt> if it is not in the map. Note this traverses the entire map
 	 * and compares every value, which may be an expensive operation.
+	 *
 	 * @param identity If true, uses == to compare the specified value with values in the map. If false, uses
-	 *           {@link #equals(Object)}. */
+	 *                 {@link #equals(Object)}.
+	 */
 	public long findKey (Object value, boolean identity, long notFound) {
-		V[] valueTable = this.valueTable;
+		final V[] valueTable = this.valueTable;
 		if (value == null) {
-			if (hasZeroValue && zeroValue == null) return 0;
+			if (hasZeroValue && zeroValue == null)
+				return 0;
 			long[] keyTable = this.keyTable;
-			for (int i = capacity + stashSize; i-- > 0;)
-				if (keyTable[i] != EMPTY && valueTable[i] == null) return keyTable[i];
+			for (int i = valueTable.length; i-- > 0; )
+				if (keyTable[i] != 0 && valueTable[i] == null)
+					return keyTable[i];
 		} else if (identity) {
-			if (value == zeroValue) return 0;
-			for (int i = capacity + stashSize; i-- > 0;)
-				if (valueTable[i] == value) return keyTable[i];
+			if (value == zeroValue)
+				return 0;
+			for (int i = valueTable.length; i-- > 0; )
+				if (valueTable[i] == value)
+					return keyTable[i];
 		} else {
-			if (hasZeroValue && value.equals(zeroValue)) return 0;
-			for (int i = capacity + stashSize; i-- > 0;)
-				if (value.equals(valueTable[i])) return keyTable[i];
+			if (hasZeroValue && value.equals(zeroValue))
+				return 0;
+			for (int i = valueTable.length; i-- > 0; )
+				if (value.equals(valueTable[i]))
+					return keyTable[i];
 		}
 		return notFound;
 	}
 
-	/** Increases the size of the backing array to accommodate the specified number of additional items. Useful before adding many
-	 * items to avoid multiple backing array resizes. */
+	/**
+	 * Increases the size of the backing array to accommodate the specified number of additional items. Useful before adding many
+	 * items to avoid multiple backing array resizes.
+	 */
 	public void ensureCapacity (int additionalCapacity) {
-		if (additionalCapacity < 0) throw new IllegalArgumentException("additionalCapacity must be >= 0: " + additionalCapacity);
+		if (additionalCapacity < 0)
+			throw new IllegalArgumentException("additionalCapacity must be >= 0: " + additionalCapacity);
 		int sizeNeeded = size + additionalCapacity;
-		if (sizeNeeded >= threshold) resize(MathUtils.nextPowerOfTwo((int)Math.ceil(sizeNeeded / loadFactor)));
+		if (sizeNeeded >= threshold)
+			resize(MathUtils.nextPowerOfTwo((int)Math.ceil(sizeNeeded / loadFactor)));
 	}
 
 	private void resize (int newSize) {
-		int oldEndIndex = capacity + stashSize;
-
-		capacity = newSize;
+		int oldCapacity = keyTable.length;
 		threshold = (int)(newSize * loadFactor);
 		mask = newSize - 1;
-		hashShift = 63 - Long.numberOfTrailingZeros(newSize);
-		stashCapacity = Math.max(3, (int)Math.ceil(Math.log(newSize)) * 2);
-		pushIterations = Math.max(Math.min(newSize, 8), (int)Math.sqrt(newSize) / 8);
+		shift = Long.numberOfLeadingZeros(mask);
 
-		long[] oldKeyTable = keyTable;
-		V[] oldValueTable = valueTable;
+		final long[] oldKeyTable = keyTable;
+		final V[] oldValueTable = valueTable;
 
-		keyTable = new long[newSize + stashCapacity];
-		valueTable = (V[])new Object[newSize + stashCapacity];
+		keyTable = new long[newSize];
+		valueTable = (V[])new Object[newSize];
 
 		int oldSize = size;
-		size = hasZeroValue ? 1 : 0;
-		stashSize = 0;
+		size = 0;
 		if (oldSize > 0) {
-			for (int i = 0; i < oldEndIndex; i++) {
+			for (int i = 0; i < oldCapacity; i++) {
 				long key = oldKeyTable[i];
-				if (key != EMPTY) putResize(key, oldValueTable[i]);
+				if (key != 0)
+					putResize(key, oldValueTable[i]);
 			}
 		}
 	}
 
-	private int hash2 (long h) {
-		h *= PRIME2;
-		return (int)((h ^ h >>> hashShift) & mask);
-	}
-
-	private int hash3 (long h) {
-		h *= PRIME3;
-		return (int)((h ^ h >>> hashShift) & mask);
-	}
-
 	public int hashCode () {
-		int h = 0;
+		int h = size;
 		if (hasZeroValue && zeroValue != null) {
-			h += zeroValue.hashCode();
+			h = zeroValue.hashCode();
 		}
 		long[] keyTable = this.keyTable;
 		V[] valueTable = this.valueTable;
-		for (int i = 0, n = capacity + stashSize; i < n; i++) {
+		for (int i = 0, n = keyTable.length; i < n; i++) {
 			long key = keyTable[i];
-			if (key != EMPTY) {
-				h += (int)(key ^ (key >>> 32)) * 31;
-
+			if (key != 0) {
+				h ^= key ^ key >>> 32;
 				V value = valueTable[i];
 				if (value != null) {
 					h += value.hashCode();
@@ -577,69 +517,93 @@ public class LongMap<V> implements Iterable<LongMap.Entry<V>> {
 	}
 
 	public boolean equals (Object obj) {
-		if (obj == this) return true;
-		if (!(obj instanceof LongMap)) return false;
+		if (obj == this)
+			return true;
+		if (!(obj instanceof LongMap))
+			return false;
 		LongMap other = (LongMap)obj;
-		if (other.size != size) return false;
-		if (other.hasZeroValue != hasZeroValue) return false;
+		if (other.size != size)
+			return false;
+		if (other.hasZeroValue != hasZeroValue)
+			return false;
 		if (hasZeroValue) {
 			if (other.zeroValue == null) {
-				if (zeroValue != null) return false;
+				if (zeroValue != null)
+					return false;
 			} else {
-				if (!other.zeroValue.equals(zeroValue)) return false;
+				if (!other.zeroValue.equals(zeroValue))
+					return false;
 			}
 		}
-		long[] keyTable = this.keyTable;
-		V[] valueTable = this.valueTable;
-		for (int i = 0, n = capacity + stashSize; i < n; i++) {
+		final long[] keyTable = this.keyTable;
+		final V[] valueTable = this.valueTable;
+		for (int i = 0, n = keyTable.length; i < n; i++) {
 			long key = keyTable[i];
-			if (key != EMPTY) {
+			if (key != 0) {
 				V value = valueTable[i];
 				if (value == null) {
-					if (other.get(key, ObjectMap.dummy) != null) return false;
+					if (other.get(key, ObjectMap.dummy) != null)
+						return false;
 				} else {
-					if (!value.equals(other.get(key))) return false;
+					if (!value.equals(other.get(key)))
+						return false;
 				}
 			}
 		}
 		return true;
 	}
 
-	/** Uses == for comparison of each value. */
+	/**
+	 * Uses == for comparison of each value.
+	 */
 	public boolean equalsIdentity (Object obj) {
-		if (obj == this) return true;
-		if (!(obj instanceof LongMap)) return false;
+		if (obj == this)
+			return true;
+		if (!(obj instanceof LongMap))
+			return false;
 		LongMap other = (LongMap)obj;
-		if (other.size != size) return false;
-		if (other.hasZeroValue != hasZeroValue) return false;
-		if (hasZeroValue && zeroValue != other.zeroValue) return false;
-		long[] keyTable = this.keyTable;
-		V[] valueTable = this.valueTable;
-		for (int i = 0, n = capacity + stashSize; i < n; i++) {
+		if (other.size != size)
+			return false;
+		if (other.hasZeroValue != hasZeroValue)
+			return false;
+		if (hasZeroValue && zeroValue != other.zeroValue)
+			return false;
+		final long[] keyTable = this.keyTable;
+		final V[] valueTable = this.valueTable;
+		for (int i = 0, n = keyTable.length; i < n; i++) {
 			long key = keyTable[i];
-			if (key != EMPTY && valueTable[i] != other.get(key, ObjectMap.dummy)) return false;
+			if (key != 0 && valueTable[i] != other.get(key, ObjectMap.dummy))
+				return false;
 		}
 		return true;
 	}
 
 	public String toString () {
-		if (size == 0) return "[]";
-		StringBuilder buffer = new StringBuilder(32);
+		if (size == 0)
+			return "[]";
+		java.lang.StringBuilder buffer = new java.lang.StringBuilder(32);
 		buffer.append('[');
-		long[] keyTable = this.keyTable;
-		V[] valueTable = this.valueTable;
+		final long[] keyTable = this.keyTable;
+		final V[] valueTable = this.valueTable;
 		int i = keyTable.length;
-		while (i-- > 0) {
-			long key = keyTable[i];
-			if (key == EMPTY) continue;
-			buffer.append(key);
-			buffer.append('=');
-			buffer.append(valueTable[i]);
-			break;
+		if (hasZeroValue) {
+			buffer.append("0=");
+			buffer.append(zeroValue);
+		} else {
+			while (i-- > 0) {
+				long key = keyTable[i];
+				if (key == 0)
+					continue;
+				buffer.append(key);
+				buffer.append('=');
+				buffer.append(valueTable[i]);
+				break;
+			}
 		}
 		while (i-- > 0) {
 			long key = keyTable[i];
-			if (key == EMPTY) continue;
+			if (key == 0)
+				continue;
 			buffer.append(", ");
 			buffer.append(key);
 			buffer.append('=');
@@ -653,12 +617,15 @@ public class LongMap<V> implements Iterable<LongMap.Entry<V>> {
 		return entries();
 	}
 
-	/** Returns an iterator for the entries in the map. Remove is supported.
+	/**
+	 * Returns an iterator for the entries in the map. Remove is supported.
 	 * <p>
 	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called.
-	 * Use the {@link Entries} constructor for nested or multithreaded iteration. */
+	 * Use the {@link Entries} constructor for nested or multithreaded iteration.
+	 */
 	public Entries<V> entries () {
-		if (Collections.allocateIterators) return new Entries(this);
+		if (Collections.allocateIterators)
+			return new Entries(this);
 		if (entries1 == null) {
 			entries1 = new Entries(this);
 			entries2 = new Entries(this);
@@ -675,12 +642,15 @@ public class LongMap<V> implements Iterable<LongMap.Entry<V>> {
 		return entries2;
 	}
 
-	/** Returns an iterator for the values in the map. Remove is supported.
+	/**
+	 * Returns an iterator for the values in the map. Remove is supported.
 	 * <p>
 	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called.
-	 * Use the {@link Entries} constructor for nested or multithreaded iteration. */
+	 * Use the {@link Entries} constructor for nested or multithreaded iteration.
+	 */
 	public Values<V> values () {
-		if (Collections.allocateIterators) return new Values(this);
+		if (Collections.allocateIterators)
+			return new Values(this);
 		if (values1 == null) {
 			values1 = new Values(this);
 			values2 = new Values(this);
@@ -697,12 +667,15 @@ public class LongMap<V> implements Iterable<LongMap.Entry<V>> {
 		return values2;
 	}
 
-	/** Returns an iterator for the keys in the map. Remove is supported.
+	/**
+	 * Returns an iterator for the keys in the map. Remove is supported.
 	 * <p>
 	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called.
-	 * Use the {@link Entries} constructor for nested or multithreaded iteration. */
+	 * Use the {@link Entries} constructor for nested or multithreaded iteration.
+	 */
 	public Keys keys () {
-		if (Collections.allocateIterators) return new Keys(this);
+		if (Collections.allocateIterators)
+			return new Keys(this);
 		if (keys1 == null) {
 			keys1 = new Keys(this);
 			keys2 = new Keys(this);
@@ -717,6 +690,26 @@ public class LongMap<V> implements Iterable<LongMap.Entry<V>> {
 		keys2.valid = true;
 		keys1.valid = false;
 		return keys2;
+	}
+
+	public void write (Json json) {
+		json.writeArrayStart("entries");
+		for (Entry<V> entry : entries()) {
+			// we're working around the lack of precise 64-bit integers in JSON here
+			json.writeValue((int)(entry.key >>> 32), Integer.class);
+			json.writeValue((int)entry.key, Integer.class);
+			json.writeValue(entry.value, null);
+		}
+		json.writeArrayEnd();
+	}
+
+	public void read (Json json, JsonValue jsonData) {
+		for (JsonValue child = jsonData.get("entries").child; child != null; child = child.next) {
+			long key = (child.asInt() & 0xFFFFFFFFL) << 32;
+			key |= (child = child.next).asInt() & 0xFFFFFFFFL;
+			V value = json.readValue(null, child = child.next);
+			put(key, value);
+		}
 	}
 
 	static public class Entry<V> {
@@ -755,8 +748,8 @@ public class LongMap<V> implements Iterable<LongMap.Entry<V>> {
 		void findNextIndex () {
 			hasNext = false;
 			long[] keyTable = map.keyTable;
-			for (int n = map.capacity + map.stashSize; ++nextIndex < n;) {
-				if (keyTable[nextIndex] != EMPTY) {
+			for (int n = keyTable.length; ++nextIndex < n; ) {
+				if (keyTable[nextIndex] != 0) {
 					hasNext = true;
 					break;
 				}
@@ -769,13 +762,20 @@ public class LongMap<V> implements Iterable<LongMap.Entry<V>> {
 				map.hasZeroValue = false;
 			} else if (currentIndex < 0) {
 				throw new IllegalStateException("next must be called before remove.");
-			} else if (currentIndex >= map.capacity) {
-				map.removeStashIndex(currentIndex);
-				nextIndex = currentIndex - 1;
-				findNextIndex();
 			} else {
-				map.keyTable[currentIndex] = EMPTY;
-				map.valueTable[currentIndex] = null;
+				final long[] keyTable = map.keyTable;
+				final V[] valueTable = map.valueTable;
+				int loc = currentIndex;
+				long key;
+				final int mask = map.mask;
+				while ((key = keyTable[loc + 1 & mask]) != 0 && (loc + 1 & mask) != map.place(key)) {
+					keyTable[loc] = key;
+					valueTable[loc] = valueTable[loc + 1 & mask];
+					++loc;
+				}
+				if(loc != currentIndex) --nextIndex;
+				keyTable[loc] = 0;
+				valueTable[loc] = null;
 			}
 			currentIndex = INDEX_ILLEGAL;
 			map.size--;
@@ -789,10 +789,14 @@ public class LongMap<V> implements Iterable<LongMap.Entry<V>> {
 			super(map);
 		}
 
-		/** Note the same entry instance is returned each time this method is called. */
+		/**
+		 * Note the same entry instance is returned each time this method is called.
+		 */
 		public Entry<V> next () {
-			if (!hasNext) throw new NoSuchElementException();
-			if (!valid) throw new GdxRuntimeException("#iterator() cannot be used nested.");
+			if (!hasNext)
+				throw new NoSuchElementException();
+			if (!valid)
+				throw new GdxRuntimeException("#iterator() cannot be used nested.");
 			long[] keyTable = map.keyTable;
 			if (nextIndex == INDEX_ZERO) {
 				entry.key = 0;
@@ -807,7 +811,8 @@ public class LongMap<V> implements Iterable<LongMap.Entry<V>> {
 		}
 
 		public boolean hasNext () {
-			if (!valid) throw new GdxRuntimeException("#iterator() cannot be used nested.");
+			if (!valid)
+				throw new GdxRuntimeException("#iterator() cannot be used nested.");
 			return hasNext;
 		}
 
@@ -826,13 +831,16 @@ public class LongMap<V> implements Iterable<LongMap.Entry<V>> {
 		}
 
 		public boolean hasNext () {
-			if (!valid) throw new GdxRuntimeException("#iterator() cannot be used nested.");
+			if (!valid)
+				throw new GdxRuntimeException("#iterator() cannot be used nested.");
 			return hasNext;
 		}
 
 		public V next () {
-			if (!hasNext) throw new NoSuchElementException();
-			if (!valid) throw new GdxRuntimeException("#iterator() cannot be used nested.");
+			if (!hasNext)
+				throw new NoSuchElementException();
+			if (!valid)
+				throw new GdxRuntimeException("#iterator() cannot be used nested.");
 			V value;
 			if (nextIndex == INDEX_ZERO)
 				value = map.zeroValue;
@@ -847,7 +855,9 @@ public class LongMap<V> implements Iterable<LongMap.Entry<V>> {
 			return this;
 		}
 
-		/** Returns a new array containing the remaining values. */
+		/**
+		 * Returns a new array containing the remaining values.
+		 */
 		public Array<V> toArray () {
 			Array array = new Array(true, map.size);
 			while (hasNext)
@@ -866,17 +876,30 @@ public class LongMap<V> implements Iterable<LongMap.Entry<V>> {
 		}
 
 		public long next () {
-			if (!hasNext) throw new NoSuchElementException();
-			if (!valid) throw new GdxRuntimeException("#iterator() cannot be used nested.");
+			if (!hasNext)
+				throw new NoSuchElementException();
+			if (!valid)
+				throw new GdxRuntimeException("#iterator() cannot be used nested.");
 			long key = nextIndex == INDEX_ZERO ? 0 : map.keyTable[nextIndex];
 			currentIndex = nextIndex;
 			findNextIndex();
 			return key;
 		}
 
-		/** Returns a new array containing the remaining values. */
+		/**
+		 * Returns a new array containing the remaining keys.
+		 */
 		public LongArray toArray () {
 			LongArray array = new LongArray(true, map.size);
+			while (hasNext)
+				array.add(next());
+			return array;
+		}
+
+		/**
+		 * Adds the remaining values to the specified array.
+		 */
+		public LongArray toArray (LongArray array) {
 			while (hasNext)
 				array.add(next());
 			return array;

--- a/gdx/src/com/badlogic/gdx/utils/LongMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/LongMap.java
@@ -53,7 +53,7 @@ public class LongMap<V> implements Iterable<LongMap.Entry<V>> {
 	private V zeroValue;
 	private boolean hasZeroValue;
 
-	private float loadFactor;
+	private final float loadFactor;
 	private int threshold;
 	/**
 	 * Used by {@link #place(long)} to bit-shift the upper bits of a {@code long} into a usable range (less than or
@@ -248,14 +248,12 @@ public class LongMap<V> implements Iterable<LongMap.Entry<V>> {
 		final long[] keyTable = this.keyTable;
 		final V[] valueTable = this.valueTable;
 		for (int i = place(key); ; i = (i + 1) & mask) {
-			// space is available so we insert and break (resize is later)
+			// space is available so we insert and break
 			if (keyTable[i] == 0) {
 				keyTable[i] = key;
 				valueTable[i] = value;
 
-				if (++size >= threshold) {
-					resize(keyTable.length << 1);
-				}
+				++size;
 				return;
 			}
 		}
@@ -748,7 +746,8 @@ public class LongMap<V> implements Iterable<LongMap.Entry<V>> {
 					loc = nl;
 					nl = loc + 1 & mask;
 				}
-				if(loc != currentIndex) --nextIndex;
+				if (loc != currentIndex)
+					--nextIndex;
 				keyTable[loc] = 0;
 				valueTable[loc] = null;
 			}
@@ -758,7 +757,7 @@ public class LongMap<V> implements Iterable<LongMap.Entry<V>> {
 	}
 
 	static public class Entries<V> extends MapIterator<V> implements Iterable<Entry<V>>, Iterator<Entry<V>> {
-		private Entry<V> entry = new Entry();
+		private final Entry<V> entry = new Entry();
 
 		public Entries (LongMap map) {
 			super(map);

--- a/gdx/src/com/badlogic/gdx/utils/LongMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/LongMap.java
@@ -251,8 +251,7 @@ public class LongMap<V> implements Iterable<LongMap.Entry<V>> {
 		}
 		final long[] keyTable = this.keyTable;
 		final V[] valueTable = this.valueTable;
-		int b = place(key);
-		for (int i = b; ; i = (i + 1) & mask) {
+		for (int i = place(key); ; i = (i + 1) & mask) {
 			// space is available so we insert and break (resize is later)
 			if (keyTable[i] == 0) {
 				keyTable[i] = key;

--- a/gdx/src/com/badlogic/gdx/utils/ObjectFloatMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/ObjectFloatMap.java
@@ -283,9 +283,12 @@ public class ObjectFloatMap<K> implements Iterable<ObjectFloatMap.Entry<K>> {
 		final K[] keyTable = this.keyTable;
 		final float[] valueTable = this.valueTable;
 		final float oldValue = valueTable[loc];
-		while ((key = keyTable[loc + 1 & mask]) != null && (loc + 1 & mask) != place(key)) {
+		int nl = (loc + 1 & mask);
+		while ((key = keyTable[nl]) != null && nl != place(key)) {
 			keyTable[loc] = key;
-			valueTable[loc] = valueTable[++loc & mask];
+			valueTable[loc] = valueTable[nl];
+			loc = nl;
+			nl = loc + 1 & mask;
 		}
 		keyTable[loc] = null;
 		--size;
@@ -596,13 +599,14 @@ public class ObjectFloatMap<K> implements Iterable<ObjectFloatMap.Entry<K>> {
 				throw new IllegalStateException("next must be called before remove.");
 			final K[] keyTable = map.keyTable;
 			final float[] valueTable = map.valueTable;
-			int loc = currentIndex;
 			final int mask = map.mask;
+			int loc = currentIndex, nl = (loc + 1 & mask);
 			K key;
-			while ((key = keyTable[loc + 1 & mask]) != null && (loc + 1 & mask) != map.place(key)) {
+			while ((key = keyTable[nl]) != null && nl != map.place(key)) {
 				keyTable[loc] = key;
-				valueTable[loc] = valueTable[loc + 1 & mask];
-				++loc;
+				valueTable[loc] = valueTable[nl];
+				loc = nl;
+				nl = loc + 1 & mask;
 			}
 			if(loc != currentIndex) --nextIndex;
 			keyTable[loc] = null;

--- a/gdx/src/com/badlogic/gdx/utils/ObjectFloatMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/ObjectFloatMap.java
@@ -49,7 +49,7 @@ import java.util.NoSuchElementException;
  * @author Tommy Ettinger
  * @author Nathan Sweet
  */
-public class ObjectFloatMap<K> implements Json.Serializable, Iterable<ObjectFloatMap.Entry<K>> {
+public class ObjectFloatMap<K> implements Iterable<ObjectFloatMap.Entry<K>> {
 
 	public int size;
 
@@ -556,42 +556,6 @@ public class ObjectFloatMap<K> implements Json.Serializable, Iterable<ObjectFloa
 		keys2.valid = true;
 		keys1.valid = false;
 		return keys2;
-	}
-
-
-	public void write (Json json) {
-		if (isEmpty())
-			return;
-		if (keys().next() instanceof String) {
-			json.writeObjectStart("entries");
-			for (Entry<K> entry : entries()) {
-				json.writeValue(String.valueOf(entry.key), entry.value, Float.class);
-			}
-			json.writeObjectEnd();
-		} else {
-			json.writeArrayStart("entries");
-			for (Entry<K> entry : entries()) {
-				json.writeValue(entry.key, null);
-				json.writeValue(entry.value, Float.class);
-			}
-			json.writeArrayEnd();
-		}
-	}
-
-	public void read (Json json, JsonValue jsonData) {
-		if (jsonData.isEmpty())
-			return;
-		JsonValue entries = jsonData.get("entries");
-		if (entries.isObject()) {
-			for (JsonValue child = entries.child; child != null; child = child.next)
-				put((K)child.name, child.asFloat());
-		} else if (entries.isArray()) {
-			for (JsonValue child = entries.child; child != null; child = child.next) {
-				K key = json.readValue(null, child);
-				float value = (child = child.next).asFloat();
-				put(key, value);
-			}
-		}
 	}
 
 	static public class Entry<K> {

--- a/gdx/src/com/badlogic/gdx/utils/ObjectFloatMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/ObjectFloatMap.java
@@ -193,7 +193,7 @@ public class ObjectFloatMap<K> implements Iterable<ObjectFloatMap.Entry<K>> {
 			throw new IllegalArgumentException("key cannot be null.");
 		K[] keyTable = this.keyTable;
 		float[] valueTable = this.valueTable;
-		
+
 		int b = place(key);
 		int loc = locateKey(key, b);
 		// an identical key already exists
@@ -233,16 +233,14 @@ public class ObjectFloatMap<K> implements Iterable<ObjectFloatMap.Entry<K>> {
 		float[] valueTable = this.valueTable;
 
 		for (int i = place(key); ; i = (i + 1) & mask) {
-			// space is available so we insert and break (resize is later)
+			// space is available so we insert and break
 			if (keyTable[i] == null) {
 				keyTable[i] = key;
 				valueTable[i] = value;
 				break;
 			}
 		}
-		if (++size >= threshold) {
-			resize(keyTable.length << 1);
-		}
+		++size;
 	}
 
 	/**
@@ -393,7 +391,7 @@ public class ObjectFloatMap<K> implements Iterable<ObjectFloatMap.Entry<K>> {
 
 		keyTable = (K[])new Object[newSize];
 		valueTable = new float[newSize];
-		
+
 		int oldSize = size;
 		size = 0;
 		if (oldSize > 0) {
@@ -603,7 +601,8 @@ public class ObjectFloatMap<K> implements Iterable<ObjectFloatMap.Entry<K>> {
 				loc = nl;
 				nl = loc + 1 & mask;
 			}
-			if(loc != currentIndex) --nextIndex;
+			if (loc != currentIndex)
+				--nextIndex;
 			keyTable[loc] = null;
 			--map.size;
 			currentIndex = -1;
@@ -642,6 +641,7 @@ public class ObjectFloatMap<K> implements Iterable<ObjectFloatMap.Entry<K>> {
 		public Entries<K> iterator () {
 			return this;
 		}
+
 		public void remove () {
 			super.remove();
 		}

--- a/gdx/src/com/badlogic/gdx/utils/ObjectFloatMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/ObjectFloatMap.java
@@ -103,7 +103,7 @@ public class ObjectFloatMap<K> implements Iterable<ObjectFloatMap.Entry<K>> {
 			throw new IllegalArgumentException("initialCapacity must be >= 0: " + initialCapacity);
 		if (loadFactor <= 0f || loadFactor >= 1f)
 			throw new IllegalArgumentException("loadFactor must be > 0 and < 1: " + loadFactor);
-		initialCapacity = MathUtils.nextPowerOfTwo((int)Math.ceil(initialCapacity / loadFactor));
+		initialCapacity = MathUtils.nextPowerOfTwo((int)Math.ceil(Math.max(1, initialCapacity) / loadFactor));
 		if (initialCapacity > 1 << 30)
 			throw new IllegalArgumentException("initialCapacity is too large: " + initialCapacity);
 

--- a/gdx/src/com/badlogic/gdx/utils/ObjectFloatMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/ObjectFloatMap.java
@@ -39,12 +39,7 @@ import java.util.NoSuchElementException;
  * Load factors greater than 0.91 greatly increase the chances the map will have to rehash to the next higher POT size.
  * Memory usage is excellent, and the aforementioned collision-resistance helps avoid too much capacity resizing.
  * <br>
- * The <a href="http://codecapsule.com/2013/11/17/robin-hood-hashing-backward-shift-deletion/">backward-shift algorithm</a>
- * used during removal apparently is key to the good performance of this implementation, even though this doesn't use Robin Hood
- * hashing; the performance of {@link #remove(Object, float)} has improved considerably over the previous libGDX version.
- * <br>
- * Iteration should be fast with OrderedSet and OrderedMap, whereas ObjectSet and ObjectMap aren't designed to provide especially
- * quick iteration.
+ * Iteration won't be as fast here as with OrderedSet and OrderedMap.
  *
  * @author Tommy Ettinger
  * @author Nathan Sweet
@@ -146,7 +141,7 @@ public class ObjectFloatMap<K> implements Iterable<ObjectFloatMap.Entry<K>> {
 	 * {@code return (int) (item.hashCode() * 0x9E3779B97F4A7C15L >>> shift);}
 	 * <br>
 	 * This can be overridden by subclasses, which you may want to do if your key type needs special consideration for
-	 * its hash (such as if you use arrays as keys, which still requires that the arrays are not modified). Subclasses
+	 * its hash (such as if you can't modify or extend a particular class that has an incorrect hashCode()). Subclasses
 	 * that don't need the collision decrease of Fibonacci Hashing (assuming the key class has a good hashCode()) may do
 	 * fine with a simple implementation:
 	 * {@code return (item.hashCode() & mask);}

--- a/gdx/src/com/badlogic/gdx/utils/ObjectFloatMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/ObjectFloatMap.java
@@ -236,8 +236,7 @@ public class ObjectFloatMap<K> implements Iterable<ObjectFloatMap.Entry<K>> {
 		K[] keyTable = this.keyTable;
 		float[] valueTable = this.valueTable;
 
-		int b = place(key);
-		for (int i = b; ; i = (i + 1) & mask) {
+		for (int i = place(key); ; i = (i + 1) & mask) {
 			// space is available so we insert and break (resize is later)
 			if (keyTable[i] == null) {
 				keyTable[i] = key;

--- a/gdx/src/com/badlogic/gdx/utils/ObjectFloatMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/ObjectFloatMap.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,390 +16,320 @@
 
 package com.badlogic.gdx.utils;
 
+import com.badlogic.gdx.math.MathUtils;
+
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
-import com.badlogic.gdx.math.MathUtils;
-
-/** An unordered map where the values are floats. This implementation is a cuckoo hash map using 3 hashes, random walking, and a
- * small stash for problematic keys. Null keys are not allowed. No allocation is done except when growing the table size. <br>
+/**
+ * An unordered map where the keys are objects and the values are unboxed floats. This implementation uses linear probing with the
+ * backward-shift algorithm for removal, and finds space for keys using Fibonacci hashing instead of the more-common power-of-two
+ * mask. Null keys are not allowed. No allocation is done except when growing the table size.
  * <br>
- * This map performs very fast get, containsKey, and remove (typically O(1), worst case O(log(n))). Put may be a bit slower,
- * depending on hash collisions. Load factors greater than 0.91 greatly increase the chances the map will have to rehash to the
- * next higher POT size.
- * @author Nathan Sweet */
-public class ObjectFloatMap<K> implements Iterable<ObjectFloatMap.Entry<K>> {
-	private static final int PRIME1 = 0xbe1f14b1;
-	private static final int PRIME2 = 0xb4b82e39;
-	private static final int PRIME3 = 0xced1c241;
+ * This map uses Fibonacci hashing to help distribute what may be very bad hashCode() results across the
+ * whole capacity. See <a href="https://probablydance.com/2018/06/16/fibonacci-hashing-the-optimization-that-the-world-forgot-or-a-better-alternative-to-integer-modulo/">Malte Skarupke's blog post</a>
+ * for more information on Fibonacci hashing. It uses linear probing to resolve collisions, which is far from the academically
+ * optimal algorithm, but performs considerably better in practice than most alternatives, and combined with Fibonacci hashing, it
+ * can handle "normal" generated hashCode() implementations, and not just theoretically optimal hashing functions. Even if all
+ * hashCode()s this is given collide, it will still work, just slowly; the older libGDX implementation using cuckoo hashing would
+ * crash with an OutOfMemoryError with under 50 collisions.
+ * <br>
+ * This map performs very fast contains and remove (typically O(1), worst case O(n) due to occasional probing, but still very
+ * fast). Add may be a bit slower, depending on hash collisions, but this data structure is somewhat collision-resistant.
+ * Load factors greater than 0.91 greatly increase the chances the map will have to rehash to the next higher POT size.
+ * Memory usage is excellent, and the aforementioned collision-resistance helps avoid too much capacity resizing.
+ * <br>
+ * The <a href="http://codecapsule.com/2013/11/17/robin-hood-hashing-backward-shift-deletion/">backward-shift algorithm</a>
+ * used during removal apparently is key to the good performance of this implementation, even though this doesn't use Robin Hood
+ * hashing; the performance of {@link #remove(Object, float)} has improved considerably over the previous libGDX version.
+ * <br>
+ * Iteration should be fast with OrderedSet and OrderedMap, whereas ObjectSet and ObjectMap aren't designed to provide especially
+ * quick iteration.
+ *
+ * @author Tommy Ettinger
+ * @author Nathan Sweet
+ */
+public class ObjectFloatMap<K> implements Json.Serializable, Iterable<ObjectFloatMap.Entry<K>> {
 
 	public int size;
 
 	K[] keyTable;
 	float[] valueTable;
-	int capacity, stashSize;
 
-	private float loadFactor;
-	private int hashShift, mask, threshold;
-	private int stashCapacity;
-	private int pushIterations;
+	float loadFactor;
+	int threshold;
+	/**
+	 * Used by {@link #place(Object)} to bit-shift the upper bits of a {@code long} into a usable range (less than or
+	 * equal to {@link #mask}, greater than or equal to 0). If you're setting it in a subclass, this shift can be
+	 * negative, which is a convenient way to match the number of bits in mask; if mask is a 7-bit number, then a shift
+	 * of -7 will correctly shift the upper 7 bits into the lowest 7 positions. If using what this class sets, shift
+	 * will be greater than 32 and less than 64; if you use this shift with an int, it will still correctly move the
+	 * upper bits of an int to the lower bits, thanks to Java's implicit modulus on shifts.
+	 * <br>
+	 * You can also use {@link #mask} to mask the low bits of a number, which may be faster for some hashCode()s, if you
+	 * reimplement {@link #place(Object)}.
+	 */
+	protected int shift;
+	/**
+	 * The bitmask used to contain hashCode()s to the indices that can be fit into the key array this uses. This should
+	 * always be all-1-bits in its low positions; that is, it must be a power of two minus 1. If you subclass and change
+	 * {@link #place(Object)}, you may want to use this instead of {@link #shift} to isolate usable bits of a hash.
+	 */
+	protected int mask;
 
-	private Entries entries1, entries2;
-	private Values values1, values2;
-	private Keys keys1, keys2;
+	Entries entries1, entries2;
+	Values values1, values2;
+	Keys keys1, keys2;
 
-	/** Creates a new map with an initial capacity of 51 and a load factor of 0.8. */
+	/**
+	 * Creates a new map with an initial capacity of 51 and a load factor of 0.8.
+	 */
 	public ObjectFloatMap () {
 		this(51, 0.8f);
 	}
 
-	/** Creates a new map with a load factor of 0.8.
-	 * @param initialCapacity If not a power of two, it is increased to the next nearest power of two. */
+	/**
+	 * Creates a new map with a load factor of 0.8.
+	 *
+	 * @param initialCapacity If not a power of two, it is increased to the next nearest power of two.
+	 */
 	public ObjectFloatMap (int initialCapacity) {
 		this(initialCapacity, 0.8f);
 	}
 
-	/** Creates a new map with the specified initial capacity and load factor. This map will hold initialCapacity items before
+	/**
+	 * Creates a new map with the specified initial capacity and load factor. This map will hold initialCapacity items before
 	 * growing the backing table.
-	 * @param initialCapacity If not a power of two, it is increased to the next nearest power of two. */
+	 *
+	 * @param initialCapacity If not a power of two, it is increased to the next nearest power of two.
+	 */
 	public ObjectFloatMap (int initialCapacity, float loadFactor) {
-		if (loadFactor <= 0) throw new IllegalArgumentException("loadFactor must be > 0: " + loadFactor);
+		if (initialCapacity < 0)
+			throw new IllegalArgumentException("initialCapacity must be >= 0: " + initialCapacity);
+		if (loadFactor <= 0f || loadFactor >= 1f)
+			throw new IllegalArgumentException("loadFactor must be > 0 and < 1: " + loadFactor);
+		initialCapacity = MathUtils.nextPowerOfTwo((int)Math.ceil(initialCapacity / loadFactor));
+		if (initialCapacity > 1 << 30)
+			throw new IllegalArgumentException("initialCapacity is too large: " + initialCapacity);
+
 		this.loadFactor = loadFactor;
 
-		if (initialCapacity < 0) throw new IllegalArgumentException("initialCapacity must be >= 0: " + initialCapacity);
-		initialCapacity = MathUtils.nextPowerOfTwo((int)Math.ceil(initialCapacity / loadFactor));
-		if (initialCapacity > 1 << 30) throw new IllegalArgumentException("initialCapacity is too large: " + initialCapacity);
-		capacity = initialCapacity;
+		threshold = (int)(initialCapacity * loadFactor);
+		mask = initialCapacity - 1;
+		shift = Long.numberOfLeadingZeros(mask);
 
-		threshold = (int)(capacity * loadFactor);
-		mask = capacity - 1;
-		hashShift = 31 - Integer.numberOfTrailingZeros(capacity);
-		stashCapacity = Math.max(3, (int)Math.ceil(Math.log(capacity)) * 2);
-		pushIterations = Math.max(Math.min(capacity, 8), (int)Math.sqrt(capacity) / 8);
-
-		keyTable = (K[])new Object[capacity + stashCapacity];
-		valueTable = new float[keyTable.length];
+		keyTable = (K[])new Object[initialCapacity];
+		valueTable = new float[initialCapacity];
 	}
 
-	/** Creates a new map identical to the specified map. */
+	/**
+	 * Creates a new map identical to the specified map.
+	 */
 	public ObjectFloatMap (ObjectFloatMap<? extends K> map) {
-		this((int)Math.floor(map.capacity * map.loadFactor), map.loadFactor);
-		stashSize = map.stashSize;
+		this((int)Math.floor(map.keyTable.length * map.loadFactor), map.loadFactor);
 		System.arraycopy(map.keyTable, 0, keyTable, 0, map.keyTable.length);
 		System.arraycopy(map.valueTable, 0, valueTable, 0, map.valueTable.length);
 		size = map.size;
 	}
 
-	public void put (K key, float value) {
-		if (key == null) throw new IllegalArgumentException("key cannot be null.");
-		K[] keyTable = this.keyTable;
+	/**
+	 * Finds an array index between 0 and {@link #mask}, both inclusive, corresponding to the hash code of {@code item}.
+	 * By default, this uses "Fibonacci Hashing" on the {@link Object#hashCode()} of {@code item}; this multiplies
+	 * {@code item.hashCode()} by a long constant (2 to the 64, divided by the golden ratio) and shifts the high-quality
+	 * uppermost bits into the lowest positions so they can be used as array indices. The multiplication by a long may
+	 * be somewhat slow on GWT, but it will be correct across all platforms and won't lose precision. Using Fibonacci
+	 * Hashing allows even very poor hashCode() implementations, such as those that only differ in their upper bits, to
+	 * work in a hash table without heavy collision rates. It has known problems when all or most hashCode()s are
+	 * multiples of larger Fibonacci numbers; see <a href="https://probablydance.com/2018/06/16/fibonacci-hashing-the-optimization-that-the-world-forgot-or-a-better-alternative-to-integer-modulo/">this blog post by Malte Skarupke</a>
+	 * for more details. In the unlikely event that most of your hashCode()s are Fibonacci numbers, you can subclass
+	 * this to change this method, which is a one-liner in this form:
+	 * {@code return (int) (item.hashCode() * 0x9E3779B97F4A7C15L >>> shift);}
+	 * <br>
+	 * This can be overridden by subclasses, which you may want to do if your key type needs special consideration for
+	 * its hash (such as if you use arrays as keys, which still requires that the arrays are not modified). Subclasses
+	 * that don't need the collision decrease of Fibonacci Hashing (assuming the key class has a good hashCode()) may do
+	 * fine with a simple implementation:
+	 * {@code return (item.hashCode() & mask);}
+	 *
+	 * @param item a key that this method will hash, by default by calling {@link Object#hashCode()} on it; non-null
+	 * @return an int between 0 and {@link #mask}, both inclusive
+	 */
+	protected int place (final K item) {
+		// shift is always greater than 32, less than 64
+		return (int)(item.hashCode() * 0x9E3779B97F4A7C15L >>> shift);
+	}
 
-		// Check for existing keys.
-		int hashCode = key.hashCode();
-		int index1 = hashCode & mask;
-		K key1 = keyTable[index1];
-		if (key.equals(key1)) {
-			valueTable[index1] = value;
-			return;
-		}
+	private int locateKey (final K key) {
+		return locateKey(key, place(key));
+	}
 
-		int index2 = hash2(hashCode);
-		K key2 = keyTable[index2];
-		if (key.equals(key2)) {
-			valueTable[index2] = value;
-			return;
-		}
-
-		int index3 = hash3(hashCode);
-		K key3 = keyTable[index3];
-		if (key.equals(key3)) {
-			valueTable[index3] = value;
-			return;
-		}
-
-		// Update key in the stash.
-		for (int i = capacity, n = i + stashSize; i < n; i++) {
+	/**
+	 * Given a key and its initial placement to try in an array, this finds the actual location of the key in the array
+	 * if it is present, or -1 if the key is not present. This can be overridden if a subclass needs to compare for
+	 * equality differently than just by calling {@link Object#equals(Object)}, but only within the same package.
+	 *
+	 * @param key       a K key that will be checked for equality if a similar-seeming key is found
+	 * @param placement as calculated by {@link #place(Object)}, almost always with {@code place(key)}
+	 * @return the location in the key array of key, if found, or -1 if it was not found.
+	 */
+	int locateKey (final K key, final int placement) {
+		for (int i = placement; ; i = i + 1 & mask) {
+			// empty space is available
+			if (keyTable[i] == null) {
+				return -1;
+			}
 			if (key.equals(keyTable[i])) {
-				valueTable[i] = value;
-				return;
+				return i;
 			}
 		}
-
-		// Check for empty buckets.
-		if (key1 == null) {
-			keyTable[index1] = key;
-			valueTable[index1] = value;
-			if (size++ >= threshold) resize(capacity << 1);
-			return;
-		}
-
-		if (key2 == null) {
-			keyTable[index2] = key;
-			valueTable[index2] = value;
-			if (size++ >= threshold) resize(capacity << 1);
-			return;
-		}
-
-		if (key3 == null) {
-			keyTable[index3] = key;
-			valueTable[index3] = value;
-			if (size++ >= threshold) resize(capacity << 1);
-			return;
-		}
-
-		push(key, value, index1, key1, index2, key2, index3, key3);
 	}
 
-	public void putAll (ObjectFloatMap<? extends K> map) {
-		for (Entry<? extends K> entry : map.entries())
-			put(entry.key, entry.value);
-	}
-
-	/** Skips checks for existing keys. */
-	private void putResize (K key, float value) {
-		// Check for empty buckets.
-		int hashCode = key.hashCode();
-		int index1 = hashCode & mask;
-		K key1 = keyTable[index1];
-		if (key1 == null) {
-			keyTable[index1] = key;
-			valueTable[index1] = value;
-			if (size++ >= threshold) resize(capacity << 1);
-			return;
-		}
-
-		int index2 = hash2(hashCode);
-		K key2 = keyTable[index2];
-		if (key2 == null) {
-			keyTable[index2] = key;
-			valueTable[index2] = value;
-			if (size++ >= threshold) resize(capacity << 1);
-			return;
-		}
-
-		int index3 = hash3(hashCode);
-		K key3 = keyTable[index3];
-		if (key3 == null) {
-			keyTable[index3] = key;
-			valueTable[index3] = value;
-			if (size++ >= threshold) resize(capacity << 1);
-			return;
-		}
-
-		push(key, value, index1, key1, index2, key2, index3, key3);
-	}
-
-	private void push (K insertKey, float insertValue, int index1, K key1, int index2, K key2, int index3, K key3) {
+	/**
+	 * Doesn't return a value, unlike other maps.
+	 * You can use {@link #get(Object, float)} with a defaultValue of {@link Float#NaN} if you want to tell with
+	 * certainty that a key is not present; comparing with NaN is tricky but {@link Float#isNaN(float)} makes it easy.
+	 * If isNaN returns true, you can generally act like another Map had returned null in the same situation (meaning
+	 * the value is unusable). This works because this class will never insert a NaN value into the map unless one is
+	 * explicitly inserted, and since NaN acts so strangely in its everyday usage, virtually all code will not place NaN
+	 * in a map.
+	 */
+	public void put (K key, float value) {
+		if (key == null)
+			throw new IllegalArgumentException("key cannot be null.");
 		K[] keyTable = this.keyTable;
 		float[] valueTable = this.valueTable;
-		int mask = this.mask;
-
-		// Push keys until an empty bucket is found.
-		K evictedKey;
-		float evictedValue;
-		int i = 0, pushIterations = this.pushIterations;
-		do {
-			// Replace the key and value for one of the hashes.
-			switch (MathUtils.random(2)) {
-			case 0:
-				evictedKey = key1;
-				evictedValue = valueTable[index1];
-				keyTable[index1] = insertKey;
-				valueTable[index1] = insertValue;
-				break;
-			case 1:
-				evictedKey = key2;
-				evictedValue = valueTable[index2];
-				keyTable[index2] = insertKey;
-				valueTable[index2] = insertValue;
-				break;
-			default:
-				evictedKey = key3;
-				evictedValue = valueTable[index3];
-				keyTable[index3] = insertKey;
-				valueTable[index3] = insertValue;
-				break;
-			}
-
-			// If the evicted key hashes to an empty bucket, put it there and stop.
-			int hashCode = evictedKey.hashCode();
-			index1 = hashCode & mask;
-			key1 = keyTable[index1];
-			if (key1 == null) {
-				keyTable[index1] = evictedKey;
-				valueTable[index1] = evictedValue;
-				if (size++ >= threshold) resize(capacity << 1);
-				return;
-			}
-
-			index2 = hash2(hashCode);
-			key2 = keyTable[index2];
-			if (key2 == null) {
-				keyTable[index2] = evictedKey;
-				valueTable[index2] = evictedValue;
-				if (size++ >= threshold) resize(capacity << 1);
-				return;
-			}
-
-			index3 = hash3(hashCode);
-			key3 = keyTable[index3];
-			if (key3 == null) {
-				keyTable[index3] = evictedKey;
-				valueTable[index3] = evictedValue;
-				if (size++ >= threshold) resize(capacity << 1);
-				return;
-			}
-
-			if (++i == pushIterations) break;
-
-			insertKey = evictedKey;
-			insertValue = evictedValue;
-		} while (true);
-
-		putStash(evictedKey, evictedValue);
-	}
-
-	private void putStash (K key, float value) {
-		if (stashSize == stashCapacity) {
-			// Too many pushes occurred and the stash is full, increase the table size.
-			resize(capacity << 1);
-			putResize(key, value);
+		
+		int b = place(key);
+		int loc = locateKey(key, b);
+		// an identical key already exists
+		if (loc != -1) {
+			valueTable[loc] = value;
 			return;
 		}
-		// Store key in the stash.
-		int index = capacity + stashSize;
-		keyTable[index] = key;
-		valueTable[index] = value;
-		stashSize++;
-		size++;
+		for (int i = b; ; i = (i + 1) & mask) {
+			// space is available so we insert and break (resize is later)
+			if (keyTable[i] == null) {
+				keyTable[i] = key;
+				valueTable[i] = value;
+				break;
+			}
+		}
+		if (++size >= threshold) {
+			resize(keyTable.length << 1);
+		}
 	}
 
-	/** @param defaultValue Returned if the key was not associated with a value. */
+	public void putAll (ObjectFloatMap<K> map) {
+		ensureCapacity(map.size);
+		final K[] keyTable = map.keyTable;
+		final float[] valueTable = map.valueTable;
+		K k;
+		for (int i = 0, n = keyTable.length; i < n; i++) {
+			if ((k = keyTable[i]) != null)
+				put(k, valueTable[i]);
+		}
+	}
+//		ensureCapacity(map.size);
+//		for (Entry<K> entry : map)
+//			put(entry.key, entry.value);
+//	}
+
+	/**
+	 * Skips checks for existing keys.
+	 */
+	private void putResize (K key, float value) {
+		K[] keyTable = this.keyTable;
+		float[] valueTable = this.valueTable;
+
+		int b = place(key);
+		for (int i = b; ; i = (i + 1) & mask) {
+			// space is available so we insert and break (resize is later)
+			if (keyTable[i] == null) {
+				keyTable[i] = key;
+				valueTable[i] = value;
+				break;
+			}
+		}
+		if (++size >= threshold) {
+			resize(keyTable.length << 1);
+		}
+	}
+
+	/**
+	 * Returns the value for the specified key, or the default value if the key is not in the map.
+	 */
 	public float get (K key, float defaultValue) {
-		int hashCode = key.hashCode();
-		int index = hashCode & mask;
-		if (!key.equals(keyTable[index])) {
-			index = hash2(hashCode);
-			if (!key.equals(keyTable[index])) {
-				index = hash3(hashCode);
-				if (!key.equals(keyTable[index])) return getStash(key, defaultValue);
-			}
-		}
-		return valueTable[index];
+		final int loc = locateKey(key);
+		return loc == -1 ? defaultValue : valueTable[loc];
 	}
 
-	private float getStash (K key, float defaultValue) {
-		K[] keyTable = this.keyTable;
-		for (int i = capacity, n = i + stashSize; i < n; i++)
-			if (key.equals(keyTable[i])) return valueTable[i];
-		return defaultValue;
-	}
-
-	/** Returns the key's current value and increments the stored value. If the key is not in the map, defaultValue + increment is
-	 * put into the map. */
+	/**
+	 * Returns the key's current value and increments the stored value. If the key is not in the map, defaultValue + increment is
+	 * put into the map.
+	 */
 	public float getAndIncrement (K key, float defaultValue, float increment) {
-		int hashCode = key.hashCode();
-		int index = hashCode & mask;
-		if (!key.equals(keyTable[index])) {
-			index = hash2(hashCode);
-			if (!key.equals(keyTable[index])) {
-				index = hash3(hashCode);
-				if (!key.equals(keyTable[index])) return getAndIncrementStash(key, defaultValue, increment);
-			}
+		final int loc = locateKey(key);
+		// key was not found
+		if (loc == -1) {
+			// because we know there's no existing duplicate key, we can use putResize().
+			putResize(key, defaultValue + increment);
+			return defaultValue;
 		}
-		float value = valueTable[index];
-		valueTable[index] = value + increment;
-		return value;
-	}
-
-	private float getAndIncrementStash (K key, float defaultValue, float increment) {
-		K[] keyTable = this.keyTable;
-		for (int i = capacity, n = i + stashSize; i < n; i++)
-			if (key.equals(keyTable[i])) {
-				float value = valueTable[i];
-				valueTable[i] = value + increment;
-				return value;
-			}
-		put(key, defaultValue + increment);
-		return defaultValue;
+		final float oldValue = valueTable[loc];
+		valueTable[loc] += increment;
+		return oldValue;
 	}
 
 	public float remove (K key, float defaultValue) {
-		int hashCode = key.hashCode();
-		int index = hashCode & mask;
-		if (key.equals(keyTable[index])) {
-			keyTable[index] = null;
-			float oldValue = valueTable[index];
-			size--;
-			return oldValue;
+		int loc = locateKey(key);
+		if (loc == -1) {
+			return defaultValue;
 		}
-
-		index = hash2(hashCode);
-		if (key.equals(keyTable[index])) {
-			keyTable[index] = null;
-			float oldValue = valueTable[index];
-			size--;
-			return oldValue;
+		final K[] keyTable = this.keyTable;
+		final float[] valueTable = this.valueTable;
+		final float oldValue = valueTable[loc];
+		while ((key = keyTable[loc + 1 & mask]) != null && (loc + 1 & mask) != place(key)) {
+			keyTable[loc] = key;
+			valueTable[loc] = valueTable[++loc & mask];
 		}
-
-		index = hash3(hashCode);
-		if (key.equals(keyTable[index])) {
-			keyTable[index] = null;
-			float oldValue = valueTable[index];
-			size--;
-			return oldValue;
-		}
-
-		return removeStash(key, defaultValue);
+		keyTable[loc] = null;
+		--size;
+		return oldValue;
 	}
 
-	float removeStash (K key, float defaultValue) {
-		K[] keyTable = this.keyTable;
-		for (int i = capacity, n = i + stashSize; i < n; i++) {
-			if (key.equals(keyTable[i])) {
-				float oldValue = valueTable[i];
-				removeStashIndex(i);
-				size--;
-				return oldValue;
-			}
-		}
-		return defaultValue;
-	}
-
-	void removeStashIndex (int index) {
-		// If the removed location was not last, move the last tuple to the removed location.
-		stashSize--;
-		int lastIndex = capacity + stashSize;
-		if (index < lastIndex) {
-			keyTable[index] = keyTable[lastIndex];
-			valueTable[index] = valueTable[lastIndex];
-			keyTable[lastIndex] = null;
-		}
-	}
-
-	/** Returns true if the map has one or more items. */
+	/**
+	 * Returns true if the map has one or more items.
+	 */
 	public boolean notEmpty () {
 		return size > 0;
 	}
 
-	/** Returns true if the map is empty. */
+	/**
+	 * Returns true if the map is empty.
+	 */
 	public boolean isEmpty () {
 		return size == 0;
 	}
 
-	/** Reduces the size of the backing arrays to be the specified capacity or less. If the capacity is already less, nothing is
-	 * done. If the map contains more items than the specified capacity, the next highest power of two capacity is used instead. */
+	/**
+	 * Reduces the size of the backing arrays to be the specified capacity or less. If the capacity is already less, nothing is
+	 * done. If the map contains more items than the specified capacity, the next highest power of two capacity is used instead.
+	 */
 	public void shrink (int maximumCapacity) {
-		if (maximumCapacity < 0) throw new IllegalArgumentException("maximumCapacity must be >= 0: " + maximumCapacity);
-		if (size > maximumCapacity) maximumCapacity = size;
-		if (capacity <= maximumCapacity) return;
-		maximumCapacity = MathUtils.nextPowerOfTwo(maximumCapacity);
-		resize(maximumCapacity);
+		if (maximumCapacity < 0)
+			throw new IllegalArgumentException("maximumCapacity must be >= 0: " + maximumCapacity);
+		if (size > maximumCapacity)
+			maximumCapacity = size;
+		if (keyTable.length <= maximumCapacity)
+			return;
+		resize(MathUtils.nextPowerOfTwo(maximumCapacity));
 	}
 
-	/** Clears the map and reduces the size of the backing arrays to be the specified capacity if they are larger. */
+	/**
+	 * Clears the map and reduces the size of the backing arrays to be the specified capacity if they are larger.
+	 */
 	public void clear (int maximumCapacity) {
-		if (capacity <= maximumCapacity) {
+		if (keyTable.length <= maximumCapacity) {
 			clear();
 			return;
 		}
@@ -408,144 +338,140 @@ public class ObjectFloatMap<K> implements Iterable<ObjectFloatMap.Entry<K>> {
 	}
 
 	public void clear () {
-		if (size == 0) return;
+		if (size == 0)
+			return;
 		K[] keyTable = this.keyTable;
-		for (int i = capacity + stashSize; i-- > 0;)
-			keyTable[i] = null;
+		for (int i = keyTable.length; i > 0; ) {
+			keyTable[--i] = null;
+		}
 		size = 0;
-		stashSize = 0;
 	}
 
-	/** Returns true if the specified value is in the map. Note this traverses the entire map and compares every value, which may
-	 * be an expensive operation. */
+	/**
+	 * Returns true if the specified value is in the map. Note this traverses the entire map and compares every value, which may
+	 * be an expensive operation.
+	 */
 	public boolean containsValue (float value) {
-		K[] keyTable = this.keyTable;
-		float[] valueTable = this.valueTable;
-		for (int i = capacity + stashSize; i-- > 0;)
-			if (keyTable[i] != null && valueTable[i] == value) return true;
+		final K[] keyTable = this.keyTable;
+		final float[] valueTable = this.valueTable;
+		for (int i = valueTable.length; i-- > 0; )
+			if (keyTable[i] != null && valueTable[i] == value)
+				return true;
 		return false;
 	}
 
 	public boolean containsKey (K key) {
-		int hashCode = key.hashCode();
-		int index = hashCode & mask;
-		if (!key.equals(keyTable[index])) {
-			index = hash2(hashCode);
-			if (!key.equals(keyTable[index])) {
-				index = hash3(hashCode);
-				if (!key.equals(keyTable[index])) return containsKeyStash(key);
-			}
-		}
-		return true;
+		return locateKey(key) != -1;
 	}
 
-	private boolean containsKeyStash (K key) {
-		K[] keyTable = this.keyTable;
-		for (int i = capacity, n = i + stashSize; i < n; i++)
-			if (key.equals(keyTable[i])) return true;
-		return false;
-	}
-
-	/** Returns the key for the specified value, or null if it is not in the map. Note this traverses the entire map and compares
-	 * every value, which may be an expensive operation. */
+	/**
+	 * Returns the key for the specified value, or null if it is not in the map. Note this traverses the entire map and compares
+	 * every value, which may be an expensive operation.
+	 */
 	public K findKey (float value) {
-		K[] keyTable = this.keyTable;
-		float[] valueTable = this.valueTable;
-		for (int i = capacity + stashSize; i-- > 0;)
-			if (keyTable[i] != null && valueTable[i] == value) return keyTable[i];
+		final K[] keyTable = this.keyTable;
+		final float[] valueTable = this.valueTable;
+		for (int i = valueTable.length; i-- > 0; ) {
+			K key = keyTable[i];
+			if (key != null && valueTable[i] == value)
+				return key;
+		}
 		return null;
 	}
 
-	/** Increases the size of the backing array to accommodate the specified number of additional items. Useful before adding many
-	 * items to avoid multiple backing array resizes. */
+	/**
+	 * Increases the size of the backing array to accommodate the specified number of additional items. Useful before adding many
+	 * items to avoid multiple backing array resizes.
+	 */
 	public void ensureCapacity (int additionalCapacity) {
-		if (additionalCapacity < 0) throw new IllegalArgumentException("additionalCapacity must be >= 0: " + additionalCapacity);
 		int sizeNeeded = size + additionalCapacity;
-		if (sizeNeeded >= threshold) resize(MathUtils.nextPowerOfTwo((int)Math.ceil(sizeNeeded / loadFactor)));
+		if (sizeNeeded >= threshold)
+			resize(MathUtils.nextPowerOfTwo((int)Math.ceil(sizeNeeded / loadFactor)));
 	}
 
-	private void resize (int newSize) {
-		int oldEndIndex = capacity + stashSize;
-
-		capacity = newSize;
+	final void resize (int newSize) {
+		int oldCapacity = keyTable.length;
 		threshold = (int)(newSize * loadFactor);
 		mask = newSize - 1;
-		hashShift = 31 - Integer.numberOfTrailingZeros(newSize);
-		stashCapacity = Math.max(3, (int)Math.ceil(Math.log(newSize)) * 2);
-		pushIterations = Math.max(Math.min(newSize, 8), (int)Math.sqrt(newSize) / 8);
+		shift = Long.numberOfLeadingZeros(mask);
 
 		K[] oldKeyTable = keyTable;
 		float[] oldValueTable = valueTable;
 
-		keyTable = (K[])new Object[newSize + stashCapacity];
-		valueTable = new float[newSize + stashCapacity];
-
+		keyTable = (K[])new Object[newSize];
+		valueTable = new float[newSize];
+		
 		int oldSize = size;
 		size = 0;
-		stashSize = 0;
 		if (oldSize > 0) {
-			for (int i = 0; i < oldEndIndex; i++) {
+			for (int i = 0; i < oldCapacity; i++) {
 				K key = oldKeyTable[i];
-				if (key != null) putResize(key, oldValueTable[i]);
+				if (key != null)
+					putResize(key, oldValueTable[i]);
 			}
 		}
 	}
 
-	private int hash2 (int h) {
-		h *= PRIME2;
-		return (h ^ h >>> hashShift) & mask;
-	}
-
-	private int hash3 (int h) {
-		h *= PRIME3;
-		return (h ^ h >>> hashShift) & mask;
-	}
-
 	public int hashCode () {
-		int h = 0;
+		int h = size;
 		K[] keyTable = this.keyTable;
 		float[] valueTable = this.valueTable;
-		for (int i = 0, n = capacity + stashSize; i < n; i++) {
+		for (int i = 0, n = keyTable.length; i < n; i++) {
 			K key = keyTable[i];
 			if (key != null) {
-				h += key.hashCode() * 31;
-
-				float value = valueTable[i];
-				h += Float.floatToIntBits(value);
+				h ^= key.hashCode();
+				final int value = NumberUtils.floatToRawIntBits(valueTable[i]);
+				// the upper bits change more reliably than lower ones in value; xorshift to improve lower bits
+				h += value ^ value >>> 16 ^ value >>> 21;
 			}
 		}
 		return h;
 	}
 
 	public boolean equals (Object obj) {
-		if (obj == this) return true;
-		if (!(obj instanceof ObjectFloatMap)) return false;
-		ObjectFloatMap<K> other = (ObjectFloatMap)obj;
-		if (other.size != size) return false;
+		if (obj == this)
+			return true;
+		if (!(obj instanceof ObjectFloatMap))
+			return false;
+		ObjectFloatMap other = (ObjectFloatMap)obj;
+		if (other.size != size)
+			return false;
 		K[] keyTable = this.keyTable;
 		float[] valueTable = this.valueTable;
-		for (int i = 0, n = capacity + stashSize; i < n; i++) {
+		for (int i = 0, n = keyTable.length; i < n; i++) {
 			K key = keyTable[i];
 			if (key != null) {
-				float otherValue = other.get(key, 0f);
-				if (otherValue == 0f && !other.containsKey(key)) return false;
-				float value = valueTable[i];
-				if (otherValue != value) return false;
+				float otherValue = other.get(key, 0);
+				if (otherValue == 0 && !other.containsKey(key))
+					return false;
+				if (otherValue != valueTable[i])
+					return false;
 			}
 		}
 		return true;
 	}
 
+	public String toString (String separator) {
+		return toString(separator, false);
+	}
+
 	public String toString () {
-		if (size == 0) return "{}";
-		StringBuilder buffer = new StringBuilder(32);
-		buffer.append('{');
+		return toString(", ", true);
+	}
+
+	private String toString (String separator, boolean braces) {
+		if (size == 0)
+			return braces ? "{}" : "";
+		java.lang.StringBuilder buffer = new java.lang.StringBuilder(32);
+		if (braces)
+			buffer.append('{');
 		K[] keyTable = this.keyTable;
 		float[] valueTable = this.valueTable;
 		int i = keyTable.length;
 		while (i-- > 0) {
 			K key = keyTable[i];
-			if (key == null) continue;
+			if (key == null)
+				continue;
 			buffer.append(key);
 			buffer.append('=');
 			buffer.append(valueTable[i]);
@@ -553,13 +479,15 @@ public class ObjectFloatMap<K> implements Iterable<ObjectFloatMap.Entry<K>> {
 		}
 		while (i-- > 0) {
 			K key = keyTable[i];
-			if (key == null) continue;
-			buffer.append(", ");
+			if (key == null)
+				continue;
+			buffer.append(separator);
 			buffer.append(key);
 			buffer.append('=');
 			buffer.append(valueTable[i]);
 		}
-		buffer.append('}');
+		if (braces)
+			buffer.append('}');
 		return buffer.toString();
 	}
 
@@ -567,12 +495,11 @@ public class ObjectFloatMap<K> implements Iterable<ObjectFloatMap.Entry<K>> {
 		return entries();
 	}
 
-	/** Returns an iterator for the entries in the map. Remove is supported.
-	 * <p>
-	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called.
-	 * Use the {@link Entries} constructor for nested or multithreaded iteration. */
+	/**
+	 * Returns an iterator for the entries in the map. Remove is supported. Note that the same iterator instance is returned each
+	 * time this method is called. Use the {@link Entries} constructor for nested or multithreaded iteration.
+	 */
 	public Entries<K> entries () {
-		if (Collections.allocateIterators) return new Entries(this);
 		if (entries1 == null) {
 			entries1 = new Entries(this);
 			entries2 = new Entries(this);
@@ -589,12 +516,11 @@ public class ObjectFloatMap<K> implements Iterable<ObjectFloatMap.Entry<K>> {
 		return entries2;
 	}
 
-	/** Returns an iterator for the values in the map. Remove is supported.
-	 * <p>
-	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called.
-	 * Use the {@link Entries} constructor for nested or multithreaded iteration. */
+	/**
+	 * Returns an iterator for the values in the map. Remove is supported. Note that the same iterator instance is returned each
+	 * time this method is called. Use the {@link Values} constructor for nested or multithreaded iteration.
+	 */
 	public Values values () {
-		if (Collections.allocateIterators) return new Values(this);
 		if (values1 == null) {
 			values1 = new Values(this);
 			values2 = new Values(this);
@@ -611,12 +537,11 @@ public class ObjectFloatMap<K> implements Iterable<ObjectFloatMap.Entry<K>> {
 		return values2;
 	}
 
-	/** Returns an iterator for the keys in the map. Remove is supported.
-	 * <p>
-	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called.
-	 * Use the {@link Entries} constructor for nested or multithreaded iteration. */
+	/**
+	 * Returns an iterator for the keys in the map. Remove is supported. Note that the same iterator instance is returned each
+	 * time this method is called. Use the {@link Keys} constructor for nested or multithreaded iteration.
+	 */
 	public Keys<K> keys () {
-		if (Collections.allocateIterators) return new Keys(this);
 		if (keys1 == null) {
 			keys1 = new Keys(this);
 			keys2 = new Keys(this);
@@ -631,6 +556,42 @@ public class ObjectFloatMap<K> implements Iterable<ObjectFloatMap.Entry<K>> {
 		keys2.valid = true;
 		keys1.valid = false;
 		return keys2;
+	}
+
+
+	public void write (Json json) {
+		if (isEmpty())
+			return;
+		if (keys().next() instanceof String) {
+			json.writeObjectStart("entries");
+			for (Entry<K> entry : entries()) {
+				json.writeValue(String.valueOf(entry.key), entry.value, Float.class);
+			}
+			json.writeObjectEnd();
+		} else {
+			json.writeArrayStart("entries");
+			for (Entry<K> entry : entries()) {
+				json.writeValue(entry.key, null);
+				json.writeValue(entry.value, Float.class);
+			}
+			json.writeArrayEnd();
+		}
+	}
+
+	public void read (Json json, JsonValue jsonData) {
+		if (jsonData.isEmpty())
+			return;
+		JsonValue entries = jsonData.get("entries");
+		if (entries.isObject()) {
+			for (JsonValue child = entries.child; child != null; child = child.next)
+				put((K)child.name, child.asFloat());
+		} else if (entries.isArray()) {
+			for (JsonValue child = entries.child; child != null; child = child.next) {
+				K key = json.readValue(null, child);
+				float value = (child = child.next).asFloat();
+				put(key, value);
+			}
+		}
 	}
 
 	static public class Entry<K> {
@@ -663,7 +624,7 @@ public class ObjectFloatMap<K> implements Iterable<ObjectFloatMap.Entry<K>> {
 		void findNextIndex () {
 			hasNext = false;
 			K[] keyTable = map.keyTable;
-			for (int n = map.capacity + map.stashSize; ++nextIndex < n;) {
+			for (int n = keyTable.length; ++nextIndex < n; ) {
 				if (keyTable[nextIndex] != null) {
 					hasNext = true;
 					break;
@@ -672,30 +633,40 @@ public class ObjectFloatMap<K> implements Iterable<ObjectFloatMap.Entry<K>> {
 		}
 
 		public void remove () {
-			if (currentIndex < 0) throw new IllegalStateException("next must be called before remove.");
-			if (currentIndex >= map.capacity) {
-				map.removeStashIndex(currentIndex);
-				nextIndex = currentIndex - 1;
-				findNextIndex();
-			} else {
-				map.keyTable[currentIndex] = null;
+			if (currentIndex < 0)
+				throw new IllegalStateException("next must be called before remove.");
+			final K[] keyTable = map.keyTable;
+			final float[] valueTable = map.valueTable;
+			int loc = currentIndex;
+			final int mask = map.mask;
+			K key;
+			while ((key = keyTable[loc + 1 & mask]) != null && (loc + 1 & mask) != map.place(key)) {
+				keyTable[loc] = key;
+				valueTable[loc] = valueTable[loc + 1 & mask];
+				++loc;
 			}
+			if(loc != currentIndex) --nextIndex;
+			keyTable[loc] = null;
+			--map.size;
 			currentIndex = -1;
-			map.size--;
 		}
 	}
 
 	static public class Entries<K> extends MapIterator<K> implements Iterable<Entry<K>>, Iterator<Entry<K>> {
-		private Entry<K> entry = new Entry();
+		Entry<K> entry = new Entry<K>();
 
 		public Entries (ObjectFloatMap<K> map) {
 			super(map);
 		}
 
-		/** Note the same entry instance is returned each time this method is called. */
+		/**
+		 * Note the same entry instance is returned each time this method is called.
+		 */
 		public Entry<K> next () {
-			if (!hasNext) throw new NoSuchElementException();
-			if (!valid) throw new GdxRuntimeException("#iterator() cannot be used nested.");
+			if (!hasNext)
+				throw new NoSuchElementException();
+			if (!valid)
+				throw new GdxRuntimeException("#iterator() cannot be used nested.");
 			K[] keyTable = map.keyTable;
 			entry.key = keyTable[nextIndex];
 			entry.value = map.valueTable[nextIndex];
@@ -705,17 +676,18 @@ public class ObjectFloatMap<K> implements Iterable<ObjectFloatMap.Entry<K>> {
 		}
 
 		public boolean hasNext () {
-			if (!valid) throw new GdxRuntimeException("#iterator() cannot be used nested.");
+			if (!valid)
+				throw new GdxRuntimeException("#iterator() cannot be used nested.");
 			return hasNext;
 		}
 
 		public Entries<K> iterator () {
 			return this;
 		}
-
 		public void remove () {
 			super.remove();
 		}
+
 	}
 
 	static public class Values extends MapIterator<Object> {
@@ -724,22 +696,40 @@ public class ObjectFloatMap<K> implements Iterable<ObjectFloatMap.Entry<K>> {
 		}
 
 		public boolean hasNext () {
-			if (!valid) throw new GdxRuntimeException("#iterator() cannot be used nested.");
+			if (!valid)
+				throw new GdxRuntimeException("#iterator() cannot be used nested.");
 			return hasNext;
 		}
 
 		public float next () {
-			if (!hasNext) throw new NoSuchElementException();
-			if (!valid) throw new GdxRuntimeException("#iterator() cannot be used nested.");
+			if (!hasNext)
+				throw new NoSuchElementException();
+			if (!valid)
+				throw new GdxRuntimeException("#iterator() cannot be used nested.");
 			float value = map.valueTable[nextIndex];
 			currentIndex = nextIndex;
 			findNextIndex();
 			return value;
 		}
 
-		/** Returns a new array containing the remaining values. */
+		public Values iterator () {
+			return this;
+		}
+
+		/**
+		 * Returns a new array containing the remaining values.
+		 */
 		public FloatArray toArray () {
 			FloatArray array = new FloatArray(true, map.size);
+			while (hasNext)
+				array.add(next());
+			return array;
+		}
+
+		/**
+		 * Adds the remaining values to the specified array.
+		 */
+		public FloatArray toArray (FloatArray array) {
 			while (hasNext)
 				array.add(next());
 			return array;
@@ -748,17 +738,20 @@ public class ObjectFloatMap<K> implements Iterable<ObjectFloatMap.Entry<K>> {
 
 	static public class Keys<K> extends MapIterator<K> implements Iterable<K>, Iterator<K> {
 		public Keys (ObjectFloatMap<K> map) {
-			super((ObjectFloatMap<K>)map);
+			super(map);
 		}
 
 		public boolean hasNext () {
-			if (!valid) throw new GdxRuntimeException("#iterator() cannot be used nested.");
+			if (!valid)
+				throw new GdxRuntimeException("#iterator() cannot be used nested.");
 			return hasNext;
 		}
 
 		public K next () {
-			if (!hasNext) throw new NoSuchElementException();
-			if (!valid) throw new GdxRuntimeException("#iterator() cannot be used nested.");
+			if (!hasNext)
+				throw new NoSuchElementException();
+			if (!valid)
+				throw new GdxRuntimeException("#iterator() cannot be used nested.");
 			K key = map.keyTable[nextIndex];
 			currentIndex = nextIndex;
 			findNextIndex();
@@ -769,23 +762,20 @@ public class ObjectFloatMap<K> implements Iterable<ObjectFloatMap.Entry<K>> {
 			return this;
 		}
 
-		/** Returns a new array containing the remaining keys. */
+		/**
+		 * Returns a new array containing the remaining keys.
+		 */
 		public Array<K> toArray () {
-			Array array = new Array(true, map.size);
-			while (hasNext)
-				array.add(next());
-			return array;
+			return toArray(new Array<K>(true, map.size));
 		}
 
-		/** Adds the remaining keys to the array. */
+		/**
+		 * Adds the remaining keys to the array.
+		 */
 		public Array<K> toArray (Array<K> array) {
 			while (hasNext)
 				array.add(next());
 			return array;
-		}
-
-		public void remove () {
-			super.remove();
 		}
 	}
 }

--- a/gdx/src/com/badlogic/gdx/utils/ObjectFloatMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/ObjectFloatMap.java
@@ -224,10 +224,6 @@ public class ObjectFloatMap<K> implements Iterable<ObjectFloatMap.Entry<K>> {
 				put(k, valueTable[i]);
 		}
 	}
-//		ensureCapacity(map.size);
-//		for (Entry<K> entry : map)
-//			put(entry.key, entry.value);
-//	}
 
 	/**
 	 * Skips checks for existing keys.

--- a/gdx/src/com/badlogic/gdx/utils/ObjectIntMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/ObjectIntMap.java
@@ -103,7 +103,7 @@ public class ObjectIntMap<K> implements Iterable<ObjectIntMap.Entry<K>> {
 			throw new IllegalArgumentException("initialCapacity must be >= 0: " + initialCapacity);
 		if (loadFactor <= 0f || loadFactor >= 1f)
 			throw new IllegalArgumentException("loadFactor must be > 0 and < 1: " + loadFactor);
-		initialCapacity = MathUtils.nextPowerOfTwo((int)Math.ceil(initialCapacity / loadFactor));
+		initialCapacity = MathUtils.nextPowerOfTwo((int)Math.ceil(Math.max(1, initialCapacity) / loadFactor));
 		if (initialCapacity > 1 << 30)
 			throw new IllegalArgumentException("initialCapacity is too large: " + initialCapacity);
 

--- a/gdx/src/com/badlogic/gdx/utils/ObjectIntMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/ObjectIntMap.java
@@ -217,10 +217,6 @@ public class ObjectIntMap<K> implements Iterable<ObjectIntMap.Entry<K>> {
 				put(k, valueTable[i]);
 		}
 	}
-//		ensureCapacity(map.size);
-//		for (Entry<K> entry : map)
-//			put(entry.key, entry.value);
-//	}
 
 	/**
 	 * Skips checks for existing keys.

--- a/gdx/src/com/badlogic/gdx/utils/ObjectIntMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/ObjectIntMap.java
@@ -49,7 +49,7 @@ import java.util.NoSuchElementException;
  * @author Tommy Ettinger
  * @author Nathan Sweet
  */
-public class ObjectIntMap<K> implements Json.Serializable, Iterable<ObjectIntMap.Entry<K>> {
+public class ObjectIntMap<K> implements Iterable<ObjectIntMap.Entry<K>> {
 
 	public int size;
 
@@ -546,41 +546,6 @@ public class ObjectIntMap<K> implements Json.Serializable, Iterable<ObjectIntMap
 		keys2.valid = true;
 		keys1.valid = false;
 		return keys2;
-	}
-
-	public void write (Json json) {
-		if (isEmpty())
-			return;
-		if (keys().next() instanceof String) {
-			json.writeObjectStart("entries");
-			for (Entry<K> entry : entries()) {
-				json.writeValue(String.valueOf(entry.key), entry.value, Integer.class);
-			}
-			json.writeObjectEnd();
-		} else {
-			json.writeArrayStart("entries");
-			for (Entry<K> entry : entries()) {
-				json.writeValue(entry.key, null);
-				json.writeValue(entry.value, Integer.class);
-			}
-			json.writeArrayEnd();
-		}
-	}
-
-	public void read (Json json, JsonValue jsonData) {
-		if (jsonData.isEmpty())
-			return;
-		JsonValue entries = jsonData.get("entries");
-		if (entries.isObject()) {
-			for (JsonValue child = entries.child; child != null; child = child.next)
-				put((K)child.name, child.asInt());
-		} else if (entries.isArray()) {
-			for (JsonValue child = entries.child; child != null; child = child.next) {
-				K key = json.readValue(null, child);
-				int value = (child = child.next).asInt();
-				put(key, value);
-			}
-		}
 	}
 
 	static public class Entry<K> {

--- a/gdx/src/com/badlogic/gdx/utils/ObjectIntMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/ObjectIntMap.java
@@ -39,12 +39,7 @@ import java.util.NoSuchElementException;
  * Load factors greater than 0.91 greatly increase the chances the map will have to rehash to the next higher POT size.
  * Memory usage is excellent, and the aforementioned collision-resistance helps avoid too much capacity resizing.
  * <br>
- * The <a href="http://codecapsule.com/2013/11/17/robin-hood-hashing-backward-shift-deletion/">backward-shift algorithm</a>
- * used during removal apparently is key to the good performance of this implementation, even though this doesn't use Robin Hood
- * hashing; the performance of {@link #remove(Object, int)} has improved considerably over the previous libGDX version.
- * <br>
- * Iteration should be fast with OrderedSet and OrderedMap, whereas ObjectSet and ObjectMap aren't designed to provide especially
- * quick iteration.
+ * Iteration won't be as fast here as with OrderedSet and OrderedMap.
  *
  * @author Tommy Ettinger
  * @author Nathan Sweet
@@ -146,7 +141,7 @@ public class ObjectIntMap<K> implements Iterable<ObjectIntMap.Entry<K>> {
 	 * {@code return (int) (item.hashCode() * 0x9E3779B97F4A7C15L >>> shift);}
 	 * <br>
 	 * This can be overridden by subclasses, which you may want to do if your key type needs special consideration for
-	 * its hash (such as if you use arrays as keys, which still requires that the arrays are not modified). Subclasses
+	 * its hash (such as if you can't modify or extend a particular class that has an incorrect hashCode()). Subclasses
 	 * that don't need the collision decrease of Fibonacci Hashing (assuming the key class has a good hashCode()) may do
 	 * fine with a simple implementation:
 	 * {@code return (item.hashCode() & mask);}

--- a/gdx/src/com/badlogic/gdx/utils/ObjectIntMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/ObjectIntMap.java
@@ -228,8 +228,7 @@ public class ObjectIntMap<K> implements Iterable<ObjectIntMap.Entry<K>> {
 	private void putResize (K key, int value) {
 		K[] keyTable = this.keyTable;
 		int[] valueTable = this.valueTable;
-		int b = place(key);
-		for (int i = b; ; i = (i + 1) & mask) {
+		for (int i = place(key); ; i = (i + 1) & mask) {
 			// space is available so we insert and break (resize is later)
 			if (keyTable[i] == null) {
 				keyTable[i] = key;

--- a/gdx/src/com/badlogic/gdx/utils/ObjectIntMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/ObjectIntMap.java
@@ -225,16 +225,14 @@ public class ObjectIntMap<K> implements Iterable<ObjectIntMap.Entry<K>> {
 		K[] keyTable = this.keyTable;
 		int[] valueTable = this.valueTable;
 		for (int i = place(key); ; i = (i + 1) & mask) {
-			// space is available so we insert and break (resize is later)
+			// space is available so we insert and break
 			if (keyTable[i] == null) {
 				keyTable[i] = key;
 				valueTable[i] = value;
 				break;
 			}
 		}
-		if (++size >= threshold) {
-			resize(keyTable.length << 1);
-		}
+		++size;
 	}
 
 	/**

--- a/gdx/src/com/badlogic/gdx/utils/ObjectIntMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/ObjectIntMap.java
@@ -275,9 +275,12 @@ public class ObjectIntMap<K> implements Iterable<ObjectIntMap.Entry<K>> {
 		final K[] keyTable = this.keyTable;
 		final int[] valueTable = this.valueTable;
 		final int oldValue = valueTable[loc];
-		while ((key = keyTable[loc + 1 & mask]) != null && (loc + 1 & mask) != place(key)) {
+		int nl = (loc + 1 & mask);
+		while ((key = keyTable[nl]) != null && nl != place(key)) {
 			keyTable[loc] = key;
-			valueTable[loc] = valueTable[++loc & mask];
+			valueTable[loc] = valueTable[nl];
+			loc = nl;
+			nl = loc + 1 & mask;
 		}
 		keyTable[loc] = null;
 		--size;
@@ -586,13 +589,14 @@ public class ObjectIntMap<K> implements Iterable<ObjectIntMap.Entry<K>> {
 				throw new IllegalStateException("next must be called before remove.");
 			final K[] keyTable = map.keyTable;
 			final int[] valueTable = map.valueTable;
-			int loc = currentIndex;
 			final int mask = map.mask;
+			int loc = currentIndex, nl = (loc + 1 & mask);
 			K key;
-			while ((key = keyTable[loc + 1 & mask]) != null && (loc + 1 & mask) != map.place(key)) {
+			while ((key = keyTable[nl]) != null && nl != map.place(key)) {
 				keyTable[loc] = key;
-				valueTable[loc] = valueTable[loc + 1 & mask];
-				++loc;
+				valueTable[loc] = valueTable[nl];
+				loc = nl;
+				nl = loc + 1 & mask;
 			}
 			if(loc != currentIndex) --nextIndex;
 			keyTable[loc] = null;

--- a/gdx/src/com/badlogic/gdx/utils/ObjectIntMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/ObjectIntMap.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,390 +16,312 @@
 
 package com.badlogic.gdx.utils;
 
+import com.badlogic.gdx.math.MathUtils;
+
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
-import com.badlogic.gdx.math.MathUtils;
-
-/** An unordered map where the values are ints. This implementation is a cuckoo hash map using 3 hashes, random walking, and a
- * small stash for problematic keys. Null keys are not allowed. No allocation is done except when growing the table size. <br>
+/**
+ * An unordered map where the keys are objects and the values are unboxed ints. This implementation uses linear probing with the
+ * backward-shift algorithm for removal, and finds space for keys using Fibonacci hashing instead of the more-common power-of-two
+ * mask. Null keys are not allowed. No allocation is done except when growing the table size.
  * <br>
- * This map performs very fast get, containsKey, and remove (typically O(1), worst case O(log(n))). Put may be a bit slower,
- * depending on hash collisions. Load factors greater than 0.91 greatly increase the chances the map will have to rehash to the
- * next higher POT size.
- * @author Nathan Sweet */
-public class ObjectIntMap<K> implements Iterable<ObjectIntMap.Entry<K>> {
-	private static final int PRIME1 = 0xbe1f14b1;
-	private static final int PRIME2 = 0xb4b82e39;
-	private static final int PRIME3 = 0xced1c241;
+ * This map uses Fibonacci hashing to help distribute what may be very bad hashCode() results across the
+ * whole capacity. See <a href="https://probablydance.com/2018/06/16/fibonacci-hashing-the-optimization-that-the-world-forgot-or-a-better-alternative-to-integer-modulo/">Malte Skarupke's blog post</a>
+ * for more information on Fibonacci hashing. It uses linear probing to resolve collisions, which is far from the academically
+ * optimal algorithm, but performs considerably better in practice than most alternatives, and combined with Fibonacci hashing, it
+ * can handle "normal" generated hashCode() implementations, and not just theoretically optimal hashing functions. Even if all
+ * hashCode()s this is given collide, it will still work, just slowly; the older libGDX implementation using cuckoo hashing would
+ * crash with an OutOfMemoryError with under 50 collisions.
+ * <br>
+ * This map performs very fast contains and remove (typically O(1), worst case O(n) due to occasional probing, but still very
+ * fast). Add may be a bit slower, depending on hash collisions, but this data structure is somewhat collision-resistant.
+ * Load factors greater than 0.91 greatly increase the chances the map will have to rehash to the next higher POT size.
+ * Memory usage is excellent, and the aforementioned collision-resistance helps avoid too much capacity resizing.
+ * <br>
+ * The <a href="http://codecapsule.com/2013/11/17/robin-hood-hashing-backward-shift-deletion/">backward-shift algorithm</a>
+ * used during removal apparently is key to the good performance of this implementation, even though this doesn't use Robin Hood
+ * hashing; the performance of {@link #remove(Object, int)} has improved considerably over the previous libGDX version.
+ * <br>
+ * Iteration should be fast with OrderedSet and OrderedMap, whereas ObjectSet and ObjectMap aren't designed to provide especially
+ * quick iteration.
+ *
+ * @author Tommy Ettinger
+ * @author Nathan Sweet
+ */
+public class ObjectIntMap<K> implements Json.Serializable, Iterable<ObjectIntMap.Entry<K>> {
 
 	public int size;
 
 	K[] keyTable;
 	int[] valueTable;
-	int capacity, stashSize;
 
-	private float loadFactor;
-	private int hashShift, mask, threshold;
-	private int stashCapacity;
-	private int pushIterations;
+	float loadFactor;
+	int threshold;
+	/**
+	 * Used by {@link #place(Object)} to bit-shift the upper bits of a {@code long} into a usable range (less than or
+	 * equal to {@link #mask}, greater than or equal to 0). If you're setting it in a subclass, this shift can be
+	 * negative, which is a convenient way to match the number of bits in mask; if mask is a 7-bit number, then a shift
+	 * of -7 will correctly shift the upper 7 bits into the lowest 7 positions. If using what this class sets, shift
+	 * will be greater than 32 and less than 64; if you use this shift with an int, it will still correctly move the
+	 * upper bits of an int to the lower bits, thanks to Java's implicit modulus on shifts.
+	 * <br>
+	 * You can also use {@link #mask} to mask the low bits of a number, which may be faster for some hashCode()s, if you
+	 * reimplement {@link #place(Object)}.
+	 */
+	protected int shift;
+	/**
+	 * The bitmask used to contain hashCode()s to the indices that can be fit into the key array this uses. This should
+	 * always be all-1-bits in its low positions; that is, it must be a power of two minus 1. If you subclass and change
+	 * {@link #place(Object)}, you may want to use this instead of {@link #shift} to isolate usable bits of a hash.
+	 */
+	protected int mask;
 
-	private Entries entries1, entries2;
-	private Values values1, values2;
-	private Keys keys1, keys2;
+	Entries entries1, entries2;
+	Values values1, values2;
+	Keys keys1, keys2;
 
-	/** Creates a new map with an initial capacity of 51 and a load factor of 0.8. */
+	/**
+	 * Creates a new map with an initial capacity of 51 and a load factor of 0.8.
+	 */
 	public ObjectIntMap () {
 		this(51, 0.8f);
 	}
 
-	/** Creates a new map with a load factor of 0.8.
-	 * @param initialCapacity If not a power of two, it is increased to the next nearest power of two. */
+	/**
+	 * Creates a new map with a load factor of 0.8.
+	 *
+	 * @param initialCapacity If not a power of two, it is increased to the next nearest power of two.
+	 */
 	public ObjectIntMap (int initialCapacity) {
 		this(initialCapacity, 0.8f);
 	}
 
-	/** Creates a new map with the specified initial capacity and load factor. This map will hold initialCapacity items before
+	/**
+	 * Creates a new map with the specified initial capacity and load factor. This map will hold initialCapacity items before
 	 * growing the backing table.
-	 * @param initialCapacity If not a power of two, it is increased to the next nearest power of two. */
+	 *
+	 * @param initialCapacity If not a power of two, it is increased to the next nearest power of two.
+	 */
 	public ObjectIntMap (int initialCapacity, float loadFactor) {
-		if (loadFactor <= 0) throw new IllegalArgumentException("loadFactor must be > 0: " + loadFactor);
+		if (initialCapacity < 0)
+			throw new IllegalArgumentException("initialCapacity must be >= 0: " + initialCapacity);
+		if (loadFactor <= 0f || loadFactor >= 1f)
+			throw new IllegalArgumentException("loadFactor must be > 0 and < 1: " + loadFactor);
+		initialCapacity = MathUtils.nextPowerOfTwo((int)Math.ceil(initialCapacity / loadFactor));
+		if (initialCapacity > 1 << 30)
+			throw new IllegalArgumentException("initialCapacity is too large: " + initialCapacity);
+
 		this.loadFactor = loadFactor;
 
-		if (initialCapacity < 0) throw new IllegalArgumentException("initialCapacity must be >= 0: " + initialCapacity);
-		initialCapacity = MathUtils.nextPowerOfTwo((int)Math.ceil(initialCapacity / loadFactor));
-		if (initialCapacity > 1 << 30) throw new IllegalArgumentException("initialCapacity is too large: " + initialCapacity);
-		capacity = initialCapacity;
+		threshold = (int)(initialCapacity * loadFactor);
+		mask = initialCapacity - 1;
+		shift = Long.numberOfLeadingZeros(mask);
 
-		threshold = (int)(capacity * loadFactor);
-		mask = capacity - 1;
-		hashShift = 31 - Integer.numberOfTrailingZeros(capacity);
-		stashCapacity = Math.max(3, (int)Math.ceil(Math.log(capacity)) * 2);
-		pushIterations = Math.max(Math.min(capacity, 8), (int)Math.sqrt(capacity) / 8);
-
-		keyTable = (K[])new Object[capacity + stashCapacity];
-		valueTable = new int[keyTable.length];
+		keyTable = (K[])new Object[initialCapacity];
+		valueTable = new int[initialCapacity];
 	}
 
-	/** Creates a new map identical to the specified map. */
+	/**
+	 * Creates a new map identical to the specified map.
+	 */
 	public ObjectIntMap (ObjectIntMap<? extends K> map) {
-		this((int)Math.floor(map.capacity * map.loadFactor), map.loadFactor);
-		stashSize = map.stashSize;
+		this((int)Math.floor(map.keyTable.length * map.loadFactor), map.loadFactor);
 		System.arraycopy(map.keyTable, 0, keyTable, 0, map.keyTable.length);
 		System.arraycopy(map.valueTable, 0, valueTable, 0, map.valueTable.length);
 		size = map.size;
 	}
 
-	public void put (K key, int value) {
-		if (key == null) throw new IllegalArgumentException("key cannot be null.");
-		K[] keyTable = this.keyTable;
+	/**
+	 * Finds an array index between 0 and {@link #mask}, both inclusive, corresponding to the hash code of {@code item}.
+	 * By default, this uses "Fibonacci Hashing" on the {@link Object#hashCode()} of {@code item}; this multiplies
+	 * {@code item.hashCode()} by a long constant (2 to the 64, divided by the golden ratio) and shifts the high-quality
+	 * uppermost bits into the lowest positions so they can be used as array indices. The multiplication by a long may
+	 * be somewhat slow on GWT, but it will be correct across all platforms and won't lose precision. Using Fibonacci
+	 * Hashing allows even very poor hashCode() implementations, such as those that only differ in their upper bits, to
+	 * work in a hash table without heavy collision rates. It has known problems when all or most hashCode()s are
+	 * multiples of larger Fibonacci numbers; see <a href="https://probablydance.com/2018/06/16/fibonacci-hashing-the-optimization-that-the-world-forgot-or-a-better-alternative-to-integer-modulo/">this blog post by Malte Skarupke</a>
+	 * for more details. In the unlikely event that most of your hashCode()s are Fibonacci numbers, you can subclass
+	 * this to change this method, which is a one-liner in this form:
+	 * {@code return (int) (item.hashCode() * 0x9E3779B97F4A7C15L >>> shift);}
+	 * <br>
+	 * This can be overridden by subclasses, which you may want to do if your key type needs special consideration for
+	 * its hash (such as if you use arrays as keys, which still requires that the arrays are not modified). Subclasses
+	 * that don't need the collision decrease of Fibonacci Hashing (assuming the key class has a good hashCode()) may do
+	 * fine with a simple implementation:
+	 * {@code return (item.hashCode() & mask);}
+	 *
+	 * @param item a key that this method will hash, by default by calling {@link Object#hashCode()} on it; non-null
+	 * @return an int between 0 and {@link #mask}, both inclusive
+	 */
+	protected int place (final K item) {
+		// shift is always greater than 32, less than 64
+		return (int)(item.hashCode() * 0x9E3779B97F4A7C15L >>> shift);
+	}
 
-		// Check for existing keys.
-		int hashCode = key.hashCode();
-		int index1 = hashCode & mask;
-		K key1 = keyTable[index1];
-		if (key.equals(key1)) {
-			valueTable[index1] = value;
-			return;
-		}
+	private int locateKey (final K key) {
+		return locateKey(key, place(key));
+	}
 
-		int index2 = hash2(hashCode);
-		K key2 = keyTable[index2];
-		if (key.equals(key2)) {
-			valueTable[index2] = value;
-			return;
-		}
-
-		int index3 = hash3(hashCode);
-		K key3 = keyTable[index3];
-		if (key.equals(key3)) {
-			valueTable[index3] = value;
-			return;
-		}
-
-		// Update key in the stash.
-		for (int i = capacity, n = i + stashSize; i < n; i++) {
+	/**
+	 * Given a key and its initial placement to try in an array, this finds the actual location of the key in the array
+	 * if it is present, or -1 if the key is not present. This can be overridden if a subclass needs to compare for
+	 * equality differently than just by calling {@link Object#equals(Object)}, but only within the same package.
+	 *
+	 * @param key       a K key that will be checked for equality if a similar-seeming key is found
+	 * @param placement as calculated by {@link #place(Object)}, almost always with {@code place(key)}
+	 * @return the location in the key array of key, if found, or -1 if it was not found.
+	 */
+	int locateKey (final K key, final int placement) {
+		for (int i = placement; ; i = i + 1 & mask) {
+			// empty space is available
+			if (keyTable[i] == null) {
+				return -1;
+			}
 			if (key.equals(keyTable[i])) {
-				valueTable[i] = value;
-				return;
+				return i;
 			}
 		}
-
-		// Check for empty buckets.
-		if (key1 == null) {
-			keyTable[index1] = key;
-			valueTable[index1] = value;
-			if (size++ >= threshold) resize(capacity << 1);
-			return;
-		}
-
-		if (key2 == null) {
-			keyTable[index2] = key;
-			valueTable[index2] = value;
-			if (size++ >= threshold) resize(capacity << 1);
-			return;
-		}
-
-		if (key3 == null) {
-			keyTable[index3] = key;
-			valueTable[index3] = value;
-			if (size++ >= threshold) resize(capacity << 1);
-			return;
-		}
-
-		push(key, value, index1, key1, index2, key2, index3, key3);
 	}
 
-	public void putAll (ObjectIntMap<? extends K> map) {
-		for (Entry<? extends K> entry : map.entries())
-			put(entry.key, entry.value);
-	}
-
-	/** Skips checks for existing keys. */
-	private void putResize (K key, int value) {
-		// Check for empty buckets.
-		int hashCode = key.hashCode();
-		int index1 = hashCode & mask;
-		K key1 = keyTable[index1];
-		if (key1 == null) {
-			keyTable[index1] = key;
-			valueTable[index1] = value;
-			if (size++ >= threshold) resize(capacity << 1);
-			return;
-		}
-
-		int index2 = hash2(hashCode);
-		K key2 = keyTable[index2];
-		if (key2 == null) {
-			keyTable[index2] = key;
-			valueTable[index2] = value;
-			if (size++ >= threshold) resize(capacity << 1);
-			return;
-		}
-
-		int index3 = hash3(hashCode);
-		K key3 = keyTable[index3];
-		if (key3 == null) {
-			keyTable[index3] = key;
-			valueTable[index3] = value;
-			if (size++ >= threshold) resize(capacity << 1);
-			return;
-		}
-
-		push(key, value, index1, key1, index2, key2, index3, key3);
-	}
-
-	private void push (K insertKey, int insertValue, int index1, K key1, int index2, K key2, int index3, K key3) {
+	/**
+	 * Doesn't return a value, unlike other maps.
+	 */
+	public void put (K key, int value) {
+		if (key == null)
+			throw new IllegalArgumentException("key cannot be null.");
 		K[] keyTable = this.keyTable;
 		int[] valueTable = this.valueTable;
-		int mask = this.mask;
-
-		// Push keys until an empty bucket is found.
-		K evictedKey;
-		int evictedValue;
-		int i = 0, pushIterations = this.pushIterations;
-		do {
-			// Replace the key and value for one of the hashes.
-			switch (MathUtils.random(2)) {
-			case 0:
-				evictedKey = key1;
-				evictedValue = valueTable[index1];
-				keyTable[index1] = insertKey;
-				valueTable[index1] = insertValue;
-				break;
-			case 1:
-				evictedKey = key2;
-				evictedValue = valueTable[index2];
-				keyTable[index2] = insertKey;
-				valueTable[index2] = insertValue;
-				break;
-			default:
-				evictedKey = key3;
-				evictedValue = valueTable[index3];
-				keyTable[index3] = insertKey;
-				valueTable[index3] = insertValue;
-				break;
-			}
-
-			// If the evicted key hashes to an empty bucket, put it there and stop.
-			int hashCode = evictedKey.hashCode();
-			index1 = hashCode & mask;
-			key1 = keyTable[index1];
-			if (key1 == null) {
-				keyTable[index1] = evictedKey;
-				valueTable[index1] = evictedValue;
-				if (size++ >= threshold) resize(capacity << 1);
-				return;
-			}
-
-			index2 = hash2(hashCode);
-			key2 = keyTable[index2];
-			if (key2 == null) {
-				keyTable[index2] = evictedKey;
-				valueTable[index2] = evictedValue;
-				if (size++ >= threshold) resize(capacity << 1);
-				return;
-			}
-
-			index3 = hash3(hashCode);
-			key3 = keyTable[index3];
-			if (key3 == null) {
-				keyTable[index3] = evictedKey;
-				valueTable[index3] = evictedValue;
-				if (size++ >= threshold) resize(capacity << 1);
-				return;
-			}
-
-			if (++i == pushIterations) break;
-
-			insertKey = evictedKey;
-			insertValue = evictedValue;
-		} while (true);
-
-		putStash(evictedKey, evictedValue);
-	}
-
-	private void putStash (K key, int value) {
-		if (stashSize == stashCapacity) {
-			// Too many pushes occurred and the stash is full, increase the table size.
-			resize(capacity << 1);
-			putResize(key, value);
+		int b = place(key);
+		int loc = locateKey(key, b);
+		// an identical key already exists
+		if (loc != -1) {
+			valueTable[loc] = value;
 			return;
 		}
-		// Store key in the stash.
-		int index = capacity + stashSize;
-		keyTable[index] = key;
-		valueTable[index] = value;
-		stashSize++;
-		size++;
+		for (int i = b; ; i = (i + 1) & mask) {
+			// space is available so we insert and break (resize is later)
+			if (keyTable[i] == null) {
+				keyTable[i] = key;
+				valueTable[i] = value;
+				break;
+			}
+		}
+		if (++size >= threshold) {
+			resize(keyTable.length << 1);
+		}
 	}
 
-	/** @param defaultValue Returned if the key was not associated with a value. */
+	public void putAll (ObjectIntMap<K> map) {
+		ensureCapacity(map.size);
+		final K[] keyTable = map.keyTable;
+		final int[] valueTable = map.valueTable;
+		K k;
+		for (int i = 0, n = keyTable.length; i < n; i++) {
+			if ((k = keyTable[i]) != null)
+				put(k, valueTable[i]);
+		}
+	}
+//		ensureCapacity(map.size);
+//		for (Entry<K> entry : map)
+//			put(entry.key, entry.value);
+//	}
+
+	/**
+	 * Skips checks for existing keys.
+	 */
+	private void putResize (K key, int value) {
+		K[] keyTable = this.keyTable;
+		int[] valueTable = this.valueTable;
+		int b = place(key);
+		for (int i = b; ; i = (i + 1) & mask) {
+			// space is available so we insert and break (resize is later)
+			if (keyTable[i] == null) {
+				keyTable[i] = key;
+				valueTable[i] = value;
+				break;
+			}
+		}
+		if (++size >= threshold) {
+			resize(keyTable.length << 1);
+		}
+	}
+
+	/**
+	 * Returns the value for the specified key, or the default value if the key is not in the map.
+	 */
 	public int get (K key, int defaultValue) {
-		int hashCode = key.hashCode();
-		int index = hashCode & mask;
-		if (!key.equals(keyTable[index])) {
-			index = hash2(hashCode);
-			if (!key.equals(keyTable[index])) {
-				index = hash3(hashCode);
-				if (!key.equals(keyTable[index])) return getStash(key, defaultValue);
-			}
-		}
-		return valueTable[index];
+		final int loc = locateKey(key);
+		return loc == -1 ? defaultValue : valueTable[loc];
 	}
 
-	private int getStash (K key, int defaultValue) {
-		K[] keyTable = this.keyTable;
-		for (int i = capacity, n = i + stashSize; i < n; i++)
-			if (key.equals(keyTable[i])) return valueTable[i];
-		return defaultValue;
-	}
-
-	/** Returns the key's current value and increments the stored value. If the key is not in the map, defaultValue + increment is
-	 * put into the map. */
+	/**
+	 * Returns the key's current value and increments the stored value. If the key is not in the map, defaultValue + increment is
+	 * put into the map.
+	 */
 	public int getAndIncrement (K key, int defaultValue, int increment) {
-		int hashCode = key.hashCode();
-		int index = hashCode & mask;
-		if (!key.equals(keyTable[index])) {
-			index = hash2(hashCode);
-			if (!key.equals(keyTable[index])) {
-				index = hash3(hashCode);
-				if (!key.equals(keyTable[index])) return getAndIncrementStash(key, defaultValue, increment);
-			}
+		final int loc = locateKey(key);
+		// key was not found
+		if (loc == -1) {
+			// because we know there's no existing duplicate key, we can use putResize().
+			putResize(key, defaultValue + increment);
+			return defaultValue;
 		}
-		int value = valueTable[index];
-		valueTable[index] = value + increment;
-		return value;
-	}
-
-	private int getAndIncrementStash (K key, int defaultValue, int increment) {
-		K[] keyTable = this.keyTable;
-		for (int i = capacity, n = i + stashSize; i < n; i++)
-			if (key.equals(keyTable[i])) {
-				int value = valueTable[i];
-				valueTable[i] = value + increment;
-				return value;
-			}
-		put(key, defaultValue + increment);
-		return defaultValue;
+		final int oldValue = valueTable[loc];
+		valueTable[loc] += increment;
+		return oldValue;
 	}
 
 	public int remove (K key, int defaultValue) {
-		int hashCode = key.hashCode();
-		int index = hashCode & mask;
-		if (key.equals(keyTable[index])) {
-			keyTable[index] = null;
-			int oldValue = valueTable[index];
-			size--;
-			return oldValue;
+		int loc = locateKey(key);
+		if (loc == -1) {
+			return defaultValue;
 		}
-
-		index = hash2(hashCode);
-		if (key.equals(keyTable[index])) {
-			keyTable[index] = null;
-			int oldValue = valueTable[index];
-			size--;
-			return oldValue;
+		final K[] keyTable = this.keyTable;
+		final int[] valueTable = this.valueTable;
+		final int oldValue = valueTable[loc];
+		while ((key = keyTable[loc + 1 & mask]) != null && (loc + 1 & mask) != place(key)) {
+			keyTable[loc] = key;
+			valueTable[loc] = valueTable[++loc & mask];
 		}
-
-		index = hash3(hashCode);
-		if (key.equals(keyTable[index])) {
-			keyTable[index] = null;
-			int oldValue = valueTable[index];
-			size--;
-			return oldValue;
-		}
-
-		return removeStash(key, defaultValue);
+		keyTable[loc] = null;
+		--size;
+		return oldValue;
 	}
 
-	int removeStash (K key, int defaultValue) {
-		K[] keyTable = this.keyTable;
-		for (int i = capacity, n = i + stashSize; i < n; i++) {
-			if (key.equals(keyTable[i])) {
-				int oldValue = valueTable[i];
-				removeStashIndex(i);
-				size--;
-				return oldValue;
-			}
-		}
-		return defaultValue;
-	}
-
-	void removeStashIndex (int index) {
-		// If the removed location was not last, move the last tuple to the removed location.
-		stashSize--;
-		int lastIndex = capacity + stashSize;
-		if (index < lastIndex) {
-			keyTable[index] = keyTable[lastIndex];
-			valueTable[index] = valueTable[lastIndex];
-			keyTable[lastIndex] = null;
-		}
-	}
-
-	/** Returns true if the map has one or more items. */
+	/**
+	 * Returns true if the map has one or more items.
+	 */
 	public boolean notEmpty () {
 		return size > 0;
 	}
 
-	/** Returns true if the map is empty. */
+	/**
+	 * Returns true if the map is empty.
+	 */
 	public boolean isEmpty () {
 		return size == 0;
 	}
 
-	/** Reduces the size of the backing arrays to be the specified capacity or less. If the capacity is already less, nothing is
-	 * done. If the map contains more items than the specified capacity, the next highest power of two capacity is used instead. */
+	/**
+	 * Reduces the size of the backing arrays to be the specified capacity or less. If the capacity is already less, nothing is
+	 * done. If the map contains more items than the specified capacity, the next highest power of two capacity is used instead.
+	 */
 	public void shrink (int maximumCapacity) {
-		if (maximumCapacity < 0) throw new IllegalArgumentException("maximumCapacity must be >= 0: " + maximumCapacity);
-		if (size > maximumCapacity) maximumCapacity = size;
-		if (capacity <= maximumCapacity) return;
-		maximumCapacity = MathUtils.nextPowerOfTwo(maximumCapacity);
-		resize(maximumCapacity);
+		if (maximumCapacity < 0)
+			throw new IllegalArgumentException("maximumCapacity must be >= 0: " + maximumCapacity);
+		if (size > maximumCapacity)
+			maximumCapacity = size;
+		if (keyTable.length <= maximumCapacity)
+			return;
+		resize(MathUtils.nextPowerOfTwo(maximumCapacity));
 	}
 
-	/** Clears the map and reduces the size of the backing arrays to be the specified capacity if they are larger. */
+	/**
+	 * Clears the map and reduces the size of the backing arrays to be the specified capacity if they are larger.
+	 */
 	public void clear (int maximumCapacity) {
-		if (capacity <= maximumCapacity) {
+		if (keyTable.length <= maximumCapacity) {
 			clear();
 			return;
 		}
@@ -408,145 +330,138 @@ public class ObjectIntMap<K> implements Iterable<ObjectIntMap.Entry<K>> {
 	}
 
 	public void clear () {
-		if (size == 0) return;
+		if (size == 0)
+			return;
 		K[] keyTable = this.keyTable;
-		for (int i = capacity + stashSize; i-- > 0;)
-			keyTable[i] = null;
+		for (int i = keyTable.length; i > 0; ) {
+			keyTable[--i] = null;
+		}
 		size = 0;
-		stashSize = 0;
 	}
 
-	/** Returns true if the specified value is in the map. Note this traverses the entire map and compares every value, which may
-	 * be an expensive operation. */
+	/**
+	 * Returns true if the specified value is in the map. Note this traverses the entire map and compares every value, which may
+	 * be an expensive operation.
+	 */
 	public boolean containsValue (int value) {
-		K[] keyTable = this.keyTable;
-		int[] valueTable = this.valueTable;
-		for (int i = capacity + stashSize; i-- > 0;)
-			if (keyTable[i] != null && valueTable[i] == value) return true;
+		final K[] keyTable = this.keyTable;
+		final int[] valueTable = this.valueTable;
+		for (int i = valueTable.length; i-- > 0; )
+			if (keyTable[i] != null && valueTable[i] == value)
+				return true;
 		return false;
-
 	}
 
 	public boolean containsKey (K key) {
-		int hashCode = key.hashCode();
-		int index = hashCode & mask;
-		if (!key.equals(keyTable[index])) {
-			index = hash2(hashCode);
-			if (!key.equals(keyTable[index])) {
-				index = hash3(hashCode);
-				if (!key.equals(keyTable[index])) return containsKeyStash(key);
-			}
-		}
-		return true;
+		return locateKey(key) != -1;
 	}
 
-	private boolean containsKeyStash (K key) {
-		K[] keyTable = this.keyTable;
-		for (int i = capacity, n = i + stashSize; i < n; i++)
-			if (key.equals(keyTable[i])) return true;
-		return false;
-	}
-
-	/** Returns the key for the specified value, or null if it is not in the map. Note this traverses the entire map and compares
-	 * every value, which may be an expensive operation. */
+	/**
+	 * Returns the key for the specified value, or null if it is not in the map. Note this traverses the entire map and compares
+	 * every value, which may be an expensive operation.
+	 */
 	public K findKey (int value) {
-		K[] keyTable = this.keyTable;
-		int[] valueTable = this.valueTable;
-		for (int i = capacity + stashSize; i-- > 0;)
-			if (keyTable[i] != null && valueTable[i] == value) return keyTable[i];
+		final K[] keyTable = this.keyTable;
+		final int[] valueTable = this.valueTable;
+		for (int i = valueTable.length; i-- > 0; ) {
+			K key = keyTable[i];
+			if (key != null && valueTable[i] == value)
+				return key;
+		}
 		return null;
 	}
 
-	/** Increases the size of the backing array to accommodate the specified number of additional items. Useful before adding many
-	 * items to avoid multiple backing array resizes. */
+	/**
+	 * Increases the size of the backing array to accommodate the specified number of additional items. Useful before adding many
+	 * items to avoid multiple backing array resizes.
+	 */
 	public void ensureCapacity (int additionalCapacity) {
-		if (additionalCapacity < 0) throw new IllegalArgumentException("additionalCapacity must be >= 0: " + additionalCapacity);
 		int sizeNeeded = size + additionalCapacity;
-		if (sizeNeeded >= threshold) resize(MathUtils.nextPowerOfTwo((int)Math.ceil(sizeNeeded / loadFactor)));
+		if (sizeNeeded >= threshold)
+			resize(MathUtils.nextPowerOfTwo((int)Math.ceil(sizeNeeded / loadFactor)));
 	}
 
-	private void resize (int newSize) {
-		int oldEndIndex = capacity + stashSize;
-
-		capacity = newSize;
+	final void resize (int newSize) {
+		int oldCapacity = keyTable.length;
 		threshold = (int)(newSize * loadFactor);
 		mask = newSize - 1;
-		hashShift = 31 - Integer.numberOfTrailingZeros(newSize);
-		stashCapacity = Math.max(3, (int)Math.ceil(Math.log(newSize)) * 2);
-		pushIterations = Math.max(Math.min(newSize, 8), (int)Math.sqrt(newSize) / 8);
+		shift = Long.numberOfLeadingZeros(mask);
 
 		K[] oldKeyTable = keyTable;
 		int[] oldValueTable = valueTable;
 
-		keyTable = (K[])new Object[newSize + stashCapacity];
-		valueTable = new int[newSize + stashCapacity];
+		keyTable = (K[])new Object[newSize];
+		valueTable = new int[newSize];
 
 		int oldSize = size;
 		size = 0;
-		stashSize = 0;
 		if (oldSize > 0) {
-			for (int i = 0; i < oldEndIndex; i++) {
+			for (int i = 0; i < oldCapacity; i++) {
 				K key = oldKeyTable[i];
-				if (key != null) putResize(key, oldValueTable[i]);
+				if (key != null)
+					putResize(key, oldValueTable[i]);
 			}
 		}
 	}
 
-	private int hash2 (int h) {
-		h *= PRIME2;
-		return (h ^ h >>> hashShift) & mask;
-	}
-
-	private int hash3 (int h) {
-		h *= PRIME3;
-		return (h ^ h >>> hashShift) & mask;
-	}
-
 	public int hashCode () {
-		int h = 0;
+		int h = size;
 		K[] keyTable = this.keyTable;
 		int[] valueTable = this.valueTable;
-		for (int i = 0, n = capacity + stashSize; i < n; i++) {
+		for (int i = 0, n = keyTable.length; i < n; i++) {
 			K key = keyTable[i];
 			if (key != null) {
-				h += key.hashCode() * 31;
-
-				int value = valueTable[i];
-				h += value;
+				h ^= key.hashCode();
+				h += valueTable[i];
 			}
 		}
 		return h;
 	}
 
 	public boolean equals (Object obj) {
-		if (obj == this) return true;
-		if (!(obj instanceof ObjectIntMap)) return false;
-		ObjectIntMap<K> other = (ObjectIntMap)obj;
-		if (other.size != size) return false;
+		if (obj == this)
+			return true;
+		if (!(obj instanceof ObjectIntMap))
+			return false;
+		ObjectIntMap other = (ObjectIntMap)obj;
+		if (other.size != size)
+			return false;
 		K[] keyTable = this.keyTable;
 		int[] valueTable = this.valueTable;
-		for (int i = 0, n = capacity + stashSize; i < n; i++) {
+		for (int i = 0, n = keyTable.length; i < n; i++) {
 			K key = keyTable[i];
 			if (key != null) {
 				int otherValue = other.get(key, 0);
-				if (otherValue == 0 && !other.containsKey(key)) return false;
-				int value = valueTable[i];
-				if (otherValue != value) return false;
+				if (otherValue == 0 && !other.containsKey(key))
+					return false;
+				if (otherValue != valueTable[i])
+					return false;
 			}
 		}
 		return true;
 	}
 
+	public String toString (String separator) {
+		return toString(separator, false);
+	}
+
 	public String toString () {
-		if (size == 0) return "{}";
-		StringBuilder buffer = new StringBuilder(32);
-		buffer.append('{');
+		return toString(", ", true);
+	}
+
+	private String toString (String separator, boolean braces) {
+		if (size == 0)
+			return braces ? "{}" : "";
+		java.lang.StringBuilder buffer = new java.lang.StringBuilder(32);
+		if (braces)
+			buffer.append('{');
 		K[] keyTable = this.keyTable;
 		int[] valueTable = this.valueTable;
 		int i = keyTable.length;
 		while (i-- > 0) {
 			K key = keyTable[i];
-			if (key == null) continue;
+			if (key == null)
+				continue;
 			buffer.append(key);
 			buffer.append('=');
 			buffer.append(valueTable[i]);
@@ -554,13 +469,15 @@ public class ObjectIntMap<K> implements Iterable<ObjectIntMap.Entry<K>> {
 		}
 		while (i-- > 0) {
 			K key = keyTable[i];
-			if (key == null) continue;
-			buffer.append(", ");
+			if (key == null)
+				continue;
+			buffer.append(separator);
 			buffer.append(key);
 			buffer.append('=');
 			buffer.append(valueTable[i]);
 		}
-		buffer.append('}');
+		if (braces)
+			buffer.append('}');
 		return buffer.toString();
 	}
 
@@ -568,12 +485,11 @@ public class ObjectIntMap<K> implements Iterable<ObjectIntMap.Entry<K>> {
 		return entries();
 	}
 
-	/** Returns an iterator for the entries in the map. Remove is supported.
-	 * <p>
-	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called.
-	 * Use the {@link Entries} constructor for nested or multithreaded iteration. */
+	/**
+	 * Returns an iterator for the entries in the map. Remove is supported. Note that the same iterator instance is returned each
+	 * time this method is called. Use the {@link Entries} constructor for nested or multithreaded iteration.
+	 */
 	public Entries<K> entries () {
-		if (Collections.allocateIterators) return new Entries(this);
 		if (entries1 == null) {
 			entries1 = new Entries(this);
 			entries2 = new Entries(this);
@@ -590,12 +506,11 @@ public class ObjectIntMap<K> implements Iterable<ObjectIntMap.Entry<K>> {
 		return entries2;
 	}
 
-	/** Returns an iterator for the values in the map. Remove is supported.
-	 * <p>
-	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called.
-	 * Use the {@link Entries} constructor for nested or multithreaded iteration. */
+	/**
+	 * Returns an iterator for the values in the map. Remove is supported. Note that the same iterator instance is returned each
+	 * time this method is called. Use the {@link Values} constructor for nested or multithreaded iteration.
+	 */
 	public Values values () {
-		if (Collections.allocateIterators) return new Values(this);
 		if (values1 == null) {
 			values1 = new Values(this);
 			values2 = new Values(this);
@@ -612,12 +527,11 @@ public class ObjectIntMap<K> implements Iterable<ObjectIntMap.Entry<K>> {
 		return values2;
 	}
 
-	/** Returns an iterator for the keys in the map. Remove is supported.
-	 * <p>
-	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called.
-	 * Use the {@link Entries} constructor for nested or multithreaded iteration. */
+	/**
+	 * Returns an iterator for the keys in the map. Remove is supported. Note that the same iterator instance is returned each
+	 * time this method is called. Use the {@link Keys} constructor for nested or multithreaded iteration.
+	 */
 	public Keys<K> keys () {
-		if (Collections.allocateIterators) return new Keys(this);
 		if (keys1 == null) {
 			keys1 = new Keys(this);
 			keys2 = new Keys(this);
@@ -632,6 +546,41 @@ public class ObjectIntMap<K> implements Iterable<ObjectIntMap.Entry<K>> {
 		keys2.valid = true;
 		keys1.valid = false;
 		return keys2;
+	}
+
+	public void write (Json json) {
+		if (isEmpty())
+			return;
+		if (keys().next() instanceof String) {
+			json.writeObjectStart("entries");
+			for (Entry<K> entry : entries()) {
+				json.writeValue(String.valueOf(entry.key), entry.value, Integer.class);
+			}
+			json.writeObjectEnd();
+		} else {
+			json.writeArrayStart("entries");
+			for (Entry<K> entry : entries()) {
+				json.writeValue(entry.key, null);
+				json.writeValue(entry.value, Integer.class);
+			}
+			json.writeArrayEnd();
+		}
+	}
+
+	public void read (Json json, JsonValue jsonData) {
+		if (jsonData.isEmpty())
+			return;
+		JsonValue entries = jsonData.get("entries");
+		if (entries.isObject()) {
+			for (JsonValue child = entries.child; child != null; child = child.next)
+				put((K)child.name, child.asInt());
+		} else if (entries.isArray()) {
+			for (JsonValue child = entries.child; child != null; child = child.next) {
+				K key = json.readValue(null, child);
+				int value = (child = child.next).asInt();
+				put(key, value);
+			}
+		}
 	}
 
 	static public class Entry<K> {
@@ -664,7 +613,7 @@ public class ObjectIntMap<K> implements Iterable<ObjectIntMap.Entry<K>> {
 		void findNextIndex () {
 			hasNext = false;
 			K[] keyTable = map.keyTable;
-			for (int n = map.capacity + map.stashSize; ++nextIndex < n;) {
+			for (int n = keyTable.length; ++nextIndex < n; ) {
 				if (keyTable[nextIndex] != null) {
 					hasNext = true;
 					break;
@@ -673,30 +622,40 @@ public class ObjectIntMap<K> implements Iterable<ObjectIntMap.Entry<K>> {
 		}
 
 		public void remove () {
-			if (currentIndex < 0) throw new IllegalStateException("next must be called before remove.");
-			if (currentIndex >= map.capacity) {
-				map.removeStashIndex(currentIndex);
-				nextIndex = currentIndex - 1;
-				findNextIndex();
-			} else {
-				map.keyTable[currentIndex] = null;
+			if (currentIndex < 0)
+				throw new IllegalStateException("next must be called before remove.");
+			final K[] keyTable = map.keyTable;
+			final int[] valueTable = map.valueTable;
+			int loc = currentIndex;
+			final int mask = map.mask;
+			K key;
+			while ((key = keyTable[loc + 1 & mask]) != null && (loc + 1 & mask) != map.place(key)) {
+				keyTable[loc] = key;
+				valueTable[loc] = valueTable[loc + 1 & mask];
+				++loc;
 			}
+			if(loc != currentIndex) --nextIndex;
+			keyTable[loc] = null;
+			--map.size;
 			currentIndex = -1;
-			map.size--;
 		}
 	}
 
 	static public class Entries<K> extends MapIterator<K> implements Iterable<Entry<K>>, Iterator<Entry<K>> {
-		private Entry<K> entry = new Entry();
+		Entry<K> entry = new Entry<K>();
 
 		public Entries (ObjectIntMap<K> map) {
 			super(map);
 		}
 
-		/** Note the same entry instance is returned each time this method is called. */
+		/**
+		 * Note the same entry instance is returned each time this method is called.
+		 */
 		public Entry<K> next () {
-			if (!hasNext) throw new NoSuchElementException();
-			if (!valid) throw new GdxRuntimeException("#iterator() cannot be used nested.");
+			if (!hasNext)
+				throw new NoSuchElementException();
+			if (!valid)
+				throw new GdxRuntimeException("#iterator() cannot be used nested.");
 			K[] keyTable = map.keyTable;
 			entry.key = keyTable[nextIndex];
 			entry.value = map.valueTable[nextIndex];
@@ -706,7 +665,8 @@ public class ObjectIntMap<K> implements Iterable<ObjectIntMap.Entry<K>> {
 		}
 
 		public boolean hasNext () {
-			if (!valid) throw new GdxRuntimeException("#iterator() cannot be used nested.");
+			if (!valid)
+				throw new GdxRuntimeException("#iterator() cannot be used nested.");
 			return hasNext;
 		}
 
@@ -725,22 +685,40 @@ public class ObjectIntMap<K> implements Iterable<ObjectIntMap.Entry<K>> {
 		}
 
 		public boolean hasNext () {
-			if (!valid) throw new GdxRuntimeException("#iterator() cannot be used nested.");
+			if (!valid)
+				throw new GdxRuntimeException("#iterator() cannot be used nested.");
 			return hasNext;
 		}
 
 		public int next () {
-			if (!hasNext) throw new NoSuchElementException();
-			if (!valid) throw new GdxRuntimeException("#iterator() cannot be used nested.");
+			if (!hasNext)
+				throw new NoSuchElementException();
+			if (!valid)
+				throw new GdxRuntimeException("#iterator() cannot be used nested.");
 			int value = map.valueTable[nextIndex];
 			currentIndex = nextIndex;
 			findNextIndex();
 			return value;
 		}
 
-		/** Returns a new array containing the remaining values. */
+		public Values iterator () {
+			return this;
+		}
+
+		/**
+		 * Returns a new array containing the remaining values.
+		 */
 		public IntArray toArray () {
 			IntArray array = new IntArray(true, map.size);
+			while (hasNext)
+				array.add(next());
+			return array;
+		}
+
+		/**
+		 * Adds the remaining values to the specified array.
+		 */
+		public IntArray toArray (IntArray array) {
 			while (hasNext)
 				array.add(next());
 			return array;
@@ -749,17 +727,20 @@ public class ObjectIntMap<K> implements Iterable<ObjectIntMap.Entry<K>> {
 
 	static public class Keys<K> extends MapIterator<K> implements Iterable<K>, Iterator<K> {
 		public Keys (ObjectIntMap<K> map) {
-			super((ObjectIntMap<K>)map);
+			super(map);
 		}
 
 		public boolean hasNext () {
-			if (!valid) throw new GdxRuntimeException("#iterator() cannot be used nested.");
+			if (!valid)
+				throw new GdxRuntimeException("#iterator() cannot be used nested.");
 			return hasNext;
 		}
 
 		public K next () {
-			if (!hasNext) throw new NoSuchElementException();
-			if (!valid) throw new GdxRuntimeException("#iterator() cannot be used nested.");
+			if (!hasNext)
+				throw new NoSuchElementException();
+			if (!valid)
+				throw new GdxRuntimeException("#iterator() cannot be used nested.");
 			K key = map.keyTable[nextIndex];
 			currentIndex = nextIndex;
 			findNextIndex();
@@ -770,23 +751,20 @@ public class ObjectIntMap<K> implements Iterable<ObjectIntMap.Entry<K>> {
 			return this;
 		}
 
-		/** Returns a new array containing the remaining keys. */
+		/**
+		 * Returns a new array containing the remaining keys.
+		 */
 		public Array<K> toArray () {
-			Array array = new Array(true, map.size);
-			while (hasNext)
-				array.add(next());
-			return array;
+			return toArray(new Array<K>(true, map.size));
 		}
 
-		/** Adds the remaining keys to the array. */
+		/**
+		 * Adds the remaining keys to the array.
+		 */
 		public Array<K> toArray (Array<K> array) {
 			while (hasNext)
 				array.add(next());
 			return array;
-		}
-
-		public void remove () {
-			super.remove();
 		}
 	}
 }

--- a/gdx/src/com/badlogic/gdx/utils/ObjectMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/ObjectMap.java
@@ -233,8 +233,7 @@ public class ObjectMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 	private void putResize (K key, V value) {
 		K[] keyTable = this.keyTable;
 		V[] valueTable = this.valueTable;
-		int b = place(key);
-		for (int i = b; ; i = (i + 1) & mask) {
+		for (int i = place(key); ; i = (i + 1) & mask) {
 			// space is available so we insert and break (resize is later)
 			if (keyTable[i] == null) {
 				keyTable[i] = key;

--- a/gdx/src/com/badlogic/gdx/utils/ObjectMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/ObjectMap.java
@@ -211,11 +211,6 @@ public class ObjectMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 		return null;
 	}
 
-	//	public void putAll (ObjectMap<K, V> map) {
-//		ensureCapacity(map.size);
-//		for (Entry<K, V> entry : map)
-//			put(entry.key, entry.value);
-//	}
 	public void putAll (ObjectMap<K, V> map) {
 		ensureCapacity(map.size);
 		final K[] keyTable = map.keyTable;
@@ -472,9 +467,9 @@ public class ObjectMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 	public boolean equalsIdentity (Object obj) {
 		if (obj == this)
 			return true;
-		if (!(obj instanceof IdentityMap))
+		if (!(obj instanceof ObjectMap))
 			return false;
-		IdentityMap other = (IdentityMap)obj;
+		ObjectMap other = (ObjectMap)obj;
 		if (other.size != size)
 			return false;
 		K[] keyTable = this.keyTable;

--- a/gdx/src/com/badlogic/gdx/utils/ObjectMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/ObjectMap.java
@@ -39,7 +39,7 @@ import java.util.NoSuchElementException;
  * Load factors greater than 0.91 greatly increase the chances the map will have to rehash to the next higher POT size.
  * Memory usage is excellent, and the aforementioned collision-resistance helps avoid too much capacity resizing.
  * <br>
-* Iteration should be fast with OrderedSet and OrderedMap, whereas ObjectSet and ObjectMap aren't designed to provide especially
+ * Iteration should be fast with OrderedSet and OrderedMap, whereas ObjectSet and ObjectMap aren't designed to provide especially
  * quick iteration.
  *
  * @author Tommy Ettinger
@@ -229,16 +229,14 @@ public class ObjectMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 		K[] keyTable = this.keyTable;
 		V[] valueTable = this.valueTable;
 		for (int i = place(key); ; i = (i + 1) & mask) {
-			// space is available so we insert and break (resize is later)
+			// space is available so we insert and break
 			if (keyTable[i] == null) {
 				keyTable[i] = key;
 				valueTable[i] = value;
 				break;
 			}
 		}
-		if (++size >= threshold) {
-			resize(keyTable.length << 1);
-		}
+		++size;
 	}
 
 	/**
@@ -590,7 +588,7 @@ public class ObjectMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 		keys1.valid = false;
 		return keys2;
 	}
-	
+
 	static public class Entry<K, V> {
 		public K key;
 		public V value;
@@ -643,7 +641,8 @@ public class ObjectMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 				loc = nl;
 				nl = loc + 1 & mask;
 			}
-			if(loc != currentIndex) --nextIndex;
+			if (loc != currentIndex)
+				--nextIndex;
 			keyTable[loc] = null;
 			valueTable[loc] = null;
 			--map.size;

--- a/gdx/src/com/badlogic/gdx/utils/ObjectMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/ObjectMap.java
@@ -49,7 +49,7 @@ import java.util.NoSuchElementException;
  * @author Tommy Ettinger
  * @author Nathan Sweet
  */
-public class ObjectMap<K, V> implements Json.Serializable, Iterable<ObjectMap.Entry<K, V>> {
+public class ObjectMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 	static final Object dummy = new Object();
 
 	public int size;
@@ -597,42 +597,7 @@ public class ObjectMap<K, V> implements Json.Serializable, Iterable<ObjectMap.En
 		keys1.valid = false;
 		return keys2;
 	}
-
-	public void write (Json json) {
-		if (isEmpty())
-			return;
-		if (keys().next() instanceof String) {
-			json.writeObjectStart("entries");
-			for (Entry<K, V> entry : entries()) {
-				json.writeValue(String.valueOf(entry.key), entry.value, null);
-			}
-			json.writeObjectEnd();
-		} else {
-			json.writeArrayStart("entries");
-			for (Entry<K, V> entry : entries()) {
-				json.writeValue(entry.key, null);
-				json.writeValue(entry.value, null);
-			}
-			json.writeArrayEnd();
-		}
-	}
-
-	public void read (Json json, JsonValue jsonData) {
-		if (jsonData.isEmpty())
-			return;
-		JsonValue entries = jsonData.get("entries");
-		if (entries.isObject()) {
-			for (JsonValue child = entries.child; child != null; child = child.next)
-				put((K)child.name, (V)json.readValue(null, child));
-		} else if (entries.isArray()) {
-			for (JsonValue child = entries.child; child != null; child = child.next) {
-				K key = json.readValue(null, child);
-				V value = json.readValue(null, child = child.next);
-				put(key, value);
-			}
-		}
-	}
-
+	
 	static public class Entry<K, V> {
 		public K key;
 		public V value;

--- a/gdx/src/com/badlogic/gdx/utils/ObjectMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/ObjectMap.java
@@ -39,11 +39,7 @@ import java.util.NoSuchElementException;
  * Load factors greater than 0.91 greatly increase the chances the map will have to rehash to the next higher POT size.
  * Memory usage is excellent, and the aforementioned collision-resistance helps avoid too much capacity resizing.
  * <br>
- * The <a href="http://codecapsule.com/2013/11/17/robin-hood-hashing-backward-shift-deletion/">backward-shift algorithm</a>
- * used during removal apparently is key to the good performance of this implementation, even though this doesn't use Robin Hood
- * hashing; the performance of {@link #remove(Object)} has improved considerably over the previous libGDX version.
- * <br>
- * Iteration should be fast with OrderedSet and OrderedMap, whereas ObjectSet and ObjectMap aren't designed to provide especially
+* Iteration should be fast with OrderedSet and OrderedMap, whereas ObjectSet and ObjectMap aren't designed to provide especially
  * quick iteration.
  *
  * @author Tommy Ettinger
@@ -147,7 +143,7 @@ public class ObjectMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 	 * {@code return (int) (item.hashCode() * 0x9E3779B97F4A7C15L >>> shift);}
 	 * <br>
 	 * This can be overridden by subclasses, which you may want to do if your key type needs special consideration for
-	 * its hash (such as if you use arrays as keys, which still requires that the arrays are not modified). Subclasses
+	 * its hash (such as if you can't modify or extend a particular class that has an incorrect hashCode()). Subclasses
 	 * that don't need the collision decrease of Fibonacci Hashing (assuming the key class has a good hashCode()) may do
 	 * fine with a simple implementation:
 	 * {@code return (item.hashCode() & mask);}

--- a/gdx/src/com/badlogic/gdx/utils/ObjectMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/ObjectMap.java
@@ -105,7 +105,7 @@ public class ObjectMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 			throw new IllegalArgumentException("initialCapacity must be >= 0: " + initialCapacity);
 		if (loadFactor <= 0f || loadFactor >= 1f)
 			throw new IllegalArgumentException("loadFactor must be > 0 and < 1: " + loadFactor);
-		initialCapacity = MathUtils.nextPowerOfTwo((int)Math.ceil(initialCapacity / loadFactor));
+		initialCapacity = MathUtils.nextPowerOfTwo((int)Math.ceil(Math.max(1, initialCapacity) / loadFactor));
 		if (initialCapacity > 1 << 30)
 			throw new IllegalArgumentException("initialCapacity is too large: " + initialCapacity);
 

--- a/gdx/src/com/badlogic/gdx/utils/ObjectMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/ObjectMap.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,395 +16,306 @@
 
 package com.badlogic.gdx.utils;
 
+import com.badlogic.gdx.math.MathUtils;
+
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
-import com.badlogic.gdx.math.MathUtils;
-
-/** An unordered map. This implementation is a cuckoo hash map using 3 hashes, random walking, and a small stash for problematic
- * keys. Null keys are not allowed. Null values are allowed. No allocation is done except when growing the table size. <br>
+/**
+ * An unordered map where the keys and values are objects. This implementation uses linear probing with the backward-shift
+ * algorithm for removal, and finds space for keys using Fibonacci hashing instead of the more-common power-of-two mask.
+ * Null keys are not allowed. No allocation is done except when growing the table size.
  * <br>
- * This map performs very fast get, containsKey, and remove (typically O(1), worst case O(log(n))). Put may be a bit slower,
- * depending on hash collisions. Load factors greater than 0.91 greatly increase the chances the map will have to rehash to the
- * next higher POT size.<br>
+ * This map uses Fibonacci hashing to help distribute what may be very bad hashCode() results across the
+ * whole capacity. See <a href="https://probablydance.com/2018/06/16/fibonacci-hashing-the-optimization-that-the-world-forgot-or-a-better-alternative-to-integer-modulo/">Malte Skarupke's blog post</a>
+ * for more information on Fibonacci hashing. It uses linear probing to resolve collisions, which is far from the academically
+ * optimal algorithm, but performs considerably better in practice than most alternatives, and combined with Fibonacci hashing, it
+ * can handle "normal" generated hashCode() implementations, and not just theoretically optimal hashing functions. Even if all
+ * hashCode()s this is given collide, it will still work, just slowly; the older libGDX implementation using cuckoo hashing would
+ * crash with an OutOfMemoryError with under 50 collisions.
  * <br>
- * Iteration can be very slow for a map with a large capacity. {@link #clear(int)} and {@link #shrink(int)} can be used to reduce
- * the capacity. {@link OrderedMap} provides much faster iteration.
- * @author Nathan Sweet */
-public class ObjectMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
-	private static final int PRIME1 = 0xbe1f14b1;
-	private static final int PRIME2 = 0xb4b82e39;
-	private static final int PRIME3 = 0xced1c241;
+ * This map performs very fast contains and remove (typically O(1), worst case O(n) due to occasional probing, but still very
+ * fast). Add may be a bit slower, depending on hash collisions, but this data structure is somewhat collision-resistant.
+ * Load factors greater than 0.91 greatly increase the chances the map will have to rehash to the next higher POT size.
+ * Memory usage is excellent, and the aforementioned collision-resistance helps avoid too much capacity resizing.
+ * <br>
+ * The <a href="http://codecapsule.com/2013/11/17/robin-hood-hashing-backward-shift-deletion/">backward-shift algorithm</a>
+ * used during removal apparently is key to the good performance of this implementation, even though this doesn't use Robin Hood
+ * hashing; the performance of {@link #remove(Object)} has improved considerably over the previous libGDX version.
+ * <br>
+ * Iteration should be fast with OrderedSet and OrderedMap, whereas ObjectSet and ObjectMap aren't designed to provide especially
+ * quick iteration.
+ *
+ * @author Tommy Ettinger
+ * @author Nathan Sweet
+ */
+public class ObjectMap<K, V> implements Json.Serializable, Iterable<ObjectMap.Entry<K, V>> {
 	static final Object dummy = new Object();
 
 	public int size;
 
 	K[] keyTable;
 	V[] valueTable;
-	int capacity, stashSize;
 
-	private float loadFactor;
-	private int hashShift, mask, threshold;
-	private int stashCapacity;
-	private int pushIterations;
+	float loadFactor;
+	int threshold;
+	/**
+	 * Used by {@link #place(Object)} to bit-shift the upper bits of a {@code long} into a usable range (less than or
+	 * equal to {@link #mask}, greater than or equal to 0). If you're setting it in a subclass, this shift can be
+	 * negative, which is a convenient way to match the number of bits in mask; if mask is a 7-bit number, then a shift
+	 * of -7 will correctly shift the upper 7 bits into the lowest 7 positions. If using what this class sets, shift
+	 * will be greater than 32 and less than 64; if you use this shift with an int, it will still correctly move the
+	 * upper bits of an int to the lower bits, thanks to Java's implicit modulus on shifts.
+	 * <br>
+	 * You can also use {@link #mask} to mask the low bits of a number, which may be faster for some hashCode()s, if you
+	 * reimplement {@link #place(Object)}.
+	 */
+	protected int shift;
+	/**
+	 * The bitmask used to contain hashCode()s to the indices that can be fit into the key array this uses. This should
+	 * always be all-1-bits in its low positions; that is, it must be a power of two minus 1. If you subclass and change
+	 * {@link #place(Object)}, you may want to use this instead of {@link #shift} to isolate usable bits of a hash.
+	 */
+	protected int mask;
 
 	Entries entries1, entries2;
 	Values values1, values2;
 	Keys keys1, keys2;
 
-	/** Creates a new map with an initial capacity of 51 and a load factor of 0.8. */
+	/**
+	 * Creates a new map with an initial capacity of 51 and a load factor of 0.8.
+	 */
 	public ObjectMap () {
 		this(51, 0.8f);
 	}
 
-	/** Creates a new map with a load factor of 0.8.
-	 * @param initialCapacity If not a power of two, it is increased to the next nearest power of two. */
+	/**
+	 * Creates a new map with a load factor of 0.8.
+	 *
+	 * @param initialCapacity If not a power of two, it is increased to the next nearest power of two.
+	 */
 	public ObjectMap (int initialCapacity) {
 		this(initialCapacity, 0.8f);
 	}
 
-	/** Creates a new map with the specified initial capacity and load factor. This map will hold initialCapacity items before
+	/**
+	 * Creates a new map with the specified initial capacity and load factor. This map will hold initialCapacity items before
 	 * growing the backing table.
-	 * @param initialCapacity If not a power of two, it is increased to the next nearest power of two. */
+	 *
+	 * @param initialCapacity If not a power of two, it is increased to the next nearest power of two.
+	 */
 	public ObjectMap (int initialCapacity, float loadFactor) {
-		if (loadFactor <= 0) throw new IllegalArgumentException("loadFactor must be > 0: " + loadFactor);
+		if (initialCapacity < 0)
+			throw new IllegalArgumentException("initialCapacity must be >= 0: " + initialCapacity);
+		if (loadFactor <= 0f || loadFactor >= 1f)
+			throw new IllegalArgumentException("loadFactor must be > 0 and < 1: " + loadFactor);
+		initialCapacity = MathUtils.nextPowerOfTwo((int)Math.ceil(initialCapacity / loadFactor));
+		if (initialCapacity > 1 << 30)
+			throw new IllegalArgumentException("initialCapacity is too large: " + initialCapacity);
+
 		this.loadFactor = loadFactor;
 
-		if (initialCapacity < 0) throw new IllegalArgumentException("initialCapacity must be >= 0: " + initialCapacity);
-		initialCapacity = MathUtils.nextPowerOfTwo((int)Math.ceil(initialCapacity / loadFactor));
-		if (initialCapacity > 1 << 30) throw new IllegalArgumentException("initialCapacity is too large: " + initialCapacity);
-		capacity = initialCapacity;
+		threshold = (int)(initialCapacity * loadFactor);
+		mask = initialCapacity - 1;
+		shift = Long.numberOfLeadingZeros(mask);
 
-		threshold = (int)(capacity * loadFactor);
-		mask = capacity - 1;
-		hashShift = 31 - Integer.numberOfTrailingZeros(capacity);
-		stashCapacity = Math.max(3, (int)Math.ceil(Math.log(capacity)) * 2);
-		pushIterations = Math.max(Math.min(capacity, 8), (int)Math.sqrt(capacity) / 8);
-
-		keyTable = (K[])new Object[capacity + stashCapacity];
-		valueTable = (V[])new Object[keyTable.length];
+		keyTable = (K[])new Object[initialCapacity];
+		valueTable = (V[])new Object[initialCapacity];
 	}
 
-	/** Creates a new map identical to the specified map. */
+	/**
+	 * Creates a new map identical to the specified map.
+	 */
 	public ObjectMap (ObjectMap<? extends K, ? extends V> map) {
-		this((int)Math.floor(map.capacity * map.loadFactor), map.loadFactor);
-		stashSize = map.stashSize;
+		this((int)Math.floor(map.keyTable.length * map.loadFactor), map.loadFactor);
 		System.arraycopy(map.keyTable, 0, keyTable, 0, map.keyTable.length);
 		System.arraycopy(map.valueTable, 0, valueTable, 0, map.valueTable.length);
 		size = map.size;
 	}
 
-	/** Returns the old value associated with the specified key, or null. */
-	public V put (K key, V value) {
-		if (key == null) throw new IllegalArgumentException("key cannot be null.");
-		K[] keyTable = this.keyTable;
+	/**
+	 * Finds an array index between 0 and {@link #mask}, both inclusive, corresponding to the hash code of {@code item}.
+	 * By default, this uses "Fibonacci Hashing" on the {@link Object#hashCode()} of {@code item}; this multiplies
+	 * {@code item.hashCode()} by a long constant (2 to the 64, divided by the golden ratio) and shifts the high-quality
+	 * uppermost bits into the lowest positions so they can be used as array indices. The multiplication by a long may
+	 * be somewhat slow on GWT, but it will be correct across all platforms and won't lose precision. Using Fibonacci
+	 * Hashing allows even very poor hashCode() implementations, such as those that only differ in their upper bits, to
+	 * work in a hash table without heavy collision rates. It has known problems when all or most hashCode()s are
+	 * multiples of larger Fibonacci numbers; see <a href="https://probablydance.com/2018/06/16/fibonacci-hashing-the-optimization-that-the-world-forgot-or-a-better-alternative-to-integer-modulo/">this blog post by Malte Skarupke</a>
+	 * for more details. In the unlikely event that most of your hashCode()s are Fibonacci numbers, you can subclass
+	 * this to change this method, which is a one-liner in this form:
+	 * {@code return (int) (item.hashCode() * 0x9E3779B97F4A7C15L >>> shift);}
+	 * <br>
+	 * This can be overridden by subclasses, which you may want to do if your key type needs special consideration for
+	 * its hash (such as if you use arrays as keys, which still requires that the arrays are not modified). Subclasses
+	 * that don't need the collision decrease of Fibonacci Hashing (assuming the key class has a good hashCode()) may do
+	 * fine with a simple implementation:
+	 * {@code return (item.hashCode() & mask);}
+	 *
+	 * @param item a key that this method will hash, by default by calling {@link Object#hashCode()} on it; non-null
+	 * @return an int between 0 and {@link #mask}, both inclusive
+	 */
+	protected int place (final K item) {
+		// shift is always greater than 32, less than 64
+		return (int)(item.hashCode() * 0x9E3779B97F4A7C15L >>> shift);
+	}
 
-		// Check for existing keys.
-		int hashCode = key.hashCode();
-		int index1 = hashCode & mask;
-		K key1 = keyTable[index1];
-		if (key.equals(key1)) {
-			V oldValue = valueTable[index1];
-			valueTable[index1] = value;
-			return oldValue;
-		}
+	private int locateKey (final K key) {
+		return locateKey(key, place(key));
+	}
 
-		int index2 = hash2(hashCode);
-		K key2 = keyTable[index2];
-		if (key.equals(key2)) {
-			V oldValue = valueTable[index2];
-			valueTable[index2] = value;
-			return oldValue;
-		}
-
-		int index3 = hash3(hashCode);
-		K key3 = keyTable[index3];
-		if (key.equals(key3)) {
-			V oldValue = valueTable[index3];
-			valueTable[index3] = value;
-			return oldValue;
-		}
-
-		// Update key in the stash.
-		for (int i = capacity, n = i + stashSize; i < n; i++) {
+	/**
+	 * Given a key and its initial placement to try in an array, this finds the actual location of the key in the array
+	 * if it is present, or -1 if the key is not present. This can be overridden if a subclass needs to compare for
+	 * equality differently than just by calling {@link Object#equals(Object)}, but only within the same package.
+	 *
+	 * @param key       a K key that will be checked for equality if a similar-seeming key is found
+	 * @param placement as calculated by {@link #place(Object)}, almost always with {@code place(key)}
+	 * @return the location in the key array of key, if found, or -1 if it was not found.
+	 */
+	int locateKey (final K key, final int placement) {
+		for (int i = placement; ; i = i + 1 & mask) {
+			// empty space is available
+			if (keyTable[i] == null) {
+				return -1;
+			}
 			if (key.equals(keyTable[i])) {
-				V oldValue = valueTable[i];
-				valueTable[i] = value;
-				return oldValue;
+				return i;
 			}
 		}
-
-		// Check for empty buckets.
-		if (key1 == null) {
-			keyTable[index1] = key;
-			valueTable[index1] = value;
-			if (size++ >= threshold) resize(capacity << 1);
-			return null;
-		}
-
-		if (key2 == null) {
-			keyTable[index2] = key;
-			valueTable[index2] = value;
-			if (size++ >= threshold) resize(capacity << 1);
-			return null;
-		}
-
-		if (key3 == null) {
-			keyTable[index3] = key;
-			valueTable[index3] = value;
-			if (size++ >= threshold) resize(capacity << 1);
-			return null;
-		}
-
-		push(key, value, index1, key1, index2, key2, index3, key3);
-		return null;
 	}
 
-	public void putAll (ObjectMap<? extends K, ? extends V> map) {
-		ensureCapacity(map.size);
-		for (Entry<? extends K, ? extends V> entry : map)
-			put(entry.key, entry.value);
-	}
-
-	/** Skips checks for existing keys. */
-	private void putResize (K key, V value) {
-		// Check for empty buckets.
-		int hashCode = key.hashCode();
-		int index1 = hashCode & mask;
-		K key1 = keyTable[index1];
-		if (key1 == null) {
-			keyTable[index1] = key;
-			valueTable[index1] = value;
-			if (size++ >= threshold) resize(capacity << 1);
-			return;
-		}
-
-		int index2 = hash2(hashCode);
-		K key2 = keyTable[index2];
-		if (key2 == null) {
-			keyTable[index2] = key;
-			valueTable[index2] = value;
-			if (size++ >= threshold) resize(capacity << 1);
-			return;
-		}
-
-		int index3 = hash3(hashCode);
-		K key3 = keyTable[index3];
-		if (key3 == null) {
-			keyTable[index3] = key;
-			valueTable[index3] = value;
-			if (size++ >= threshold) resize(capacity << 1);
-			return;
-		}
-
-		push(key, value, index1, key1, index2, key2, index3, key3);
-	}
-
-	private void push (K insertKey, V insertValue, int index1, K key1, int index2, K key2, int index3, K key3) {
+	/**
+	 * Returns the old value associated with the specified key, or null.
+	 */
+	public V put (K key, V value) {
+		if (key == null)
+			throw new IllegalArgumentException("key cannot be null.");
 		K[] keyTable = this.keyTable;
 		V[] valueTable = this.valueTable;
-		int mask = this.mask;
-
-		// Push keys until an empty bucket is found.
-		K evictedKey;
-		V evictedValue;
-		int i = 0, pushIterations = this.pushIterations;
-		do {
-			// Replace the key and value for one of the hashes.
-			switch (MathUtils.random(2)) {
-			case 0:
-				evictedKey = key1;
-				evictedValue = valueTable[index1];
-				keyTable[index1] = insertKey;
-				valueTable[index1] = insertValue;
-				break;
-			case 1:
-				evictedKey = key2;
-				evictedValue = valueTable[index2];
-				keyTable[index2] = insertKey;
-				valueTable[index2] = insertValue;
-				break;
-			default:
-				evictedKey = key3;
-				evictedValue = valueTable[index3];
-				keyTable[index3] = insertKey;
-				valueTable[index3] = insertValue;
+		int b = place(key);
+		int loc = locateKey(key, b);
+		// an identical key already exists
+		if (loc != -1) {
+			V tv = valueTable[loc];
+			valueTable[loc] = value;
+			return tv;
+		}
+		for (int i = b; ; i = (i + 1) & mask) {
+			// space is available so we insert and break (resize is later)
+			if (keyTable[i] == null) {
+				keyTable[i] = key;
+				valueTable[i] = value;
 				break;
 			}
-
-			// If the evicted key hashes to an empty bucket, put it there and stop.
-			int hashCode = evictedKey.hashCode();
-			index1 = hashCode & mask;
-			key1 = keyTable[index1];
-			if (key1 == null) {
-				keyTable[index1] = evictedKey;
-				valueTable[index1] = evictedValue;
-				if (size++ >= threshold) resize(capacity << 1);
-				return;
-			}
-
-			index2 = hash2(hashCode);
-			key2 = keyTable[index2];
-			if (key2 == null) {
-				keyTable[index2] = evictedKey;
-				valueTable[index2] = evictedValue;
-				if (size++ >= threshold) resize(capacity << 1);
-				return;
-			}
-
-			index3 = hash3(hashCode);
-			key3 = keyTable[index3];
-			if (key3 == null) {
-				keyTable[index3] = evictedKey;
-				valueTable[index3] = evictedValue;
-				if (size++ >= threshold) resize(capacity << 1);
-				return;
-			}
-
-			if (++i == pushIterations) break;
-
-			insertKey = evictedKey;
-			insertValue = evictedValue;
-		} while (true);
-
-		putStash(evictedKey, evictedValue);
-	}
-
-	private void putStash (K key, V value) {
-		if (stashSize == stashCapacity) {
-			// Too many pushes occurred and the stash is full, increase the table size.
-			resize(capacity << 1);
-			putResize(key, value);
-			return;
 		}
-		// Store key in the stash.
-		int index = capacity + stashSize;
-		keyTable[index] = key;
-		valueTable[index] = value;
-		stashSize++;
-		size++;
-	}
-
-	/** Returns the value (which may be null) for the specified key, or null if the key is not in the map. */
-	public V get (K key) {
-		int hashCode = key.hashCode();
-		int index = hashCode & mask;
-		if (!key.equals(keyTable[index])) {
-			index = hash2(hashCode);
-			if (!key.equals(keyTable[index])) {
-				index = hash3(hashCode);
-				if (!key.equals(keyTable[index])) return getStash(key, null);
-			}
-		}
-		return valueTable[index];
-	}
-
-	/** Returns the value (which may be null) for the specified key, or the default value if the key is not in the map. */
-	public V get (K key, V defaultValue) {
-		int hashCode = key.hashCode();
-		int index = hashCode & mask;
-		if (!key.equals(keyTable[index])) {
-			index = hash2(hashCode);
-			if (!key.equals(keyTable[index])) {
-				index = hash3(hashCode);
-				if (!key.equals(keyTable[index])) return getStash(key, defaultValue);
-			}
-		}
-		return valueTable[index];
-	}
-
-	private V getStash (K key, V defaultValue) {
-		K[] keyTable = this.keyTable;
-		for (int i = capacity, n = i + stashSize; i < n; i++)
-			if (key.equals(keyTable[i])) return valueTable[i];
-		return defaultValue;
-	}
-
-	/** Returns the value associated with the key, or null. */
-	public V remove (K key) {
-		int hashCode = key.hashCode();
-		int index = hashCode & mask;
-		if (key.equals(keyTable[index])) {
-			keyTable[index] = null;
-			V oldValue = valueTable[index];
-			valueTable[index] = null;
-			size--;
-			return oldValue;
-		}
-
-		index = hash2(hashCode);
-		if (key.equals(keyTable[index])) {
-			keyTable[index] = null;
-			V oldValue = valueTable[index];
-			valueTable[index] = null;
-			size--;
-			return oldValue;
-		}
-
-		index = hash3(hashCode);
-		if (key.equals(keyTable[index])) {
-			keyTable[index] = null;
-			V oldValue = valueTable[index];
-			valueTable[index] = null;
-			size--;
-			return oldValue;
-		}
-
-		return removeStash(key);
-	}
-
-	V removeStash (K key) {
-		K[] keyTable = this.keyTable;
-		for (int i = capacity, n = i + stashSize; i < n; i++) {
-			if (key.equals(keyTable[i])) {
-				V oldValue = valueTable[i];
-				removeStashIndex(i);
-				size--;
-				return oldValue;
-			}
+		if (++size >= threshold) {
+			resize(keyTable.length << 1);
 		}
 		return null;
 	}
 
-	void removeStashIndex (int index) {
-		// If the removed location was not last, move the last tuple to the removed location.
-		stashSize--;
-		int lastIndex = capacity + stashSize;
-		if (index < lastIndex) {
-			keyTable[index] = keyTable[lastIndex];
-			valueTable[index] = valueTable[lastIndex];
-			keyTable[lastIndex] = null;
-			valueTable[lastIndex] = null;
-		} else {
-			keyTable[index] = null;
-			valueTable[index] = null;
+	//	public void putAll (ObjectMap<K, V> map) {
+//		ensureCapacity(map.size);
+//		for (Entry<K, V> entry : map)
+//			put(entry.key, entry.value);
+//	}
+	public void putAll (ObjectMap<K, V> map) {
+		ensureCapacity(map.size);
+		final K[] keyTable = map.keyTable;
+		final V[] valueTable = map.valueTable;
+		K k;
+		for (int i = 0, n = keyTable.length; i < n; i++) {
+			if ((k = keyTable[i]) != null)
+				put(k, valueTable[i]);
 		}
 	}
 
-	/** Returns true if the map has one or more items. */
+	/**
+	 * Skips checks for existing keys.
+	 */
+	private void putResize (K key, V value) {
+		K[] keyTable = this.keyTable;
+		V[] valueTable = this.valueTable;
+		int b = place(key);
+		for (int i = b; ; i = (i + 1) & mask) {
+			// space is available so we insert and break (resize is later)
+			if (keyTable[i] == null) {
+				keyTable[i] = key;
+				valueTable[i] = value;
+				break;
+			}
+		}
+		if (++size >= threshold) {
+			resize(keyTable.length << 1);
+		}
+	}
+
+	/**
+	 * Returns the value for the specified key, or null if the key is not in the map.
+	 */
+	public V get (K key) {
+		final int loc = locateKey(key);
+		return loc == -1 ? null : valueTable[loc];
+	}
+
+	/**
+	 * Returns the value for the specified key, or the default value if the key is not in the map.
+	 */
+	public V get (K key, V defaultValue) {
+		final int loc = locateKey(key);
+		return loc == -1 ? defaultValue : valueTable[loc];
+	}
+
+	public V remove (K key) {
+		int loc = locateKey(key);
+		if (loc == -1) {
+			return null;
+		}
+		V oldValue = valueTable[loc];
+		while ((key = keyTable[loc + 1 & mask]) != null && (loc + 1 & mask) != place(key)) {
+			keyTable[loc] = key;
+			valueTable[loc] = valueTable[++loc & mask];
+		}
+		keyTable[loc] = null;
+		valueTable[loc] = null;
+		--size;
+		return oldValue;
+	}
+
+	/**
+	 * Returns true if the map has one or more items.
+	 */
 	public boolean notEmpty () {
 		return size > 0;
 	}
 
-	/** Returns true if the map is empty. */
+	/**
+	 * Returns true if the map is empty.
+	 */
 	public boolean isEmpty () {
 		return size == 0;
 	}
 
-	/** Reduces the size of the backing arrays to be the specified capacity or less. If the capacity is already less, nothing is
-	 * done. If the map contains more items than the specified capacity, the next highest power of two capacity is used instead. */
+	/**
+	 * Reduces the size of the backing arrays to be the specified capacity or less. If the capacity is already less, nothing is
+	 * done. If the map contains more items than the specified capacity, the next highest power of two capacity is used instead.
+	 */
 	public void shrink (int maximumCapacity) {
-		if (maximumCapacity < 0) throw new IllegalArgumentException("maximumCapacity must be >= 0: " + maximumCapacity);
-		if (size > maximumCapacity) maximumCapacity = size;
-		if (capacity <= maximumCapacity) return;
-		maximumCapacity = MathUtils.nextPowerOfTwo(maximumCapacity);
-		resize(maximumCapacity);
+		if (maximumCapacity < 0)
+			throw new IllegalArgumentException("maximumCapacity must be >= 0: " + maximumCapacity);
+		if (size > maximumCapacity)
+			maximumCapacity = size;
+		if (keyTable.length <= maximumCapacity)
+			return;
+		resize(MathUtils.nextPowerOfTwo(maximumCapacity));
 	}
 
-	/** Clears the map and reduces the size of the backing arrays to be the specified capacity, if they are larger. The reduction
-	 * is done by allocating new arrays, though for large arrays this can be faster than clearing the existing array. */
+	/**
+	 * Clears the map and reduces the size of the backing arrays to be the specified capacity if they are larger.
+	 */
 	public void clear (int maximumCapacity) {
-		if (capacity <= maximumCapacity) {
+		if (keyTable.length <= maximumCapacity) {
 			clear();
 			return;
 		}
@@ -412,133 +323,115 @@ public class ObjectMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 		resize(maximumCapacity);
 	}
 
-	/** Clears the map, leaving the backing arrays at the current capacity. When the capacity is high and the population is low,
-	 * iteration can be unnecessarily slow. {@link #clear(int)} can be used to reduce the capacity. */
 	public void clear () {
-		if (size == 0) return;
+		if (size == 0)
+			return;
 		K[] keyTable = this.keyTable;
 		V[] valueTable = this.valueTable;
-		for (int i = capacity + stashSize; i-- > 0;) {
-			keyTable[i] = null;
+		for (int i = keyTable.length; i > 0; ) {
+			keyTable[--i] = null;
 			valueTable[i] = null;
 		}
 		size = 0;
-		stashSize = 0;
 	}
 
-	/** Returns true if the specified value is in the map. Note this traverses the entire map and compares every value, which may
+	/**
+	 * Returns true if the specified value is in the map. Note this traverses the entire map and compares every value, which may
 	 * be an expensive operation.
+	 *
 	 * @param identity If true, uses == to compare the specified value with values in the map. If false, uses
-	 *           {@link #equals(Object)}. */
+	 *                 {@link #equals(Object)}.
+	 */
 	public boolean containsValue (Object value, boolean identity) {
 		V[] valueTable = this.valueTable;
 		if (value == null) {
 			K[] keyTable = this.keyTable;
-			for (int i = capacity + stashSize; i-- > 0;)
-				if (keyTable[i] != null && valueTable[i] == null) return true;
+			for (int i = valueTable.length; i-- > 0; )
+				if (keyTable[i] != null && valueTable[i] == null)
+					return true;
 		} else if (identity) {
-			for (int i = capacity + stashSize; i-- > 0;)
-				if (valueTable[i] == value) return true;
+			for (int i = valueTable.length; i-- > 0; )
+				if (valueTable[i] == value)
+					return true;
 		} else {
-			for (int i = capacity + stashSize; i-- > 0;)
-				if (value.equals(valueTable[i])) return true;
+			for (int i = valueTable.length; i-- > 0; )
+				if (value.equals(valueTable[i]))
+					return true;
 		}
 		return false;
 	}
 
 	public boolean containsKey (K key) {
-		int hashCode = key.hashCode();
-		int index = hashCode & mask;
-		if (!key.equals(keyTable[index])) {
-			index = hash2(hashCode);
-			if (!key.equals(keyTable[index])) {
-				index = hash3(hashCode);
-				if (!key.equals(keyTable[index])) return containsKeyStash(key);
-			}
-		}
-		return true;
+		return locateKey(key) != -1;
 	}
 
-	private boolean containsKeyStash (K key) {
-		K[] keyTable = this.keyTable;
-		for (int i = capacity, n = i + stashSize; i < n; i++)
-			if (key.equals(keyTable[i])) return true;
-		return false;
-	}
-
-	/** Returns the key for the specified value, or null if it is not in the map. Note this traverses the entire map and compares
+	/**
+	 * Returns the key for the specified value, or null if it is not in the map. Note this traverses the entire map and compares
 	 * every value, which may be an expensive operation.
+	 *
 	 * @param identity If true, uses == to compare the specified value with values in the map. If false, uses
-	 *           {@link #equals(Object)}. */
+	 *                 {@link #equals(Object)}.
+	 */
 	public K findKey (Object value, boolean identity) {
 		V[] valueTable = this.valueTable;
 		if (value == null) {
 			K[] keyTable = this.keyTable;
-			for (int i = capacity + stashSize; i-- > 0;)
-				if (keyTable[i] != null && valueTable[i] == null) return keyTable[i];
+			for (int i = valueTable.length; i-- > 0; )
+				if (keyTable[i] != null && valueTable[i] == null)
+					return keyTable[i];
 		} else if (identity) {
-			for (int i = capacity + stashSize; i-- > 0;)
-				if (valueTable[i] == value) return keyTable[i];
+			for (int i = valueTable.length; i-- > 0; )
+				if (valueTable[i] == value)
+					return keyTable[i];
 		} else {
-			for (int i = capacity + stashSize; i-- > 0;)
-				if (value.equals(valueTable[i])) return keyTable[i];
+			for (int i = valueTable.length; i-- > 0; )
+				if (value.equals(valueTable[i]))
+					return keyTable[i];
 		}
 		return null;
 	}
 
-	/** Increases the size of the backing array to accommodate the specified number of additional items. Useful before adding many
-	 * items to avoid multiple backing array resizes. */
+	/**
+	 * Increases the size of the backing array to accommodate the specified number of additional items. Useful before adding many
+	 * items to avoid multiple backing array resizes.
+	 */
 	public void ensureCapacity (int additionalCapacity) {
-		if (additionalCapacity < 0) throw new IllegalArgumentException("additionalCapacity must be >= 0: " + additionalCapacity);
 		int sizeNeeded = size + additionalCapacity;
-		if (sizeNeeded >= threshold) resize(MathUtils.nextPowerOfTwo((int)Math.ceil(sizeNeeded / loadFactor)));
+		if (sizeNeeded >= threshold)
+			resize(MathUtils.nextPowerOfTwo((int)Math.ceil(sizeNeeded / loadFactor)));
 	}
 
-	private void resize (int newSize) {
-		int oldEndIndex = capacity + stashSize;
-
-		capacity = newSize;
+	final void resize (int newSize) {
+		int oldCapacity = keyTable.length;
 		threshold = (int)(newSize * loadFactor);
 		mask = newSize - 1;
-		hashShift = 31 - Integer.numberOfTrailingZeros(newSize);
-		stashCapacity = Math.max(3, (int)Math.ceil(Math.log(newSize)) * 2);
-		pushIterations = Math.max(Math.min(newSize, 8), (int)Math.sqrt(newSize) / 8);
+		shift = Long.numberOfLeadingZeros(mask);
 
 		K[] oldKeyTable = keyTable;
 		V[] oldValueTable = valueTable;
 
-		keyTable = (K[])new Object[newSize + stashCapacity];
-		valueTable = (V[])new Object[newSize + stashCapacity];
+		keyTable = (K[])new Object[newSize];
+		valueTable = (V[])new Object[newSize];
 
 		int oldSize = size;
 		size = 0;
-		stashSize = 0;
 		if (oldSize > 0) {
-			for (int i = 0; i < oldEndIndex; i++) {
+			for (int i = 0; i < oldCapacity; i++) {
 				K key = oldKeyTable[i];
-				if (key != null) putResize(key, oldValueTable[i]);
+				if (key != null)
+					putResize(key, oldValueTable[i]);
 			}
 		}
 	}
 
-	private int hash2 (int h) {
-		h *= PRIME2;
-		return (h ^ h >>> hashShift) & mask;
-	}
-
-	private int hash3 (int h) {
-		h *= PRIME3;
-		return (h ^ h >>> hashShift) & mask;
-	}
-
 	public int hashCode () {
-		int h = 0;
+		int h = size;
 		K[] keyTable = this.keyTable;
 		V[] valueTable = this.valueTable;
-		for (int i = 0, n = capacity + stashSize; i < n; i++) {
+		for (int i = 0, n = keyTable.length; i < n; i++) {
 			K key = keyTable[i];
 			if (key != null) {
-				h += key.hashCode() * 31;
+				h ^= key.hashCode();
 
 				V value = valueTable[i];
 				if (value != null) {
@@ -550,37 +443,48 @@ public class ObjectMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 	}
 
 	public boolean equals (Object obj) {
-		if (obj == this) return true;
-		if (!(obj instanceof ObjectMap)) return false;
+		if (obj == this)
+			return true;
+		if (!(obj instanceof ObjectMap))
+			return false;
 		ObjectMap other = (ObjectMap)obj;
-		if (other.size != size) return false;
+		if (other.size != size)
+			return false;
 		K[] keyTable = this.keyTable;
 		V[] valueTable = this.valueTable;
-		for (int i = 0, n = capacity + stashSize; i < n; i++) {
+		for (int i = 0, n = keyTable.length; i < n; i++) {
 			K key = keyTable[i];
 			if (key != null) {
 				V value = valueTable[i];
 				if (value == null) {
-					if (other.get(key, dummy) != null) return false;
+					if (other.get(key, dummy) != null)
+						return false;
 				} else {
-					if (!value.equals(other.get(key))) return false;
+					if (!value.equals(other.get(key)))
+						return false;
 				}
 			}
 		}
 		return true;
 	}
 
-	/** Uses == for comparison of each value. */
+	/**
+	 * Uses == for comparison of each value.
+	 */
 	public boolean equalsIdentity (Object obj) {
-		if (obj == this) return true;
-		if (!(obj instanceof IdentityMap)) return false;
+		if (obj == this)
+			return true;
+		if (!(obj instanceof IdentityMap))
+			return false;
 		IdentityMap other = (IdentityMap)obj;
-		if (other.size != size) return false;
+		if (other.size != size)
+			return false;
 		K[] keyTable = this.keyTable;
 		V[] valueTable = this.valueTable;
-		for (int i = 0, n = capacity + stashSize; i < n; i++) {
+		for (int i = 0, n = keyTable.length; i < n; i++) {
 			K key = keyTable[i];
-			if (key != null && valueTable[i] != other.get(key, dummy)) return false;
+			if (key != null && valueTable[i] != other.get(key, dummy))
+				return false;
 		}
 		return true;
 	}
@@ -594,29 +498,36 @@ public class ObjectMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 	}
 
 	private String toString (String separator, boolean braces) {
-		if (size == 0) return braces ? "{}" : "";
-		StringBuilder buffer = new StringBuilder(32);
-		if (braces) buffer.append('{');
+		if (size == 0)
+			return braces ? "{}" : "";
+		java.lang.StringBuilder buffer = new java.lang.StringBuilder(32);
+		if (braces)
+			buffer.append('{');
 		K[] keyTable = this.keyTable;
 		V[] valueTable = this.valueTable;
 		int i = keyTable.length;
 		while (i-- > 0) {
 			K key = keyTable[i];
-			if (key == null) continue;
-			buffer.append(key);
+			if (key == null)
+				continue;
+			buffer.append(key == this ? "(this)" : key);
 			buffer.append('=');
-			buffer.append(valueTable[i]);
+			V value = valueTable[i];
+			buffer.append(value == this ? "(this)" : value);
 			break;
 		}
 		while (i-- > 0) {
 			K key = keyTable[i];
-			if (key == null) continue;
+			if (key == null)
+				continue;
 			buffer.append(separator);
-			buffer.append(key);
+			buffer.append(key == this ? "(this)" : key);
 			buffer.append('=');
-			buffer.append(valueTable[i]);
+			V value = valueTable[i];
+			buffer.append(value == this ? "(this)" : value);
 		}
-		if (braces) buffer.append('}');
+		if (braces)
+			buffer.append('}');
 		return buffer.toString();
 	}
 
@@ -624,12 +535,11 @@ public class ObjectMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 		return entries();
 	}
 
-	/** Returns an iterator for the entries in the map. Remove is supported.
-	 * <p>
-	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called.
-	 * Use the {@link Entries} constructor for nested or multithreaded iteration. */
+	/**
+	 * Returns an iterator for the entries in the map. Remove is supported. Note that the same iterator instance is returned each
+	 * time this method is called. Use the {@link Entries} constructor for nested or multithreaded iteration.
+	 */
 	public Entries<K, V> entries () {
-		if (Collections.allocateIterators) return new Entries(this);
 		if (entries1 == null) {
 			entries1 = new Entries(this);
 			entries2 = new Entries(this);
@@ -646,12 +556,11 @@ public class ObjectMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 		return entries2;
 	}
 
-	/** Returns an iterator for the values in the map. Remove is supported.
-	 * <p>
-	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called.
-	 * Use the {@link Values} constructor for nested or multithreaded iteration. */
+	/**
+	 * Returns an iterator for the values in the map. Remove is supported. Note that the same iterator instance is returned each
+	 * time this method is called. Use the {@link Values} constructor for nested or multithreaded iteration.
+	 */
 	public Values<V> values () {
-		if (Collections.allocateIterators) return new Values(this);
 		if (values1 == null) {
 			values1 = new Values(this);
 			values2 = new Values(this);
@@ -668,12 +577,11 @@ public class ObjectMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 		return values2;
 	}
 
-	/** Returns an iterator for the keys in the map. Remove is supported.
-	 * <p>
-	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called.
-	 * Use the {@link Keys} constructor for nested or multithreaded iteration. */
+	/**
+	 * Returns an iterator for the keys in the map. Remove is supported. Note that the same iterator instance is returned each
+	 * time this method is called. Use the {@link Keys} constructor for nested or multithreaded iteration.
+	 */
 	public Keys<K> keys () {
-		if (Collections.allocateIterators) return new Keys(this);
 		if (keys1 == null) {
 			keys1 = new Keys(this);
 			keys2 = new Keys(this);
@@ -688,6 +596,41 @@ public class ObjectMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 		keys2.valid = true;
 		keys1.valid = false;
 		return keys2;
+	}
+
+	public void write (Json json) {
+		if (isEmpty())
+			return;
+		if (keys().next() instanceof String) {
+			json.writeObjectStart("entries");
+			for (Entry<K, V> entry : entries()) {
+				json.writeValue(String.valueOf(entry.key), entry.value, null);
+			}
+			json.writeObjectEnd();
+		} else {
+			json.writeArrayStart("entries");
+			for (Entry<K, V> entry : entries()) {
+				json.writeValue(entry.key, null);
+				json.writeValue(entry.value, null);
+			}
+			json.writeArrayEnd();
+		}
+	}
+
+	public void read (Json json, JsonValue jsonData) {
+		if (jsonData.isEmpty())
+			return;
+		JsonValue entries = jsonData.get("entries");
+		if (entries.isObject()) {
+			for (JsonValue child = entries.child; child != null; child = child.next)
+				put((K)child.name, (V)json.readValue(null, child));
+		} else if (entries.isArray()) {
+			for (JsonValue child = entries.child; child != null; child = child.next) {
+				K key = json.readValue(null, child);
+				V value = json.readValue(null, child = child.next);
+				put(key, value);
+			}
+		}
 	}
 
 	static public class Entry<K, V> {
@@ -720,7 +663,7 @@ public class ObjectMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 		void findNextIndex () {
 			hasNext = false;
 			K[] keyTable = map.keyTable;
-			for (int n = map.capacity + map.stashSize; ++nextIndex < n;) {
+			for (int n = keyTable.length; ++nextIndex < n; ) {
 				if (keyTable[nextIndex] != null) {
 					hasNext = true;
 					break;
@@ -729,31 +672,41 @@ public class ObjectMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 		}
 
 		public void remove () {
-			if (currentIndex < 0) throw new IllegalStateException("next must be called before remove.");
-			if (currentIndex >= map.capacity) {
-				map.removeStashIndex(currentIndex);
-				nextIndex = currentIndex - 1;
-				findNextIndex();
-			} else {
-				map.keyTable[currentIndex] = null;
-				map.valueTable[currentIndex] = null;
+			if (currentIndex < 0)
+				throw new IllegalStateException("next must be called before remove.");
+			K[] keyTable = map.keyTable;
+			V[] valueTable = map.valueTable;
+			int loc = currentIndex;
+			final int mask = map.mask;
+			K key;
+			while ((key = keyTable[loc + 1 & mask]) != null && (loc + 1 & mask) != map.place(key)) {
+				keyTable[loc] = key;
+				valueTable[loc] = valueTable[loc + 1 & mask];
+				++loc;
 			}
+			if(loc != currentIndex) --nextIndex;
+			keyTable[loc] = null;
+			valueTable[loc] = null;
+			--map.size;
 			currentIndex = -1;
-			map.size--;
 		}
 	}
 
 	static public class Entries<K, V> extends MapIterator<K, V, Entry<K, V>> {
-		Entry<K, V> entry = new Entry();
+		Entry<K, V> entry = new Entry<K, V>();
 
 		public Entries (ObjectMap<K, V> map) {
 			super(map);
 		}
 
-		/** Note the same entry instance is returned each time this method is called. */
+		/**
+		 * Note the same entry instance is returned each time this method is called.
+		 */
 		public Entry<K, V> next () {
-			if (!hasNext) throw new NoSuchElementException();
-			if (!valid) throw new GdxRuntimeException("#iterator() cannot be used nested.");
+			if (!hasNext)
+				throw new NoSuchElementException();
+			if (!valid)
+				throw new GdxRuntimeException("#iterator() cannot be used nested.");
 			K[] keyTable = map.keyTable;
 			entry.key = keyTable[nextIndex];
 			entry.value = map.valueTable[nextIndex];
@@ -763,12 +716,17 @@ public class ObjectMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 		}
 
 		public boolean hasNext () {
-			if (!valid) throw new GdxRuntimeException("#iterator() cannot be used nested.");
+			if (!valid)
+				throw new GdxRuntimeException("#iterator() cannot be used nested.");
 			return hasNext;
 		}
 
 		public Entries<K, V> iterator () {
 			return this;
+		}
+
+		public void remove () {
+			super.remove();
 		}
 	}
 
@@ -778,13 +736,16 @@ public class ObjectMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 		}
 
 		public boolean hasNext () {
-			if (!valid) throw new GdxRuntimeException("#iterator() cannot be used nested.");
+			if (!valid)
+				throw new GdxRuntimeException("#iterator() cannot be used nested.");
 			return hasNext;
 		}
 
 		public V next () {
-			if (!hasNext) throw new NoSuchElementException();
-			if (!valid) throw new GdxRuntimeException("#iterator() cannot be used nested.");
+			if (!hasNext)
+				throw new NoSuchElementException();
+			if (!valid)
+				throw new GdxRuntimeException("#iterator() cannot be used nested.");
 			V value = map.valueTable[nextIndex];
 			currentIndex = nextIndex;
 			findNextIndex();
@@ -795,12 +756,16 @@ public class ObjectMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 			return this;
 		}
 
-		/** Returns a new array containing the remaining values. */
+		/**
+		 * Returns a new array containing the remaining values.
+		 */
 		public Array<V> toArray () {
 			return toArray(new Array(true, map.size));
 		}
 
-		/** Adds the remaining values to the specified array. */
+		/**
+		 * Adds the remaining values to the specified array.
+		 */
 		public Array<V> toArray (Array<V> array) {
 			while (hasNext)
 				array.add(next());
@@ -814,13 +779,16 @@ public class ObjectMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 		}
 
 		public boolean hasNext () {
-			if (!valid) throw new GdxRuntimeException("#iterator() cannot be used nested.");
+			if (!valid)
+				throw new GdxRuntimeException("#iterator() cannot be used nested.");
 			return hasNext;
 		}
 
 		public K next () {
-			if (!hasNext) throw new NoSuchElementException();
-			if (!valid) throw new GdxRuntimeException("#iterator() cannot be used nested.");
+			if (!hasNext)
+				throw new NoSuchElementException();
+			if (!valid)
+				throw new GdxRuntimeException("#iterator() cannot be used nested.");
 			K key = map.keyTable[nextIndex];
 			currentIndex = nextIndex;
 			findNextIndex();
@@ -831,12 +799,16 @@ public class ObjectMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 			return this;
 		}
 
-		/** Returns a new array containing the remaining keys. */
+		/**
+		 * Returns a new array containing the remaining keys.
+		 */
 		public Array<K> toArray () {
-			return toArray(new Array(true, map.size));
+			return toArray(new Array<K>(true, map.size));
 		}
 
-		/** Adds the remaining keys to the array. */
+		/**
+		 * Adds the remaining keys to the array.
+		 */
 		public Array<K> toArray (Array<K> array) {
 			while (hasNext)
 				array.add(next());

--- a/gdx/src/com/badlogic/gdx/utils/ObjectMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/ObjectMap.java
@@ -269,9 +269,12 @@ public class ObjectMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 			return null;
 		}
 		V oldValue = valueTable[loc];
-		while ((key = keyTable[loc + 1 & mask]) != null && (loc + 1 & mask) != place(key)) {
+		int nl = (loc + 1 & mask);
+		while ((key = keyTable[nl]) != null && nl != place(key)) {
 			keyTable[loc] = key;
-			valueTable[loc] = valueTable[++loc & mask];
+			valueTable[loc] = valueTable[nl];
+			loc = nl;
+			nl = loc + 1 & mask;
 		}
 		keyTable[loc] = null;
 		valueTable[loc] = null;
@@ -637,13 +640,14 @@ public class ObjectMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 				throw new IllegalStateException("next must be called before remove.");
 			K[] keyTable = map.keyTable;
 			V[] valueTable = map.valueTable;
-			int loc = currentIndex;
 			final int mask = map.mask;
+			int loc = currentIndex, nl = (loc + 1 & mask);
 			K key;
-			while ((key = keyTable[loc + 1 & mask]) != null && (loc + 1 & mask) != map.place(key)) {
+			while ((key = keyTable[nl]) != null && nl != map.place(key)) {
 				keyTable[loc] = key;
-				valueTable[loc] = valueTable[loc + 1 & mask];
-				++loc;
+				valueTable[loc] = valueTable[nl];
+				loc = nl;
+				nl = loc + 1 & mask;
 			}
 			if(loc != currentIndex) --nextIndex;
 			keyTable[loc] = null;

--- a/gdx/src/com/badlogic/gdx/utils/ObjectSet.java
+++ b/gdx/src/com/badlogic/gdx/utils/ObjectSet.java
@@ -240,8 +240,7 @@ public class ObjectSet<T> implements Iterable<T> {
 	 */
 	private void addResize (T key) {
 		T[] keyTable = this.keyTable;
-		int b = place(key);
-		for (int i = b; ; i = (i + 1) & mask) {
+		for (int i = place(key); ; i = (i + 1) & mask) {
 			// space is available so we insert and break (resize is later)
 			if (keyTable[i] == null) {
 				keyTable[i] = key;

--- a/gdx/src/com/badlogic/gdx/utils/ObjectSet.java
+++ b/gdx/src/com/badlogic/gdx/utils/ObjectSet.java
@@ -39,7 +39,7 @@ import java.util.NoSuchElementException;
  * Load factors greater than 0.91 greatly increase the chances the set will have to rehash to the next higher POT size.
  * Memory usage is excellent, and the aforementioned collision-resistance helps avoid too much capacity resizing.
  * <br>
-* Iteration should be fast with OrderedSet and OrderedMap, whereas ObjectSet and ObjectMap aren't designed to provide especially
+ * Iteration should be fast with OrderedSet and OrderedMap, whereas ObjectSet and ObjectMap aren't designed to provide especially
  * quick iteration.
  *
  * @author Tommy Ettinger
@@ -239,15 +239,13 @@ public class ObjectSet<T> implements Iterable<T> {
 	private void addResize (T key) {
 		T[] keyTable = this.keyTable;
 		for (int i = place(key); ; i = (i + 1) & mask) {
-			// space is available so we insert and break (resize is later)
+			// space is available so we insert and break
 			if (keyTable[i] == null) {
 				keyTable[i] = key;
 				break;
 			}
 		}
-		if (++size >= threshold) {
-			resize(keyTable.length << 1);
-		}
+		++size;
 	}
 
 	/**
@@ -458,7 +456,7 @@ public class ObjectSet<T> implements Iterable<T> {
 		set.addAll(array);
 		return set;
 	}
-	
+
 	static public class ObjectSetIterator<K> implements Iterable<K>, Iterator<K> {
 		public boolean hasNext;
 
@@ -501,7 +499,8 @@ public class ObjectSet<T> implements Iterable<T> {
 				loc = nl;
 				nl = loc + 1 & mask;
 			}
-			if(loc != currentIndex) --nextIndex;
+			if (loc != currentIndex)
+				--nextIndex;
 			keyTable[loc] = null;
 			currentIndex = -1;
 			set.size--;

--- a/gdx/src/com/badlogic/gdx/utils/ObjectSet.java
+++ b/gdx/src/com/badlogic/gdx/utils/ObjectSet.java
@@ -100,7 +100,7 @@ public class ObjectSet<T> implements Iterable<T> {
 			throw new IllegalArgumentException("initialCapacity must be >= 0: " + initialCapacity);
 		if (loadFactor <= 0f || loadFactor >= 1f)
 			throw new IllegalArgumentException("loadFactor must be > 0 and < 1: " + loadFactor);
-		initialCapacity = MathUtils.nextPowerOfTwo((int)Math.ceil(initialCapacity / loadFactor));
+		initialCapacity = MathUtils.nextPowerOfTwo((int)Math.ceil(Math.max(1, initialCapacity) / loadFactor));
 		if (initialCapacity > 1 << 30)
 			throw new IllegalArgumentException("initialCapacity is too large: " + initialCapacity);
 

--- a/gdx/src/com/badlogic/gdx/utils/ObjectSet.java
+++ b/gdx/src/com/badlogic/gdx/utils/ObjectSet.java
@@ -39,11 +39,7 @@ import java.util.NoSuchElementException;
  * Load factors greater than 0.91 greatly increase the chances the set will have to rehash to the next higher POT size.
  * Memory usage is excellent, and the aforementioned collision-resistance helps avoid too much capacity resizing.
  * <br>
- * The <a href="http://codecapsule.com/2013/11/17/robin-hood-hashing-backward-shift-deletion/">backward-shift algorithm</a>
- * used during removal apparently is key to the good performance of this implementation, even though this doesn't use Robin Hood
- * hashing; the performance of {@link #remove(Object)} has improved considerably over the previous libGDX version.
- * <br>
- * Iteration should be fast with OrderedSet and OrderedMap, whereas ObjectSet and ObjectMap aren't designed to provide especially
+* Iteration should be fast with OrderedSet and OrderedMap, whereas ObjectSet and ObjectMap aren't designed to provide especially
  * quick iteration.
  *
  * @author Tommy Ettinger
@@ -139,7 +135,7 @@ public class ObjectSet<T> implements Iterable<T> {
 	 * {@code return (int) (item.hashCode() * 0x9E3779B97F4A7C15L >>> shift);}
 	 * <br>
 	 * This can be overridden by subclasses, which you may want to do if your key type needs special consideration for
-	 * its hash (such as if you use arrays as keys, which still requires that the arrays are not modified). Subclasses
+	 * its hash (such as if you can't modify or extend a particular class that has an incorrect hashCode()). Subclasses
 	 * that don't need the collision decrease of Fibonacci Hashing (assuming the key class has a good hashCode()) may do
 	 * fine with a simple implementation:
 	 * {@code return (item.hashCode() & mask);}

--- a/gdx/src/com/badlogic/gdx/utils/ObjectSet.java
+++ b/gdx/src/com/badlogic/gdx/utils/ObjectSet.java
@@ -49,7 +49,7 @@ import java.util.NoSuchElementException;
  * @author Tommy Ettinger
  * @author Nathan Sweet
  */
-public class ObjectSet<T> implements Json.Serializable, Iterable<T> {
+public class ObjectSet<T> implements Iterable<T> {
 	public int size;
 
 	T[] keyTable;
@@ -462,16 +462,7 @@ public class ObjectSet<T> implements Json.Serializable, Iterable<T> {
 		set.addAll(array);
 		return set;
 	}
-
-	public void write (Json json) {
-		Array<T> items = iterator().toArray();
-		json.writeValue("items", items, Array.class);
-	}
-
-	public void read (Json json, JsonValue jsonData) {
-		addAll(json.readValue("items", Array.class, jsonData));
-	}
-
+	
 	static public class ObjectSetIterator<K> implements Iterable<K>, Iterator<K> {
 		public boolean hasNext;
 

--- a/gdx/src/com/badlogic/gdx/utils/ObjectSet.java
+++ b/gdx/src/com/badlogic/gdx/utils/ObjectSet.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,122 +16,191 @@
 
 package com.badlogic.gdx.utils;
 
+import com.badlogic.gdx.math.MathUtils;
+
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
-import com.badlogic.gdx.math.MathUtils;
-
-/** An unordered set where the keys are objects. This implementation uses cuckoo hashing using 3 hashes, random walking, and a
- * small stash for problematic keys. Null keys are not allowed. No allocation is done except when growing the table size. <br>
+/**
+ * An unordered set where the keys are objects. This implementation uses linear probing with the backward-shift algorithm for
+ * removal, and finds space for keys using Fibonacci hashing instead of the more-common power-of-two mask.
+ * Null keys are not allowed. No allocation is done except when growing the table size.
  * <br>
- * This set performs very fast contains and remove (typically O(1), worst case O(log(n))). Add may be a bit slower, depending on
- * hash collisions. Load factors greater than 0.91 greatly increase the chances the set will have to rehash to the next higher POT
- * size.<br>
+ * This set uses Fibonacci hashing to help distribute what may be very bad hashCode() results across the
+ * whole capacity. See <a href="https://probablydance.com/2018/06/16/fibonacci-hashing-the-optimization-that-the-world-forgot-or-a-better-alternative-to-integer-modulo/">Malte Skarupke's blog post</a>
+ * for more information on Fibonacci hashing. It uses linear probing to resolve collisions, which is far from the academically
+ * optimal algorithm, but performs considerably better in practice than most alternatives, and combined with Fibonacci hashing, it
+ * can handle "normal" generated hashCode() implementations, and not just theoretically optimal hashing functions. Even if all
+ * hashCode()s this is given collide, it will still work, just slowly; the older libGDX implementation using cuckoo hashing would
+ * crash with an OutOfMemoryError with under 50 collisions.
  * <br>
- * Iteration can be very slow for a set with a large capacity. {@link #clear(int)} and {@link #shrink(int)} can be used to reduce
- * the capacity. {@link OrderedSet} provides much faster iteration.
- * @author Nathan Sweet */
-public class ObjectSet<T> implements Iterable<T> {
-	private static final int PRIME1 = 0xbe1f14b1;
-	private static final int PRIME2 = 0xb4b82e39;
-	private static final int PRIME3 = 0xced1c241;
-
+ * This map performs very fast contains and remove (typically O(1), worst case O(n) due to occasional probing, but still very
+ * fast). Add may be a bit slower, depending on hash collisions, but this data structure is somewhat collision-resistant.
+ * Load factors greater than 0.91 greatly increase the chances the set will have to rehash to the next higher POT size.
+ * Memory usage is excellent, and the aforementioned collision-resistance helps avoid too much capacity resizing.
+ * <br>
+ * The <a href="http://codecapsule.com/2013/11/17/robin-hood-hashing-backward-shift-deletion/">backward-shift algorithm</a>
+ * used during removal apparently is key to the good performance of this implementation, even though this doesn't use Robin Hood
+ * hashing; the performance of {@link #remove(Object)} has improved considerably over the previous libGDX version.
+ * <br>
+ * Iteration should be fast with OrderedSet and OrderedMap, whereas ObjectSet and ObjectMap aren't designed to provide especially
+ * quick iteration.
+ *
+ * @author Tommy Ettinger
+ * @author Nathan Sweet
+ */
+public class ObjectSet<T> implements Json.Serializable, Iterable<T> {
 	public int size;
 
 	T[] keyTable;
-	int capacity, stashSize;
 
-	private float loadFactor;
-	private int hashShift, mask, threshold;
-	private int stashCapacity;
-	private int pushIterations;
+	float loadFactor;
+	int threshold;
+	/**
+	 * Used by {@link #place(Object)} to bit-shift the upper bits of a {@code long} into a usable range (less than or
+	 * equal to {@link #mask}, greater than or equal to 0). If you're setting it in a subclass, this shift can be
+	 * negative, which is a convenient way to match the number of bits in mask; if mask is a 7-bit number, then a shift
+	 * of -7 will correctly shift the upper 7 bits into the lowest 7 positions. If using what this class sets, shift
+	 * will be greater than 32 and less than 64; if you use this shift with an int, it will still correctly move the
+	 * upper bits of an int to the lower bits, thanks to Java's implicit modulus on shifts.
+	 * <br>
+	 * You can also use {@link #mask} to mask the low bits of a number, which may be faster for some hashCode()s, if you
+	 * reimplement {@link #place(Object)}.
+	 */
+	protected int shift;
+	/**
+	 * The bitmask used to contain hashCode()s to the indices that can be fit into the key array this uses. This should
+	 * always be all-1-bits in its low positions; that is, it must be a power of two minus 1. If you subclass and change
+	 * {@link #place(Object)}, you may want to use this instead of {@link #shift} to isolate usable bits of a hash.
+	 */
+	protected int mask;
 
 	private ObjectSetIterator iterator1, iterator2;
 
-	/** Creates a new set with an initial capacity of 51 and a load factor of 0.8. */
+	/**
+	 * Creates a new set with an initial capacity of 51 and a load factor of 0.8.
+	 */
 	public ObjectSet () {
 		this(51, 0.8f);
 	}
 
-	/** Creates a new set with a load factor of 0.8.
-	 * @param initialCapacity If not a power of two, it is increased to the next nearest power of two. */
+	/**
+	 * Creates a new set with a load factor of 0.8.
+	 *
+	 * @param initialCapacity If not a power of two, it is increased to the next nearest power of two.
+	 */
 	public ObjectSet (int initialCapacity) {
 		this(initialCapacity, 0.8f);
 	}
 
-	/** Creates a new set with the specified initial capacity and load factor. This set will hold initialCapacity items before
+	/**
+	 * Creates a new set with the specified initial capacity and load factor. This set will hold initialCapacity items before
 	 * growing the backing table.
-	 * @param initialCapacity If not a power of two, it is increased to the next nearest power of two. */
+	 *
+	 * @param initialCapacity If not a power of two, it is increased to the next nearest power of two.
+	 */
 	public ObjectSet (int initialCapacity, float loadFactor) {
-		if (loadFactor <= 0) throw new IllegalArgumentException("loadFactor must be > 0: " + loadFactor);
+		if (initialCapacity < 0)
+			throw new IllegalArgumentException("initialCapacity must be >= 0: " + initialCapacity);
+		if (loadFactor <= 0f || loadFactor >= 1f)
+			throw new IllegalArgumentException("loadFactor must be > 0 and < 1: " + loadFactor);
+		initialCapacity = MathUtils.nextPowerOfTwo((int)Math.ceil(initialCapacity / loadFactor));
+		if (initialCapacity > 1 << 30)
+			throw new IllegalArgumentException("initialCapacity is too large: " + initialCapacity);
+
 		this.loadFactor = loadFactor;
 
-		if (initialCapacity < 0) throw new IllegalArgumentException("initialCapacity must be >= 0: " + initialCapacity);
-		initialCapacity = MathUtils.nextPowerOfTwo((int)Math.ceil(initialCapacity / loadFactor));
-		if (initialCapacity > 1 << 30) throw new IllegalArgumentException("initialCapacity is too large: " + initialCapacity);
-		capacity = initialCapacity;
-
-		threshold = (int)(capacity * loadFactor);
-		mask = capacity - 1;
-		hashShift = 31 - Integer.numberOfTrailingZeros(capacity);
-		stashCapacity = Math.max(3, (int)Math.ceil(Math.log(capacity)) * 2);
-		pushIterations = Math.max(Math.min(capacity, 8), (int)Math.sqrt(capacity) / 8);
-
-		keyTable = (T[])new Object[capacity + stashCapacity];
+		threshold = (int)(initialCapacity * loadFactor);
+		mask = initialCapacity - 1;
+		shift = Long.numberOfLeadingZeros(mask);
+		keyTable = (T[])(new Object[initialCapacity]);
 	}
 
-	/** Creates a new set identical to the specified set. */
+	/**
+	 * Creates a new set identical to the specified set.
+	 */
 	public ObjectSet (ObjectSet<? extends T> set) {
-		this((int)Math.floor(set.capacity * set.loadFactor), set.loadFactor);
-		stashSize = set.stashSize;
+		this((int)Math.ceil(set.keyTable.length * set.loadFactor), set.loadFactor);
 		System.arraycopy(set.keyTable, 0, keyTable, 0, set.keyTable.length);
 		size = set.size;
 	}
 
-	/** Returns true if the key was not already in the set. If this set already contains the key, the set is left unchanged and
-	 * false is returned. */
+	/**
+	 * Finds an array index between 0 and {@link #mask}, both inclusive, corresponding to the hash code of {@code item}.
+	 * By default, this uses "Fibonacci Hashing" on the {@link Object#hashCode()} of {@code item}; this multiplies
+	 * {@code item.hashCode()} by a long constant (2 to the 64, divided by the golden ratio) and shifts the high-quality
+	 * uppermost bits into the lowest positions so they can be used as array indices. The multiplication by a long may
+	 * be somewhat slow on GWT, but it will be correct across all platforms and won't lose precision. Using Fibonacci
+	 * Hashing allows even very poor hashCode() implementations, such as those that only differ in their upper bits, to
+	 * work in a hash table without heavy collision rates. It has known problems when all or most hashCode()s are
+	 * multiples of larger Fibonacci numbers; see <a href="https://probablydance.com/2018/06/16/fibonacci-hashing-the-optimization-that-the-world-forgot-or-a-better-alternative-to-integer-modulo/">this blog post by Malte Skarupke</a>
+	 * for more details. In the unlikely event that most of your hashCode()s are Fibonacci numbers, you can subclass
+	 * this to change this method, which is a one-liner in this form:
+	 * {@code return (int) (item.hashCode() * 0x9E3779B97F4A7C15L >>> shift);}
+	 * <br>
+	 * This can be overridden by subclasses, which you may want to do if your key type needs special consideration for
+	 * its hash (such as if you use arrays as keys, which still requires that the arrays are not modified). Subclasses
+	 * that don't need the collision decrease of Fibonacci Hashing (assuming the key class has a good hashCode()) may do
+	 * fine with a simple implementation:
+	 * {@code return (item.hashCode() & mask);}
+	 *
+	 * @param item a key that this method will hash, by default by calling {@link Object#hashCode()} on it; non-null
+	 * @return an int between 0 and {@link #mask}, both inclusive
+	 */
+	protected int place (final T item) {
+		// shift is always greater than 32, less than 64
+		return (int)(item.hashCode() * 0x9E3779B97F4A7C15L >>> shift);
+	}
+
+	private int locateKey (final T key) {
+
+		return locateKey(key, place(key));
+	}
+
+	/**
+	 * Given a key and its initial placement to try in an array, this finds the actual location of the key in the array
+	 * if it is present, or -1 if the key is not present. This can be overridden if a subclass needs to compare for
+	 * equality differently than just by calling {@link Object#equals(Object)}, but only within the same package.
+	 *
+	 * @param key       a K key that will be checked for equality if a similar-seeming key is found
+	 * @param placement as calculated by {@link #place(Object)}, almost always with {@code place(key)}
+	 * @return the location in the key array of key, if found, or -1 if it was not found.
+	 */
+	int locateKey (final T key, final int placement) {
+		for (int i = placement; ; i = i + 1 & mask) {
+			// empty space is available
+			if (keyTable[i] == null) {
+				return -1;
+			}
+			if (key.equals(keyTable[i])) {
+				return i;
+			}
+		}
+	}
+
+	/**
+	 * Returns true if the key was not already in the set. If this set already contains the key, the call leaves the set unchanged
+	 * and returns false.
+	 */
 	public boolean add (T key) {
-		if (key == null) throw new IllegalArgumentException("key cannot be null.");
+		if (key == null)
+			throw new IllegalArgumentException("key cannot be null.");
 		T[] keyTable = this.keyTable;
-
-		// Check for existing keys.
-		int hashCode = key.hashCode();
-		int index1 = hashCode & mask;
-		T key1 = keyTable[index1];
-		if (key.equals(key1)) return false;
-
-		int index2 = hash2(hashCode);
-		T key2 = keyTable[index2];
-		if (key.equals(key2)) return false;
-
-		int index3 = hash3(hashCode);
-		T key3 = keyTable[index3];
-		if (key.equals(key3)) return false;
-
-		// Find key in the stash.
-		for (int i = capacity, n = i + stashSize; i < n; i++)
-			if (key.equals(keyTable[i])) return false;
-
-		// Check for empty buckets.
-		if (key1 == null) {
-			keyTable[index1] = key;
-			if (size++ >= threshold) resize(capacity << 1);
-			return true;
+		int b = place(key);
+		// an identical key already exists
+		if (locateKey(key, b) != -1) {
+			return false;
 		}
-
-		if (key2 == null) {
-			keyTable[index2] = key;
-			if (size++ >= threshold) resize(capacity << 1);
-			return true;
+		for (int i = b; ; i = (i + 1) & mask) {
+			// space is available so we insert and break (resize is later)
+			if (keyTable[i] == null) {
+				keyTable[i] = key;
+				break;
+			}
 		}
-
-		if (key3 == null) {
-			keyTable[index3] = key;
-			if (size++ >= threshold) resize(capacity << 1);
-			return true;
+		if (++size >= threshold) {
+			resize(keyTable.length << 1);
 		}
-
-		push(key, index1, key1, index2, key2, index3, key3);
 		return true;
 	}
 
@@ -141,7 +210,8 @@ public class ObjectSet<T> implements Iterable<T> {
 
 	public void addAll (Array<? extends T> array, int offset, int length) {
 		if (offset + length > array.size)
-			throw new IllegalArgumentException("offset + length must be <= size: " + offset + " + " + length + " <= " + array.size);
+			throw new IllegalArgumentException(
+				"offset + length must be <= size: " + offset + " + " + length + " <= " + array.size);
 		addAll((T[])array.items, offset, length);
 	}
 
@@ -159,186 +229,86 @@ public class ObjectSet<T> implements Iterable<T> {
 
 	public void addAll (ObjectSet<T> set) {
 		ensureCapacity(set.size);
-		for (T key : set)
-			add(key);
+		final T[] keyTable = set.keyTable;
+		T t;
+		for (int i = 0, n = keyTable.length; i < n; i++) {
+			if ((t = keyTable[i]) != null)
+				add(t);
+		}
+//		for (T key : set)
+//			add(key);
 	}
 
-	/** Skips checks for existing keys. */
+	/**
+	 * Skips checks for existing keys.
+	 */
 	private void addResize (T key) {
-		// Check for empty buckets.
-		int hashCode = key.hashCode();
-		int index1 = hashCode & mask;
-		T key1 = keyTable[index1];
-		if (key1 == null) {
-			keyTable[index1] = key;
-			if (size++ >= threshold) resize(capacity << 1);
-			return;
-		}
-
-		int index2 = hash2(hashCode);
-		T key2 = keyTable[index2];
-		if (key2 == null) {
-			keyTable[index2] = key;
-			if (size++ >= threshold) resize(capacity << 1);
-			return;
-		}
-
-		int index3 = hash3(hashCode);
-		T key3 = keyTable[index3];
-		if (key3 == null) {
-			keyTable[index3] = key;
-			if (size++ >= threshold) resize(capacity << 1);
-			return;
-		}
-
-		push(key, index1, key1, index2, key2, index3, key3);
-	}
-
-	private void push (T insertKey, int index1, T key1, int index2, T key2, int index3, T key3) {
 		T[] keyTable = this.keyTable;
-		int mask = this.mask;
-
-		// Push keys until an empty bucket is found.
-		T evictedKey;
-		int i = 0, pushIterations = this.pushIterations;
-		do {
-			// Replace the key and value for one of the hashes.
-			switch (MathUtils.random(2)) {
-			case 0:
-				evictedKey = key1;
-				keyTable[index1] = insertKey;
-				break;
-			case 1:
-				evictedKey = key2;
-				keyTable[index2] = insertKey;
-				break;
-			default:
-				evictedKey = key3;
-				keyTable[index3] = insertKey;
+		int b = place(key);
+		for (int i = b; ; i = (i + 1) & mask) {
+			// space is available so we insert and break (resize is later)
+			if (keyTable[i] == null) {
+				keyTable[i] = key;
 				break;
 			}
-
-			// If the evicted key hashes to an empty bucket, put it there and stop.
-			int hashCode = evictedKey.hashCode();
-			index1 = hashCode & mask;
-			key1 = keyTable[index1];
-			if (key1 == null) {
-				keyTable[index1] = evictedKey;
-				if (size++ >= threshold) resize(capacity << 1);
-				return;
-			}
-
-			index2 = hash2(hashCode);
-			key2 = keyTable[index2];
-			if (key2 == null) {
-				keyTable[index2] = evictedKey;
-				if (size++ >= threshold) resize(capacity << 1);
-				return;
-			}
-
-			index3 = hash3(hashCode);
-			key3 = keyTable[index3];
-			if (key3 == null) {
-				keyTable[index3] = evictedKey;
-				if (size++ >= threshold) resize(capacity << 1);
-				return;
-			}
-
-			if (++i == pushIterations) break;
-
-			insertKey = evictedKey;
-		} while (true);
-
-		addStash(evictedKey);
-	}
-
-	private void addStash (T key) {
-		if (stashSize == stashCapacity) {
-			// Too many pushes occurred and the stash is full, increase the table size.
-			resize(capacity << 1);
-			addResize(key);
-			return;
 		}
-		// Store key in the stash.
-		int index = capacity + stashSize;
-		keyTable[index] = key;
-		stashSize++;
-		size++;
+		if (++size >= threshold) {
+			resize(keyTable.length << 1);
+		}
 	}
 
-	/** Returns true if the key was removed. */
+	/**
+	 * Returns true if the key was removed.
+	 */
 	public boolean remove (T key) {
-		int hashCode = key.hashCode();
-		int index = hashCode & mask;
-		if (key.equals(keyTable[index])) {
-			keyTable[index] = null;
-			size--;
-			return true;
+		int loc = locateKey(key);
+		if (loc == -1) {
+			return false;
 		}
-
-		index = hash2(hashCode);
-		if (key.equals(keyTable[index])) {
-			keyTable[index] = null;
-			size--;
-			return true;
+		while ((key = keyTable[loc + 1 & mask]) != null && (loc + 1 & mask) != place(key)) {
+			keyTable[loc] = key;
+			++loc;
 		}
-
-		index = hash3(hashCode);
-		if (key.equals(keyTable[index])) {
-			keyTable[index] = null;
-			size--;
-			return true;
-		}
-
-		return removeStash(key);
+		keyTable[loc] = null;
+		--size;
+		return true;
 	}
 
-	boolean removeStash (T key) {
-		T[] keyTable = this.keyTable;
-		for (int i = capacity, n = i + stashSize; i < n; i++) {
-			if (key.equals(keyTable[i])) {
-				removeStashIndex(i);
-				size--;
-				return true;
-			}
-		}
-		return false;
-	}
-
-	void removeStashIndex (int index) {
-		// If the removed location was not last, move the last tuple to the removed location.
-		stashSize--;
-		int lastIndex = capacity + stashSize;
-		if (index < lastIndex) {
-			keyTable[index] = keyTable[lastIndex];
-			keyTable[lastIndex] = null;
-		}
-	}
-
-	/** Returns true if the set has one or more items. */
+	/**
+	 * Returns true if the set has one or more items.
+	 */
 	public boolean notEmpty () {
 		return size > 0;
 	}
 
-	/** Returns true if the set is empty. */
+	/**
+	 * Returns true if the set is empty.
+	 */
 	public boolean isEmpty () {
 		return size == 0;
 	}
 
-	/** Reduces the size of the backing arrays to be the specified capacity or less. If the capacity is already less, nothing is
-	 * done. If the set contains more items than the specified capacity, the next highest power of two capacity is used instead. */
+	/**
+	 * Reduces the size of the backing arrays to be the specified capacity or less. If the capacity is already less, nothing is
+	 * done. If the set contains more items than the specified capacity, the next highest power of two capacity is used instead.
+	 */
 	public void shrink (int maximumCapacity) {
-		if (maximumCapacity < 0) throw new IllegalArgumentException("maximumCapacity must be >= 0: " + maximumCapacity);
-		if (size > maximumCapacity) maximumCapacity = size;
-		if (capacity <= maximumCapacity) return;
+		if (maximumCapacity < 0)
+			throw new IllegalArgumentException("maximumCapacity must be >= 0: " + maximumCapacity);
+		if (size > maximumCapacity)
+			maximumCapacity = size;
+		if (keyTable.length <= maximumCapacity)
+			return;
 		maximumCapacity = MathUtils.nextPowerOfTwo(maximumCapacity);
 		resize(maximumCapacity);
 	}
 
-	/** Clears the set and reduces the size of the backing arrays to be the specified capacity, if they are larger. The reduction
-	 * is done by allocating new arrays, though for large arrays this can be faster than clearing the existing array. */
+	/**
+	 * Clears the set and reduces the size of the backing arrays to be the specified capacity, if they are larger. The reduction
+	 * is done by allocating new arrays, though for large arrays this can be faster than clearing the existing array.
+	 */
 	public void clear (int maximumCapacity) {
-		if (capacity <= maximumCapacity) {
+		if (keyTable.length <= maximumCapacity) {
 			clear();
 			return;
 		}
@@ -346,118 +316,92 @@ public class ObjectSet<T> implements Iterable<T> {
 		resize(maximumCapacity);
 	}
 
-	/** Clears the set, leaving the backing arrays at the current capacity. When the capacity is high and the population is low,
-	 * iteration can be unnecessarily slow. {@link #clear(int)} can be used to reduce the capacity. */
+	/**
+	 * Clears the set, leaving the backing arrays at the current capacity. When the capacity is high and the population is low,
+	 * iteration can be unnecessarily slow. {@link #clear(int)} can be used to reduce the capacity.
+	 */
 	public void clear () {
-		if (size == 0) return;
+		if (size == 0)
+			return;
 		T[] keyTable = this.keyTable;
-		for (int i = capacity + stashSize; i-- > 0;)
-			keyTable[i] = null;
+		for (int i = keyTable.length; i > 0; ) {
+			keyTable[--i] = null;
+		}
 		size = 0;
-		stashSize = 0;
 	}
 
 	public boolean contains (T key) {
-		int hashCode = key.hashCode();
-		int index = hashCode & mask;
-		if (!key.equals(keyTable[index])) {
-			index = hash2(hashCode);
-			if (!key.equals(keyTable[index])) {
-				index = hash3(hashCode);
-				if (!key.equals(keyTable[index])) return getKeyStash(key) != null;
-			}
-		}
-		return true;
+		return locateKey(key) != -1;
 	}
 
-	/** @return May be null. */
+	/**
+	 * @return May be null.
+	 */
 	public T get (T key) {
-		int hashCode = key.hashCode();
-		int index = hashCode & mask;
-		T found = keyTable[index];
-		if (!key.equals(found)) {
-			index = hash2(hashCode);
-			found = keyTable[index];
-			if (!key.equals(found)) {
-				index = hash3(hashCode);
-				found = keyTable[index];
-				if (!key.equals(found)) return getKeyStash(key);
-			}
-		}
-		return found;
-	}
-
-	private T getKeyStash (T key) {
-		T[] keyTable = this.keyTable;
-		for (int i = capacity, n = i + stashSize; i < n; i++)
-			if (key.equals(keyTable[i])) return keyTable[i];
-		return null;
+		final int loc = locateKey(key);
+		return loc == -1 ? null : keyTable[loc];
 	}
 
 	public T first () {
 		T[] keyTable = this.keyTable;
-		for (int i = 0, n = capacity + stashSize; i < n; i++)
-			if (keyTable[i] != null) return keyTable[i];
+		for (int i = 0, n = keyTable.length; i < n; i++)
+			if (keyTable[i] != null)
+				return keyTable[i];
 		throw new IllegalStateException("ObjectSet is empty.");
 	}
 
-	/** Increases the size of the backing array to accommodate the specified number of additional items. Useful before adding many
-	 * items to avoid multiple backing array resizes. */
+	/**
+	 * Increases the size of the backing array to accommodate the specified number of additional items. Useful before adding many
+	 * items to avoid multiple backing array resizes.
+	 */
 	public void ensureCapacity (int additionalCapacity) {
-		if (additionalCapacity < 0) throw new IllegalArgumentException("additionalCapacity must be >= 0: " + additionalCapacity);
+		if (additionalCapacity < 0)
+			throw new IllegalArgumentException("additionalCapacity must be >= 0: " + additionalCapacity);
 		int sizeNeeded = size + additionalCapacity;
-		if (sizeNeeded >= threshold) resize(MathUtils.nextPowerOfTwo((int)Math.ceil(sizeNeeded / loadFactor)));
+		if (sizeNeeded >= threshold)
+			resize(MathUtils.nextPowerOfTwo((int)Math.ceil(sizeNeeded / loadFactor)));
 	}
 
 	private void resize (int newSize) {
-		int oldEndIndex = capacity + stashSize;
-
-		capacity = newSize;
+		int oldCapacity = keyTable.length;
 		threshold = (int)(newSize * loadFactor);
 		mask = newSize - 1;
-		hashShift = 31 - Integer.numberOfTrailingZeros(newSize);
-		stashCapacity = Math.max(3, (int)Math.ceil(Math.log(newSize)) * 2);
-		pushIterations = Math.max(Math.min(newSize, 8), (int)Math.sqrt(newSize) / 8);
-
+		shift = Long.numberOfLeadingZeros(mask);
 		T[] oldKeyTable = keyTable;
 
-		keyTable = (T[])new Object[newSize + stashCapacity];
+		keyTable = (T[])(new Object[newSize]);
 
 		int oldSize = size;
 		size = 0;
-		stashSize = 0;
 		if (oldSize > 0) {
-			for (int i = 0; i < oldEndIndex; i++) {
+			for (int i = 0; i < oldCapacity; i++) {
 				T key = oldKeyTable[i];
-				if (key != null) addResize(key);
+				if (key != null)
+					addResize(key);
 			}
 		}
 	}
 
-	private int hash2 (int h) {
-		h *= PRIME2;
-		return (h ^ h >>> hashShift) & mask;
-	}
-
-	private int hash3 (int h) {
-		h *= PRIME3;
-		return (h ^ h >>> hashShift) & mask;
-	}
-
 	public int hashCode () {
-		int h = 0;
-		for (int i = 0, n = capacity + stashSize; i < n; i++)
-			if (keyTable[i] != null) h += keyTable[i].hashCode();
+		int h = size;
+		for (int i = 0, n = keyTable.length; i < n; i++) {
+			if (keyTable[i] != null) {
+				h += keyTable[i].hashCode();
+			}
+		}
 		return h;
 	}
 
 	public boolean equals (Object obj) {
-		if (!(obj instanceof ObjectSet)) return false;
+		if (!(obj instanceof ObjectSet))
+			return false;
 		ObjectSet other = (ObjectSet)obj;
-		if (other.size != size) return false;
+		if (other.size != size)
+			return false;
 		T[] keyTable = this.keyTable;
-		for (int i = 0, n = capacity + stashSize; i < n; i++)
-			if (keyTable[i] != null && !other.contains(keyTable[i])) return false;
+		for (int i = 0, n = keyTable.length; i < n; i++)
+			if (keyTable[i] != null && !other.contains(keyTable[i]))
+				return false;
 		return true;
 	}
 
@@ -466,31 +410,37 @@ public class ObjectSet<T> implements Iterable<T> {
 	}
 
 	public String toString (String separator) {
-		if (size == 0) return "";
-		StringBuilder buffer = new StringBuilder(32);
+		if (size == 0)
+			return "";
+		java.lang.StringBuilder buffer = new java.lang.StringBuilder(32);
 		T[] keyTable = this.keyTable;
 		int i = keyTable.length;
 		while (i-- > 0) {
 			T key = keyTable[i];
-			if (key == null) continue;
-			buffer.append(key);
+			if (key == null)
+				continue;
+			buffer.append(key == this ? "(this)" : key);
 			break;
 		}
 		while (i-- > 0) {
 			T key = keyTable[i];
-			if (key == null) continue;
+			if (key == null)
+				continue;
 			buffer.append(separator);
-			buffer.append(key);
+			buffer.append(key == this ? "(this)" : key);
 		}
 		return buffer.toString();
 	}
 
-	/** Returns an iterator for the keys in the set. Remove is supported.
+	/**
+	 * Returns an iterator for the keys in the set. Remove is supported.
 	 * <p>
-	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called.
-	 * Use the {@link ObjectSetIterator} constructor for nested or multithreaded iteration. */
+	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called. Use the
+	 * {@link ObjectSetIterator} constructor for nested or multithreaded iteration.
+	 */
 	public ObjectSetIterator<T> iterator () {
-		if (Collections.allocateIterators) return new ObjectSetIterator(this);
+		if (Collections.allocateIterators)
+			return new ObjectSetIterator(this);
 		if (iterator1 == null) {
 			iterator1 = new ObjectSetIterator(this);
 			iterator2 = new ObjectSetIterator(this);
@@ -508,9 +458,18 @@ public class ObjectSet<T> implements Iterable<T> {
 	}
 
 	static public <T> ObjectSet<T> with (T... array) {
-		ObjectSet set = new ObjectSet();
+		ObjectSet<T> set = new ObjectSet<T>();
 		set.addAll(array);
 		return set;
+	}
+
+	public void write (Json json) {
+		Array<T> items = iterator().toArray();
+		json.writeValue("items", items, Array.class);
+	}
+
+	public void read (Json json, JsonValue jsonData) {
+		addAll(json.readValue("items", Array.class, jsonData));
 	}
 
 	static public class ObjectSetIterator<K> implements Iterable<K>, Iterator<K> {
@@ -534,7 +493,7 @@ public class ObjectSet<T> implements Iterable<T> {
 		private void findNextIndex () {
 			hasNext = false;
 			K[] keyTable = set.keyTable;
-			for (int n = set.capacity + set.stashSize; ++nextIndex < n;) {
+			for (int n = set.keyTable.length; ++nextIndex < n; ) {
 				if (keyTable[nextIndex] != null) {
 					hasNext = true;
 					break;
@@ -543,26 +502,34 @@ public class ObjectSet<T> implements Iterable<T> {
 		}
 
 		public void remove () {
-			if (currentIndex < 0) throw new IllegalStateException("next must be called before remove.");
-			if (currentIndex >= set.capacity) {
-				set.removeStashIndex(currentIndex);
-				nextIndex = currentIndex - 1;
-				findNextIndex();
-			} else {
-				set.keyTable[currentIndex] = null;
+			if (currentIndex < 0)
+				throw new IllegalStateException("next must be called before remove.");
+
+			K[] keyTable = set.keyTable;
+			final int mask = set.mask;
+			int loc = currentIndex;
+			K key;
+			while ((key = keyTable[loc + 1 & mask]) != null && (loc + 1 & mask) != set.place(key)) {
+				keyTable[loc] = key;
+				++loc;
 			}
+			if(loc != currentIndex) --nextIndex;
+			keyTable[loc] = null;
 			currentIndex = -1;
 			set.size--;
 		}
 
 		public boolean hasNext () {
-			if (!valid) throw new GdxRuntimeException("#iterator() cannot be used nested.");
+			if (!valid)
+				throw new GdxRuntimeException("#iterator() cannot be used nested.");
 			return hasNext;
 		}
 
 		public K next () {
-			if (!hasNext) throw new NoSuchElementException();
-			if (!valid) throw new GdxRuntimeException("#iterator() cannot be used nested.");
+			if (!hasNext)
+				throw new NoSuchElementException();
+			if (!valid)
+				throw new GdxRuntimeException("#iterator() cannot be used nested.");
 			K key = set.keyTable[nextIndex];
 			currentIndex = nextIndex;
 			findNextIndex();
@@ -573,16 +540,20 @@ public class ObjectSet<T> implements Iterable<T> {
 			return this;
 		}
 
-		/** Adds the remaining values to the array. */
+		/**
+		 * Adds the remaining values to the array.
+		 */
 		public Array<K> toArray (Array<K> array) {
 			while (hasNext)
 				array.add(next());
 			return array;
 		}
 
-		/** Returns a new array containing the remaining values. */
+		/**
+		 * Returns a new array containing the remaining values.
+		 */
 		public Array<K> toArray () {
-			return toArray(new Array(true, set.size));
+			return toArray(new Array<K>(true, set.size));
 		}
 	}
 }

--- a/gdx/src/com/badlogic/gdx/utils/ObjectSet.java
+++ b/gdx/src/com/badlogic/gdx/utils/ObjectSet.java
@@ -261,9 +261,12 @@ public class ObjectSet<T> implements Iterable<T> {
 		if (loc == -1) {
 			return false;
 		}
-		while ((key = keyTable[loc + 1 & mask]) != null && (loc + 1 & mask) != place(key)) {
+
+		int nl = (loc + 1 & mask);
+		while ((key = keyTable[nl]) != null && nl != place(key)) {
 			keyTable[loc] = key;
-			++loc;
+			loc = nl;
+			nl = loc + 1 & mask;
 		}
 		keyTable[loc] = null;
 		--size;
@@ -494,11 +497,12 @@ public class ObjectSet<T> implements Iterable<T> {
 
 			K[] keyTable = set.keyTable;
 			final int mask = set.mask;
-			int loc = currentIndex;
+			int loc = currentIndex, nl = (loc + 1 & mask);
 			K key;
-			while ((key = keyTable[loc + 1 & mask]) != null && (loc + 1 & mask) != set.place(key)) {
+			while ((key = keyTable[nl]) != null && nl != set.place(key)) {
 				keyTable[loc] = key;
-				++loc;
+				loc = nl;
+				nl = loc + 1 & mask;
 			}
 			if(loc != currentIndex) --nextIndex;
 			keyTable[loc] = null;

--- a/gdx/src/com/badlogic/gdx/utils/ObjectSet.java
+++ b/gdx/src/com/badlogic/gdx/utils/ObjectSet.java
@@ -231,8 +231,6 @@ public class ObjectSet<T> implements Iterable<T> {
 			if ((t = keyTable[i]) != null)
 				add(t);
 		}
-//		for (T key : set)
-//			add(key);
 	}
 
 	/**

--- a/gdx/src/com/badlogic/gdx/utils/OrderedMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/OrderedMap.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,12 +18,36 @@ package com.badlogic.gdx.utils;
 
 import java.util.NoSuchElementException;
 
-/** An {@link ObjectMap} that also stores keys in an {@link Array} using the insertion order. Iteration over the
- * {@link #entries()}, {@link #keys()}, and {@link #values()} is ordered and faster than an unordered map. Keys can also be
- * accessed and the order changed using {@link #orderedKeys()}. There is some additional overhead for put and remove. When used
- * for faster iteration versus ObjectMap and the order does not actually matter, copying during remove can be greatly reduced by
- * setting {@link Array#ordered} to false for {@link OrderedMap#orderedKeys()}.
- * @author Nathan Sweet */
+/**
+ * A {@link ObjectMap} that also stores keys in an {@link Array} using the insertion order. Iteration over the
+ * {@link #entries()}, {@link #keys()}, and {@link #values()} is ordered and faster than an unordered map. Keys can also
+ * be accessed and the order changed using {@link #orderedKeys()}. There is some additional overhead for put and remove.
+ * When used for faster iteration versus ObjectMap and the order does not actually matter, copying during remove
+ * can be greatly reduced by setting {@link Array#ordered} to false for {@link OrderedMap#orderedKeys()}.
+ * <br>
+ * This map uses Fibonacci hashing to help distribute what may be very bad hashCode() results across the whole capacity.
+ * See <a href="https://probablydance.com/2018/06/16/fibonacci-hashing-the-optimization-that-the-world-forgot-or-a-better-alternative-to-integer-modulo/">Malte Skarupke's blog post</a>
+ * for more information on Fibonacci hashing. It uses linear probing to resolve collisions, which is far from the academically
+ * optimal algorithm, but performs considerably better in practice than most alternatives, and combined with Fibonacci hashing, it
+ * can handle "normal" generated hashCode() implementations, and not just theoretically optimal hashing functions. Even if all
+ * hashCode()s this is given collide, it will still work, just slowly; the older libGDX implementation using cuckoo hashing would
+ * crash with an OutOfMemoryError with under 50 collisions.
+ * <br>
+ * This map performs very fast contains and remove (typically O(1), worst case O(n) due to moving items in an Array, but still
+ * very fast). Add may be a bit slower, depending on hash collisions, but this data structure is somewhat collision-resistant.
+ * Load factors greater than 0.91 greatly increase the chances the map will have to rehash to the next higher POT size.
+ * Memory usage is excellent, and the aforementioned collision-resistance helps avoid too much capacity resizing.
+ * <br>
+ * The <a href="http://codecapsule.com/2013/11/17/robin-hood-hashing-backward-shift-deletion/">backward-shift algorithm</a>
+ * used during removal apparently is key to the good performance of this implementation, even though this doesn't use Robin Hood
+ * hashing; the performance of {@link #remove(Object)} has improved considerably over the previous libGDX version.
+ * <br>
+ * Iteration should be fast with OrderedSet and OrderedMap, whereas ObjectSet and ObjectMap aren't designed to provide especially
+ * quick iteration.
+ *
+ * @author Tommy Ettinger
+ * @author Nathan Sweet
+ */
 public class OrderedMap<K, V> extends ObjectMap<K, V> {
 	final Array<K> keys;
 
@@ -33,12 +57,12 @@ public class OrderedMap<K, V> extends ObjectMap<K, V> {
 
 	public OrderedMap (int initialCapacity) {
 		super(initialCapacity);
-		keys = new Array(capacity);
+		keys = new Array(initialCapacity);
 	}
 
 	public OrderedMap (int initialCapacity, float loadFactor) {
 		super(initialCapacity, loadFactor);
-		keys = new Array(capacity);
+		keys = new Array(initialCapacity);
 	}
 
 	public OrderedMap (OrderedMap<? extends K, ? extends V> map) {
@@ -47,8 +71,40 @@ public class OrderedMap<K, V> extends ObjectMap<K, V> {
 	}
 
 	public V put (K key, V value) {
-		if (!containsKey(key)) keys.add(key);
-		return super.put(key, value);
+		if (key == null)
+			throw new IllegalArgumentException("key cannot be null.");
+		V[] valueTable = this.valueTable;
+		int b = place(key);
+		int loc = locateKey(key, b);
+		// an identical key already exists
+		if (loc != -1) {
+			V tv = valueTable[loc];
+			valueTable[loc] = value;
+			return tv;
+		}
+		keys.add(key);
+		K[] keyTable = this.keyTable;
+		for (int i = b; ; i = (i + 1) & mask) {
+			// space is available so we insert and break (resize is later)
+			if (keyTable[i] == null) {
+				keyTable[i] = key;
+				valueTable[i] = value;
+				break;
+			}
+		}
+		if (++size >= threshold) {
+			resize(keyTable.length << 1);
+		}
+		return null;
+	}
+
+	public void putAll (OrderedMap<K, V> map) {
+		ensureCapacity(map.size);
+		final K[] keys = map.keys.items;
+		K k;
+		for (int i = 0, n = map.keys.size; i < n; i++) {
+			put((k = keys[i]), map.get(k));
+		}
 	}
 
 	public V remove (K key) {
@@ -58,6 +114,46 @@ public class OrderedMap<K, V> extends ObjectMap<K, V> {
 
 	public V removeIndex (int index) {
 		return super.remove(keys.removeIndex(index));
+	}
+
+	/**
+	 * Changes the key {@code before} to {@code after} without changing its position in the order or its value.
+	 * Returns true if {@code after} has been added to the OrderedMap and {@code before} has been removed;
+	 * returns false if {@code after} is already present or {@code before} is not present. If you are iterating
+	 * over an OrderedMap and have an index, you should prefer {@link #alterIndex(int, Object)}, which doesn't
+	 * need to search for an index like this does and so can be faster.
+	 * @param before a key that must be present for this to succeed
+	 * @param after a key that must not be in this map for this to succeed
+	 * @return true if {@code before} was removed and {@code after} was added, false otherwise
+	 */
+	public boolean alter(K before, K after)
+	{
+		if(containsKey(after))
+			return false;
+		final int index = keys.indexOf(before, false);
+		if(index == -1)
+			return false;
+		super.put(after, super.remove(before));
+		keys.set(index, after);
+		return true;
+	}
+
+	/**
+	 * Changes the key at the given {@code index} in the order to {@code after}, without changing the ordering of other entries or
+	 * any values If {@code after} is already present, this returns false; it will also return false if {@code index} is invalid
+	 * for the size of this map. Otherwise, it returns true. Unlike {@link #alter(Object, Object)}, this operates in constant
+	 * time.
+	 * @param index the index in the order of the key to change; must be non-negative and less than {@link #size}
+	 * @param after the key that will replace the contents at {@code index}; this key must not be present for this to succeed
+	 * @return true if {@code after} successfully replaced the key at {@code index}, false otherwise
+	 */
+	public boolean alterIndex(int index, K after)
+	{
+		if(index < 0 || index >= size || containsKey(after))
+			return false;
+		super.put(after, super.remove(keys.get(index)));
+		keys.set(index, after);
+		return true;
 	}
 
 	public void clear (int maximumCapacity) {
@@ -78,12 +174,15 @@ public class OrderedMap<K, V> extends ObjectMap<K, V> {
 		return entries();
 	}
 
-	/** Returns an iterator for the entries in the map. Remove is supported.
+	/**
+	 * Returns an iterator for the entries in the map. Remove is supported.
 	 * <p>
 	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called.
-	 * Use the {@link OrderedMapEntries} constructor for nested or multithreaded iteration. */
+	 * Use the {@link OrderedMapEntries} constructor for nested or multithreaded iteration.
+	 */
 	public Entries<K, V> entries () {
-		if (Collections.allocateIterators) return new OrderedMapEntries(this);
+		if (Collections.allocateIterators)
+			return new OrderedMapEntries(this);
 		if (entries1 == null) {
 			entries1 = new OrderedMapEntries(this);
 			entries2 = new OrderedMapEntries(this);
@@ -100,12 +199,15 @@ public class OrderedMap<K, V> extends ObjectMap<K, V> {
 		return entries2;
 	}
 
-	/** Returns an iterator for the values in the map. Remove is supported.
+	/**
+	 * Returns an iterator for the values in the map. Remove is supported.
 	 * <p>
 	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called.
-	 * Use the {@link OrderedMapValues} constructor for nested or multithreaded iteration. */
+	 * Use the {@link OrderedMapValues} constructor for nested or multithreaded iteration.
+	 */
 	public Values<V> values () {
-		if (Collections.allocateIterators) return new OrderedMapValues(this);
+		if (Collections.allocateIterators)
+			return new OrderedMapValues(this);
 		if (values1 == null) {
 			values1 = new OrderedMapValues(this);
 			values2 = new OrderedMapValues(this);
@@ -122,12 +224,15 @@ public class OrderedMap<K, V> extends ObjectMap<K, V> {
 		return values2;
 	}
 
-	/** Returns an iterator for the keys in the map. Remove is supported.
+	/**
+	 * Returns an iterator for the keys in the map. Remove is supported.
 	 * <p>
 	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called.
-	 * Use the {@link OrderedMapKeys} constructor for nested or multithreaded iteration. */
+	 * Use the {@link OrderedMapKeys} constructor for nested or multithreaded iteration.
+	 */
 	public Keys<K> keys () {
-		if (Collections.allocateIterators) return new OrderedMapKeys(this);
+		if (Collections.allocateIterators)
+			return new OrderedMapKeys(this);
 		if (keys1 == null) {
 			keys1 = new OrderedMapKeys(this);
 			keys2 = new OrderedMapKeys(this);
@@ -145,13 +250,15 @@ public class OrderedMap<K, V> extends ObjectMap<K, V> {
 	}
 
 	public String toString () {
-		if (size == 0) return "{}";
-		StringBuilder buffer = new StringBuilder(32);
+		if (size == 0)
+			return "{}";
+		java.lang.StringBuilder buffer = new java.lang.StringBuilder(32);
 		buffer.append('{');
 		Array<K> keys = this.keys;
 		for (int i = 0, n = keys.size; i < n; i++) {
 			K key = keys.get(i);
-			if (i > 0) buffer.append(", ");
+			if (i > 0)
+				buffer.append(", ");
 			buffer.append(key);
 			buffer.append('=');
 			buffer.append(get(key));
@@ -169,13 +276,17 @@ public class OrderedMap<K, V> extends ObjectMap<K, V> {
 		}
 
 		public void reset () {
+			currentIndex = -1;
 			nextIndex = 0;
 			hasNext = map.size > 0;
 		}
 
 		public Entry next () {
-			if (!hasNext) throw new NoSuchElementException();
-			if (!valid) throw new GdxRuntimeException("#iterator() cannot be used nested.");
+			if (!hasNext)
+				throw new NoSuchElementException();
+			if (!valid)
+				throw new GdxRuntimeException("#iterator() cannot be used nested.");
+			currentIndex = nextIndex;
 			entry.key = keys.get(nextIndex);
 			entry.value = map.get(entry.key);
 			nextIndex++;
@@ -184,9 +295,11 @@ public class OrderedMap<K, V> extends ObjectMap<K, V> {
 		}
 
 		public void remove () {
-			if (currentIndex < 0) throw new IllegalStateException("next must be called before remove.");
+			if (currentIndex < 0)
+				throw new IllegalStateException("next must be called before remove.");
 			map.remove(entry.key);
 			nextIndex--;
+			currentIndex = -1;
 		}
 	}
 
@@ -199,13 +312,16 @@ public class OrderedMap<K, V> extends ObjectMap<K, V> {
 		}
 
 		public void reset () {
+			currentIndex = -1;
 			nextIndex = 0;
 			hasNext = map.size > 0;
 		}
 
 		public K next () {
-			if (!hasNext) throw new NoSuchElementException();
-			if (!valid) throw new GdxRuntimeException("#iterator() cannot be used nested.");
+			if (!hasNext)
+				throw new NoSuchElementException();
+			if (!valid)
+				throw new GdxRuntimeException("#iterator() cannot be used nested.");
 			K key = keys.get(nextIndex);
 			currentIndex = nextIndex;
 			nextIndex++;
@@ -214,8 +330,9 @@ public class OrderedMap<K, V> extends ObjectMap<K, V> {
 		}
 
 		public void remove () {
-			if (currentIndex < 0) throw new IllegalStateException("next must be called before remove.");
-			((OrderedMap)map).removeIndex(nextIndex - 1);
+			if (currentIndex < 0)
+				throw new IllegalStateException("next must be called before remove.");
+			((OrderedMap)map).removeIndex(currentIndex);
 			nextIndex = currentIndex;
 			currentIndex = -1;
 		}
@@ -241,13 +358,16 @@ public class OrderedMap<K, V> extends ObjectMap<K, V> {
 		}
 
 		public void reset () {
+			currentIndex = -1;
 			nextIndex = 0;
 			hasNext = map.size > 0;
 		}
 
 		public V next () {
-			if (!hasNext) throw new NoSuchElementException();
-			if (!valid) throw new GdxRuntimeException("#iterator() cannot be used nested.");
+			if (!hasNext)
+				throw new NoSuchElementException();
+			if (!valid)
+				throw new GdxRuntimeException("#iterator() cannot be used nested.");
 			V value = map.get(keys.get(nextIndex));
 			currentIndex = nextIndex;
 			nextIndex++;
@@ -256,7 +376,8 @@ public class OrderedMap<K, V> extends ObjectMap<K, V> {
 		}
 
 		public void remove () {
-			if (currentIndex < 0) throw new IllegalStateException("next must be called before remove.");
+			if (currentIndex < 0)
+				throw new IllegalStateException("next must be called before remove.");
 			((OrderedMap)map).removeIndex(currentIndex);
 			nextIndex = currentIndex;
 			currentIndex = -1;

--- a/gdx/src/com/badlogic/gdx/utils/OrderedMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/OrderedMap.java
@@ -38,11 +38,7 @@ import java.util.NoSuchElementException;
  * Load factors greater than 0.91 greatly increase the chances the map will have to rehash to the next higher POT size.
  * Memory usage is excellent, and the aforementioned collision-resistance helps avoid too much capacity resizing.
  * <br>
- * The <a href="http://codecapsule.com/2013/11/17/robin-hood-hashing-backward-shift-deletion/">backward-shift algorithm</a>
- * used during removal apparently is key to the good performance of this implementation, even though this doesn't use Robin Hood
- * hashing; the performance of {@link #remove(Object)} has improved considerably over the previous libGDX version.
- * <br>
- * Iteration should be fast with OrderedSet and OrderedMap, whereas ObjectSet and ObjectMap aren't designed to provide especially
+* Iteration should be fast with OrderedSet and OrderedMap, whereas ObjectSet and ObjectMap aren't designed to provide especially
  * quick iteration.
  *
  * @author Tommy Ettinger
@@ -122,16 +118,16 @@ public class OrderedMap<K, V> extends ObjectMap<K, V> {
 	 * returns false if {@code after} is already present or {@code before} is not present. If you are iterating
 	 * over an OrderedMap and have an index, you should prefer {@link #alterIndex(int, Object)}, which doesn't
 	 * need to search for an index like this does and so can be faster.
+	 *
 	 * @param before a key that must be present for this to succeed
-	 * @param after a key that must not be in this map for this to succeed
+	 * @param after  a key that must not be in this map for this to succeed
 	 * @return true if {@code before} was removed and {@code after} was added, false otherwise
 	 */
-	public boolean alter(K before, K after)
-	{
-		if(containsKey(after))
+	public boolean alter (K before, K after) {
+		if (containsKey(after))
 			return false;
 		final int index = keys.indexOf(before, false);
-		if(index == -1)
+		if (index == -1)
 			return false;
 		super.put(after, super.remove(before));
 		keys.set(index, after);
@@ -143,13 +139,13 @@ public class OrderedMap<K, V> extends ObjectMap<K, V> {
 	 * any values If {@code after} is already present, this returns false; it will also return false if {@code index} is invalid
 	 * for the size of this map. Otherwise, it returns true. Unlike {@link #alter(Object, Object)}, this operates in constant
 	 * time.
+	 *
 	 * @param index the index in the order of the key to change; must be non-negative and less than {@link #size}
 	 * @param after the key that will replace the contents at {@code index}; this key must not be present for this to succeed
 	 * @return true if {@code after} successfully replaced the key at {@code index}, false otherwise
 	 */
-	public boolean alterIndex(int index, K after)
-	{
-		if(index < 0 || index >= size || containsKey(after))
+	public boolean alterIndex (int index, K after) {
+		if (index < 0 || index >= size || containsKey(after))
 			return false;
 		super.put(after, super.remove(keys.get(index)));
 		keys.set(index, after);

--- a/gdx/src/com/badlogic/gdx/utils/OrderedSet.java
+++ b/gdx/src/com/badlogic/gdx/utils/OrderedSet.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,12 +18,37 @@ package com.badlogic.gdx.utils;
 
 import java.util.NoSuchElementException;
 
-/** An {@link ObjectSet} that also stores keys in an {@link Array} using the insertion order. {@link #iterator() Iteration} is
- * ordered and faster than an unordered set. Keys can also be accessed and the order changed using {@link #orderedItems()}. There
- * is some additional overhead for put and remove. When used for faster iteration versus ObjectSet and the order does not actually
- * matter, copying during remove can be greatly reduced by setting {@link Array#ordered} to false for
- * {@link OrderedSet#orderedItems()}.
- * @author Nathan Sweet */
+/**
+ * A {@link ObjectSet} that also stores keys in an {@link Array} using the insertion order.
+ * {@link #iterator() Iteration} is ordered and faster than an unordered set. Keys can also be accessed and the order
+ * changed using {@link #orderedItems()}. There is some slight overhead for put and remove. When used for faster
+ * iteration versus ObjectSet and the order does not actually matter, copying during remove can be greatly reduced by
+ * setting {@link Array#ordered} to false for {@link OrderedSet#orderedItems()}.
+ * <br>
+ * This set uses Fibonacci hashing to help distribute what may be very bad hashCode() results across the
+ * whole capacity. See <a href="https://probablydance.com/2018/06/16/fibonacci-hashing-the-optimization-that-the-world-forgot-or-a-better-alternative-to-integer-modulo/">Malte Skarupke's blog post</a>
+ * for more information on Fibonacci hashing. It uses linear probing to resolve collisions, which is far from the academically
+ * optimal algorithm, but performs considerably better in practice than most alternatives, and combined with Fibonacci hashing, it
+ * can handle "normal" generated hashCode() implementations, and not just theoretically optimal hashing functions. Even if all
+ * hashCode()s this is given collide, it will still work, just slowly; the older libGDX implementation using cuckoo hashing would
+ * crash with an OutOfMemoryError with under 50 collisions.
+ * <br>
+ * This set performs very fast contains and remove (typically O(1), worst case O(n) due to moving items in an Array, but still
+ * very fast). Add may be a bit slower, depending on hash collisions, but this data structure is somewhat collision-resistant.
+ * Load factors greater than 0.91 greatly increase the chances the set will have to rehash to the next higher POT size.
+ * Memory usage is excellent, and the aforementioned collision-resistance helps avoid too much capacity resizing.
+ * <br>
+ * The <a href="http://codecapsule.com/2013/11/17/robin-hood-hashing-backward-shift-deletion/">backward-shift algorithm</a>
+ * used during removal apparently is key to the good performance of this implementation, even though this doesn't use Robin Hood
+ * hashing; the performance of {@link #remove(Object)} has improved considerably over the previous libGDX version.
+ * <br>
+ * Iteration should be fast with OrderedSet and OrderedMap, whereas ObjectSet and ObjectMap aren't designed to provide especially
+ * quick iteration.
+ *
+ * @author Tommy Ettinger
+ * @author Nathan Sweet
+ */
+
 public class OrderedSet<T> extends ObjectSet<T> {
 	final Array<T> items;
 	OrderedSetIterator iterator1, iterator2;
@@ -34,40 +59,52 @@ public class OrderedSet<T> extends ObjectSet<T> {
 
 	public OrderedSet (int initialCapacity, float loadFactor) {
 		super(initialCapacity, loadFactor);
-		items = new Array(capacity);
+		items = new Array(initialCapacity);
 	}
 
 	public OrderedSet (int initialCapacity) {
 		super(initialCapacity);
-		items = new Array(capacity);
+		items = new Array(initialCapacity);
 	}
 
 	public OrderedSet (OrderedSet<? extends T> set) {
 		super(set);
-		items = new Array(capacity);
-		items.addAll(set.items);
+		items = new Array(set.items);
 	}
 
 	public boolean add (T key) {
-		if (!super.add(key)) return false;
+		if (!super.add(key))
+			return false;
 		items.add(key);
 		return true;
 	}
 
-	/** Sets the key at the specfied index. Returns true if the key was not already in the set. If this set already contains the
-	 * key, the existing key's index is changed if needed and false is returned. */
+	/**
+	 * Sets the key at the specfied index. Returns true if the key was not already in the set. If this set already contains the
+	 * key, the existing key's index is changed if needed and false is returned.
+	 */
 	public boolean add (T key, int index) {
 		if (!super.add(key)) {
 			int oldIndex = items.indexOf(key, true);
-			if (oldIndex != index) items.insert(index, items.removeIndex(oldIndex));
+			if (oldIndex != index)
+				items.insert(index, items.removeIndex(oldIndex));
 			return false;
 		}
 		items.insert(index, key);
 		return true;
 	}
 
+	public void addAll (OrderedSet<T> set) {
+		ensureCapacity(set.size);
+		final T[] keys = set.items.items;
+		for (int i = 0, n = set.items.size; i < n; i++) {
+			add(keys[i]);
+		}
+	}
+
 	public boolean remove (T key) {
-		if (!super.remove(key)) return false;
+		if (!super.remove(key))
+			return false;
 		items.removeValue(key, false);
 		return true;
 	}
@@ -76,6 +113,45 @@ public class OrderedSet<T> extends ObjectSet<T> {
 		T key = items.removeIndex(index);
 		super.remove(key);
 		return key;
+	}
+
+	/**
+	 * Changes the item {@code before} to {@code after} without changing its position in the order.
+	 * Returns true if {@code after} has been added to the OrderedSet and {@code before} has been removed;
+	 * returns false if {@code after} is already present or {@code before} is not present. If you are iterating
+	 * over an OrderedSet and have an index, you should prefer {@link #alterIndex(int, Object)}, which doesn't
+	 * need to search for an index like this does and so can be faster.
+	 * @param before an item that must be present for this to succeed
+	 * @param after an item that must not be in this set for this to succeed
+	 * @return true if {@code before} was removed and {@code after} was added, false otherwise
+	 */
+	public boolean alter(T before, T after)
+	{
+		if(contains(after))
+			return false;
+		if(!super.remove(before))
+			return false;
+		super.add(after);
+		items.set(items.indexOf(before, false), after);
+		return true;
+	}
+
+	/**
+	 * Changes the item at the given {@code index} in the order to {@code after}, without changing the ordering of other items.
+	 * If {@code after} is already present, this returns false; it will also return false if {@code index} is invalid for the size
+	 * of this set. Otherwise, it returns true. Unlike {@link #alter(Object, Object)}, this operates in constant time.
+ 	 * @param index the index in the order of the item to change; must be non-negative and less than {@link #size}
+	 * @param after the item that will replace the contents at {@code index}; this item must not be present for this to succeed
+	 * @return true if {@code after} successfully replaced the contents at {@code index}, false otherwise
+	 */
+	public boolean alterIndex(int index, T after)
+	{
+		if(index < 0 || index >= size || contains(after))
+			return false;
+		super.remove(items.get(index));
+		super.add(after);
+		items.set(index, after);
+		return true;
 	}
 
 	public void clear (int maximumCapacity) {
@@ -93,7 +169,8 @@ public class OrderedSet<T> extends ObjectSet<T> {
 	}
 
 	public OrderedSetIterator<T> iterator () {
-		if (Collections.allocateIterators) return new OrderedSetIterator(this);
+		if (Collections.allocateIterators)
+			return new OrderedSetIterator(this);
 		if (iterator1 == null) {
 			iterator1 = new OrderedSetIterator(this);
 			iterator2 = new OrderedSetIterator(this);
@@ -111,9 +188,10 @@ public class OrderedSet<T> extends ObjectSet<T> {
 	}
 
 	public String toString () {
-		if (size == 0) return "{}";
+		if (size == 0)
+			return "{}";
 		T[] items = this.items.items;
-		StringBuilder buffer = new StringBuilder(32);
+		java.lang.StringBuilder buffer = new java.lang.StringBuilder(32);
 		buffer.append('{');
 		buffer.append(items[0]);
 		for (int i = 1; i < size; i++) {
@@ -142,8 +220,10 @@ public class OrderedSet<T> extends ObjectSet<T> {
 		}
 
 		public K next () {
-			if (!hasNext) throw new NoSuchElementException();
-			if (!valid) throw new GdxRuntimeException("#iterator() cannot be used nested.");
+			if (!hasNext)
+				throw new NoSuchElementException();
+			if (!valid)
+				throw new GdxRuntimeException("#iterator() cannot be used nested.");
 			K key = items.get(nextIndex);
 			nextIndex++;
 			hasNext = nextIndex < set.size;
@@ -151,7 +231,8 @@ public class OrderedSet<T> extends ObjectSet<T> {
 		}
 
 		public void remove () {
-			if (nextIndex < 0) throw new IllegalStateException("next must be called before remove.");
+			if (nextIndex < 0)
+				throw new IllegalStateException("next must be called before remove.");
 			nextIndex--;
 			((OrderedSet)set).removeIndex(nextIndex);
 		}
@@ -167,4 +248,11 @@ public class OrderedSet<T> extends ObjectSet<T> {
 			return toArray(new Array(true, set.size - nextIndex));
 		}
 	}
+
+	static public <T> OrderedSet<T> with (T... array) {
+		OrderedSet<T> set = new OrderedSet<T>();
+		set.addAll(array);
+		return set;
+	}
+
 }

--- a/gdx/src/com/badlogic/gdx/utils/OrderedSet.java
+++ b/gdx/src/com/badlogic/gdx/utils/OrderedSet.java
@@ -38,11 +38,7 @@ import java.util.NoSuchElementException;
  * Load factors greater than 0.91 greatly increase the chances the set will have to rehash to the next higher POT size.
  * Memory usage is excellent, and the aforementioned collision-resistance helps avoid too much capacity resizing.
  * <br>
- * The <a href="http://codecapsule.com/2013/11/17/robin-hood-hashing-backward-shift-deletion/">backward-shift algorithm</a>
- * used during removal apparently is key to the good performance of this implementation, even though this doesn't use Robin Hood
- * hashing; the performance of {@link #remove(Object)} has improved considerably over the previous libGDX version.
- * <br>
- * Iteration should be fast with OrderedSet and OrderedMap, whereas ObjectSet and ObjectMap aren't designed to provide especially
+* Iteration should be fast with OrderedSet and OrderedMap, whereas ObjectSet and ObjectMap aren't designed to provide especially
  * quick iteration.
  *
  * @author Tommy Ettinger
@@ -121,15 +117,15 @@ public class OrderedSet<T> extends ObjectSet<T> {
 	 * returns false if {@code after} is already present or {@code before} is not present. If you are iterating
 	 * over an OrderedSet and have an index, you should prefer {@link #alterIndex(int, Object)}, which doesn't
 	 * need to search for an index like this does and so can be faster.
+	 *
 	 * @param before an item that must be present for this to succeed
-	 * @param after an item that must not be in this set for this to succeed
+	 * @param after  an item that must not be in this set for this to succeed
 	 * @return true if {@code before} was removed and {@code after} was added, false otherwise
 	 */
-	public boolean alter(T before, T after)
-	{
-		if(contains(after))
+	public boolean alter (T before, T after) {
+		if (contains(after))
 			return false;
-		if(!super.remove(before))
+		if (!super.remove(before))
 			return false;
 		super.add(after);
 		items.set(items.indexOf(before, false), after);
@@ -140,13 +136,13 @@ public class OrderedSet<T> extends ObjectSet<T> {
 	 * Changes the item at the given {@code index} in the order to {@code after}, without changing the ordering of other items.
 	 * If {@code after} is already present, this returns false; it will also return false if {@code index} is invalid for the size
 	 * of this set. Otherwise, it returns true. Unlike {@link #alter(Object, Object)}, this operates in constant time.
- 	 * @param index the index in the order of the item to change; must be non-negative and less than {@link #size}
+	 *
+	 * @param index the index in the order of the item to change; must be non-negative and less than {@link #size}
 	 * @param after the item that will replace the contents at {@code index}; this item must not be present for this to succeed
 	 * @return true if {@code after} successfully replaced the contents at {@code index}, false otherwise
 	 */
-	public boolean alterIndex(int index, T after)
-	{
-		if(index < 0 || index >= size || contains(after))
+	public boolean alterIndex (int index, T after) {
+		if (index < 0 || index >= size || contains(after))
 			return false;
 		super.remove(items.get(index));
 		super.add(after);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/CollectionsTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/CollectionsTest.java
@@ -16,10 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import java.util.Iterator;
-import java.util.Random;
-
-import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.tests.utils.GdxTest;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.ArrayMap;
@@ -48,6 +44,8 @@ import com.badlogic.gdx.utils.reflect.ClassReflection;
 import com.badlogic.gdx.utils.reflect.Constructor;
 import com.badlogic.gdx.utils.reflect.Method;
 
+import java.util.Iterator;
+
 /** Tests for the collection classes. Currently, only equals() and hashCode() methods are tested. */
 public class CollectionsTest extends GdxTest {
 	// Objects to use for test keys/values; no duplicates may exist. All arrays are 10 elements.
@@ -59,6 +57,15 @@ public class CollectionsTest extends GdxTest {
 	private Byte[] byteValues = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
 	private Short[] shortValues = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
 	private Character[] charValues = {'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J'};
+	
+	// 49 String keys that all have the same two hashCode() results
+	// It is extremely easy to generate String keys that have colliding hashCode()s, so we check to make
+	// sure ObjectSet and OrderedSet can tolerate them in case of low-complexity malicious use.
+	// If they can tolerate these problem values, then ObjectMap and others should too.
+	private String[] problemValues = 
+		("21oo 0oq1 0opP 0ooo 0pPo 21pP 21q1 1Poo 1Pq1 1PpP 0q31 0pR1 0q2P 0q1o 232P 231o 2331 0pQP 22QP" 
+			+ " 22Po 22R1 1QQP 1R1o 1QR1 1R2P 1R31 1QPo 1Qup 1S7p 0r8Q 0r7p 0r92 23X2 2492 248Q 247p 22vQ" 
+			+ " 22up 1S92 1S8Q 23WQ 23Vp 22w2 1QvQ 1Qw2 1RVp 1RWQ 1RX2 0qX2").split(" ");
 
 	/** Checks that the two values are equal, and that their hashcodes are equal. */
 	private void assertEquals (Object a, Object b) {
@@ -228,6 +235,9 @@ public class CollectionsTest extends GdxTest {
 		testSet(IntSet.class, intValues);
 		testSet(ObjectSet.class, values);
 		testSet(OrderedSet.class, values);
+
+		testSet(ObjectSet.class, problemValues);
+		testSet(OrderedSet.class, problemValues);
 
 		System.out.println("Success!");
 	}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/CollectionsTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/CollectionsTest.java
@@ -171,6 +171,95 @@ public class CollectionsTest extends GdxTest {
 		}
 	}
 
+	private void testEmptyMaps () {
+		{
+			System.out.println(IntIntMap.class);
+			Object map = new IntIntMap(0);
+			Integer[] keys = intValues, values = intValues;
+			Object otherMap = new IntIntMap(0);
+			assertEquals(map, map);
+			for (int i = 0, n = keys.length; i < n; ++i) {
+				Object anotherMap = copy(map);
+				assertEquals(map, anotherMap);
+				assertEquals(((IntIntMap)map).get(keys[n - 1], 0), 0);
+				((IntIntMap)map).put(keys[i], values[i]);
+				((IntIntMap)otherMap).put(keys[i], values[i]);
+				assertEquals(map, otherMap);
+				assertNotEquals(map, anotherMap);
+				((IntIntMap)anotherMap).put(keys[(i + 1) % n], values[i]);
+				assertNotEquals(map, anotherMap);
+			}
+
+			// perform an iteration test
+			Object anotherMap = copy(map);
+			Iterator it = ((Iterable)anotherMap).iterator();
+			int iterationCount = 0;
+			while (it.hasNext()) {
+				it.next();
+				iterationCount++;
+			}
+			assertEquals(iterationCount, keys.length);
+
+			// perform an iteration and remove test for every index
+			for (int i = 0, n = keys.length; i < n; ++i) {
+				anotherMap = copy(map);
+				it = ((Iterable)anotherMap).iterator();
+				iterationCount = 0;
+				while (it.hasNext()) {
+					it.next();
+					if (iterationCount == i) {
+						it.remove();
+					}
+					iterationCount++;
+				}
+				assertEquals(iterationCount, keys.length);
+			}
+		}
+		{
+			System.out.println(IntMap.class);
+			Object map = new IntMap(0);
+			Integer[] keys = intValues, values = intValues;
+			Object otherMap = new IntMap(0);
+			assertEquals(map, map);
+			for (int i = 0, n = keys.length; i < n; ++i) {
+				Object anotherMap = copy(map);
+				assertEquals(map, anotherMap);
+				if(((IntMap)map).get(keys[n - 1]) != null) throw new GdxRuntimeException("get() on an impossible key returned non-null");
+				((IntMap)map).put(keys[i], values[i]);
+				((IntMap)otherMap).put(keys[i], values[i]);
+				assertEquals(map, otherMap);
+				assertNotEquals(map, anotherMap);
+				((IntMap)anotherMap).put(keys[(i + 1) % n], values[i]);
+				assertNotEquals(map, anotherMap);
+			}
+
+			// perform an iteration test
+			Object anotherMap = copy(map);
+			Iterator it = ((Iterable)anotherMap).iterator();
+			int iterationCount = 0;
+			while (it.hasNext()) {
+				it.next();
+				iterationCount++;
+			}
+			assertEquals(iterationCount, keys.length);
+
+			// perform an iteration and remove test for every index
+			for (int i = 0, n = keys.length; i < n; ++i) {
+				anotherMap = copy(map);
+				it = ((Iterable)anotherMap).iterator();
+				iterationCount = 0;
+				while (it.hasNext()) {
+					it.next();
+					if (iterationCount == i) {
+						it.remove();
+					}
+					iterationCount++;
+				}
+				assertEquals(iterationCount, keys.length);
+			}
+		}
+	}
+
 	private void testArray (Class<?> arrayClass, Object[] values) {
 		System.out.println(arrayClass);
 		Object array = newInstance(arrayClass);
@@ -221,7 +310,9 @@ public class CollectionsTest extends GdxTest {
 		testMap(ObjectIntMap.class, values, intValues);
 		testMap(ObjectMap.class, values, valuesWithNulls);
 		testMap(OrderedMap.class, values, valuesWithNulls);
-
+		
+		testEmptyMaps();
+		
 		testArray(Array.class, valuesWithNulls);
 		testArray(BooleanArray.class, new Boolean[] {true, false});
 		testArray(ByteArray.class, byteValues);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/JsonTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/JsonTest.java
@@ -1,17 +1,19 @@
 
 package com.badlogic.gdx.tests;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
-
 import com.badlogic.gdx.tests.utils.GdxTest;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.ArrayMap;
 import com.badlogic.gdx.utils.Json;
 import com.badlogic.gdx.utils.JsonWriter.OutputType;
+import com.badlogic.gdx.utils.LongMap;
+import com.badlogic.gdx.utils.ObjectFloatMap;
 import com.badlogic.gdx.utils.ObjectMap;
 import com.badlogic.gdx.utils.reflect.ArrayReflection;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 
 public class JsonTest extends GdxTest {
 	Json json;
@@ -53,6 +55,12 @@ public class JsonTest extends GdxTest {
 		test.objectArray = new Array();
 		test.objectArray.add("meow");
 		test.objectArray.add(new Test1());
+		test.longMap = new LongMap<String>(4);
+		test.longMap.put(42L, "The Answer");
+		test.longMap.put(0x9E3779B97F4A7C15L, "Golden Ratio");
+		test.stringFloatMap = new ObjectFloatMap<String>(4);
+		test.stringFloatMap.put("point one", 0.1f);
+		test.stringFloatMap.put("point double oh seven", 0.007f);
 		test.someEnum = SomeEnum.b;
 		roundTrip(test);
 
@@ -204,6 +212,8 @@ public class JsonTest extends GdxTest {
 		public ObjectMap<String, Integer> map;
 		public Array<String> stringArray;
 		public Array objectArray;
+		public LongMap<String> longMap;
+		public ObjectFloatMap<String> stringFloatMap;
 		public SomeEnum someEnum;
 
 		public boolean equals (Object obj) {


### PR DESCRIPTION
# The Problem:


Almost 5 years ago in #2903 , a seemingly-obscure condition was found that causes ObjectSet, ObjectMap, and related data structures to throw an OutOfMemoryError long before heap should run out. That issue doesn't really convey how serious the bug is; OutOfMemoryErrors are thrown not just by tens of thousands of random keys, but by thousands of typical GridPoint2 keys, hundreds of regular Vector2 keys, or less than 50 maliciously-chosen Strings (!). To make matters worse, memory usage balloons before an OutOfMemoryError would be thrown, and the low-memory-usage goal of libGDX collections becomes missed entirely even if there is no crash. The high memory usage is caused by the capacity doubling in size whenever the stash increases in size by 2 items. While partial fixes are possible by allowing the stash to increase to much larger sizes without changing capacity, this slows the data structure down to a crawl as the stash gets large.

To verify, try to insert the following group of 49 String keys into an ObjectSet:
```java
mySet.addAll("21oo 0oq1 0opP 0ooo 0pPo 21pP 21q1 1Poo 1Pq1 1PpP 0q31 0pR1 0q2P 0q1o 232P 231o 2331 0pQP 22QP 22Po 22R1 1QQP 1R1o 1QR1 1R2P 1R31 1QPo 1Qup 1S7p 0r8Q 0r7p 0r92 23X2 2492 248Q 247p 22vQ 22up 1S92 1S8Q 23WQ 23Vp 22w2 1QvQ 1Qw2 1RVp 1RWQ 1RX2 0qX2".split(" "));
```

These Strings have two possible hashCode() results across 49 non-equal keys, which exhausts more than 8GB of heap because of this bug. Malicious users could use these 49 keys (or many others) as usernames or other potential keys in online games and cause havoc.

# The Fix

I have reimplemented all hash-table-based maps and sets in libGDX to use linear probing and Fibonacci hashing, while keeping their current API (adding some protected fields and methods to make it easier for users to extend some classes). Linear probing is mentioned almost everywhere new hash table algorithms are. [The Wikipedia page on cuckoo hashing](https://en.wikipedia.org/wiki/Cuckoo_hashing#Practice) mentions that linear probing tends to be faster, while cuckoo hashing can offer better worst-case algorithmic complexity (libGDX's current approach does not have this worst-case guarantee, because its stash can resize). Fibonacci hashing helps a lot with practical hashCode()s, which could be biased toward changing only upper or lower bits of their result, by using a relatively simple step to disperse most kinds of hashCode() evenly across the current capacity.

I have also made sure that Json acts the same with these collections as the earlier ones, while also widening support to all hash-based data structures (including ObjectFloatMap, LongMap, etc.). I have not changed UBJson or XML readers or writers. since I don't use either and don't really know what UBJson is. The code in Json for ObjectSet and ObjectMap reading/writing didn't change.

I have run extensive tests on speed, memory usage, and stability against problem hashCodes()s. These data structures, which are called `MERRY` in the test data, routinely are at the best or within a few bytes of the best memory usage of all libraries tested, have the best total memory consumption across the tested sizes, and don't use more memory when hashCode()s are frequently nearing collisions. The speed of these collections tends to be close to libGDX (usually a few percent slower), except that the versions in this PR are twice as fast as the libGDX maps and sets at removal (the current libGDX sets have unusually slow removal when compared across libraries). [Speed graphs for unordered sets on Java 13](https://tommyettinger.github.io/assorted-benchmarks/). [Speed graphs for ordered sets on Java 13](https://tommyettinger.github.io/assorted-benchmarks/ordered/).  [Speed graphs for unordered sets on Java 8](https://tommyettinger.github.io/assorted-benchmarks/java8/). [Speed graphs for ordered sets on Java 8](https://tommyettinger.github.io/assorted-benchmarks/ordered8/). [Memory results on well-distributed Float hashCode()s](https://github.com/tommyettinger/assorted-benchmarks/blob/cfc096c139745e673e181e76808785233cb8cd81/jmh/memory_results_raw.txt#L190-L513), as an analogue to realistic hashCode()s. [Memory results on problematic but non-colliding Integer keys](https://github.com/tommyettinger/assorted-benchmarks/blob/cfc096c139745e673e181e76808785233cb8cd81/jmh/memory_results_raw.txt#L515-L922). [Code that shows ObjectSet crashing with various key types](https://github.com/tommyettinger/assorted-benchmarks/tree/master/src/test/java/com/badlogic/gdx/utils). [JMH benchmarks for libGDX, the PR collections, and many more](https://github.com/tommyettinger/assorted-benchmarks/tree/master/jmh), if you want to spend hours running the speed benchmarks yourself. [Code for the memory benchmark](https://github.com/tommyettinger/assorted-benchmarks/blob/master/jmh/src/test/java/de/heidelberg/pvs/container_bench/MemoryMBeanCheck.java).

## NOTE

This is a complex PR, but it should be API-compatible and not affect the functionality of other code in libGDX. I think that the security bug here is actually quite significant, and if it won't be addressed by updating the maps and sets to some other implementation, it can only be resolved by replacing their usage in front-facing code with JDK Collections.
