### PR TITLE
Implemented 2nd loop for better HeadlessApplication-Support ...

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphics.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphics.java
@@ -475,7 +475,8 @@ public class AndroidGraphics implements Graphics, Renderer {
 			}
 			app.getInput().processEvents();
 			frameId++;
-			app.getApplicationListener().render();
+			app.getApplicationListener().update(Gdx.graphics.getDeltaTime());
+			app.getApplicationListener().render(Gdx.graphics.getDeltaTime());
 		}
 
 		if (lpause) {

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphicsLiveWallpaper.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphicsLiveWallpaper.java
@@ -214,7 +214,8 @@ public final class AndroidGraphicsLiveWallpaper extends AndroidGraphics {
 
 			app.getInput().processEvents();
 			frameId++;
-			app.getApplicationListener().render();
+			app.getApplicationListener().update(Gdx.graphics.getDeltaTime());
+			app.getApplicationListener().render(Gdx.graphics.getDeltaTime());
 		}
 
 		// jw: never called on lvp, why? see description in AndroidLiveWallpaper.onPause

--- a/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/HeadlessApplication.java
+++ b/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/HeadlessApplication.java
@@ -128,7 +128,9 @@ public class HeadlessApplication implements Application {
 				graphics.updateTime();
 				graphics.incrementFrameId();
 				listener.update(graphics.getDeltaTime());
-				//listener.render(graphics.getDeltaTime());
+
+				//Leaving update for better support updating an old application to this version (only adding the float value is required)
+				listener.render(graphics.getDeltaTime());
 	
 				// If one of the runnables set running to false, for example after an exit().
 				if (!running) break;

--- a/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/HeadlessApplication.java
+++ b/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/HeadlessApplication.java
@@ -125,9 +125,10 @@ public class HeadlessApplication implements Application {
 					t = n + renderInterval;
 				
 				executeRunnables();
-				graphics.incrementFrameId();
-				listener.render();
 				graphics.updateTime();
+				graphics.incrementFrameId();
+				listener.update(graphics.getDeltaTime());
+				//listener.render(graphics.getDeltaTime());
 	
 				// If one of the runnables set running to false, for example after an exit().
 				if (!running) break;

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglAWTCanvas.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglAWTCanvas.java
@@ -276,7 +276,8 @@ public class LwjglAWTCanvas implements Application {
 		if (shouldRender) {
 			graphics.updateTime();
 			graphics.frameId++;
-			listener.render();
+			listener.update(Gdx.graphics.getDeltaTime());
+			listener.render(Gdx.graphics.getDeltaTime());
 			canvas.swapBuffers();
 		}
 

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglApplication.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglApplication.java
@@ -230,7 +230,8 @@ public class LwjglApplication implements Application {
 			if (shouldRender) {
 				graphics.updateTime();
 				graphics.frameId++;
-				listener.render();
+				listener.update(Gdx.graphics.getDeltaTime());
+				listener.render(Gdx.graphics.getDeltaTime());
 				Display.update(false);
 			} else {
 				// Sleeps to avoid wasting CPU in an empty loop.

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglCanvas.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglCanvas.java
@@ -262,7 +262,8 @@ public class LwjglCanvas implements Application {
 					if (shouldRender) {
 						graphics.updateTime();
 						graphics.frameId++;
-						listener.render();
+						listener.update(Gdx.graphics.getDeltaTime());
+						listener.render(Gdx.graphics.getDeltaTime());
 						Display.update(false);
 					}
 

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Graphics.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Graphics.java
@@ -19,6 +19,7 @@ package com.badlogic.gdx.backends.lwjgl3;
 import java.nio.IntBuffer;
 
 import com.badlogic.gdx.Application;
+import com.badlogic.gdx.Gdx;
 import org.lwjgl.BufferUtils;
 import org.lwjgl.PointerBuffer;
 import org.lwjgl.glfw.GLFW;
@@ -69,7 +70,8 @@ public class Lwjgl3Graphics implements Graphics, Disposable {
 			window.makeCurrent();
 			gl20.glViewport(0, 0, width, height);
 			window.getListener().resize(getWidth(), getHeight());
-			window.getListener().render();
+			window.getListener().update(Gdx.graphics.getDeltaTime());
+			window.getListener().render(Gdx.graphics.getDeltaTime());
 			GLFW.glfwSwapBuffers(windowHandle);
 		}
 	};

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Window.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Window.java
@@ -396,7 +396,8 @@ public class Lwjgl3Window implements Disposable {
 		
 		if (shouldRender) {
 			graphics.update();
-			listener.render();
+			listener.update(Gdx.graphics.getDeltaTime());
+			listener.render(Gdx.graphics.getDeltaTime());
 			GLFW.glfwSwapBuffers(windowHandle);
 		}
 

--- a/backends/gdx-backend-moe/src/com/badlogic/gdx/backends/iosmoe/IOSGraphics.java
+++ b/backends/gdx-backend-moe/src/com/badlogic/gdx/backends/iosmoe/IOSGraphics.java
@@ -259,7 +259,8 @@ public class IOSGraphics extends NSObject implements Graphics, GLKViewDelegate, 
 
 		input.processEvents();
 		frameId++;
-		app.listener.render();
+		app.listener.update(Gdx.graphics.getDeltaTime());
+		app.listener.render(Gdx.graphics.getDeltaTime());
 	}
 
 	void makeCurrent () {

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
@@ -358,7 +358,8 @@ public class IOSGraphics extends NSObject implements Graphics, GLKViewDelegate, 
 
 		input.processEvents();
 		frameId++;
-		app.listener.render();
+		app.listener.update(Gdx.graphics.getDeltaTime());
+		app.listener.render(Gdx.graphics.getDeltaTime());
 	}
 
 	void makeCurrent () {

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplication.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplication.java
@@ -258,7 +258,8 @@ public abstract class GwtApplication implements EntryPoint, Application {
 		}
 		runnablesHelper.clear();
 		graphics.frameId++;
-		listener.render();
+		listener.update(Gdx.graphics.getDeltaTime());
+		listener.render(Gdx.graphics.getDeltaTime());
 		input.reset();
 	}
 	

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tiledmappacker/TiledMapPacker.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tiledmappacker/TiledMapPacker.java
@@ -496,7 +496,11 @@ public class TiledMapPacker {
 			}
 
 			@Override
-			public void render () {
+			public void update(float delta) {
+			}
+
+			@Override
+			public void render(float delta) {
 			}
 
 			@Override

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tiledmappacker/TiledMapPackerTestRender.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tiledmappacker/TiledMapPackerTestRender.java
@@ -73,7 +73,7 @@ public class TiledMapPackerTestRender extends ApplicationAdapter {
 	}
 
 	@Override
-	public void render () {
+	public void render (float delta) {
 		Gdx.gl.glClearColor(0, 0, 0, 1f);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/FlameMain.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/FlameMain.java
@@ -750,18 +750,16 @@ public class FlameMain extends JFrame implements AssetErrorListener {
 			ui.getViewport().update(width, height, true);
 		}
 
-		public void render () {
-			float delta = Math.max(0, Gdx.graphics.getDeltaTime() * deltaMultiplier.getValue());
-			update(delta);
-			renderWorld();
+		@Override
+		public void update(final float delta) {
 		}
 
-		private void update (float delta) {
+		public void render (final float delta) {
 			worldCamera.fieldOfView = fovValue.getValue();
 			worldCamera.update();
-			cameraInputController.update();
+			cameraInputController.update(delta);
 			if(isUpdate){
-				particleSystem.update(delta);
+				particleSystem.update(Math.max(0, Gdx.graphics.getDeltaTime() * deltaMultiplier.getValue()));
 				//Update ui
 				stringBuilder.delete(0, stringBuilder.length);
 				stringBuilder.append("Point Sprites : ").append(pointSpriteBatch.getBufferedCount());
@@ -776,10 +774,11 @@ public class FlameMain extends JFrame implements AssetErrorListener {
 			stringBuilder.delete(0, stringBuilder.length);
 			stringBuilder.append("FPS : ").append(Gdx.graphics.getFramesPerSecond());
 			fpsLabel.setText(stringBuilder);
-			ui.act(Gdx.graphics.getDeltaTime());
+			ui.act(delta);
+			renderWorld(delta);
 		}
 
-		private void renderWorld () {
+		private void renderWorld (final float delta) {
 			float[] colors = backgroundColor.getColors();
 			Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
 			Gdx.gl.glClearColor(colors[0], colors[1], colors[2], 0);
@@ -794,7 +793,7 @@ public class FlameMain extends JFrame implements AssetErrorListener {
 			//Draw
 			modelBatch.render(particleSystem, environment);
 			modelBatch.end();
-			ui.draw();
+			ui.draw(delta);
 		}
 
 		@Override

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/ParticleEditor.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/ParticleEditor.java
@@ -418,11 +418,17 @@ public class ParticleEditor extends JFrame {
 			shapeRenderer.end();
 		}
 
-		public void render () {
+		@Override
+		public void update(final float delta) {
+
+		}
+
+		@Override
+		public void render(final float delta) {
 			int viewWidth = Gdx.graphics.getWidth();
 			int viewHeight = Gdx.graphics.getHeight();
 
-			float delta = Math.max(0, Gdx.graphics.getDeltaTime() * deltaMultiplier.getValue());
+			float renderDelta = Math.max(0, delta * deltaMultiplier.getValue());
 
 			float[] colors = backgroundColor.getColors();
 			Gdx.gl.glClearColor(colors[0], colors[1], colors[2], 1.0f);
@@ -469,7 +475,7 @@ public class ParticleEditor extends JFrame {
 				if (emitter.getSprites().size == 0 && emitter.getImagePaths().size > 0) loadImages(emitter);
 				boolean enabled = isEnabled(emitter);
 				if (enabled) {
-					if (emitter.getSprites().size > 0) emitter.draw(spriteBatch, delta);
+					if (emitter.getSprites().size > 0) emitter.draw(spriteBatch, renderDelta);
 					activeCount += emitter.getActiveCount();
 					if (!emitter.isComplete()) complete = false;
 				}
@@ -478,7 +484,7 @@ public class ParticleEditor extends JFrame {
 			if (complete) effect.start();
 
 			maxActive = Math.max(maxActive, activeCount);
-			maxActiveTimer += delta;
+			maxActiveTimer += renderDelta;
 			if (maxActiveTimer > 3) {
 				maxActiveTimer = 0;
 				lastMaxActive = maxActive;

--- a/gdx/src/com/badlogic/gdx/ApplicationAdapter.java
+++ b/gdx/src/com/badlogic/gdx/ApplicationAdapter.java
@@ -28,7 +28,12 @@ public abstract class ApplicationAdapter implements ApplicationListener {
 	}
 
 	@Override
-	public void render () {
+	public void update (float delta) {
+	}
+
+	@Override
+	public void render (float delta) {
+
 	}
 
 	@Override

--- a/gdx/src/com/badlogic/gdx/ApplicationListener.java
+++ b/gdx/src/com/badlogic/gdx/ApplicationListener.java
@@ -39,8 +39,13 @@ public interface ApplicationListener {
 	 * @param height the new height in pixels */
 	public void resize (int width, int height);
 
-	/** Called when the {@link Application} should render itself. */
-	public void render ();
+	/** Called when the {@link Application} should update itself.
+	 * @param delta The time in seconds since the last render. */
+	public void update (final float delta);
+
+	/** Called when the {@link Application} should render itself.
+	 * @param delta The time in seconds since the last render. */
+	public void render (final float delta);
 
 	/** Called when the {@link Application} is paused, usually when it's not active or visible on-screen. An Application is also
 	 * paused before it is destroyed. */

--- a/gdx/src/com/badlogic/gdx/Game.java
+++ b/gdx/src/com/badlogic/gdx/Game.java
@@ -42,8 +42,13 @@ public abstract class Game implements ApplicationListener {
 	}
 
 	@Override
-	public void render () {
-		if (screen != null) screen.render(Gdx.graphics.getDeltaTime());
+	public void update (float delta) {
+		if (screen != null) screen.update(delta);
+	}
+
+	@Override
+	public void render (float delta) {
+		if (screen != null) screen.render(delta);
 	}
 
 	@Override

--- a/gdx/src/com/badlogic/gdx/Screen.java
+++ b/gdx/src/com/badlogic/gdx/Screen.java
@@ -27,6 +27,10 @@ public interface Screen {
 	
 	/** Called when this screen becomes the current screen for a {@link Game}. */
 	public void show ();
+
+	/** Called when the screen should update itself.
+	 * @param delta The time in seconds since the last render. */
+	public void update (float delta);
 	
 	/** Called when the screen should render itself.
 	 * @param delta The time in seconds since the last render. */

--- a/gdx/src/com/badlogic/gdx/ScreenAdapter.java
+++ b/gdx/src/com/badlogic/gdx/ScreenAdapter.java
@@ -19,9 +19,6 @@ package com.badlogic.gdx;
 /** Convenience implementation of {@link Screen}. Derive from this and only override what you need.
  * @author semtiko */
 public class ScreenAdapter implements Screen {
-	@Override
-	public void render (float delta) {
-	}
 
 	@Override
 	public void resize (int width, int height) {
@@ -29,6 +26,14 @@ public class ScreenAdapter implements Screen {
 
 	@Override
 	public void show () {
+	}
+
+	@Override
+	public void update(float delta) {
+	}
+
+	@Override
+	public void render (float delta) {
 	}
 
 	@Override

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/utils/AnimationController.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/utils/AnimationController.java
@@ -165,7 +165,7 @@ public class AnimationController extends BaseAnimationController {
 
 	/** Update any animations currently being played.
 	 * @param delta The time elapsed since last update, change this to alter the overall speed (can be negative). */
-	public void update (float delta) {
+	public void update (final float delta) {
 		if (paused) return;
 		if (previous != null && ((transitionCurrentTime += delta) >= transitionTargetTime)) {
 			removeAnimation(previous.animation);

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/utils/CameraInputController.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/utils/CameraInputController.java
@@ -132,9 +132,8 @@ public class CameraInputController extends GestureDetector {
 		this(new CameraGestureListener(), camera);
 	}
 
-	public void update () {
+	public void update (float delta) {
 		if (rotateRightPressed || rotateLeftPressed || forwardPressed || backwardPressed) {
-			final float delta = Gdx.graphics.getDeltaTime();
 			if (rotateRightPressed) camera.rotate(camera.up, -delta * rotateAngle);
 			if (rotateLeftPressed) camera.rotate(camera.up, delta * rotateAngle);
 			if (forwardPressed) {

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/utils/FirstPersonCameraController.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/utils/FirstPersonCameraController.java
@@ -77,10 +77,6 @@ public class FirstPersonCameraController extends InputAdapter {
 		return true;
 	}
 
-	public void update () {
-		update(Gdx.graphics.getDeltaTime());
-	}
-
 	public void update (float deltaTime) {
 		if (keys.containsKey(FORWARD)) {
 			tmp.set(camera.direction).nor().scl(deltaTime * velocity);

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/Stage.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/Stage.java
@@ -116,7 +116,7 @@ public class Stage extends InputAdapter implements Disposable {
 		viewport.update(Gdx.graphics.getWidth(), Gdx.graphics.getHeight(), true);
 	}
 
-	public void draw () {
+	public void draw (final float delta) {
 		Camera camera = viewport.getCamera();
 		camera.update();
 
@@ -181,15 +181,10 @@ public class Stage extends InputAdapter implements Disposable {
 		}
 	}
 
-	/** Calls {@link #act(float)} with {@link Graphics#getDeltaTime()}, limited to a minimum of 30fps. */
-	public void act () {
-		act(Math.min(Gdx.graphics.getDeltaTime(), 1 / 30f));
-	}
-
 	/** Calls the {@link Actor#act(float)} method on each actor in the stage. Typically called each frame. This method also fires
 	 * enter and exit events.
 	 * @param delta Time in seconds since the last frame. */
-	public void act (float delta) {
+	public void act (final float delta) {
 		// Update over actors. Done in act() because actors may change position, which can fire enter/exit without an input event.
 		for (int pointer = 0, n = pointerOverActors.length; pointer < n; pointer++) {
 			Actor overLast = pointerOverActors[pointer];

--- a/tests/gdx-tests-android/src/com/badlogic/gdx/tests/android/APKExpansionTest.java
+++ b/tests/gdx-tests-android/src/com/badlogic/gdx/tests/android/APKExpansionTest.java
@@ -85,7 +85,7 @@ public class APKExpansionTest extends GdxTest {
     }
 
     @Override
-    public void render () {
+    public void render (final float delta) {
         Gdx.gl.glClearColor(1, 0, 0, 1);
         Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
         batch.begin();

--- a/tests/gdx-tests-android/src/com/badlogic/gdx/tests/android/MatrixTest.java
+++ b/tests/gdx-tests-android/src/com/badlogic/gdx/tests/android/MatrixTest.java
@@ -72,7 +72,7 @@ public class MatrixTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClear(GL10.GL_COLOR_BUFFER_BIT);
 		batch.begin();
 		font.draw(batch, results, 20, 300);

--- a/tests/gdx-tests-android/src/com/badlogic/gdx/tests/android/WindowedTest.java
+++ b/tests/gdx-tests-android/src/com/badlogic/gdx/tests/android/WindowedTest.java
@@ -88,7 +88,12 @@ public class WindowedTest extends AndroidApplication implements ApplicationListe
 	}
 
 	@Override
-	public void render () {
+	public void update(final float delta) {
+
+	}
+
+	@Override
+	public void render (final float delta) {
 		Gdx.gl.glClearColor(color.r, color.g, color.g, color.a);
 		Gdx.gl.glClear(GL10.GL_COLOR_BUFFER_BIT);
 

--- a/tests/gdx-tests-lwjgl/src/com/badlogic/gdx/tests/lwjgl/SwingLwjglTest.java
+++ b/tests/gdx-tests-lwjgl/src/com/badlogic/gdx/tests/lwjgl/SwingLwjglTest.java
@@ -77,7 +77,7 @@ public class SwingLwjglTest extends JFrame {
 		}
 
 		@Override
-		public void render () {
+		public void render (final float delta) {
 			Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 			batch.begin();
 			font.draw(batch, "Click to create a new window", 10, 100);

--- a/tests/gdx-tests-lwjgl3/src/com/badlogic/gdx/tests/lwjgl3/DragNDropTest.java
+++ b/tests/gdx-tests-lwjgl3/src/com/badlogic/gdx/tests/lwjgl3/DragNDropTest.java
@@ -52,14 +52,17 @@ public class DragNDropTest extends GdxTest {
       root.align(Align.left | Align.top);
       stage.addActor(root);
 	}
-		
+
 	@Override
-	public void render () {
+	public void update(final float delta) {
+		stage.act(delta);
+	}
+
+	@Override
+	public void render (final float delta) {
 		Gdx.gl.glClearColor(1, 0, 0, 1);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-		
-		stage.act();
-		stage.draw();
+		stage.draw(delta);
 	}
 
 	@Override

--- a/tests/gdx-tests-lwjgl3/src/com/badlogic/gdx/tests/lwjgl3/Lwjgl3DebugStarter.java
+++ b/tests/gdx-tests-lwjgl3/src/com/badlogic/gdx/tests/lwjgl3/Lwjgl3DebugStarter.java
@@ -140,7 +140,7 @@ public class Lwjgl3DebugStarter {
 			long start = System.nanoTime();
 
 			@Override
-			public void render () {
+			public void render (final float delta) {
 				Gdx.gl.glClearColor(1, 0, 0, 1);
 				Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 				HdpiUtils.glViewport(0, 0, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());

--- a/tests/gdx-tests-lwjgl3/src/com/badlogic/gdx/tests/lwjgl3/Lwjgl3TestStarter.java
+++ b/tests/gdx-tests-lwjgl3/src/com/badlogic/gdx/tests/lwjgl3/Lwjgl3TestStarter.java
@@ -112,16 +112,20 @@ public class Lwjgl3TestStarter {
 				// Since ScrollPane takes some time for scrolling to a position, we just "fake" time
 				stage.act(1f);
 				stage.act(1f);
-				stage.draw();
+				stage.draw(1f);
 			}
 		}
 
 		@Override
-		public void render () {
+		public void update(final float delta) {
+			stage.act(delta);
+		}
+
+		@Override
+		public void render (final float delta) {
 			Gdx.gl.glClearColor(0, 0, 0, 1);
 			Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-			stage.act();
-			stage.draw();
+			stage.draw(delta);
 		}
 
 		@Override

--- a/tests/gdx-tests-lwjgl3/src/com/badlogic/gdx/tests/lwjgl3/MultiWindowCursorTest.java
+++ b/tests/gdx-tests-lwjgl3/src/com/badlogic/gdx/tests/lwjgl3/MultiWindowCursorTest.java
@@ -41,7 +41,7 @@ public class MultiWindowCursorTest {
 		}
 
 		@Override
-		public void update(float delta) {
+		public void update(final float delta) {
 			listener.update(delta);
 		}
 

--- a/tests/gdx-tests-lwjgl3/src/com/badlogic/gdx/tests/lwjgl3/MultiWindowCursorTest.java
+++ b/tests/gdx-tests-lwjgl3/src/com/badlogic/gdx/tests/lwjgl3/MultiWindowCursorTest.java
@@ -41,8 +41,13 @@ public class MultiWindowCursorTest {
 		}
 
 		@Override
-		public void render() {
-			listener.render();
+		public void update(float delta) {
+			listener.update(delta);
+		}
+
+		@Override
+		public void render(final float delta) {
+			listener.render(delta);
 		}
 
 		@Override

--- a/tests/gdx-tests-lwjgl3/src/com/badlogic/gdx/tests/lwjgl3/MultiWindowTest.java
+++ b/tests/gdx-tests-lwjgl3/src/com/badlogic/gdx/tests/lwjgl3/MultiWindowTest.java
@@ -39,7 +39,7 @@ public class MultiWindowTest {
 		}
 
 		@Override		
-		public void render () {
+		public void render (final float delta) {
 			Gdx.gl.glClearColor(1, 0, 0, 1);
 			Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 			sharedSpriteBatch.getProjectionMatrix().setToOrtho2D(0, 0, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/AccelerometerTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/AccelerometerTest.java
@@ -33,7 +33,7 @@ public class AccelerometerTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		batch.begin();
 		font.draw(batch, "accel: [" + Gdx.input.getAccelerometerX() + "," + Gdx.input.getAccelerometerY() + ","

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ActionSequenceTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ActionSequenceTest.java
@@ -68,11 +68,14 @@ public class ActionSequenceTest extends GdxTest implements Runnable {
 	}
 
 	@Override
-	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+	public void update(float delta) {
+		stage.act(delta);
+	}
 
-		stage.act(Math.min(Gdx.graphics.getDeltaTime(), 1 / 30f));
-		stage.draw();
+	@Override
+	public void render (final float delta) {
+		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		stage.draw(delta);
 	}
 
 	@Override

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ActionSequenceTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ActionSequenceTest.java
@@ -68,7 +68,7 @@ public class ActionSequenceTest extends GdxTest implements Runnable {
 	}
 
 	@Override
-	public void update(float delta) {
+	public void update(final float delta) {
 		stage.act(delta);
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ActionTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ActionTest.java
@@ -55,7 +55,7 @@ public class ActionTest extends GdxTest {
 	}
 
 	@Override
-	public void update(float delta) {
+	public void update(final float delta) {
 		stage.act(delta);
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ActionTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ActionTest.java
@@ -55,10 +55,14 @@ public class ActionTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void update(float delta) {
+		stage.act(delta);
+	}
+
+	@Override
+	public void render (final float delta) {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-		stage.act(Math.min(Gdx.graphics.getDeltaTime(), 1 / 30f));
-		stage.draw();
+		stage.draw(delta);
 	}
 
 	@Override

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/AlphaTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/AlphaTest.java
@@ -43,7 +43,7 @@ public class AlphaTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		batch.begin();
 		batch.draw(texture, 0, 0, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/AnimationTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/AnimationTest.java
@@ -83,7 +83,7 @@ public class AnimationTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClearColor(0.1f, 0f, 0.25f, 1f);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		batch.begin();
@@ -96,7 +96,7 @@ public class AnimationTest extends GdxTest {
 		batch.end();
 
 		for (int i = 0; i < cavemen.length; i++) {
-			cavemen[i].update(Gdx.graphics.getDeltaTime());
+			cavemen[i].update(delta);
 		}
 
 		fpsLog.log();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/AnimationTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/AnimationTest.java
@@ -41,7 +41,7 @@ public class AnimationTest extends GdxTest {
 			this.stateTime = (float)Math.random();
 		}
 
-		public void update (float deltaTime) {
+		public void update (final float deltaTime) {
 			stateTime += deltaTime;
 			pos.x = pos.x + (headsLeft ? -VELOCITY * deltaTime : VELOCITY * deltaTime);
 			if (pos.x < -64) pos.x = Gdx.graphics.getWidth();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/AnnotationTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/AnnotationTest.java
@@ -142,7 +142,7 @@ public class AnnotationTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		batch.begin();
 		font.draw(batch, message, 20, Gdx.graphics.getHeight() - 20);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/AudioRecorderTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/AudioRecorderTest.java
@@ -47,7 +47,7 @@ public class AudioRecorderTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (float delta) {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/AudioRecorderTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/AudioRecorderTest.java
@@ -47,7 +47,7 @@ public class AudioRecorderTest extends GdxTest {
 	}
 
 	@Override
-	public void render (float delta) {
+	public void render (final float delta) {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/BitmapFontAlignmentTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/BitmapFontAlignmentTest.java
@@ -62,7 +62,7 @@ public class BitmapFontAlignmentTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClearColor(0.7f, 0, 0, 1);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		spriteBatch.begin();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/BitmapFontAtlasRegionTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/BitmapFontAtlasRegionTest.java
@@ -51,7 +51,7 @@ public class BitmapFontAtlasRegionTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 
 		batch.begin();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/BitmapFontDistanceFieldTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/BitmapFontDistanceFieldTest.java
@@ -86,7 +86,7 @@ public class BitmapFontDistanceFieldTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClearColor(1, 1, 1, 1);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/BitmapFontFlipTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/BitmapFontFlipTest.java
@@ -96,8 +96,8 @@ public class BitmapFontFlipTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
-		red.a = (red.a + Gdx.graphics.getDeltaTime() * 0.1f) % 1;
+	public void render (final float delta) {
+		red.a = (red.a + delta * 0.1f) % 1;
 
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		spriteBatch.begin();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/BitmapFontMetricsTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/BitmapFontMetricsTest.java
@@ -45,7 +45,7 @@ public class BitmapFontMetricsTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		// red.a = (red.a + Gdx.graphics.getDeltaTime() * 0.1f) % 1;
 
 		int viewHeight = Gdx.graphics.getHeight();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/BitmapFontTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/BitmapFontTest.java
@@ -86,7 +86,12 @@ public class BitmapFontTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void update(final float delta) {
+		stage.act(delta);
+	}
+
+	@Override
+	public void render (final float delta) {
 		// red.a = (red.a + Gdx.graphics.getDeltaTime() * 0.1f) % 1;
 
 		int viewHeight = Gdx.graphics.getHeight();
@@ -224,9 +229,7 @@ public class BitmapFontTest extends GdxTest {
 			renderer.rect(x, viewHeight - y - 200, alignmentWidth, 200);
 			renderer.end();
 		}
-
-		stage.act(Gdx.graphics.getDeltaTime());
-		stage.draw();
+		stage.draw(delta);
 	}
 
 	public void resize (int width, int height) {

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/BitmapFontWriterTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/BitmapFontWriterTest.java
@@ -103,7 +103,7 @@ public class BitmapFontWriterTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClearColor(1f, 0.5f, 0.5f, 1f);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/Box2DCharacterControllerTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/Box2DCharacterControllerTest.java
@@ -182,7 +182,7 @@ public class Box2DCharacterControllerTest extends GdxTest implements Application
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		cam.position.set(player.getPosition().x, player.getPosition().y, 0);
 		cam.update();
@@ -190,7 +190,7 @@ public class Box2DCharacterControllerTest extends GdxTest implements Application
 
 		Vector2 vel = player.getLinearVelocity();
 		Vector2 pos = player.getPosition();
-		boolean grounded = isPlayerGrounded(Gdx.graphics.getDeltaTime());
+		boolean grounded = isPlayerGrounded(delta);
 		if (grounded) {
 			lastGroundTime = TimeUtils.nanoTime();
 		} else {
@@ -266,7 +266,7 @@ public class Box2DCharacterControllerTest extends GdxTest implements Application
 		// update platforms
 		for (int i = 0; i < platforms.size; i++) {
 			Platform platform = platforms.get(i);
-			platform.update(Math.max(1 / 30.0f, Gdx.graphics.getDeltaTime()));
+			platform.update(delta);
 		}
 
 		// le step...

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/Box2DCharacterControllerTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/Box2DCharacterControllerTest.java
@@ -284,7 +284,7 @@ public class Box2DCharacterControllerTest extends GdxTest implements Application
 		batch.end();
 	}
 
-	private boolean isPlayerGrounded (float deltaTime) {
+	private boolean isPlayerGrounded (final float deltaTime) {
 		groundedPlatform = null;
 		Array<Contact> contactList = world.getContactList();
 		for (int i = 0; i < contactList.size; i++) {
@@ -350,7 +350,7 @@ public class Box2DCharacterControllerTest extends GdxTest implements Application
 	}
 
 	abstract class Platform {
-		abstract void update (float deltatime);
+		abstract void update (final float deltatime);
 	}
 
 	class CirclePlatform extends Platform {
@@ -365,7 +365,7 @@ public class Box2DCharacterControllerTest extends GdxTest implements Application
 		}
 
 		@Override
-		void update (float deltatime) {
+		void update (final float deltatime) {
 		}
 	}
 
@@ -389,7 +389,8 @@ public class Box2DCharacterControllerTest extends GdxTest implements Application
 			platform.setUserData(this);
 		}
 
-		public void update (float deltaTime) {
+		@Override
+		public void update (final float deltaTime) {
 			dist += dir.len() * deltaTime;
 			if (dist > maxDist) {
 				dir.scl(-1);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/Box2DTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/Box2DTest.java
@@ -234,7 +234,7 @@ public class Box2DTest extends GdxTest implements InputProcessor {
 	}
 
 	@Override
-	public void update(float delta) {
+	public void update(final float delta) {
 		// first we update the world. For simplicity
 		// we use the delta time provided by the Graphics
 		// instance. Normally you'll want to fix the time

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/Box2DTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/Box2DTest.java
@@ -84,6 +84,9 @@ public class Box2DTest extends GdxTest implements InputProcessor {
 	/** a hit body **/
 	Body hitBody = null;
 
+	/** Time messurement updateTime **/
+	private float updateTime;
+
 	@Override
 	public void create () {
 		// setup the camera. In Box2D we operate on a
@@ -231,15 +234,19 @@ public class Box2DTest extends GdxTest implements InputProcessor {
 	}
 
 	@Override
-	public void render () {
+	public void update(float delta) {
 		// first we update the world. For simplicity
 		// we use the delta time provided by the Graphics
 		// instance. Normally you'll want to fix the time
 		// step.
 		long start = TimeUtils.nanoTime();
-		world.step(Gdx.graphics.getDeltaTime(), 8, 3);
-		float updateTime = (TimeUtils.nanoTime() - start) / 1000000000.0f;
+		world.step(delta, 8, 3);
+		updateTime = (TimeUtils.nanoTime() - start) / 1000000000.0f;
 
+	}
+
+	@Override
+	public void render (final float delta) {
 		// next we clear the color buffer and set the camera
 		// matrices
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/Box2DTestCollection.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/Box2DTestCollection.java
@@ -55,8 +55,8 @@ public class Box2DTestCollection extends GdxTest implements InputProcessor, Gest
 	private Application app = null;
 
 	@Override
-	public void render () {
-		tests[testIndex].render();
+	public void render (final float delta) {
+		tests[testIndex].render(delta);
 	}
 
 	@Override

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/Bresenham2Test.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/Bresenham2Test.java
@@ -52,7 +52,7 @@ public class Bresenham2Test extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		batch.begin();
 		batch.draw(result, 0, 0);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/BulletTestCollection.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/BulletTestCollection.java
@@ -55,12 +55,12 @@ public class BulletTestCollection extends GdxTest implements InputProcessor, Ges
 	private CameraInputController cameraController;
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		if ((loading > 0) && (++loading > 2)) loadnext();
 
-		tests[testIndex].render();
+		tests[testIndex].render(delta);
 		fpsLabel.setText(tests[testIndex].performance);
-		hud.draw();
+		hud.draw(delta);
 	}
 
 	@Override

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ClipboardTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ClipboardTest.java
@@ -70,8 +70,12 @@ public class ClipboardTest extends GdxTest {
 	}
 
 	@Override
-	public void render() {
-		stage.act();
-		stage.draw();
+	public void update(float delta) {
+		stage.act(delta);
+	}
+
+	@Override
+	public void render(final float delta) {
+		stage.draw(delta);
 	}
 }

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ClipboardTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ClipboardTest.java
@@ -70,7 +70,7 @@ public class ClipboardTest extends GdxTest {
 	}
 
 	@Override
-	public void update(float delta) {
+	public void update(final float delta) {
 		stage.act(delta);
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ColorTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ColorTest.java
@@ -89,12 +89,15 @@ public class ColorTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void update(float delta) {
+		stage.act(delta);
+	}
+
+	@Override
+	public void render (final float delta) {
 		Gdx.gl.glClearColor(0.2f, 0.2f, 0.2f, 1);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-
-		stage.act(Math.min(Gdx.graphics.getDeltaTime(), 1 / 30f));
-		stage.draw();
+		stage.draw(delta);
 	}
 
 	@Override

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ColorTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ColorTest.java
@@ -89,7 +89,7 @@ public class ColorTest extends GdxTest {
 	}
 
 	@Override
-	public void update(float delta) {
+	public void update(final float delta) {
 		stage.act(delta);
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ComplexActionTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ComplexActionTest.java
@@ -66,10 +66,14 @@ public class ComplexActionTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void update(float delta) {
+		stage.act(delta);
+	}
+
+	@Override
+	public void render (final float delta) {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-		stage.act(Math.min(Gdx.graphics.getDeltaTime(), 1 / 30f));
-		stage.draw();
+		stage.draw(delta);
 	}
 
 	@Override

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ComplexActionTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ComplexActionTest.java
@@ -66,7 +66,7 @@ public class ComplexActionTest extends GdxTest {
 	}
 
 	@Override
-	public void update(float delta) {
+	public void update(final float delta) {
 		stage.act(delta);
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ContainerTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ContainerTest.java
@@ -76,11 +76,15 @@ public class ContainerTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void update(float delta) {
+		stage.act(delta);
+	}
+
+	@Override
+	public void render (final float delta) {
 		Gdx.gl.glClearColor(0.2f, 0.2f, 0.2f, 1);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-		stage.act();
-		stage.draw();
+		stage.draw(delta);
 	}
 
 	@Override

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ContainerTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ContainerTest.java
@@ -76,7 +76,7 @@ public class ContainerTest extends GdxTest {
 	}
 
 	@Override
-	public void update(float delta) {
+	public void update(final float delta) {
 		stage.act(delta);
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/CpuSpriteBatchTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/CpuSpriteBatchTest.java
@@ -117,12 +117,17 @@ public class CpuSpriteBatchTest extends GdxTest {
 		return group;
 	}
 
-	public void render () {
+	@Override
+	public void update(float delta) {
+		stage.act(delta);
+	}
+
+	@Override
+	public void render (final float delta) {
 		Gdx.gl.glClearColor(0.5f, 0.5f, 0.5f, 1);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 
-		stage.act(Gdx.graphics.getDeltaTime());
-		stage.draw();
+		stage.draw(delta);
 
 		long now = TimeUtils.nanoTime();
 		sampleFrames++;

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/CpuSpriteBatchTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/CpuSpriteBatchTest.java
@@ -88,7 +88,7 @@ public class CpuSpriteBatchTest extends GdxTest {
 
 		Actor hat = new DrawableActor(bob) {
 			@Override
-			public void act (float delta) {
+			public void act (final float delta) {
 				rotateBy(delta * -300);
 			}
 		};
@@ -98,7 +98,7 @@ public class CpuSpriteBatchTest extends GdxTest {
 
 		Group group = new Group() {
 			@Override
-			public void act (float delta) {
+			public void act (final float delta) {
 				rotateBy(delta * 120);
 				setScale(0.9f + 0.2f * MathUtils.cos(MathUtils.degreesToRadians * getRotation()));
 				super.act(delta);
@@ -118,7 +118,7 @@ public class CpuSpriteBatchTest extends GdxTest {
 	}
 
 	@Override
-	public void update(float delta) {
+	public void update(final float delta) {
 		stage.act(delta);
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/CullTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/CullTest.java
@@ -73,7 +73,7 @@ public class CullTest extends GdxTest implements ApplicationListener {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		GL20 gl = Gdx.gl20;
 
 		gl.glClearColor(0, 0, 0, 0);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/CustomShaderSpriteBatchTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/CustomShaderSpriteBatchTest.java
@@ -39,7 +39,7 @@ public class CustomShaderSpriteBatchTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		batch.begin();
 		batch.draw(texture, 0, 0);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/DecalTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/DecalTest.java
@@ -81,20 +81,24 @@ public class DecalTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void update(float delta) {
+
+	}
+
+	@Override
+	public void render (final float delta) {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
 
-		float elapsed = Gdx.graphics.getDeltaTime();
 		float scale = timePassed > 0.5 ? 1 - timePassed / 2 : 0.5f + timePassed / 2;
 
 		for (Decal decal : toRender) {
-			decal.rotateZ(elapsed * 45);
+			decal.rotateZ(delta * 45);
 			decal.setScale(scale);
 			batch.add(decal);
 		}
 		batch.flush();
 
-		timePassed += elapsed;
+		timePassed += delta;
 		frames++;
 		if (timePassed > 1.0f) {
 			System.out.println("DecalPerformanceTest2 fps: " + frames + " at spritecount: " + toRender.size());

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/DecalTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/DecalTest.java
@@ -81,7 +81,7 @@ public class DecalTest extends GdxTest {
 	}
 
 	@Override
-	public void update(float delta) {
+	public void update(final float delta) {
 
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/DeltaTimeTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/DeltaTimeTest.java
@@ -30,11 +30,11 @@ public class DeltaTimeTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (float delta) {
 		long frameTime = TimeUtils.nanoTime();
 		float deltaTime = (frameTime - lastFrameTime) / 1000000000.0f;
 		lastFrameTime = frameTime;
 
-		Gdx.app.log("DeltaTimeTest", "delta: " + deltaTime + ", gdx delta: " + Gdx.graphics.getDeltaTime());
+		Gdx.app.log("DeltaTimeTest", "delta: " + deltaTime + ", gdx delta: " + Gdx.graphics.getDeltaTime() + ", gdx cycle delta:" + delta);
 	}
 }

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/DeltaTimeTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/DeltaTimeTest.java
@@ -30,7 +30,7 @@ public class DeltaTimeTest extends GdxTest {
 	}
 
 	@Override
-	public void render (float delta) {
+	public void render (final float delta) {
 		long frameTime = TimeUtils.nanoTime();
 		float deltaTime = (frameTime - lastFrameTime) / 1000000000.0f;
 		lastFrameTime = frameTime;

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/DeviceInfoTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/DeviceInfoTest.java
@@ -33,6 +33,6 @@ public class DeviceInfoTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 	}
 }

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/DirtyRenderingTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/DirtyRenderingTest.java
@@ -54,7 +54,7 @@ public class DirtyRenderingTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (float delta) {
 		Gdx.gl.glClearColor(MathUtils.random(), MathUtils.random(), MathUtils.random(), MathUtils.random());
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 	}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/DirtyRenderingTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/DirtyRenderingTest.java
@@ -54,7 +54,7 @@ public class DirtyRenderingTest extends GdxTest {
 	}
 
 	@Override
-	public void render (float delta) {
+	public void render (final float delta) {
 		Gdx.gl.glClearColor(MathUtils.random(), MathUtils.random(), MathUtils.random(), MathUtils.random());
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 	}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/DownloadTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/DownloadTest.java
@@ -51,7 +51,7 @@ public class DownloadTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		batch.begin();
 		if(texture != null) batch.draw(texture, 0, 0);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/DpiTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/DpiTest.java
@@ -17,7 +17,7 @@ public class DpiTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		batch.begin();
 		font.draw(batch, 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/DragAndDropTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/DragAndDropTest.java
@@ -105,10 +105,15 @@ public class DragAndDropTest extends GdxTest {
 		});
 	}
 
-	public void render () {
+	@Override
+	public void update(final float delta) {
+		stage.act(delta);
+	}
+
+	@Override
+	public void render (final float delta) {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-		stage.act(Gdx.graphics.getDeltaTime());
-		stage.draw();
+		stage.draw(delta);
 	}
 
 	public void resize (int width, int height) {

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ETC1Test.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ETC1Test.java
@@ -62,7 +62,7 @@ public class ETC1Test extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 
 		camera.update();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ExitTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ExitTest.java
@@ -22,7 +22,7 @@ import com.badlogic.gdx.tests.utils.GdxTest;
 public class ExitTest extends GdxTest {
 
 	@Override
-	public void render () {
+	public void render (float delta) {
 		if (Gdx.input.justTouched()) Gdx.app.exit();
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ExitTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ExitTest.java
@@ -22,7 +22,7 @@ import com.badlogic.gdx.tests.utils.GdxTest;
 public class ExitTest extends GdxTest {
 
 	@Override
-	public void render (float delta) {
+	public void render (final float delta) {
 		if (Gdx.input.justTouched()) Gdx.app.exit();
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/FilesTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/FilesTest.java
@@ -452,7 +452,7 @@ public class FilesTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		batch.begin();
 		font.draw(batch, message, 20, Gdx.graphics.getHeight() - 20);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/FrameBufferTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/FrameBufferTest.java
@@ -57,7 +57,7 @@ public class FrameBufferTest extends GdxTest {
 	SpriteBatch spriteBatch;
 
 	@Override
-	public void render () {
+	public void render (final float render) {
 		frameBuffer.begin();
 		Gdx.gl20.glViewport(0, 0, frameBuffer.getWidth(), frameBuffer.getHeight());
 		Gdx.gl20.glClearColor(0f, 1f, 0f, 1);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/FramebufferToTextureTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/FramebufferToTextureTest.java
@@ -65,7 +65,7 @@ public class FramebufferToTextureTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glViewport(0, 0, Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight());
 		Gdx.gl.glClearColor(clearColor.r, clearColor.g, clearColor.b, clearColor.a);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
@@ -73,7 +73,7 @@ public class FramebufferToTextureTest extends GdxTest {
 
 		cam.update();
 
-		modelInstance.transform.rotate(Vector3.Y, 45 * Gdx.graphics.getDeltaTime());
+		modelInstance.transform.rotate(Vector3.Y, 45 * delta);
 		modelBatch.begin(cam);
 		modelBatch.render(modelInstance);
 		modelBatch.end();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/FullscreenTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/FullscreenTest.java
@@ -49,7 +49,7 @@ public class FullscreenTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClearColor(0, 0, 0, 1);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/GLES30Test.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/GLES30Test.java
@@ -28,7 +28,7 @@ public class GLES30Test extends GdxTest {
     }
 
     @Override
-    public void render() {
+    public void render(final float delta) {
         Gdx.gl.glClearColor(0, 0, 0, 1f);
         Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/GLProfilerErrorTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/GLProfilerErrorTest.java
@@ -54,7 +54,7 @@ public class GLProfilerErrorTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClearColor(0.2f, 0.2f, 0.2f, 1);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/Gdx2DTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/Gdx2DTest.java
@@ -140,7 +140,7 @@ public class Gdx2DTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClearColor(0.2f, 0.2f, 0.2f, 1.0f);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		batch.begin();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/GestureDetectorTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/GestureDetectorTest.java
@@ -118,7 +118,7 @@ public class GestureDetectorTest extends GdxTest implements ApplicationListener 
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		controller.update();
 		camera.update();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/GroupCullingTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/GroupCullingTest.java
@@ -73,14 +73,14 @@ public class GroupCullingTest extends GdxTest {
 	}
 
 	@Override
-	public void update(float delta) {
+	public void update(final float delta) {
+		drawn = 0;
 		stage.act(delta);
 	}
 
 	@Override
 	public void render (final float delta) {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-		drawn = 0;
 		stage.draw(delta);
 		drawnLabel.setText("Drawn: " + drawn + "/" + count);
 		drawnLabel.invalidateHierarchy();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/GroupCullingTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/GroupCullingTest.java
@@ -72,11 +72,16 @@ public class GroupCullingTest extends GdxTest {
 		root.invalidate();
 	}
 
-	public void render () {
+	@Override
+	public void update(float delta) {
+		stage.act(delta);
+	}
+
+	@Override
+	public void render (final float delta) {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		drawn = 0;
-		stage.act(Gdx.graphics.getDeltaTime());
-		stage.draw();
+		stage.draw(delta);
 		drawnLabel.setText("Drawn: " + drawn + "/" + count);
 		drawnLabel.invalidateHierarchy();
 	}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/GroupFadeTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/GroupFadeTest.java
@@ -51,7 +51,7 @@ public class GroupFadeTest extends GdxTest {
 	}
 
 	@Override
-	public void update(float delta) {
+	public void update(final float delta) {
 		stage.act(delta);
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/GroupFadeTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/GroupFadeTest.java
@@ -51,10 +51,14 @@ public class GroupFadeTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void update(float delta) {
+		stage.act(delta);
+	}
+
+	@Override
+	public void render (final float delta) {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-		stage.act(Gdx.graphics.getDeltaTime());
-		stage.draw();
+		stage.draw(delta);
 	}
 
 	@Override

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/GroupTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/GroupTest.java
@@ -121,7 +121,8 @@ public class GroupTest extends GdxTest {
 		stage.addActor(vertWrap);
 	}
 
-	public void render () {
+	@Override
+	public void render (final float delta) {
 
 		horiz.setVisible(true);
 		horiz.setWidth(Gdx.input.getX() - horiz.getX());
@@ -158,7 +159,7 @@ public class GroupTest extends GdxTest {
 
 		Gdx.gl.glClearColor(0, 0, 0, 1);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-		stage.draw();
+		stage.draw(delta);
 
 		renderer.setProjectionMatrix(batch.getProjectionMatrix());
 		renderer.begin(ShapeType.Filled);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/HexagonalTiledMapTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/HexagonalTiledMapTest.java
@@ -77,7 +77,7 @@ public class HexagonalTiledMapTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClearColor(0.25f, 0.25f, 0.25f, 1f);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		camera.update();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/I18NMessageTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/I18NMessageTest.java
@@ -95,7 +95,7 @@ public class I18NMessageTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		batch.begin();
 		font.draw(batch, message, 20, Gdx.graphics.getHeight() - 20);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/I18NSimpleMessageTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/I18NSimpleMessageTest.java
@@ -97,7 +97,7 @@ public class I18NSimpleMessageTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		batch.begin();
 		font.draw(batch, message, 20, Gdx.graphics.getHeight() - 20);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ImageScaleTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ImageScaleTest.java
@@ -47,10 +47,10 @@ public class ImageScaleTest extends GdxTest {
 
 	}
 
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClearColor(0, 0, 0, 1);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-		stage.draw();
+		stage.draw(delta);
 	}
 
 	@Override

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ImageTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ImageTest.java
@@ -26,6 +26,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.Skin;
 import com.badlogic.gdx.scenes.scene2d.ui.Table;
 import com.badlogic.gdx.tests.utils.GdxTest;
 import com.badlogic.gdx.utils.Scaling;
+import com.sun.org.apache.xerces.internal.impl.xs.XSAttributeUseImpl;
 
 public class ImageTest extends GdxTest {
 	Skin skin;
@@ -58,11 +59,15 @@ public class ImageTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void update(float delta) {
+		ui.act(delta);
+	}
+
+	@Override
+	public void render (final float delta) {
 		Gdx.gl.glClearColor(0.2f, 0.2f, 0.2f, 1);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-		ui.act(Math.min(Gdx.graphics.getDeltaTime(), 1 / 30f));
-		ui.draw();
+		ui.draw(delta);
 	}
 
 	@Override

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ImageTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ImageTest.java
@@ -59,7 +59,7 @@ public class ImageTest extends GdxTest {
 	}
 
 	@Override
-	public void update(float delta) {
+	public void update(final float delta) {
 		ui.act(delta);
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ImmediateModeRendererTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ImmediateModeRendererTest.java
@@ -35,7 +35,7 @@ public class ImmediateModeRendererTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		Gdx.gl.glEnable(GL20.GL_TEXTURE_2D);
 		texture.bind();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/IndexBufferObjectShaderTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/IndexBufferObjectShaderTest.java
@@ -42,7 +42,7 @@ public class IndexBufferObjectShaderTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 // System.out.println( "render");
 
 		Gdx.gl.glViewport(0, 0, Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight());

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/InputTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/InputTest.java
@@ -32,7 +32,7 @@ public class InputTest extends GdxTest implements InputProcessor {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		if (Gdx.input.justTouched()) {
 			Gdx.app.log("Input Test", "just touched, button: " + (Gdx.input.isButtonPressed(Buttons.LEFT) ? "left " : "")
 				+ (Gdx.input.isButtonPressed(Buttons.MIDDLE) ? "middle " : "")

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/InterpolationTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/InterpolationTest.java
@@ -139,7 +139,7 @@ public class InterpolationTest extends GdxTest {
 	}
 
 	@Override
-	public void update(float delta) {
+	public void update(final float delta) {
 		stage.act(delta);
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/InterpolationTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/InterpolationTest.java
@@ -138,7 +138,13 @@ public class InterpolationTest extends GdxTest {
 		}));
 	}
 
-	public void render () {
+	@Override
+	public void update(float delta) {
+		stage.act(delta);
+	}
+
+	@Override
+	public void render (final float delta) {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 
 		float bottomLeftX = Gdx.graphics.getWidth() / 2 - graphSize / 2, bottomLeftY = Gdx.graphics.getHeight() / 2 - graphSize / 2;
@@ -163,7 +169,7 @@ public class InterpolationTest extends GdxTest {
 			lastX = x;
 			lastY = y;
 		}
-		time += Gdx.graphics.getDeltaTime();
+		time += delta;
 		if (time > duration) {
 			time = Float.NaN; // stop "walking"
 			startPosition.set(targetPosition); // set startPosition to targetPosition for next click
@@ -184,8 +190,7 @@ public class InterpolationTest extends GdxTest {
 		renderer.circle(position.x, position.y, 7);
 		renderer.end();
 
-		stage.act();
-		stage.draw();
+		stage.draw(delta);
 	}
 
 	public void resize (int width, int height) {

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/InverseKinematicsTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/InverseKinematicsTest.java
@@ -72,7 +72,7 @@ public class InverseKinematicsTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 
 		camera.update();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/IsometricTileTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/IsometricTileTest.java
@@ -88,7 +88,7 @@ public class IsometricTileTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClearColor(0.7f, 0.7f, 0.7f, 1);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		cam.update();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/KTXTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/KTXTest.java
@@ -155,9 +155,9 @@ public class KTXTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
-		time += Gdx.graphics.getDeltaTime();
-		inputController.update();
+	public void render (final float delta) {
+		time += delta;
+		inputController.update(delta);
 		int gw = Gdx.graphics.getWidth(), gh = Gdx.graphics.getHeight();
 		int pw = gw > gh ? gw / 2 : gw, ph = gw > gh ? gh : gh / 2;
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/LabelScaleTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/LabelScaleTest.java
@@ -64,12 +64,15 @@ public class LabelScaleTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void update(float delta) {
+		stage.act(delta);
+	}
+
+	@Override
+	public void render (final float delta) {
 		Gdx.gl.glClearColor(0.2f, 0.2f, 0.2f, 1);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-
-		stage.act(Math.min(Gdx.graphics.getDeltaTime(), 1 / 30f));
-		stage.draw();
+		stage.draw(delta);
 	}
 
 	@Override

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/LabelScaleTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/LabelScaleTest.java
@@ -64,7 +64,7 @@ public class LabelScaleTest extends GdxTest {
 	}
 
 	@Override
-	public void update(float delta) {
+	public void update(final float delta) {
 		stage.act(delta);
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/LabelTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/LabelTest.java
@@ -119,12 +119,15 @@ public class LabelTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void update(float delta) {
+		stage.act(delta);
+	}
+
+	@Override
+	public void render (final float delta) {
 		Gdx.gl.glClearColor(0.2f, 0.2f, 0.2f, 1);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-
-		stage.act(Math.min(Gdx.graphics.getDeltaTime(), 1 / 30f));
-		stage.draw();
+		stage.draw(delta);
 
 		float x = 40, y = 15 + 20 * scale;
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/LabelTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/LabelTest.java
@@ -119,7 +119,7 @@ public class LabelTest extends GdxTest {
 	}
 
 	@Override
-	public void update(float delta) {
+	public void update(final float delta) {
 		stage.act(delta);
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/LifeCycleTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/LifeCycleTest.java
@@ -17,6 +17,7 @@
 package com.badlogic.gdx.tests;
 
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.FPSLogger;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.tests.utils.GdxTest;
 
@@ -24,6 +25,8 @@ import com.badlogic.gdx.tests.utils.GdxTest;
  * 
  * @author mzechner */
 public class LifeCycleTest extends GdxTest {
+
+	private FPSLogger fpsLogger;
 
 	@Override
 	public void dispose () {
@@ -41,12 +44,18 @@ public class LifeCycleTest extends GdxTest {
 	}
 
 	@Override
+	public void update(float delta) {
+		fpsLogger.log();
+	}
+
+	@Override
 	public void render (final float delta) {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 	}
 
 	@Override
 	public void create () {
+		fpsLogger = new FPSLogger();
 		Gdx.app.log("Test", "app created: " + Gdx.graphics.getWidth() + "x" + Gdx.graphics.getHeight());
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/LifeCycleTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/LifeCycleTest.java
@@ -44,7 +44,7 @@ public class LifeCycleTest extends GdxTest {
 	}
 
 	@Override
-	public void update(float delta) {
+	public void update(final float delta) {
 		fpsLogger.log();
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/LifeCycleTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/LifeCycleTest.java
@@ -41,7 +41,7 @@ public class LifeCycleTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/MeshShaderTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/MeshShaderTest.java
@@ -81,8 +81,8 @@ public class MeshShaderTest extends GdxTest {
 	float angle = 0;
 
 	@Override
-	public void render () {
-		angle += Gdx.graphics.getDeltaTime() * 45;
+	public void render (final float delta) {
+		angle += delta * 45;
 		matrix.setToRotation(axis, angle);
 		
 		Mesh meshToDraw = Gdx.input.isButtonPressed(0) ? meshCustomVA : mesh;

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/MipMapTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/MipMapTest.java
@@ -112,7 +112,7 @@ public class MipMapTest extends GdxTest {
 	}
 
 	@Override
-	public void update(float delta) {
+	public void update(final float delta) {
 		ui.act(delta);
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/MipMapTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/MipMapTest.java
@@ -112,7 +112,12 @@ public class MipMapTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void update(float delta) {
+		ui.act(delta);
+	}
+
+	@Override
+	public void render (float delta) {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		Gdx.gl.glEnable(GL20.GL_TEXTURE_2D);
 
@@ -128,8 +133,7 @@ public class MipMapTest extends GdxTest {
 		mesh.render(shader, GL20.GL_TRIANGLE_FAN);
 		shader.end();
 
-		ui.act();
-		ui.draw();
+		ui.draw(delta);
 	}
 
 	@Override

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/MultitouchTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/MultitouchTest.java
@@ -39,7 +39,7 @@ public class MultitouchTest extends GdxTest {
 
 	Vector2 tp = new Vector2();
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glViewport(0, 0, Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight());
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		camera.update();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/MusicTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/MusicTest.java
@@ -146,7 +146,7 @@ public class MusicTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		currentPosition = music.getPosition();
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		batch.begin();
@@ -157,8 +157,8 @@ public class MusicTest extends GdxTest {
 		sliderUpdating = true;
 		slider.setValue((currentPosition / songDuration) * 100f);
 		sliderUpdating = false;
-		stage.act();
-		stage.draw();
+		stage.act(delta);
+		stage.draw(delta);
 
 		if (Gdx.input.justTouched()) {
 			if (Gdx.input.getY() > Gdx.graphics.getHeight() - 64) {

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/NinePatchTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/NinePatchTest.java
@@ -159,14 +159,14 @@ public class NinePatchTest extends GdxTest {
 	private final Color oldColor = new Color();
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		final int screenWidth = Gdx.graphics.getWidth();
 		final int screenHeight = Gdx.graphics.getHeight();
 
 		Gdx.gl.glClearColor(0, 0, 0, 0);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 
-		timePassed += Gdx.graphics.getDeltaTime();
+		timePassed += delta;
 
 		b.begin();
 		final int sz = ninePatches.size;

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/NoncontinuousRenderingTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/NoncontinuousRenderingTest.java
@@ -81,8 +81,7 @@ public class NoncontinuousRenderingTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
-		float delta = Math.min(Gdx.graphics.getDeltaTime(), 1 / 30f);
+	public void render (final float delta) {
 		elapsed += delta;
 		float value = elapsed % 1f;
 		value = value < 0.5f ? 
@@ -113,7 +112,7 @@ public class NoncontinuousRenderingTest extends GdxTest {
 		batch.end();
 		
 		stage.act(delta);
-		stage.draw();
+		stage.draw(delta);
 	}
 	
 	private void populateTable (){

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ParallaxTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ParallaxTest.java
@@ -81,7 +81,7 @@ public class ParallaxTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClearColor(242 / 255.0f, 210 / 255.0f, 111 / 255.0f, 1);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ParticleEmittersTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ParticleEmittersTest.java
@@ -102,10 +102,12 @@ public class ParticleEmittersTest extends GdxTest {
 		ui.getViewport().update(width, height);
 	}
 
-	public void render () {
-		ui.act();
+	public void update(final float delta) {
+		ui.act(delta);
+	}
+
+	public void render (final float delta) {
 		spriteBatch.getProjectionMatrix().setToOrtho2D(0, 0, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
-		float delta = Gdx.graphics.getDeltaTime();
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		spriteBatch.begin();
 		for (ParticleEffect e : effects)
@@ -119,7 +121,7 @@ public class ParticleEmittersTest extends GdxTest {
 			Gdx.app.log("libgdx", log);
 			logLabel.setText(log);
 		}
-		ui.draw();
+		ui.draw(delta);
 	}
 
 	public boolean needsGL20 () {

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/PathTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/PathTest.java
@@ -92,7 +92,7 @@ public class PathTest extends GdxTest {
 	float avg_speed;
 
 	@Override
-	public void render (float delta) {
+	public void render (final float delta) {
 		GL20 gl = Gdx.gl20;
 		gl.glClearColor(0.7f, 0.7f, 0.7f, 1);
 		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/PathTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/PathTest.java
@@ -92,16 +92,16 @@ public class PathTest extends GdxTest {
 	float avg_speed;
 
 	@Override
-	public void render () {
+	public void render (float delta) {
 		GL20 gl = Gdx.gl20;
 		gl.glClearColor(0.7f, 0.7f, 0.7f, 1);
 		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 
 		if (wait > 0)
-			wait -= Gdx.graphics.getDeltaTime();
+			wait -= delta;
 		else {
-			t += speed * Gdx.graphics.getDeltaTime();
-			zt += zspeed * Gdx.graphics.getDeltaTime();
+			t += speed * delta;
+			zt += zspeed * delta;
 			while (t >= 1f) {
 				currentPath = (currentPath + 1) % paths.size;
 				pathLength = paths.get(currentPath).approxLength(500);
@@ -124,7 +124,7 @@ public class PathTest extends GdxTest {
 			paths.get(currentPath).derivativeAt(tmpV2, t);
 
 			paths.get(currentPath).derivativeAt(tmpV3, t2);
-			t2 += avg_speed * Gdx.graphics.getDeltaTime() / tmpV3.len();
+			t2 += avg_speed * delta / tmpV3.len();
 
 			paths.get(currentPath).valueAt(tmpV4, t2);
 			// obj.setRotation(tmpV2.angle());

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/PixelPerfectTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/PixelPerfectTest.java
@@ -51,7 +51,7 @@ public class PixelPerfectTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClearColor(1, 0, 1, 1);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		cam.update();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/PixmapBlendingTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/PixmapBlendingTest.java
@@ -64,7 +64,7 @@ public class PixmapBlendingTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 
 		Gdx.gl.glClearColor(0, 1, 0, 1);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/PixmapPackerIOTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/PixmapPackerIOTest.java
@@ -162,7 +162,7 @@ public class PixmapPackerIOTest extends GdxTest {
 		}	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClearColor(0.2f, 0.2f, 0.2f, 1);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		int size = Math.min(Gdx.graphics.getWidth(), Gdx.graphics.getHeight());

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/PixmapPackerTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/PixmapPackerTest.java
@@ -133,7 +133,7 @@ public class PixmapPackerTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClearColor(0.2f, 0.2f, 0.2f, 1);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		int size = Math.min(Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
@@ -149,7 +149,7 @@ public class PixmapPackerTest extends GdxTest {
 		shapeRenderer.rect(0, 0, size, size);
 		shapeRenderer.end();
 
-		stateTime += Gdx.graphics.getDeltaTime();
+		stateTime += delta;
 	}
 
 	@Override

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/PolygonRegionTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/PolygonRegionTest.java
@@ -72,7 +72,7 @@ public class PolygonRegionTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		Gdx.gl.glClearColor(0.25f, 0.25f, 0.25f, 1.0f);
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/PolygonSpriteTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/PolygonSpriteTest.java
@@ -71,7 +71,7 @@ public class PolygonSpriteTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		Gdx.gl.glClearColor(0.2f, 0.2f, 0.2f, 1.0f);
 
@@ -82,8 +82,8 @@ public class PolygonSpriteTest extends GdxTest {
 
 		for (int i = 0; i < sprites.size; i++) {
 			PolygonSprite sprite = sprites.get(i);
-			sprite.rotate(45 * Gdx.graphics.getDeltaTime());
-			sprite.translateX(10 * Gdx.graphics.getDeltaTime());
+			sprite.rotate(45 * delta);
+			sprite.translateX(10 * delta);
 
 			if (sprite.getX() > 450) sprite.setX(-50);
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ProjectTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ProjectTest.java
@@ -66,7 +66,7 @@ public class ProjectTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
 		Gdx.gl.glEnable(GL20.GL_DEPTH_TEST);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ProjectiveTextureTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ProjectiveTextureTest.java
@@ -139,7 +139,7 @@ public class ProjectiveTextureTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
 		Gdx.gl.glEnable(GL20.GL_DEPTH_TEST);
 
@@ -168,8 +168,8 @@ public class ProjectiveTextureTest extends GdxTest {
 		projTexShader.end();
 
 		fps.setText("fps: " + Gdx.graphics.getFramesPerSecond());
-		ui.act();
-		ui.draw();
+		ui.act(delta);
+		ui.draw(delta);
 	}
 
 	Vector3 position = new Vector3();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ReflectionTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ReflectionTest.java
@@ -93,7 +93,7 @@ public class ReflectionTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		batch.begin();
 		font.draw(batch, message, 20, Gdx.graphics.getHeight() - 20);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/RotationTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/RotationTest.java
@@ -38,7 +38,7 @@ public class RotationTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		batch.begin();
 		batch.draw(texture, 0, 0);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/RunnablePostTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/RunnablePostTest.java
@@ -42,7 +42,7 @@ public class RunnablePostTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		if (Gdx.input.justTouched()) {
 			expectIt = true;
 			Gdx.app.postRunnable(new Runnable() {

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/Scene2dTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/Scene2dTest.java
@@ -209,7 +209,7 @@ public class Scene2dTest extends GdxTest {
 	}
 
 	@Override
-	public void update(float delta) {
+	public void update(final float delta) {
 		stage.act(delta);
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/Scene2dTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/Scene2dTest.java
@@ -208,11 +208,16 @@ public class Scene2dTest extends GdxTest {
 		checkBoxRight.debug();
 	}
 
-	public void render () {
+	@Override
+	public void update(float delta) {
+		stage.act(delta);
+	}
+
+	@Override
+	public void render (final float delta) {
 		// System.out.println(meow.getValue());
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-		stage.act(Gdx.graphics.getDeltaTime());
-		stage.draw();
+		stage.draw(delta);
 
 		stage.getBatch().begin();
 		patch.draw(stage.getBatch(), 300, 100, 126, 126);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ScrollPane2Test.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ScrollPane2Test.java
@@ -78,7 +78,7 @@ public class ScrollPane2Test extends GdxTest {
 	}
 
 	@Override
-	public void update(float delta) {
+	public void update(final float delta) {
 		stage.act(delta);
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ScrollPane2Test.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ScrollPane2Test.java
@@ -77,11 +77,16 @@ public class ScrollPane2Test extends GdxTest {
 		stage.addActor(pane);
 	}
 
-	public void render () {
+	@Override
+	public void update(float delta) {
+		stage.act(delta);
+	}
+
+	@Override
+	public void render (final float delta) {
 		Gdx.gl.glClearColor(0, 0, 0, 1);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-		stage.act(Gdx.graphics.getDeltaTime());
-		stage.draw();
+		stage.draw(delta);
 	}
 
 	public void resize (int width, int height) {

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ScrollPaneScrollBarsTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ScrollPaneScrollBarsTest.java
@@ -233,7 +233,7 @@ public class ScrollPaneScrollBarsTest extends GdxTest {
 	}
 
 	@Override
-	public void update(float delta) {
+	public void update(final float delta) {
 		stage.act(delta);
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ScrollPaneScrollBarsTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ScrollPaneScrollBarsTest.java
@@ -232,10 +232,15 @@ public class ScrollPaneScrollBarsTest extends GdxTest {
 		}
 	}
 
-	public void render () {
+	@Override
+	public void update(float delta) {
+		stage.act(delta);
+	}
+
+	@Override
+	public void render (final float delta) {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-		stage.act(Gdx.graphics.getDeltaTime());
-		stage.draw();
+		stage.draw(delta);
 	}
 
 	public void resize (int width, int height) {

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ScrollPaneTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ScrollPaneTest.java
@@ -120,7 +120,7 @@ public class ScrollPaneTest extends GdxTest {
 	}
 
 	@Override
-	public void update(float delta) {
+	public void update(final float delta) {
 		stage.act(delta);
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ScrollPaneTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ScrollPaneTest.java
@@ -119,10 +119,14 @@ public class ScrollPaneTest extends GdxTest {
 		container.add(fadeButton).left().expandX();
 	}
 
-	public void render () {
+	@Override
+	public void update(float delta) {
+		stage.act(delta);
+	}
+
+	public void render (final float delta) {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-		stage.act(Gdx.graphics.getDeltaTime());
-		stage.draw();
+		stage.draw(delta);
 	}
 
 	public void resize (int width, int height) {

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ScrollPaneTextAreaTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ScrollPaneTextAreaTest.java
@@ -80,7 +80,7 @@ public class ScrollPaneTextAreaTest extends GdxTest {
    }
 
     @Override
-    public void update(float delta) {
+    public void update(final float delta) {
         stage.act(delta);
     }
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ScrollPaneTextAreaTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ScrollPaneTextAreaTest.java
@@ -79,16 +79,20 @@ public class ScrollPaneTextAreaTest extends GdxTest {
       container.debugAll();
    }
 
-   @Override
-   public void render () {
+    @Override
+    public void update(float delta) {
+        stage.act(delta);
+    }
+
+    @Override
+   public void render (final float delta) {
    	if (textArea.getHeight() != textArea.getPrefHeight()) {
    		scrollPane.invalidate();
    		scrollPane.scrollTo(0, textArea.getHeight() - textArea.getCursorY(), 0, textArea.getStyle().font.getLineHeight());
    	}
 
       Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-      stage.act(Gdx.graphics.getDeltaTime());
-      stage.draw();
+      stage.draw(delta);
    }
 
    @Override

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ScrollPaneWithDynamicScrolling.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ScrollPaneWithDynamicScrolling.java
@@ -77,10 +77,16 @@ public class ScrollPaneWithDynamicScrolling extends GdxTest {
 		
 	}
 
-	public void render () {
+	@Override
+	public void update(float delta) {
+		stage.act(delta);
+	}
+
+	@Override
+	public void render (final float delta) {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		stage.act(Gdx.graphics.getDeltaTime());
-		stage.draw();
+		stage.draw(delta);
 	}
 
 	public void resize (int width, int height) {

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ScrollPaneWithDynamicScrolling.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ScrollPaneWithDynamicScrolling.java
@@ -78,7 +78,7 @@ public class ScrollPaneWithDynamicScrolling extends GdxTest {
 	}
 
 	@Override
-	public void update(float delta) {
+	public void update(final float delta) {
 		stage.act(delta);
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/SensorTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/SensorTest.java
@@ -90,7 +90,7 @@ public class SensorTest extends BaseG3dTest {
 	}
 
 	@Override
-	public void render (final Array<ModelInstance> instances) {
+	public void render (final float delta, final Array<ModelInstance> instances) {
 		tmpUp.set(cam.up);
 		tmpDirection.set(cam.direction);
 
@@ -103,11 +103,11 @@ public class SensorTest extends BaseG3dTest {
 		cam.rotate(tmpRotation);
 		cam.update();
 
-		super.render(instances);
+		super.render(delta, instances);
 	}
 
 	@Override
-	protected void render (ModelBatch batch, Array<ModelInstance> instances) {
+	protected void render (final float delta, ModelBatch batch, Array<ModelInstance> instances) {
 		batch.render(instances, lights);
 		if (skydome != null) batch.render(skydome);
 	}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ShapeRendererAlphaTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ShapeRendererAlphaTest.java
@@ -33,7 +33,7 @@ public class ShapeRendererAlphaTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		Gdx.gl.glEnable(GL20.GL_BLEND);
 		Gdx.gl.glBlendFunc(GL20.GL_SRC_ALPHA, GL20.GL_ONE_MINUS_SRC_ALPHA);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/SimpleAnimationTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/SimpleAnimationTest.java
@@ -63,9 +63,9 @@ public class SimpleAnimationTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-		currentFrameTime += Gdx.graphics.getDeltaTime();
+		currentFrameTime += delta;
 
 		spriteBatch.begin();
 		TextureRegion frame = currentWalk.getKeyFrame(currentFrameTime, true);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/SimpleStageCullingTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/SimpleStageCullingTest.java
@@ -130,9 +130,15 @@ public class SimpleStageCullingTest extends GdxTest {
 		font = new BitmapFont(Gdx.files.internal("data/arial-15.fnt"), false);
 	}
 
-	public void render () {
+	@Override
+	public void update(float delta) {
+		stage.act(delta);
+	}
+
+	@Override
+	public void render (final float delta) {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-		stage.draw();
+		stage.draw(delta);
 
 		// check how many actors are visible.
 		Array<Actor> actors = stage.getActors();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/SimpleStageCullingTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/SimpleStageCullingTest.java
@@ -131,7 +131,7 @@ public class SimpleStageCullingTest extends GdxTest {
 	}
 
 	@Override
-	public void update(float delta) {
+	public void update(final float delta) {
 		stage.act(delta);
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/SoftKeyboardTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/SoftKeyboardTest.java
@@ -61,7 +61,7 @@ public class SoftKeyboardTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		batch.begin();
 		font.draw(batch, textBuffer, 0, Gdx.graphics.getHeight() - 20);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/SortedSpriteTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/SortedSpriteTest.java
@@ -114,7 +114,7 @@ public class SortedSpriteTest extends GdxTest {
 	}
 
 	@Override
-	public void render (float delta) {
+	public void render (final float delta) {
 		Gdx.gl.glClearColor(0.2f, 0.2f, 0.2f, 1);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/SortedSpriteTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/SortedSpriteTest.java
@@ -114,7 +114,7 @@ public class SortedSpriteTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (float delta) {
 		Gdx.gl.glClearColor(0.2f, 0.2f, 0.2f, 1);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/SoundTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/SoundTest.java
@@ -114,10 +114,14 @@ public class SoundTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void update(final float delta) {
+		ui.act(delta);
+	}
+
+	@Override
+	public void render (final float delta) {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-		ui.act(Gdx.graphics.getDeltaTime());
-		ui.draw();
+		ui.draw(delta);
 	}
 
 	@Override

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/SpriteBatchOriginScaleTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/SpriteBatchOriginScaleTest.java
@@ -41,7 +41,7 @@ public class SpriteBatchOriginScaleTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClearColor(0.2f, 0.2f, 0.2f, 1);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/SpriteBatchRotationTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/SpriteBatchRotationTest.java
@@ -34,7 +34,7 @@ public class SpriteBatchRotationTest extends GdxTest {
 	IntBuffer pixelBuffer;
 
 	@Override
-	public void render (float delta) {
+	public void render (final float delta) {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		spriteBatch.begin();
 		spriteBatch.draw(texture, 16, 10, 16, 16, 32, 32, 1, 1, 0, 0, 0, texture.getWidth(), texture.getHeight(), false, false);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/SpriteBatchRotationTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/SpriteBatchRotationTest.java
@@ -34,7 +34,7 @@ public class SpriteBatchRotationTest extends GdxTest {
 	IntBuffer pixelBuffer;
 
 	@Override
-	public void render () {
+	public void render (float delta) {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		spriteBatch.begin();
 		spriteBatch.draw(texture, 16, 10, 16, 16, 32, 32, 1, 1, 0, 0, 0, texture.getWidth(), texture.getHeight(), false, false);
@@ -50,8 +50,8 @@ public class SpriteBatchRotationTest extends GdxTest {
 			false);
 
 		spriteBatch.end();
-		angle += 20 * Gdx.graphics.getDeltaTime();
-		scale += vScale * Gdx.graphics.getDeltaTime();
+		angle += 20 * delta;
+		scale += vScale * delta;
 		if (scale > 2) {
 			vScale = -vScale;
 			scale = 2;

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/SpriteBatchShaderTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/SpriteBatchShaderTest.java
@@ -46,7 +46,7 @@ public class SpriteBatchShaderTest extends GdxTest {
 	float vertices[] = new float[SPRITES * 6 * (2 + 2 + 4)];
 
 	@Override
-	public void render (float delta) {
+	public void render (final float delta) {
 		GL20 gl = Gdx.gl20;
 		gl.glClearColor(0.7f, 0.7f, 0.7f, 1);
 		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/SpriteBatchShaderTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/SpriteBatchShaderTest.java
@@ -46,7 +46,7 @@ public class SpriteBatchShaderTest extends GdxTest {
 	float vertices[] = new float[SPRITES * 6 * (2 + 2 + 4)];
 
 	@Override
-	public void render () {
+	public void render (float delta) {
 		GL20 gl = Gdx.gl20;
 		gl.glClearColor(0.7f, 0.7f, 0.7f, 1);
 		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/SpriteBatchTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/SpriteBatchTest.java
@@ -48,7 +48,7 @@ public class SpriteBatchTest extends GdxTest implements InputProcessor {
 	int renderMethod = 0;
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		if (renderMethod == 0) renderNormal();
 		;
 		if (renderMethod == 1) renderSprites();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/SpriteCacheTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/SpriteCacheTest.java
@@ -46,7 +46,7 @@ public class SpriteCacheTest extends GdxTest implements InputProcessor {
 	private float[] sprites2;
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		if (renderMethod == 0) renderNormal();
 		;
 		if (renderMethod == 1) renderSprites();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/StageDebugTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/StageDebugTest.java
@@ -100,10 +100,14 @@ public class StageDebugTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void update(float delta) {
+		stage.act(delta);
+	}
+
+	@Override
+	public void render (final float delta) {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
-		stage.act();
-		stage.draw();
+		stage.draw(delta);
 	}
 
 	@Override

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/StageDebugTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/StageDebugTest.java
@@ -100,7 +100,7 @@ public class StageDebugTest extends GdxTest {
 	}
 
 	@Override
-	public void update(float delta) {
+	public void update(final float delta) {
 		stage.act(delta);
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/StagePerformanceTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/StagePerformanceTest.java
@@ -74,7 +74,7 @@ public class StagePerformanceTest extends GdxTest {
 	}
 
 	@Override
-	public void update(float delta) {
+	public void update(final float delta) {
 		if (useStage)
 			stage.act(delta);
 	}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/StagePerformanceTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/StagePerformanceTest.java
@@ -74,18 +74,23 @@ public class StagePerformanceTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void update(float delta) {
+		if (useStage)
+			stage.act(delta);
+	}
+
+	@Override
+	public void render (final float delta) {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 
 		if (useStage) {
-			stage.act(Gdx.graphics.getDeltaTime());
 			stage.getBatch().disableBlending();
 			Group root = stage.getRoot();
 			Array<Actor> actors = root.getChildren();
 // for(int i = 0; i < actors.size(); i++) {
 // actors.get(i).rotation += 45 * Gdx.graphics.getDeltaTime();
 // }
-			stage.draw();
+			stage.draw(delta);
 		} else {
 			batch.getProjectionMatrix().setToOrtho2D(0, 0, 24, 12);
 			batch.getTransformMatrix().idt();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/StageTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/StageTest.java
@@ -171,7 +171,7 @@ public class StageTest extends GdxTest implements InputProcessor {
 	private final Vector2 stageCoords = new Vector2();
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glViewport(0, 0, Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight());
 		Gdx.gl.glClearColor(0.2f, 0.2f, 0.2f, 1);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
@@ -187,10 +187,10 @@ public class StageTest extends GdxTest implements InputProcessor {
 		int len = actors.size;
 		if (rotateSprites) {
 			for (int i = 0; i < len; i++)
-				actors.get(i).rotateBy(Gdx.graphics.getDeltaTime() * 10);
+				actors.get(i).rotateBy(delta * 10);
 		}
 
-		scale += vScale * Gdx.graphics.getDeltaTime();
+		scale += vScale * delta;
 		if (scale > 1) {
 			scale = 1;
 			vScale = -vScale;
@@ -204,7 +204,7 @@ public class StageTest extends GdxTest implements InputProcessor {
 		for (int i = 0; i < len; i++) {
 			Actor sprite = sprites.get(i);
 			if (rotateSprites)
-				sprite.rotateBy(-40 * Gdx.graphics.getDeltaTime());
+				sprite.rotateBy(-40 * delta);
 			else
 				sprite.setRotation(0);
 
@@ -215,7 +215,7 @@ public class StageTest extends GdxTest implements InputProcessor {
 			}
 		}
 
-		stage.draw();
+		stage.draw(delta);
 
 		renderer.begin(ShapeType.Point);
 		renderer.setColor(1, 0, 0, 1);
@@ -227,7 +227,7 @@ public class StageTest extends GdxTest implements InputProcessor {
 		renderer.end();
 
 		fps.setText("fps: " + Gdx.graphics.getFramesPerSecond() + ", actors " + sprites.size + ", groups " + sprites.size);
-		ui.draw();
+		ui.draw(delta);
 	}
 
 	@Override

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TableLayoutTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TableLayoutTest.java
@@ -88,7 +88,7 @@ public class TableLayoutTest extends GdxTest {
 	}
 
 	@Override
-	public void update(float delta) {
+	public void update(final float delta) {
 		stage.act(delta);
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TableLayoutTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TableLayoutTest.java
@@ -87,10 +87,15 @@ public class TableLayoutTest extends GdxTest {
 		table2.add(button2);
 	}
 
-	public void render () {
+	@Override
+	public void update(float delta) {
+		stage.act(delta);
+	}
+
+	@Override
+	public void render (final float delta) {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-		stage.act(Gdx.graphics.getDeltaTime());
-		stage.draw();
+		stage.draw(delta);
 	}
 
 	public void resize (int width, int height) {

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TableTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TableTest.java
@@ -102,7 +102,7 @@ public class TableTest extends GdxTest {
 	}
 
 	@Override
-	public void update(float delta) {
+	public void update(final float delta) {
 		stage.act(delta);
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TableTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TableTest.java
@@ -102,12 +102,15 @@ public class TableTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void update(float delta) {
+		stage.act(delta);
+	}
+
+	@Override
+	public void render (final float delta) {
 		Gdx.gl.glClearColor(0.2f, 0.2f, 0.2f, 1);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-
-		stage.act(Math.min(Gdx.graphics.getDeltaTime(), 1 / 30f));
-		stage.draw();
+		stage.draw(delta);
 	}
 
 	@Override

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TextAreaTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TextAreaTest.java
@@ -53,10 +53,15 @@ public class TextAreaTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void update(float delta) {
+		stage.act(delta);
+	}
+
+	@Override
+	public void render (final float delta) {
 		Gdx.gl.glClearColor(0.2f, 0.2f, 0.2f, 1);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-		stage.draw();
+		stage.draw(delta);
 		Gdx.app.log("X", "FPS: " + Gdx.graphics.getFramesPerSecond());
 		SpriteBatch spriteBatch = (SpriteBatch)stage.getBatch();
 		Gdx.app.log("X", "render calls: " + spriteBatch.totalRenderCalls);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TextAreaTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TextAreaTest.java
@@ -53,7 +53,7 @@ public class TextAreaTest extends GdxTest {
 	}
 
 	@Override
-	public void update(float delta) {
+	public void update(final float delta) {
 		stage.act(delta);
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TextAreaTest2.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TextAreaTest2.java
@@ -56,10 +56,10 @@ public class TextAreaTest2 extends GdxTest {
     }
 
     @Override
-    public void render () {
+    public void render (final float delta) {
         Gdx.gl.glClearColor(0.2f, 0.2f, 0.2f, 1);
         Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-        stage.draw();
+        stage.draw(delta);
         Gdx.app.log("X", "FPS: " + Gdx.graphics.getFramesPerSecond());
         SpriteBatch spriteBatch = (SpriteBatch)stage.getBatch();
         Gdx.app.log("X", "render calls: " + spriteBatch.totalRenderCalls);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TextButtonTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TextButtonTest.java
@@ -45,10 +45,10 @@ public class TextButtonTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClearColor(0.2f, 0.2f, 0.2f, 1);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-		stage.draw();
+		stage.draw(delta);
 		Gdx.app.log("X", "FPS: " + Gdx.graphics.getFramesPerSecond());
 		SpriteBatch spriteBatch = (SpriteBatch)stage.getBatch();
 		Gdx.app.log("X", "render calls: " + spriteBatch.totalRenderCalls);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TextureDownloadTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TextureDownloadTest.java
@@ -95,7 +95,7 @@ public class TextureDownloadTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClearColor(0.2f, 0.2f, 0.2f, 1);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TextureFormatTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TextureFormatTest.java
@@ -51,7 +51,7 @@ public class TextureFormatTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClearColor(0.2f, 0.2f, 0.2f, 1);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		batch.begin();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TideMapAssetManagerTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TideMapAssetManagerTest.java
@@ -65,7 +65,7 @@ public class TideMapAssetManagerTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClearColor(0.55f, 0.55f, 0.55f, 1f);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		camera.update();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TideMapDirectLoaderTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TideMapDirectLoaderTest.java
@@ -57,7 +57,7 @@ public class TideMapDirectLoaderTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClearColor(0.55f, 0.55f, 0.55f, 1f);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		camera.update();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TileTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TileTest.java
@@ -68,7 +68,7 @@ public class TileTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		cam.update();
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapAnimationLoadingTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapAnimationLoadingTest.java
@@ -81,7 +81,7 @@ public class TiledMapAnimationLoadingTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClearColor(0.55f, 0.55f, 0.55f, 1f);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		camera.update();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapAssetManagerTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapAssetManagerTest.java
@@ -128,7 +128,7 @@ public class TiledMapAssetManagerTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClearColor(100f / 255f, 100f / 255f, 250f / 255f, 1f);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		camera.update();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapAtlasAssetManagerTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapAtlasAssetManagerTest.java
@@ -80,7 +80,7 @@ public class TiledMapAtlasAssetManagerTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClearColor(100f / 255f, 100f / 255f, 250f / 255f, 1f);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		camera.update();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapAtlasDirectLoaderTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapAtlasDirectLoaderTest.java
@@ -57,7 +57,7 @@ public class TiledMapAtlasDirectLoaderTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClearColor(0.55f, 0.55f, 0.55f, 1f);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		camera.update();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapDirectLoaderTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapDirectLoaderTest.java
@@ -57,7 +57,7 @@ public class TiledMapDirectLoaderTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClearColor(0.55f, 0.55f, 0.55f, 1f);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		camera.update();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapGroupLayerTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapGroupLayerTest.java
@@ -61,7 +61,7 @@ public class TiledMapGroupLayerTest extends GdxTest {
 		assetManager.load(fileName, TiledMap.class);
 	}
 
-	@Override public void render () {
+	@Override public void render (final float delta) {
 		Gdx.gl.glClearColor(100f / 255f, 100f / 255f, 250f / 255f, 1f);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		camera.update();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapLayerOffsetTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapLayerOffsetTest.java
@@ -86,7 +86,7 @@ public class TiledMapLayerOffsetTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		if (Gdx.input.isKeyJustPressed(Input.Keys.NUM_1)) {
 			if (mapType != 0) {
 				if (renderer instanceof Disposable) ((Disposable)renderer).dispose();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapModifiedExternalTilesetTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapModifiedExternalTilesetTest.java
@@ -45,7 +45,7 @@ public class TiledMapModifiedExternalTilesetTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClearColor(0.55f, 0.55f, 0.55f, 1f);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		camera.update();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapObjectLoadingTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapObjectLoadingTest.java
@@ -96,7 +96,7 @@ public class TiledMapObjectLoadingTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClearColor(0.55f, 0.55f, 0.55f, 1f);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		camera.update();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TimeUtilsTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TimeUtilsTest.java
@@ -50,7 +50,7 @@ public class TimeUtilsTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TouchpadTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TouchpadTest.java
@@ -38,11 +38,14 @@ public class TouchpadTest extends GdxTest {
 		stage.addActor(touchpad);
 	}
 
-	public void render () {
+	public void update(final float delta) {
+		stage.act(delta);
+	}
+
+	public void render (final float delta) {
 		// System.out.println(touchpad.getKnobPercentX() + " " + touchpad.getKnobPercentY());
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-		stage.act(Gdx.graphics.getDeltaTime());
-		stage.draw();
+		stage.draw(delta);
 	}
 
 	public void resize (int width, int height) {

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TreeTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TreeTest.java
@@ -99,7 +99,7 @@ public class TreeTest extends GdxTest {
 	}
 
 	@Override
-	public void update(float delta) {
+	public void update(final float delta) {
 		stage.act(delta);
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TreeTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TreeTest.java
@@ -98,11 +98,16 @@ public class TreeTest extends GdxTest {
 		table.add(tree).fill().expand();
 	}
 
-	public void render () {
+	@Override
+	public void update(float delta) {
+		stage.act(delta);
+	}
+
+	@Override
+	public void render (final float delta) {
 		// System.out.println(meow.getValue());
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-		stage.act(Gdx.graphics.getDeltaTime());
-		stage.draw();
+		stage.draw(delta);
 
 		label.setText(tree.toString());
 		label.pack();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/UISimpleTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/UISimpleTest.java
@@ -92,11 +92,15 @@ public class UISimpleTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void update(float delta) {
+		stage.act(delta);
+	}
+
+	@Override
+	public void render (final float delta) {
 		Gdx.gl.glClearColor(0.2f, 0.2f, 0.2f, 1);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-		stage.act(Math.min(Gdx.graphics.getDeltaTime(), 1 / 30f));
-		stage.draw();
+		stage.draw(delta);
 	}
 
 	@Override

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/UISimpleTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/UISimpleTest.java
@@ -92,7 +92,7 @@ public class UISimpleTest extends GdxTest {
 	}
 
 	@Override
-	public void update(float delta) {
+	public void update(final float delta) {
 		stage.act(delta);
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/UITest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/UITest.java
@@ -208,14 +208,17 @@ public class UITest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void update(float delta) {
+		stage.act(delta);
+	}
+
+	@Override
+	public void render (final float delta) {
 		Gdx.gl.glClearColor(0.2f, 0.2f, 0.2f, 1);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 
 		fpsLabel.setText("fps: " + Gdx.graphics.getFramesPerSecond());
-
-		stage.act(Math.min(Gdx.graphics.getDeltaTime(), 1 / 30f));
-		stage.draw();
+		stage.draw(delta);
 	}
 
 	@Override

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/UITest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/UITest.java
@@ -208,7 +208,7 @@ public class UITest extends GdxTest {
 	}
 
 	@Override
-	public void update(float delta) {
+	public void update(final float delta) {
 		stage.act(delta);
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/UtfFontTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/UtfFontTest.java
@@ -20,7 +20,7 @@ public class UtfFontTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		batch.begin();
 		font.draw(batch, "test ⌘", 29, 20);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/VBOWithVAOPerformanceTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/VBOWithVAOPerformanceTest.java
@@ -193,7 +193,7 @@ public class VBOWithVAOPerformanceTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl20.glViewport(0, 0, Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight());
 		Gdx.gl20.glClearColor(0.2f, 0.2f, 0.2f, 1);
 		Gdx.gl20.glClear(GL20.GL_COLOR_BUFFER_BIT);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/Vector2dTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/Vector2dTest.java
@@ -60,7 +60,7 @@ public class Vector2dTest extends GdxTest {
 	}
 
 	@Override
-	public void render (float delta) {
+	public void render (final float delta) {
 		Gdx.gl.glClearColor(0, 0, 0, 0);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/Vector2dTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/Vector2dTest.java
@@ -60,7 +60,7 @@ public class Vector2dTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (float delta) {
 		Gdx.gl.glClearColor(0, 0, 0, 0);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 
@@ -83,11 +83,10 @@ public class Vector2dTest extends GdxTest {
 		renderer.setColor(Color.YELLOW);
 		renderVectorAt(0, 0, sum);
 
-		final float changeRate = Gdx.graphics.getDeltaTime();
 		renderer.setColor(Color.WHITE);
 
 		renderVectorAt(2, 2, rotating);
-		rotating.rotate(93 * changeRate);
+		rotating.rotate(93 * delta);
 
 		renderVectorAt(2, -2, scalingX);
 		scalingX.set(0, MathUtils.sin((System.currentTimeMillis() - start) / 520.0f));

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/VertexBufferObjectShaderTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/VertexBufferObjectShaderTest.java
@@ -42,7 +42,7 @@ public class VertexBufferObjectShaderTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		GL20 gl = Gdx.gl20;
 		gl.glViewport(0, 0, Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight());
 		Gdx.gl.glClearColor(0.7f, 0, 0, 1);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/VibratorTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/VibratorTest.java
@@ -34,7 +34,7 @@ public class VibratorTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		batch.begin();
 		font.draw(batch, "Touch screen to vibrate", 100, 100);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ViewportTest1.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ViewportTest1.java
@@ -81,11 +81,14 @@ public class ViewportTest1 extends GdxTest {
 		}, stage));
 	}
 
-	public void render () {
-		stage.act();
+	@Override
+	public void update(final float delta) {
+		stage.act(delta);
+	}
 
+	public void render (final float delta) {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-		stage.draw();
+		stage.draw(delta);
 	}
 
 	public void resize (int width, int height) {

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/YDownTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/YDownTest.java
@@ -90,7 +90,7 @@ public class YDownTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		// clear the screen, update the camera and make the sprite batch
 		// use its matrices.
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
@@ -116,8 +116,8 @@ public class YDownTest extends GdxTest {
 		batch.end();
 
 		// tell the stage to act and draw itself
-		stage.act(Gdx.graphics.getDeltaTime());
-		stage.draw();
+		stage.act(delta);
+		stage.draw(delta);
 	}
 
 	/** A very simple actor implementation that does not obey rotation/scale/origin set on the actor. Allows dragging of the actor.

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/bench/TiledMapBench.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/bench/TiledMapBench.java
@@ -86,7 +86,7 @@ public class TiledMapBench extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClearColor(100f / 255f, 100f / 255f, 250f / 255f, 1f);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		camera.update();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/box2d/BodyTypes.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/box2d/BodyTypes.java
@@ -146,7 +146,7 @@ public class BodyTypes extends Box2DTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		if (m_platform.getType() == BodyType.KinematicBody) {
 			Vector2 p = m_platform.getTransform().getPosition();
 			Vector2 v = m_platform.getLinearVelocity();
@@ -157,7 +157,7 @@ public class BodyTypes extends Box2DTest {
 			}
 		}
 
-		super.render();
+		super.render(delta);
 
 		// if (renderer.batch != null) {
 		// renderer.batch.begin();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/box2d/Box2DTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/box2d/Box2DTest.java
@@ -73,19 +73,28 @@ public abstract class Box2DTest implements ApplicationListener, InputProcessor {
 	/** a hit body **/
 	protected Body hitBody = null;
 
+	/** Time measurement startTime **/
+	private long startTime;
+	/** Time measurement updateTime **/
+	private float updateTime;
+
 	protected abstract void createWorld (World world);
 
 	/** temp vector **/
 	protected Vector2 tmp = new Vector2();
 
 	@Override
-	public void render () {
+	public void update(float delta) {
 		// update the world with a fixed time step
-		long startTime = TimeUtils.nanoTime();
-		world.step(Gdx.app.getGraphics().getDeltaTime(), 3, 3);
-		float updateTime = (TimeUtils.nanoTime() - startTime) / 1000000000.0f;
+		startTime = TimeUtils.nanoTime();
+		world.step(delta, 3, 3);
+		updateTime = (TimeUtils.nanoTime() - startTime) / 1000000000.0f;
 
 		startTime = TimeUtils.nanoTime();
+	}
+
+	@Override
+	public void render (final float delta) {
 		// clear the screen and setup the projection matrix
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		camera.update();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/box2d/Box2DTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/box2d/Box2DTest.java
@@ -84,7 +84,7 @@ public abstract class Box2DTest implements ApplicationListener, InputProcessor {
 	protected Vector2 tmp = new Vector2();
 
 	@Override
-	public void update(float delta) {
+	public void update(final float delta) {
 		// update the world with a fixed time step
 		startTime = TimeUtils.nanoTime();
 		world.step(delta, 3, 3);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/box2d/ContinuousTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/box2d/ContinuousTest.java
@@ -84,8 +84,9 @@ public class ContinuousTest extends Box2DTest {
 		m_body.setAngularVelocity(m_angularVelocity);
 	}
 
-	public void render () {
-		super.render();
+	@Override
+	public void render (final float delta) {
+		super.render(delta);
 
 		m_stepCount++;
 		if (m_stepCount % 60 == 0) launch();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/box2d/Prismatic.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/box2d/Prismatic.java
@@ -94,8 +94,8 @@ public class Prismatic extends Box2DTest {
 
 	}
 
-	public void render () {
-		super.render();
+	public void render (final float delta) {
+		super.render(delta);
 
 		// if (renderer.batch != null) {
 		// renderer.batch.begin();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/box2d/VerticalStack.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/box2d/VerticalStack.java
@@ -127,8 +127,9 @@ public class VerticalStack extends Box2DTest {
 		return false;
 	}
 
-	public void render () {
-		super.render();
+	@Override
+	public void render (final float delta) {
+		super.render(delta);
 
 		// if (renderer.batch != null) {
 		// renderer.batch.begin();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/BaseBulletTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/BaseBulletTest.java
@@ -160,7 +160,7 @@ public class BaseBulletTest extends BulletTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		render(true);
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/BasicBulletTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/BasicBulletTest.java
@@ -169,7 +169,7 @@ public class BasicBulletTest extends BulletTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glViewport(0, 0, Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight());
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
 
@@ -177,7 +177,7 @@ public class BasicBulletTest extends BulletTest {
 
 		performanceCounter.tick();
 		performanceCounter.start();
-		((btDynamicsWorld)collisionWorld).stepSimulation(Gdx.graphics.getDeltaTime(), 5);
+		((btDynamicsWorld)collisionWorld).stepSimulation(delta, 5);
 		performanceCounter.stop();
 
 		int c = motionStates.size;

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/BulletTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/BulletTest.java
@@ -83,7 +83,11 @@ public class BulletTest implements ApplicationListener, InputProcessor, GestureL
 	}
 
 	@Override
-	public void render () {
+	public void update(final float delta) {
+	}
+
+	@Override
+	public void render (final float render) {
 	}
 
 	@Override

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/CollisionTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/CollisionTest.java
@@ -77,7 +77,7 @@ public class CollisionTest extends ShootTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		process();
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/CollisionWorldTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/CollisionWorldTest.java
@@ -93,13 +93,13 @@ public class CollisionWorldTest extends BaseBulletTest {
 	Color tmpColor = new Color();
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		movingBox.transform.val[Matrix4.M03] = movingBox.transform.val[Matrix4.M13] = movingBox.transform.val[Matrix4.M23] = 0f;
 		movingBox.transform.rotate(Vector3.Y, Gdx.graphics.getDeltaTime() * 45f);
 		movingBox.transform.translate(-5f, 1f, 0f);
 		movingBox.body.setWorldTransform(movingBox.transform);
 
-		super.render();
+		super.render(delta);
 	}
 
 	@Override

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/ConvexHullDistanceTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/ConvexHullDistanceTest.java
@@ -70,8 +70,8 @@ public class ConvexHullDistanceTest extends BaseBulletTest {
 	}
 
 	@Override
-	public void render () {
-		super.render();
+	public void render (final float delta) {
+		super.render(delta);
 
 		// Draw the lines of the distances
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/FrustumCullingTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/FrustumCullingTest.java
@@ -190,12 +190,11 @@ public class FrustumCullingTest extends BaseBulletTest {
 	}
 
 	@Override
-	public void render () {
-		final float dt = Gdx.graphics.getDeltaTime();
+	public void render (final float delta) {
 		frustumEntity.transform.idt();
-		frustumEntity.transform.rotate(Vector3.X, angleX = (angleX + dt * SPEED_X) % 360);
-		frustumEntity.transform.rotate(Vector3.Y, angleY = (angleY + dt * SPEED_Y) % 360);
-		frustumEntity.transform.rotate(Vector3.Z, angleZ = (angleZ + dt * SPEED_Z) % 360);
+		frustumEntity.transform.rotate(Vector3.X, angleX = (angleX + delta * SPEED_X) % 360);
+		frustumEntity.transform.rotate(Vector3.Y, angleY = (angleY + delta * SPEED_Y) % 360);
+		frustumEntity.transform.rotate(Vector3.Z, angleZ = (angleZ + delta * SPEED_Z) % 360);
 
 		// Transform the ghost object
 		frustumEntity.body.setWorldTransform(frustumEntity.transform);
@@ -206,7 +205,7 @@ public class FrustumCullingTest extends BaseBulletTest {
 		frustumCam.rotate(frustumEntity.transform);
 		frustumCam.update();
 
-		super.render();
+		super.render(delta);
 
 		performance.append(" visible: ").append(visibleEntities.size);
 	}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/InternalTickTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/InternalTickTest.java
@@ -87,10 +87,10 @@ public class InternalTickTest extends BaseBulletTest {
 	boolean toggleAttach = false;
 
 	@Override
-	public void render () {
-		super.render();
+	public void render (final float delta) {
+		super.render(delta);
 		if (internalTickCallback == null) return;
-		if ((toggleTime += Gdx.graphics.getDeltaTime()) > 1.0f) {
+		if ((toggleTime += delta) > 1.0f) {
 			toggleTime -= 1.0f;
 			if (toggleAttach)
 				internalTickCallback.detach();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/KinematicTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/KinematicTest.java
@@ -60,8 +60,8 @@ public class KinematicTest extends BaseBulletTest {
 	}
 
 	@Override
-	public void render () {
-		angle = angle + Gdx.graphics.getDeltaTime() * 360f / 5f;
+	public void render (final float delta) {
+		angle = angle + delta * 360f / 5f;
 		kinematicBox3.transform.idt().rotate(Vector3.Y, 360f - 2f * angle).translate(position3);
 
 		if (angle >= 360f) {
@@ -73,7 +73,7 @@ public class KinematicTest extends BaseBulletTest {
 		// This makes bullet call btMotionState#getWorldTransform once:
 		kinematicBox.body.setActivationState(Collision.ACTIVE_TAG);
 
-		super.render();
+		super.render(delta);
 	}
 
 	@Override

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/OcclusionCullingTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/OcclusionCullingTest.java
@@ -360,8 +360,8 @@ public class OcclusionCullingTest extends BaseBulletTest {
 	}
 
 	@Override
-	public void render () {
-		super.render();
+	public void render (final float delta) {
+		super.render(delta);
 		if ((state & SHOW_DEBUG_IMAGE) == SHOW_DEBUG_IMAGE) renderOclDebugImage();
 		performance.append(", Culling: ").append(cullingPolicy.name());
 		performance.append(", Visible: ").append(visibleEntities.size).append("/").append(world.entities.size);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/PairCacheTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/PairCacheTest.java
@@ -112,12 +112,11 @@ public class PairCacheTest extends BaseBulletTest {
 	}
 
 	@Override
-	public void render () {
-		final float dt = Gdx.graphics.getDeltaTime();
+	public void render (final float delta) {
 		ghostEntity.transform.idt();
-		ghostEntity.transform.rotate(Vector3.X, angleX = (angleX + dt * SPEED_X) % 360);
-		ghostEntity.transform.rotate(Vector3.Y, angleY = (angleY + dt * SPEED_Y) % 360);
-		ghostEntity.transform.rotate(Vector3.Z, angleZ = (angleZ + dt * SPEED_Z) % 360);
+		ghostEntity.transform.rotate(Vector3.X, angleX = (angleX + delta * SPEED_X) % 360);
+		ghostEntity.transform.rotate(Vector3.Y, angleY = (angleY + delta * SPEED_Y) % 360);
+		ghostEntity.transform.rotate(Vector3.Z, angleZ = (angleZ + delta * SPEED_Z) % 360);
 
 		// Transform the ghost object
 		ghostEntity.body.setWorldTransform(ghostEntity.transform);
@@ -129,7 +128,7 @@ public class PairCacheTest extends BaseBulletTest {
 		frustumCam.rotate(ghostEntity.transform);
 		frustumCam.update();
 
-		super.render();
+		super.render(delta);
 
 		// Find all overlapping pairs which contain the ghost object and draw lines between the collision points.
 		shapeRenderer.setProjectionMatrix(camera.combined);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/SoftMeshTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/SoftMeshTest.java
@@ -117,14 +117,14 @@ public class SoftMeshTest extends BaseBulletTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		if (world.renderMeshes) {
 			MeshPart meshPart = model.nodes.get(0).parts.get(0).meshPart;
 			softBody.getVertices(meshPart.mesh.getVerticesBuffer(), meshPart.mesh.getVertexSize(), positionOffset, normalOffset,
 				meshPart.mesh.getIndicesBuffer(), meshPart.offset, meshPart.size, indexMap, 0);
 			softBody.getWorldTransform(entity.transform);
 		}
-		super.render();
+		super.render(delta);
 	}
 
 	@Override

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/TriangleRaycastTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/TriangleRaycastTest.java
@@ -134,8 +134,8 @@ public class TriangleRaycastTest extends BaseBulletTest {
 	}
 
 	@Override
-	public void render () {
-		super.render();
+	public void render (final float delta) {
+		super.render(delta);
 		Gdx.gl.glLineWidth(5);
 		shapeRenderer.setProjectionMatrix(camera.combined);
 		shapeRenderer.begin(ShapeRenderer.ShapeType.Line);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/extensions/ControllersTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/extensions/ControllersTest.java
@@ -175,10 +175,14 @@ public class ControllersTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void update(final float delta) {
 		initialize();
+		stage.act(delta);
+	}
+
+	@Override
+	public void render (final float delta) {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-		stage.act(Gdx.graphics.getDeltaTime());
-		stage.draw();
+		stage.draw(delta);
 	}
 }

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/extensions/FreeTypeAtlasTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/extensions/FreeTypeAtlasTest.java
@@ -97,7 +97,7 @@ public class FreeTypeAtlasTest extends GdxTest {
 	}
 
 	@Override
-	public void render(float delta) {
+	public void render(final float delta) {
 		Gdx.gl.glClearColor(0.2f, 0.2f, 0.2f, 1);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/extensions/FreeTypeAtlasTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/extensions/FreeTypeAtlasTest.java
@@ -97,7 +97,7 @@ public class FreeTypeAtlasTest extends GdxTest {
 	}
 
 	@Override
-	public void render() {
+	public void render(float delta) {
 		Gdx.gl.glClearColor(0.2f, 0.2f, 0.2f, 1);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/extensions/FreeTypeFontLoaderTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/extensions/FreeTypeFontLoaderTest.java
@@ -48,7 +48,7 @@ public class FreeTypeFontLoaderTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (float delta) {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		if (manager.update() && manager.isLoaded("size10.ttf")) {
 			batch.begin();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/extensions/FreeTypeFontLoaderTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/extensions/FreeTypeFontLoaderTest.java
@@ -48,7 +48,7 @@ public class FreeTypeFontLoaderTest extends GdxTest {
 	}
 
 	@Override
-	public void render (float delta) {
+	public void render (final float delta) {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		if (manager.update() && manager.isLoaded("size10.ttf")) {
 			batch.begin();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/extensions/FreeTypeMetricsTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/extensions/FreeTypeMetricsTest.java
@@ -55,7 +55,7 @@ public class FreeTypeMetricsTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (float delta) {
 		// red.a = (red.a + Gdx.graphics.getDeltaTime() * 0.1f) % 1;
 
 		int viewHeight = Gdx.graphics.getHeight();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/extensions/FreeTypeMetricsTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/extensions/FreeTypeMetricsTest.java
@@ -55,7 +55,7 @@ public class FreeTypeMetricsTest extends GdxTest {
 	}
 
 	@Override
-	public void render (float delta) {
+	public void render (final float delta) {
 		// red.a = (red.a + Gdx.graphics.getDeltaTime() * 0.1f) % 1;
 
 		int viewHeight = Gdx.graphics.getHeight();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/extensions/FreeTypePackTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/extensions/FreeTypePackTest.java
@@ -94,7 +94,7 @@ public class FreeTypePackTest extends GdxTest {
 	}
 
 	@Override
-	public void render (float delta) {
+	public void render (final float delta) {
 		Gdx.gl.glClearColor(0.2f, 0.2f, 0.2f, 1);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/extensions/FreeTypePackTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/extensions/FreeTypePackTest.java
@@ -94,7 +94,7 @@ public class FreeTypePackTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (float delta) {
 		Gdx.gl.glClearColor(0.2f, 0.2f, 0.2f, 1);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/extensions/FreeTypeTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/extensions/FreeTypeTest.java
@@ -64,7 +64,7 @@ public class FreeTypeTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (float delta) {
 		Gdx.gl.glClearColor(0.2f, 0.2f, 0.2f, 1);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/extensions/FreeTypeTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/extensions/FreeTypeTest.java
@@ -64,7 +64,7 @@ public class FreeTypeTest extends GdxTest {
 	}
 
 	@Override
-	public void render (float delta) {
+	public void render (final float delta) {
 		Gdx.gl.glClearColor(0.2f, 0.2f, 0.2f, 1);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/extensions/InternationalFontsTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/extensions/InternationalFontsTest.java
@@ -75,7 +75,7 @@ public class InternationalFontsTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 
 		batch.setProjectionMatrix(cam.combined);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g2d/ProgressiveJPEGTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g2d/ProgressiveJPEGTest.java
@@ -44,7 +44,7 @@ public class ProgressiveJPEGTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClearColor(1, 1, 1, 1);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/Animation3DTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/Animation3DTest.java
@@ -116,12 +116,12 @@ public class Animation3DTest extends BaseG3dHudTest {
 	float angle = 0f;
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		if (character != null) {
-			animation.update(Gdx.graphics.getDeltaTime());
+			animation.update(delta);
 			if (Gdx.input.isKeyPressed(Keys.UP)) {
 				if (!animation.inAction) {
-					trTmp.idt().lerp(trForward, Gdx.graphics.getDeltaTime() / animation.current.animation.duration);
+					trTmp.idt().lerp(trForward, delta / animation.current.animation.duration);
 					character.transform.mul(trTmp.toMatrix4(tmpMatrix));
 				}
 				if (status != walk) {
@@ -130,7 +130,7 @@ public class Animation3DTest extends BaseG3dHudTest {
 				}
 			} else if (Gdx.input.isKeyPressed(Keys.DOWN)) {
 				if (!animation.inAction) {
-					trTmp.idt().lerp(trBackward, Gdx.graphics.getDeltaTime() / animation.current.animation.duration);
+					trTmp.idt().lerp(trBackward, delta / animation.current.animation.duration);
 					character.transform.mul(trTmp.toMatrix4(tmpMatrix));
 				}
 				if (status != back) {
@@ -142,10 +142,10 @@ public class Animation3DTest extends BaseG3dHudTest {
 				status = idle;
 			}
 			if (Gdx.input.isKeyPressed(Keys.RIGHT) && (status == walk || status == back) && !animation.inAction) {
-				trTmp.idt().lerp(trRight, Gdx.graphics.getDeltaTime() / animation.current.animation.duration);
+				trTmp.idt().lerp(trRight, delta / animation.current.animation.duration);
 				character.transform.mul(trTmp.toMatrix4(tmpMatrix));
 			} else if (Gdx.input.isKeyPressed(Keys.LEFT) && (status == walk || status == back) && !animation.inAction) {
-				trTmp.idt().lerp(trLeft, Gdx.graphics.getDeltaTime() / animation.current.animation.duration);
+				trTmp.idt().lerp(trLeft, delta / animation.current.animation.duration);
 				character.transform.mul(trTmp.toMatrix4(tmpMatrix));
 			}
 			if (Gdx.input.isKeyPressed(Keys.SPACE) && !animation.inAction) {
@@ -163,11 +163,11 @@ public class Animation3DTest extends BaseG3dHudTest {
 			shadowBatch.end();
 			shadowLight.end();
 		}
-		super.render();
+		super.render(delta);
 	}
 
 	@Override
-	protected void render (ModelBatch batch, Array<ModelInstance> instances) {
+	protected void render (final float delta, ModelBatch batch, Array<ModelInstance> instances) {
 		batch.render(instances, lights);
 		if (skydome != null) batch.render(skydome);
 	}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/AnisotropyTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/AnisotropyTest.java
@@ -62,7 +62,7 @@ public class AnisotropyTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		if (Gdx.input.isKeyJustPressed(Input.Keys.SPACE))
 			changeAnisotropy();
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/BaseG3dHudTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/BaseG3dHudTest.java
@@ -139,7 +139,12 @@ public abstract class BaseG3dHudTest extends BaseG3dTest {
 	protected float rotation, movement;
 
 	@Override
-	public void render () {
+	public void update(float delta) {
+		super.update(delta);
+	}
+
+	@Override
+	public void render (final float delta) {
 		transform.idt();
 		if (rotateCheckBox.isChecked())
 			transform.rotate(Vector3.Y, rotation = (rotation + rotationSpeed * Gdx.graphics.getRawDeltaTime()) % 360);
@@ -150,13 +155,13 @@ public abstract class BaseG3dHudTest extends BaseG3dTest {
 			transform.trn(0, moveRadius * cm, moveRadius * sm);
 		}
 
-		super.render();
+		super.render(delta);
 
 		stringBuilder.setLength(0);
 		getStatus(stringBuilder);
 		fpsLabel.setText(stringBuilder);
-		hud.act(Gdx.graphics.getDeltaTime());
-		hud.draw();
+		hud.act(delta);
+		hud.draw(delta);
 	}
 
 	@Override

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/BaseG3dHudTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/BaseG3dHudTest.java
@@ -139,7 +139,7 @@ public abstract class BaseG3dHudTest extends BaseG3dTest {
 	protected float rotation, movement;
 
 	@Override
-	public void update(float delta) {
+	public void update(final float delta) {
 		super.update(delta);
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/BaseG3dTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/BaseG3dTest.java
@@ -86,33 +86,33 @@ public abstract class BaseG3dTest extends GdxTest {
 		axesInstance = new ModelInstance(axesModel);
 	}
 
-	protected abstract void render (final ModelBatch batch, final Array<ModelInstance> instances);
+	protected abstract void render (final float delta, final ModelBatch batch, final Array<ModelInstance> instances);
 
 	protected boolean loading = false;
 
 	protected void onLoaded () {
 	}
 
-	public void render (final Array<ModelInstance> instances) {
+	public void render (final float delta, final Array<ModelInstance> instances) {
 		modelBatch.begin(cam);
 		if (showAxes) modelBatch.render(axesInstance);
-		if (instances != null) render(modelBatch, instances);
+		if (instances != null) render(delta, modelBatch, instances);
 		modelBatch.end();
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		if (loading && assets.update()) {
 			loading = false;
 			onLoaded();
 		}
 
-		inputController.update();
+		inputController.update(delta);
 
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
 		Gdx.gl.glClearColor(bgColor.r, bgColor.g, bgColor.b, bgColor.a);
 
-		render(instances);
+		render(delta, instances);
 	}
 
 	@Override

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/Basic3DSceneTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/Basic3DSceneTest.java
@@ -99,9 +99,9 @@ public class Basic3DSceneTest extends GdxTest implements ApplicationListener {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		if (loading && assets.update()) doneLoading();
-		camController.update();
+		camController.update(delta);
 
 		Gdx.gl.glViewport(0, 0, Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight());
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/Basic3DTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/Basic3DTest.java
@@ -66,8 +66,8 @@ public class Basic3DTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
-		inputController.update();
+	public void render (final float delta) {
+		inputController.update(delta);
 
 		Gdx.gl.glViewport(0, 0, Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight());
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/Benchmark3DTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/Benchmark3DTest.java
@@ -206,7 +206,7 @@ public class Benchmark3DTest extends BaseG3dHudTest {
 	}
 
 	@Override
-	protected void render (ModelBatch batch, Array<ModelInstance> instances) {
+	protected void render (final float delta, ModelBatch batch, Array<ModelInstance> instances) {
 		if (lighting) {
 			batch.render(instances, environment);
 		} else {

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/FogTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/FogTest.java
@@ -66,11 +66,11 @@ public class FogTest extends GdxTest implements ApplicationListener {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 
 		animate();
 
-		inputController.update();
+		inputController.update(delta);
 
 		Gdx.gl.glViewport(0, 0, Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight());
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/FrameBufferCubemapTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/FrameBufferCubemapTest.java
@@ -57,17 +57,17 @@ public class FrameBufferCubemapTest extends Basic3DSceneTest {
 	}
 	
 	@Override
-	public void render () {
-		renderScene();
-		renderCube();
+	public void render (final float delta) {
+		renderScene(delta);
+		renderCube(delta);
 	}
 	
-	public void renderScene() {
+	public void renderScene(final float delta) {
 		Gdx.gl.glViewport(0, 0, Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight());
 		Gdx.gl.glDisable(GL20.GL_SCISSOR_TEST);
 		
 		// Render scene to screen
-		super.render();
+		super.render(delta);
 		
 		// Render scene to cubemap
 		camFb.position.set(cam.position);
@@ -92,7 +92,7 @@ public class FrameBufferCubemapTest extends Basic3DSceneTest {
 	}
 	
 	float yaw, pitch, roll;
-	public void renderCube() {
+	public void renderCube(final float delta) {
 		int w = Gdx.graphics.getBackBufferWidth();
 		int h = Gdx.graphics.getBackBufferHeight();
 		int x = (int)(w - w*0.5f);
@@ -106,8 +106,8 @@ public class FrameBufferCubemapTest extends Basic3DSceneTest {
 		Gdx.gl.glClearColor(1, 1, 1, 1);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
 		
-		pitch += 25 * Gdx.graphics.getDeltaTime();
-		yaw += 45 * Gdx.graphics.getDeltaTime();
+		pitch += 25 * delta;
+		yaw += 45 * delta;
 		cubeInstance.transform.setFromEulerAngles(yaw, pitch, roll);
 		cubeBatch.begin(camCube);
 		cubeBatch.render(cubeInstance);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/HeightMapTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/HeightMapTest.java
@@ -64,7 +64,7 @@ public class HeightMapTest extends BaseG3dTest {
 	}
 
 	@Override
-	protected void render (ModelBatch batch, Array<ModelInstance> instances) {
+	protected void render (final float delta, ModelBatch batch, Array<ModelInstance> instances) {
 		batch.render(instances);
 		batch.render(ground);
 	}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/LightsTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/LightsTest.java
@@ -66,8 +66,7 @@ public class LightsTest extends ModelTest {
 	}
 
 	@Override
-	protected void render (ModelBatch batch, Array<ModelInstance> instances) {
-		final float delta = Gdx.graphics.getDeltaTime();
+	protected void render (final float delta, ModelBatch batch, Array<ModelInstance> instances) {
 		dirLight.direction.rotate(Vector3.X, delta * 45f);
 		dirLight.direction.rotate(Vector3.Y, delta * 25f);
 		dirLight.direction.rotate(Vector3.Z, delta * 33f);
@@ -81,7 +80,7 @@ public class LightsTest extends ModelTest {
 		pLight.worldTransform.setTranslation(pointLight.position);
 		batch.render(pLight);
 
-		super.render(batch, instances);
+		super.render(delta, batch, instances);
 	}
 
 	@Override

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/MaterialEmissiveTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/MaterialEmissiveTest.java
@@ -105,8 +105,8 @@ public class MaterialEmissiveTest extends GdxTest {
 	private float counter = 0.f;
 
 	@Override
-	public void render () {
-		counter = (counter + Gdx.graphics.getDeltaTime()) % 1.f;
+	public void render (final float delta) {
+		counter = (counter + delta) % 1.f;
 		blendingAttribute.opacity = 0.25f + Math.abs(0.5f - counter);
 
 		Gdx.gl.glViewport(0, 0, Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight());

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/MaterialTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/MaterialTest.java
@@ -91,14 +91,14 @@ public class MaterialTest extends GdxTest {
 	private float counter = 0.f;
 
 	@Override
-	public void render () {
-		counter = (counter + Gdx.graphics.getDeltaTime()) % 1.f;
+	public void render (final float delta) {
+		counter = (counter + delta) % 1.f;
 		blendingAttribute.opacity = 0.25f + Math.abs(0.5f - counter);
 
 		Gdx.gl.glViewport(0, 0, Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight());
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
 
-		modelInstance.transform.rotate(Vector3.Y, 30 * Gdx.graphics.getDeltaTime());
+		modelInstance.transform.rotate(Vector3.Y, 30 * delta);
 		modelBatch.begin(camera);
 		modelBatch.render(background);
 		modelBatch.render(modelInstance);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/MeshBuilderTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/MeshBuilderTest.java
@@ -133,7 +133,7 @@ public class MeshBuilderTest extends BaseG3dHudTest {
 	}
 
 	@Override
-	protected void render (ModelBatch batch, Array<ModelInstance> instances) {
+	protected void render (final float delta, ModelBatch batch, Array<ModelInstance> instances) {
 		batch.render(instances, environment);
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/ModelCacheTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/ModelCacheTest.java
@@ -24,7 +24,7 @@ public class ModelCacheTest extends Benchmark3DTest {
 	}
 	
 	@Override
-	protected void render (ModelBatch batch, Array<ModelInstance> instances) {
+	protected void render (final float delta, ModelBatch batch, Array<ModelInstance> instances) {
 		if (cacheCheckBox.isChecked()) {
 			modelCache.begin();
 			modelCache.add(instances);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/ModelLoaderTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/ModelLoaderTest.java
@@ -55,7 +55,7 @@ public class ModelLoaderTest extends GdxTest {
 	float counter;
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		if ((instance != null) && ((counter += Gdx.graphics.getDeltaTime()) >= 1f)) {
 			counter = 0f;
 			instance = null;

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/ModelTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/ModelTest.java
@@ -57,9 +57,9 @@ public class ModelTest extends BaseG3dHudTest {
 	private final BoundingBox bounds = new BoundingBox();
 
 	@Override
-	protected void render (ModelBatch batch, Array<ModelInstance> instances) {
+	protected void render (final float delta, ModelBatch batch, Array<ModelInstance> instances) {
 		for (ObjectMap.Entry<ModelInstance, AnimationController> e : animationControllers.entries())
-			e.value.update(Gdx.graphics.getDeltaTime());
+			e.value.update(delta);
 		batch.render(instances, environment);
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/MultipleRenderTargetTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/MultipleRenderTargetTest.java
@@ -343,7 +343,7 @@ public class MultipleRenderTargetTest extends GdxTest {
 		float vx;
 		float vz;
 
-		public void update (float deltaTime) {
+		public void update (final float deltaTime) {
 			vy += -30f * deltaTime;
 
 			position.y += vy * deltaTime;

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/MultipleRenderTargetTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/MultipleRenderTargetTest.java
@@ -206,13 +206,13 @@ public class MultipleRenderTargetTest extends GdxTest {
 	float track;
 
 	@Override
-	public void render () {
-		track += Gdx.graphics.getDeltaTime();
+	public void render (final float delta) {
+		track += delta;
 
 		Gdx.gl.glClearColor(0f, 0f, 0f, 1f);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
 
-		cameraController.update(Gdx.graphics.getDeltaTime());
+		cameraController.update(delta);
 
 		renderContext.begin();
 
@@ -226,7 +226,7 @@ public class MultipleRenderTargetTest extends GdxTest {
 		modelCache.add(cannon);
 		modelCache.add(floorInstance);
 		for (Light light : lights) {
-			light.update(Gdx.graphics.getDeltaTime());
+			light.update(delta);
 			modelCache.add(light.lightInstance);
 		}
 		modelCache.end();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/ParticleControllerInfluencerSingleTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/ParticleControllerInfluencerSingleTest.java
@@ -152,10 +152,14 @@ public class ParticleControllerInfluencerSingleTest extends BaseG3dTest {
 	}
 
 	@Override
-	protected void render (ModelBatch batch, Array<ModelInstance> instances) {
+	public void update(float delta) {
+		super.update(delta);
+	}
+
+	@Override
+	protected void render (final float delta, ModelBatch batch, Array<ModelInstance> instances) {
 		if (emitters.size > 0) {
 			// Update
-			float delta = Gdx.graphics.getDeltaTime();
 			builder.delete(0, builder.length());
 			builder.append(Gdx.graphics.getFramesPerSecond());
 			fpsLabel.setText(builder);
@@ -170,6 +174,6 @@ public class ParticleControllerInfluencerSingleTest extends BaseG3dTest {
 			batch.render(billboardParticleBatch, environment);
 		}
 		batch.render(instances, environment);
-		ui.draw();
+		ui.draw(delta);
 	}
 }

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/ParticleControllerInfluencerSingleTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/ParticleControllerInfluencerSingleTest.java
@@ -152,7 +152,7 @@ public class ParticleControllerInfluencerSingleTest extends BaseG3dTest {
 	}
 
 	@Override
-	public void update(float delta) {
+	public void update(final float delta) {
 		super.update(delta);
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/ParticleControllerTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/ParticleControllerTest.java
@@ -62,7 +62,7 @@ public class ParticleControllerTest extends BaseG3dTest{
 		}
 
 		@Override
-		public boolean act (float delta) {
+		public boolean act (final float delta) {
 			emitter.getTransform(tmpMatrix);
 			tmpQuaternion.set(axis, angle*delta).toMatrix(tmpMatrix4.val);
 			tmpMatrix4.mul(tmpMatrix);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/ParticleControllerTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/ParticleControllerTest.java
@@ -198,10 +198,9 @@ public class ParticleControllerTest extends BaseG3dTest{
 	}
 
 	@Override
-	protected void render (ModelBatch batch, Array<ModelInstance> instances) {
+	protected void render (final float delta, ModelBatch batch, Array<ModelInstance> instances) {
 		if(emitters.size > 0){
 			//Update
-			float delta = Gdx.graphics.getDeltaTime();
 			builder.delete(0, builder.length());
 			builder.append(Gdx.graphics.getFramesPerSecond());
 			fpsLabel.setText(builder);
@@ -216,6 +215,6 @@ public class ParticleControllerTest extends BaseG3dTest{
 			batch.render(billboardParticleBatch, environment);
 		}
 		batch.render(instances, environment);
-		ui.draw();
+		ui.draw(delta);
 	}
 }

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/PolarAccelerationTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/PolarAccelerationTest.java
@@ -134,10 +134,9 @@ public class PolarAccelerationTest extends BaseG3dTest {
 	}
 
 	@Override
-	protected void render (ModelBatch batch, Array<ModelInstance> instances) {
+	protected void render (final float delta, ModelBatch batch, Array<ModelInstance> instances) {
 		if (emitters.size > 0) {
 			// Update
-			float delta = Gdx.graphics.getDeltaTime();
 			builder.delete(0, builder.length());
 			builder.append(Gdx.graphics.getFramesPerSecond());
 			fpsLabel.setText(builder);
@@ -152,6 +151,6 @@ public class PolarAccelerationTest extends BaseG3dTest {
 			batch.render(billboardParticleBatch, environment);
 		}
 		batch.render(instances, environment);
-		ui.draw();
+		ui.draw(delta);
 	}
 }

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/ShaderCollectionTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/ShaderCollectionTest.java
@@ -215,16 +215,16 @@ public class ShaderCollectionTest extends BaseG3dHudTest {
 	private final BoundingBox bounds = new BoundingBox();
 
 	@Override
-	protected void render (ModelBatch batch, Array<ModelInstance> instances) {
+	protected void render (final float delta, ModelBatch batch, Array<ModelInstance> instances) {
 	}
 
 	final Vector3 dirLightRotAxis = new Vector3(-1, -1, -1).nor();
 
 	@Override
-	public void render (Array<ModelInstance> instances) {
+	public void render (final float delta, Array<ModelInstance> instances) {
 		dirLight.direction.rotate(dirLightRotAxis, Gdx.graphics.getDeltaTime() * 45f);
 
-		super.render(null);
+		super.render(delta, null);
 		for (ObjectMap.Entry<ModelInstance, AnimationController> e : animationControllers.entries())
 			e.value.update(Gdx.graphics.getDeltaTime());
 		shaderBatch.begin(cam);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/ShaderTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/ShaderTest.java
@@ -245,12 +245,12 @@ public class ShaderTest extends GdxTest {
 	private float counter;
 
 	@Override
-	public void render () {
-		counter = (counter + Gdx.graphics.getDeltaTime()) % 2.f;
+	public void render (final float delta) {
+		counter = (counter + delta) % 2.f;
 		testAttribute1.value = Math.abs(1f - counter);
 		testAttribute2.value = 1f - testAttribute1.value;
 
-		camController.update();
+		camController.update(delta);
 
 		Gdx.gl.glViewport(0, 0, Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight());
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/ShadowMappingTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/ShadowMappingTest.java
@@ -79,8 +79,8 @@ public class ShadowMappingTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
-		camController.update();
+	public void render (final float delta) {
+		camController.update(delta);
 
 		Gdx.gl.glViewport(0, 0, Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight());
 		Gdx.gl.glClearColor(0, 0, 0, 1);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/SkeletonTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/SkeletonTest.java
@@ -60,9 +60,9 @@ public class SkeletonTest extends BaseG3dHudTest {
 	private final static Quaternion tmpQ = new Quaternion();
 
 	@Override
-	protected void render (ModelBatch batch, Array<ModelInstance> instances) {
+	protected void render (final float delta, ModelBatch batch, Array<ModelInstance> instances) {
 		for (ObjectMap.Entry<ModelInstance, AnimationController> e : animationControllers.entries())
-			e.value.update(Gdx.graphics.getDeltaTime());
+			e.value.update(delta);
 		for (final ModelInstance instance : instances)
 			renderSkeleton(instance);
 		batch.render(instances);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/TangentialAccelerationTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/TangentialAccelerationTest.java
@@ -134,7 +134,7 @@ public class TangentialAccelerationTest extends BaseG3dTest {
 	}
 
 	@Override
-	public void update(float delta) {
+	public void update(final float delta) {
 		if (emitters.size > 0) {
 			ui.act(delta);
 		}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/TangentialAccelerationTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/TangentialAccelerationTest.java
@@ -134,14 +134,18 @@ public class TangentialAccelerationTest extends BaseG3dTest {
 	}
 
 	@Override
-	protected void render (ModelBatch batch, Array<ModelInstance> instances) {
+	public void update(float delta) {
 		if (emitters.size > 0) {
-			// Update
-			float delta = Gdx.graphics.getDeltaTime();
+			ui.act(delta);
+		}
+	}
+
+	@Override
+	protected void render (final float delta, ModelBatch batch, Array<ModelInstance> instances) {
+		if (emitters.size > 0) {
 			builder.delete(0, builder.length());
 			builder.append(Gdx.graphics.getFramesPerSecond());
 			fpsLabel.setText(builder);
-			ui.act(delta);
 
 			billboardParticleBatch.begin();
 			for (ParticleController controller : emitters) {
@@ -152,6 +156,6 @@ public class TangentialAccelerationTest extends BaseG3dTest {
 			batch.render(billboardParticleBatch, environment);
 		}
 		batch.render(instances, environment);
-		ui.draw();
+		ui.draw(delta);
 	}
 }

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/TextureArrayTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/TextureArrayTest.java
@@ -108,7 +108,7 @@ public class TextureArrayTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
 		Gdx.gl.glEnable(GL20.GL_DEPTH_TEST);
 		Gdx.gl.glDepthFunc(GL20.GL_LEQUAL);
@@ -116,7 +116,7 @@ public class TextureArrayTest extends GdxTest {
 
 		modelView.translate(10f, 0, 10f).rotate(0, 1f, 0, 2f * Gdx.graphics.getDeltaTime()).translate(-10f, 0, -10f);
 
-		cameraController.update();
+		cameraController.update(delta);
 
 		textureArray.bind();
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/TextureRegion3DTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/TextureRegion3DTest.java
@@ -69,9 +69,9 @@ public class TextureRegion3DTest extends GdxTest {
 	}
 	
 	@Override
-	public void render () {
-		inputController.update();
-		if ((time += Gdx.graphics.getDeltaTime()) >= 1f) {
+	public void render (final float delta) {
+		inputController.update(delta);
+		if ((time += delta) >= 1f) {
 			time -= 1f;
 			index = (index + 1) % regions.size;
 			attribute.set(regions.get(index));

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/shadows/system/BaseShadowSystem.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/shadows/system/BaseShadowSystem.java
@@ -233,7 +233,7 @@ public abstract class BaseShadowSystem implements ShadowSystem, Disposable {
 	}
 
 	@Override
-	public void update () {
+	public void update (final float delta) {
 		for (ObjectMap.Entry<SpotLight, LightProperties> e : spotCameras) {
 			e.value.camera.position.set(e.key.position);
 			e.value.camera.direction.set(e.key.direction);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/shadows/system/ShadowSystem.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/shadows/system/ShadowSystem.java
@@ -133,7 +133,7 @@ public interface ShadowSystem {
 	public boolean hasLight (PointLight point);
 
 	/** Update shadowSystem */
-	public void update ();
+	public void update (final float delta);
 
 	/** Begin shadow system with main camera and renderable providers.
 	 * @param camera

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/voxel/VoxelTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/voxel/VoxelTest.java
@@ -70,13 +70,13 @@ public class VoxelTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClearColor(0.4f, 0.4f, 0.4f, 1f);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
 		modelBatch.begin(camera);
 		modelBatch.render(voxelWorld, lights);
 		modelBatch.end();
-		controller.update();
+		controller.update(delta);
 
 		spriteBatch.begin();
 		font.draw(spriteBatch, "fps: " + Gdx.graphics.getFramesPerSecond() + ", #visible chunks: " + voxelWorld.renderedChunks

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gles2/HelloTriangle.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gles2/HelloTriangle.java
@@ -43,7 +43,7 @@ public class HelloTriangle extends GdxTest {
 	}
 
 	@Override
-	public void render (float delta) {
+	public void render (final float delta) {
 		Gdx.gl20.glViewport(0, 0, Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight());
 		Gdx.gl20.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		shader.begin();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gles2/HelloTriangle.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gles2/HelloTriangle.java
@@ -43,7 +43,7 @@ public class HelloTriangle extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (float delta) {
 		Gdx.gl20.glViewport(0, 0, Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight());
 		Gdx.gl20.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		shader.begin();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gles2/SimpleVertexShader.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gles2/SimpleVertexShader.java
@@ -61,7 +61,7 @@ public class SimpleVertexShader extends GdxTest {
 	}
 
 	@Override
-	public void render (float delta) {
+	public void render (final float delta) {
 		angle += delta * 40.0f;
 		float aspect = Gdx.graphics.getWidth() / (float)Gdx.graphics.getHeight();
 		projection.setToProjection(1.0f, 20.0f, 60.0f, aspect);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gles2/SimpleVertexShader.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gles2/SimpleVertexShader.java
@@ -61,8 +61,8 @@ public class SimpleVertexShader extends GdxTest {
 	}
 
 	@Override
-	public void render () {
-		angle += Gdx.graphics.getDeltaTime() * 40.0f;
+	public void render (float delta) {
+		angle += delta * 40.0f;
 		float aspect = Gdx.graphics.getWidth() / (float)Gdx.graphics.getHeight();
 		projection.setToProjection(1.0f, 20.0f, 60.0f, aspect);
 		view.idt().trn(0, 0, -2.0f);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gles3/InstancedRenderingTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gles3/InstancedRenderingTest.java
@@ -80,7 +80,7 @@ public class InstancedRenderingTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClearColor(0.2f, 0.2f, 0.2f, 1f);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtBinaryTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtBinaryTest.java
@@ -42,7 +42,7 @@ public class GwtBinaryTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClearColor(1, 0, 0, 1);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 	}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtInputTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtInputTest.java
@@ -42,7 +42,7 @@ public class GwtInputTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClearColor(0, 0, 0, 1);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		renderer.begin(ShapeType.Filled);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtTest.java
@@ -91,7 +91,7 @@ public class GwtTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClearColor(0.2f, 0.2f, 0.2f, 1);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		texture.bind(0);
@@ -103,12 +103,12 @@ public class GwtTest extends GdxTest {
 
 		batch.begin();
 		batch.draw(atlas.findRegion("font"), 0, 100);
-		sprite.rotate(Gdx.graphics.getDeltaTime() * 45);
+		sprite.rotate(delta * 45);
 		for (Vector2 position : positions) {
 			sprite.setPosition(position.x, position.y);
 			sprite.draw(batch);
 		}
-		font.draw(batch, "fps:" + Gdx.graphics.getFramesPerSecond() + ", delta: " + Gdx.graphics.getDeltaTime() + ", #sprites: "
+		font.draw(batch, "fps:" + Gdx.graphics.getFramesPerSecond() + ", delta: " + delta + ", #sprites: "
 			+ numSprites, 0, 30);
 		cache.setPosition(200, 200);
 		cache.draw(batch);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtTestWrapper.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtTestWrapper.java
@@ -196,13 +196,14 @@ public class GwtTestWrapper extends GdxTest {
 		Gdx.app.log("GdxTestGwt", "Test picker UI setup complete.");
 	}
 
-	public void render () {
+	@Override
+	public void render (final float delta) {
 		if (test == null) {
 			Gdx.gl.glViewport(0, 0, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
 			Gdx.gl.glClearColor(0, 0, 0, 0);
 			Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-			ui.act(Gdx.graphics.getDeltaTime());
-			ui.draw();
+			ui.act(delta);
+			ui.draw(delta);
 		} else {
 			if (dispose) {
 				test.pause();
@@ -215,7 +216,7 @@ public class GwtTestWrapper extends GdxTest {
 				wrapper.lastProcessor = null;
 				dispose = false;
 			} else {
-				test.render();
+				test.render(delta);
 			}
 		}
 	}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtWindowModeTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtWindowModeTest.java
@@ -61,7 +61,7 @@ public class GwtWindowModeTest extends GdxTest {
 	}
 
 	@Override
-	public void update(float delta) {
+	public void update(final float delta) {
 		stage.act(delta);
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtWindowModeTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtWindowModeTest.java
@@ -60,10 +60,15 @@ public class GwtWindowModeTest extends GdxTest {
 		});
 	}
 
-	public void render () {
+	@Override
+	public void update(float delta) {
+		stage.act(delta);
+	}
+
+	@Override
+	public void render (final float delta) {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-		stage.act(Gdx.graphics.getDeltaTime());
-		stage.draw();
+		stage.draw(delta);
 	}
 
 	public void resize (int width, int height) {

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/net/NetAPITest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/net/NetAPITest.java
@@ -261,7 +261,12 @@ public class NetAPITest extends GdxTest implements HttpResponseListener {
 	}
 
 	@Override
-	public void render () {
+	public void update(float delta) {
+		stage.act(delta);
+	}
+
+	@Override
+	public void render (final float delta) {
 		Gdx.gl.glClearColor(0.2f, 0.2f, 0.2f, 1);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 
@@ -274,9 +279,7 @@ public class NetAPITest extends GdxTest implements HttpResponseListener {
 			font.draw(batch, text, 10, Gdx.graphics.getHeight() - 10);
 			batch.end();
 		}
-
-		stage.act(Gdx.graphics.getDeltaTime());
-		stage.draw();
+		stage.draw(delta);
 	}
 
 	@Override

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/net/NetAPITest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/net/NetAPITest.java
@@ -261,7 +261,7 @@ public class NetAPITest extends GdxTest implements HttpResponseListener {
 	}
 
 	@Override
-	public void update(float delta) {
+	public void update(final float delta) {
 		stage.act(delta);
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/superkoalio/SuperKoalio.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/superkoalio/SuperKoalio.java
@@ -119,40 +119,13 @@ public class SuperKoalio extends GdxTest {
 	}
 
 	@Override
-	public void render () {
-		// clear the screen
-		Gdx.gl.glClearColor(0.7f, 0.7f, 1.0f, 1);
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+	public void update(float delta) {
+		if (delta == 0) return;
 
-		// get the delta time
-		float deltaTime = Gdx.graphics.getDeltaTime();
+		if (delta > 0.1f)
+			delta = 0.1f;
 
-		// update the koala (process input, collision detection, position update)
-		updateKoala(deltaTime);
-
-		// let the camera follow the koala, x-axis only
-		camera.position.x = koala.position.x;
-		camera.update();
-
-		// set the TiledMapRenderer view based on what the
-		// camera sees, and render the map
-		renderer.setView(camera);
-		renderer.render();
-
-		// render the koala
-		renderKoala(deltaTime);
-
-		// render debug rectangles
-		if (debug) renderDebug();
-	}
-
-	private void updateKoala (float deltaTime) {
-		if (deltaTime == 0) return;
-
-		if (deltaTime > 0.1f)
-			deltaTime = 0.1f;
-
-		koala.stateTime += deltaTime;
+		koala.stateTime += delta;
 
 		// check input and apply to velocity & state
 		if ((Gdx.input.isKeyPressed(Keys.SPACE) || isTouched(0.5f, 1)) && koala.grounded) {
@@ -191,7 +164,7 @@ public class SuperKoalio extends GdxTest {
 
 		// multiply by delta time so we know how far we go
 		// in this frame
-		koala.velocity.scl(deltaTime);
+		koala.velocity.scl(delta);
 
 		// perform collision detection & response, on each axis, separately
 		// if the koala is moving right, check the tiles to the right of it's
@@ -251,11 +224,56 @@ public class SuperKoalio extends GdxTest {
 		// unscale the velocity by the inverse delta time and set
 		// the latest position
 		koala.position.add(koala.velocity);
-		koala.velocity.scl(1 / deltaTime);
+		koala.velocity.scl(1 / delta);
 
 		// Apply damping to the velocity on the x-axis so we don't
 		// walk infinitely once a key was pressed
 		koala.velocity.x *= Koala.DAMPING;
+	}
+
+	@Override
+	public void render(float delta) {
+		// clear the screen
+		Gdx.gl.glClearColor(0.7f, 0.7f, 1.0f, 1);
+		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+
+		// let the camera follow the koala, x-axis only
+		camera.position.x = koala.position.x;
+		camera.update();
+
+		// set the TiledMapRenderer view based on what the
+		// camera sees, and render the map
+		renderer.setView(camera);
+		renderer.render();
+
+		// based on the koala state, get the animation frame
+		TextureRegion frame = null;
+		switch (koala.state) {
+			case Standing:
+				frame = stand.getKeyFrame(koala.stateTime);
+				break;
+			case Walking:
+				frame = walk.getKeyFrame(koala.stateTime);
+				break;
+			case Jumping:
+				frame = jump.getKeyFrame(koala.stateTime);
+				break;
+		}
+
+		// draw the koala, depending on the current velocity
+		// on the x-axis, draw the koala facing either right
+		// or left
+		Batch batch = renderer.getBatch();
+		batch.begin();
+		if (koala.facesRight) {
+			batch.draw(frame, koala.position.x, koala.position.y, Koala.WIDTH, Koala.HEIGHT);
+		} else {
+			batch.draw(frame, koala.position.x + Koala.WIDTH, koala.position.y, -Koala.WIDTH, Koala.HEIGHT);
+		}
+		batch.end();
+
+		// render debug rectangles
+		if (debug) renderDebug();
 	}
 
 	private boolean isTouched (float startX, float endX) {
@@ -284,34 +302,6 @@ public class SuperKoalio extends GdxTest {
 				}
 			}
 		}
-	}
-
-	private void renderKoala (float deltaTime) {
-		// based on the koala state, get the animation frame
-		TextureRegion frame = null;
-		switch (koala.state) {
-		case Standing:
-			frame = stand.getKeyFrame(koala.stateTime);
-			break;
-		case Walking:
-			frame = walk.getKeyFrame(koala.stateTime);
-			break;
-		case Jumping:
-			frame = jump.getKeyFrame(koala.stateTime);
-			break;
-		}
-
-		// draw the koala, depending on the current velocity
-		// on the x-axis, draw the koala facing either right
-		// or left
-		Batch batch = renderer.getBatch();
-		batch.begin();
-		if (koala.facesRight) {
-			batch.draw(frame, koala.position.x, koala.position.y, Koala.WIDTH, Koala.HEIGHT);
-		} else {
-			batch.draw(frame, koala.position.x + Koala.WIDTH, koala.position.y, -Koala.WIDTH, Koala.HEIGHT);
-		}
-		batch.end();
 	}
 
 	private void renderDebug () {

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/superkoalio/SuperKoalio.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/superkoalio/SuperKoalio.java
@@ -119,11 +119,8 @@ public class SuperKoalio extends GdxTest {
 	}
 
 	@Override
-	public void update(float delta) {
+	public void update(final float delta) {
 		if (delta == 0) return;
-
-		if (delta > 0.1f)
-			delta = 0.1f;
 
 		koala.stateTime += delta;
 
@@ -232,7 +229,7 @@ public class SuperKoalio extends GdxTest {
 	}
 
 	@Override
-	public void render(float delta) {
+	public void render(final float delta) {
 		// clear the screen
 		Gdx.gl.glClearColor(0.7f, 0.7f, 1.0f, 1);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTest.java
@@ -38,10 +38,10 @@ public abstract class GdxTest extends InputAdapter implements ApplicationListene
 	public void resume () {
 	}
 
-	public void update (float delta) {
+	public void update (final float delta) {
 	}
 
-	public void render (float delta) {
+	public void render (final float delta) {
 	}
 
 	public void resize (int width, int height) {

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTest.java
@@ -38,7 +38,10 @@ public abstract class GdxTest extends InputAdapter implements ApplicationListene
 	public void resume () {
 	}
 
-	public void render () {
+	public void update (float delta) {
+	}
+
+	public void render (float delta) {
 	}
 
 	public void resize (int width, int height) {

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/IssueTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/IssueTest.java
@@ -24,7 +24,7 @@ public class IssueTest extends GdxTest {
 	}
 
 	@Override
-	public void render () {
+	public void render (final float delta) {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		batch.begin();
 		batch.draw(img, 0, 0);


### PR DESCRIPTION
..., added `final float delta` to loops

While implementing Libgdx I wondered why there isn't an update loop to keep code spitted in client server applications.

The Major reason I want to announce this is that Headless-Applications need a spitted cycle, one that is updating the game and the other one that is rendering the game on client side.

I added the `final float delta` parameter, because it's needed in most cycle implementations.

update -> updating world positions, etc.
render -> draw them

Pro:
- call of `Gdx.graphics.getDeltaTime()` in different places of the Application is not needed anymore.
- makes it possible to modify the delta for sub calls.
- allows Headless-Applications only use the update()-cycle
- performance increase for headless apps (ensures that no rendering calcs are done)
- splits update code from rendering code.
- reduces redundancy in implementations for Client and Server.

Con:
- old apps upgrading to new gdx version need to implement the new loop, more or less changes needed, depending on implementation.

What do you think about that change?

Some minor Code changes will follow entirely marking all values as final.