### PR TITLE
WIP: Loops the 2nd, this won't break any Changes

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphics.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphics.java
@@ -475,6 +475,8 @@ public class AndroidGraphics implements Graphics, Renderer {
 			}
 			app.getInput().processEvents();
 			frameId++;
+			app.getApplicationListener().update(Gdx.graphics.getDeltaTime());
+			app.getApplicationListener().render(Gdx.graphics.getDeltaTime());
 			app.getApplicationListener().render();
 		}
 

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphicsLiveWallpaper.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphicsLiveWallpaper.java
@@ -214,6 +214,8 @@ public final class AndroidGraphicsLiveWallpaper extends AndroidGraphics {
 
 			app.getInput().processEvents();
 			frameId++;
+			app.getApplicationListener().update(Gdx.graphics.getDeltaTime());
+			app.getApplicationListener().render(Gdx.graphics.getDeltaTime());
 			app.getApplicationListener().render();
 		}
 

--- a/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/HeadlessApplication.java
+++ b/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/HeadlessApplication.java
@@ -126,6 +126,7 @@ public class HeadlessApplication implements Application {
 				
 				executeRunnables();
 				graphics.incrementFrameId();
+				listener.update(Gdx.graphics.getDeltaTime());
 				listener.render();
 				graphics.updateTime();
 	

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglAWTCanvas.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglAWTCanvas.java
@@ -276,6 +276,8 @@ public class LwjglAWTCanvas implements Application {
 		if (shouldRender) {
 			graphics.updateTime();
 			graphics.frameId++;
+			listener.update(Gdx.graphics.getDeltaTime());
+			listener.render(Gdx.graphics.getDeltaTime());
 			listener.render();
 			canvas.swapBuffers();
 		}

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglApplication.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglApplication.java
@@ -230,6 +230,8 @@ public class LwjglApplication implements Application {
 			if (shouldRender) {
 				graphics.updateTime();
 				graphics.frameId++;
+				listener.update(Gdx.graphics.getDeltaTime());
+				listener.render(Gdx.graphics.getDeltaTime());
 				listener.render();
 				Display.update(false);
 			} else {

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglCanvas.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglCanvas.java
@@ -262,6 +262,8 @@ public class LwjglCanvas implements Application {
 					if (shouldRender) {
 						graphics.updateTime();
 						graphics.frameId++;
+						listener.update(Gdx.graphics.getDeltaTime());
+						listener.render(Gdx.graphics.getDeltaTime());
 						listener.render();
 						Display.update(false);
 					}

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Graphics.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Graphics.java
@@ -69,6 +69,8 @@ public class Lwjgl3Graphics implements Graphics, Disposable {
 			window.makeCurrent();
 			gl20.glViewport(0, 0, width, height);
 			window.getListener().resize(getWidth(), getHeight());
+			window.getListener().update(getDeltaTime());
+			window.getListener().render(getDeltaTime());
 			window.getListener().render();
 			GLFW.glfwSwapBuffers(windowHandle);
 		}

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Window.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Window.java
@@ -396,6 +396,8 @@ public class Lwjgl3Window implements Disposable {
 		
 		if (shouldRender) {
 			graphics.update();
+			listener.update(graphics.getDeltaTime());
+			listener.render(graphics.getDeltaTime());
 			listener.render();
 			GLFW.glfwSwapBuffers(windowHandle);
 		}

--- a/backends/gdx-backend-moe/src/com/badlogic/gdx/backends/iosmoe/IOSGraphics.java
+++ b/backends/gdx-backend-moe/src/com/badlogic/gdx/backends/iosmoe/IOSGraphics.java
@@ -259,6 +259,8 @@ public class IOSGraphics extends NSObject implements Graphics, GLKViewDelegate, 
 
 		input.processEvents();
 		frameId++;
+		app.listener.update(getDeltaTime());
+		app.listener.render(getDeltaTime());
 		app.listener.render();
 	}
 

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
@@ -358,6 +358,8 @@ public class IOSGraphics extends NSObject implements Graphics, GLKViewDelegate, 
 
 		input.processEvents();
 		frameId++;
+		app.listener.update(getDeltaTime());
+		app.listener.render(getDeltaTime());
 		app.listener.render();
 	}
 

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplication.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplication.java
@@ -258,6 +258,8 @@ public abstract class GwtApplication implements EntryPoint, Application {
 		}
 		runnablesHelper.clear();
 		graphics.frameId++;
+		listener.update(graphics.getDeltaTime());
+		listener.render(graphics.getDeltaTime());
 		listener.render();
 		input.reset();
 	}

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tiledmappacker/TiledMapPacker.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tiledmappacker/TiledMapPacker.java
@@ -496,6 +496,14 @@ public class TiledMapPacker {
 			}
 
 			@Override
+			public void update(float delta) {
+			}
+
+			@Override
+			public void render(float delta) {
+			}
+
+			@Override
 			public void render () {
 			}
 

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/FlameMain.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/FlameMain.java
@@ -750,13 +750,21 @@ public class FlameMain extends JFrame implements AssetErrorListener {
 			ui.getViewport().update(width, height, true);
 		}
 
+		@Override
+		public void update(float delta) {
+		}
+
+		@Override
+		public void render(float delta) {
+		}
+
 		public void render () {
 			float delta = Math.max(0, Gdx.graphics.getDeltaTime() * deltaMultiplier.getValue());
-			update(delta);
+			updating(delta);
 			renderWorld();
 		}
 
-		private void update (float delta) {
+		private void updating(float delta) {
 			worldCamera.fieldOfView = fovValue.getValue();
 			worldCamera.update();
 			cameraInputController.update();

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/ParticleEditor.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/ParticleEditor.java
@@ -418,6 +418,14 @@ public class ParticleEditor extends JFrame {
 			shapeRenderer.end();
 		}
 
+		@Override
+		public void update(float delta) {
+		}
+
+		@Override
+		public void render(float delta) {
+		}
+
 		public void render () {
 			int viewWidth = Gdx.graphics.getWidth();
 			int viewHeight = Gdx.graphics.getHeight();

--- a/gdx/src/com/badlogic/gdx/ApplicationAdapter.java
+++ b/gdx/src/com/badlogic/gdx/ApplicationAdapter.java
@@ -28,6 +28,14 @@ public abstract class ApplicationAdapter implements ApplicationListener {
 	}
 
 	@Override
+	public void update(float delta) {
+	}
+
+	@Override
+	public void render(float delta) {
+	}
+
+	@Override
 	public void render () {
 	}
 

--- a/gdx/src/com/badlogic/gdx/ApplicationListener.java
+++ b/gdx/src/com/badlogic/gdx/ApplicationListener.java
@@ -48,6 +48,7 @@ public interface ApplicationListener {
 	 * </ul>
 	 * The {@link ApplicationListener#update(float)} is used for updating purposes.
 	 * Especially the {@link HeadlessApplication} requires this loop to update game objects.
+	 * Should be used to update server and client objects only.
 	 * @param delta The time in seconds since the last update. */
 	public void update(float delta);
 
@@ -58,7 +59,7 @@ public interface ApplicationListener {
 	 * <li>{@link ApplicationListener#render(float)}</li>
 	 * <li>{@link ApplicationListener#render()}</li>
 	 * </ul>
-	 * The {@link ApplicationListener#render(float)} is used for all drawing purposes.
+	 * The {@link ApplicationListener#render(float)} should be used for all drawing purposes and ui updates.
 	 * It is not used by {@link HeadlessApplication}!
 	 * @param delta The time in seconds since the last render.
 	 */

--- a/gdx/src/com/badlogic/gdx/ApplicationListener.java
+++ b/gdx/src/com/badlogic/gdx/ApplicationListener.java
@@ -70,7 +70,7 @@ public interface ApplicationListener {
 	 * <ul>
  	 * <li>{@link ApplicationListener#update(float)}</li>
 	 * <li>{@link ApplicationListener#render(float)}</li>
-     * <li>{@link ApplicationListener#render()}</li>
+	 * <li>{@link ApplicationListener#render()}</li>
 	 * </ul>
 	 * @deprecated use the {@link ApplicationListener#update(float)} and {@link ApplicationListener#render(float)}
 	 * in newer implementations of you application instead of {@link ApplicationListener#render()}.

--- a/gdx/src/com/badlogic/gdx/ApplicationListener.java
+++ b/gdx/src/com/badlogic/gdx/ApplicationListener.java
@@ -39,7 +39,24 @@ public interface ApplicationListener {
 	 * @param height the new height in pixels */
 	public void resize (int width, int height);
 
-	/** Called when the {@link Application} should render itself. */
+	/** Called when the {@link Application} should update itself.
+	 * The {@link ApplicationListener#update(float)} is used for updating purposes.
+	 * Especially the {@link HeadlessApplication} requires this loop to update game objects.
+	 * @param delta The time in seconds since the last render. */
+	public void update(float delta);
+
+	/** Called when the {@link Application} should render itself.
+	 * The {@link ApplicationListener#render(float)} is used for all drawing purposes.
+	 * It is not used by {@link HeadlessApplication}.
+	 * @param delta The time in seconds since the last render.
+	 */
+	public void render(float delta);
+
+	/** Called when the {@link Application} should render itself.
+	 * @deprecated use the {@link ApplicationListener#update(float)} and {@link ApplicationListener#render(float)}
+	 * in newer implementations of you application instead of {@link ApplicationListener#render()}.
+	 **/
+	@Deprecated
 	public void render ();
 
 	/** Called when the {@link Application} is paused, usually when it's not active or visible on-screen. An Application is also

--- a/gdx/src/com/badlogic/gdx/ApplicationListener.java
+++ b/gdx/src/com/badlogic/gdx/ApplicationListener.java
@@ -40,19 +40,37 @@ public interface ApplicationListener {
 	public void resize (int width, int height);
 
 	/** Called when the {@link Application} should update itself.
+	 * The order of calling loop-methods is:
+	 * <ul>
+	 * <li>{@link ApplicationListener#update(float)}</li>
+	 * <li>{@link ApplicationListener#render(float)}</li>
+	 * <li>{@link ApplicationListener#render()}</li>
+	 * </ul>
 	 * The {@link ApplicationListener#update(float)} is used for updating purposes.
 	 * Especially the {@link HeadlessApplication} requires this loop to update game objects.
-	 * @param delta The time in seconds since the last render. */
+	 * @param delta The time in seconds since the last update. */
 	public void update(float delta);
 
 	/** Called when the {@link Application} should render itself.
+	 * The order of calling loop-methods is:
+	 * <ul>
+	 * <li>{@link ApplicationListener#update(float)}</li>
+	 * <li>{@link ApplicationListener#render(float)}</li>
+	 * <li>{@link ApplicationListener#render()}</li>
+	 * </ul>
 	 * The {@link ApplicationListener#render(float)} is used for all drawing purposes.
-	 * It is not used by {@link HeadlessApplication}.
+	 * It is not used by {@link HeadlessApplication}!
 	 * @param delta The time in seconds since the last render.
 	 */
 	public void render(float delta);
 
 	/** Called when the {@link Application} should render itself.
+	 * The order of calling loop-methods is:
+	 * <ul>
+ 	 * <li>{@link ApplicationListener#update(float)}</li>
+	 * <li>{@link ApplicationListener#render(float)}</li>
+     * <li>{@link ApplicationListener#render()}</li>
+	 * </ul>
 	 * @deprecated use the {@link ApplicationListener#update(float)} and {@link ApplicationListener#render(float)}
 	 * in newer implementations of you application instead of {@link ApplicationListener#render()}.
 	 **/

--- a/gdx/src/com/badlogic/gdx/Screen.java
+++ b/gdx/src/com/badlogic/gdx/Screen.java
@@ -29,7 +29,7 @@ public interface Screen {
 	public void show ();
 
 	/** Called when the screen should update itself.
-	 * @param delta The time in seconds since the last render. */
+	 * @param delta The time in seconds since the last update. */
 	public void update(float delta);
 
 	/** Called when the screen should render itself.

--- a/gdx/src/com/badlogic/gdx/Screen.java
+++ b/gdx/src/com/badlogic/gdx/Screen.java
@@ -27,7 +27,11 @@ public interface Screen {
 	
 	/** Called when this screen becomes the current screen for a {@link Game}. */
 	public void show ();
-	
+
+	/** Called when the screen should update itself.
+	 * @param delta The time in seconds since the last render. */
+	public void update(float delta);
+
 	/** Called when the screen should render itself.
 	 * @param delta The time in seconds since the last render. */
 	public void render (float delta);

--- a/gdx/src/com/badlogic/gdx/ScreenAdapter.java
+++ b/gdx/src/com/badlogic/gdx/ScreenAdapter.java
@@ -19,9 +19,6 @@ package com.badlogic.gdx;
 /** Convenience implementation of {@link Screen}. Derive from this and only override what you need.
  * @author semtiko */
 public class ScreenAdapter implements Screen {
-	@Override
-	public void render (float delta) {
-	}
 
 	@Override
 	public void resize (int width, int height) {
@@ -29,6 +26,14 @@ public class ScreenAdapter implements Screen {
 
 	@Override
 	public void show () {
+	}
+
+	@Override
+	public void update(float delta) {
+	}
+
+	@Override
+	public void render (float delta) {
 	}
 
 	@Override

--- a/tests/gdx-tests-android/src/com/badlogic/gdx/tests/android/WindowedTest.java
+++ b/tests/gdx-tests-android/src/com/badlogic/gdx/tests/android/WindowedTest.java
@@ -88,10 +88,17 @@ public class WindowedTest extends AndroidApplication implements ApplicationListe
 	}
 
 	@Override
-	public void render () {
+	public void update(float delta) {
+	}
+
+	@Override
+	public void render(float delta) {
 		Gdx.gl.glClearColor(color.r, color.g, color.g, color.a);
 		Gdx.gl.glClear(GL10.GL_COLOR_BUFFER_BIT);
+	}
 
+	@Override
+	public void render () {
 	}
 
 	@Override

--- a/tests/gdx-tests-lwjgl3/src/com/badlogic/gdx/tests/lwjgl3/MultiWindowCursorTest.java
+++ b/tests/gdx-tests-lwjgl3/src/com/badlogic/gdx/tests/lwjgl3/MultiWindowCursorTest.java
@@ -41,6 +41,14 @@ public class MultiWindowCursorTest {
 		}
 
 		@Override
+		public void update(float delta) {
+		}
+
+		@Override
+		public void render(float delta) {
+		}
+
+		@Override
 		public void render() {
 			listener.render();
 		}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/box2d/Box2DTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/box2d/Box2DTest.java
@@ -79,6 +79,14 @@ public abstract class Box2DTest implements ApplicationListener, InputProcessor {
 	protected Vector2 tmp = new Vector2();
 
 	@Override
+	public void update(float delta) {
+	}
+
+	@Override
+	public void render(float delta) {
+	}
+
+	@Override
 	public void render () {
 		// update the world with a fixed time step
 		long startTime = TimeUtils.nanoTime();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/BulletTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/BulletTest.java
@@ -83,6 +83,14 @@ public class BulletTest implements ApplicationListener, InputProcessor, GestureL
 	}
 
 	@Override
+	public void update(float delta) {
+	}
+
+	@Override
+	public void render(float delta) {
+	}
+
+	@Override
 	public void render () {
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTest.java
@@ -32,21 +32,36 @@ import com.badlogic.gdx.ApplicationListener;
 import com.badlogic.gdx.InputAdapter;
 
 public abstract class GdxTest extends InputAdapter implements ApplicationListener {
+
+	@Override
 	public void create () {
 	}
 
+	@Override
 	public void resume () {
 	}
 
+	@Override
+	public void update(float delta) {
+	}
+
+	@Override
+	public void render(float delta) {
+	}
+
+	@Override
 	public void render () {
 	}
 
+	@Override
 	public void resize (int width, int height) {
 	}
 
+	@Override
 	public void pause () {
 	}
 
+	@Override
 	public void dispose () {
 	}
 }


### PR DESCRIPTION
I know that my old pr #5902  was an overkill. Especially in breaking changes.

- Now it's implemented in that way, that all platforms will keep their current behaving and ensure a better server-client architecture for games need to be run on both sides.
- This reduces the strong difference in implementing the Screen, Game, ApplicationListener classes.
- They are now applicable for the use with HealessApplication and <Other>Application.
- This leads to simpler implementation with synchronous running instances of the game, communication with each other. There is not much afford needed (if implemented as intended) to run the game in Headless-Mode as a Server.

Another discussion would be:
> When adding new loop methods, i could improve this pr to use the update loop multi threaded with additionally an `int threadIndex` param.
> The number of cores would be configurable via Application Configuration. So there is a possibility to use the update-loop for updating game objects multi threaded, for client and server it would be a hard improvement in Object updating and would increase the possibilities of libgdx from ground.

So give it a try.
Regards.

PS: if yes i can put in some extra afford, implementing the multi-threaded variant, before a normal update loop is getting default for most apps (Reason for WIP).

### EDIT
> Depending on early responses, another solution would be the implementation of a second ApplicationListener, Game and Screen, facing multi threading, i'm pretty sure this should also work fine. What do you think about that?
> Then absolutely no Game would be affected in any minor case, due to decorator-pattern.