### PR TITLE
unbind method must call 'disableVertexAttribute'

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/glutils/InstanceBufferObject.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/InstanceBufferObject.java
@@ -255,7 +255,7 @@ public class InstanceBufferObject implements InstanceData {
 				if (location < 0)
 					continue;
 				int unitOffset = +attribute.unit;
-				shader.enableVertexAttribute(location + unitOffset);
+				shader.disableVertexAttribute(location + unitOffset);
 			}
 		}
 		gl.glBindBuffer(GL20.GL_ARRAY_BUFFER, 0);


### PR DESCRIPTION
This is a simple bugfix in class InstaneBufferObject. In method "unbind" the function "disableVertexAttribute" must be called on the ShaderProgram instance instead of "enableVertexAttribute".