### PR TITLE
added isInstanced()-method to indicate whether a mesh uses instancing

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/Mesh.java
+++ b/gdx/src/com/badlogic/gdx/graphics/Mesh.java
@@ -312,6 +312,11 @@ public class Mesh implements Disposable {
 
 		return this;
 	}
+	
+	/** @return Indicates whether this mesh uses instancing. */
+	public boolean isInstanced () {
+		return this.isInstanced;
+	}
 
 	/** Sets the vertices of this Mesh. The attributes are assumed to be given in float format.
 	 *


### PR DESCRIPTION
As already mentioned in a feature request (see below) an isInstanced method in the mesh class would be useful. Currently, it is not possible to determine whether instancing is active for a mesh.

Feature request: #5915