### PR TITLE
fix some camera/viewport project/unproject

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/Camera.java
+++ b/gdx/src/com/badlogic/gdx/graphics/Camera.java
@@ -194,7 +194,7 @@ public abstract class Camera {
 	public Vector3 unproject (Vector3 screenCoords, float viewportX, float viewportY, float viewportWidth, float viewportHeight) {
 		float x = screenCoords.x, y = screenCoords.y;
 		x = x - viewportX;
-		y = Gdx.graphics.getHeight() - y - 1;
+		y = Gdx.graphics.getHeight() - y;
 		y = y - viewportY;
 		screenCoords.x = (2 * x) / viewportWidth - 1;
 		screenCoords.y = (2 * y) / viewportHeight - 1;

--- a/gdx/src/com/badlogic/gdx/utils/viewport/Viewport.java
+++ b/gdx/src/com/badlogic/gdx/utils/viewport/Viewport.java
@@ -117,7 +117,7 @@ public abstract class Viewport {
 	public Vector2 toScreenCoordinates (Vector2 worldCoords, Matrix4 transformMatrix) {
 		tmp.set(worldCoords.x, worldCoords.y, 0);
 		tmp.mul(transformMatrix);
-		camera.project(tmp);
+		camera.project(tmp, screenX, screenY, screenWidth, screenHeight);
 		tmp.y = Gdx.graphics.getHeight() - tmp.y;
 		worldCoords.x = tmp.x;
 		worldCoords.y = tmp.y;

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/CoordinatesTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/CoordinatesTest.java
@@ -1,0 +1,180 @@
+package com.badlogic.gdx.tests;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.Camera;
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.OrthographicCamera;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.Batch;
+import com.badlogic.gdx.graphics.g2d.TextureRegion;
+import com.badlogic.gdx.graphics.glutils.HdpiMode;
+import com.badlogic.gdx.graphics.glutils.HdpiUtils;
+import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
+import com.badlogic.gdx.graphics.glutils.ShapeRenderer.ShapeType;
+import com.badlogic.gdx.math.Vector2;
+import com.badlogic.gdx.math.Vector3;
+import com.badlogic.gdx.scenes.scene2d.Stage;
+import com.badlogic.gdx.scenes.scene2d.ui.Image;
+import com.badlogic.gdx.scenes.scene2d.ui.Label;
+import com.badlogic.gdx.scenes.scene2d.ui.Skin;
+import com.badlogic.gdx.scenes.scene2d.ui.Table;
+import com.badlogic.gdx.scenes.scene2d.utils.TextureRegionDrawable;
+import com.badlogic.gdx.tests.utils.GdxTest;
+import com.badlogic.gdx.utils.viewport.FitViewport;
+import com.badlogic.gdx.utils.viewport.Viewport;
+
+public class CoordinatesTest extends GdxTest {
+	Skin skin;
+	Stage stage;
+	ShapeRenderer shapeRenderer;
+	Viewport stageViewport;
+	Viewport gameViewport;
+	Camera camera;
+	private Image img;
+	
+	private final Vector2 localActorScreen = new Vector2();
+	private Label inScreenLabel;
+	private Label vpScreenLabel;
+	private Label stScreenLabel;
+	private Label acScreenLabel;
+	private Label cmScreenLabel;
+
+	private final Vector2 vec2 = new Vector2();
+	private final Vector3 vec3 = new Vector3();
+
+	@Override
+	public void create () {
+		
+		skin = new Skin(Gdx.files.internal("data/uiskin.json"));
+		TextureRegionDrawable logo = new TextureRegionDrawable(new TextureRegion(new Texture(Gdx.files.internal("data/badlogic.jpg"))));
+		
+		stageViewport = new FitViewport(500, 500);
+		gameViewport = new FitViewport(100, 100);
+		
+		camera = new OrthographicCamera(Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+		
+		stage = new Stage(stageViewport);
+		Gdx.input.setInputProcessor(stage);
+
+		shapeRenderer = new ShapeRenderer();
+		
+		Table root = new Table();
+		root.setFillParent(true);
+		stage.addActor(root);
+		
+		Table metrics = new Table(skin);
+		root.add(metrics).expand().top().left();
+		metrics.defaults().pad(3).expandX().left();
+		
+		img = new Image(logo){
+			@Override
+			public void draw (Batch batch, float parentAlpha) {
+				stage.toScreenCoordinates(localActorScreen.set(getX(), getY()), batch.getTransformMatrix());
+				super.draw(batch, parentAlpha);
+			}
+		};
+		img.setSize(64, 64);
+		stage.addActor(img);
+		
+		inScreenLabel = metrics.add("").getActor();
+		metrics.row();
+		vpScreenLabel = metrics.add("").getActor();
+		metrics.row();
+		cmScreenLabel = metrics.add("").getActor();
+		metrics.row();
+		stScreenLabel = metrics.add("").getActor();
+		metrics.row();
+		acScreenLabel = metrics.add("").getActor();
+		metrics.row();
+	}
+	
+	@Override
+	public void render () {
+		
+		final float screenHeight = Gdx.graphics.getHeight();
+		
+		// display screen coordinates for actor, stage, viewport, and camera
+		int pointerX = Gdx.input.getX();
+		int pointerY = Gdx.input.getY();
+		inScreenLabel.setText("input: " + pointerX + " " + pointerY);
+		
+		gameViewport.unproject(vec2.set(pointerX, pointerY));
+		float vpWorldX = vec2.x;
+		float vpWorldY = vec2.y;
+		
+		gameViewport.project(vec2);
+		float vpScreenX = vec2.x;
+		float vpScreenY = screenHeight - vec2.y;
+		vpScreenLabel.setText("viewport re-project: " + vpScreenX + " " + vpScreenY);
+		
+		camera.unproject(vec3.set(pointerX, pointerY, 0));
+		float cmWorldX = vec3.x;
+		float cmWorldY = vec3.y;
+		float cmWorldZ = vec3.z;
+		
+		camera.project(vec3.set(cmWorldX, cmWorldY, cmWorldZ));
+		float cmScreenX = vec3.x;
+		float cmScreenY = screenHeight - vec3.y;
+		cmScreenLabel.setText("camera re-project: " + cmScreenX + " " + cmScreenY);
+		
+		stage.screenToStageCoordinates(vec2.set(pointerX, pointerY));
+		float stWorldX = vec2.x;
+		float stWorldY = vec2.y;
+		
+		stage.stageToScreenCoordinates(vec2);
+		float stScreenX = vec2.x;
+		float stScreenY = vec2.y;
+		stScreenLabel.setText("stage re-project: " + stScreenX + " " + stScreenY);
+		
+		
+		acScreenLabel.setText("actor real: " + localActorScreen.x + " " + localActorScreen.y);
+		
+		// clear screen with dark color
+		Gdx.gl.glClearColor(0.2f, 0.2f, 0.2f, 1);
+		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		
+		// clear viewport virtual screen with lighter color
+		Gdx.gl.glEnable(GL20.GL_SCISSOR_TEST);
+		Gdx.gl.glScissor(gameViewport.getScreenX(), gameViewport.getScreenY(), gameViewport.getScreenWidth(), gameViewport.getScreenHeight());
+		Gdx.gl.glClearColor(0.5f, 0.5f, 0.5f, 1);
+		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		Gdx.gl.glDisable(GL20.GL_SCISSOR_TEST);
+		
+		// test stage world coordinates
+		img.setPosition(stWorldX, stWorldY);
+		stage.getViewport().apply();
+		stage.act();
+		stage.draw();
+		
+		
+		// test viewport world coordinates
+		gameViewport.apply();
+		shapeRenderer.setProjectionMatrix(gameViewport.getCamera().combined);
+		shapeRenderer.begin(ShapeType.Line);
+		shapeRenderer.setColor(Color.RED);
+		shapeRenderer.rect(vpWorldX, vpWorldY, 10, 10);
+		shapeRenderer.end();
+		
+		// test camera world coordinates
+		HdpiUtils.glViewport(0, 0, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+		shapeRenderer.setProjectionMatrix(camera.combined);
+		shapeRenderer.begin(ShapeType.Line);
+		shapeRenderer.setColor(Color.GREEN);
+		shapeRenderer.rect(cmWorldX, cmWorldY, 10, 10);
+		shapeRenderer.end();
+	}
+
+	@Override
+	public void resize (int width, int height) {
+		stageViewport.update(width, height, true);
+		gameViewport.update(width, height);
+	}
+
+	@Override
+	public void dispose () {
+		stage.dispose();
+		skin.dispose();
+		shapeRenderer.dispose();
+	}
+}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
@@ -120,6 +120,7 @@ public class GdxTests {
 		CollectionsTest.class,
 		ColorTest.class,
 		ContainerTest.class,
+		CoordinatesTest.class,
 		CpuSpriteBatchTest.class,
 		CullTest.class,
 		CursorTest.class,


### PR DESCRIPTION
i was trying to understand #5854 issue, so i write a test.

It took me a while to understand that project is not the inverse of unproject, there are some Y flips required in between. I thought it was a bug but reading javadoc carefully i understood it was intentional.

Anyway, during my tests i noticed and fixed few little bugs : 
* camera#unproject had a 1 pixel error (propbably a mistake)
* viewport#toScreenCoordinates is only used in GroupTest but this test doesn't show the issue since it use a ScreenViewport (virtual screen bounds are the same as real screen bounds). My test illustrate the issue.

My PR doesn't fix #5854 (if there is an issue) but i think the test class i added could be a good base to track it down.