### PR TITLE
[MobiVM] Set default treeShaker setting to conservative

### DIFF
--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/ios/robovm.xml
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/ios/robovm.xml
@@ -5,6 +5,7 @@
   <arch>thumbv7</arch>
   <target>ios</target>
   <iosInfoPList>Info.plist.xml</iosInfoPList>
+  <treeShaker>conservative</treeShaker>
   <resources>
     <resource>
       <directory>../%ASSET_PATH%</directory>


### PR DESCRIPTION
Setting default tree shaker setting to `conservative` is totally safe (confirmed by dkmitsa on Gitter) and saves around 10MB on .app and 2MB on the .ipa file sizes.

A bit of context: Tree shaker was implemented on RoboVM as a mechanism to trim the build sizes for unused branches of code in an early version. For a long time `none` was default but in a late version of RoboVM it was set to `conservative` (see release notes https://www.gamefromscratch.com/post/2015/12/17/RoboVM-112-Released-Adds-Experimental-tvOS-and-iOS-92-Support.aspx).

When MobiVM was forked, the RoboVM version had still not set the default value to `conservative` (which only trims annotated classes/methods) but it should have been set. Until MobiVM changes its default behaviour, libGDX projects can benefit from setting this default.