### PR TITLE
Fix for ObjectMap/LongMap/others when mixing put()/remove()

### DIFF
--- a/gdx/src/com/badlogic/gdx/utils/IntFloatMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/IntFloatMap.java
@@ -16,11 +16,11 @@
 
 package com.badlogic.gdx.utils;
 
-import static com.badlogic.gdx.utils.ObjectSet.*;
-
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+
+import static com.badlogic.gdx.utils.ObjectSet.tableSize;
 
 /** An unordered map where the keys are unboxed ints and values are unboxed floats. No allocation is done except when growing the
  * table size.
@@ -227,10 +227,14 @@ public class IntFloatMap implements Iterable<IntFloatMap.Entry> {
 		float[] valueTable = this.valueTable;
 		float oldValue = valueTable[i];
 		int next = i + 1 & mask;
-		while ((key = keyTable[next]) != 0 && next != place(key)) {
-			keyTable[i] = key;
-			valueTable[i] = valueTable[next];
-			i = next;
+		int placement;
+		while ((key = keyTable[next]) != 0) {
+			placement = place(key);
+			if((next - placement & mask) > (i - placement & mask)) {
+				keyTable[i] = key;
+				valueTable[i] = valueTable[next];
+				i = next;
+			}
 			next = next + 1 & mask;
 		}
 		keyTable[i] = 0;
@@ -522,10 +526,14 @@ public class IntFloatMap implements Iterable<IntFloatMap.Entry> {
 				int[] keyTable = map.keyTable;
 				float[] valueTable = map.valueTable;
 				int mask = map.mask, next = i + 1 & mask, key;
-				while ((key = keyTable[next]) != 0 && next != map.place(key)) {
-					keyTable[i] = key;
-					valueTable[i] = valueTable[next];
-					i = next;
+				int placement;
+				while ((key = keyTable[next]) != 0) {
+					placement = map.place(key);
+					if((next - placement & mask) > (i - placement & mask)) {
+						keyTable[i] = key;
+						valueTable[i] = valueTable[next];
+						i = next;
+					}
 					next = next + 1 & mask;
 				}
 				keyTable[i] = 0;

--- a/gdx/src/com/badlogic/gdx/utils/IntIntMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/IntIntMap.java
@@ -16,11 +16,11 @@
 
 package com.badlogic.gdx.utils;
 
-import static com.badlogic.gdx.utils.ObjectSet.*;
-
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+
+import static com.badlogic.gdx.utils.ObjectSet.tableSize;
 
 /** An unordered map where the keys and values are unboxed ints. No allocation is done except when growing the table size.
  * <p>
@@ -226,10 +226,14 @@ public class IntIntMap implements Iterable<IntIntMap.Entry> {
 		int[] valueTable = this.valueTable;
 		int oldValue = valueTable[i];
 		int next = i + 1 & mask;
-		while ((key = keyTable[next]) != 0 && next != place(key)) {
-			keyTable[i] = key;
-			valueTable[i] = valueTable[next];
-			i = next;
+		int placement;
+		while ((key = keyTable[next]) != 0) {
+			placement = place(key);
+			if((next - placement & mask) > (i - placement & mask)) {
+				keyTable[i] = key;
+				valueTable[i] = valueTable[next];
+				i = next;
+			}
 			next = next + 1 & mask;
 		}
 		keyTable[i] = 0;
@@ -521,10 +525,14 @@ public class IntIntMap implements Iterable<IntIntMap.Entry> {
 				int[] keyTable = map.keyTable;
 				int[] valueTable = map.valueTable;
 				int mask = map.mask, next = i + 1 & mask, key;
-				while ((key = keyTable[next]) != 0 && next != map.place(key)) {
-					keyTable[i] = key;
-					valueTable[i] = valueTable[next];
-					i = next;
+				int placement;
+				while ((key = keyTable[next]) != 0) {
+					placement = map.place(key);
+					if((next - placement & mask) > (i - placement & mask)) {
+						keyTable[i] = key;
+						valueTable[i] = valueTable[next];
+						i = next;
+					}
 					next = next + 1 & mask;
 				}
 				keyTable[i] = 0;

--- a/gdx/src/com/badlogic/gdx/utils/IntMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/IntMap.java
@@ -16,11 +16,11 @@
 
 package com.badlogic.gdx.utils;
 
-import static com.badlogic.gdx.utils.ObjectSet.*;
-
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+
+import static com.badlogic.gdx.utils.ObjectSet.tableSize;
 
 /** An unordered map where the keys are unboxed ints and values are objects. No allocation is done except when growing the table
  * size.
@@ -213,10 +213,14 @@ public class IntMap<V> implements Iterable<IntMap.Entry<V>> {
 		V[] valueTable = this.valueTable;
 		V oldValue = valueTable[i];
 		int next = i + 1 & mask;
-		while ((key = keyTable[next]) != 0 && next != place(key)) {
-			keyTable[i] = key;
-			valueTable[i] = valueTable[next];
-			i = next;
+		int placement;
+		while ((key = keyTable[next]) != 0) {
+			placement = place(key);
+			if((next - placement & mask) > (i - placement & mask)) {
+				keyTable[i] = key;
+				valueTable[i] = valueTable[next];
+				i = next;
+			}
 			next = next + 1 & mask;
 		}
 		keyTable[i] = 0;
@@ -562,10 +566,14 @@ public class IntMap<V> implements Iterable<IntMap.Entry<V>> {
 				int[] keyTable = map.keyTable;
 				V[] valueTable = map.valueTable;
 				int mask = map.mask, next = i + 1 & mask, key;
-				while ((key = keyTable[next]) != 0 && next != map.place(key)) {
-					keyTable[i] = key;
-					valueTable[i] = valueTable[next];
-					i = next;
+				int placement;
+				while ((key = keyTable[next]) != 0) {
+					placement = map.place(key);
+					if((next - placement & mask) > (i - placement & mask)) {
+						keyTable[i] = key;
+						valueTable[i] = valueTable[next];
+						i = next;
+					}
 					next = next + 1 & mask;
 				}
 				keyTable[i] = 0;

--- a/gdx/src/com/badlogic/gdx/utils/IntSet.java
+++ b/gdx/src/com/badlogic/gdx/utils/IntSet.java
@@ -16,10 +16,10 @@
 
 package com.badlogic.gdx.utils;
 
-import static com.badlogic.gdx.utils.ObjectSet.*;
-
 import java.util.Arrays;
 import java.util.NoSuchElementException;
+
+import static com.badlogic.gdx.utils.ObjectSet.tableSize;
 
 /** An unordered set where the items are unboxed ints. No allocation is done except when growing the table size.
  * <p>
@@ -196,9 +196,13 @@ public class IntSet {
 		if (i < 0) return false;
 		int[] keyTable = this.keyTable;
 		int next = i + 1 & mask;
-		while ((key = keyTable[next]) != 0 && next != place(key)) {
-			keyTable[i] = key;
-			i = next;
+		int placement;
+		while ((key = keyTable[next]) != 0) {
+			placement = place(key);
+			if((next - placement & mask) > (i - placement & mask)) {
+				keyTable[i] = key;
+				i = next;
+			}
 			next = next + 1 & mask;
 		}
 		keyTable[i] = 0;
@@ -400,9 +404,13 @@ public class IntSet {
 			} else {
 				int[] keyTable = set.keyTable;
 				int mask = set.mask, next = i + 1 & mask, key;
-				while ((key = keyTable[next]) != 0 && next != set.place(key)) {
-					keyTable[i] = key;
-					i = next;
+				int placement;
+				while ((key = keyTable[next]) != 0) {
+					placement = set.place(key);
+					if((next - placement & mask) > (i - placement & mask)) {
+						keyTable[i] = key;
+						i = next;
+					}
 					next = next + 1 & mask;
 				}
 				keyTable[i] = 0;

--- a/gdx/src/com/badlogic/gdx/utils/LongMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/LongMap.java
@@ -16,11 +16,11 @@
 
 package com.badlogic.gdx.utils;
 
-import static com.badlogic.gdx.utils.ObjectSet.*;
-
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+
+import static com.badlogic.gdx.utils.ObjectSet.tableSize;
 
 /** An unordered map where the keys are unboxed longs and values are objects. No allocation is done except when growing the table
  * size.
@@ -213,10 +213,14 @@ public class LongMap<V> implements Iterable<LongMap.Entry<V>> {
 		V[] valueTable = this.valueTable;
 		V oldValue = valueTable[i];
 		int next = i + 1 & mask;
-		while ((key = keyTable[next]) != 0 && next != place(key)) {
-			keyTable[i] = key;
-			valueTable[i] = valueTable[next];
-			i = next;
+		int placement;
+		while ((key = keyTable[next]) != 0) {
+			placement = place(key);
+			if((next - placement & mask) > (i - placement & mask)) {
+				keyTable[i] = key;
+				valueTable[i] = valueTable[next];
+				i = next;
+			}
 			next = next + 1 & mask;
 		}
 		keyTable[i] = 0;
@@ -563,10 +567,14 @@ public class LongMap<V> implements Iterable<LongMap.Entry<V>> {
 				V[] valueTable = map.valueTable;
 				int mask = map.mask, next = i + 1 & mask;
 				long key;
-				while ((key = keyTable[next]) != 0 && next != map.place(key)) {
-					keyTable[i] = key;
-					valueTable[i] = valueTable[next];
-					i = next;
+				int placement;
+				while ((key = keyTable[next]) != 0) {
+					placement = map.place(key);
+					if((next - placement & mask) > (i - placement & mask)) {
+						keyTable[i] = key;
+						valueTable[i] = valueTable[next];
+						i = next;
+					}
 					next = next + 1 & mask;
 				}
 				keyTable[i] = 0;

--- a/gdx/src/com/badlogic/gdx/utils/ObjectFloatMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/ObjectFloatMap.java
@@ -16,11 +16,11 @@
 
 package com.badlogic.gdx.utils;
 
-import static com.badlogic.gdx.utils.ObjectSet.*;
-
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+
+import static com.badlogic.gdx.utils.ObjectSet.tableSize;
 
 /** An unordered map where the keys are objects and the values are unboxed floats. Null keys are not allowed. No allocation is
  * done except when growing the table size.
@@ -201,10 +201,14 @@ public class ObjectFloatMap<K> implements Iterable<ObjectFloatMap.Entry<K>> {
 		float[] valueTable = this.valueTable;
 		float oldValue = valueTable[i];
 		int next = i + 1 & mask;
-		while ((key = keyTable[next]) != null && next != place(key)) {
-			keyTable[i] = key;
-			valueTable[i] = valueTable[next];
-			i = next;
+		int placement;
+		while ((key = keyTable[next]) != null) {
+			placement = place(key);
+			if((next - placement & mask) > (i - placement & mask)) {
+				keyTable[i] = key;
+				valueTable[i] = valueTable[next];
+				i = next;
+			}
 			next = next + 1 & mask;
 		}
 		keyTable[i] = null;
@@ -472,10 +476,14 @@ public class ObjectFloatMap<K> implements Iterable<ObjectFloatMap.Entry<K>> {
 			float[] valueTable = map.valueTable;
 			int mask = map.mask, next = i + 1 & mask;
 			K key;
-			while ((key = keyTable[next]) != null && next != map.place(key)) {
-				keyTable[i] = key;
-				valueTable[i] = valueTable[next];
-				i = next;
+			int placement;
+			while ((key = keyTable[next]) != null) {
+				placement = map.place(key);
+				if((next - placement & mask) > (i - placement & mask)) {
+					keyTable[i] = key;
+					valueTable[i] = valueTable[next];
+					i = next;
+				}
 				next = next + 1 & mask;
 			}
 			keyTable[i] = null;

--- a/gdx/src/com/badlogic/gdx/utils/ObjectIntMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/ObjectIntMap.java
@@ -16,11 +16,11 @@
 
 package com.badlogic.gdx.utils;
 
-import static com.badlogic.gdx.utils.ObjectSet.*;
-
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+
+import static com.badlogic.gdx.utils.ObjectSet.tableSize;
 
 /** An unordered map where the keys are objects and the values are unboxed ints. Null keys are not allowed. No allocation is done
  * except when growing the table size.
@@ -197,10 +197,14 @@ public class ObjectIntMap<K> implements Iterable<ObjectIntMap.Entry<K>> {
 		int[] valueTable = this.valueTable;
 		int oldValue = valueTable[i];
 		int next = i + 1 & mask;
-		while ((key = keyTable[next]) != null && next != place(key)) {
-			keyTable[i] = key;
-			valueTable[i] = valueTable[next];
-			i = next;
+		int placement;
+		while ((key = keyTable[next]) != null) {
+			placement = place(key);
+			if((next - placement & mask) > (i - placement & mask)) {
+				keyTable[i] = key;
+				valueTable[i] = valueTable[next];
+				i = next;
+			}
 			next = next + 1 & mask;
 		}
 		keyTable[i] = null;
@@ -468,10 +472,14 @@ public class ObjectIntMap<K> implements Iterable<ObjectIntMap.Entry<K>> {
 			int[] valueTable = map.valueTable;
 			int mask = map.mask, next = i + 1 & mask;
 			K key;
-			while ((key = keyTable[next]) != null && next != map.place(key)) {
-				keyTable[i] = key;
-				valueTable[i] = valueTable[next];
-				i = next;
+			int placement;
+			while ((key = keyTable[next]) != null) {
+				placement = map.place(key);
+				if((next - placement & mask) > (i - placement & mask)) {
+					keyTable[i] = key;
+					valueTable[i] = valueTable[next];
+					i = next;
+				}
 				next = next + 1 & mask;
 			}
 			keyTable[i] = null;

--- a/gdx/src/com/badlogic/gdx/utils/ObjectMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/ObjectMap.java
@@ -16,11 +16,11 @@
 
 package com.badlogic.gdx.utils;
 
-import static com.badlogic.gdx.utils.ObjectSet.*;
-
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+
+import static com.badlogic.gdx.utils.ObjectSet.tableSize;
 
 /** An unordered map where the keys and values are objects. Null keys are not allowed. No allocation is done except when growing
  * the table size.
@@ -194,10 +194,14 @@ public class ObjectMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 		V[] valueTable = this.valueTable;
 		V oldValue = valueTable[i];
 		int next = i + 1 & mask;
-		while ((key = keyTable[next]) != null && next != place(key)) {
-			keyTable[i] = key;
-			valueTable[i] = valueTable[next];
-			i = next;
+		int placement;
+		while ((key = keyTable[next]) != null) {
+			placement = place(key);
+			if((next - placement & mask) > (i - placement & mask)) {
+				keyTable[i] = key;
+				valueTable[i] = valueTable[next];
+				i = next;
+			}
 			next = next + 1 & mask;
 		}
 		keyTable[i] = null;
@@ -509,10 +513,14 @@ public class ObjectMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 			V[] valueTable = map.valueTable;
 			int mask = map.mask, next = i + 1 & mask;
 			K key;
-			while ((key = keyTable[next]) != null && next != map.place(key)) {
-				keyTable[i] = key;
-				valueTable[i] = valueTable[next];
-				i = next;
+			int placement;
+			while ((key = keyTable[next]) != null) {
+				placement = map.place(key);
+				if((next - placement & mask) > (i - placement & mask)) {
+					keyTable[i] = key;
+					valueTable[i] = valueTable[next];
+					i = next;
+				}
 				next = next + 1 & mask;
 			}
 			keyTable[i] = null;

--- a/gdx/src/com/badlogic/gdx/utils/ObjectSet.java
+++ b/gdx/src/com/badlogic/gdx/utils/ObjectSet.java
@@ -16,11 +16,11 @@
 
 package com.badlogic.gdx.utils;
 
+import com.badlogic.gdx.math.MathUtils;
+
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
-
-import com.badlogic.gdx.math.MathUtils;
 
 /** An unordered set where the keys are objects. Null keys are not allowed. No allocation is done except when growing the table
  * size.
@@ -186,9 +186,13 @@ public class ObjectSet<T> implements Iterable<T> {
 		if (i < 0) return false;
 		T[] keyTable = this.keyTable;
 		int next = i + 1 & mask;
-		while ((key = keyTable[next]) != null && next != place(key)) {
-			keyTable[i] = key;
-			i = next;
+		int placement;
+		while ((key = keyTable[next]) != null) {
+			placement = place(key);
+			if((next - placement & mask) > (i - placement & mask)) {
+				keyTable[i] = key;
+				i = next;
+			}
 			next = next + 1 & mask;
 		}
 		keyTable[i] = null;
@@ -391,9 +395,13 @@ public class ObjectSet<T> implements Iterable<T> {
 			K[] keyTable = set.keyTable;
 			int mask = set.mask, next = i + 1 & mask;
 			K key;
-			while ((key = keyTable[next]) != null && next != set.place(key)) {
-				keyTable[i] = key;
-				i = next;
+			int placement;
+			while ((key = keyTable[next]) != null) {
+				placement = set.place(key);
+				if((next - placement & mask) > (i - placement & mask)) {
+					keyTable[i] = key;
+					i = next;
+				}
 				next = next + 1 & mask;
 			}
 			keyTable[i] = null;

--- a/gdx/test/com/badlogic/gdx/utils/MixedPutRemoveTest.java
+++ b/gdx/test/com/badlogic/gdx/utils/MixedPutRemoveTest.java
@@ -1,0 +1,123 @@
+package com.badlogic.gdx.utils;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+public class MixedPutRemoveTest {
+	@Test
+	public void testLongMapPut() {
+		LongMap<Integer> gdxMap = new LongMap<Integer>();
+		HashMap<Long, Integer> jdkMap = new HashMap<Long, Integer>();
+		long stateA = 0L, stateB = 1L;
+		int gdxRepeats = 0, jdkRepeats = 0;
+		long item;
+		for (int i = 0; i < 0x100000; i++) { // a million should do
+			// simple-ish RNG that repeats more than RandomXS128; we want repeats to test behavior
+			stateA += 0xC6BC279692B5C323L;
+			item = (stateA ^ stateA >>> 31) * (stateB += 0x9E3779B97F4A7C16L);
+			item &= item >>> 24; // causes 64-bit state to get crammed into 40 bits, with item biased toward low bit counts 
+			if(gdxMap.put(item, i) != null) gdxRepeats++;
+			if(jdkMap.put(item, i) != null) jdkRepeats++;
+			Assert.assertEquals(gdxMap.size, jdkMap.size());
+		}
+		Assert.assertEquals(gdxRepeats, jdkRepeats);
+	}
+	@Test
+	public void testLongMapMix() {
+		LongMap<Integer> gdxMap = new LongMap<Integer>();
+		HashMap<Long, Integer> jdkMap = new HashMap<Long, Integer>();
+		long stateA = 0L, stateB = 1L;
+		int gdxRemovals = 0, jdkRemovals = 0;
+		long item;
+		for (int i = 0; i < 0x100000; i++) { // 1 million should do
+			// simple-ish RNG that repeats more than RandomXS128; we want repeats to test behavior
+			stateA += 0xC6BC279692B5C323L;
+			item = (stateA ^ stateA >>> 31) * (stateB += 0x9E3779B97F4A7C16L);
+			item &= item >>> 24; // causes 64-bit state to get crammed into 40 bits, with item biased toward low bit counts 
+			if(gdxMap.remove(item) == null) gdxMap.put(item, i);
+			else gdxRemovals++;
+			if(jdkMap.remove(item) == null) jdkMap.put(item, i);
+			else jdkRemovals++;
+			Assert.assertEquals(gdxMap.size, jdkMap.size());
+		}
+		Assert.assertEquals(gdxRemovals, jdkRemovals);
+	}
+	@Test
+	public void testIntMapPut() {
+		IntMap<Integer> gdxMap = new IntMap<Integer>();
+		HashMap<Integer, Integer> jdkMap = new HashMap<Integer, Integer>();
+		long stateA = 0L, stateB = 1L, temp;
+		int gdxRepeats = 0, jdkRepeats = 0;
+		int item;
+		for (int i = 0; i < 0x100000; i++) { // 1 million should do
+			// simple-ish RNG that repeats more than RandomXS128; we want repeats to test behavior
+			stateA += 0xC6BC279692B5C323L;
+			temp = (stateA ^ stateA >>> 31) * (stateB += 0x9E3779B97F4A7C16L);
+			item = (int)(temp & temp >>> 24); // causes 64-bit state to get crammed into 32 bits, with item biased toward low bit counts 
+			if(gdxMap.put(item, i) != null) gdxRepeats++;
+			if(jdkMap.put(item, i) != null) jdkRepeats++;
+			Assert.assertEquals(gdxMap.size, jdkMap.size());
+		}
+		Assert.assertEquals(gdxRepeats, jdkRepeats);
+	}
+	@Test
+	public void testIntMapMix() {
+		IntMap<Integer> gdxMap = new IntMap<Integer>();
+		HashMap<Integer, Integer> jdkMap = new HashMap<Integer, Integer>();
+		long stateA = 0L, stateB = 1L, temp;
+		int gdxRemovals = 0, jdkRemovals = 0;
+		int item;
+		for (int i = 0; i < 0x100000; i++) { // 1 million should do
+			// simple-ish RNG that repeats more than RandomXS128; we want repeats to test behavior
+			stateA += 0xC6BC279692B5C323L;
+			temp = (stateA ^ stateA >>> 31) * (stateB += 0x9E3779B97F4A7C16L);
+			item = (int)(temp & temp >>> 24); // causes 64-bit state to get crammed into 32 bits, with item biased toward low bit counts 
+			if(gdxMap.remove(item) == null) gdxMap.put(item, i);
+			else gdxRemovals++;
+			if(jdkMap.remove(item) == null) jdkMap.put(item, i);
+			else jdkRemovals++;
+			Assert.assertEquals(gdxMap.size, jdkMap.size());
+		}
+		Assert.assertEquals(gdxRemovals, jdkRemovals);
+	}
+	@Test
+	public void testObjectMapPut() {
+		ObjectMap<Integer, Integer> gdxMap = new ObjectMap<Integer, Integer>();
+		HashMap<Integer, Integer> jdkMap = new HashMap<Integer, Integer>();
+		long stateA = 0L, stateB = 1L, temp;
+		int gdxRepeats = 0, jdkRepeats = 0;
+		int item;
+		for (int i = 0; i < 0x100000; i++) { // 1 million should do
+			// simple-ish RNG that repeats more than RandomXS128; we want repeats to test behavior
+			stateA += 0xC6BC279692B5C323L;
+			temp = (stateA ^ stateA >>> 31) * (stateB += 0x9E3779B97F4A7C16L);
+			item = (int)(temp & temp >>> 24); // causes 64-bit state to get crammed into 32 bits, with item biased toward low bit counts 
+			if(gdxMap.put(item, i) != null) gdxRepeats++;
+			if(jdkMap.put(item, i) != null) jdkRepeats++;
+			Assert.assertEquals(gdxMap.size, jdkMap.size());
+		}
+		Assert.assertEquals(gdxRepeats, jdkRepeats);
+	}
+	@Test
+	public void testObjectMapMix() {
+		ObjectMap<Integer, Integer> gdxMap = new ObjectMap<Integer, Integer>();
+		HashMap<Integer, Integer> jdkMap = new HashMap<Integer, Integer>();
+		long stateA = 0L, stateB = 1L, temp;
+		int gdxRemovals = 0, jdkRemovals = 0;
+		int item;
+		for (int i = 0; i < 0x100000; i++) { // 1 million should do
+			// simple-ish RNG that repeats more than RandomXS128; we want repeats to test behavior
+			stateA += 0xC6BC279692B5C323L;
+			temp = (stateA ^ stateA >>> 31) * (stateB += 0x9E3779B97F4A7C16L);
+			item = (int)(temp & temp >>> 24); // causes 64-bit state to get crammed into 32 bits, with item biased toward low bit counts 
+			if(gdxMap.remove(item) == null) gdxMap.put(item, i);
+			else gdxRemovals++;
+			if(jdkMap.remove(item) == null) jdkMap.put(item, i);
+			else jdkRemovals++;
+			Assert.assertEquals(gdxMap.size, jdkMap.size());
+		}
+		Assert.assertEquals(gdxRemovals, jdkRemovals);
+	}
+}


### PR DESCRIPTION
This should fix #5930 and #5931 , it may also help with #5929 .

This is a relatively small set of changes; the backwards-shift algorithm for deletion was (if I remember it right) correct when the maps and sets used Robin Hood hashing, but not for linear probing. The changes needed to fix all the maps and sets are the same; it just needs to avoid backwards-shifting any keys to before where their place() slot would be without probing. The code is somewhat hard to read because it needs to compare two differences between slots while considering wrap-around from the mask; I don't see any way around this. Each file for a hash-based map or set should have changed in two places (remove() and the iterator's remove()), except IdentityMap, OrderedMap, and OrderedSet, which use a parent implementation. There is a JUnit test; without the changes in the first commit, the test should fail, but with the changes it should pass.