### PR TITLE
Set min iOS version to 8.0

### DIFF
--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/ios/Info.plist.xml
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/resources/ios/Info.plist.xml
@@ -28,6 +28,8 @@
     <false/>
     <key>UIStatusBarHidden</key>
     <true/>
+    <key>MinimumOSVersion</key>
+    <string>8.0</string>
     <key>UIDeviceFamily</key>
     <array>
         <integer>1</integer>
@@ -35,7 +37,6 @@
     </array>
     <key>UIRequiredDeviceCapabilities</key>
     <array>
-        <string>armv7</string>
         <string>opengles-2</string>
     </array>
     <key>UISupportedInterfaceOrientations</key>


### PR DESCRIPTION
~~Current RoboVM version sets the `MinimumOSVersion` to 6 if not declared on the app's `Info.plist`. Currently GDX setup doesn't set it so it defaults to 6 which is not supported even by RoboVM itself.~~ 
Ok, the problem is less important than I originally thought but the PR may still be relevant. Currently RoboVM is not handling properly the `MinimumOSVersion` (see https://github.com/MobiVM/robovm/pull/463) which may lead to confusion in terms of what the actual minimum supported iOS version is.

MobimVM official minimum supported version is 8. If `MinimumOSVersion` is not declared on the app's `Info.plist` it will be set to 8 by default. There's currently a small bug that, in case `MinimumOSVersion` is missing, even if it uses iOS 8, it internally adds the key with a value of 6 (instead of 8) to the Info.plist NSBundle, returning the wrong value if reading it programatically.

**Explicitely setting it in libGDX has the advantage of defining the min iOS version supported by libGDX itself independenlty of MobiVM as well as making it easier to know and change (in most cases users will need to set it to 9 due to being a requirement by many popular 3rd party SDKs).**

Also, `armv7` has been removed from the list of Required Device Capabilities as All devices that support iOS 8 have it as a capability (see support matrix https://developer.apple.com/support/required-device-capabilities/).