### PR TITLE
Fixed incorrect padding of knobAfter

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ProgressBar.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ProgressBar.java
@@ -163,10 +163,10 @@ public class ProgressBar extends Widget implements Disableable {
 				if (round) {
 					knobAfter.draw(batch, Math.round(x + (width - knobAfter.getMinWidth()) * 0.5f),
 						Math.round(y + position + knobHeightHalf), Math.round(knobAfter.getMinWidth()),
-						Math.round(height - position - knobHeightHalf));
+						Math.round(height - position - knobHeightHalf - bgBottomHeight));
 				} else {
 					knobAfter.draw(batch, x + (width - knobAfter.getMinWidth()) * 0.5f, y + position + knobHeightHalf,
-						knobAfter.getMinWidth(), height - position - knobHeightHalf);
+						knobAfter.getMinWidth(), height - position - knobHeightHalf - bgBottomHeight);
 				}
 			}
 			if (knob != null) {
@@ -214,11 +214,11 @@ public class ProgressBar extends Widget implements Disableable {
 			if (knobAfter != null) {
 				if (round) {
 					knobAfter.draw(batch, Math.round(x + position + knobWidthHalf),
-						Math.round(y + (height - knobAfter.getMinHeight()) * 0.5f), Math.round(width - position - knobWidthHalf),
+						Math.round(y + (height - knobAfter.getMinHeight()) * 0.5f), Math.round(width - position - knobWidthHalf - bgRightWidth),
 						Math.round(knobAfter.getMinHeight()));
 				} else {
 					knobAfter.draw(batch, x + position + knobWidthHalf, y + (height - knobAfter.getMinHeight()) * 0.5f,
-						width - position - knobWidthHalf, knobAfter.getMinHeight());
+						width - position - knobWidthHalf - bgRightWidth, knobAfter.getMinHeight());
 				}
 			}
 			if (knob != null) {


### PR DESCRIPTION
In this issue #1419 it was found that the rendering knobBefore taking in consideration the padding of the background was incorrect. The same was true for knobAfter yet nothing was done about it (fix was only applied to knobBefore). This results in knobBefore getting drawn up to the end of the bar without caring about the padding of the background:

![image](https://user-images.githubusercontent.com/8527540/75936707-f04a0980-5e50-11ea-8de7-f8ed22a7610d.png)

Fixed version:

![image](https://user-images.githubusercontent.com/8527540/75936990-a9104880-5e51-11ea-92fd-f9bdccf670c5.png)

Note that this only affects: Uses of ProgressBar with knobAfter that have a background with non-zero padding. It is possible that nobody noticed this bug for many years given how uncommon the use of knobAfter is. (Even myself don't really need it in a vanilla type of way)

Another issue with progress bar was later fixed after the initial one I mentionned: #4446  But this issue only address the typo which caused the bar to have an extra length of the size of the knob. The test example for this has no padding and doesn't mention the padding problem I am fixing here in anyway.

To test this bug fix: make a progress bar with a ninepatch background with padding, and add both knobBefore and knobAfter to be something.