### PR TITLE
Fix DefaultTextureBinder replacing WEIGHTED strategy by LRU

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -15,6 +15,7 @@
 - API Change: scene2d: In TextField, only revert the text if the change event was cancelled. This allows the text to be manipulated in the change listener.
 - API Change: scene2d: Tree.Node#removeAll renamed to clearChildren.
 - API Addition: scene2d: Added SelectBox#setSelectedPrefWidth to make the pref width based on the selected item and SelectBoxStyle#overFontColor.
+- API Change: DefaultTextureBinder WEIGHTED strategy replaced by LRU strategy.
 
 [1.9.10]
 - API Addition: Allow target display for maximization LWJGL3 backend

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/ModelBatch.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/ModelBatch.java
@@ -79,7 +79,7 @@ public class ModelBatch implements Disposable {
 	public ModelBatch (final RenderContext context, final ShaderProvider shaderProvider, final RenderableSorter sorter) {
 		this.sorter = (sorter == null) ? new DefaultRenderableSorter() : sorter;
 		this.ownContext = (context == null);
-		this.context = (context == null) ? new RenderContext(new DefaultTextureBinder(DefaultTextureBinder.WEIGHTED, 1)) : context;
+		this.context = (context == null) ? new RenderContext(new DefaultTextureBinder(DefaultTextureBinder.LRU, 1)) : context;
 		this.shaderProvider = (shaderProvider == null) ? new DefaultShaderProvider() : shaderProvider;
 	}
 

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/utils/DefaultTextureBinder.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/utils/DefaultTextureBinder.java
@@ -58,15 +58,10 @@ public final class DefaultTextureBinder implements TextureBinder {
 		this(method, offset, -1);
 	}
 
-	/** Uses reuse weight of 10 */
-	public DefaultTextureBinder (final int method, final int offset, final int count) {
-		this(method, offset, count, 10);
-	}
-
-	public DefaultTextureBinder (final int method, final int offset, int count, final int reuseWeight) {
+	public DefaultTextureBinder (final int method, final int offset, int count) {
 		final int max = Math.min(getMaxTextureUnits(), MAX_GLES_UNITS);
 		if (count < 0) count = max - offset;
-		if (offset < 0 || count < 0 || (offset + count) > max || reuseWeight < 1)
+		if (offset < 0 || count < 0 || (offset + count) > max)
 			throw new GdxRuntimeException("Illegal arguments");
 		this.method = method;
 		this.offset = offset;

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/utils/DefaultTextureBinderTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/utils/DefaultTextureBinderTest.java
@@ -1,0 +1,130 @@
+package com.badlogic.gdx.tests.g3d.utils;
+
+
+import java.nio.IntBuffer;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.Pixmap;
+import com.badlogic.gdx.graphics.Pixmap.Format;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g3d.utils.DefaultTextureBinder;
+import com.badlogic.gdx.tests.utils.GdxTest;
+import com.badlogic.gdx.utils.Array;
+import com.badlogic.gdx.utils.BufferUtils;
+import com.badlogic.gdx.utils.IntIntMap;
+
+public class DefaultTextureBinderTest extends GdxTest {
+
+	private static final int numTextures = 64;
+	private DefaultTextureBinder binderLRU;
+	private Array<Texture> textures;
+	private DefaultTextureBinder binderW;
+	private DefaultTextureBinder binderRR;
+	private int maxUnits;
+	private IntIntMap map;
+
+	@Override
+	public void create () {
+		binderLRU = new DefaultTextureBinder(DefaultTextureBinder.LRU, 0, 4);
+		binderW = new DefaultTextureBinder(DefaultTextureBinder.WEIGHTED, 0, 4);
+		binderRR = new DefaultTextureBinder(DefaultTextureBinder.ROUNDROBIN, 0, 4);
+		textures = new Array<Texture>();
+		map = new IntIntMap();
+		for(int i=0 ; i < numTextures ; i++){
+			textures.add( new Texture(new Pixmap(16, 16, Format.RGBA8888)));
+			map.put(textures.peek().getTextureObjectHandle(), i);
+		}
+		
+		IntBuffer buffer = BufferUtils.newIntBuffer(16);
+		Gdx.gl.glGetIntegerv(GL20.GL_MAX_TEXTURE_IMAGE_UNITS, buffer);
+		maxUnits = buffer.get(0);
+		// XXX
+		maxUnits = 4;
+		
+	}
+	@Override
+	public void render () {
+		
+		// Test LRU
+		binderLRU.begin();
+		binderLRU.bind(textures.get(0));
+		binderLRU.bind(textures.get(1));
+		binderLRU.bind(textures.get(2));
+		binderLRU.bind(textures.get(2));
+		assertBindReuseCounts(3, 1);
+		assertBinding(0, 1, 2);
+		
+		binderLRU.bind(textures.get(3));
+		assertBindReuseCounts(1, 0);
+		assertBinding(0, 1, 2, 3);
+		
+		binderLRU.bind(textures.get(1));
+		assertBindReuseCounts(0, 1);
+		assertBinding(0, 1, 2, 3);
+		
+		binderLRU.bind(textures.get(5));
+		binderLRU.bind(textures.get(2));
+		assertBindReuseCounts(1, 1);
+		assertBinding(5, 1, 2, 3);
+		
+		binderLRU.end();
+		
+		// Test Weighted
+		binderW.begin();
+		
+		// mesh part 1 with 3 textures (drawn 10 times)
+		for(int i=0 ; i<10 ; i++){
+			binderW.bind(textures.get(0));
+			binderW.bind(textures.get(1));
+			binderW.bind(textures.get(2));
+		}
+		
+		// mesh part 2 with 3 others textures
+		binderW.bind(textures.get(3));
+		printBindings(4);
+		
+		binderW.bind(textures.get(4)); 
+		printBindings(4); // FIXME here texture 3 get stolen!
+		
+		binderW.end();
+		
+		
+		for(int i=0 ; i<maxUnits ; i++){
+			Gdx.gl.glActiveTexture(GL20.GL_TEXTURE0 + i);
+			IntBuffer buffer = BufferUtils.newIntBuffer(16);
+			Gdx.gl.glGetIntegerv(GL20.GL_TEXTURE_BINDING_2D, buffer);
+			int tex = buffer.get(0);
+			int textureID = map.get(tex, 0);
+			System.out.println("UNIT " + i + " texture " + textureID);
+		}
+	}
+	private void assertBinding (int ...b) {
+		for(int i=0 ; i<b.length ; i++){
+			Gdx.gl.glActiveTexture(GL20.GL_TEXTURE0 + i);
+			IntBuffer buffer = BufferUtils.newIntBuffer(16);
+			Gdx.gl.glGetIntegerv(GL20.GL_TEXTURE_BINDING_2D, buffer);
+			int tex = buffer.get(0);
+			int textureID = map.get(tex, -1);
+			if(textureID != b[i]){
+				System.err.println("UNIT " + i + " texture " + textureID + " expected " + b[i]);
+			}
+		}
+	}
+	private void printBindings (int n) {
+		for(int i=0 ; i<n ; i++){
+			Gdx.gl.glActiveTexture(GL20.GL_TEXTURE0 + i);
+			IntBuffer buffer = BufferUtils.newIntBuffer(16);
+			Gdx.gl.glGetIntegerv(GL20.GL_TEXTURE_BINDING_2D, buffer);
+			int tex = buffer.get(0);
+			int textureID = map.get(tex, -1);
+			System.out.println("UNIT " + i + " texture " + textureID);
+		}
+	}
+	private void assertBindReuseCounts (int expectedBC, int expectedRC) {
+		if(expectedBC != binderLRU.getBindCount()) System.err.println("bad bind count: " + binderLRU.getBindCount() + " expected" + expectedBC);
+		if(expectedRC != binderLRU.getReuseCount()) System.err.println("bad resuse count: " + binderLRU.getReuseCount() + " expected" + expectedRC);
+		binderLRU.resetCounts();
+	}
+
+}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/utils/DefaultTextureBinderTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/utils/DefaultTextureBinderTest.java
@@ -19,30 +19,28 @@ public class DefaultTextureBinderTest extends GdxTest {
 	private static final int numTextures = 64;
 	private DefaultTextureBinder binderLRU;
 	private Array<Texture> textures;
-	private DefaultTextureBinder binderW;
 	private DefaultTextureBinder binderRR;
-	private int maxUnits;
 	private IntIntMap map;
 
 	@Override
 	public void create () {
 		binderLRU = new DefaultTextureBinder(DefaultTextureBinder.LRU, 0, 4);
-		binderW = new DefaultTextureBinder(DefaultTextureBinder.WEIGHTED, 0, 4);
 		binderRR = new DefaultTextureBinder(DefaultTextureBinder.ROUNDROBIN, 0, 4);
 		textures = new Array<Texture>();
 		map = new IntIntMap();
 		for(int i=0 ; i < numTextures ; i++){
-			textures.add( new Texture(new Pixmap(16, 16, Format.RGBA8888)));
+			textures.add(new Texture(16, 16, Format.RGBA8888));
 			map.put(textures.peek().getTextureObjectHandle(), i);
 		}
-		
-		IntBuffer buffer = BufferUtils.newIntBuffer(16);
-		Gdx.gl.glGetIntegerv(GL20.GL_MAX_TEXTURE_IMAGE_UNITS, buffer);
-		maxUnits = buffer.get(0);
-		// XXX
-		maxUnits = 4;
-		
 	}
+	
+	@Override
+	public void dispose () {
+		for(Texture texture : textures){
+			texture.dispose();
+		}
+	}
+	
 	@Override
 	public void render () {
 		
@@ -70,34 +68,7 @@ public class DefaultTextureBinderTest extends GdxTest {
 		
 		binderLRU.end();
 		
-		// Test Weighted
-		binderW.begin();
-		
-		// mesh part 1 with 3 textures (drawn 10 times)
-		for(int i=0 ; i<10 ; i++){
-			binderW.bind(textures.get(0));
-			binderW.bind(textures.get(1));
-			binderW.bind(textures.get(2));
-		}
-		
-		// mesh part 2 with 3 others textures
-		binderW.bind(textures.get(3));
 		printBindings(4);
-		
-		binderW.bind(textures.get(4)); 
-		printBindings(4); // FIXME here texture 3 get stolen!
-		
-		binderW.end();
-		
-		
-		for(int i=0 ; i<maxUnits ; i++){
-			Gdx.gl.glActiveTexture(GL20.GL_TEXTURE0 + i);
-			IntBuffer buffer = BufferUtils.newIntBuffer(16);
-			Gdx.gl.glGetIntegerv(GL20.GL_TEXTURE_BINDING_2D, buffer);
-			int tex = buffer.get(0);
-			int textureID = map.get(tex, 0);
-			System.out.println("UNIT " + i + " texture " + textureID);
-		}
 	}
 	private void assertBinding (int ...b) {
 		for(int i=0 ; i<b.length ; i++){

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
@@ -74,6 +74,7 @@ import com.badlogic.gdx.tests.g3d.SkeletonTest;
 import com.badlogic.gdx.tests.g3d.TangentialAccelerationTest;
 import com.badlogic.gdx.tests.g3d.TextureArrayTest;
 import com.badlogic.gdx.tests.g3d.TextureRegion3DTest;
+import com.badlogic.gdx.tests.g3d.utils.DefaultTextureBinderTest;
 import com.badlogic.gdx.tests.gles2.HelloTriangle;
 import com.badlogic.gdx.tests.gles2.SimpleVertexShader;
 import com.badlogic.gdx.tests.net.NetAPITest;
@@ -125,6 +126,7 @@ public class GdxTests {
 		CullTest.class,
 		CursorTest.class,
 		DecalTest.class,
+		DefaultTextureBinderTest.class,
 		DelaunayTriangulatorTest.class,
 		DeltaTimeTest.class,
 		DirtyRenderingTest.class,


### PR DESCRIPTION
DefaultTextureBinder WEIGHTED method doesn't work. Consider this example : 
- a DefaultTextureBinder with count=4
- a model A with 3 textures (textures 1, 2 and 3)
- a model B with 3 other textures (textures 4, 5, 6)
- render model A several times (textures 1, 2, and 3 get high weights)
- render model B : 
    - texture 4 is bounds to the last available slot with a light weight
    - texture 5 takes texture 4 slot because of its lighter weight, then model B cannot be rendered correctly.

I split my changes in several commits for readability and so you can test it yourself this bad behavior with first commit. (please squash them all when merging)

the new LRU strategy becomes the default which may be a little better than round robin method for most use cases.