### PR TITLE
remove unnecessary glUseProgram(0)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,7 @@
 - API Change: scene2d: Tree.Node#removeAll renamed to clearChildren.
 - API Addition: scene2d: Added SelectBox#setSelectedPrefWidth to make the pref width based on the selected item and SelectBoxStyle#overFontColor.
 - API Change: DefaultTextureBinder WEIGHTED strategy replaced by LRU strategy.
+- API Change: ShaderProgram begin and end methods are deprecated in favor to bind method.
 
 [1.9.10]
 - API Addition: Allow target display for maximization LWJGL3 backend

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/CustomShading.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/CustomShading.java
@@ -145,7 +145,7 @@ public class CustomShading {
 		hasMissingSamplers = false;
 		missingSamplerMessage = "";
 
-		shader.begin();
+		shader.bind();
 		for (int i = 0; i < extraTextures.size; i++) {
 			int unit = i + 1;
 			int location = shader.fetchUniformLocation("u_texture" + unit, false);
@@ -156,6 +156,5 @@ public class CustomShading {
 				missingSamplerMessage += "uniform sampler2D u_texture" + unit + " missing in shader program.\n";
 			}
 		}
-		shader.end();
 	}
 }

--- a/gdx/src/com/badlogic/gdx/graphics/Mesh.java
+++ b/gdx/src/com/badlogic/gdx/graphics/Mesh.java
@@ -543,7 +543,7 @@ public class Mesh implements Disposable {
 	 * </p>
 	 *
 	 * <p>
-	 * This method must only be called after the {@link ShaderProgram#begin()} method has been called!
+	 * This method must only be called after the {@link ShaderProgram#bind()} method has been called!
 	 * </p>
 	 *
 	 * <p>
@@ -567,7 +567,7 @@ public class Mesh implements Disposable {
 	 * </p>
 	 *
 	 * <p>
-	 * This method must only be called after the {@link ShaderProgram#begin()} method has been called!
+	 * This method must only be called after the {@link ShaderProgram#bind()} method has been called!
 	 * </p>
 	 *
 	 * <p>
@@ -594,7 +594,7 @@ public class Mesh implements Disposable {
 	 * </p>
 	 *
 	 * <p>
-	 * This method must only be called after the {@link ShaderProgram#begin()} method has been called!
+	 * This method must only be called after the {@link ShaderProgram#bind()} method has been called!
 	 * </p>
 	 *
 	 * <p>

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/PolygonSpriteBatch.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/PolygonSpriteBatch.java
@@ -154,9 +154,9 @@ public class PolygonSpriteBatch implements PolygonBatch {
 
 		Gdx.gl.glDepthMask(false);
 		if (customShader != null)
-			customShader.begin();
+			customShader.bind();
 		else
-			shader.begin();
+			shader.bind();
 		setupMatrices();
 
 		drawing = true;
@@ -172,11 +172,6 @@ public class PolygonSpriteBatch implements PolygonBatch {
 		GL20 gl = Gdx.gl;
 		gl.glDepthMask(true);
 		if (isBlendingEnabled()) gl.glDisable(GL20.GL_BLEND);
-
-		if (customShader != null)
-			customShader.end();
-		else
-			shader.end();
 	}
 
 	@Override
@@ -1326,17 +1321,13 @@ public class PolygonSpriteBatch implements PolygonBatch {
 	public void setShader (ShaderProgram shader) {
 		if (drawing) {
 			flush();
-			if (customShader != null)
-				customShader.end();
-			else
-				this.shader.end();
 		}
 		customShader = shader;
 		if (drawing) {
 			if (customShader != null)
-				customShader.begin();
+				customShader.bind();
 			else
-				this.shader.begin();
+				this.shader.bind();
 			setupMatrices();
 		}
 	}

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/SpriteBatch.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/SpriteBatch.java
@@ -171,9 +171,9 @@ public class SpriteBatch implements Batch {
 
 		Gdx.gl.glDepthMask(false);
 		if (customShader != null)
-			customShader.begin();
+			customShader.bind();
 		else
-			shader.begin();
+			shader.bind();
 		setupMatrices();
 
 		drawing = true;
@@ -189,11 +189,6 @@ public class SpriteBatch implements Batch {
 		GL20 gl = Gdx.gl;
 		gl.glDepthMask(true);
 		if (isBlendingEnabled()) gl.glDisable(GL20.GL_BLEND);
-
-		if (customShader != null)
-			customShader.end();
-		else
-			shader.end();
 	}
 
 	@Override
@@ -1077,17 +1072,13 @@ public class SpriteBatch implements Batch {
 	public void setShader (ShaderProgram shader) {
 		if (drawing) {
 			flush();
-			if (customShader != null)
-				customShader.end();
-			else
-				this.shader.end();
 		}
 		customShader = shader;
 		if (drawing) {
 			if (customShader != null)
-				customShader.begin();
+				customShader.bind();
 			else
-				this.shader.begin();
+				this.shader.bind();
 			setupMatrices();
 		}
 	}

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/SpriteCache.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/SpriteCache.java
@@ -855,14 +855,14 @@ public class SpriteCache implements Disposable {
 		Gdx.gl20.glDepthMask(false);
 
 		if (customShader != null) {
-			customShader.begin();
+			customShader.bind();
 			customShader.setUniformMatrix("u_proj", projectionMatrix);
 			customShader.setUniformMatrix("u_trans", transformMatrix);
 			customShader.setUniformMatrix("u_projTrans", combinedMatrix);
 			customShader.setUniformi("u_texture", 0);
 			mesh.bind(customShader);
 		} else {
-			shader.begin();
+			shader.bind();
 			shader.setUniformMatrix("u_projectionViewMatrix", combinedMatrix);
 			shader.setUniformi("u_texture", 0);
 			mesh.bind(shader);
@@ -875,7 +875,6 @@ public class SpriteCache implements Disposable {
 		if (!drawing) throw new IllegalStateException("begin must be called before end.");
 		drawing = false;
 
-		shader.end();
 		GL20 gl = Gdx.gl20;
 		gl.glDepthMask(true);
 		if (customShader != null)

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/decals/CameraGroupStrategy.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/decals/CameraGroupStrategy.java
@@ -165,14 +165,13 @@ public class CameraGroupStrategy implements GroupStrategy, Disposable {
 	@Override
 	public void beforeGroups () {
 		Gdx.gl.glEnable(GL20.GL_DEPTH_TEST);
-		shader.begin();
+		shader.bind();
 		shader.setUniformMatrix("u_projectionViewMatrix", camera.combined);
 		shader.setUniformi("u_texture", 0);
 	}
 
 	@Override
 	public void afterGroups () {
-		shader.end();
 		Gdx.gl.glDisable(GL20.GL_DEPTH_TEST);
 	}
 

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/model/MeshPart.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/model/MeshPart.java
@@ -144,16 +144,14 @@ public class MeshPart {
 		return equals((MeshPart)arg0);
 	}
 
-	/** Renders the mesh part using the specified shader, must be called in between {@link ShaderProgram#begin()} and
-	 * {@link ShaderProgram#end()}.
+	/** Renders the mesh part using the specified shader, must be called after {@link ShaderProgram#bind()}.
 	 * @param shader the shader to be used
 	 * @param autoBind overrides the autoBind member of the Mesh */
 	public void render (ShaderProgram shader, boolean autoBind) {
 		mesh.render(shader, primitiveType, offset, size, autoBind);
 	}
 
-	/** Renders the mesh part using the specified shader, must be called in between {@link ShaderProgram#begin()} and
-	 * {@link ShaderProgram#end()}.
+	/** Renders the mesh part using the specified shader, must be called after {@link ShaderProgram#bind()}.
 	 * @param shader the shader to be used */
 	public void render (ShaderProgram shader) {
 		mesh.render(shader, primitiveType, offset, size);

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/BaseShader.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/BaseShader.java
@@ -204,7 +204,7 @@ public abstract class BaseShader implements Shader {
 	public void begin (Camera camera, RenderContext context) {
 		this.camera = camera;
 		this.context = context;
-		program.begin();
+		program.bind();
 		currentMesh = null;
 		for (int u, i = 0; i < globalUniforms.size; ++i)
 			if (setters.get(u = globalUniforms.get(i)) != null) setters.get(u).set(this, u, null, null);
@@ -250,7 +250,6 @@ public abstract class BaseShader implements Shader {
 			currentMesh.unbind(program, tempArray.items);
 			currentMesh = null;
 		}
-		program.end();
 	}
 
 	@Override

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/ImmediateModeRenderer20.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/ImmediateModeRenderer20.java
@@ -143,13 +143,12 @@ public class ImmediateModeRenderer20 implements ImmediateModeRenderer {
 
 	public void flush () {
 		if (numVertices == 0) return;
-		shader.begin();
+		shader.bind();
 		shader.setUniformMatrix("u_projModelView", projModelView);
 		for (int i = 0; i < numTexCoords; i++)
 			shader.setUniformi(shaderUniformNames[i], i);
 		mesh.setVertices(vertices, 0, vertexIdx);
 		mesh.render(shader, primitiveType);
-		shader.end();
 
 		numSetTexCoords = 0;
 		vertexIdx = 0;

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/ShaderProgram.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/ShaderProgram.java
@@ -686,19 +686,21 @@ public class ShaderProgram implements Disposable {
 		gl.glVertexAttribPointer(location, size, type, normalize, stride, offset);
 	}
 
-	/** Makes OpenGL ES 2.0 use this vertex and fragment shader pair. When you are done with this shader you have to call
-	 * {@link ShaderProgram#end()}. */
+	/** @deprecated use {@link #bind()} instead, this method will be remove in future version */
+	@Deprecated
 	public void begin () {
+		bind();
+	}
+
+	public void bind(){
 		GL20 gl = Gdx.gl20;
 		checkManaged();
 		gl.glUseProgram(program);
 	}
 
-	/** Disables this shader. Must be called when one is done with the shader. Don't mix it with dispose, that will release the
-	 * shader resources. */
+	/** @deprecated no longer necessary, this method will be remove in future version */
+	@Deprecated
 	public void end () {
-		GL20 gl = Gdx.gl20;
-		gl.glUseProgram(0);
 	}
 
 	/** Disposes all resources associated with this shader. Must be called when the shader is no longer used. */

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/ShaderProgram.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/ShaderProgram.java
@@ -44,15 +44,11 @@ import com.badlogic.gdx.utils.ObjectMap;
  * 
  * <p>
  * After construction a ShaderProgram can be used to draw {@link Mesh}. To make the GPU use a specific ShaderProgram the programs
- * {@link ShaderProgram#begin()} method must be used which effectively binds the program.
+ * {@link ShaderProgram#bind()} method must be used which effectively binds the program.
  * </p>
  * 
  * <p>
  * When a ShaderProgram is bound one can set uniforms, vertex attributes and attributes as needed via the respective methods.
- * </p>
- * 
- * <p>
- * A ShaderProgram can be unbound with a call to {@link ShaderProgram#end()}
  * </p>
  * 
  * <p>

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/FloatTextureTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/FloatTextureTest.java
@@ -112,29 +112,26 @@ public class FloatTextureTest extends GdxTest {
 		Gdx.gl20.glClear(GL20.GL_COLOR_BUFFER_BIT);
 
 		fb.begin();
-		fbshader.begin();
+		fbshader.bind();
 		fbshader.setUniformf("u_viewport", fb.getWidth(), fb.getHeight());
 		fbshader.setUniformf("u_color", 0.0f, 1.0f, 0.0f);
 		quad.render(fbshader, GL20.GL_TRIANGLES);
-		fbshader.end();
 		fb.end();
 
 		ffb.begin();
-		fbshader.begin();
+		fbshader.bind();
 		fbshader.setUniformf("u_viewport", ffb.getWidth(), ffb.getHeight());
 		fbshader.setUniformf("u_color", 1.0f, 0.0f, 0.0f);
 		quad.render(fbshader, GL20.GL_TRIANGLES);
-		fbshader.end();
 		ffb.end();
 
-		shader.begin();
+		shader.bind();
 		fb.getColorBufferTexture().bind(0);
 		ffb.getColorBufferTexture().bind(1);
 		shader.setUniformMatrix("u_worldView", screenCamera.combined);
 		shader.setUniformi("u_fbtex", 0);
 		shader.setUniformi("u_ffbtex", 1);
 		screenQuad.render(shader, GL20.GL_TRIANGLES);
-		shader.end();
 	}
 
 	private void createQuad () {

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/FrameBufferTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/FrameBufferTest.java
@@ -64,10 +64,9 @@ public class FrameBufferTest extends GdxTest {
 		Gdx.gl20.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		Gdx.gl20.glEnable(GL20.GL_TEXTURE_2D);
 		texture.bind();
-		meshShader.begin();
+		meshShader.bind();
 		meshShader.setUniformi("u_texture", 0);
 		mesh.render(meshShader, GL20.GL_TRIANGLES);
-		meshShader.end();
 		frameBuffer.end();
 
 		stencilFrameBuffer.begin();
@@ -86,18 +85,16 @@ public class FrameBufferTest extends GdxTest {
 		Gdx.gl20.glStencilMask(0xFF);
 		Gdx.gl20.glClear(GL20.GL_STENCIL_BUFFER_BIT);
 
-		meshShader.begin();
+		meshShader.bind();
 		stencilMesh.render(meshShader, GL20.GL_TRIANGLES);
-		meshShader.end();
 
 		Gdx.gl20.glColorMask(true, true, true, true);
 		Gdx.gl20.glDepthMask(true);
 		Gdx.gl20.glStencilMask(0x00);
 		Gdx.gl20.glStencilFunc(GL20.GL_EQUAL, 1, 0xFF);
 
-		meshShader.begin();
+		meshShader.bind();
 		mesh.render(meshShader, GL20.GL_TRIANGLES);
-		meshShader.end();
 
 		Gdx.gl20.glDisable(GL20.GL_STENCIL_TEST);
 		stencilFrameBuffer.end();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/IndexBufferObjectShaderTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/IndexBufferObjectShaderTest.java
@@ -49,7 +49,7 @@ public class IndexBufferObjectShaderTest extends GdxTest {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 
 		Gdx.gl.glEnable(GL20.GL_TEXTURE_2D);
-		shader.begin();
+		shader.bind();
 		shader.setUniformi("u_texture", 0);
 		texture.bind();
 		vbo.bind(shader);
@@ -57,7 +57,6 @@ public class IndexBufferObjectShaderTest extends GdxTest {
 		Gdx.gl20.glDrawElements(GL20.GL_TRIANGLES, 3, GL20.GL_UNSIGNED_SHORT, 0);
 		ibo.unbind();
 		vbo.unbind(shader);
-		shader.end();
 	}
 
 	@Override

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/MeshShaderTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/MeshShaderTest.java
@@ -94,11 +94,10 @@ public class MeshShaderTest extends GdxTest {
 		Gdx.gl20.glEnable(GL20.GL_BLEND);
 		Gdx.gl20.glBlendFunc(GL20.GL_SRC_ALPHA, GL20.GL_ONE_MINUS_SRC_ALPHA);
 		texture.bind();
-		shader.begin();
+		shader.bind();
 		shader.setUniformMatrix("u_worldView", matrix);
 		shader.setUniformi("u_texture", 0);
 		meshToDraw.render(shader, GL20.GL_TRIANGLES);
-		shader.end();
 	}
 
 	@Override

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/MipMapTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/MipMapTest.java
@@ -122,11 +122,10 @@ public class MipMapTest extends GdxTest {
 		currTexture.bind();
 		currTexture.setFilter(TextureFilter.valueOf(minFilter.getSelected()), TextureFilter.valueOf(magFilter.getSelected()));
 
-		shader.begin();
+		shader.bind();
 		shader.setUniformMatrix("u_projTrans", camera.combined);
 		shader.setUniformi("s_texture", 0);
 		mesh.render(shader, GL20.GL_TRIANGLE_FAN);
-		shader.end();
 
 		ui.act();
 		ui.draw();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ProjectiveTextureTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ProjectiveTextureTest.java
@@ -150,7 +150,7 @@ public class ProjectiveTextureTest extends GdxTest {
 		projector.update();
 
 		texture.bind();
-		projTexShader.begin();
+		projTexShader.bind();
 
 		if (camera.getSelectedIndex() == 0) {
 			renderMesh(projTexShader, cam.combined, projector.combined, planeTrans, plane, Color.WHITE);
@@ -164,8 +164,6 @@ public class ProjectiveTextureTest extends GdxTest {
 			 * Color.WHITE);
 			 */
 		}
-
-		projTexShader.end();
 
 		fps.setText("fps: " + Gdx.graphics.getFramesPerSecond());
 		ui.act();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ShaderMultitextureTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ShaderMultitextureTest.java
@@ -96,13 +96,11 @@ public class ShaderMultitextureTest extends GdxTest {
 		Gdx.gl20.glActiveTexture(GL20.GL_TEXTURE1);
 		texture2.bind();
 
-		shader.begin();
+		shader.bind();
 		shader.setUniformi("s_texture", 0);
 		shader.setUniformi("s_texture2", 1);
 
 		mesh.render(shader, GL20.GL_TRIANGLES);
-
-		shader.end();
 	}
 
 	@Override

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/VBOWithVAOPerformanceTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/VBOWithVAOPerformanceTest.java
@@ -203,7 +203,7 @@ public class VBOWithVAOPerformanceTest extends GdxTest {
 
 
 		texture.bind();
-		shader.begin();
+		shader.bind();
 		shader.setUniformMatrix("u_worldView", matrix);
 		shader.setUniformi("u_texture", 0);
 
@@ -211,12 +211,11 @@ public class VBOWithVAOPerformanceTest extends GdxTest {
 		oldVBOWithVAOMesh.render(shader, GL20.GL_TRIANGLES);
 		Gdx.gl.glFlush();
 		oldCounter.addValue((System.nanoTime() - beforeOld));
-		shader.end();
 
 		Gdx.gl20.glClear(GL20.GL_COLOR_BUFFER_BIT);
 
 		texture.bind();
-		shader.begin();
+		shader.bind();
 		shader.setUniformMatrix("u_worldView", matrix);
 		shader.setUniformi("u_texture", 0);
 
@@ -224,13 +223,12 @@ public class VBOWithVAOPerformanceTest extends GdxTest {
 		newVBOWithVAOMesh.render(shader, GL20.GL_TRIANGLES);
 		Gdx.gl.glFlush();
 		newCounter.addValue((System.nanoTime() - beforeNew));
-		shader.end();
 
 
 		Gdx.gl20.glClear(GL20.GL_COLOR_BUFFER_BIT);
 
 		texture.bind();
-		shader.begin();
+		shader.bind();
 		shader.setUniformMatrix("u_worldView", matrix);
 		shader.setUniformi("u_texture", 0);
 
@@ -239,13 +237,12 @@ public class VBOWithVAOPerformanceTest extends GdxTest {
 			oldVBOWithVAOMesh.render(shader, GL20.GL_TRIANGLES);
 		Gdx.gl.glFlush();
 		oldCounterStress.addValue((System.nanoTime() - beforeOldStress));
-		shader.end();
 
 
 		Gdx.gl20.glClear(GL20.GL_COLOR_BUFFER_BIT);
 
 		texture.bind();
-		shader.begin();
+		shader.bind();
 		shader.setUniformMatrix("u_worldView", matrix);
 		shader.setUniformi("u_texture", 0);
 
@@ -254,7 +251,6 @@ public class VBOWithVAOPerformanceTest extends GdxTest {
 			newVBOWithVAOMesh.render(shader, GL20.GL_TRIANGLES);
 		Gdx.gl.glFlush();
 		newCounterStress.addValue((System.nanoTime() - beforeNewStress));
-		shader.end();
 
 
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/VertexBufferObjectShaderTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/VertexBufferObjectShaderTest.java
@@ -49,7 +49,7 @@ public class VertexBufferObjectShaderTest extends GdxTest {
 		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 
 		gl.glEnable(GL20.GL_TEXTURE_2D);
-		shader.begin();
+		shader.bind();
 		shader.setUniformi("u_texture", 0);
 		texture.bind();
 		vbo.bind(shader);
@@ -57,7 +57,6 @@ public class VertexBufferObjectShaderTest extends GdxTest {
 		gl.glDrawElements(GL20.GL_TRIANGLES, 3, GL20.GL_UNSIGNED_SHORT, indices.getBuffer().position());
 		indices.unbind();
 		vbo.unbind(shader);
-		shader.end();
 	}
 
 	@Override

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/MultipleRenderTargetTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/MultipleRenderTargetTest.java
@@ -251,7 +251,7 @@ public class MultipleRenderTargetTest extends GdxTest {
 
 		frameBuffer.end();
 
-		mrtSceneShader.begin();
+		mrtSceneShader.bind();
 		mrtSceneShader.setUniformi("u_diffuseTexture",
 			renderContext.textureBinder.bind(frameBuffer.getTextureAttachments().get(DIFFUSE_ATTACHMENT)));
 		mrtSceneShader.setUniformi("u_normalTexture",
@@ -267,7 +267,6 @@ public class MultipleRenderTargetTest extends GdxTest {
 		mrtSceneShader.setUniformf("u_viewPos", camera.position);
 		mrtSceneShader.setUniformMatrix("u_inverseProjectionMatrix", camera.invProjectionView);
 		quad.render(mrtSceneShader, GL30.GL_TRIANGLE_FAN);
-		mrtSceneShader.end();
 		renderContext.end();
 
 
@@ -422,7 +421,7 @@ public class MultipleRenderTargetTest extends GdxTest {
 		@Override
 		public void begin (Camera camera, RenderContext context) {
 			this.context = context;
-			shaderProgram.begin();
+			shaderProgram.bind();
 			shaderProgram.setUniformMatrix("u_projViewTrans", camera.combined);
 			context.setDepthTest(GL20.GL_LEQUAL);
 			context.setCullFace(GL20.GL_BACK);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/ShaderTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/ShaderTest.java
@@ -151,7 +151,7 @@ public class ShaderTest extends GdxTest {
 
 		@Override
 		public void begin (Camera camera, RenderContext context) {
-			program.begin();
+			program.bind();
 			context.setDepthTest(GL20.GL_LEQUAL, 0f, 1f);
 			context.setDepthMask(true);
 			set(u_projTrans, camera.combined);
@@ -170,11 +170,6 @@ public class ShaderTest extends GdxTest {
 			}
 
 			renderable.meshPart.render(program);
-		}
-
-		@Override
-		public void end () {
-			program.end();
 		}
 
 		@Override

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/TextureArrayTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/TextureArrayTest.java
@@ -120,12 +120,11 @@ public class TextureArrayTest extends GdxTest {
 
 		textureArray.bind();
 
-		shaderProgram.begin();
+		shaderProgram.bind();
 		shaderProgram.setUniformi("u_textureArray", 0);
 		shaderProgram.setUniformMatrix("u_projViewTrans", camera.combined);
 		shaderProgram.setUniformMatrix("u_modelView", modelView);
 		terrain.render(shaderProgram, GL20.GL_TRIANGLES);
-		shaderProgram.end();
 	}
 
 	@Override

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gles2/HelloTriangle.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gles2/HelloTriangle.java
@@ -46,8 +46,7 @@ public class HelloTriangle extends GdxTest {
 	public void render () {
 		Gdx.gl20.glViewport(0, 0, Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight());
 		Gdx.gl20.glClear(GL20.GL_COLOR_BUFFER_BIT);
-		shader.begin();
+		shader.bind();
 		mesh.render(shader, GL20.GL_TRIANGLES);
-		shader.end();
 	}
 }

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gles2/MipMap2D.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gles2/MipMap2D.java
@@ -86,7 +86,7 @@ public class MipMap2D extends GdxTest {
 
 		Gdx.gl20.glActiveTexture(GL20.GL_TEXTURE0);
 		texture.bind();
-		shader.begin();
+		shader.bind();
 		shader.setUniformf("s_texture", 0);
 
 		Gdx.gl20.glTexParameteri(GL20.GL_TEXTURE_2D, GL20.GL_TEXTURE_MIN_FILTER, GL20.GL_NEAREST);
@@ -96,7 +96,5 @@ public class MipMap2D extends GdxTest {
 		Gdx.gl20.glTexParameteri(GL20.GL_TEXTURE_2D, GL20.GL_TEXTURE_MIN_FILTER, GL20.GL_LINEAR_MIPMAP_LINEAR);
 		shader.setUniformf("u_offset", 0.6f);
 		mesh.render(shader, GL20.GL_TRIANGLES);
-
-		shader.end();
 	}
 }

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gles2/SimpleVertexShader.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gles2/SimpleVertexShader.java
@@ -71,10 +71,9 @@ public class SimpleVertexShader extends GdxTest {
 
 		Gdx.gl20.glViewport(0, 0, Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight());
 		Gdx.gl20.glClear(GL20.GL_COLOR_BUFFER_BIT);
-		shader.begin();
+		shader.bind();
 		shader.setUniformMatrix("u_mvpMatrix", combined);
 		mesh.render(shader, GL20.GL_TRIANGLES);
-		shader.end();
 
 		Gdx.app.log("angle", "" + angle);
 	}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gles3/InstancedRenderingTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gles3/InstancedRenderingTest.java
@@ -84,8 +84,7 @@ public class InstancedRenderingTest extends GdxTest {
 		Gdx.gl.glClearColor(0.2f, 0.2f, 0.2f, 1f);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 
-		shader.begin();
+		shader.bind();
 		mesh.render(shader, GL30.GL_TRIANGLES);
-		shader.end();
 	}
 }

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtTest.java
@@ -95,11 +95,10 @@ public class GwtTest extends GdxTest {
 		Gdx.gl.glClearColor(0.2f, 0.2f, 0.2f, 1);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		texture.bind(0);
-		shader.begin();
+		shader.bind();
 		shader.setUniformMatrix("u_projView", matrix);
 		shader.setUniformi("u_texture", 0);
 		mesh.render(shader, GL20.GL_TRIANGLES);
-		shader.end();
 
 		batch.begin();
 		batch.draw(atlas.findRegion("font"), 0, 100);


### PR DESCRIPTION
Unbinding a shader program is not necessary, it was useful to enable the old fixed-function pipeline which libgdx don't use.

ShaderProgram begin and end method are deprecated for a smooth transition.

I made a quick dumb test to see how my GPU was impacted (if my GPU driver optimize it or not) : 

here is the code:
```java
    private ShaderProgram sp;
    public void render () {
        int N = 1000;
        for(int i=0 ; i<N ; i++){
            sp.begin();
            sp.end();
        }
        logger.log();
    }
```
by commenting begin/end in all combinations i get:
- calling none of them (baseline): ~ 10 500 FPS
- calling only end: ~ 9500 FPS
- calling only begin: ~ 2000 FPS
- calling both begin and end: ~ 1000 FPS

GPU : Nvidia GTX 950m

I'm not calling this a benchmark, i just wanted to highlight this small optimization and ensure there was no drawbacks. Most of games try to minimize shader switches to only a few anyway, so i don't think it would improve perf. noticeably. But it still better to not call it at all.

Note that my original issue was GLProfiler counting a shader switch as twice because of it. This issue is then fixed by this PR as well.