### PR TITLE
Correct IntFloatMap.getAndIncrement() parameter types

### DIFF
--- a/gdx/src/com/badlogic/gdx/utils/IntFloatMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/IntFloatMap.java
@@ -188,7 +188,7 @@ public class IntFloatMap implements Iterable<IntFloatMap.Entry> {
 
 	/** Returns the key's current value and increments the stored value. If the key is not in the map, defaultValue + increment is
 	 * put into the map and defaultValue is returned. */
-	public float getAndIncrement (int key, int defaultValue, int increment) {
+	public float getAndIncrement (int key, float defaultValue, float increment) {
 		if (key == 0) {
 			if (!hasZeroValue) {
 				hasZeroValue = true;


### PR DESCRIPTION
This was a copy-paste error; it was found by Raymond Buckley trying to use 1.9.11-SNAPSHOT with Typing-Label (which doesn't build with the snapshot right now).

I didn't notice any similar problems in IntIntMap, ObjectFloatMap or ObjectIntMap.