### PR TITLE
Update libGDX min Android SDK version for startup check

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplicationBase.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplicationBase.java
@@ -38,7 +38,7 @@ import com.badlogic.gdx.utils.SnapshotArray;
  * @author davebaol */
 public interface AndroidApplicationBase extends Application {
 
-	static final int MINIMUM_SDK = 9;
+	static final int MINIMUM_SDK = 14;
 
 	/** The application or activity context
 	 * 


### PR DESCRIPTION
Missed changing this one when we updated to 14. It's just used for a check on app startup in case min SDK is set to a value less than libGDX minimum supported.