### PR TITLE
Add AndroidLiveWallpaper.notifyColorsChanged

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -59,6 +59,7 @@
 	- 32-bit: ARMv7/armhf
 	- 64-bit: ARMv8/AArch64
 - API Change: Removed arm abi from SharedLibraryLoader
+- API Addition: Added AndroidLiveWallpaper.notifyColorsChanged() to communicate visually significant colors back to the wallpaper engine.
 
 [1.9.10]
 - API Addition: Allow target display for maximization LWJGL3 backend

--- a/CHANGES
+++ b/CHANGES
@@ -11,6 +11,7 @@
 - Gdx.files.external on Android now uses app external storage - see wiki article File handling for more information
 - API Addition: Added setProgrammaticChangeEvents to ProgressBar/Slider.
 - Keyboard events working on RoboVM on iOS 13.5 and up, uses same API as on other platforms
+- API Addition: Added AndroidLiveWallpaper.notifyColorsChanged() to communicate visually significant colors back to the wallpaper engine.
 
 [1.9.11]
 - Update to MobiVM 2.3.8
@@ -59,7 +60,6 @@
 	- 32-bit: ARMv7/armhf
 	- 64-bit: ARMv8/AArch64
 - API Change: Removed arm abi from SharedLibraryLoader
-- API Addition: Added AndroidLiveWallpaper.notifyColorsChanged() to communicate visually significant colors back to the wallpaper engine.
 
 [1.9.10]
 - API Addition: Allow target display for maximization LWJGL3 backend

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidLiveWallpaper.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidLiveWallpaper.java
@@ -18,6 +18,7 @@ package com.badlogic.gdx.backends.android;
 
 import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
 import android.os.Debug;
 import android.os.Handler;
 import android.os.Looper;
@@ -26,6 +27,7 @@ import android.view.Window;
 import android.view.WindowManager;
 import com.badlogic.gdx.*;
 import com.badlogic.gdx.backends.android.surfaceview.FillResolutionStrategy;
+import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.utils.*;
 
 /** An implementation of the {@link Application} interface to be used with an AndroidLiveWallpaperService. Not directly
@@ -52,6 +54,7 @@ public class AndroidLiveWallpaper implements AndroidApplicationBase {
 	protected final SnapshotArray<LifecycleListener> lifecycleListeners = new SnapshotArray<LifecycleListener>(LifecycleListener.class);
 	protected int logLevel = LOG_INFO;
 	protected ApplicationLogger applicationLogger;
+	protected volatile Color[] wallpaperColors = null;
 
 	public AndroidLiveWallpaper (AndroidLiveWallpaperService service) {
 		this.service = service;
@@ -374,4 +377,23 @@ public class AndroidLiveWallpaper implements AndroidApplicationBase {
 		throw new UnsupportedOperationException();
 	}
 
+	/**
+	 * Notify the wallpaper engine that the significant colors of the wallpaper have changed. This
+	 * method may be called before initializing the live wallpaper.
+	 * @param primaryColor The most visually significant color.
+	 * @param secondaryColor The second most visually significant color.
+	 * @param tertiaryColor The third most visually significant color.
+	 */
+	public void notifyColorsChanged (Color primaryColor, Color secondaryColor, Color tertiaryColor) {
+		if (Build.VERSION.SDK_INT < 27)
+			return;
+		final Color[] colors = new Color[3];
+		colors[0] = new Color(primaryColor);
+		colors[1] = new Color(secondaryColor);
+		colors[2] = new Color(tertiaryColor);
+		wallpaperColors = colors;
+		AndroidLiveWallpaperService.AndroidWallpaperEngine engine = service.linkedEngine;
+		if (engine != null)
+			engine.notifyColorsChanged();
+	}
 }

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidLiveWallpaperService.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidLiveWallpaperService.java
@@ -15,17 +15,20 @@
 package com.badlogic.gdx.backends.android;
 
 import android.content.Context;
+import android.os.Build;
 import android.os.Bundle;
 import android.service.wallpaper.WallpaperService;
 import android.util.Log;
 import android.view.MotionEvent;
 import android.view.SurfaceHolder;
 import android.view.WindowManager;
+import android.app.WallpaperColors;
 
 import com.badlogic.gdx.Application;
 import com.badlogic.gdx.ApplicationListener;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Graphics;
+import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.utils.GdxNativesLoader;
 
 /** An implementation of the {@link Application} interface dedicated for android live wallpapers.
@@ -606,6 +609,22 @@ public abstract class AndroidLiveWallpaperService extends WallpaperService {
 				});
 			}
 		}
-		
+
+		@Override
+		public WallpaperColors onComputeColors () {
+			Application app = Gdx.app;
+			if (Build.VERSION.SDK_INT >= 27 && app instanceof AndroidLiveWallpaper) {
+				AndroidLiveWallpaper liveWallpaper = (AndroidLiveWallpaper) app;
+				Color[] colors = liveWallpaper.wallpaperColors;
+				if (colors != null)
+					return new WallpaperColors(
+							android.graphics.Color.valueOf(colors[0].r, colors[0].g, colors[0].b, colors[0].a),
+							android.graphics.Color.valueOf(colors[1].r, colors[1].g, colors[1].b, colors[1].a),
+							android.graphics.Color.valueOf(colors[2].r, colors[2].g, colors[2].b, colors[2].a)
+					);
+			}
+			return super.onComputeColors();
+		}
+
 	}
 }


### PR DESCRIPTION
This exposes the live wallpaper engine's ability to report "visually significant" colors for the launcher and lock screen to use. I don't have a phone that noticeably uses this feature, but one of my users confirmed after I updated my app with this code that their lock screen now correctly shows bright text for the clock overlay when my wallpaper is dark, and vice versa.

I didn't add the method to the `Application` interface, since it would just be clutter for anything that isn't a Live Wallpaper. If it needs to be called from the `core` module, a platform resolver interface can be used.

I thought it would be most convenient to use Gdx's `Color` class for reporting the colors. The Colors are copied rather than directly referenced so this method can be thread-safe. The documentation of `WallpaperService.Engine` doesn't specify whether `onComputeColors()` has to be thread-safe, so I just went ahead and did it. This isn't a method that will be called frequently.