### PR TITLE
Build.gradle for gdx-setup

### DIFF
--- a/extensions/gdx-setup/build.gradle
+++ b/extensions/gdx-setup/build.gradle
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+plugins {
+	id 'application'
+}
+
+application {
+	mainClassName = 'com.badlogic.gdx.setup.GdxSetup'
+}
+
+jar {
+	archiveName = 'gdx-setup.jar'
+	manifest {
+		attributes 'Main-Class': project.mainClassName
+	}
+}


### PR DESCRIPTION
With this config, the old ant config isn't necessary anymore to create the setup jar.
The _gdx-setup.jar_ can be easily created via `gradlew extensions:gdx-setup:jar` and can be found in _extensions/gdx-setup/build/libs_.
The setup can also get started via gradle with the command `gradlew extensions:gdx-setup:run`.