### PR TITLE
Remove check for tools directory in android sdk root in gdx-setup

### DIFF
--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetup.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetup.java
@@ -34,7 +34,7 @@ import com.badlogic.gdx.setup.Executor.CharCallback;
  * @author Tomski */
 public class GdxSetup {
 	public static boolean isSdkLocationValid (String sdkLocation) {
-		return new File(sdkLocation, "tools").exists() && new File(sdkLocation, "platforms").exists();
+		return new File(sdkLocation, "platforms").exists();
 	}
 
 	public static boolean isEmptyDirectory (String destination) {
@@ -80,7 +80,7 @@ public class GdxSetup {
 		}
 
 		int newestLocalApi = getLatestApi(apis);
-		if (newestLocalApi > Integer.valueOf(DependencyBank.androidAPILevel)) {
+		if (newestLocalApi > Integer.parseInt(DependencyBank.androidAPILevel)) {
 			int value = JOptionPane.showConfirmDialog(null,
 				"You have a more recent Android API than the recommended.\nDo you want to use your more recent version?", "Warning!",
 				JOptionPane.YES_NO_OPTION);
@@ -90,7 +90,7 @@ public class GdxSetup {
 				DependencyBank.androidAPILevel = String.valueOf(newestLocalApi);
 			}
 		} else {
-			if (newestLocalApi != Integer.valueOf(DependencyBank.androidAPILevel)) {
+			if (newestLocalApi != Integer.parseInt(DependencyBank.androidAPILevel)) {
 				JOptionPane.showMessageDialog(null, "Please update your Android SDK, you need the Android API: "
 					+ DependencyBank.androidAPILevel);
 				return false;
@@ -191,14 +191,14 @@ public class GdxSetup {
 			}
 		}
 	}
-	
+
 	private static boolean versionsEqual(int[] testVersion, int[] targetVersion) {
 		for (int i = 0; i < 3; i++) {
 			if (testVersion[i] != targetVersion[i]) return false;
 		}
 		return true;
 	}
-	
+
 	private static boolean compareVersions(int[] version, int[] testVersion) {
 		if (testVersion[0] > version[0]) {
 			return true;
@@ -342,7 +342,7 @@ public class GdxSetup {
 			project.files.add(new ProjectFile("ios/robovm.xml", true));
 		}
 
-		if(builder.modules.contains(ProjectType.IOSMOE)) {			
+		if(builder.modules.contains(ProjectType.IOSMOE)) {
 			project.files.add(new ProjectFile("ios-moe/src/IOSMoeLauncher", "ios-moe/src/" + packageDir + "/IOSMoeLauncher.java", true));			
 			project.files.add(new ProjectFile("ios-moe/xcode/ios-moe/Default-1024w-1366h@2x~ipad.png", false));
 			project.files.add(new ProjectFile("ios-moe/xcode/ios-moe/Default-375w-667h@2x.png", false));
@@ -510,7 +510,7 @@ public class GdxSetup {
 			throw new RuntimeException("Couldn't create dir '" + outFile.getAbsolutePath() + "'");
 		}
 
-		boolean isTemp = file instanceof TemporaryProjectFile ? true : false;
+		boolean isTemp = file instanceof TemporaryProjectFile;
 
 		if (file.isTemplate) {
 			String txt;
@@ -605,7 +605,7 @@ public class GdxSetup {
 
 	private String parseGwtInherits (ProjectBuilder builder) {
 		String parsed = "";
-		
+
 		for (Dependency dep : builder.dependencies) {
 			if (dep.getGwtInherits() != null) {
 				for (String inherit : dep.getGwtInherits()) {
@@ -613,7 +613,7 @@ public class GdxSetup {
 				}
 			}
 		}
-		
+
 		return parsed;
 	}
 


### PR DESCRIPTION
If someone tries to generate a new libgdx project, the gdx-setup checks whether the android sdk contains a directory named _tools_. 
During the installation of android studio, the directory does not get created. Also installing the command line tools via the sdk manager of android studio, the directory won't be created.
So users can't create a new project, unless they create the directory themself.
This problem happened also there: #5934