### PR TITLE
BaseTmxMapLoader, TmxMapLoader,AtlasTmxMapLoader: private methods -> protected

### DIFF
--- a/gdx/src/com/badlogic/gdx/maps/tiled/AtlasTmxMapLoader.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/AtlasTmxMapLoader.java
@@ -47,7 +47,7 @@ public class AtlasTmxMapLoader extends BaseTmxMapLoader<AtlasTmxMapLoader.AtlasT
 		public boolean forceTextureFilters = false;
 	}
 
-	private interface AtlasResolver extends ImageResolver {
+	protected interface AtlasResolver extends ImageResolver {
 
 		public TextureAtlas getAtlas ();
 
@@ -203,7 +203,7 @@ public class AtlasTmxMapLoader extends BaseTmxMapLoader<AtlasTmxMapLoader.AtlasT
 		}
 	}
 
-	private FileHandle getAtlasFileHandle (FileHandle tmxFile) {
+	protected FileHandle getAtlasFileHandle (FileHandle tmxFile) {
 		Element properties = root.getChildByName("properties");
 
 		String atlasFilePath = null;
@@ -227,7 +227,7 @@ public class AtlasTmxMapLoader extends BaseTmxMapLoader<AtlasTmxMapLoader.AtlasT
 		}
 	}
 
-	private void setTextureFilters (Texture.TextureFilter min, Texture.TextureFilter mag) {
+	protected void setTextureFilters (Texture.TextureFilter min, Texture.TextureFilter mag) {
 		for (Texture texture : trackedTextures) {
 			texture.setFilter(min, mag);
 		}

--- a/gdx/src/com/badlogic/gdx/maps/tiled/BaseTmxMapLoader.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/BaseTmxMapLoader.java
@@ -426,7 +426,7 @@ public abstract class BaseTmxMapLoader<P extends BaseTmxMapLoader.Parameters> ex
 		}
 	}
 
-	private Object castProperty (String name, String value, String type) {
+	protected Object castProperty (String name, String value, String type) {
 		if (type == null) {
 			return value;
 		} else if (type.equals("int")) {

--- a/gdx/src/com/badlogic/gdx/maps/tiled/TmxMapLoader.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/TmxMapLoader.java
@@ -105,7 +105,7 @@ public class TmxMapLoader extends BaseTmxMapLoader<TmxMapLoader.Parameters> {
 		return descriptors;
 	}
 
-	private Array<FileHandle> getDependencyFileHandles (FileHandle tmxFile) {
+	protected Array<FileHandle> getDependencyFileHandles (FileHandle tmxFile) {
 		Array<FileHandle> fileHandles = new Array<FileHandle>();
 
 		// TileSet descriptors


### PR DESCRIPTION
BaseTmxMapLoader, TmxMapLoader and AtlasTmxMapLoader have a few private methods/interfaces which make it unnecessarily hard or impossible to extend these classes.

This pull request just makes these methods/interfaces protected instead of private.