### PR TITLE
Add a method to obtain the handle of a ShaderProgram

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -18,6 +18,7 @@
 - API Change: DefaultTextureBinder WEIGHTED strategy replaced by LRU strategy.
 - API Change: ShaderProgram begin and end methods are deprecated in favor to bind method.
 - API Addition: Added a OpenALAudio#getSourceId(long) method.
+- API Addition: Added a ShaderProgram#getHandle() method.
 
 [1.9.10]
 - API Addition: Allow target display for maximization LWJGL3 backend

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/ShaderProgram.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/ShaderProgram.java
@@ -915,4 +915,9 @@ public class ShaderProgram implements Disposable {
 	public String getFragmentShaderSource () {
 		return fragmentShaderSource;
 	}
+
+	/** @return the handle of the shader program */
+	public int getHandle () {
+		return program;
+	}
 }


### PR DESCRIPTION
This PR adds a method to obtain the OpenGL handle of a `ShaderProgram`. This is needed for some OpenGL methods (e.g. `GL32C.glBindFragDataLocation(handle, 0, "albedoOut")`).

Extending `ShaderProgram` is not possible, as the variable in question is private.