### PR TITLE
Fix running tests on IDEA

### DIFF
--- a/gdx/build.gradle
+++ b/gdx/build.gradle
@@ -19,8 +19,11 @@ apply plugin: "java"
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
-sourceSets.main.resources.srcDirs = ["res"]
 sourceSets.main.java.srcDirs = ["src"]
+sourceSets.main.resources.srcDirs = ["res"]
+// Workaround the Idea limitation that only takes output folder for classpath resolution when running
+// from other modules (such as /tests)
+sourceSets.main.output.resourcesDir = file("$buildDir/classes/java/main")
 
 sourceSets.test.java.srcDirs = ["test"]
 


### PR DESCRIPTION
This PR fixes the issue of IDEA not adding resources from the `gdx` module to classpath when running tests suites from `tests` modules on libGDX project.

Steps to reproduce:
1. On IDEA `Build -> Clean Project`
2. On IDEA `Run` a test suite such as `tests/gdx-tests-lwjgl3` `Lwjgl3TestStarter` (use IDE `Run`, not from the Gradle task list menu).
3. Choose `UISimpleTest` from the list
4. Crash with
```Exception in thread "main" com.badlogic.gdx.utils.GdxRuntimeException: File not found: com\badlogic\gdx\utils\arial-15.fnt (Classpath)
	at com.badlogic.gdx.files.FileHandle.read(FileHandle.java:142)
	at com.badlogic.gdx.graphics.g2d.BitmapFont$BitmapFontData.load(BitmapFont.java:493)
	at com.badlogic.gdx.graphics.g2d.BitmapFont$BitmapFontData.<init>(BitmapFont.java:485)
	at com.badlogic.gdx.graphics.g2d.BitmapFont.<init>(BitmapFont.java:131)
	at com.badlogic.gdx.graphics.g2d.BitmapFont.<init>(BitmapFont.java:72)
	at com.badlogic.gdx.tests.UISimpleTest.create(UISimpleTest.java:59)
	at com.badlogic.gdx.backends.lwjgl3.Lwjgl3Window.initializeListener(Lwjgl3Window.java:431)
	at com.badlogic.gdx.backends.lwjgl3.Lwjgl3Window.update(Lwjgl3Window.java:379)
	at com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application.loop(Lwjgl3Application.java:137)
	at com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application.<init>(Lwjgl3Application.java:111)
	at com.badlogic.gdx.tests.lwjgl3.Lwjgl3TestStarter.main(Lwjgl3TestStarter.java:45)
```