### PR TITLE
Rename gdx-box2d and gdx-controllers in gradle

### DIFF
--- a/extensions/gdx-controllers/gdx-controllers-android/build.gradle
+++ b/extensions/gdx-controllers/gdx-controllers-android/build.gradle
@@ -17,5 +17,5 @@
 dependencies {
     compileOnly project(":backends:gdx-backend-android")
     compileOnly fileTree(dir: '../../../backends/gdx-backend-android/libs', include: ['*.jar'])
-    compileOnly project(":extensions:gdx-controllers:gdx-controllers")
+    compileOnly project(":extensions:gdx-controllers:gdx-controllers-core")
 }

--- a/extensions/gdx-controllers/gdx-controllers-desktop/build.gradle
+++ b/extensions/gdx-controllers/gdx-controllers-desktop/build.gradle
@@ -15,7 +15,7 @@
  ******************************************************************************/
 
 dependencies {
-    compileOnly project(":extensions:gdx-controllers:gdx-controllers")
+    compileOnly project(":extensions:gdx-controllers:gdx-controllers-core")
     compileOnly project(":extensions:gdx-jnigen")
     compileOnly libraries.lwjgl
 }

--- a/extensions/gdx-controllers/gdx-controllers-gwt/build.gradle
+++ b/extensions/gdx-controllers/gdx-controllers-gwt/build.gradle
@@ -15,6 +15,6 @@
  ******************************************************************************/
 
 dependencies {
-    compileOnly project(":extensions:gdx-controllers:gdx-controllers")
+    compileOnly project(":extensions:gdx-controllers:gdx-controllers-core")
     compileOnly libraries.gwt
 }

--- a/extensions/gdx-controllers/gdx-controllers-lwjgl3/build.gradle
+++ b/extensions/gdx-controllers/gdx-controllers-lwjgl3/build.gradle
@@ -15,6 +15,6 @@
  ******************************************************************************/
 
 dependencies {
-    compileOnly project(":extensions:gdx-controllers:gdx-controllers")
+    compileOnly project(":extensions:gdx-controllers:gdx-controllers-core")
     compileOnly libraries.lwjgl3
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -47,3 +47,5 @@ include ":tests:gdx-tests-lwjgl"
 include ":tests:gdx-tests-lwjgl3"
 
 rootProject.name = "libgdx"
+project(":extensions:gdx-box2d:gdx-box2d").name = "gdx-box2d-core"
+project(":extensions:gdx-controllers:gdx-controllers").name = "gdx-controllers-core"

--- a/tests/gdx-tests-android/build.gradle
+++ b/tests/gdx-tests-android/build.gradle
@@ -26,7 +26,7 @@ apply from: "obb.gradle"
 dependencies {
 	compile project(":tests:gdx-tests")
 	compile project(":gdx")
-	compile project(":extensions:gdx-box2d:gdx-box2d")
+	compile project(":extensions:gdx-box2d:gdx-box2d-core")
 	compile project(":extensions:gdx-bullet")
 	compile project(":extensions:gdx-controllers:gdx-controllers-android")
 	compile project(":extensions:gdx-freetype")

--- a/tests/gdx-tests-gwt/build.gradle
+++ b/tests/gdx-tests-gwt/build.gradle
@@ -101,7 +101,7 @@ task addSource {
         sourceSets.main.compileClasspath += files(project(':tests:gdx-tests').sourceSets.main.allJava.srcDirs)
         sourceSets.main.compileClasspath += files(project(':backends:gdx-backends-gwt').sourceSets.main.allJava.srcDirs)
         sourceSets.main.compileClasspath += files(project(':extensions:gdx-box2d:gdx-box2d-gwt').sourceSets.main.allJava.srcDirs)
-        sourceSets.main.compileClasspath += files(project(':extensions:gdx-controllers:gdx-controllers').sourceSets.main.allJava.srcDirs)
+        sourceSets.main.compileClasspath += files(project(':extensions:gdx-controllers:gdx-controllers-core').sourceSets.main.allJava.srcDirs)
         sourceSets.main.compileClasspath += files(project(':extensions:gdx-controllers:gdx-controllers-gwt').sourceSets.main.allJava.srcDirs)
         sourceSets.main.compileClasspath += files(project(':gdx').sourceSets.main.allJava.srcDirs)
         sourceSets.main.compileClasspath += files(sourceSets.main.resources.srcDirs)

--- a/tests/gdx-tests/build.gradle
+++ b/tests/gdx-tests/build.gradle
@@ -16,9 +16,9 @@
 
 dependencies {
     compile project(":gdx")
-    compile project(":extensions:gdx-box2d:gdx-box2d")
+    compile project(":extensions:gdx-box2d:gdx-box2d-core")
     compile project(":extensions:gdx-bullet")
-    compile project(":extensions:gdx-controllers:gdx-controllers")
+    compile project(":extensions:gdx-controllers:gdx-controllers-core")
     compile project(":extensions:gdx-freetype")
     compileOnly project(":extensions:gdx-tools")
 }


### PR DESCRIPTION
As discussed in #5846, the android-gradle plugin makes some noise with same named parent and child projects.
So we found a way to fix it without renaming the whole directory, but only changing the module names in gradle.