### PR TITLE
Add isWrap() to Label

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Label.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Label.java
@@ -272,7 +272,7 @@ public class Label extends Widget {
 		invalidateHierarchy();
 	}
 
-	public boolean isWrap () {
+	public boolean getWrap () {
 		return wrap;
 	}
 

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Label.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Label.java
@@ -272,6 +272,10 @@ public class Label extends Widget {
 		invalidateHierarchy();
 	}
 
+	public boolean isWrap () {
+		return wrap;
+	}
+
 	public int getLabelAlign () {
 		return labelAlign;
 	}


### PR DESCRIPTION
A Discord user has requested being able to get the "wrap" property value.

The use case is a shadow object that makes an identical version of the Actor passed in, but light grey and slightly offset. To use it with a label he needs to set the shadow label as all the same features
like width, height, alignment, wrap etc (and there's not a new Label (Label label) constructor either).