### PR TITLE
Fix android gap in music when looping

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidAudio.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidAudio.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -113,37 +113,16 @@ public final class AndroidAudio implements Audio {
 		}
 		AndroidFileHandle aHandle = (AndroidFileHandle)file;
 
-		MediaPlayer mediaPlayer = new MediaPlayer();
-
-		if (aHandle.type() == FileType.Internal) {
-			try {
-				AssetFileDescriptor descriptor = aHandle.getAssetFileDescriptor();
-				mediaPlayer.setDataSource(descriptor.getFileDescriptor(), descriptor.getStartOffset(), descriptor.getLength());
-				descriptor.close();
-				mediaPlayer.prepare();
-				AndroidMusic music = new AndroidMusic(this, mediaPlayer);
-				synchronized (musics) {
-					musics.add(music);
-				}
-				return music;
-			} catch (Exception ex) {
-				throw new GdxRuntimeException("Error loading audio file: " + file
+		try {
+			AndroidMusic music = new AndroidMusic(this, aHandle, aHandle.type() == FileType.Internal ? AndroidMusic.INTERNAL : AndroidMusic.PATH);
+			synchronized (musics) {
+				musics.add(music);
+			}
+			return music;
+		} catch (Exception ex) {
+			throw new GdxRuntimeException("Error loading audio file: " + file
 					+ "\nNote: Internal audio files must be placed in the assets directory.", ex);
-			}
-		} else {
-			try {
-				mediaPlayer.setDataSource(aHandle.file().getPath());
-				mediaPlayer.prepare();
-				AndroidMusic music = new AndroidMusic(this, mediaPlayer);
-				synchronized (musics) {
-					musics.add(music);
-				}
-				return music;
-			} catch (Exception ex) {
-				throw new GdxRuntimeException("Error loading audio file: " + file, ex);
-			}
 		}
-
 	}
 
 	/** Creates a new Music instance from the provided FileDescriptor. It is the caller's responsibility to close the file
@@ -164,7 +143,7 @@ public final class AndroidAudio implements Audio {
 			mediaPlayer.setDataSource(fd);
 			mediaPlayer.prepare();
 
-			AndroidMusic music = new AndroidMusic(this, mediaPlayer);
+			AndroidMusic music = new AndroidMusic(this, fd);
 			synchronized (musics) {
 				musics.add(music);
 			}

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidMusic.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidMusic.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,117 +16,205 @@
 
 package com.badlogic.gdx.backends.android;
 
+import java.io.FileDescriptor;
 import java.io.IOException;
 
+import android.content.res.AssetFileDescriptor;
 import android.media.MediaPlayer;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.audio.Music;
 
-public class AndroidMusic implements Music, MediaPlayer.OnCompletionListener {
+public class AndroidMusic implements Music {
+	// which file is getting played
+	public static final int FILE_DESCRIPTOR = 1;
+	public static final int INTERNAL = 2;
+	public static final int PATH = 3;
+
+	// states of the media player
+	public static final int STATE_PLAYING = 1;
+	public static final int STATE_PAUSED = 2;
+	public static final int STATE_STOP = 3;
+
+	// current state
+	private int state = STATE_STOP;
+
+	// current mediaPlayer which is playing
+	private int mediaPlayerIndex = -1;
+
+	private final AndroidMusic.MediaPlayerWrapper mediaPlayerWrapper = new AndroidMusic.MediaPlayerWrapper();
+	private AndroidFileHandle aHandle;
+	private FileDescriptor fd;
+	private int type;
 	private final AndroidAudio audio;
-	private MediaPlayer player;
 	private boolean isPrepared = true;
+	private boolean isLooping;
 	protected boolean wasPlaying = false;
 	private float volume = 1f;
 	protected OnCompletionListener onCompletionListener;
 
-	AndroidMusic (AndroidAudio audio, MediaPlayer player) {
+	AndroidMusic(AndroidAudio audio, FileDescriptor fd) {
+		this(audio, null, fd, FILE_DESCRIPTOR);
+	}
+
+	AndroidMusic(AndroidAudio audio, AndroidFileHandle aHandle, int type) {
+		this(audio, aHandle, null, type);
+	}
+
+	AndroidMusic(AndroidAudio audio, AndroidFileHandle aHandle, FileDescriptor fd, int type) {
 		this.audio = audio;
-		this.player = player;
+		this.aHandle = aHandle;
+		this.fd = fd;
+		this.type = type;
 		this.onCompletionListener = null;
-		this.player.setOnCompletionListener(this);
 	}
 
 	@Override
 	public void dispose () {
-		if (player == null) return;
-		try {
-			player.release();
-		} catch (Throwable t) {
-			Gdx.app.log("AndroidMusic", "error while disposing AndroidMusic instance, non-fatal");
-		} finally {
-			player = null;
-			onCompletionListener = null;
-			synchronized (audio.musics) {
-				audio.musics.remove(this);
+		synchronized (mediaPlayerWrapper) {
+			for (int i = 0; i < mediaPlayerWrapper.size(); i++) {
+				MediaPlayer mediaPlayer = mediaPlayerWrapper.getValue(i);
+				if (mediaPlayer == null) return;
+				try {
+					mediaPlayer.release();
+				} catch (Throwable t) {
+					Gdx.app.log("AndroidMusic", "error while disposing AndroidMusic instance, non-fatal");
+				} finally {
+					mediaPlayer = null;
+					synchronized (audio.musics) {
+						audio.musics.remove(this);
+					}
+				}
 			}
 		}
 	}
 
 	@Override
 	public boolean isLooping () {
-		if (player == null) return false;
-		try {
-			return player.isLooping();
-		} catch (Exception e) {
-			// NOTE: isLooping() can potentially throw an exception and crash the application
-			e.printStackTrace();
-			return false;
-		}
+		return isLooping;
 	}
 
 	@Override
 	public boolean isPlaying () {
-		if (player == null) return false;
-		try {
-			return player.isPlaying();
-		} catch (Exception e) {
-			// NOTE: isPlaying() can potentially throw an exception and crash the application
-			e.printStackTrace();
-			return false;
+		synchronized (mediaPlayerWrapper) {
+			boolean isPlaying = false;
+			for (int i = 0; i < mediaPlayerWrapper.size(); i++) {
+				MediaPlayer mediaPlayer = mediaPlayerWrapper.getValue(i);
+				if (mediaPlayer == null) continue;
+				try {
+					isPlaying = isPlaying || mediaPlayer.isPlaying();
+				} catch (Exception e) {
+					// NOTE: isPlaying() can potentially throw an exception and crash the application
+					e.printStackTrace();
+				}
+			}
+			return isPlaying;
 		}
 	}
 
 	@Override
-	public void pause () { 
-		if (player == null) return;
-		try {
-			if (player.isPlaying()) {			
-				player.pause();
+	public void pause () {
+		synchronized (mediaPlayerWrapper) {
+			wasPlaying = false;
+			for (int i = 0; i < mediaPlayerWrapper.size(); i++) {
+				MediaPlayer mediaPlayer = mediaPlayerWrapper.getValue(i);
+				if (mediaPlayer == null) continue;
+				try {
+					if (mediaPlayer.isPlaying()) {
+						mediaPlayer.pause();
+						wasPlaying = true;
+					}
+				} catch (Exception e) {
+					// NOTE: isPlaying() can potentially throw an exception and crash the application
+					e.printStackTrace();
+				}
 			}
-		} catch (Exception e) {
-			// NOTE: isPlaying() can potentially throw an exception and crash the application
-			e.printStackTrace();
 		}
-		wasPlaying = false;
 	}
 
 	@Override
 	public void play () {
-		if (player == null) return;
-		try {
-			if (player.isPlaying()) return;
-		} catch (Exception e) {
-			// NOTE: isPlaying() can potentially throw an exception and crash the application
-			e.printStackTrace();
-			return;
-		}
-
-		try {
-			if (!isPrepared) {
-				player.prepare();
-				isPrepared = true;
+		synchronized (mediaPlayerWrapper) {
+			for (int i = 0; i < mediaPlayerWrapper.size(); i++) {
+				mediaPlayerWrapper.setValue(i, new MediaPlayer());
+				switch (type) {
+					case FILE_DESCRIPTOR:
+						try {
+							mediaPlayerWrapper.getValue(i).setDataSource(fd);
+							mediaPlayerWrapper.getValue(i).prepare();
+						} catch (IOException e) {
+							e.printStackTrace();
+						}
+						break;
+					case INTERNAL:
+						try {
+							AssetFileDescriptor descriptor = aHandle.getAssetFileDescriptor();
+							mediaPlayerWrapper.getValue(i).setDataSource(descriptor.getFileDescriptor(), descriptor.getStartOffset(), descriptor.getLength());
+							descriptor.close();
+							mediaPlayerWrapper.getValue(i).prepare();
+						} catch (IOException e) {
+							e.printStackTrace();
+						}
+						break;
+					case PATH:
+						try {
+							mediaPlayerWrapper.getValue(i).setDataSource(aHandle.file().getPath());
+							mediaPlayerWrapper.getValue(i).prepare();
+						} catch (IOException e) {
+							e.printStackTrace();
+						}
+						break;
+				}
+				mediaPlayerWrapper.getValue(i).setVolume(volume, volume);
+				mediaPlayerWrapper.getValue(i).setOnCompletionListener(isLooping() ? loopingCompletionListener : completionListener);
 			}
-			player.start();
-		} catch (IllegalStateException e) {
-			e.printStackTrace();
-		} catch (IOException e) {
-			e.printStackTrace();
+			// set nextMediaPlayers
+			if(isLooping()) {
+				mediaPlayerWrapper.getValue(0).setNextMediaPlayer(mediaPlayerWrapper.getValue(1));
+				mediaPlayerWrapper.getValue(1).setNextMediaPlayer(mediaPlayerWrapper.getValue(2));
+			}
+			mediaPlayerIndex = 0;
+			MediaPlayer mediaPlayer = mediaPlayerWrapper.getValue(mediaPlayerIndex);
+			if (mediaPlayer == null) return;
+			try {
+				if (mediaPlayer.isPlaying()) return;
+			} catch (Exception e) {
+				// NOTE: isPlaying() can potentially throw an exception and crash the application
+				e.printStackTrace();
+				return;
+			}
+
+			try {
+				if (!isPrepared) {
+					mediaPlayer.prepare();
+					isPrepared = true;
+				}
+				mediaPlayer.start();
+				state = STATE_PLAYING;
+			} catch (IllegalStateException e) {
+				e.printStackTrace();
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
 		}
 	}
 
 	@Override
 	public void setLooping (boolean isLooping) {
-		if (player == null) return;
-		player.setLooping(isLooping);
+		this.isLooping = isLooping;
 	}
 
 	@Override
 	public void setVolume (float volume) {
-		if (player == null) return;
-		player.setVolume(volume, volume);
-		this.volume = volume;
+		synchronized (mediaPlayerWrapper) {
+			this.volume = volume;
+			for (int i = 0; i < mediaPlayerWrapper.size(); i++) {
+				MediaPlayer mediaPlayer = mediaPlayerWrapper.getValue(i);
+				if (mediaPlayer != null) {
+					mediaPlayer.setVolume(volume, volume);
+				}
+			}
+		}
 	}
 
 	@Override
@@ -136,70 +224,174 @@ public class AndroidMusic implements Music, MediaPlayer.OnCompletionListener {
 
 	@Override
 	public void setPan (float pan, float volume) {
-		if (player == null) return;
-		float leftVolume = volume;
-		float rightVolume = volume;
+		synchronized (mediaPlayerWrapper) {
+			for (int i = 0; i < mediaPlayerWrapper.size(); i++) {
+				MediaPlayer mediaPlayer = mediaPlayerWrapper.getValue(i);
+				if (mediaPlayer == null) return;
+				float leftVolume = volume;
+				float rightVolume = volume;
 
-		if (pan < 0) {
-			rightVolume *= (1 - Math.abs(pan));
-		} else if (pan > 0) {
-			leftVolume *= (1 - Math.abs(pan));
+				if (pan < 0) {
+					rightVolume *= (1 - Math.abs(pan));
+				} else if (pan > 0) {
+					leftVolume *= (1 - Math.abs(pan));
+				}
+
+				mediaPlayer.setVolume(leftVolume, rightVolume);
+			}
+			this.volume = volume;
 		}
-
-		player.setVolume(leftVolume, rightVolume);
-		this.volume = volume;
-	}
-
-	@Override
-	public void stop () {
-		if (player == null) return;
-		if (isPrepared) {
-			player.seekTo(0);
-		}
-		player.stop();
-		isPrepared = false;
 	}
 
 	public void setPosition (float position) {
-		if (player == null) return;
-		try {
-			if (!isPrepared) {
-				player.prepare();
-				isPrepared = true;
+		synchronized (mediaPlayerWrapper) {
+			for (int i = 0; i < mediaPlayerWrapper.size(); i++) {
+				MediaPlayer mediaPlayer = mediaPlayerWrapper.getValue(i);
+				if (mediaPlayer == null) return;
+				try {
+					if (!isPrepared) {
+						mediaPlayer.prepare();
+						isPrepared = true;
+					}
+					mediaPlayer.seekTo((int) (position * 1000));
+				} catch (IllegalStateException e) {
+					e.printStackTrace();
+				} catch (IOException e) {
+					e.printStackTrace();
+				}
 			}
-			player.seekTo((int)(position * 1000));
-		} catch (IllegalStateException e) {
-			e.printStackTrace();
-		} catch (IOException e) {
-			e.printStackTrace();
 		}
 	}
 
 	@Override
 	public float getPosition () {
-		if (player == null) return 0.0f;
-		return player.getCurrentPosition() / 1000f;
+		synchronized (mediaPlayerWrapper) {
+			if (mediaPlayerWrapper.getValue(mediaPlayerIndex) == null) return 0.0f;
+			return mediaPlayerWrapper.getValue(mediaPlayerIndex).getCurrentPosition() / 1000f;
+		}
 	}
 
 	public float getDuration () {
-		if (player == null) return 0.0f;
-		return player.getDuration() / 1000f;
+		synchronized (mediaPlayerWrapper) {
+			if (mediaPlayerWrapper.getValue(mediaPlayerIndex) == null) return 0.0f;
+			return mediaPlayerWrapper.getValue(mediaPlayerIndex).getDuration() / 1000f;
+		}
 	}
 
-	@Override
 	public void setOnCompletionListener (OnCompletionListener listener) {
 		onCompletionListener = listener;
 	}
 
-	@Override
-	public void onCompletion (MediaPlayer mp) {
-		if (onCompletionListener != null) {
-			Gdx.app.postRunnable(new Runnable() {
-				@Override
-				public void run () {
-					onCompletionListener.onCompletion(AndroidMusic.this);
-				}
-			});
+	/**
+	 * internal listener which handles looping thing
+	 */
+	private MediaPlayer.OnCompletionListener completionListener = new MediaPlayer.OnCompletionListener() {
+		@Override
+		public void onCompletion(MediaPlayer mediaPlayer) {
+			if(onCompletionListener != null) onCompletionListener.onCompletion(AndroidMusic.this);
 		}
 	};
+
+	private MediaPlayer.OnCompletionListener loopingCompletionListener = new MediaPlayer.OnCompletionListener() {
+
+		@Override
+		public void onCompletion(MediaPlayer curmp) {
+			synchronized (mediaPlayerWrapper) {
+				int mpPlaying = 0;
+				int mpNext = 0;
+				if (curmp == mediaPlayerWrapper.getValue(0)) {
+					mpPlaying = 1;
+					mpNext = 2;
+				} else if (curmp == mediaPlayerWrapper.getValue(1)) {
+					mpPlaying = 2;
+					mpNext = 0;  // corrected, else index out of range
+				} else if (curmp == mediaPlayerWrapper.getValue(2)) {
+					mpPlaying = 0; // corrected, else index out of range
+					mpNext = 1; // corrected, else index out of range
+				}
+
+				// as we have set mp2 mp1's next, so index will be 1
+				mediaPlayerIndex = mpPlaying;
+				try {
+					// mp3 is already playing release it
+					if (mediaPlayerWrapper.getValue(mpNext) != null) {
+						mediaPlayerWrapper.getValue(mpNext).release();
+					}
+					// if we are playing uri
+					mediaPlayerWrapper.setValue(mpNext, new MediaPlayer());
+					AssetFileDescriptor descriptor = aHandle.getAssetFileDescriptor();
+					mediaPlayerWrapper.getValue(mpNext).setDataSource(descriptor.getFileDescriptor(), descriptor.getStartOffset(), descriptor.getLength());
+					descriptor.close();
+					mediaPlayerWrapper.getValue(mpNext).prepare();
+					// set listener to mp3
+					mediaPlayerWrapper.getValue(mpNext).setOnCompletionListener(this);
+					// set volume
+					mediaPlayerWrapper.getValue(mpNext).setVolume(volume, volume);
+					// set nextMediaPlayer
+					mediaPlayerWrapper.getValue(mpPlaying).setNextMediaPlayer(mediaPlayerWrapper.getValue(mpNext));
+					// set nextMediaPlayer volume
+					mediaPlayerWrapper.getValue(mpPlaying).setVolume(volume, volume);
+				} catch (Exception e) {
+					e.printStackTrace();
+				}
+			}
+		}
+	};
+
+	/**
+	 * pause current playing session
+	 */
+	public void newPause() {
+		synchronized (mediaPlayerWrapper) {
+			if (state == STATE_PLAYING) {
+				mediaPlayerWrapper.getValue(mediaPlayerIndex).pause();
+				//Log.d("BZMediaPlayer", "pausing");
+				state = STATE_PAUSED;
+			}
+		}
+	}
+
+	/**
+	 * get current state
+	 * @return
+	 */
+	public int getState() {
+		return state;
+	}
+
+	/**
+	 * stop every mediaplayer
+	 */
+	@Override
+	public void stop() {
+		synchronized (mediaPlayerWrapper) {
+			for (int i = 0; i < mediaPlayerWrapper.size(); i++) {
+				MediaPlayer mediaPlayer = mediaPlayerWrapper.getValue(i);
+				mediaPlayer.stop();
+				if (mediaPlayer.isPlaying()) {
+					mediaPlayer.release();
+				}
+			}
+			state = STATE_STOP;
+		}
+	}
+
+	class MediaPlayerWrapper {
+		private MediaPlayer[] mediaPlayers = new MediaPlayer[3];
+		public int size() {
+			return mediaPlayers.length;
+		}
+
+		public void setValue(int index, MediaPlayer value) {
+			synchronized (mediaPlayers) {
+				mediaPlayers[index] = value;
+			}
+		}
+
+		public MediaPlayer getValue(int index) {
+			synchronized (mediaPlayers) {
+				return mediaPlayers[index];
+			}
+		}
+	}
 }


### PR DESCRIPTION
Fixes longstanding issue with android looping problems in music.

Currently there is often a small quiet gap between the end of music finishing and starting again on Android.

This fix uses 3 Mediaplayers that queue up the music to be played one after the other instead of looping on the one Mediaplayer. 

This fix has come from someone else on the internet fixing it for non LibGDX app, but it works here (I've used it in two of my games so far).

It's possible that it could work with just 2 Mediaplayers, but as it works as it is, I've never felt the need to refactor it to try. I guess having 2 would be less memory intensive.