### PR TITLE
[Label] Fixed the setText() that won't update the size.

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Label.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Label.java
@@ -112,6 +112,7 @@ public class Label extends Widget {
 			text.setLength(0);
 			text.append(newText);
 		}
+		if (newText.length() > 0) setSize(getPrefWidth(), getPrefHeight());
 		intValue = Integer.MIN_VALUE;
 		invalidateHierarchy();
 	}


### PR DESCRIPTION
After Label created with short string than use setText() with a long string, The background I have using LabelStyle won't update with new string length.

The image shows Label with debug enabled, and the dark background using LabelStyle:
![image](https://user-images.githubusercontent.com/35620587/79808520-59f68680-83b1-11ea-8de9-cfe22a80c120.png)

With this fix. It will always update the size after the text changed.