### PR TITLE
Rename Android Audio and Input implementations

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplication.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplication.java
@@ -496,11 +496,11 @@ public class AndroidApplication extends Activity implements AndroidApplicationBa
 
 	@Override
 	public AndroidAudio createAudio (Context context, AndroidApplicationConfiguration config) {
-		return new AndroidAudioImpl(context, config);
+		return new DefaultAndroidAudio(context, config);
 	}
 
 	@Override
 	public AndroidInput createInput (Application activity, Context context, Object view, AndroidApplicationConfiguration config) {
-		return new AndroidInputImpl(this, this, graphics.view, config);
+		return new DefaultAndroidInput(this, this, graphics.view, config);
 	}
 }

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidDaydream.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidDaydream.java
@@ -38,8 +38,6 @@ import com.badlogic.gdx.utils.Clipboard;
 import com.badlogic.gdx.utils.GdxNativesLoader;
 import com.badlogic.gdx.utils.SnapshotArray;
 
-import java.util.Arrays;
-
 /** An implementation of the {@link Application} interface for Android. Create an {@link Activity} that derives from this class. In
  * the Activity#onCreate(Bundle) method call the {@link #initialize(ApplicationListener)} method specifying the configuration for
  * the {@link GLSurfaceView}.
@@ -410,12 +408,12 @@ public class AndroidDaydream extends DreamService implements AndroidApplicationB
 
 	@Override
 	public AndroidAudio createAudio (Context context, AndroidApplicationConfiguration config) {
-		return new AndroidAudioImpl(context, config);
+		return new DefaultAndroidAudio(context, config);
 	}
 
 	@Override
 	public AndroidInput createInput (Application activity, Context context, Object view, AndroidApplicationConfiguration config) {
-		return new AndroidInputImpl(this, this, graphics.view, config);
+		return new DefaultAndroidInput(this, this, graphics.view, config);
 	}
 
 	@Override

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidFragmentApplication.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidFragmentApplication.java
@@ -449,12 +449,12 @@ public class AndroidFragmentApplication extends Fragment implements AndroidAppli
 
 	@Override
 	public AndroidAudio createAudio (Context context, AndroidApplicationConfiguration config) {
-		return new AndroidAudioImpl(context, config);
+		return new DefaultAndroidAudio(context, config);
 	}
 
 	@Override
 	public AndroidInput createInput (Application activity, Context context, Object view, AndroidApplicationConfiguration config) {
-		return new AndroidInputImpl(this, getActivity(), graphics.view, config);
+		return new DefaultAndroidInput(this, getActivity(), graphics.view, config);
 	}
 
 	@Override

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidLiveWallpaper.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidLiveWallpaper.java
@@ -348,12 +348,12 @@ public class AndroidLiveWallpaper implements AndroidApplicationBase {
 
 	@Override
 	public AndroidAudio createAudio (Context context, AndroidApplicationConfiguration config) {
-		return new AndroidAudioImpl(context, config);
+		return new DefaultAndroidAudio(context, config);
 	}
 
 	@Override
 	public AndroidInput createInput (Application activity, Context context, Object view, AndroidApplicationConfiguration config) {
-		return new AndroidInputImpl(this, this.getService(), graphics.view, config);
+		return new DefaultAndroidInput(this, this.getService(), graphics.view, config);
 	}
 
 	@Override

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidMouseHandler.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidMouseHandler.java
@@ -20,7 +20,7 @@ import android.view.InputDevice;
 import android.view.MotionEvent;
 
 import com.badlogic.gdx.Gdx;
-import com.badlogic.gdx.backends.android.AndroidInputImpl.TouchEvent;
+import com.badlogic.gdx.backends.android.DefaultAndroidInput.TouchEvent;
 
 /** Mouse handler for devices running Android >= 3.1.
  * 
@@ -29,7 +29,7 @@ public class AndroidMouseHandler {
 	private int deltaX = 0;
 	private int deltaY = 0;
 
-	public boolean onGenericMotion (MotionEvent event, AndroidInputImpl input) {
+	public boolean onGenericMotion (MotionEvent event, DefaultAndroidInput input) {
 		if ((event.getSource() & InputDevice.SOURCE_CLASS_POINTER) == 0) return false;
 
 		final int action = event.getAction() & MotionEvent.ACTION_MASK;
@@ -75,7 +75,7 @@ public class AndroidMouseHandler {
 		Gdx.app.log("AndroidMouseHandler", "action " + actionStr);
 	}
 
-	private void postTouchEvent (AndroidInputImpl input, int type, int x, int y, int scrollAmount, long timeStamp) {
+	private void postTouchEvent (DefaultAndroidInput input, int type, int x, int y, int scrollAmount, long timeStamp) {
 		TouchEvent event = input.usedTouchEvents.obtain();
 		event.timeStamp = timeStamp;
 		event.x = x;

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidTouchHandler.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidTouchHandler.java
@@ -21,14 +21,14 @@ import android.view.MotionEvent;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input.Buttons;
-import com.badlogic.gdx.backends.android.AndroidInputImpl.TouchEvent;
+import com.badlogic.gdx.backends.android.DefaultAndroidInput.TouchEvent;
 
 /** Multitouch handler for devices running Android >= 2.0. If device is capable of (fake) multitouch this will report additional
  * pointers.
  * 
  * @author badlogicgames@gmail.com */
 public class AndroidTouchHandler {
-	public void onTouch (MotionEvent event, AndroidInputImpl input) {
+	public void onTouch (MotionEvent event, DefaultAndroidInput input) {
 		final int action = event.getAction() & MotionEvent.ACTION_MASK;
 		int pointerIndex = (event.getAction() & MotionEvent.ACTION_POINTER_INDEX_MASK) >> MotionEvent.ACTION_POINTER_INDEX_SHIFT;
 		int pointerId = event.getPointerId(pointerIndex);
@@ -43,7 +43,7 @@ public class AndroidTouchHandler {
 			case MotionEvent.ACTION_DOWN:
 			case MotionEvent.ACTION_POINTER_DOWN:
 				realPointerIndex = input.getFreePointerIndex(); // get a free pointer index as reported by Input.getX() etc.
-				if (realPointerIndex >= AndroidInputImpl.NUM_TOUCHES) break;
+				if (realPointerIndex >= DefaultAndroidInput.NUM_TOUCHES) break;
 				input.realId[realPointerIndex] = pointerId;
 				x = (int)event.getX(pointerIndex);
 				y = (int)event.getY(pointerIndex);
@@ -63,7 +63,7 @@ public class AndroidTouchHandler {
 			case MotionEvent.ACTION_OUTSIDE:
 				realPointerIndex = input.lookUpPointerIndex(pointerId);
 				if (realPointerIndex == -1) break;
-				if (realPointerIndex >= AndroidInputImpl.NUM_TOUCHES) break;
+				if (realPointerIndex >= DefaultAndroidInput.NUM_TOUCHES) break;
 				input.realId[realPointerIndex] = -1;
 				x = (int)event.getX(pointerIndex);
 				y = (int)event.getY(pointerIndex);
@@ -100,7 +100,7 @@ public class AndroidTouchHandler {
 					y = (int)event.getY(pointerIndex);
 					realPointerIndex = input.lookUpPointerIndex(pointerId);
 					if (realPointerIndex == -1) continue;
-					if (realPointerIndex >= AndroidInputImpl.NUM_TOUCHES) break;
+					if (realPointerIndex >= DefaultAndroidInput.NUM_TOUCHES) break;
 					button = input.button[realPointerIndex];
 					if (button != -1)
 						postTouchEvent(input, TouchEvent.TOUCH_DRAGGED, x, y, realPointerIndex, button, timeStamp);
@@ -148,7 +148,7 @@ public class AndroidTouchHandler {
 		return -1;
 	}
 
-	private void postTouchEvent (AndroidInputImpl input, int type, int x, int y, int pointer, int button, long timeStamp) {
+	private void postTouchEvent (DefaultAndroidInput input, int type, int x, int y, int pointer, int button, long timeStamp) {
 		TouchEvent event = input.usedTouchEvents.obtain();
 		event.timeStamp = timeStamp;
 		event.pointer = pointer;

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/DefaultAndroidAudio.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/DefaultAndroidAudio.java
@@ -42,12 +42,12 @@ import java.util.List;
 /** An implementation of the {@link Audio} interface for Android.
  * 
  * @author mzechner */
-public final class AndroidAudioImpl implements AndroidAudio {
+public final class DefaultAndroidAudio implements AndroidAudio {
 	private final SoundPool soundPool;
 	private final AudioManager manager;
 	private final List<AndroidMusic> musics = new ArrayList<AndroidMusic>();
 
-	public AndroidAudioImpl (Context context, AndroidApplicationConfiguration config) {
+	public DefaultAndroidAudio (Context context, AndroidApplicationConfiguration config) {
 		if (!config.disableAudio) {
 			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
 				AudioAttributes audioAttrib = new AudioAttributes.Builder()

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/DefaultAndroidInput.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/DefaultAndroidInput.java
@@ -53,7 +53,7 @@ import java.util.List;
  * 
  * @author mzechner */
 /** @author jshapcot */
-public class AndroidInputImpl implements AndroidInput {
+public class DefaultAndroidInput implements AndroidInput {
 
 	static class KeyEvent {
 		static final int KEY_DOWN = 0;
@@ -148,7 +148,7 @@ public class AndroidInputImpl implements AndroidInput {
 	private final ArrayList<OnGenericMotionListener> genericMotionListeners = new ArrayList();
 	private final AndroidMouseHandler mouseHandler;
 
-	public AndroidInputImpl (Application activity, Context context, Object view, AndroidApplicationConfiguration config) {
+	public DefaultAndroidInput (Application activity, Context context, Object view, AndroidApplicationConfiguration config) {
 		// we hook into View, for LWPs we call onTouch below directly from
 		// within the AndroidLivewallpaperEngine#onTouchEvent() method.
 		if (view instanceof View) {


### PR DESCRIPTION
`AndroidAudioImpl` and `AndroidInputImpl` have been renamed to `DefaultAndroidAudio`and `DefaultAndroidInput` to follow better naming conventions (see comments on https://github.com/libgdx/libgdx/pull/6014).