### PR TITLE
Makes ios-moe generated by gdx-setup.jar work

### DIFF
--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/DependencyBank.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/DependencyBank.java
@@ -26,7 +26,7 @@ public class DependencyBank {
 	//Temporary snapshot version, we need a more dynamic solution for pointing to the latest nightly
 	static String libgdxNightlyVersion = "1.9.11-SNAPSHOT";
 	static String roboVMVersion = "2.3.8";
-	static String moeVersion = "1.4.0";
+	static String moeVersion = "1.5.1";
 	static String buildToolsVersion = "29.0.2";
 	static String androidAPILevel = "29";
 	static String gwtVersion = "2.8.2";
@@ -44,7 +44,7 @@ public class DependencyBank {
 	static String gwtPluginImport = "org.wisepersist:gwt-gradle-plugin:1.0.9";
 	static String androidPluginImport = "com.android.tools.build:gradle:3.4.1";
 	static String roboVMPluginImport = "com.mobidevelop.robovm:robovm-gradle-plugin:" + roboVMVersion;
-	static String moePluginImport = "org.multi-os-engine:moe-gradle:" + moeVersion;
+	static String moePluginImport = "org.multi-os-engine.community:moe-gradle:" + moeVersion;
 	
 	//Extension versions
 	static String box2DLightsVersion = "1.4";

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetup.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetup.java
@@ -401,6 +401,10 @@ public class GdxSetup {
 		// HACK executable flag isn't preserved for whatever reason...
 		new File(outputDir, "gradlew").setExecutable(true);
 
+		if(builder.modules.contains(ProjectType.IOSMOE)) {
+			Executor.execute(new File(outputDir), "gradlew.bat", "gradlew", "moeUpdateXcodeSettings" + parseGradleArgs(builder.modules, gradleArgs), callback);
+		}
+
 		Executor.execute(new File(outputDir), "gradlew.bat", "gradlew", "clean" + parseGradleArgs(builder.modules, gradleArgs), callback);
 	}
 


### PR DESCRIPTION
This PR makes ios-moe generated by gdx-setup.jar work.
libGDX with Multi-OS Engine(community) is available.

About org.multi-os-engine.community
https://discuss.multi-os-engine.org/t/moe-sdk-gradle-plugin-community-edition-release-1-5-0/2769

Generate project sample (using gdx-setup.jar)
https://github.com/ark100/multi-os-engine-libgdx-generateproject-sample
