### PR TITLE
Use better implementation to get iOS version

### DIFF
--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSApplication.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSApplication.java
@@ -23,6 +23,7 @@ import org.robovm.apple.coregraphics.CGRect;
 import org.robovm.apple.foundation.Foundation;
 import org.robovm.apple.foundation.NSMutableDictionary;
 import org.robovm.apple.foundation.NSObject;
+import org.robovm.apple.foundation.NSProcessInfo;
 import org.robovm.apple.foundation.NSString;
 import org.robovm.apple.foundation.NSThread;
 import org.robovm.apple.uikit.UIApplication;
@@ -128,8 +129,7 @@ public class IOSApplication implements Application {
 
 		Gdx.app.debug("IOSApplication", "Running in " + (Bro.IS_64BIT ? "64-bit" : "32-bit") + " mode");
 
-		float scale = (float)(getIosVersion() >= 8 ? UIScreen.getMainScreen().getNativeScale() : UIScreen.getMainScreen()
-			.getScale());
+		float scale = (float) UIScreen.getMainScreen().getNativeScale();
 		if (scale >= 2.0f) {
 			Gdx.app.debug("IOSApplication", "scale: " + scale);
 			if (UIDevice.getCurrentDevice().getUserInterfaceIdiom() == UIUserInterfaceIdiom.Pad) {
@@ -184,12 +184,6 @@ public class IOSApplication implements Application {
 
 	protected IOSInput createInput() {
 		 return new IOSInput(this);
-	}
-
-	int getIosVersion () {
-		String systemVersion = UIDevice.getCurrentDevice().getSystemVersion();
-		int version = Integer.parseInt(systemVersion.split("\\.")[0]);
-		return version;
 	}
 
 	/** Return the UI view controller of IOSApplication
@@ -389,7 +383,7 @@ public class IOSApplication implements Application {
 
 	@Override
 	public int getVersion () {
-		return Integer.parseInt(UIDevice.getCurrentDevice().getSystemVersion().split("\\.")[0]);
+		return (int) NSProcessInfo.getSharedProcessInfo().getOperatingSystemVersion().getMajorVersion();
 	}
 
 	@Override

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSInput.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSInput.java
@@ -111,7 +111,7 @@ public class IOSInput implements Input {
 		UIDevice device = UIDevice.getCurrentDevice();
 		if (device.getModel().equalsIgnoreCase("iphone")) hasVibrator = true;
 
-		if (app.getIosVersion() >= 9){
+		if (app.getVersion() >= 9){
 			UIForceTouchCapability forceTouchCapability = UIScreen.getMainScreen().getTraitCollection().getForceTouchCapability();
 			pressureSupported = forceTouchCapability == UIForceTouchCapability.Available;
 		}


### PR DESCRIPTION
iOS 8 added a more efficient and robust mechanism to get the iOS version that doesn't require parsing and splitting a String through `NSProcessInfo` (https://stackoverflow.com/questions/3339722/how-to-check-ios-version).

The `getVersion()` implementation on `IOSApplication` has been modified and the unnecessary/duplicated `getIosVersion()` has been deleted.