### PR TITLE
[Image] Add getter for align.

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Image.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Image.java
@@ -167,6 +167,10 @@ public class Image extends Widget {
 		this.align = align;
 		invalidate();
 	}
+	
+	public int getAlign () {
+		return align;
+	}
 
 	public float getMinWidth () {
 		return 0;


### PR DESCRIPTION
 I needed to get alignment so I can use `setPosition(x, y, alignment)`, so I can re-position the UI when windows resized.

Not sure why there's no getter for alignment where other UI class does. (Likely forgotten to add getter)