### PR TITLE
Change TiledMapTileLayer#tileWidth/Height to an integer.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -23,6 +23,7 @@
 - API Addition: Created interfaces AndroidAudio and AndroidInput and added AndroidApplication#createAudio and AndroidApplication#createInput to allow initializing custom module implementations.
 - Allows up to 64k (65536) vertices in a Mesh instead of 32k before. Indices can use unsigned short range, so index above 32767 should be converted to int using bitwise mask, eg. int unsigneShortIndex = (shortIndex & 0xFFFF).
 - API Change: DragAndDrop only removes actors that were not already in the stage. This is to better support using a source actor as the drag actor, see #5675 and #5403.
+- API Change: Changed TiledMapTileLayer#tileWidth & #tileHeight from float to int
 
 [1.9.10]
 - API Addition: Allow target display for maximization LWJGL3 backend

--- a/gdx/src/com/badlogic/gdx/maps/tiled/TiledMapTileLayer.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/TiledMapTileLayer.java
@@ -24,8 +24,8 @@ public class TiledMapTileLayer extends MapLayer {
 	private int width;
 	private int height;
 
-	private float tileWidth;
-	private float tileHeight;
+	private int tileWidth;
+	private int tileHeight;
 
 	private Cell[][] cells;
 
@@ -40,12 +40,12 @@ public class TiledMapTileLayer extends MapLayer {
 	}
 
 	/** @return tiles' width in pixels */
-	public float getTileWidth () {
+	public int getTileWidth () {
 		return tileWidth;
 	}
 
 	/** @return tiles' height in pixels */
-	public float getTileHeight () {
+	public int getTileHeight () {
 		return tileHeight;
 	}
 


### PR DESCRIPTION
`TiledMapTileLayer#tileWidth/Height` are changed to integers, as the constructor (and the map loaders) are already only allowing integer values. Fixes #3821.