### PR TITLE
Clarify plattform specific behaviour of preferences

### DIFF
--- a/gdx/src/com/badlogic/gdx/Preferences.java
+++ b/gdx/src/com/badlogic/gdx/Preferences.java
@@ -22,11 +22,12 @@ import java.util.Map;
  * A Preference instance is a hash map holding different values. It is stored alongside your application (SharedPreferences on
  * Android, LocalStorage on GWT, on the desktop a Java Preferences file in a ".prefs" directory will be created, and on iOS an
  * NSMutableDictionary will be written to the given file). CAUTION: On the desktop platform, all libgdx applications share the same
- * ".prefs" directory. To avoid collisions use specific names like "com.myname.game1.settings" instead of "settings"
+ * ".prefs" directory. To avoid collisions use specific names like "com.myname.game1.settings" instead of "settings".
  * </p>
  * 
  * <p>
- * Changes to a preferences instance will be cached in memory until {@link #flush()} is invoked.
+ * To persist changes made to a preferences instance {@link #flush()} has to be invoked. With the exception of Android, changes are
+ * cached in memory prior to flushing.
  * </p>
  * 
  * <p>

--- a/gdx/src/com/badlogic/gdx/Preferences.java
+++ b/gdx/src/com/badlogic/gdx/Preferences.java
@@ -27,7 +27,7 @@ import java.util.Map;
  * 
  * <p>
  * To persist changes made to a preferences instance {@link #flush()} has to be invoked. With the exception of Android, changes are
- * cached in memory prior to flushing.
+ * cached in memory prior to flushing. On iOS changes are not synchronized between different preferences instances.
  * </p>
  * 
  * <p>


### PR DESCRIPTION
Clarifies plattform specific behaviour of preferences:
- On Android, prior to flushing, changes to the preferences are not available to the user
- On iOS changes are not synchronized between different preferences instances

Fixes #5558. 