### PR TITLE
added convenient Matrix4 rotate methods

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -23,6 +23,7 @@
 - API Addition: Created interfaces AndroidAudio and AndroidInput and added AndroidApplication#createAudio and AndroidApplication#createInput to allow initializing custom module implementations.
 - Allows up to 64k (65536) vertices in a Mesh instead of 32k before. Indices can use unsigned short range, so index above 32767 should be converted to int using bitwise mask, eg. int unsigneShortIndex = (shortIndex & 0xFFFF).
 - API Change: DragAndDrop only removes actors that were not already in the stage. This is to better support using a source actor as the drag actor, see #5675 and #5403.
+- API Addition: convenient Matrix4 rotate methods: rotateTowardDirection and rotateTowardTarget
 
 [1.9.10]
 - API Addition: Allow target display for maximization LWJGL3 backend

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/math/Matrix4.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/math/Matrix4.java
@@ -1568,6 +1568,43 @@ public class Matrix4 implements Serializable {
 		return rotate(quat.setFromCross(v1, v2));
 	}
 
+	/** Post-multiplies this matrix by a rotation toward a direction.
+	 * @param direction direction to rotate toward
+	 * @param up up vector
+	 * @return This matrix for chaining */
+	public Matrix4 rotateTowardDirection (final Vector3 direction, final Vector3 up) {
+		l_vez.set(direction).nor();
+		l_vex.set(direction).crs(up).nor();
+		l_vey.set(l_vex).crs(l_vez).nor();
+		tmp[M00] = l_vex.x;
+		tmp[M10] = l_vex.y;
+		tmp[M20] = l_vex.z;
+		tmp[M30] = 0f;
+		tmp[M01] = l_vey.x;
+		tmp[M11] = l_vey.y;
+		tmp[M21] = l_vey.z;
+		tmp[M31] = 0f;
+		tmp[M02] = -l_vez.x;
+		tmp[M12] = -l_vez.y;
+		tmp[M22] = -l_vez.z;
+		tmp[M32] = 0f;
+		tmp[M03] = 0f;
+		tmp[M13] = 0f;
+		tmp[M23] = 0f;
+		tmp[M33] = 1f;
+		mul(val, tmp);
+		return this;
+	}
+
+	/** Post-multiplies this matrix by a rotation toward a target.
+	 * @param target the target to rotate to
+	 * @param up the up vector
+	 * @return This matrix for chaining */
+	public Matrix4 rotateTowardTarget (final Vector3 target, final Vector3 up) {
+		tmpVec.set(target.x - val[M03], target.y - val[M13], target.z - val[M23]);
+		return rotateTowardDirection(tmpVec, up);
+	}
+
 	/** Postmultiplies this matrix with a scale matrix. Postmultiplication is also used by OpenGL ES' 1.x
 	 * glTranslate/glRotate/glScale.
 	 * @param scaleX The scale in the x-axis.

--- a/gdx/src/com/badlogic/gdx/math/Matrix4.java
+++ b/gdx/src/com/badlogic/gdx/math/Matrix4.java
@@ -1513,6 +1513,43 @@ public class Matrix4 implements Serializable {
 		return rotate(quat.setFromCross(v1, v2));
 	}
 
+	/** Post-multiplies this matrix by a rotation toward a direction.
+	 * @param direction direction to rotate toward
+	 * @param up up vector
+	 * @return This matrix for chaining */
+	public Matrix4 rotateTowardDirection (final Vector3 direction, final Vector3 up) {
+		l_vez.set(direction).nor();
+		l_vex.set(direction).crs(up).nor();
+		l_vey.set(l_vex).crs(l_vez).nor();
+		tmp[M00] = l_vex.x;
+		tmp[M10] = l_vex.y;
+		tmp[M20] = l_vex.z;
+		tmp[M30] = 0f;
+		tmp[M01] = l_vey.x;
+		tmp[M11] = l_vey.y;
+		tmp[M21] = l_vey.z;
+		tmp[M31] = 0f;
+		tmp[M02] = -l_vez.x;
+		tmp[M12] = -l_vez.y;
+		tmp[M22] = -l_vez.z;
+		tmp[M32] = 0f;
+		tmp[M03] = 0f;
+		tmp[M13] = 0f;
+		tmp[M23] = 0f;
+		tmp[M33] = 1f;
+		mul(val, tmp);
+		return this;
+	}
+
+	/** Post-multiplies this matrix by a rotation toward a target.
+	 * @param target the target to rotate to
+	 * @param up the up vector
+	 * @return This matrix for chaining */
+	public Matrix4 rotateTowardTarget (final Vector3 target, final Vector3 up) {
+		tmpVec.set(target.x - val[M03], target.y - val[M13], target.z - val[M23]);
+		return rotateTowardDirection(tmpVec, up);
+	}
+
 	/** Postmultiplies this matrix with a scale matrix. Postmultiplication is also used by OpenGL ES' 1.x
 	 * glTranslate/glRotate/glScale.
 	 * @param scaleX The scale in the x-axis.

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/MatrixJNITest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/MatrixJNITest.java
@@ -24,8 +24,15 @@ import com.badlogic.gdx.utils.GdxRuntimeException;
 import com.badlogic.gdx.utils.TimeUtils;
 
 public class MatrixJNITest extends GdxTest {
+	
+	private static final float EPSILON = 1e-6f;
+	
 	@Override
 	public void create () {
+		
+		testRotateTowardDirection();
+		testRotateTowardTarget();
+		
 		Matrix4 mat1 = new Matrix4();
 		Matrix4 mat2 = new Matrix4();
 		Matrix4 mat3 = new Matrix4();
@@ -134,5 +141,55 @@ public class MatrixJNITest extends GdxTest {
 		for (int i = 0; i < 16; i++) {
 			if (mat1.val[i] != mat2.val[i]) throw new GdxRuntimeException("matrices not equal");
 		}
+	}
+	
+	public void testRotateTowardDirection(){
+		
+		Vector3 direction = new Vector3(1, 0, 1).nor();
+		Vector3 up = new Vector3(1, 1, 0).nor();
+		
+		Matrix4 m1 = new Matrix4().setToLookAt(direction, up).inv();
+		
+		Matrix4 m2 = new Matrix4().rotateTowardDirection(direction, up);
+		
+		assertEquals(m1, m2, EPSILON);
+	}
+	
+	public void testRotateTowardTarget(){
+		
+		Vector3 position = new Vector3(-4, -2, 30).nor();
+		Vector3 target = new Vector3(10, 8, 3).nor();
+		Vector3 up = new Vector3(0, 1, 0).nor();
+		
+		Matrix4 m1 = new Matrix4().setToLookAt(position, target, up).inv();
+		
+		Matrix4 m2 = new Matrix4().translate(position).rotateTowardTarget(target, up);
+		
+		assertEquals(m1, m2, EPSILON);
+	}
+	
+	private static void assertEquals(Matrix4 expected, Matrix4 actual, float delta) {
+		assertEquals(expected.val[Matrix4.M00], actual.val[Matrix4.M00], delta);
+		assertEquals(expected.val[Matrix4.M01], actual.val[Matrix4.M01], delta);
+		assertEquals(expected.val[Matrix4.M02], actual.val[Matrix4.M02], delta);
+		assertEquals(expected.val[Matrix4.M03], actual.val[Matrix4.M03], delta);
+		
+		assertEquals(expected.val[Matrix4.M10], actual.val[Matrix4.M10], delta);
+		assertEquals(expected.val[Matrix4.M11], actual.val[Matrix4.M11], delta);
+		assertEquals(expected.val[Matrix4.M12], actual.val[Matrix4.M12], delta);
+		assertEquals(expected.val[Matrix4.M13], actual.val[Matrix4.M13], delta);
+		
+		assertEquals(expected.val[Matrix4.M20], actual.val[Matrix4.M20], delta);
+		assertEquals(expected.val[Matrix4.M21], actual.val[Matrix4.M21], delta);
+		assertEquals(expected.val[Matrix4.M22], actual.val[Matrix4.M22], delta);
+		assertEquals(expected.val[Matrix4.M23], actual.val[Matrix4.M23], delta);
+		
+		assertEquals(expected.val[Matrix4.M30], actual.val[Matrix4.M30], delta);
+		assertEquals(expected.val[Matrix4.M31], actual.val[Matrix4.M31], delta);
+		assertEquals(expected.val[Matrix4.M32], actual.val[Matrix4.M32], delta);
+		assertEquals(expected.val[Matrix4.M33], actual.val[Matrix4.M33], delta);
+	}
+	private static void assertEquals(float expected, float actual, float delta){
+		if(Math.abs(expected - actual) > delta) throw new GdxRuntimeException("assertion failed: expected " + expected + " actual " + actual);
 	}
 }


### PR DESCRIPTION
Current Matrix4.setToLookAt methods are design to build a view matrix for camera. Sometimes it's useful to rotate a model toward a target or direction. So i added 2 new methods.