### PR TITLE
Set correct android version on pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <android.version>7.1</android.version>
+    <android.version>9.0</android.version>
     <gwt.version>2.8.2</gwt.version>
     <lwjgl.version>2.9.3</lwjgl.version>
     <lwjgl3.version>3.2.3</lwjgl3.version>


### PR DESCRIPTION
https://github.com/libgdx/libgdx/pull/5979 changed Android SDK version to 9.0. Not that it makes a difference afaik but for consistency sake.