### PR TITLE
[Label] Set text to int value opt

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Label.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Label.java
@@ -95,21 +95,25 @@ public class Label extends Widget {
 	 * @return true if the text was changed. */
 	public boolean setText (int value) {
 		if (this.intValue == value) return false;
-		setText(Integer.toString(value));
+		text.clear();
+		text.append(value);
 		intValue = value;
+		invalidateHierarchy();
 		return true;
 	}
 
 	/** @param newText May be null, "" will be used. */
 	public void setText (@Null CharSequence newText) {
-		if (newText == null) newText = "";
-		if (newText instanceof StringBuilder) {
+		if (newText == null) {
+			if (text.length == 0) return;
+			text.clear();
+		} else if (newText instanceof StringBuilder) {
 			if (text.equals(newText)) return;
-			text.setLength(0);
+			text.clear();
 			text.append((StringBuilder)newText);
 		} else {
 			if (textEquals(newText)) return;
-			text.setLength(0);
+			text.clear();
 			text.append(newText);
 		}
 		intValue = Integer.MIN_VALUE;


### PR DESCRIPTION
I removed the `Integer.toString` and replaced it with the `StringBuilder.append` to avoid some object creations. Side effect, some redundant checks in `setText(CharSequence)` are no longer performed.

I also used the `StringBuilder.clear()` instead of the `StringBuilder.setLength(0)` as is more descriptive and more efficient.

I changed slightly the null check (which I now realize is irrelevant) to avoid some redundant checks.

I would also suggest that `setText(CharSequence)` also return a boolean like `setText(int)`.