### PR TITLE
Specify encoding for Base64Coder.encodeString(), as the rest of GDX does

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -31,6 +31,7 @@
 - API Addition: TextField and TextArea are providing the protected method TextField#checkFocusTraverse(char) to handle the focus traversal.
 - API Addition: UIUtils provides the constants UIUtils#isAndroid and UIUtils#isIos now.
 - Fixed: The behaving of TextFields and TextAreas new line and focus traversal works like intended on all platforms now.
+- API Change: Changed Base64Coder#encodeString() to use UTF-8 instead of the platform default encoding. See #6061
 
 [1.9.10]
 - API Addition: Allow target display for maximization LWJGL3 backend

--- a/gdx/src/com/badlogic/gdx/utils/Base64Coder.java
+++ b/gdx/src/com/badlogic/gdx/utils/Base64Coder.java
@@ -29,6 +29,8 @@
 
 package com.badlogic.gdx.utils;
 
+import java.io.UnsupportedEncodingException;
+
 public class Base64Coder {
 	public static class CharMap {
 		protected final char[] encodingMap = new char[64];
@@ -76,11 +78,21 @@ public class Base64Coder {
 		return encodeString(s, false);
 	}
 
+	/** Encodes a string into Base64 format, optionally using URL-safe encoding instead of the "regular" Base64 encoding.
+	 * No blanks or line breaks are inserted.
+	 * @param s A String to be encoded.
+	 * @param useUrlsafeEncoding If true, this encodes the result with an alternate URL-safe set of characters.
+	 * @return A String containing the Base64 encoded data. */
 	public static String encodeString (String s, boolean useUrlsafeEncoding) {
-		return new String(encode(s.getBytes(), useUrlsafeEncoding ? urlsafeMap.encodingMap : regularMap.encodingMap));
+		try {
+			return new String(encode(s.getBytes("UTF-8"), useUrlsafeEncoding ? urlsafeMap.encodingMap : regularMap.encodingMap));
+		} catch (UnsupportedEncodingException e) {
+			// shouldn't ever happen; only needed because we specify an encoding with a String
+			return "";
+		}
 	}
 
-	/** Encodes a byte array into Base 64 format and breaks the output into lines of 76 characters. This method is compatible with
+	/** Encodes a byte array into Base64 format and breaks the output into lines of 76 characters. This method is compatible with
 	 * <code>sun.misc.BASE64Encoder.encodeBuffer(byte[])</code>.
 	 * @param in An array containing the data bytes to be encoded.
 	 * @return A String containing the Base64 encoded data, broken into lines. */
@@ -92,7 +104,7 @@ public class Base64Coder {
 		return encodeLines(in, iOff, iLen, lineLen, lineSeparator, charMap.encodingMap);
 	}
 
-	/** Encodes a byte array into Base 64 format and breaks the output into lines.
+	/** Encodes a byte array into Base64 format and breaks the output into lines.
 	 * @param in An array containing the data bytes to be encoded.
 	 * @param iOff Offset of the first byte in <code>in</code> to be processed.
 	 * @param iLen Number of bytes to be processed in <code>in</code>, starting at <code>iOff</code>.


### PR DESCRIPTION
Without specifying a String encoding for String.getBytes(), it uses a platform-dependent encoding that can break Base64 data transmitted between computers. Almost all of libGDX specifies "UTF-8" as the encoding; only a few tests don't (and currently Base64Coder.encodeString()).

This commit also adds Javadocs where they were missing for one encodeString() and makes the spelling of "Base64" consistently "Base64" and not sometimes "Base 64".

EDIT FOR FUTURE REFERENCE:

This PR should have no effect if you only use Base64Encoder's byte array encoding, or if you use String encoding with ASCII strings only. If you previously wrote Base64 data using `Base64Coder.encodeString()` and used non-ASCII characters, then that data was written with the platform's encoding, which can vary at least on Windows and Linux. If two different encodings are used for encoding and decoding, then the retrieved data won't be the same. This PR changes the default to use UTF-8 encoding for `encodeString()`, which is what Android and iOS already use, and will make it so the output of `encodeString()` is consistent across all platforms. If you want to continue to use the platform encoding, you can use this instead of calling `Base64Coder.encodeString(s, useUrlsafeEncoding)`:
```java
new String(encode(s.getBytes(), useUrlsafeEncoding ? Base64Coder.urlsafeMap : Base64Coder.regularMap));
```

Using the platform encoding may be a good idea if you need to save files onto one device only and need to maintain compatibility with earlier saved files. If the Base64-encoded files go between devices on different OSes, you should use UTF-8 or handle the conversion to bytes yourself.
