### PR TITLE
fix SphereShapeBuilder poles are now merged

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -32,6 +32,7 @@
 - API Addition: UIUtils provides the constants UIUtils#isAndroid and UIUtils#isIos now.
 - Fixed: The behaving of TextFields and TextAreas new line and focus traversal works like intended on all platforms now.
 - API Change: Changed Base64Coder#encodeString() to use UTF-8 instead of the platform default encoding. See #6061
+- Fixed: SphereShapeBuilder poles are now merged which removes lighting artifacts, see #6068 for more information.
 
 [1.9.10]
 - API Addition: Allow target display for maximization LWJGL3 backend

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/utils/shapebuilders/SphereShapeBuilder.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/utils/shapebuilders/SphereShapeBuilder.java
@@ -49,7 +49,8 @@ public class SphereShapeBuilder extends BaseShapeBuilder {
 	@Deprecated
 	public static void build (MeshPartBuilder builder, final Matrix4 transform, float width, float height, float depth,
 		int divisionsU, int divisionsV, float angleUFrom, float angleUTo, float angleVFrom, float angleVTo) {
-		// FIXME create better sphere method (- only one vertex for each pole, - position)
+		final boolean closedVFrom = MathUtils.isEqual(angleVFrom, 0f);
+		final boolean closedVTo = MathUtils.isEqual(angleVTo, 180f);
 		final float hw = width * 0.5f;
 		final float hh = height * 0.5f;
 		final float hd = depth * 0.5f;
@@ -83,16 +84,29 @@ public class SphereShapeBuilder extends BaseShapeBuilder {
 			final float h = MathUtils.cos(angleV) * hh;
 			for (int iu = 0; iu <= divisionsU; iu++) {
 				angleU = auo + stepU * iu;
-				u = 1f - us * iu;
+				if (iv == 0 && closedVFrom || iv == divisionsV && closedVTo) {
+					u = 1f - us * (iu - .5f);
+				} else {
+					u = 1f - us * iu;
+				}
 				curr1.position.set(MathUtils.cos(angleU) * hw * t, h, MathUtils.sin(angleU) * hd * t);
 				curr1.normal.set(curr1.position).mul(normalTransform).nor();
 				curr1.position.mul(transform);
 				curr1.uv.set(u, v);
 				tmpIndices.set(tempOffset, builder.vertex(curr1));
 				final int o = tempOffset + s;
-				if ((iv > 0) && (iu > 0)) // FIXME don't duplicate lines and points
-					builder.rect(tmpIndices.get(tempOffset), tmpIndices.get((o - 1) % s), tmpIndices.get((o - (divisionsU + 2)) % s),
-						tmpIndices.get((o - (divisionsU + 1)) % s));
+				if ((iv > 0) && (iu > 0)) { // FIXME don't duplicate lines and points
+					if (iv == 1 && closedVFrom) {
+						builder.triangle(tmpIndices.get(tempOffset), tmpIndices.get((o - 1) % s),
+							tmpIndices.get((o - (divisionsU + 1)) % s));
+					} else if (iv == divisionsV && closedVTo) {
+						builder.triangle(tmpIndices.get(tempOffset), tmpIndices.get((o - (divisionsU + 2)) % s),
+							tmpIndices.get((o - (divisionsU + 1)) % s));
+					} else {
+						builder.rect(tmpIndices.get(tempOffset), tmpIndices.get((o - 1) % s),
+							tmpIndices.get((o - (divisionsU + 2)) % s), tmpIndices.get((o - (divisionsU + 1)) % s));
+					}
+				}
 				tempOffset = (tempOffset + 1) % tmpIndices.size;
 			}
 		}


### PR DESCRIPTION
Previous algorithm didn't merge sphere poles and used quads to join them to the rings which produced lighting artifacts (because of normals) as you can see here (before fix on the left, after fix on the right) : 
![Screenshot 2020-06-04 10:20:27](https://user-images.githubusercontent.com/8074238/83734479-59f3d280-a64f-11ea-8790-8c5b98863ca5.png)

Manually moving vertices poles help to see the flat triangles : 
![Screenshot 2020-06-04 10:21:54](https://user-images.githubusercontent.com/8074238/83734587-7e4faf00-a64f-11ea-8b71-2bcbf20dc394.png)

You can also see how normals on poles was weird (before the fix on the right) : 
![Screenshot 2020-06-04 10:23:58](https://user-images.githubusercontent.com/8074238/83734860-d8e90b00-a64f-11ea-9bb9-29845e79ee1f.png)

UVs was also a bit off because of flat edge on pole. Here is UVs before the fix: 
![Screenshot 2020-06-04 10:24:23](https://user-images.githubusercontent.com/8074238/83735001-0afa6d00-a650-11ea-9c3a-cdeab9a0d385.png)

UVs are now like this (similar to default Blender UV sphere) : 
![Screenshot 2020-06-04 10:24:32](https://user-images.githubusercontent.com/8074238/83735027-151c6b80-a650-11ea-8377-a27f9fbeeeab.png)

Note that this change doesn't impact opened spheres (eg. when V angle range from 30 to 150).