### PR TITLE
[FPSLogger] Support for an upper bound

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/FPSLogger.java
+++ b/gdx/src/com/badlogic/gdx/graphics/FPSLogger.java
@@ -25,16 +25,27 @@ import com.badlogic.gdx.utils.TimeUtils;
  * @author mzechner */
 public class FPSLogger {
 	long startTime;
+	int bound;
 
 	public FPSLogger () {
+		this(Integer.MAX_VALUE);
+	}
+
+	/** @param bound only logs when they frames per second are less than the bound */
+	public FPSLogger (int bound) {
+		this.bound = bound;
 		startTime = TimeUtils.nanoTime();
 	}
 
 	/** Logs the current frames per second to the console. */
 	public void log () {
-		if (TimeUtils.nanoTime() - startTime > 1000000000) /* 1,000,000,000ns == one second */{
-			Gdx.app.log("FPSLogger", "fps: " + Gdx.graphics.getFramesPerSecond());
-			startTime = TimeUtils.nanoTime();
+		final long nanoTime = TimeUtils.nanoTime();
+		if (nanoTime - startTime > 1_000_000_000) /* 1,000,000,000ns == one second */ {
+			final int fps = Gdx.graphics.getFramesPerSecond();
+			if (fps < bound) {
+				Gdx.app.log("FPSLogger", "fps: " + fps);
+				startTime = nanoTime;
+			}
 		}
 	}
 }


### PR DESCRIPTION
If the fps is lower than bound the behavior is the same as before, but if the fps >= bound nothing is logged (and the one second counter is not reset in order to the have the first log be as soon as the fps goes bellow the bound).

For example: `new FPSLogger(60)`, given a game that should be able to run in 60fps, will only log when the 60fps is not reached instead of spamming 60fps all the time.

The current `new FPSLogger()` behavior (and performance cost) remains the same.