### PR TITLE
Fix an error that occurs when loading models by AssetManager when the…

### DIFF
--- a/gdx/src/com/badlogic/gdx/assets/loaders/resolvers/InternalFileHandleResolver.java
+++ b/gdx/src/com/badlogic/gdx/assets/loaders/resolvers/InternalFileHandleResolver.java
@@ -20,9 +20,12 @@ import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.assets.loaders.FileHandleResolver;
 import com.badlogic.gdx.files.FileHandle;
 
+import java.nio.file.Paths;
+
 public class InternalFileHandleResolver implements FileHandleResolver {
 	@Override
 	public FileHandle resolve (String fileName) {
-		return Gdx.files.internal(fileName);
+		String normalizedFileName = Paths.get(fileName).normalize().toString();
+		return Gdx.files.internal(normalizedFileName);
 	}
 }


### PR DESCRIPTION
… program is run from a JAR file and the relative reference is used in the loaded file. For example, the G3DJ model refers to the texture file: ../..textures/texture.png. InternalFileHandleResolver encounters the path: assets/models/../../textures/texture.png that it can't handle when the resource being loaded from inside the JAR file. This problem does not occur when the file being read is available directly on FS. It can be bypassed in two ways: 1. always keep the textures in the same directory as the model (this solution is most often recommended on forums), 2. By creating AssetManager with the indication InternalFileHandleResolver, while overwriting method: FileHandle resolve (String fileName)