### PR TITLE
Remove unnecessary normalization

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/Camera.java
+++ b/gdx/src/com/badlogic/gdx/graphics/Camera.java
@@ -98,7 +98,7 @@ public abstract class Camera {
 	/** Normalizes the up vector by first calculating the right vector via a cross product between direction and up, and then
 	 * recalculating the up vector via a cross product between right and direction. */
 	public void normalizeUp () {
-		tmpVec.set(direction).crs(up).nor();
+		tmpVec.set(direction).crs(up);
 		up.set(tmpVec).crs(direction).nor();
 	}
 

--- a/gdx/src/com/badlogic/gdx/math/Matrix4.java
+++ b/gdx/src/com/badlogic/gdx/math/Matrix4.java
@@ -835,8 +835,7 @@ public class Matrix4 implements Serializable {
 	 * @return This matrix for the purpose of chaining methods together. */
 	public Matrix4 setToLookAt (Vector3 direction, Vector3 up) {
 		l_vez.set(direction).nor();
-		l_vex.set(direction).nor();
-		l_vex.crs(up).nor();
+		l_vex.set(direction).crs(up).nor();
 		l_vey.set(l_vex).crs(l_vez).nor();
 		idt();
 		val[M00] = l_vex.x;


### PR DESCRIPTION
This PR will not break anything, it just removed unnecessary normalizations to reduce the number of operations (and errors) when lookAt method is called multiple times. It will avoid 1 square root calculation (2 if you call the update method).

This is an attempt to fix: #5159

### How to test
A good way to test it is to run the [SimpleDecalTest](https://github.com/libgdx/libgdx/blob/master/tests/gdx-tests/src/com/badlogic/gdx/tests/SimpleDecalTest.java) (or any other test that calls lookAt) and check if the behavior is the same.

### Why it works?
The first line will produce a non-unit vector but the second line will calculate the perpendicular vector and normalize it. (as @obigu explained, the length of the vector will not affect the cross product).

```
tmpVec.set(direction).crs(up);
up.set(tmpVec).crs(direction).nor();
```
If you are not convinced yet, the same thing is done at: https://github.com/libgdx/libgdx/blob/master/gdx/src/com/badlogic/gdx/math/Matrix4.java#L1522

