### PR TITLE
Moved adding touch focus from Actor#notify to InputListener#handle.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -36,6 +36,7 @@
 - API Change: Matrix3#setToRotation(Vector3, float float) now rotates counter-clockwise about the axis provided. This also changes Matrix3:setToRotation(Vector3, float) and the 3d particles will rotate counter-clockwise as well. 
 - API Change: TexturePacker uses a dash when naming atlas page image files if the name ends with a digit or a digit + 'x'.
 - API Addition: Added Skin#setScale to control the size of drawables from the skin. This enables scaling a UI and using different sized images to match, without affecting layout.
+- API Change: Moved adding touch focus from Actor#notify to InputListener#handle (see #6082).
 
 [1.9.10]
 - API Addition: Allow target display for maximization LWJGL3 backend

--- a/CHANGES
+++ b/CHANGES
@@ -36,7 +36,7 @@
 - API Change: Matrix3#setToRotation(Vector3, float float) now rotates counter-clockwise about the axis provided. This also changes Matrix3:setToRotation(Vector3, float) and the 3d particles will rotate counter-clockwise as well. 
 - API Change: TexturePacker uses a dash when naming atlas page image files if the name ends with a digit or a digit + 'x'.
 - API Addition: Added Skin#setScale to control the size of drawables from the skin. This enables scaling a UI and using different sized images to match, without affecting layout.
-- API Change: Moved adding touch focus from Actor#notify to InputListener#handle (see #6082).
+- API Change: Moved adding touch focus from Actor#notify to InputListener#handle (see #6082). Code that overrides InputListener#handle or otherwise handles InputEvent.Type.touchDown events must now call Stage#addTouchFocus to get touchDragged and touchUp events.
 
 [1.9.10]
 - API Addition: Allow target display for maximization LWJGL3 backend

--- a/gdx/src/com/badlogic/gdx/input/GestureDetector.java
+++ b/gdx/src/com/badlogic/gdx/input/GestureDetector.java
@@ -272,7 +272,7 @@ public class GestureDetector extends InputAdapter {
 		return Math.abs(x - centerX) < tapRectangleWidth && Math.abs(y - centerY) < tapRectangleHeight;
 	}
 
-	/** The tap square will not longer be used for the current touch. */
+	/** The tap square will no longer be used for the current touch. */
 	public void invalidateTapSquare () {
 		inTapRectangle = false;
 	}

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/Actor.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/Actor.java
@@ -26,7 +26,6 @@ import com.badlogic.gdx.graphics.glutils.ShapeRenderer.ShapeType;
 import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.math.Rectangle;
 import com.badlogic.gdx.math.Vector2;
-import com.badlogic.gdx.scenes.scene2d.InputEvent.Type;
 import com.badlogic.gdx.scenes.scene2d.utils.ActorGestureListener;
 import com.badlogic.gdx.scenes.scene2d.utils.ClickListener;
 import com.badlogic.gdx.scenes.scene2d.utils.ScissorStack;
@@ -185,19 +184,8 @@ public class Actor {
 
 		try {
 			listeners.begin();
-			for (int i = 0, n = listeners.size; i < n; i++) {
-				EventListener listener = listeners.get(i);
-				if (listener.handle(event)) {
-					event.handle();
-					if (event instanceof InputEvent) {
-						InputEvent inputEvent = (InputEvent)event;
-						if (inputEvent.getType() == Type.touchDown) {
-							event.getStage().addTouchFocus(listener, this, inputEvent.getTarget(), inputEvent.getPointer(),
-								inputEvent.getButton());
-						}
-					}
-				}
-			}
+			for (int i = 0, n = listeners.size; i < n; i++)
+				if (listeners.get(i).handle(event)) event.handle();
 			listeners.end();
 		} catch (RuntimeException ex) {
 			String context = toString();

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/Actor.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/Actor.java
@@ -390,6 +390,7 @@ public class Actor {
 	}
 
 	/** @deprecated Use {@link #ascendantsVisible()}. */
+	@Deprecated
 	public boolean ancestorsVisible () {
 		return ascendantsVisible();
 	}

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/InputEvent.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/InputEvent.java
@@ -20,7 +20,7 @@ import com.badlogic.gdx.Input.Buttons;
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.utils.Null;
 
-/** Event for actor input: touch, mouse, keyboard, and scroll.
+/** Event for actor input: touch, mouse, touch/mouse actor enter/exit, mouse scroll, and keyboard events.
  * @see InputListener */
 public class InputEvent extends Event {
 	private Type type;
@@ -28,6 +28,7 @@ public class InputEvent extends Event {
 	private int pointer, button, keyCode, scrollAmount;
 	private char character;
 	@Null private Actor relatedActor;
+	private boolean touchFocus = true;
 
 	public void reset () {
 		super.reset();
@@ -35,7 +36,8 @@ public class InputEvent extends Event {
 		button = -1;
 	}
 
-	/** The stage x coordinate where the event occurred. Valid for: touchDown, touchDragged, touchUp, mouseMoved, enter, and exit. */
+	/** The stage x coordinate where the event occurred. Valid for: touchDown, touchDragged, touchUp, mouseMoved, enter, and
+	 * exit. */
 	public float getStageX () {
 		return stageX;
 	}
@@ -44,7 +46,8 @@ public class InputEvent extends Event {
 		this.stageX = stageX;
 	}
 
-	/** The stage x coordinate where the event occurred. Valid for: touchDown, touchDragged, touchUp, mouseMoved, enter, and exit. */
+	/** The stage x coordinate where the event occurred. Valid for: touchDown, touchDragged, touchUp, mouseMoved, enter, and
+	 * exit. */
 	public float getStageY () {
 		return stageY;
 	}
@@ -129,9 +132,19 @@ public class InputEvent extends Event {
 		return actorCoords;
 	}
 
-	/** Returns true of this event is a touchUp triggered by {@link Stage#cancelTouchFocus()}. */
+	/** Returns true if this event is a touchUp triggered by {@link Stage#cancelTouchFocus()}. */
 	public boolean isTouchFocusCancel () {
 		return stageX == Integer.MIN_VALUE || stageY == Integer.MIN_VALUE;
+	}
+
+	/** If false, {@link InputListener#handle(Event)} will not add the listener to the stage's touch focus when a touch down event
+	 * is handled. Default is true. */
+	public boolean getTouchFocus () {
+		return touchFocus;
+	}
+
+	public void setTouchFocus (boolean touchFocus) {
+		this.touchFocus = touchFocus;
 	}
 
 	public String toString () {

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/InputListener.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/InputListener.java
@@ -38,6 +38,12 @@ import com.badlogic.gdx.utils.Null;
 public class InputListener implements EventListener {
 	static private final Vector2 tmpCoords = new Vector2();
 
+	/** Try to handle the given event, if it is an {@link InputEvent}.
+	 * <p>
+	 * If the input event is of type {@link InputEvent.Type#touchDown} and {@link InputEvent#getTouchFocus()} is true and
+	 * {@link #touchDown(InputEvent, float, float, int, int)} returns true (indicating the event was handled) then this listener is
+	 * added to the stage's {@link Stage#addTouchFocus(EventListener, Actor, Actor, int, int) touch focus} so it will receive all
+	 * touch dragged events until the next touch up event. */
 	public boolean handle (Event e) {
 		if (!(e instanceof InputEvent)) return false;
 		InputEvent event = (InputEvent)e;
@@ -55,7 +61,10 @@ public class InputListener implements EventListener {
 
 		switch (event.getType()) {
 		case touchDown:
-			return touchDown(event, tmpCoords.x, tmpCoords.y, event.getPointer(), event.getButton());
+			boolean handled = touchDown(event, tmpCoords.x, tmpCoords.y, event.getPointer(), event.getButton());
+			if (handled && event.getTouchFocus()) event.getStage().addTouchFocus(this, event.getListenerActor(), event.getTarget(),
+				event.getPointer(), event.getButton());
+			return handled;
 		case touchUp:
 			touchUp(event, tmpCoords.x, tmpCoords.y, event.getPointer(), event.getButton());
 			return true;

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/ActorGestureListener.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/ActorGestureListener.java
@@ -112,6 +112,8 @@ public class ActorGestureListener implements EventListener {
 			detector.touchDown(event.getStageX(), event.getStageY(), event.getPointer(), event.getButton());
 			actor.stageToLocalCoordinates(tmpCoords.set(event.getStageX(), event.getStageY()));
 			touchDown(event, tmpCoords.x, tmpCoords.y, event.getPointer(), event.getButton());
+			if (event.getTouchFocus()) event.getStage().addTouchFocus(this, event.getListenerActor(), event.getTarget(),
+				event.getPointer(), event.getButton());
 			return true;
 		case touchUp:
 			if (event.isTouchFocusCancel()) {
@@ -155,14 +157,13 @@ public class ActorGestureListener implements EventListener {
 	public void pan (InputEvent event, float x, float y, float deltaX, float deltaY) {
 	}
 
-    public void panStop (InputEvent event, float x, float y, int pointer, int button) {
-    }
+	public void panStop (InputEvent event, float x, float y, int pointer, int button) {
+	}
 
 	public void zoom (InputEvent event, float initialDistance, float distance) {
 	}
 
-	public void pinch (InputEvent event, Vector2 initialPointer1, Vector2 initialPointer2,
-					   Vector2 pointer1, Vector2 pointer2) {
+	public void pinch (InputEvent event, Vector2 initialPointer1, Vector2 initialPointer2, Vector2 pointer1, Vector2 pointer2) {
 	}
 
 	public GestureDetector getGestureDetector () {

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/ClickListener.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/ClickListener.java
@@ -131,7 +131,7 @@ public class ClickListener extends InputListener {
 		return touchDownX != -1;
 	}
 
-	/** The tap square will not longer be used for the current touch. */
+	/** The tap square will no longer be used for the current touch. */
 	public void invalidateTapSquare () {
 		touchDownX = -1;
 		touchDownY = -1;


### PR DESCRIPTION
Actor#notify used to have a special case: when a listener handles a touchdown input event, it added the listener to the stage's touch focus. 

First, this logic seems to fit better in InputListener, where the touchdown is handled, rather than jamming it in Stage.

Second, it was difficult to manually inject input events for some desired behavior. For example, after sending touchdown/dragged/up using Actor#notify, the actor would have touch focus. That means the actor will see a touchup on the next real click and behave incorrectly. Fixing this with Stage#cancelTouchFocus is problematic, as the actor needs to detect the event is a touch focus cancel else it will act on the touchup. Fixing this with Stage#removeTouchFocus is difficult, as which listeners handled the event aren't easily known.

InputEvent now has a touchFocus boolean. When true (the default) InputListener will add the touch focus. When injecting it can be set to false to avoid the touch focus.

While these changes don't seem terribly risky, they are made as a PR to get more eyes on them before merging and to give people a chance to try it out with their apps in case there are unforeseen problems with existing code. Ideas for improvements are welcome.