### PR TITLE
Correct link to the Wiki page for Json class

### DIFF
--- a/gdx/src/com/badlogic/gdx/utils/Json.java
+++ b/gdx/src/com/badlogic/gdx/utils/Json.java
@@ -41,7 +41,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /** Reads/writes Java objects to/from JSON, automatically. See the wiki for usage:
- * https://github.com/libgdx/libgdx/wiki/Reading-%26-writing-JSON
+ * https://github.com/libgdx/libgdx/wiki/Reading-and-writing-JSON
  * @author Nathan Sweet */
 public class Json {
 	static private final boolean debug = false;


### PR DESCRIPTION
I have noticed the link in the **Json** class description does not lead to the actual page in the GitHub Wiki, so this tiny PR is to correct that.