### PR TITLE
Allow Slider to be configured to only trigger on certain mouse button clicks.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -40,6 +40,7 @@
 - API Addition: Added AsynchronousAssetLoader#unloadAsync to fix memory leaks when an asset is unloaded during loading.
 - Fixed Label text wrapping when it shouldn't (#6098).
 - Fixed ShapeRenderer not being able to render alpha 0xff (was max 0xfe).
+- API Addition: Slider can now be configured to only trigger on certain mouse button clicks (Slider#setBuztton(int)).
 
 [1.9.10]
 - API Addition: Allow target display for maximization LWJGL3 backend

--- a/CHANGES
+++ b/CHANGES
@@ -40,7 +40,7 @@
 - API Addition: Added AsynchronousAssetLoader#unloadAsync to fix memory leaks when an asset is unloaded during loading.
 - Fixed Label text wrapping when it shouldn't (#6098).
 - Fixed ShapeRenderer not being able to render alpha 0xff (was max 0xfe).
-- API Addition: Slider can now be configured to only trigger on certain mouse button clicks (Slider#setBuztton(int)).
+- API Addition: Slider can now be configured to only trigger on certain mouse button clicks (Slider#setButton(int)).
 
 [1.9.10]
 - API Addition: Allow target display for maximization LWJGL3 backend

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Slider.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Slider.java
@@ -21,7 +21,6 @@ import com.badlogic.gdx.Input.Keys;
 import com.badlogic.gdx.graphics.g2d.NinePatch;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.math.Interpolation;
-import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.InputEvent;
 import com.badlogic.gdx.scenes.scene2d.InputListener;
@@ -40,6 +39,7 @@ import com.badlogic.gdx.utils.Pools;
  * @author mzechner
  * @author Nathan Sweet */
 public class Slider extends ProgressBar {
+	int button = -1;
 	int draggingPointer = -1;
 	boolean mouseOver;
 	private Interpolation visualInterpolationInverse = Interpolation.linear;
@@ -69,6 +69,7 @@ public class Slider extends ProgressBar {
 		addListener(new InputListener() {
 			public boolean touchDown (InputEvent event, float x, float y, int pointer, int button) {
 				if (disabled) return false;
+				if (Slider.this.button != -1 && Slider.this.button != button) return false;
 				if (draggingPointer != -1) return false;
 				draggingPointer = pointer;
 				calculatePositionAndValue(x, y);
@@ -175,6 +176,11 @@ public class Slider extends ProgressBar {
 	/** Returns true if the slider is being dragged. */
 	public boolean isDragging () {
 		return draggingPointer != -1;
+	}
+
+	/** Sets the mouse button, which can trigger a change of the slider. Is -1, so every button, by default. */
+	public void setButton (int button) {
+		this.button = button;
 	}
 
 	/** Sets the inverse interpolation to use for display. This should perform the inverse of the


### PR DESCRIPTION
Currently every mouse button click triggers a change of a slider. This may be unwanted in certain cases, e.g. a right click shouldn't be able to change the slider's value.

This PR allows registering one mouse button that can trigger the change (`Slider#setButton(int)`). By default it is set to `-1`, so the behaviour stays the same way it was before: every mouse click is registered.

Extending Slider as an alternative solution is, sadly, not possible, as nearly everything in the class is not visible.