### PR TITLE
fix save method not numbering pages correctly if a page within only contains fonts

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g2d/PixmapPackerIO.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/PixmapPackerIO.java
@@ -64,18 +64,9 @@ public class PixmapPackerIO {
 		Writer writer = file.writer(false);
 		int index = 0;
 		for (Page page : packer.pages) {
+			index++;
+			FileHandle pageFile = writeImageFile(file, index, parameters, page);
 			if (page.rects.size > 0) {
-				FileHandle pageFile = file.sibling(file.nameWithoutExtension() + "_" + (++index) + parameters.format.getExtension());
-				switch (parameters.format) {
-					case CIM:{
-						PixmapIO.writeCIM(pageFile, page.image);
-						break;
-					}
-					case PNG: {
-						PixmapIO.writePNG(pageFile, page.image);
-						break;
-					}
-				}
 				writer.write("\n");
 				writer.write(pageFile.name() + "\n");
 				writer.write("size: " + page.image.getWidth() + "," + page.image.getHeight() + "\n");
@@ -112,5 +103,19 @@ public class PixmapPackerIO {
 		}		
 		writer.close();
 	}
-	
+
+	private FileHandle writeImageFile(FileHandle file, int index, SaveParameters parameters, Page page) {
+		FileHandle pageFile = file.sibling(file.nameWithoutExtension() + "_" + (index) + parameters.format.getExtension());
+		switch (parameters.format) {
+			case CIM:{
+				PixmapIO.writeCIM(pageFile, page.image);
+				break;
+			}
+			case PNG: {
+				PixmapIO.writePNG(pageFile, page.image);
+				break;
+			}
+		}
+		return pageFile;
+	}
 }


### PR DESCRIPTION
When using `FreeTypeFontGenerator` to create fonts and then pack them in a pixmap, the following method is used 

`public synchronized Rectangle pack (Pixmap image) {
	return pack(null, image);
}`

Later when the rect is put onto rects with 

`
if (name != null) {
	page.rects.put(name, rect);
	page.addedRects.add(name);
}`

because there is no `name` it's not added to the rects. This is fine it still works etc, but in the PixmapPackerIO save method the file names are currently incremented and saved when `if (page.rects.size > 0) {` and therefore the pages are not incremented correctly, and the wrong files are used for images/fonts.

This only happens if the entire Pixmap is made up of fonts, which happens to me quite often. 

The fix increments and saves the Pixmap regardless of the size of rects.