### PR TITLE
Samsung keyboard TextField fix

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/surfaceview/GLSurfaceView20.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/surfaceview/GLSurfaceView20.java
@@ -22,6 +22,7 @@ import android.content.Context;
 import android.graphics.PixelFormat;
 import android.opengl.GLSurfaceView;
 import android.os.SystemClock;
+import android.text.InputType;
 import android.util.Log;
 import android.view.KeyCharacterMap;
 import android.view.KeyEvent;
@@ -77,6 +78,7 @@ public class GLSurfaceView20 extends GLSurfaceView {
 		// add this line, the IME can show the selectable words when use chinese input method editor.
 		if (outAttrs != null) {
 			outAttrs.imeOptions = outAttrs.imeOptions | EditorInfo.IME_FLAG_NO_EXTRACT_UI;
+			outAttrs.inputType = InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD | InputType.TYPE_NULL;
 		}
 
 		BaseInputConnection connection = new BaseInputConnection(this, false) {

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/surfaceview/GLSurfaceView20API18.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/surfaceview/GLSurfaceView20API18.java
@@ -22,6 +22,7 @@ import android.content.Context;
 import android.graphics.PixelFormat;
 import android.opengl.GLSurfaceView;
 import android.os.SystemClock;
+import android.text.InputType;
 import android.util.Log;
 import android.view.KeyCharacterMap;
 import android.view.KeyEvent;
@@ -72,6 +73,7 @@ public class GLSurfaceView20API18 extends GLSurfaceViewAPI18 {
 		// add this line, the IME can show the selectable words when use chinese input method editor.
 		if (outAttrs != null) {
 			outAttrs.imeOptions = outAttrs.imeOptions | EditorInfo.IME_FLAG_NO_EXTRACT_UI;
+			outAttrs.inputType = InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD | InputType.TYPE_NULL;
 		}
 		
 		BaseInputConnection connection = new BaseInputConnection(this, false) {


### PR DESCRIPTION
On samsung keyboards `onKey` is not always fired for all key presses, in the current codebase. Because of this, when entering text in TextField, the typed letters don't appear until the keyboard is closed. The user has no idea that anything is being entered until after closing which is very poor UI.

The https://developer.android.com/reference/android/view/View.OnKeyListener#onKey(android.view.View,%20int,%20android.view.KeyEvent) is used inside `AndroidInput` but as the web page states 

`Called when a hardware key is dispatched to a view. This allows listeners to get a chance to respond before the target view.

Key presses in software keyboards will generally NOT trigger this method, although some may elect to do so in some situations. Do not assume a software input method has to be key-based; even if it is, it may use key presses in a different way than you expect, so there is no way to reliably catch soft input key presses.`

It seems that this works for a lot of keyboards but not on the official Samsung one. The fix has been suggested on an Issue raised many years ago, but has come to my attention (and some others) recently.

https://github.com/libgdx/libgdx/issues/3896#issuecomment-214619945

One person commented that this fix reverts if someone changes the language, though I have tried that and can't replicate it myself so I'm not sure if that's still an issue.

One thing I think that might be worth adding, that is not in this PR (I wouldn't know how to do it) is to put a check in to see if the device is Samsung or even if the keyboard is Samsung, that way it wouldn't affect everyone. Though when I've tested this fix against GBoard app it doesn't have any adverse affects.
