### PR TITLE
Lwjgl3GL20's glGetActiveUniform and glGetActiveAttrib report incorrect sizes and types

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGL20.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGL20.java
@@ -288,31 +288,27 @@ public class AndroidGL20 implements GL20 {
 		return ints[0];
 	}
 
-	public String glGetActiveAttrib(int program, int index, IntBuffer size, Buffer type) {
-		//it is assumed that size and type are both int buffers of length 1 with a single integer at position 0
-		
-		//length
-		ints[0] = 0;
-		//size
-		ints2[0] = size.get(0);
-		//type
-		ints3[0] = ((IntBuffer)type).get(0);
-
+	public String glGetActiveAttrib(int program, int index, IntBuffer size, IntBuffer type) {
 		GLES20.glGetActiveAttrib(program, index, buffer.length, ints, 0, ints2, 0, ints3, 0, buffer, 0);
+
+		//size
+		size.put(ints2[0]);
+		//type
+		type.put(ints3[0]);
+
 		return new String(buffer, 0, ints[0]);
 	}
 
-    	public String glGetActiveUniform(int program, int index, IntBuffer size, Buffer type) {
-        	//length
-        	ints[0] = 0;
-        	//size
-        	ints2[0] = size.get(0);
-        	//type
-        	ints3[0] = ((IntBuffer)type).get(0);
+	public String glGetActiveUniform(int program, int index, IntBuffer size, IntBuffer type) {
+		GLES20.glGetActiveUniform(program, index, buffer.length, ints, 0, ints2, 0, ints3, 0, buffer, 0);
 
-        	GLES20.glGetActiveUniform(program, index, buffer.length, ints, 0, ints2, 0, ints3, 0, buffer, 0);
-        	return new String(buffer, 0, ints[0]);
-    	}
+		//size
+		size.put(ints2[0]);
+		//type
+		type.put(ints3[0]);
+
+		return new String(buffer, 0, ints[0]);
+	}
 
 	public void glGetAttachedShaders (int program, int maxcount, Buffer count, IntBuffer shaders) {
 		GLES20.glGetAttachedShaders (program, maxcount, (IntBuffer)count, shaders);

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGL20.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGL20.java
@@ -352,21 +352,21 @@ class LwjglGL20 implements com.badlogic.gdx.graphics.GL20 {
 		EXTFramebufferObject.glGenerateMipmapEXT(target);
 	}
 
-	public String glGetActiveAttrib (int program, int index, IntBuffer size, Buffer type) {
+	public String glGetActiveAttrib (int program, int index, IntBuffer size, IntBuffer type) {
 		// FIXME this is less than ideal of course...
 		IntBuffer typeTmp = BufferUtils.createIntBuffer(2);
 		String name = GL20.glGetActiveAttrib(program, index, 256, typeTmp);
 		size.put(typeTmp.get(0));
-		if (type instanceof IntBuffer) ((IntBuffer)type).put(typeTmp.get(1));
+		type.put(typeTmp.get(1));
 		return name;
 	}
 
-	public String glGetActiveUniform (int program, int index, IntBuffer size, Buffer type) {
+	public String glGetActiveUniform (int program, int index, IntBuffer size, IntBuffer type) {
 		// FIXME this is less than ideal of course...
 		IntBuffer typeTmp = BufferUtils.createIntBuffer(2);
 		String name = GL20.glGetActiveUniform(program, index, 256, typeTmp);
 		size.put(typeTmp.get(0));
-		if (type instanceof IntBuffer) ((IntBuffer)type).put(typeTmp.get(1));
+		type.put(typeTmp.get(1));
 		return name;
 	}
 

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3GL20.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3GL20.java
@@ -352,20 +352,12 @@ class Lwjgl3GL20 implements com.badlogic.gdx.graphics.GL20 {
 		EXTFramebufferObject.glGenerateMipmapEXT(target);
 	}
 
-	public String glGetActiveAttrib (int program, int index, IntBuffer size, Buffer type) {
-		IntBuffer typeTmp = BufferUtils.createIntBuffer(2);
-		String name = GL20.glGetActiveAttrib(program, index, 256, size, typeTmp);
-		size.put(typeTmp.get(0));
-		if (type instanceof IntBuffer) ((IntBuffer)type).put(typeTmp.get(1));
-		return name;
+	public String glGetActiveAttrib (int program, int index, IntBuffer size, IntBuffer type) {
+		return GL20.glGetActiveAttrib(program, index, 256, size, type);
 	}
 
-	public String glGetActiveUniform (int program, int index, IntBuffer size, Buffer type) {
-		IntBuffer typeTmp = BufferUtils.createIntBuffer(2);
-		String name = GL20.glGetActiveUniform(program, index, 256, size, typeTmp);
-		size.put(typeTmp.get(0));
-		if (type instanceof IntBuffer) ((IntBuffer)type).put(typeTmp.get(1));
-		return name;
+	public String glGetActiveUniform (int program, int index, IntBuffer size, IntBuffer type) {
+		return GL20.glGetActiveUniform(program, index, 256, size, type);
 	}
 
 	public void glGetAttachedShaders (int program, int maxcount, Buffer count, IntBuffer shaders) {

--- a/backends/gdx-backend-moe/src/com/badlogic/gdx/backends/iosrobovm/IOSGLES20.java
+++ b/backends/gdx-backend-moe/src/com/badlogic/gdx/backends/iosrobovm/IOSGLES20.java
@@ -159,9 +159,9 @@ public class IOSGLES20 implements GL20
 	
 	public native int glGenTexture();
 
-	public native String glGetActiveAttrib ( int program, int index, IntBuffer size, Buffer type );
+	public native String glGetActiveAttrib ( int program, int index, IntBuffer size, IntBuffer type );
 
-	public native String glGetActiveUniform ( int program, int index, IntBuffer size, Buffer type );
+	public native String glGetActiveUniform ( int program, int index, IntBuffer size, IntBuffer type );
 
 	public native void glGetAttachedShaders ( int program, int maxcount, Buffer count, IntBuffer shaders );
 

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGLES20.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGLES20.java
@@ -159,9 +159,9 @@ public class IOSGLES20 implements GL20
 	
 	public native int glGenTexture();
 
-	public native String glGetActiveAttrib ( int program, int index, IntBuffer size, Buffer type );
+	public native String glGetActiveAttrib ( int program, int index, IntBuffer size, IntBuffer type );
 
-	public native String glGetActiveUniform ( int program, int index, IntBuffer size, Buffer type );
+	public native String glGetActiveUniform ( int program, int index, IntBuffer size, IntBuffer type );
 
 	public native void glGetAttachedShaders ( int program, int maxcount, Buffer count, IntBuffer shaders );
 

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtGL20.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtGL20.java
@@ -546,18 +546,18 @@ public class GwtGL20 implements GL20 {
 
 
 	@Override
-	public String glGetActiveAttrib (int program, int index, IntBuffer size, Buffer type) {
+	public String glGetActiveAttrib (int program, int index, IntBuffer size, IntBuffer type) {
 		WebGLActiveInfo activeAttrib = gl.getActiveAttrib(programs.get(program), index);
 		size.put(activeAttrib.getSize());
-		((IntBuffer)type).put(activeAttrib.getType());
+		type.put(activeAttrib.getType());
 		return activeAttrib.getName();
 	}
 
 	@Override
-	public String glGetActiveUniform (int program, int index, IntBuffer size, Buffer type) {
+	public String glGetActiveUniform (int program, int index, IntBuffer size, IntBuffer type) {
 		WebGLActiveInfo activeUniform = gl.getActiveUniform(programs.get(program), index);
 		size.put(activeUniform.getSize());
-		((IntBuffer)type).put(activeUniform.getType());
+		type.put(activeUniform.getType());
 		return activeUniform.getName();
 	}
 

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtGL20Debug.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtGL20Debug.java
@@ -536,7 +536,7 @@ public class GwtGL20Debug extends GwtGL20 {
 	}
 
 	@Override
-	public String glGetActiveAttrib (int program, int index, IntBuffer size, Buffer type) {
+	public String glGetActiveAttrib (int program, int index, IntBuffer size, IntBuffer type) {
 		 
 		String attrib = super.glGetActiveAttrib(program, index, size, type);
 		checkError();
@@ -544,7 +544,7 @@ public class GwtGL20Debug extends GwtGL20 {
 	}
 
 	@Override
-	public String glGetActiveUniform (int program, int index, IntBuffer size, Buffer type) {
+	public String glGetActiveUniform (int program, int index, IntBuffer size, IntBuffer type) {
 		 
 		String uniform = super.glGetActiveUniform(program, index, size, type);
 		checkError();

--- a/gdx/jni/iosgl/iosgl20.h
+++ b/gdx/jni/iosgl/iosgl20.h
@@ -522,7 +522,7 @@ JNIEXPORT jint JNICALL Java_com_badlogic_gdx_backends_iosrobovm_IOSGLES20_glGenT
 /*
  * Class:     com_badlogic_gdx_backends_iosrobovm_IOSGLES20
  * Method:    glGetActiveAttrib
- * Signature: (IILjava/nio/IntBuffer;Ljava/nio/Buffer;)Ljava/lang/String;
+ * Signature: (IILjava/nio/IntBuffer;Ljava/nio/IntBuffer;)Ljava/lang/String;
  */
 JNIEXPORT jstring JNICALL Java_com_badlogic_gdx_backends_iosrobovm_IOSGLES20_glGetActiveAttrib
   (JNIEnv *, jobject, jint, jint, jobject, jobject);
@@ -530,7 +530,7 @@ JNIEXPORT jstring JNICALL Java_com_badlogic_gdx_backends_iosrobovm_IOSGLES20_glG
 /*
  * Class:     com_badlogic_gdx_backends_iosrobovm_IOSGLES20
  * Method:    glGetActiveUniform
- * Signature: (IILjava/nio/IntBuffer;Ljava/nio/Buffer;)Ljava/lang/String;
+ * Signature: (IILjava/nio/IntBuffer;Ljava/nio/IntBuffer;)Ljava/lang/String;
  */
 JNIEXPORT jstring JNICALL Java_com_badlogic_gdx_backends_iosrobovm_IOSGLES20_glGetActiveUniform
   (JNIEnv *, jobject, jint, jint, jobject, jobject);

--- a/gdx/src/com/badlogic/gdx/graphics/GL20.java
+++ b/gdx/src/com/badlogic/gdx/graphics/GL20.java
@@ -498,10 +498,10 @@ public interface GL20 {
 	public void glGenRenderbuffers (int n, IntBuffer renderbuffers);
 
 	// deviates
-	public String glGetActiveAttrib (int program, int index, IntBuffer size, Buffer type);
+	public String glGetActiveAttrib (int program, int index, IntBuffer size, IntBuffer type);
 
 	// deviates
-	public String glGetActiveUniform (int program, int index, IntBuffer size, Buffer type);
+	public String glGetActiveUniform (int program, int index, IntBuffer size, IntBuffer type);
 
 	public void glGetAttachedShaders (int program, int maxcount, Buffer count, IntBuffer shaders);
 

--- a/gdx/src/com/badlogic/gdx/graphics/profiling/GL20Interceptor.java
+++ b/gdx/src/com/badlogic/gdx/graphics/profiling/GL20Interceptor.java
@@ -614,7 +614,7 @@ public class GL20Interceptor extends GLInterceptor implements GL20 {
 	}
 
 	@Override
-	public String glGetActiveAttrib (int program, int index, IntBuffer size, Buffer type) {
+	public String glGetActiveAttrib (int program, int index, IntBuffer size, IntBuffer type) {
 		calls++;
 		String result = gl20.glGetActiveAttrib(program, index, size, type);
 		check();
@@ -622,7 +622,7 @@ public class GL20Interceptor extends GLInterceptor implements GL20 {
 	}
 
 	@Override
-	public String glGetActiveUniform (int program, int index, IntBuffer size, Buffer type) {
+	public String glGetActiveUniform (int program, int index, IntBuffer size, IntBuffer type) {
 		calls++;
 		String result = gl20.glGetActiveUniform(program, index, size, type);
 		check();

--- a/gdx/src/com/badlogic/gdx/graphics/profiling/GL30Interceptor.java
+++ b/gdx/src/com/badlogic/gdx/graphics/profiling/GL30Interceptor.java
@@ -616,7 +616,7 @@ public class GL30Interceptor extends GLInterceptor implements GL30 {
 	}
 
 	@Override
-	public String glGetActiveAttrib (int program, int index, IntBuffer size, Buffer type) {
+	public String glGetActiveAttrib (int program, int index, IntBuffer size, IntBuffer type) {
 		calls++;
 		String result = gl30.glGetActiveAttrib(program, index, size, type);
 		check();
@@ -624,7 +624,7 @@ public class GL30Interceptor extends GLInterceptor implements GL30 {
 	}
 
 	@Override
-	public String glGetActiveUniform (int program, int index, IntBuffer size, Buffer type) {
+	public String glGetActiveUniform (int program, int index, IntBuffer size, IntBuffer type) {
 		calls++;
 		String result = gl30.glGetActiveUniform(program, index, size, type);
 		check();


### PR DESCRIPTION
#### Issue details
In the LWJGL3 backend, `Lwjgl3GL20#glGetActiveUniform` and `...ActiveAttrib` report incorrect sizes and types. This causes the size and type of uniforms and attributes reported by `ShaderProgram` to be incorrect when using the LWJGL3 backend.
From here on I will only describe the case of uniforms.

<details>
  <summary>Lwjgl3GL20#glGetActiveUniform implementation</summary>
  
  ```java
  public String glGetActiveUniform (int program, int index, IntBuffer size, Buffer type) {
    IntBuffer typeTmp = BufferUtils.createIntBuffer(2);
    String name = GL20.glGetActiveUniform(program, index, 256, size, typeTmp);
    size.put(typeTmp.get(0));
    if (type instanceof IntBuffer) ((IntBuffer)type).put(typeTmp.get(1));
    return name;
  }
  ```
</details>

For some reason, the call to `GL20#glGetActiveUniform` is not given the `type` argument from the caller, but instead a new buffer allocated in the method body. This buffer's first element is then put into `size`, overriding the `size` value obtained from the `GL20#glGetActiveUniform` call; and the buffer's second element is put into `type` of the caller. This seems to be incorrect, maybe this is an artifact from an older version.

Workaround: Manually call `org.lwjgl.opengl.GL20#glGetActiveUniform`. This is obviously not a very good solution because it breaks compability with other backends.

#### Reproduction steps/code
<details>
  <summary>Example code showing the bug and a workaround (for uniforms)</summary>
  
  ```java
  package net.haspamelodica.gdx;
  
  import java.lang.reflect.Field;
  import java.nio.IntBuffer;
  import java.util.Arrays;
  
  import org.lwjgl.BufferUtils;
  
  import com.badlogic.gdx.ApplicationListener;
  import com.badlogic.gdx.Gdx;
  import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application;
  import com.badlogic.gdx.backends.lwjgl3.Lwjgl3ApplicationConfiguration;
  import com.badlogic.gdx.graphics.GL20;
  import com.badlogic.gdx.graphics.glutils.ShaderProgram;
  
  public class ShowLwjgl3GL20Bug implements ApplicationListener
  {
    @Override
    public void create()
    {
      ShaderProgram shader = new ShaderProgram(
          "void main() {gl_Position = vec4(0.0);}",
          "uniform float[5] exampleUniform; void main() {gl_FragColor = vec4(exampleUniform[0]);}");
      String uniformName = "exampleUniform[0]";
  
      if(!shader.isCompiled())
      {
        System.err.println("Error compiling shader:");
        System.err.println(shader.getLog());
      } else
      {
        System.out.println("GL_FLOAT: " + GL20.GL_FLOAT);
        System.out.println("shader.getUniforms(): " + Arrays.toString(shader.getUniforms()));
  
        //print size and type reported by the shader
        System.out.println("--- ShaderProgram");
        System.out.println("shader.getUniformSize(...): " + shader.getUniformSize(uniformName)); //5126 (GL_FLOAT) - should be 5
        System.out.println("shader.getUniformType(...): " + shader.getUniformType(uniformName)); //0 - should be 5126 (GL_FLOAT)
  
        int program = getProgramNumber(shader);
        int exampleUniformLocation = shader.getUniformLocation(uniformName);
        IntBuffer sizeBuf = BufferUtils.createIntBuffer(2);
        IntBuffer typeBuf = BufferUtils.createIntBuffer(2);
  
        //print size and type reported by Gdx.gl
        System.out.println("--- Gdx.gl");
        String uniformNameGdx = Gdx.gl.glGetActiveUniform(program, exampleUniformLocation, sizeBuf, typeBuf);
        System.out.println("Gdx.gl.glGetActiveUniform(...) returns: \"" + uniformNameGdx + "\"");
        System.out.println("size[0]: " + sizeBuf.get(0)); //5126 (GL_FLOAT) - should be 5
        System.out.println("size[1]: " + sizeBuf.get(1)); //0
        System.out.println("type[0]: " + typeBuf.get(0)); //0 - should be 5126 (GL_FLOAT)
        System.out.println("type[1]: " + typeBuf.get(1)); //0
  
        sizeBuf.position(0);
        typeBuf.position(0);
  
        //print size and type reported by LWJGL's GL20
        System.out.println("--- LWJGL's GL20");
        String uniformNameLWJGL = org.lwjgl.opengl.GL20.glGetActiveUniform(program, exampleUniformLocation, sizeBuf, typeBuf);
        System.out.println("org.lwjgl.opengl.GL20.glGetActiveUniform(...) returns: \"" + uniformNameLWJGL + "\"");
        System.out.println("size[0]: " + sizeBuf.get(0)); //5 - correct
        System.out.println("size[1]: " + sizeBuf.get(1)); //0
        System.out.println("type[0]: " + typeBuf.get(0)); //5126 (GL_FLOAT) - correct
        System.out.println("type[1]: " + typeBuf.get(1)); //0
      }
  
      shader.dispose();
      Gdx.app.exit();//don't keep the annoying black window
    }
  
    private int getProgramNumber(ShaderProgram shader)
    {
      //TODO is there a better way?
      try
      {
        Field programF = ShaderProgram.class.getDeclaredField("program");
        programF.setAccessible(true);
        return (int) programF.get(shader);
      } catch(Exception e)
      {
        throw new RuntimeException(e);
      }
    }
  
    @Override
    public void resize(int width, int height)
    {}
    @Override
    public void render()
    {}
    @Override
    public void pause()
    {}
    @Override
    public void resume()
    {}
    @Override
    public void dispose()
    {}
  
    public static void main(String[] args)
    {
      new Lwjgl3Application(new ShowLwjgl3GL20Bug(), new Lwjgl3ApplicationConfiguration());
    }
  }
  ```
</details>

#### Version of LibGDX and/or relevant dependencies
libGDX version 1.9.10
LWJGL version 3.2.3

#### Stacktrace
_n/a_

#### Please select the affected platforms
- [ ] Android
- [ ] iOS (robovm)
- [ ] iOS (MOE)
- [ ] HTML/GWT
- [x] Windows
- [ ] Linux
- [ ] MacOS
_Note: I only tested this on Windows, but the bug probably occurs on every platform when using the LWJGL3 backend._