### PR TITLE
Remove constructor with preFill argument from Pool

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+[1.9.12]
+- API Change: Removed Pool constructor with preFill parameter in favor of using Pool#fill() method. See #6117
+
 [1.9.11]
 - Update to MobiVM 2.3.8
 - Update to LWJGL 3.2.3

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/ParticleEffectPool.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/ParticleEffectPool.java
@@ -28,11 +28,6 @@ public class ParticleEffectPool extends Pool<PooledEffect> {
 		this.effect = effect;
 	}
 
-	public ParticleEffectPool (ParticleEffect effect, int initialCapacity, int max, boolean preFill) {
-		super(initialCapacity, max, preFill);
-		this.effect = effect;
-	}
-
 	protected PooledEffect newObject () {
 		PooledEffect pooledEffect = new PooledEffect(effect);
 		pooledEffect.start();

--- a/gdx/src/com/badlogic/gdx/utils/FlushablePool.java
+++ b/gdx/src/com/badlogic/gdx/utils/FlushablePool.java
@@ -34,10 +34,6 @@ public abstract class FlushablePool<T> extends Pool<T> {
 		super(initialCapacity, max);
 	}
 
-	public FlushablePool (int initialCapacity, int max, boolean preFill) {
-		super(initialCapacity, max, preFill);
-	}
-
 	@Override
 	public T obtain () {
 		T result = super.obtain();

--- a/gdx/src/com/badlogic/gdx/utils/Pool.java
+++ b/gdx/src/com/badlogic/gdx/utils/Pool.java
@@ -29,33 +29,20 @@ abstract public class Pool<T> {
 
 	/** Creates a pool with an initial capacity of 16 and no maximum. */
 	public Pool () {
-		this(16, Integer.MAX_VALUE, false);
+		this(16, Integer.MAX_VALUE);
 	}
 
 	/** Creates a pool with the specified initial capacity and no maximum. */
 	public Pool (int initialCapacity) {
-		this(initialCapacity, Integer.MAX_VALUE, false);
+		this(initialCapacity, Integer.MAX_VALUE);
 	}
 
-	/** @param max The maximum number of free objects to store in this pool. */
+	/** @param initialCapacity The initial size of the array supporting the pool. No objects are created/pre-allocated.
+	 *                             Use {@link #fill(int) after instantiation if needed.
+	 * @param max The maximum number of free objects to store in this pool. */
 	public Pool (int initialCapacity, int max) {
-		this(initialCapacity, max, false);
-	}
-
-	/** @param initialCapacity The initial size of the array supporting the pool. No objects are created unless preFill is true.
-	 * @param max The maximum number of free objects to store in this pool.
-	 * @param preFill Whether to pre-fill the pool with objects. The number of pre-filled objects will be equal to the initial
-	 *           capacity. */
-	public Pool (int initialCapacity, int max, boolean preFill) {
-		if (initialCapacity > max && preFill)
-			throw new IllegalArgumentException("max must be larger than initialCapacity if preFill is set to true.");
 		freeObjects = new Array(false, initialCapacity);
 		this.max = max;
-		if (preFill) {
-			for (int i = 0; i < initialCapacity; i++)
-				freeObjects.add(newObject());
-			peak = freeObjects.size;
-		}
 	}
 
 	abstract protected T newObject ();

--- a/gdx/src/com/badlogic/gdx/utils/ReflectionPool.java
+++ b/gdx/src/com/badlogic/gdx/utils/ReflectionPool.java
@@ -27,19 +27,15 @@ public class ReflectionPool<T> extends Pool<T> {
 	private final Constructor constructor;
 
 	public ReflectionPool (Class<T> type) {
-		this(type, 16, Integer.MAX_VALUE, false);
+		this(type, 16, Integer.MAX_VALUE);
 	}
 
 	public ReflectionPool (Class<T> type, int initialCapacity) {
-		this(type, initialCapacity, Integer.MAX_VALUE, false);
+		this(type, initialCapacity, Integer.MAX_VALUE);
 	}
 
 	public ReflectionPool (Class<T> type, int initialCapacity, int max) {
-		this(type, initialCapacity, max, false);
-	}
-
-	public ReflectionPool (Class<T> type, int initialCapacity, int max, boolean preFill) {
-		super(initialCapacity, max, preFill);
+		super(initialCapacity, max);
 		constructor = findConstructor(type);
 		if (constructor == null)
 			throw new RuntimeException("Class cannot be created (missing no-arg constructor): " + type.getName());


### PR DESCRIPTION
Unfortunately I've realised that the constructor based mechanisms that https://github.com/libgdx/libgdx/pull/5773 introduced to prefill a Pool is bad and should be removed (we can keep calling `fill()` after instantiation).

Calling a protected method (`newObject()`) on the constructor is an anti pattern and can cause state consistency issues as the object may not have been fully initialized. A simple example can be seen on `ParticleEffectPool` in which if we use the constructor passing `preFill()` as `true`, `newObject()` will be called before `effect`has been set throwing a `NullPointerException`.

I should have seen this issue before, sorry for that :(