### PR TITLE
Cache Box2D Fixture filter data to avoid JNI overhead

### DIFF
--- a/extensions/gdx-box2d/gdx-box2d/src/com/badlogic/gdx/physics/box2d/Filter.java
+++ b/extensions/gdx-box2d/gdx-box2d/src/com/badlogic/gdx/physics/box2d/Filter.java
@@ -28,4 +28,10 @@ public class Filter {
 	/** Collision groups allow a certain group of objects to never collide (negative) or always collide (positive). Zero means no
 	 * collision group. Non-zero group filtering always wins against the mask bits. */
 	public short groupIndex = 0;
+
+	public void set(Filter filter) {
+		categoryBits = filter.categoryBits;
+		maskBits = filter.maskBits;
+		groupIndex = filter.groupIndex;
+	}
 }

--- a/extensions/gdx-box2d/gdx-box2d/src/com/badlogic/gdx/physics/box2d/Fixture.java
+++ b/extensions/gdx-box2d/gdx-box2d/src/com/badlogic/gdx/physics/box2d/Fixture.java
@@ -31,6 +31,9 @@ public class Fixture {
 	/** the address of the fixture **/
 	protected long addr;
 
+	/** the fixture filter data, initialized lazily **/
+	private Filter filter;
+
 	/** the shape, initialized lazy **/
 	protected Shape shape;
 
@@ -141,6 +144,9 @@ public class Fixture {
 	 * awake. This automatically calls Refilter. */
 	public void setFilterData (Filter filter) {
 		jniSetFilterData(addr, filter.categoryBits, filter.maskBits, filter.groupIndex);
+		if (this.filter == null)
+			this.filter = new Filter();
+		this.filter.set(filter);
 	}
 
 	private native void jniSetFilterData (long addr, short categoryBits, short maskBits, short groupIndex); /*
@@ -154,14 +160,18 @@ public class Fixture {
 
 	/** Get the contact filtering data. */
 	private final short[] tmp = new short[3];
-	private final Filter filter = new Filter();
+	private final Filter tmpFilter = new Filter();
 
 	public Filter getFilterData () {
-		jniGetFilterData(addr, tmp);
-		filter.maskBits = tmp[0];
-		filter.categoryBits = tmp[1];
-		filter.groupIndex = tmp[2];
-		return filter;
+		if (filter == null) {
+			jniGetFilterData(addr, tmp);
+			filter = new Filter();
+			filter.maskBits = tmp[0];
+			filter.categoryBits = tmp[1];
+			filter.groupIndex = tmp[2];
+		}
+		tmpFilter.set(filter);
+		return tmpFilter;
 	}
 
 	private native void jniGetFilterData (long addr, short[] filter); /*


### PR DESCRIPTION
This PR fixes performance issues caused by JNI overhead in certain Box2D scenarios.

Box2D resolves if 2 objects should collide or not in `World#contactFilter`. Every time 2 fixtures overlap, Box2D needs to know wether they need to collide or not. In certain scenarios with lots of bodies, even if they don't collide with one another, that method will be called many times every time there's an overlap.

In the libGDX Box2D integration we have several ways to make the "should collide" resolution.
1. Mask/Category bits
2. Group id
3. Custom `ContactFilter`

Checking the `World#contactFilter` implementation we see that unless we use option 3, 2 JNI calls to `jniGetFilterData` will be made. The only thing `jniGetFilterData` does is to get the `Filter` data from the `Fixture`. The problem is the JNI calls cause quite an overhead which have a very important impact.

The solution is to cache the Filter data on the Java side of the `Filter`class.

I've created a modified version of `Box2DTest` to profile the issue that shows the problem with current libGDX by taking advatage of the fact that using a `ContactFilter`we avoid the JNI calls so we can switch it or on off. It starts with 100 boxes. Every time you tap the screen it adds 100 more boxes. https://github.com/obigu/libgdx/blob/box2dtests/tests/gdx-tests/src/com/badlogic/gdx/tests/Box2DTest.java

The results are very noticeable on a mobile device.

- You can switch between JNI calls (resolution 1) and No JNI calls (resolution 3) changing the constant `USE_CONTACT_FILTER` to `false` and `true`.
- There's always a small initial time after tapping in which fps drops until it stabilizes due to initialization/creation.


On an Android Pixel 3:
- 1000 boxes 60fps with USE_CONTACT_FILTER = true (no JNI calls)
- 500 boxes 60fps with USE_CONTACT_FILTER = false (JNI calls to `jniGetFilterData`)

![Screenshot_20200724-193233](https://user-images.githubusercontent.com/1794492/88419403-6c83c000-cde5-11ea-8af6-164f3dfc0d2a.jpg)

I've also confirmed the culprit is `jniGetFilterData` by using Android Profiler and analysing CPU usage.