### PR TITLE
Android build.gradle template for AndroidX compatibility

### DIFF
--- a/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/android/build.gradle
+++ b/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/android/build.gradle
@@ -43,7 +43,7 @@ task copyAndroidNatives {
         file("libs/x86_64/").mkdirs()
         file("libs/x86/").mkdirs()
 
-        configurations.natives.files.each { jar ->
+        configurations.natives.copy().files.each { jar ->
             def outputDir = null
             if (jar.name.endsWith("natives-arm64-v8a.jar")) outputDir = file("libs/arm64-v8a")
             if (jar.name.endsWith("natives-armeabi-v7a.jar")) outputDir = file("libs/armeabi-v7a")


### PR DESCRIPTION
As suggested in #5303, Android's build.gradle file must be changed if AndroidX is enabled in the project. The change works if AndroidX is not enabled.