### PR TITLE
Fixed typo in Intersector comment.

### DIFF
--- a/gdx/src/com/badlogic/gdx/math/Intersector.java
+++ b/gdx/src/com/badlogic/gdx/math/Intersector.java
@@ -571,7 +571,7 @@ public final class Intersector {
 				}
 			}
 		}
-		// max y
+		// max z
 		if (ray.origin.z >= box.max.z && ray.direction.z < 0) {
 			t = (box.max.z - ray.origin.z) / ray.direction.z;
 			if (t >= 0) {


### PR DESCRIPTION
Fixed a minor typo in a comment for Intersector.intersectRayBounds().