### PR TITLE
[scene2d.ui] set culling area for scrollpane's widget if it only wrap a Group

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ScrollPane.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ScrollPane.java
@@ -562,6 +562,15 @@ public class ScrollPane extends WidgetGroup {
 			widgetCullingArea.width = widgetAreaBounds.width;
 			widgetCullingArea.height = widgetAreaBounds.height;
 			((Cullable)widget).setCullingArea(widgetCullingArea);
+			
+			if(widget instanceof Group)
+			{
+				Group group = (Group) widget;
+				if(group.getChildren().size == 1 && group.getChildren().get(0) instanceof Cullable)
+				{
+					((Cullable)group.getChildren().get(0)).setCullingArea(widgetCullingArea);
+				}
+			}
 		}
 	}
 

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ScrollPane.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ScrollPane.java
@@ -25,6 +25,7 @@ import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.math.Rectangle;
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.scenes.scene2d.Actor;
+import com.badlogic.gdx.scenes.scene2d.Group;
 import com.badlogic.gdx.scenes.scene2d.Event;
 import com.badlogic.gdx.scenes.scene2d.InputEvent;
 import com.badlogic.gdx.scenes.scene2d.InputListener;


### PR DESCRIPTION
Solves https://github.com/kotcrab/vis-ui/issues/266

Maybe there is a better way to handle that on vis-ui part, but i'm pretty sure there is something else to do with the ScrollPane implementation, what do you think?