### PR TITLE
Make external files work on Android 10 and up

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,7 @@
 - API Addition: Added an insertRange method to array collections.
 - Fixed GestureDetector maxFlingDelay.
 - API Change: Changed default GestureDetector maxFlingDelay to Integer.MAX_VALUE (didn't work before, this matches that).
+- Gdx.files.external on Android now uses app external storage - see wiki article File handling for more information
 
 [1.9.11]
 - Update to MobiVM 2.3.8

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplication.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplication.java
@@ -121,7 +121,7 @@ public class AndroidApplication extends Activity implements AndroidApplicationBa
 		input = createInput(this, this, graphics.view, config);
 		audio = createAudio(this, config);
 		this.getFilesDir(); // workaround for Android bug #10515463
-		files = new AndroidFiles(this.getAssets(), this.getFilesDir().getAbsolutePath());
+		files = new AndroidFiles(this.getAssets(), this);
 		net = new AndroidNet(this, config);
 		this.listener = listener;
 		this.handler = new Handler();

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidDaydream.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidDaydream.java
@@ -114,7 +114,7 @@ public class AndroidDaydream extends DreamService implements AndroidApplicationB
 		input = createInput(this, this, graphics.view, config);
 		audio = createAudio(this, config);
 		this.getFilesDir(); // workaround for Android bug #10515463
-		files = new AndroidFiles(this.getAssets(), this.getFilesDir().getAbsolutePath());
+		files = new AndroidFiles(this.getAssets(), this);
 		net = new AndroidNet(this, config);
 		this.listener = listener;
 		this.handler = new Handler();

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidFiles.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidFiles.java
@@ -16,11 +16,13 @@
 
 package com.badlogic.gdx.backends.android;
 
+import java.io.File;
 import java.io.IOException;
 
 import android.app.Activity;
 import android.app.Fragment;
 import android.content.Context;
+import android.content.ContextWrapper;
 import android.content.res.AssetManager;
 import android.os.Environment;
 
@@ -32,20 +34,25 @@ import com.badlogic.gdx.utils.GdxRuntimeException;
 /** @author mzechner
  * @author Nathan Sweet */
 public class AndroidFiles implements Files {
-	protected final String sdcard = Environment.getExternalStorageDirectory().getAbsolutePath() + "/";
+	protected final String externalFilesPath;
 	protected final String localpath;
 
 	protected final AssetManager assets;
 	private ZipResourceFile expansionFile = null;
 
-	public AndroidFiles (AssetManager assets) {
+	public AndroidFiles (AssetManager assets, ContextWrapper contextWrapper) {
 		this.assets = assets;
-		localpath = sdcard;
-	}
 
-	public AndroidFiles (AssetManager assets, String localpath) {
-		this.assets = assets;
-		this.localpath = localpath.endsWith("/") ? localpath : localpath + "/";
+		String localPath = contextWrapper.getFilesDir().getAbsolutePath();
+		this.localpath = localPath.endsWith("/") ? localPath : localPath + "/";
+
+		File externalFilesDir = contextWrapper.getExternalFilesDir(null);
+		if (externalFilesDir != null) {
+			String externalFilesPath = externalFilesDir.getAbsolutePath();
+			this.externalFilesPath = externalFilesPath.endsWith("/") ? externalFilesPath : externalFilesPath + "/";
+		} else {
+			this.externalFilesPath = null;
+		}
 	}
 
 	@Override
@@ -98,12 +105,12 @@ public class AndroidFiles implements Files {
 
 	@Override
 	public String getExternalStoragePath () {
-		return sdcard;
+		return externalFilesPath;
 	}
 
 	@Override
 	public boolean isExternalStorageAvailable () {
-		return Environment.getExternalStorageState().equals(Environment.MEDIA_MOUNTED);
+		return externalFilesPath != null;
 	}
 
 	@Override

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidFragmentApplication.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidFragmentApplication.java
@@ -137,7 +137,7 @@ public class AndroidFragmentApplication extends Fragment implements AndroidAppli
 			: config.resolutionStrategy);
 		input = createInput(this, getActivity(), graphics.view, config);
 		audio = createAudio(getActivity(), config);
-		files = new AndroidFiles(getResources().getAssets(), getActivity().getFilesDir().getAbsolutePath());
+		files = new AndroidFiles(getResources().getAssets(), getActivity());
 		net = new AndroidNet(this, config);
 		this.listener = listener;
 		this.handler = new Handler();

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidLiveWallpaper.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidLiveWallpaper.java
@@ -74,7 +74,7 @@ public class AndroidLiveWallpaper implements AndroidApplicationBase {
 
 		// added initialization of android local storage: /data/data/<app package>/files/
 		this.getService().getFilesDir(); // workaround for Android bug #10515463
-		files = new AndroidFiles(this.getService().getAssets(), this.getService().getFilesDir().getAbsolutePath());
+		files = new AndroidFiles(this.getService().getAssets(), this.getService());
 		net = new AndroidNet(this, config);
 		this.listener = listener;
 		clipboard = new AndroidClipboard(this.getService());

--- a/gdx/src/com/badlogic/gdx/Files.java
+++ b/gdx/src/com/badlogic/gdx/Files.java
@@ -19,7 +19,7 @@ package com.badlogic.gdx;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.utils.GdxRuntimeException;
 
-/** Provides standard access to the filesystem, classpath, Android SD card, and Android assets directory.
+/** Provides standard access to the filesystem, classpath, Android app storage (internal and external), and Android assets directory.
  * @author mzechner
  * @author Nathan Sweet */
 public interface Files {
@@ -37,7 +37,7 @@ public interface Files {
 		 * Internal files are always readonly. */
 		Internal,
 
-		/** Path relative to the root of the SD card on Android and to the home directory of the current user on the desktop. */
+		/** Path relative to the root of the app external storage on Android and to the home directory of the current user on the desktop. */
 		External,
 
 		/** Path that is a fully qualified, absolute filesystem path. To ensure portability across platforms use absolute files only
@@ -69,12 +69,11 @@ public interface Files {
 	/** Convenience method that returns a {@link FileType#Local} file handle. */
 	public FileHandle local (String path);
 
-	/** Returns the external storage path directory. This is the SD card on Android and the home directory of the current user on
-	 * the desktop. */
+	/** Returns the external storage path directory. This is the app external storage on Android and the home directory of the
+	 * current user on the desktop. */
 	public String getExternalStoragePath ();
 
-	/** Returns true if the external storage is ready for file IO. Eg, on Android, the SD card is not available when mounted for use
-	 * with a PC. */
+	/** Returns true if the external storage is ready for file IO. */
 	public boolean isExternalStorageAvailable ();
 
 	/** Returns the local storage path directory. This is the private files directory on Android and the directory of the jar on the

--- a/gdx/src/com/badlogic/gdx/files/FileHandle.java
+++ b/gdx/src/com/badlogic/gdx/files/FileHandle.java
@@ -44,7 +44,7 @@ import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.utils.GdxRuntimeException;
 import com.badlogic.gdx.utils.StreamUtils;
 
-/** Represents a file or directory on the filesystem, classpath, Android SD card, or Android assets directory. FileHandles are
+/** Represents a file or directory on the filesystem, classpath, Android app storage, or Android assets directory. FileHandles are
  * created via a {@link Files} instance.
  * 
  * Because some of the file types are backed by composite files and may be compressed (for example, if they are in an Android .apk


### PR DESCRIPTION
Since Android 6, the use of the sd card is only possible by showing a runtime permission dialog. This is not easy to implement and somehow scary for most users. Since Android 10, access to the sd card is not possible at all.

This PR changes the used path to the app external storage dir that is intended for the app to write to for other apps to read from. No runtime or other permissions are needed to use it.