### PR TITLE
iOS RoboVM: Support hardware keyboard events

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/DefaultAndroidInput.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/DefaultAndroidInput.java
@@ -648,7 +648,7 @@ public class DefaultAndroidInput implements AndroidInput {
 
 	@Override
 	public boolean isCatchKey (int keycode) {
-		return keysToCatch.contains(keyCount);
+		return keysToCatch.contains(keycode);
 	}
 
 	@Override

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/DefaultLwjglInput.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/DefaultLwjglInput.java
@@ -67,7 +67,7 @@ final public class DefaultLwjglInput implements LwjglInput {
 	int deltaX, deltaY;
 	int pressedKeys = 0;
 	boolean keyJustPressed = false;
-	boolean[] justPressedKeys = new boolean[256];
+	boolean[] justPressedKeys = new boolean[Keys.MAX_KEYCODE + 1];
 	boolean[] justPressedButtons = new boolean[5];
 	boolean justTouched = false;
 	IntSet pressedButtons = new IntSet();

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglAWTInput.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglAWTInput.java
@@ -109,9 +109,9 @@ public class LwjglAWTInput implements Input, MouseMotionListener, MouseListener,
 	boolean touchDown = false;
 	boolean justTouched = false;
 	int keyCount = 0;
-	boolean[] keys = new boolean[256];
+	boolean[] keys = new boolean[Keys.MAX_KEYCODE + 1];
 	boolean keyJustPressed = false;
-	boolean[] justPressedKeys = new boolean[256];
+	boolean[] justPressedKeys = new boolean[Keys.MAX_KEYCODE + 1];
 	boolean[] justPressedButtons = new boolean[5];
 	IntSet pressedButtons = new IntSet();
 	InputProcessor processor;

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/DefaultLwjgl3Input.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/DefaultLwjgl3Input.java
@@ -41,7 +41,7 @@ public class DefaultLwjgl3Input implements Lwjgl3Input {
 	boolean justTouched;
 	int pressedKeys;
 	boolean keyJustPressed;
-	boolean[] justPressedKeys = new boolean[256];
+	boolean[] justPressedKeys = new boolean[Keys.MAX_KEYCODE + 1];
 	boolean[] justPressedButtons = new boolean[5];
 	char lastCharacter;
 		

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/DefaultIOSInput.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/DefaultIOSInput.java
@@ -387,7 +387,7 @@ public class DefaultIOSInput implements IOSInput {
 		if (key == Input.Keys.ANY_KEY) {
 			return keyCount > 0;
 		}
-		if (key < 0 || key >= Keys.MAX_KEYCODE) {
+		if (key < 0 || key > Keys.MAX_KEYCODE) {
 			return false;
 		}
 		return keys[key];
@@ -398,7 +398,7 @@ public class DefaultIOSInput implements IOSInput {
 		if (key == Input.Keys.ANY_KEY) {
 			return keyJustPressed;
 		}
-		if (key < 0 || key >= Keys.MAX_KEYCODE) {
+		if (key < 0 || key > Keys.MAX_KEYCODE) {
 			return false;
 		}
 		return justPressedKeys[key];

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/DefaultIOSInput.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/DefaultIOSInput.java
@@ -130,6 +130,7 @@ public class DefaultIOSInput implements IOSInput {
 	private IntSet keysToCatch = new IntSet();
 	private boolean keyJustPressed = false;
 	private int keyCount = 0;
+	private boolean hadHardwareKeyEvent = true;
 	private final boolean[] keys = new boolean[Keys.MAX_KEYCODE + 1];
 	private final boolean[] justPressedKeys = new boolean[Keys.MAX_KEYCODE + 1];
 
@@ -600,6 +601,7 @@ public class DefaultIOSInput implements IOSInput {
 		if (peripheral == Peripheral.Compass) return compassSupported;
 		if (peripheral == Peripheral.OnscreenKeyboard) return true;
 		if (peripheral == Peripheral.Pressure) return pressureSupported;
+		if (peripheral == Peripheral.HardwareKeyboard) return hadHardwareKeyEvent;
 		return false;
 	}
 
@@ -659,6 +661,8 @@ public class DefaultIOSInput implements IOSInput {
 
 		if (keyCode != Keys.UNKNOWN)
 			synchronized (keyEvents) {
+				hadHardwareKeyEvent = true;
+
 				KeyEvent event = keyEventPool.obtain();
 				long timeStamp = System.nanoTime();
 				event.timeStamp = timeStamp;

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/DefaultIOSInput.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/DefaultIOSInput.java
@@ -130,7 +130,7 @@ public class DefaultIOSInput implements IOSInput {
 	private IntSet keysToCatch = new IntSet();
 	private boolean keyJustPressed = false;
 	private int keyCount = 0;
-	private boolean hadHardwareKeyEvent = true;
+	private boolean hadHardwareKeyEvent = false;
 	private final boolean[] keys = new boolean[Keys.MAX_KEYCODE + 1];
 	private final boolean[] justPressedKeys = new boolean[Keys.MAX_KEYCODE + 1];
 

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/DefaultIOSInput.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/DefaultIOSInput.java
@@ -672,11 +672,25 @@ public class DefaultIOSInput implements IOSInput {
 				keyEvents.add(event);
 
 				if (!down) {
-					String characters = key.getCharacters();
-					// special keys return constants like "UIKeyInputF5", so we check for length 1
-					if (characters != null && characters.length() == 1) {
-						char character = characters.charAt(0);
+					char character;
 
+					switch (keyCode) {
+						case Keys.DEL:
+							character = 8;
+							break;
+						case Keys.FORWARD_DEL:
+							character = 127;
+							break;
+						case Keys.ENTER:
+							character = 13;
+							break;
+						default:
+							String characters = key.getCharacters();
+							// special keys return constants like "UIKeyInputF5", so we check for length 1
+							character = (characters != null && characters.length() == 1) ? characters.charAt(0) : 0;
+					}
+
+					if (character >= 0) {
 						event = keyEventPool.obtain();
 						event.timeStamp = timeStamp;
 						event.type = KeyEvent.KEY_TYPED;

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
@@ -32,6 +32,7 @@ import com.badlogic.gdx.utils.Array;
 import org.robovm.apple.coregraphics.CGRect;
 import org.robovm.apple.foundation.Foundation;
 import org.robovm.apple.foundation.NSObject;
+import org.robovm.apple.foundation.NSSet;
 import org.robovm.apple.glkit.GLKView;
 import org.robovm.apple.glkit.GLKViewController;
 import org.robovm.apple.glkit.GLKViewControllerDelegate;
@@ -47,6 +48,8 @@ import org.robovm.apple.uikit.UIEdgeInsets;
 import org.robovm.apple.uikit.UIEvent;
 import org.robovm.apple.uikit.UIInterfaceOrientation;
 import org.robovm.apple.uikit.UIInterfaceOrientationMask;
+import org.robovm.apple.uikit.UIPress;
+import org.robovm.apple.uikit.UIPressesEvent;
 import org.robovm.apple.uikit.UIRectEdge;
 import org.robovm.apple.uikit.UIView;
 import org.robovm.objc.Selector;
@@ -147,6 +150,20 @@ public class IOSGraphics extends NSObject implements Graphics, GLKViewDelegate, 
 			UIInterfaceOrientation orientation) {
 			return self.shouldAutorotateToInterfaceOrientation(orientation);
 		}
+
+        @Override
+        public void pressesBegan(NSSet<UIPress> presses, UIPressesEvent event) {
+            if (presses == null || presses.isEmpty() || !app.input.onKey(presses.getValues().first().getKey(), true)) {
+                super.pressesBegan(presses, event);
+            }
+        }
+
+        @Override
+        public void pressesEnded(NSSet<UIPress> presses, UIPressesEvent event) {
+            if (presses == null || presses.isEmpty() || !app.input.onKey(presses.getValues().first().getKey(), false)) {
+                super.pressesEnded(presses, event);
+            }
+        }
 	}
 
 	static class IOSUIView extends GLKView {

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSInput.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSInput.java
@@ -2,6 +2,8 @@ package com.badlogic.gdx.backends.iosrobovm;
 
 import com.badlogic.gdx.Input;
 
+import org.robovm.apple.uikit.UIKey;
+
 public interface IOSInput extends Input {
 
 	/** Initializes peripherals (such as compass or accelerometer) */
@@ -12,4 +14,6 @@ public interface IOSInput extends Input {
 
 	/** Process all touch events that have been registered on #onTouch(). */
 	void processEvents();
+
+	boolean onKey(UIKey key, boolean down);
 }

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/DefaultGwtInput.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/DefaultGwtInput.java
@@ -45,9 +45,9 @@ public class DefaultGwtInput implements GwtInput {
 	IntSet pressedButtons = new IntSet();
 	int pressedKeyCount = 0;
 	IntSet pressedKeySet = new IntSet();
-	boolean[] pressedKeys = new boolean[256];
+	boolean[] pressedKeys = new boolean[Keys.MAX_KEYCODE + 1];
 	boolean keyJustPressed = false;
-	boolean[] justPressedKeys = new boolean[256];
+	boolean[] justPressedKeys = new boolean[Keys.MAX_KEYCODE + 1];
 	boolean[] justPressedButtons = new boolean[5];
 	InputProcessor processor;
 	long currentEventTimeStamp;

--- a/gdx/src/com/badlogic/gdx/Input.java
+++ b/gdx/src/com/badlogic/gdx/Input.java
@@ -241,11 +241,13 @@ public interface Input {
 		public static final int F11 = 254;
 		public static final int F12 = 255;
 
+		public static final int MAX_KEYCODE = 255;
+
 		/** @return a human readable representation of the keycode. The returned value can be used in
 		 *         {@link Input.Keys#valueOf(String)} */
 		public static String toString (int keycode) {
 			if (keycode < 0) throw new IllegalArgumentException("keycode cannot be negative, keycode: " + keycode);
-			if (keycode > 255) throw new IllegalArgumentException("keycode cannot be greater than 255, keycode: " + keycode);
+			if (keycode > MAX_KEYCODE) throw new IllegalArgumentException("keycode cannot be greater than 255, keycode: " + keycode);
 			switch (keycode) {
 			// META* variables should not be used with this method.
 			case UNKNOWN:

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -20,7 +20,7 @@ ext {
     testnatives = [:]
 }
 
-versions.robovm = "2.3.8"
+versions.robovm = "2.3.10-SNAPSHOT"
 versions.moe = "1.4.0"
 versions.gwt = "2.8.2"
 versions.gwtPlugin = "1.0.9"


### PR DESCRIPTION
Since iOS 13.5, iOS gives us real key events from hardware keyboards. I've added that to our robovm backend.
It is downwards compatible, older iOS versions since 9 have the used callback but don't call it (it was used on tvOS only) and therefore on older iOS versions nothing happens. But the game must be build with iOS SDK 13.5 or newer, that means robovm 2.3.10 is needed and therefore the dependency changed.

Since key event handling is used very different in libGDX (keys vs keyTyped, polling vs event handling, not to speak about Scene2d text fields, I was not able to test every type of key input. However, I tested with my game, with InputTest and SoftKeyboardTest on iOS 12, 13.2 and 13.4. As this is an addition, situation is in any case better with than without it. :-)

EDIT: Can be tested conveniently on Simulator.

Hint: [iOS 14 will add the ability to access hardware keyboard connection state and handle mouse events/lock mouse cursor as well.](https://developer.apple.com/videos/play/wwdc2020/10617)