### PR TITLE
Add gdx-gamesvcs to external extensions

### DIFF
--- a/extensions/gdx-setup/res/com/badlogic/gdx/setup/data/extensions.xml
+++ b/extensions/gdx-setup/res/com/badlogic/gdx/setup/data/extensions.xml
@@ -242,4 +242,31 @@
 			</html>
 		</projects>
 	</extension>
+	<extension>
+		<name>gdx-gamesvcs</name>
+		<description>Provides support for Google Play Games, Apple Game Center, GameJolt API</description>
+		<package>de.golfgl.gdxgamesvcs</package>
+		<version>1.0.2</version>
+		<compatibility>1.9.8</compatibility>
+		<website>https://github.com/MrStahlfelge/gdx-gamesvcs</website>
+		<gwtInherits>de.golfgl.gdxgamesvcs.gdx_gamesvcs_gwt</gwtInherits>
+		<projects>
+			<core>
+				<dependency>de.golfgl.gdxgamesvcs:gdx-gamesvcs-core</dependency>
+			</core>
+			<desktop>
+				<dependency>de.golfgl.gdxgamesvcs:gdx-gamesvcs-core-gamejolt</dependency>
+			</desktop>
+			<android>
+				<dependency>de.golfgl.gdxgamesvcs:gdx-gamesvcs-android-gpgs</dependency>
+			</android>
+			<ios>
+				<dependency>de.golfgl.gdxgamesvcs:gdx-gamesvcs-ios-gamecenter</dependency>
+			</ios>
+			<html>
+				<dependency>de.golfgl.gdxgamesvcs:gdx-gamesvcs-core:sources</dependency>
+				<dependency>de.golfgl.gdxgamesvcs:gdx-gamesvcs-core-gamejolt:sources</dependency>
+			</html>
+		</projects>
+	</extension>
 </extensions>


### PR DESCRIPTION
I don't know what the requirements are to be added to the external extensions list, that's why I hesitated to make an attempt to add my lib to the list for the last three years. :-) 

But since the lib is feature-complete and stable for at least a year, brings a widely used feature to the framework and is more popular than other listed extensions (based on the GitHub stars), I give it a try now. 

This adds [gdx-gamesvcs](https://github.com/MrStahlfelge/gdx-gamesvcs) to the list of 3rd party extensions of the projekt setup generator. 