### PR TITLE
fix 3D model test emissive color

### DIFF
--- a/tests/gdx-tests-android/assets/data/g3d/knight.g3dj
+++ b/tests/gdx-tests-android/assets/data/g3d/knight.g3dj
@@ -878,7 +878,6 @@
 		{
 			"id": "knight__Knight_png", 
 			"diffuse": [ 0.800000,  0.800000,  0.800000], 
-			"emissive": [ 0.800000,  0.800000,  0.800000], 
 			"textures": [
 				{
 					"id": "Knight_png", 


### PR DESCRIPTION
This model have emissive color which was not used before but make this model ultra white now (related to #5529).

I checked all other G3DJ files, only this one was wrong (other doesn't have emissive attribute). I'm not able to fix G3DB files because i don't know where are original models if any.