### PR TITLE
Prevent StackOverflowError in some cases, fixes #6136

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g3d/utils/AnimationController.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/utils/AnimationController.java
@@ -357,7 +357,7 @@ public class AnimationController extends BaseAnimationController {
 
 	/** Changes the current animation by blending the new on top of the old during the transition time. */
 	protected AnimationDesc animate (final AnimationDesc anim, float transitionTime) {
-		if (current == null)
+		if (current == null || current.loopCount == 0)
 			current = anim;
 		else if (inAction)
 			queue(anim, transitionTime);


### PR DESCRIPTION
As described in issue #6136 there was inconsistency check in 2 methods calling each other, resulting to a StackOverflowError in some cases : 
* queue method considering both animation==null and loopCount==0 as stopped animation
* animate method considering only animation==null as stopped animation