### PR TITLE
Fix asset manager path conversion and unload ordering

### DIFF
--- a/gdx/src/com/badlogic/gdx/assets/AssetDescriptor.java
+++ b/gdx/src/com/badlogic/gdx/assets/AssetDescriptor.java
@@ -38,14 +38,14 @@ public class AssetDescriptor<T> {
 	}
 
 	public AssetDescriptor (String fileName, Class<T> assetType, AssetLoaderParameters<T> params) {
-		this.fileName = fileName.replaceAll("\\\\", "/");
+		this.fileName = fileName.replace('\\', '/');
 		this.type = assetType;
 		this.params = params;
 	}
 
 	/** Creates an AssetDescriptor with an already resolved name. */
 	public AssetDescriptor (FileHandle file, Class<T> assetType, AssetLoaderParameters<T> params) {
-		this.fileName = file.path().replaceAll("\\\\", "/");
+		this.fileName = file.path().replace('\\', '/');
 		this.file = file;
 		this.type = assetType;
 		this.params = params;


### PR DESCRIPTION
Uses `replace` to convert path separators in `AssetDescriptor` as this will avoid the pattern compile. Adds similar path separator conversion in `unload` to fix use of backslash in asset paths, as shown:

```java
AssetManager assetManager = new AssetManager();

// No runtime exception using expected paths
assetManager.load("resource/image.png", Texture.class);
assetManager.unload("resource/image.png");

// Runtime exception on unload (as unload does not convert)
assetManager.load("resource\\image.png", Texture.class);
assetManager.unload("resource\\image.png");
```

Reorders the `unload` method to look at loaded assets before removing from the pending queue. The current logic can cause unpredictable dangling assets in larger projects (e.g. when unloading and abandoning an asset from callback):

```java
AssetManager assetManager = new AssetManager();

// Add first asset to load queue and wait
assetManager.load("resource/image.png", Texture.class);
assetManager.finishLoading();

// Add identical asset to load queue
assetManager.load("resource/image.png", Texture.class);

// Unload first asset from storage (keep queue)
assetManager.unload("resource/image.png");

// Our first asset is left and second was removed instead
```