### PR TITLE
Fixed the glBufferData bug in bufferChanged().

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/glutils/VertexBufferObjectWithVAO.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/VertexBufferObjectWithVAO.java
@@ -44,6 +44,7 @@ public class VertexBufferObjectWithVAO implements VertexData {
 	final int usage;
 	boolean isDirty = false;
 	boolean isBound = false;
+	boolean isBufferBound = false;
 	int vaoHandle = -1;
 	IntArray cachedLocations = new IntArray();
 
@@ -117,6 +118,10 @@ public class VertexBufferObjectWithVAO implements VertexData {
 
 	private void bufferChanged () {
 		if (isBound) {
+			if (!isBufferBound) {
+				Gdx.gl20.glBindBuffer(GL20.GL_ARRAY_BUFFER, bufferHandle);
+				isBufferBound = true;
+			}
 			Gdx.gl20.glBufferData(GL20.GL_ARRAY_BUFFER, byteBuffer.limit(), byteBuffer, usage);
 			isDirty = false;
 		}
@@ -187,6 +192,7 @@ public class VertexBufferObjectWithVAO implements VertexData {
 
 		if (!stillValid) {
 			Gdx.gl.glBindBuffer(GL20.GL_ARRAY_BUFFER, bufferHandle);
+			isBufferBound = true;
 			unbindAttributes(shader);
 			this.cachedLocations.clear();
 
@@ -226,6 +232,7 @@ public class VertexBufferObjectWithVAO implements VertexData {
 	private void bindData (GL20 gl) {
 		if (isDirty) {
 			gl.glBindBuffer(GL20.GL_ARRAY_BUFFER, bufferHandle);
+			isBufferBound = true;
 			byteBuffer.limit(buffer.limit() * 4);
 			gl.glBufferData(GL20.GL_ARRAY_BUFFER, byteBuffer.limit(), byteBuffer, usage);
 			isDirty = false;
@@ -247,6 +254,7 @@ public class VertexBufferObjectWithVAO implements VertexData {
 		GL30 gl = Gdx.gl30;
 		gl.glBindVertexArray(0);
 		isBound = false;
+		isBufferBound = false;
 	}
 
 	/**

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/VertexBufferObjectWithVAO.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/VertexBufferObjectWithVAO.java
@@ -44,7 +44,6 @@ public class VertexBufferObjectWithVAO implements VertexData {
 	final int usage;
 	boolean isDirty = false;
 	boolean isBound = false;
-	boolean isBufferBound = false;
 	int vaoHandle = -1;
 	IntArray cachedLocations = new IntArray();
 
@@ -118,10 +117,7 @@ public class VertexBufferObjectWithVAO implements VertexData {
 
 	private void bufferChanged () {
 		if (isBound) {
-			if (!isBufferBound) {
-				Gdx.gl20.glBindBuffer(GL20.GL_ARRAY_BUFFER, bufferHandle);
-				isBufferBound = true;
-			}
+			Gdx.gl20.glBindBuffer(GL20.GL_ARRAY_BUFFER, bufferHandle);
 			Gdx.gl20.glBufferData(GL20.GL_ARRAY_BUFFER, byteBuffer.limit(), byteBuffer, usage);
 			isDirty = false;
 		}
@@ -192,7 +188,6 @@ public class VertexBufferObjectWithVAO implements VertexData {
 
 		if (!stillValid) {
 			Gdx.gl.glBindBuffer(GL20.GL_ARRAY_BUFFER, bufferHandle);
-			isBufferBound = true;
 			unbindAttributes(shader);
 			this.cachedLocations.clear();
 
@@ -232,7 +227,6 @@ public class VertexBufferObjectWithVAO implements VertexData {
 	private void bindData (GL20 gl) {
 		if (isDirty) {
 			gl.glBindBuffer(GL20.GL_ARRAY_BUFFER, bufferHandle);
-			isBufferBound = true;
 			byteBuffer.limit(buffer.limit() * 4);
 			gl.glBufferData(GL20.GL_ARRAY_BUFFER, byteBuffer.limit(), byteBuffer, usage);
 			isDirty = false;
@@ -254,7 +248,6 @@ public class VertexBufferObjectWithVAO implements VertexData {
 		GL30 gl = Gdx.gl30;
 		gl.glBindVertexArray(0);
 		isBound = false;
-		isBufferBound = false;
 	}
 
 	/**


### PR DESCRIPTION
It's possible to change the buffer data without _(required)_ `glBindBuffer`.

Bug reproduction:
```java
VertexBufferObjectWithVAO vbo1 = new VertexBufferObjectWithVAO(true, nums, attributes);
vbo1.setVertices(vertices, 0, count);
VertexBufferObjectWithVAO vbo2 = new VertexBufferObjectWithVAO(true, nums, attributes);
vbo2.setVertices(vertices, 0, count);

vbo1.bind(shader);
// render
vbo1.unbind(shader);

vbo2.bind(shader);
// render
vbo2.unbind(shader);

vbo1.bind(shader); // no glBindBuffer.
vbo1.setVertices(vertices, 0, count); // ERROR: possibly updates vbo2's buffer instead.
```

I need feedback please, thanks.