### PR TITLE
Jnigen will add `erroronmissingdir="false"` to jar tasks

### DIFF
--- a/extensions/gdx-box2d/gdx-box2d/jni/build.xml
+++ b/extensions/gdx-box2d/gdx-box2d/jni/build.xml
@@ -23,13 +23,13 @@
 	
 	<target name="pack-natives">
 		<jar destfile="../libs/gdx-box2d-natives.jar">
-			<fileset dir="../libs/windows32" includes="gdx-box2d.dll"/>
-			<fileset dir="../libs/windows64" includes="gdx-box2d64.dll"/>
-			<fileset dir="../libs/linux32" includes="libgdx-box2d.so"/>
-			<fileset dir="../libs/linux64" includes="libgdx-box2d64.so"/>
-			<fileset dir="../libs/linuxarm32" includes="libgdx-box2darm.so"/>
-			<fileset dir="../libs/linuxarm64" includes="libgdx-box2darm64.so"/>
-			<fileset dir="../libs/macosx64" includes="libgdx-box2d64.dylib"/>
+			<fileset dir="../libs/windows32" erroronmissingdir="false" includes="gdx-box2d.dll"/>
+			<fileset dir="../libs/windows64" erroronmissingdir="false" includes="gdx-box2d64.dll"/>
+			<fileset dir="../libs/linux32" erroronmissingdir="false" includes="libgdx-box2d.so"/>
+			<fileset dir="../libs/linux64" erroronmissingdir="false" includes="libgdx-box2d64.so"/>
+			<fileset dir="../libs/linuxarm32" erroronmissingdir="false" includes="libgdx-box2darm.so"/>
+			<fileset dir="../libs/linuxarm64" erroronmissingdir="false" includes="libgdx-box2darm64.so"/>
+			<fileset dir="../libs/macosx64" erroronmissingdir="false" includes="libgdx-box2d64.dylib"/>
 
 		</jar>
 	</target>

--- a/extensions/gdx-bullet/jni/build.xml
+++ b/extensions/gdx-bullet/jni/build.xml
@@ -23,13 +23,13 @@
 	
 	<target name="pack-natives">
 		<jar destfile="../libs/gdx-bullet-natives.jar">
-			<fileset dir="../libs/windows32" includes="gdx-bullet.dll"/>
-			<fileset dir="../libs/windows64" includes="gdx-bullet64.dll"/>
-			<fileset dir="../libs/linux32" includes="libgdx-bullet.so"/>
-			<fileset dir="../libs/linux64" includes="libgdx-bullet64.so"/>
-			<fileset dir="../libs/linuxarm32" includes="libgdx-bulletarm.so"/>
-			<fileset dir="../libs/linuxarm64" includes="libgdx-bulletarm64.so"/>
-			<fileset dir="../libs/macosx64" includes="libgdx-bullet64.dylib"/>
+			<fileset dir="../libs/windows32" erroronmissingdir="false" includes="gdx-bullet.dll"/>
+			<fileset dir="../libs/windows64" erroronmissingdir="false" includes="gdx-bullet64.dll"/>
+			<fileset dir="../libs/linux32" erroronmissingdir="false" includes="libgdx-bullet.so"/>
+			<fileset dir="../libs/linux64" erroronmissingdir="false" includes="libgdx-bullet64.so"/>
+			<fileset dir="../libs/linuxarm32" erroronmissingdir="false" includes="libgdx-bulletarm.so"/>
+			<fileset dir="../libs/linuxarm64" erroronmissingdir="false" includes="libgdx-bulletarm64.so"/>
+			<fileset dir="../libs/macosx64" erroronmissingdir="false" includes="libgdx-bullet64.dylib"/>
 
 		</jar>
 	</target>

--- a/extensions/gdx-controllers/gdx-controllers-desktop/jni/build.xml
+++ b/extensions/gdx-controllers/gdx-controllers-desktop/jni/build.xml
@@ -21,13 +21,13 @@
 	
 	<target name="pack-natives">
 		<jar destfile="../libs/gdx-controllers-desktop-natives.jar">
-			<fileset dir="../libs/windows32" includes="gdx-controllers-desktop.dll"/>
-			<fileset dir="../libs/windows64" includes="gdx-controllers-desktop64.dll"/>
-			<fileset dir="../libs/linux32" includes="libgdx-controllers-desktop.so"/>
-			<fileset dir="../libs/linux64" includes="libgdx-controllers-desktop64.so"/>
-			<fileset dir="../libs/linuxarm32" includes="libgdx-controllers-desktoparm.so"/>
-			<fileset dir="../libs/linuxarm64" includes="libgdx-controllers-desktoparm64.so"/>
-			<fileset dir="../libs/macosx64" includes="libgdx-controllers-desktop64.dylib"/>
+			<fileset dir="../libs/windows32" erroronmissingdir="false" includes="gdx-controllers-desktop.dll"/>
+			<fileset dir="../libs/windows64" erroronmissingdir="false" includes="gdx-controllers-desktop64.dll"/>
+			<fileset dir="../libs/linux32" erroronmissingdir="false" includes="libgdx-controllers-desktop.so"/>
+			<fileset dir="../libs/linux64" erroronmissingdir="false" includes="libgdx-controllers-desktop64.so"/>
+			<fileset dir="../libs/linuxarm32" erroronmissingdir="false" includes="libgdx-controllers-desktoparm.so"/>
+			<fileset dir="../libs/linuxarm64" erroronmissingdir="false" includes="libgdx-controllers-desktoparm64.so"/>
+			<fileset dir="../libs/macosx64" erroronmissingdir="false" includes="libgdx-controllers-desktop64.dylib"/>
 
 		</jar>
 	</target>

--- a/extensions/gdx-freetype/jni/build.xml
+++ b/extensions/gdx-freetype/jni/build.xml
@@ -23,13 +23,13 @@
 	
 	<target name="pack-natives">
 		<jar destfile="../libs/gdx-freetype-natives.jar">
-			<fileset dir="../libs/windows32" includes="gdx-freetype.dll"/>
-			<fileset dir="../libs/windows64" includes="gdx-freetype64.dll"/>
-			<fileset dir="../libs/linux32" includes="libgdx-freetype.so"/>
-			<fileset dir="../libs/linux64" includes="libgdx-freetype64.so"/>
-			<fileset dir="../libs/linuxarm32" includes="libgdx-freetypearm.so"/>
-			<fileset dir="../libs/linuxarm64" includes="libgdx-freetypearm64.so"/>
-			<fileset dir="../libs/macosx64" includes="libgdx-freetype64.dylib"/>
+			<fileset dir="../libs/windows32" erroronmissingdir="false" includes="gdx-freetype.dll"/>
+			<fileset dir="../libs/windows64" erroronmissingdir="false" includes="gdx-freetype64.dll"/>
+			<fileset dir="../libs/linux32" erroronmissingdir="false" includes="libgdx-freetype.so"/>
+			<fileset dir="../libs/linux64" erroronmissingdir="false" includes="libgdx-freetype64.so"/>
+			<fileset dir="../libs/linuxarm32" erroronmissingdir="false" includes="libgdx-freetypearm.so"/>
+			<fileset dir="../libs/linuxarm64" erroronmissingdir="false" includes="libgdx-freetypearm64.so"/>
+			<fileset dir="../libs/macosx64" erroronmissingdir="false" includes="libgdx-freetype64.dylib"/>
 
 		</jar>
 	</target>

--- a/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/AntScriptGenerator.java
+++ b/extensions/gdx-jnigen/src/com/badlogic/gdx/jnigen/AntScriptGenerator.java
@@ -125,7 +125,7 @@ public class AntScriptGenerator {
 			compile.append("\t\t<ant antfile=\"" + buildFiles.get(i) + "\"/>\n");
 		}
 		for (int i = 0; i < libsDirs.size(); i++) {
-			pack.append("\t\t\t<fileset dir=\"" + libsDirs.get(i) + "\" includes=\"" + sharedLibFiles.get(i) + "\"/>\n");
+			pack.append("\t\t\t<fileset dir=\"" + libsDirs.get(i) + "\" erroronmissingdir=\"false\" includes=\"" + sharedLibFiles.get(i) + "\"/>\n");
 		}
 
 		if (config.sharedLibs != null) {

--- a/gdx/jni/build.xml
+++ b/gdx/jni/build.xml
@@ -23,13 +23,13 @@
 	
 	<target name="pack-natives">
 		<jar destfile="../libs/gdx-natives.jar">
-			<fileset dir="../libs/macosx64" includes="libgdx64.dylib"/>
-			<fileset dir="../libs/windows32" includes="gdx.dll"/>
-			<fileset dir="../libs/windows64" includes="gdx64.dll"/>
-			<fileset dir="../libs/linux32" includes="libgdx.so"/>
-			<fileset dir="../libs/linux64" includes="libgdx64.so"/>
-			<fileset dir="../libs/linuxarm32" includes="libgdxarm.so"/>
-			<fileset dir="../libs/linuxarm64" includes="libgdxarm64.so"/>
+			<fileset dir="../libs/macosx64" erroronmissingdir="false" includes="libgdx64.dylib"/>
+			<fileset dir="../libs/windows32" erroronmissingdir="false" includes="gdx.dll"/>
+			<fileset dir="../libs/windows64" erroronmissingdir="false" includes="gdx64.dll"/>
+			<fileset dir="../libs/linux32" erroronmissingdir="false" includes="libgdx.so"/>
+			<fileset dir="../libs/linux64" erroronmissingdir="false" includes="libgdx64.so"/>
+			<fileset dir="../libs/linuxarm32" erroronmissingdir="false" includes="libgdxarm.so"/>
+			<fileset dir="../libs/linuxarm64" erroronmissingdir="false" includes="libgdxarm64.so"/>
 
 		</jar>
 	</target>


### PR DESCRIPTION
Will prevent failure when we dont have certain compilers on path and the downloaded natives from libgdx's website aren't present.

I really don't like this, so I will want to look into this more later.