### PR TITLE
AnimationController action end up at duration time, fixes #6145

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g3d/utils/AnimationController.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/utils/AnimationController.java
@@ -179,11 +179,11 @@ public class AnimationController extends BaseAnimationController {
 		}
 		if (current == null || current.loopCount == 0 || current.animation == null) return;
 		final float remain = current.update(delta);
-		if (remain != 0f && queued != null) {
+		if (queued != null) {
 			inAction = false;
 			animate(queued, queuedTransitionTime);
 			queued = null;			
-			update(remain);
+			if(remain != 0f) update(remain);
 			return;
 		}
 		if (previous != null)

--- a/gdx/test/com/badlogic/gdx/graphics/g3d/utils/AnimationControllerTest.java
+++ b/gdx/test/com/badlogic/gdx/graphics/g3d/utils/AnimationControllerTest.java
@@ -3,7 +3,12 @@ package com.badlogic.gdx.graphics.g3d.utils;
 import org.junit.Assert;
 import org.junit.Test;
 
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.g3d.Model;
+import com.badlogic.gdx.graphics.g3d.ModelInstance;
+import com.badlogic.gdx.graphics.g3d.model.Animation;
 import com.badlogic.gdx.graphics.g3d.model.NodeKeyframe;
+import com.badlogic.gdx.graphics.g3d.utils.AnimationController.AnimationDesc;
 import com.badlogic.gdx.utils.Array;
 
 public class AnimationControllerTest {
@@ -45,5 +50,44 @@ public class AnimationControllerTest {
 		Array<NodeKeyframe<String>> keyFrames = new Array<NodeKeyframe<String>>();
 		
 		Assert.assertEquals(0, BaseAnimationController.getFirstKeyframeIndexAtTime(keyFrames, 3f));
+	}
+
+	private static void assertSameAnimation (Animation expected, AnimationDesc actual) {
+		if(!expected.id.equals(actual.animation.id)){
+			Assert.fail("expected: " + expected.id + ", actual: " + actual.animation.id);
+		}
+	}
+
+	@Test
+	public void testEndUpActionAtDurationTime(){
+		
+		Animation loop = new Animation();
+      loop.id = "loop";
+      loop.duration = 1f;
+
+      Animation action = new Animation();
+      action.id = "action";
+      action.duration = 0.2f;
+
+      ModelInstance modelInstance = new ModelInstance(new Model());
+      modelInstance.animations.add(loop);
+      modelInstance.animations.add(action);
+
+      AnimationController animationController = new AnimationController(modelInstance);
+      
+      animationController.setAnimation("loop", -1);
+      assertSameAnimation(loop, animationController.current);
+      
+      animationController.update(1);
+      assertSameAnimation(loop, animationController.current);
+      
+      animationController.update(0.01f);
+      assertSameAnimation(loop, animationController.current);
+
+      animationController.action("action", 1, 1f, null, 0f);
+      assertSameAnimation(action, animationController.current);
+
+      animationController.update(0.2f);
+      assertSameAnimation(loop, animationController.current);
 	}
 }

--- a/gdx/test/com/badlogic/gdx/graphics/g3d/utils/AnimationControllerTest.java
+++ b/gdx/test/com/badlogic/gdx/graphics/g3d/utils/AnimationControllerTest.java
@@ -62,32 +62,32 @@ public class AnimationControllerTest {
 	public void testEndUpActionAtDurationTime(){
 		
 		Animation loop = new Animation();
-      loop.id = "loop";
-      loop.duration = 1f;
+		loop.id = "loop";
+		loop.duration = 1f;
 
-      Animation action = new Animation();
-      action.id = "action";
-      action.duration = 0.2f;
+		Animation action = new Animation();
+		action.id = "action";
+		action.duration = 0.2f;
 
-      ModelInstance modelInstance = new ModelInstance(new Model());
-      modelInstance.animations.add(loop);
-      modelInstance.animations.add(action);
+		ModelInstance modelInstance = new ModelInstance(new Model());
+		modelInstance.animations.add(loop);
+		modelInstance.animations.add(action);
 
-      AnimationController animationController = new AnimationController(modelInstance);
-      
-      animationController.setAnimation("loop", -1);
-      assertSameAnimation(loop, animationController.current);
-      
-      animationController.update(1);
-      assertSameAnimation(loop, animationController.current);
-      
-      animationController.update(0.01f);
-      assertSameAnimation(loop, animationController.current);
+		AnimationController animationController = new AnimationController(modelInstance);
 
-      animationController.action("action", 1, 1f, null, 0f);
-      assertSameAnimation(action, animationController.current);
+		animationController.setAnimation("loop", -1);
+		assertSameAnimation(loop, animationController.current);
 
-      animationController.update(0.2f);
-      assertSameAnimation(loop, animationController.current);
+		animationController.update(1);
+		assertSameAnimation(loop, animationController.current);
+
+		animationController.update(0.01f);
+		assertSameAnimation(loop, animationController.current);
+
+		animationController.action("action", 1, 1f, null, 0f);
+		assertSameAnimation(action, animationController.current);
+
+		animationController.update(0.2f);
+		assertSameAnimation(loop, animationController.current);
 	}
 }


### PR DESCRIPTION
Issue #6145 describe the edge case where action (queued animation) was not removed when just finished.
The extra update is not necessary with zero delta time in this case.
@asu-talk thank you a lot for your test case, i rewrote it as a JUnit.