### PR TITLE
Set vsync setting again after enabling fullscreen mode.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -20,6 +20,7 @@
 	- 32-bit: ARMv7/armhf
 	- 64-bit: ARMv8/AArch64
 - API Change: Removed arm abi from SharedLibraryLoader
+- API Change: Enabling fullscreen mode on the lwjgl3 backend now automatically sets the vsync setting again.
 
 [1.9.11]
 - Update to MobiVM 2.3.8

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
@@ -402,7 +402,7 @@ public class Lwjgl3Application implements Lwjgl3ApplicationBase {
 
 	void createWindow(Lwjgl3Window window, Lwjgl3ApplicationConfiguration config, long sharedContext) {
 		long windowHandle = createGlfwWindow(config, sharedContext);
-		window.create(windowHandle);
+		window.create(windowHandle,  config.vSyncEnabled);
 		window.setVisible(config.initialVisible);
 
 		for (int i = 0; i < 2; i++) {

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Graphics.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Graphics.java
@@ -55,7 +55,7 @@ public class Lwjgl3Graphics implements Graphics, Disposable {
 	private int windowPosXBeforeFullscreen;
 	private int windowPosYBeforeFullscreen;
 	private DisplayMode displayModeBeforeFullscreen = null;
-	private boolean vsync;
+	boolean vsync;
 
 	IntBuffer tmpBuffer = BufferUtils.createIntBuffer(1);
 	IntBuffer tmpBuffer2 = BufferUtils.createIntBuffer(1);
@@ -367,7 +367,7 @@ public class Lwjgl3Graphics implements Graphics, Disposable {
 		}
 		updateFramebufferInfo();
 
-		setVSync(vsync);
+ 		setVSync(vsync);
 
 		return true;
 	}

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Graphics.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Graphics.java
@@ -55,6 +55,7 @@ public class Lwjgl3Graphics implements Graphics, Disposable {
 	private int windowPosXBeforeFullscreen;
 	private int windowPosYBeforeFullscreen;
 	private DisplayMode displayModeBeforeFullscreen = null;
+	private boolean vsync;
 
 	IntBuffer tmpBuffer = BufferUtils.createIntBuffer(1);
 	IntBuffer tmpBuffer2 = BufferUtils.createIntBuffer(1);
@@ -365,6 +366,9 @@ public class Lwjgl3Graphics implements Graphics, Disposable {
 					0, 0, newMode.width, newMode.height, newMode.refreshRate);
 		}
 		updateFramebufferInfo();
+
+		setVSync(vsync);
+
 		return true;
 	}
 	
@@ -416,6 +420,7 @@ public class Lwjgl3Graphics implements Graphics, Disposable {
 
 	@Override
 	public void setVSync(boolean vsync) {
+		this.vsync = vsync;
 		GLFW.glfwSwapInterval(vsync ? 1 : 0);
 	}
 

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Window.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Window.java
@@ -163,10 +163,11 @@ public class Lwjgl3Window implements Disposable {
 		this.tmpBuffer2 = BufferUtils.createIntBuffer(1);
 	}
 
-	void create(long windowHandle) {
+	void create(long windowHandle, boolean vsync) {
 		this.windowHandle = windowHandle;
 		this.input = application.createInput(this);
 		this.graphics = new Lwjgl3Graphics(this);
+		this.graphics.vsync = vsync;
 
 		GLFW.glfwSetWindowFocusCallback(windowHandle, focusCallback);
 		GLFW.glfwSetWindowIconifyCallback(windowHandle, iconifyCallback);


### PR DESCRIPTION
On Windows, the vsync setting is ignored if fullscreen mode is enabled. Setting the vsync mode again fixes this, see #5826.