### PR TITLE
Add a Lwjgl3ApplicationConfiguration#foregroundFPS option.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -20,6 +20,7 @@
 	- 32-bit: ARMv7/armhf
 	- 64-bit: ARMv8/AArch64
 - API Change: Removed arm abi from SharedLibraryLoader
+- API Addition: Added a Lwjgl3ApplicationConfiguration#foregroundFPS option.
 
 [1.9.11]
 - Update to MobiVM 2.3.8

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
@@ -74,6 +74,7 @@ public class Lwjgl3Application implements Lwjgl3ApplicationBase {
 	private static GLFWErrorCallback errorCallback;
 	private static GLVersion glVersion;
 	private static Callback glDebugCallback;
+	private final Sync sync;
 
 	static void initializeGlfw() {
 		if (errorCallback == null) {
@@ -107,6 +108,8 @@ public class Lwjgl3Application implements Lwjgl3ApplicationBase {
 		this.files = Gdx.files = new Lwjgl3Files();
 		this.net = Gdx.net = new Lwjgl3Net(config);
 		this.clipboard = new Lwjgl3Clipboard();
+
+		this.sync = new Sync();
 
 		Lwjgl3Window window = createWindow(config, listener, 0);
 		windows.add(window);
@@ -187,6 +190,8 @@ public class Lwjgl3Application implements Lwjgl3ApplicationBase {
 				} catch (InterruptedException e) {
 					// ignore
 				}
+			} else if(config.foregroundFPS > 0) {
+				sync.sync(config.foregroundFPS); // sleep as needed to meet the target framerate
 			}
 		}
 	}

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3ApplicationConfiguration.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3ApplicationConfiguration.java
@@ -57,6 +57,7 @@ public class Lwjgl3ApplicationConfiguration extends Lwjgl3WindowConfiguration {
 	boolean transparentFramebuffer;
 
 	int idleFPS = 60;
+	int foregroundFPS = 0;
 
 	String preferencesDirectory = ".prefs/";
 	Files.FileType preferencesFileType = FileType.External;
@@ -90,6 +91,7 @@ public class Lwjgl3ApplicationConfiguration extends Lwjgl3WindowConfiguration {
 		samples = config.samples;
 		transparentFramebuffer = config.transparentFramebuffer;
 		idleFPS = config.idleFPS;
+		foregroundFPS = config.foregroundFPS;
 		preferencesDirectory = config.preferencesDirectory;
 		preferencesFileType = config.preferencesFileType;
 		hdpiMode = config.hdpiMode;
@@ -205,6 +207,12 @@ public class Lwjgl3ApplicationConfiguration extends Lwjgl3WindowConfiguration {
 	 * Default is 60. */
 	public void setIdleFPS (int fps) {
 		this.idleFPS = fps;
+	}
+
+	/**Sets the target framerate for the application. The CPU sleeps as needed. Must be positive.
+	 * Use 0 to never sleep. Default is 0. */
+	public void setForegroundFPS (int fps) {
+		this.foregroundFPS = fps;
 	}
 
 	/**

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Sync.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Sync.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2002-2012 LWJGL Project
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'LWJGL' nor the names of
+ *   its contributors may be used to endorse or promote products derived
+ *   from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.badlogic.gdx.backends.lwjgl3;
+
+import static org.lwjgl.glfw.GLFW.glfwGetTime;
+ 
+/**
+* A highly accurate sync method that continually adapts to the system
+* it runs on to provide reliable results.
+*
+* @author Riven
+* @author kappaOne
+*/
+class Sync {
+     
+    /** number of nano seconds in a second */
+    private static final long NANOS_IN_SECOND = 1000L * 1000L * 1000L;
+ 
+    /** The time to sleep/yield until the next frame */
+    private long nextFrame = 0;
+     
+    /** whether the initialisation code has run */
+    private boolean initialised = false;
+     
+    /** for calculating the averages the previous sleep/yield times are stored */
+    private RunningAvg sleepDurations = new RunningAvg(10);
+    private RunningAvg yieldDurations = new RunningAvg(10);
+     
+    public Sync() {
+         
+    }
+     
+    /**
+     * An accurate sync method that will attempt to run at a constant frame rate.
+     * It should be called once every frame.
+     *
+     * @param fps - the desired frame rate, in frames per second
+     */
+    public void sync(int fps) {
+        if (fps <= 0) return;
+        if (!initialised) initialise();
+         
+        try {
+            // sleep until the average sleep time is greater than the time remaining till nextFrame
+            for (long t0 = getTime(), t1; (nextFrame - t0) > sleepDurations.avg(); t0 = t1) {
+                Thread.sleep(1);
+                sleepDurations.add((t1 = getTime()) - t0); // update average sleep time
+            }
+     
+            // slowly dampen sleep average if too high to avoid yielding too much
+            sleepDurations.dampenForLowResTicker();
+     
+            // yield until the average yield time is greater than the time remaining till nextFrame
+            for (long t0 = getTime(), t1; (nextFrame - t0) > yieldDurations.avg(); t0 = t1) {
+                Thread.yield();
+                yieldDurations.add((t1 = getTime()) - t0); // update average yield time
+            }
+        } catch (InterruptedException e) {
+             
+        }
+         
+        // schedule next frame, drop frame(s) if already too late for next frame
+        nextFrame = Math.max(nextFrame + NANOS_IN_SECOND / fps, getTime());
+    }
+     
+    /**
+     * This method will initialise the sync method by setting initial
+     * values for sleepDurations/yieldDurations and nextFrame.
+     *
+     * If running on windows it will start the sleep timer fix.
+     */
+    private void initialise() {
+        initialised = true;
+         
+        sleepDurations.init(1000 * 1000);
+        yieldDurations.init((int) (-(getTime() - getTime()) * 1.333));
+         
+        nextFrame = getTime();
+         
+        String osName = System.getProperty("os.name");
+         
+        if (osName.startsWith("Win")) {
+            // On windows the sleep functions can be highly inaccurate by
+            // over 10ms making in unusable. However it can be forced to
+            // be a bit more accurate by running a separate sleeping daemon
+            // thread.
+            Thread timerAccuracyThread = new Thread(new Runnable() {
+                public void run() {
+                    try {
+                        Thread.sleep(Long.MAX_VALUE);
+                    } catch (Exception e) {}
+                }
+            });
+             
+            timerAccuracyThread.setName("LWJGL3 Timer");
+            timerAccuracyThread.setDaemon(true);
+            timerAccuracyThread.start();
+        }
+    }
+ 
+    /**
+     * Get the system time in nano seconds
+     *
+     * @return will return the current time in nano's
+     */
+    private long getTime() {
+        return (long)(glfwGetTime() * NANOS_IN_SECOND);
+    }
+ 
+    private class RunningAvg {
+        private final long[] slots;
+        private int offset;
+         
+        private static final long DAMPEN_THRESHOLD = 10 * 1000L * 1000L; // 10ms
+        private static final float DAMPEN_FACTOR = 0.9f; // don't change: 0.9f is exactly right!
+ 
+        public RunningAvg(int slotCount) {
+            this.slots = new long[slotCount];
+            this.offset = 0;
+        }
+ 
+        public void init(long value) {
+            while (this.offset < this.slots.length) {
+                this.slots[this.offset++] = value;
+            }
+        }
+ 
+        public void add(long value) {
+            this.slots[this.offset++ % this.slots.length] = value;
+            this.offset %= this.slots.length;
+        }
+ 
+        public long avg() {
+            long sum = 0;
+            for (int i = 0; i < this.slots.length; i++) {
+                sum += this.slots[i];
+            }
+            return sum / this.slots.length;
+        }
+         
+        public void dampenForLowResTicker() {
+            if (this.avg() > DAMPEN_THRESHOLD) {
+                for (int i = 0; i < this.slots.length; i++) {
+                    this.slots[i] *= DAMPEN_FACTOR;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add an option to configure the target framerate for a lwjgl3 application. This can be used to circumvent issues with vsync (as described [here](https://github.com/libgdx/libgdx/issues/4274#issuecomment-535882414)) or whenever someone wants to set another target framerate than the display refresh rate, so using vsync doesn't work. This is commonly used as a workaround by the community.

This PR uses the well-proven [Sync class](https://github.com/LWJGL/lwjgl/blob/master/src/java/org/lwjgl/opengl/Sync.java) from lwjgl2. It is licensed under the [LWJGL 2 License](http://legacy.lwjgl.org/license.php.html).