### PR TITLE
Gdxsetup config

### DIFF
--- a/extensions/gdx-setup/README.md
+++ b/extensions/gdx-setup/README.md
@@ -3,7 +3,7 @@ Libgdx gradle setup
 
 Modular setup powered by gradle, allowing any combination of sub projects and official extensions to get you up and running in a few clicks.  Although this tool will handle setup for you, LEARN GRADLE!
 
-![Setup Ui](http://i.imgur.com/7fUXXM3.png)
+![Setup Ui](http://i.imgur.com/M1e5TLU.png)
 
 Example of use:
 

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/ExternalExtensionsDialog.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/ExternalExtensionsDialog.java
@@ -25,6 +25,7 @@ import static java.awt.GridBagConstraints.SOUTH;
 import static java.awt.GridBagConstraints.SOUTHEAST;
 
 import java.awt.Color;
+import java.awt.Component;
 import java.awt.Desktop;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
@@ -109,8 +110,9 @@ public class ExternalExtensionsDialog extends JDialog implements TableModelListe
 		setLocationRelativeTo(null);
 	}
 
-	public void showDialog () {
+	public void showDialog (Component parent) {
 		takeSnapshot();
+		setLocationRelativeTo(parent);
 		setVisible(true);
 	}
 

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetupUI.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetupUI.java
@@ -268,7 +268,7 @@ public class GdxSetupUI extends JFrame {
 					}
 				}, ui.settings.getGradleArgs());
 				log("Done!");
-				log("To import in Eclipse: File -> Import -> Gradle -> Gradle Project");
+				log("To import in Eclipse: File -> Import -> Gradle -> Existing Gradle Project");
 				log("To import to Intellij IDEA: File -> Open -> build.gradle");
 				log("To import to NetBeans: File -> Open Project...");
 				SwingUtilities.invokeLater(new Runnable() {
@@ -493,6 +493,12 @@ public class GdxSetupUI extends JFrame {
 				extensionPanel.setOpaque(true);
 				extensionPanel.setBackground(new Color(46, 46, 46));
 			}
+
+			nameLabel.setToolTipText("The name of the application used in gradle");
+			packageLabel.setToolTipText("The Java package name of the application");
+			gameClassLabel.setToolTipText("The name of the main Java class implementing ApplicationListener");
+			destinationLabel.setToolTipText("The root directory of the project to write the generated files to");
+			sdkLocationLabel.setToolTipText("The location of your Android SDK");
 		}
 
 		private void uiLayout () {
@@ -611,10 +617,10 @@ public class GdxSetupUI extends JFrame {
 			add(showMoreExtensionsButton, new GridBagConstraints(0, 12, 0, 1, 0, 0, CENTER, WEST, new Insets(10, 0, 10, 0), 0, 0));
 		}
 
-		File getDirectory () {
+		File getDirectory (String dialogTitle) {
 			if (System.getProperty("os.name").contains("Mac")) {
 				System.setProperty("apple.awt.fileDialogForDirectories", "true");
-				FileDialog dialog = new FileDialog(GdxSetupUI.this, "Choose destination", FileDialog.LOAD);
+				FileDialog dialog = new FileDialog(GdxSetupUI.this, dialogTitle, FileDialog.LOAD);
 				dialog.setVisible(true);
 				String name = dialog.getFile();
 				String dir = dialog.getDirectory();
@@ -623,7 +629,7 @@ public class GdxSetupUI extends JFrame {
 			} else {
 				JFileChooser chooser = new JFileChooser();
 				chooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
-				chooser.setDialogTitle("Choose destination");
+				chooser.setDialogTitle(dialogTitle);
 				int result = chooser.showOpenDialog(null);
 				if (result == JFileChooser.APPROVE_OPTION) {
 					File dir = chooser.getSelectedFile();
@@ -639,7 +645,7 @@ public class GdxSetupUI extends JFrame {
 		private void uiEvents () {
 			destinationButton.addActionListener(new ActionListener() {
 				public void actionPerformed (ActionEvent e) {
-					File path = getDirectory();
+					File path = getDirectory("Choose destination");
 					if (path != null) {
 						destinationText.setText(path.getAbsolutePath());
 					}
@@ -648,7 +654,7 @@ public class GdxSetupUI extends JFrame {
 			sdkLocationButton.addActionListener(new ActionListener() {
 				@Override
 				public void actionPerformed (ActionEvent e) {
-					File path = getDirectory();
+					File path = getDirectory("Choose Android SDK");
 					if (path != null) {
 						sdkLocationText.setText(path.getAbsolutePath());
 						prefs.putString("ANDROID_HOME", path.getAbsolutePath());

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetupUI.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetupUI.java
@@ -426,7 +426,7 @@ public class GdxSetupUI extends JFrame {
 		private void uiEvents () {
 			advancedButton.addActionListener(new ActionListener() {
 				public void actionPerformed (ActionEvent e) {
-					settings.showDialog(form.gwtCheckBox);
+					settings.showDialog(form, form.gwtCheckBox);
 				}
 			});
 			generateButton.addActionListener(new ActionListener() {
@@ -495,9 +495,9 @@ public class GdxSetupUI extends JFrame {
 			}
 
 			nameLabel.setToolTipText("The name of the application used in gradle");
-			packageLabel.setToolTipText("The Java package name of the application");
-			gameClassLabel.setToolTipText("The name of the main Java class implementing ApplicationListener");
-			destinationLabel.setToolTipText("The root directory of the project to write the generated files to");
+			packageLabel.setToolTipText("The package name of the application");
+			gameClassLabel.setToolTipText("The name of the main class implementing ApplicationListener");
+			destinationLabel.setToolTipText("The root directory of the project, it will be created if it does not exist");
 			sdkLocationLabel.setToolTipText("The location of your Android SDK");
 		}
 
@@ -630,7 +630,7 @@ public class GdxSetupUI extends JFrame {
 				JFileChooser chooser = new JFileChooser();
 				chooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
 				chooser.setDialogTitle(dialogTitle);
-				int result = chooser.showOpenDialog(null);
+				int result = chooser.showOpenDialog(GdxSetupUI.this);
 				if (result == JFileChooser.APPROVE_OPTION) {
 					File dir = chooser.getSelectedFile();
 					if (dir == null) return null;
@@ -664,7 +664,7 @@ public class GdxSetupUI extends JFrame {
 			});
 			showMoreExtensionsButton.addActionListener(new ActionListener() {
 				 public void actionPerformed (ActionEvent e) {
-					  externalExtensionsDialog.showDialog();
+					  externalExtensionsDialog.showDialog(Form.this);
 				 }
 			});
 		}

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/SettingsDialog.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/SettingsDialog.java
@@ -26,6 +26,7 @@ import static java.awt.GridBagConstraints.SOUTHEAST;
 import static java.awt.GridBagConstraints.WEST;
 
 import java.awt.Color;
+import java.awt.Component;
 import java.awt.Cursor;
 import java.awt.Desktop;
 import java.awt.GridBagConstraints;
@@ -232,8 +233,9 @@ public class SettingsDialog extends JDialog {
 		mavenTextField.setForeground(new Color(255, 255, 255));
 	}
 
-	public void showDialog (SetupCheckBox gwtCheckBox) {
+	public void showDialog (Component parent, SetupCheckBox gwtCheckBox) {
 		takeSnapshot();
+		setLocationRelativeTo(parent);
 		setVisible(true);
 		if (gwtCheckBox.isSelected()) {
 			kotlinBox.setSelected(false);

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/SetupPreferences.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/SetupPreferences.java
@@ -29,9 +29,30 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
 
-public class SetupPreferences {	
+public class SetupPreferences {
+
+	private static final File[] files = new File[] {
+		// $HOME/.gdxsetup
+		new File(new File(System.getProperty("user.home")), ".gdxsetup"),
+		// $CONFIG_HOME/gdxsetup/config
+		new File(new File(new File(findConfigHomePath()), "gdxsetup"), "config")};
+
+	private static final String findConfigHomePath () {
+		Map<String, String> env = System.getenv();
+		if (env.containsKey("XDG_CONFIG_HOME")) return env.get("XDG_CONFIG_HOME");
+		// TODO add windows and mac config home paths
+		return System.getProperty("user.home") + "/.config";
+	}
+
+	private static final File findFile () {
+		for (File i : files) {
+			if (i.exists()) return i;
+		}
+		return files[0]; // default to $HOME/.gdxsetup
+	}
+
 	private final Properties properties = new Properties();
-	private final File file = new File(new File(System.getProperty("user.home")), ".gdxsetup");
+	private final File file = findFile();
 
 	public SetupPreferences () {		
 		if (!file.exists()) return;

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/SetupPreferences.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/SetupPreferences.java
@@ -32,10 +32,10 @@ import java.util.Properties;
 public class SetupPreferences {
 
 	private static final File[] files = new File[] {
-		// $HOME/.gdxsetup
-		new File(new File(System.getProperty("user.home")), ".gdxsetup"),
 		// $CONFIG_HOME/gdxsetup/config
-		new File(new File(new File(findConfigHomePath()), "gdxsetup"), "config")};
+		new File(new File(new File(findConfigHomePath()), "gdxsetup"), "config"),
+		// $HOME/.gdxsetup
+		new File(new File(System.getProperty("user.home")), ".gdxsetup")};
 
 	private static final String findConfigHomePath () {
 		Map<String, String> env = System.getenv();
@@ -48,7 +48,7 @@ public class SetupPreferences {
 		for (File i : files) {
 			if (i.exists()) return i;
 		}
-		return files[0]; // default to $HOME/.gdxsetup
+		return files[files.length-1]; // default to $HOME/.gdxsetup
 	}
 
 	private final Properties properties = new Properties();


### PR DESCRIPTION
Support more location for the preferences file, using the same conventions as git. With no user action the behavior remains the same.

- $HOME/.gdxsetup
- $XDG_CONFIG_HOME/gdxsetup/config
- $HOME/.config/gdxsetup/config

(The corresponding of XDG_CONFIG_HOME for windows and mac could be added)

Also minor visual improvements, mainly a tooltip for the ambiguous destination field (and updated the screenshot).
