### PR TITLE
More efficient way of setting bone state 

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/DefaultShader.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/DefaultShader.java
@@ -205,11 +205,13 @@ public class DefaultShader extends BaseShader {
 
 			@Override
 			public void set (BaseShader shader, int inputID, Renderable renderable, Attributes combinedAttributes) {
-				for (int i = 0; i < bones.length; i++) {
-					final int idx = i / 16;
-					bones[i] = (renderable.bones == null || idx >= renderable.bones.length || renderable.bones[idx] == null) ? idtMatrix.val[i % 16]
-						: renderable.bones[idx].val[i % 16];
-				}
+                for (int i = 0; i < bones.length; i += 16) {
+                    final int idx = i / 16;
+                    if (renderable.bones == null || idx >= renderable.bones.length || renderable.bones[idx] == null)
+                        System.arraycopy(idtMatrix.val, 0, bones, i, 16);
+                    else
+                        System.arraycopy(renderable.bones[idx].val, 0, bones, i, 16);
+                }
 				shader.program.setUniformMatrix4fv(shader.loc(inputID), bones, 0, bones.length);
 			}
 		}

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/DefaultShader.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/DefaultShader.java
@@ -205,13 +205,13 @@ public class DefaultShader extends BaseShader {
 
 			@Override
 			public void set (BaseShader shader, int inputID, Renderable renderable, Attributes combinedAttributes) {
-                for (int i = 0; i < bones.length; i += 16) {
-                    final int idx = i / 16;
-                    if (renderable.bones == null || idx >= renderable.bones.length || renderable.bones[idx] == null)
-                        System.arraycopy(idtMatrix.val, 0, bones, i, 16);
-                    else
-                        System.arraycopy(renderable.bones[idx].val, 0, bones, i, 16);
-                }
+				for (int i = 0; i < bones.length; i += 16) {
+					final int idx = i / 16;
+					if (renderable.bones == null || idx >= renderable.bones.length || renderable.bones[idx] == null)
+						System.arraycopy(idtMatrix.val, 0, bones, i, 16);
+					else
+						System.arraycopy(renderable.bones[idx].val, 0, bones, i, 16);
+				}
 				shader.program.setUniformMatrix4fv(shader.loc(inputID), bones, 0, bones.length);
 			}
 		}


### PR DESCRIPTION
Each matrix is copied in one go, rather than 1 element at a time.