### PR TITLE
Gwt Backend support resizable application

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplicationConfiguration.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplicationConfiguration.java
@@ -24,10 +24,17 @@ import com.google.gwt.user.client.ui.TextArea;
 public class GwtApplicationConfiguration {
 	/** If true, audio backend will not be used. This means {@link Application#getAudio()} returns null. */
 	public boolean disableAudio;
-	/** the width of the drawing area in pixels **/
-	public int width;
-	/** the height of the drawing area in pixels **/
-	public int height;
+	/** the width of the drawing area in pixels, or 0 for using the available space **/
+	public final int width;
+	/** the height of the drawing area in pixels, or 0 for using the available space **/
+	public final int height;
+	/**
+	 * Padding to use for resizing the game content in the browser window, for resizable applications only.
+	 * Defaults to 10. The padding is necessary to prevent the browser from showing scrollbars. This
+	 * can happen if the game content is of the same size than the browser window.
+	 * The padding is given in logical pixels, not affected by {@link #usePhysicalPixels}.
+	 */
+	public int padHorizontal = 10, padVertical = 10;
 	/** whether to use a stencil buffer **/
 	public boolean stencil = false;
 	/** whether to enable antialiasing **/
@@ -45,7 +52,7 @@ public class GwtApplicationConfiguration {
 	 * fixed-size games or non-mobile games expecting performance issues on huge resolutions. If you target mobiles
 	 * and desktops, consider using physical device pixels on mobile devices only by using the return value of
 	 * {@link GwtApplication#isMobileDevice()} . */
-	public boolean usePhysicalPixels;
+	public final boolean usePhysicalPixels;
 	/** a TextArea to log messages to, can be null in which case a TextArea will be added to the body element of the DOM. */
 	public TextArea log;
 	/** whether to use debugging mode for OpenGL calls. Errors will result in a RuntimeException being thrown. */
@@ -68,14 +75,41 @@ public class GwtApplicationConfiguration {
 	/** whether to use the gyroscope. default: false **/
 	public boolean useGyroscope = false;
 
-	public GwtApplicationConfiguration (int width, int height) {
-		this.width = width;
-		this.height = height;
+	/**
+	 * Creates configuration for a resizable application, using available browser window space
+	 * minus padding (see {@link #padVertical}, {@link #padHorizontal}).
+	 */
+	public GwtApplicationConfiguration () {
+		this(false);
 	}
 
+	/**
+	 * Creates configuration for a resizable application, using available browser window space
+	 * minus padding (see {@link #padVertical}, {@link #padHorizontal}).
+	 * Also see {@link #usePhysicalPixels} documentation.
+	 */
+	public GwtApplicationConfiguration (boolean usePhysicalPixels) {
+		this(0, 0, usePhysicalPixels);
+	}
+
+	/**
+	 * Creates configuration for a fixed size application
+	 */
+	public GwtApplicationConfiguration (int width, int height) {
+		this(width, height, false);
+	}
+
+	/**
+	 * Creates configuration for a fixed size application
+	 * Also see {@link #usePhysicalPixels} documentation.
+	 */
 	public GwtApplicationConfiguration (int width, int height, boolean usePhysicalPixels) {
 		this.width = width;
 		this.height = height;
 		this.usePhysicalPixels = usePhysicalPixels;
+	}
+
+	public boolean isFixedSizeApplication() {
+		return width != 0 && height != 0;
 	}
 }

--- a/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/html/src/HtmlLauncher
+++ b/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/html/src/HtmlLauncher
@@ -7,56 +7,13 @@ import %PACKAGE%.%MAIN_CLASS%;
 
 public class HtmlLauncher extends GwtApplication {
 
-        // USE THIS CODE FOR A FIXED SIZE APPLICATION
         @Override
         public GwtApplicationConfiguration getConfig () {
-                return new GwtApplicationConfiguration(480, 320);
+                // Resizable application, uses available space in browser
+                return new GwtApplicationConfiguration(true);
+                // Fixed size application:
+                //return new GwtApplicationConfiguration(480, 320);
         }
-        // END CODE FOR FIXED SIZE APPLICATION
-
-        // UNCOMMENT THIS CODE FOR A RESIZABLE APPLICATION
-        // PADDING is to avoid scrolling in iframes, set to 20 if you have problems
-        // private static final int PADDING = 0;
-        // private GwtApplicationConfiguration cfg;
-        //
-        // @Override
-        // public GwtApplicationConfiguration getConfig() {
-        //     int w = Window.getClientWidth() - PADDING;
-        //     int h = Window.getClientHeight() - PADDING;
-        //     cfg = new GwtApplicationConfiguration(w, h);
-        //     Window.enableScrolling(false);
-        //     Window.setMargin("0");
-        //     Window.addResizeHandler(new ResizeListener());
-        //
-        //     If you want to support mobile screens, set usePhysicalPixels and convert the size
-        //     cfg.usePhysicalPixels = true;
-        //     double density = GwtGraphics.getNativeScreenDensity();
-        //     cfg.width = (int) (cfg.width * density);
-        //     cfg.height = (int) (cfg.height * density);
-        //
-        //     return cfg;
-        // }
-        //
-        // class ResizeListener implements ResizeHandler {
-        //     @Override
-        //     public void onResize(ResizeEvent event) {
-        //         if (Gdx.graphics.isFullscreen())
-        //             return;
-        //
-        //         int width = event.getWidth() - PADDING;
-        //         int height = event.getHeight() - PADDING;
-        //         getRootPanel().setWidth("" + width + "px");
-        //         getRootPanel().setHeight("" + height + "px");
-        //         if (cfg.usePhysicalPixels) {
-        //             double density = GwtGraphics.getNativeScreenDensity();
-        //             width = (int) (width * density);
-        //             height = (int) (height * density);
-        //         }
-        //         getApplicationListener().resize(width, height);
-        //         Gdx.graphics.setWindowedMode(width, height);
-        //     }
-        // }
-        // END OF CODE FOR RESIZABLE APPLICATION
 
         @Override
         public ApplicationListener createApplicationListener () {

--- a/tests/gdx-tests-gwt/src/com/badlogic/gdx/tests/gwt/client/GwtTestStarter.java
+++ b/tests/gdx-tests-gwt/src/com/badlogic/gdx/tests/gwt/client/GwtTestStarter.java
@@ -25,12 +25,10 @@ import com.badlogic.gdx.tests.gwt.GwtTestWrapper;
 public class GwtTestStarter extends GwtApplication {
 	@Override
 	public GwtApplicationConfiguration getConfig () {
-		GwtApplicationConfiguration config = new GwtApplicationConfiguration(480, 320, true);
+		GwtApplicationConfiguration config = new GwtApplicationConfiguration(true);
 		config.useGyroscope = true;
+		config.padVertical = 150;
 		//config.openURLInNewWindow = true;
-		double density = GwtGraphics.getNativeScreenDensity();
-		config.width = (int) (config.width * density);
-		config.height = (int) (config.height * density);
 		return config;
 	}
 

--- a/tests/gdx-tests-gwt/war/index.html
+++ b/tests/gdx-tests-gwt/war/index.html
@@ -8,7 +8,9 @@
     <h1>libGDX GWT Test Runner</h1>
     UI should load here shortly:<br>
     <div id="embed-com.badlogic.gdx.tests.gwt.GdxTestsGwt"></div>
-    <small>This page is from <code>tests/gdx-tests-gwt/war/index.html</code></small>
+    <small>This page is from <code>tests/gdx-tests-gwt/war/index.html</code>. Enter superdev here:
+    <a class="superdev" href="javascript:%7B%20window.__gwt_bookmarklet_params%20%3D%20%7B'server_url'%3A'http%3A%2F%2Flocalhost%3A9876%2F'%7D%3B%20var%20s%20%3D%20document.createElement('script')%3B%20s.src%20%3D%20'http%3A%2F%2Flocalhost%3A9876%2Fdev_mode_on.js'%3B%20void(document.getElementsByTagName('head')%5B0%5D.appendChild(s))%3B%7D">&#8635;</a>
+    </small>
     <script type="text/javascript" language="javascript" src="com.badlogic.gdx.tests.gwt.GdxTestsGwt/com.badlogic.gdx.tests.gwt.GdxTestsGwt.nocache.js">
 window.onkeydown =
   function(event) {

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtTestWrapper.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtTestWrapper.java
@@ -42,6 +42,7 @@ import com.badlogic.gdx.tests.g3d.ShadowMappingTest;
 import com.badlogic.gdx.tests.net.OpenBrowserExample;
 import com.badlogic.gdx.tests.superkoalio.SuperKoalio;
 import com.badlogic.gdx.tests.utils.GdxTest;
+import com.badlogic.gdx.utils.viewport.ExtendViewport;
 
 import java.util.Arrays;
 import java.util.Comparator;
@@ -59,7 +60,7 @@ public class GwtTestWrapper extends GdxTest {
 		Gdx.app.setLogLevel(Application.LOG_DEBUG);
 		Gdx.app.log("GdxTestGwt", "Setting up for " + tests.length + " tests.");
 
-		ui = new Stage();
+		ui = new Stage(new ExtendViewport(480, 320));
 		skin = new Skin(Gdx.files.internal("data/uiskin.json"));
 		font = new BitmapFont(Gdx.files.internal("data/arial-15.fnt"), false);
 		container = new Table();
@@ -68,6 +69,7 @@ public class GwtTestWrapper extends GdxTest {
 		Table table = new Table();
 		ScrollPane scroll = new ScrollPane(table);
 		container.add(scroll).expand().fill();
+		container.setFillParent(true);
 		table.pad(10).defaults().expandX().space(4);
 		Arrays.sort(tests, new Comparator<Instancer>() {
 			@Override
@@ -147,7 +149,6 @@ public class GwtTestWrapper extends GdxTest {
 
 	public void resize (int width, int height) {
 		ui.getViewport().update(width, height, true);
-		container.setSize(width, height);
 		if (test != null) {
 			test.resize(width, height);
 		}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtWindowModeTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtWindowModeTest.java
@@ -27,7 +27,6 @@ import com.badlogic.gdx.tests.utils.GdxTest;
 
 public class GwtWindowModeTest extends GdxTest {
 	private Stage stage;
-	boolean isWindowed;
 	TextButton changeModeButton;
 	private final String windowedInstructions = "click for Full screen Mode";
 	private final String fullScreenInstructions = "click for window Mode";
@@ -35,7 +34,6 @@ public class GwtWindowModeTest extends GdxTest {
 
 	public void create () {
 		stage = new Stage();
-		isWindowed = true;
 		Gdx.input.setInputProcessor(stage);
 		Skin skin = new Skin(Gdx.files.internal("data/uiskin.json"));
 
@@ -48,21 +46,17 @@ public class GwtWindowModeTest extends GdxTest {
 			@Override
 			public void clicked (InputEvent event, float x, float y) {
 				super.clicked(event, x, y);
-				if (Gdx.graphics.supportsDisplayModeChange()) {
-					if (isWindowed) {
-						isWindowed = false;
-						changeModeButton.setText(fullScreenInstructions);
-						Gdx.graphics.setFullscreenMode(Gdx.graphics.getDisplayMode());
-					} else {
-						isWindowed = true;
-						changeModeButton.setText(windowedInstructions);
-						Gdx.graphics.setWindowedMode(Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
-					}
+				if (!Gdx.graphics.isFullscreen()) {
+					Gdx.graphics.setFullscreenMode(Gdx.graphics.getDisplayMode());
 				} else {
-					changeModeButton.setText(notSupported);
+					Gdx.graphics.setWindowedMode(Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
 				}
 			}
 		});
+		if (!Gdx.graphics.supportsDisplayModeChange()) {
+			changeModeButton.setDisabled(true);
+			changeModeButton.setText(notSupported);
+		}
 	}
 
 	public void render () {
@@ -73,6 +67,13 @@ public class GwtWindowModeTest extends GdxTest {
 
 	public void resize (int width, int height) {
 		stage.getViewport().update(width, height, true);
+		if (Gdx.graphics.supportsDisplayModeChange()) {
+			if (Gdx.graphics.isFullscreen()) {
+				changeModeButton.setText(fullScreenInstructions);
+			} else {
+				changeModeButton.setText(windowedInstructions);
+			}
+		}
 	}
 
 	public void dispose () {


### PR DESCRIPTION
In the past, we had frequent questions how an application can be made resizable on GWT, that means taking up the available space in browser. This was solved eventually with some example code in HTMLLauncher.

However, this was more a workaround then a real solution, and I am moving the code from HTMLLauncher into the backend with this PR. It is easy to see that the behaviour is unaffected if we start a fixed size application with set width and height, therefore I mark this as non-breaking. 

I also improved the Gwt tests: there was no way to enter superdev debugging mode before, and the windowed mode test had a wrong button label often.

I tested resizeability with usePhysicalPixels on and off on Firefox Desktop, Chrome Desktop, Chrome Mobile, Firefox Mobile and Safari Mobile. I discovered during testing that Firefox Mobile's full screen mode is broken, but this is independant from this PR and I am confident to say that it's Firefox, not our code. Surprisingly, even Safari works well. :-)

Would be great if this would go into the snapshot before the jam starts!