### PR TITLE
Improved GdxTests and enable distribution for desktop tests

### DIFF
--- a/tests/gdx-tests-android/assets/data/shaders/instanced-rendering.frag
+++ b/tests/gdx-tests-android/assets/data/shaders/instanced-rendering.frag
@@ -1,5 +1,3 @@
-#version 300 es
-
 precision mediump float;
 
 in vec4 v_color;

--- a/tests/gdx-tests-android/assets/data/shaders/instanced-rendering.vert
+++ b/tests/gdx-tests-android/assets/data/shaders/instanced-rendering.vert
@@ -1,5 +1,3 @@
-#version 300 es
-
 in vec4 a_position;
 in vec2 i_offset;
 in vec4 i_color;

--- a/tests/gdx-tests-android/assets/data/uiskin.json
+++ b/tests/gdx-tests-android/assets/data/uiskin.json
@@ -5,16 +5,17 @@ Color: {
 	white: { a: 1, b: 1, g: 1, r: 1 },
 	red: { a: 1, b: 0, g: 0, r: 1 },
 	black: { a: 1, b: 0, g: 0, r: 0 },
+	gray: { a: 1, b: 0.8, g: 0.8, r: 0.8 },
 },
 TintedDrawable: {
 	dialogDim: { name: white, color: { r: 0, g: 0, b: 0, a: 0.45 } },
 },
 ButtonStyle: {
-	default: { down: default-round-down, up: default-round },
+	default: { down: default-round-down, up: default-round, disabled: default-round },
 	toggle: { parent: default, checked: default-round-down }
 },
 TextButtonStyle: {
-	default: { parent: default, font: default-font, fontColor: white },
+	default: { parent: default, font: default-font, fontColor: white, disabledFontColor: gray },
 	toggle: { parent: default, checked: default-round-down, downFontColor: red }
 },
 ScrollPaneStyle: {

--- a/tests/gdx-tests-lwjgl/build.gradle
+++ b/tests/gdx-tests-lwjgl/build.gradle
@@ -17,6 +17,7 @@
 ext {
     mainTestClass = "com.badlogic.gdx.tests.lwjgl.LwjglTestStarter"
 }
+sourceSets.main.resources.srcDirs = ["../gdx-tests-android/assets"]
 
 dependencies {
     compile project(":tests:gdx-tests")
@@ -35,4 +36,14 @@ task launchTestsLwjgl (dependsOn: classes, type: JavaExec) {
 configure (launchTestsLwjgl) {
     group "LibGDX"
     description = "Run the Lwjgl tests"
+}
+task dist(type: Jar, dependsOn: classes) {
+    manifest {
+        attributes 'Main-Class': project.mainTestClass
+    }
+    dependsOn configurations.runtimeClasspath
+    from {
+        configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
+    }
+    with jar
 }

--- a/tests/gdx-tests-lwjgl/src/com/badlogic/gdx/tests/lwjgl/LwjglTestStarter.java
+++ b/tests/gdx-tests-lwjgl/src/com/badlogic/gdx/tests/lwjgl/LwjglTestStarter.java
@@ -41,10 +41,14 @@ import com.badlogic.gdx.backends.lwjgl.LwjglFiles;
 import com.badlogic.gdx.backends.lwjgl.LwjglPreferences;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.glutils.ShaderProgram;
+import com.badlogic.gdx.tests.utils.CommandLineOptions;
 import com.badlogic.gdx.tests.utils.GdxTest;
 import com.badlogic.gdx.tests.utils.GdxTests;
+import com.badlogic.gdx.utils.Array;
 
 public class LwjglTestStarter extends JFrame {
+	private static CommandLineOptions options;
+
 	public LwjglTestStarter () throws HeadlessException {
 		super("libgdx Tests");
 		setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
@@ -62,7 +66,7 @@ public class LwjglTestStarter extends JFrame {
 	 * @return {@code true} if the test was found and run, {@code false} otherwise
 	 */
 	public static boolean runTest (String testName) {
-		boolean useGL30 = false;
+		boolean useGL30 = options.gl30;
 		GdxTest test = GdxTests.newTest(testName);
 		if (test == null) {
 			return false;
@@ -91,7 +95,7 @@ public class LwjglTestStarter extends JFrame {
 
 			final JButton button = new JButton("Run Test");
 
-			final JList list = new JList(GdxTests.getNames().toArray());
+			final JList list = new JList(options.getCompatibleTests());
 			JScrollPane pane = new JScrollPane(list);
 
 			DefaultListSelectionModel m = new DefaultListSelectionModel();
@@ -139,12 +143,14 @@ public class LwjglTestStarter extends JFrame {
 	 * 
 	 * If no arguments are provided on the command line, shows a list of tests to choose from.
 	 * If an argument is present, the test with that name will immediately be run.
+	 * Additional options can be passed, see {@link CommandLineOptions}
 	 * 
 	 * @param argv command line arguments
 	 */
 	public static void main (String[] argv) throws Exception {
-		if (argv.length > 0) {
-			if (runTest(argv[0])) {
+		options = new CommandLineOptions(argv);
+		if (options.startupTestName != null) {
+			if (runTest(options.startupTestName)) {
 				return;
 				// Otherwise, fall back to showing the list
 			}

--- a/tests/gdx-tests-lwjgl3/build.gradle
+++ b/tests/gdx-tests-lwjgl3/build.gradle
@@ -17,6 +17,7 @@
 ext {
     mainTestClass = "com.badlogic.gdx.tests.lwjgl3.Lwjgl3TestStarter"
 }
+sourceSets.main.resources.srcDirs = ["../gdx-tests-android/assets"]
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
@@ -43,4 +44,14 @@ task launchTestsLwjgl3 (dependsOn: classes, type: JavaExec) {
 configure (launchTestsLwjgl3) {
     group "LibGDX"
     description = "Run the Lwjgl3 tests"
+}
+task dist(type: Jar, dependsOn: classes) {
+    manifest {
+        attributes 'Main-Class': project.mainTestClass
+    }
+    dependsOn configurations.runtimeClasspath
+    from {
+        configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
+    }
+    with jar
 }

--- a/tests/gdx-tests-lwjgl3/src/com/badlogic/gdx/tests/lwjgl3/Lwjgl3TestStarter.java
+++ b/tests/gdx-tests-lwjgl3/src/com/badlogic/gdx/tests/lwjgl3/Lwjgl3TestStarter.java
@@ -26,21 +26,43 @@ import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Graphics;
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3WindowConfiguration;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.InputEvent;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.scenes.scene2d.ui.ScrollPane;
 import com.badlogic.gdx.scenes.scene2d.ui.Skin;
 import com.badlogic.gdx.scenes.scene2d.ui.Table;
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
+import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
 import com.badlogic.gdx.scenes.scene2d.utils.ClickListener;
+import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener.ChangeEvent;
+import com.badlogic.gdx.tests.utils.CommandLineOptions;
+import com.badlogic.gdx.tests.utils.GdxTest;
+import com.badlogic.gdx.tests.utils.GdxTestConfig;
 import com.badlogic.gdx.tests.utils.GdxTests;
 import com.badlogic.gdx.utils.viewport.ScreenViewport;
 
 public class Lwjgl3TestStarter {
+	
+	private static CommandLineOptions options;
+
+	/**
+	 * Runs libgdx tests.
+	 * 
+	 * some options can be passed, see {@link CommandLineOptions}
+	 * 
+	 * @param argv command line arguments
+	 */
 	public static void main (String[] argv) {
 		System.setProperty("java.awt.headless", "true");
+
+		options = new CommandLineOptions(argv);
+		
 		Lwjgl3ApplicationConfiguration config = new Lwjgl3ApplicationConfiguration();
 		config.setWindowedMode(640, 480);
+		if(options.gl30){
+			config.useOpenGL3(true, 3, 2);
+		}
 
 		new Lwjgl3Application(new TestChooser(), config);
 	}
@@ -72,11 +94,13 @@ public class Lwjgl3TestStarter {
 			table.pad(10).defaults().expandX().space(tableSpace);
 			for (final String testName : GdxTests.getNames()) {
 				final TextButton testButton = new TextButton(testName, skin);
+				testButton.setDisabled(!options.isTestCompatible(testName));
 				testButton.setName(testName);
 				table.add(testButton).fillX();
 				table.row();
-				testButton.addListener(new ClickListener() {
-					public void clicked (InputEvent event, float x, float y) {
+				testButton.addListener(new ChangeListener() {
+					@Override
+					public void changed (ChangeEvent event, Actor actor) {
 						ApplicationListener test = GdxTests.newTest(testName);
 						Lwjgl3WindowConfiguration winConfig = new Lwjgl3WindowConfiguration();
 						winConfig.setTitle(testName);

--- a/tests/gdx-tests/res/com/badlogic/gdx/GdxTests.gwt.xml
+++ b/tests/gdx-tests/res/com/badlogic/gdx/GdxTests.gwt.xml
@@ -43,7 +43,9 @@
 		<exclude name="**/VorbisTest.java"/> <!-- native -->
 		<exclude name="**/WavTest.java"/> <!-- naive -->
 		<exclude name="**/voxel/*.java"/> <!-- PerlinNoiseGenerator uses a method not in the emulated version of Buffer -->
+		<exclude name="utils/CommandLineOptions.java"/>
 	</source>
 	<extend-configuration-property name="gdx.reflect.include" value="com.badlogic.gdx.tests.AnnotationTest" />
 	<extend-configuration-property name="gdx.reflect.include" value="com.badlogic.gdx.tests.ReflectionCorrectnessTest" />
+	<extend-configuration-property name="gdx.reflect.include" value="com.badlogic.gdx.tests.utils.GdxTestConfig" />
 </module>

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/VBOWithVAOPerformanceTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/VBOWithVAOPerformanceTest.java
@@ -33,6 +33,7 @@ import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.math.Matrix4;
 import com.badlogic.gdx.math.WindowedMean;
 import com.badlogic.gdx.tests.utils.GdxTest;
+import com.badlogic.gdx.tests.utils.GdxTestConfig;
 import com.badlogic.gdx.utils.BufferUtils;
 import com.badlogic.gdx.utils.GdxRuntimeException;
 import com.badlogic.gdx.utils.StringBuilder;
@@ -41,6 +42,7 @@ import java.nio.ByteBuffer;
 import java.nio.FloatBuffer;
 import java.nio.IntBuffer;
 
+@GdxTestConfig(requireGL30=true)
 public class VBOWithVAOPerformanceTest extends GdxTest {
 
 	ShaderProgram shader;

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/MultipleRenderTargetTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/MultipleRenderTargetTest.java
@@ -55,6 +55,7 @@ import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.math.Matrix3;
 import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.tests.utils.GdxTest;
+import com.badlogic.gdx.tests.utils.GdxTestConfig;
 import com.badlogic.gdx.utils.*;
 import com.badlogic.gdx.utils.StringBuilder;
 
@@ -68,6 +69,7 @@ import java.util.Map;
  * Thanks to http://www.blendswap.com/blends/view/73922 for the cannon model, licensed under CC-BY-SA
  *
  /** @author Tomski */
+@GdxTestConfig(requireGL30=true)
 public class MultipleRenderTargetTest extends GdxTest {
 
 	RenderContext renderContext;

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gles3/InstancedRenderingTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gles3/InstancedRenderingTest.java
@@ -24,11 +24,13 @@ import com.badlogic.gdx.graphics.VertexAttribute;
 import com.badlogic.gdx.graphics.VertexAttributes.Usage;
 import com.badlogic.gdx.graphics.glutils.ShaderProgram;
 import com.badlogic.gdx.tests.utils.GdxTest;
+import com.badlogic.gdx.tests.utils.GdxTestConfig;
 import com.badlogic.gdx.utils.BufferUtils;
 import com.badlogic.gdx.utils.GdxRuntimeException;
 
 import java.nio.FloatBuffer;
 
+@GdxTestConfig(requireGL30=true)
 public class InstancedRenderingTest extends GdxTest {
 
 	ShaderProgram shader;
@@ -42,7 +44,8 @@ public class InstancedRenderingTest extends GdxTest {
 		if (Gdx.gl30 == null) {
 			throw new GdxRuntimeException("GLES 3.0 profile required for this test");
 		}
-
+		ShaderProgram.prependVertexCode = "#version 300 es\n";
+		ShaderProgram.prependFragmentCode = "#version 300 es\n";
 		shader = new ShaderProgram(Gdx.files.internal("data/shaders/instanced-rendering.vert"), Gdx.files.internal("data/shaders/instanced-rendering.frag"));
 		if (!shader.isCompiled()) {
 			throw new GdxRuntimeException("Shader compile error: " + shader.getLog());

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtTestWrapper.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtTestWrapper.java
@@ -25,6 +25,7 @@ import com.badlogic.gdx.InputProcessor;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
+import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.InputEvent;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.scenes.scene2d.ui.Label;
@@ -33,7 +34,9 @@ import com.badlogic.gdx.scenes.scene2d.ui.ScrollPane;
 import com.badlogic.gdx.scenes.scene2d.ui.Skin;
 import com.badlogic.gdx.scenes.scene2d.ui.Table;
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
+import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
 import com.badlogic.gdx.scenes.scene2d.utils.ClickListener;
+import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener.ChangeEvent;
 import com.badlogic.gdx.tests.*;
 import com.badlogic.gdx.tests.conformance.DisplayModeTest;
 import com.badlogic.gdx.tests.extensions.ControllersTest;
@@ -78,9 +81,9 @@ public class GwtTestWrapper extends GdxTest {
 		for (final Instancer instancer : tests) {
 			table.row();
 			TextButton button = new TextButton(instancer.instance().getClass().getSimpleName(), skin);
-			button.addListener(new ClickListener() {
+			button.addListener(new ChangeListener() {
 				@Override
-				public void clicked (InputEvent event, float x, float y) {
+				public void changed (ChangeEvent event, Actor actor) {
 					((InputWrapper)Gdx.input).multiplexer.removeProcessor(ui);
 					test = instancer.instance();
 					Gdx.app.log("GdxTestGwt", "Clicked on " + test.getClass().getName());

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/CommandLineOptions.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/CommandLineOptions.java
@@ -1,0 +1,49 @@
+package com.badlogic.gdx.tests.utils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.swing.ListModel;
+
+import com.badlogic.gdx.utils.Array;
+
+/**
+ * Shared class for desktop launchers.
+ * 
+ * options:
+ * --gl30 enable GLES 3.2 (default is GLES 2.0)
+ */
+public class CommandLineOptions {
+	
+	public String startupTestName = null;
+	public boolean gl30 = false;
+	
+	public CommandLineOptions (String [] argv) {
+		Array<String> args = new Array<String>(argv);
+		for(String arg : args){
+			if(arg.startsWith("-")){
+				if(arg.equals("--gl30")) gl30 = true;
+				else System.err.println("skip unrecognized option " + arg);
+			}else{
+				startupTestName = arg;
+			}
+		}
+	}
+
+	public boolean isTestCompatible (String testName) {
+		final Class<? extends GdxTest> clazz = GdxTests.forName(testName);
+		GdxTestConfig config = clazz.getAnnotation(GdxTestConfig.class);
+		if(config != null){
+			if(config.requireGL30() && !gl30) return false;
+		}
+		return true;
+	}
+
+	public Object[] getCompatibleTests () {
+		List<String> names = new ArrayList<>();
+		for(String name : GdxTests.getNames()){
+			if(isTestCompatible(name)) names.add(name);
+		}
+		return names.toArray();
+	}
+}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTestConfig.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTestConfig.java
@@ -1,0 +1,13 @@
+package com.badlogic.gdx.tests.utils;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Retention(RUNTIME)
+@Target(TYPE)
+public @interface GdxTestConfig {
+	boolean requireGL30() default false;
+}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
@@ -77,6 +77,7 @@ import com.badlogic.gdx.tests.g3d.TextureRegion3DTest;
 import com.badlogic.gdx.tests.g3d.utils.DefaultTextureBinderTest;
 import com.badlogic.gdx.tests.gles2.HelloTriangle;
 import com.badlogic.gdx.tests.gles2.SimpleVertexShader;
+import com.badlogic.gdx.tests.gles3.InstancedRenderingTest;
 import com.badlogic.gdx.tests.net.NetAPITest;
 import com.badlogic.gdx.tests.superkoalio.SuperKoalio;
 import com.badlogic.gdx.utils.ObjectMap;
@@ -164,6 +165,7 @@ public class GdxTests {
 		ImmediateModeRendererTest.class,
 		IndexBufferObjectShaderTest.class,
 		InputTest.class,
+		InstancedRenderingTest.class,
 		IntegerBitmapFontTest.class,
 		InterpolationTest.class,
 		InverseKinematicsTest.class,
@@ -335,7 +337,7 @@ public class GdxTests {
 		return names;
 	}
 
-	private static Class<? extends GdxTest> forName (String name) {
+	public static Class<? extends GdxTest> forName (String name) {
 		name = originalToObfuscated.get(name, name);
 		for (Class clazz : tests)
 			if (clazz.getSimpleName().equals(name)) return clazz;


### PR DESCRIPTION
this PR adds some improvement to Gdx tests and enable distribution for both Lwjgl and Lwjgl3 launchers : 
* gl30 switch can now be enable via CLI argument (--gl30)
* non compatible tests are disabled : 
    * with Lwjgl3 launcher, items are disabled (grayed)
    * with Lwjgl2 launcher, items are removed (i didn't want to mess with Swing, please forgive me)
    * a new Annotation allow to say if a test requires gl30 or not.
* InstancedRenderingTest was missing in the list but it fails with Lwjgl2 (glVertexAttribDivisor method is not properly mapped apparently)

Notes: 
* this new mechanism (argv options and annotation) may be used for future needs, when application configuration needs some special setting for a particular test.
* gl30 options enable GLES 3.2 to be compatible with MacOSX.

Gdx tests dists can be build like this : 
* `./gradlew :tests:gdx-tests-lwjgl:dist`
* `./gradlew :tests:gdx-tests-lwjgl:dist`
* or simply `./gradlew dist` to build them all including gwt tests

I enable distribution to test some bugs only testable within a jar (relative path) so even if we don't plan to "distribute it publicly" it help for some fixes. Also, gl30 option was a bit annoying before, having to temporarily change the code...