### PR TITLE
Minor MathUtils constants improvements

### DIFF
--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/audio/OpenALLwjglAudio.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/audio/OpenALLwjglAudio.java
@@ -259,8 +259,8 @@ public class OpenALLwjglAudio implements LwjglAudio {
 	public void setSoundPan (long soundId, float pan, float volume) {
 		int sourceId = soundIdToSource.get(soundId, -1);
 		if (sourceId != -1) {
-			AL10.alSource3f(sourceId, AL10.AL_POSITION, MathUtils.cos((pan - 1) * MathUtils.PI / 2), 0,
-				MathUtils.sin((pan + 1) * MathUtils.PI / 2));
+			AL10.alSource3f(sourceId, AL10.AL_POSITION, MathUtils.cos((pan - 1) * MathUtils.HALF_PI), 0,
+				MathUtils.sin((pan + 1) * MathUtils.HALF_PI));
 			AL10.alSourcef(sourceId, AL10.AL_GAIN, volume);
 		}
 	}

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/audio/OpenALMusic.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/audio/OpenALMusic.java
@@ -150,8 +150,8 @@ public abstract class OpenALMusic implements Music {
 		this.pan = pan;
 		if (audio.noDevice) return;
 		if (sourceID == -1) return;
-		alSource3f(sourceID, AL_POSITION, MathUtils.cos((pan - 1) * MathUtils.PI / 2), 0,
-			MathUtils.sin((pan + 1) * MathUtils.PI / 2));
+		alSource3f(sourceID, AL_POSITION, MathUtils.cos((pan - 1) * MathUtils.HALF_PI), 0,
+			MathUtils.sin((pan + 1) * MathUtils.HALF_PI));
 		alSourcef(sourceID, AL_GAIN, volume);
 	}
 

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALLwjgl3Audio.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALLwjgl3Audio.java
@@ -293,8 +293,8 @@ public class OpenALLwjgl3Audio implements Lwjgl3Audio {
 	public void setSoundPan (long soundId, float pan, float volume) {
 		int sourceId = soundIdToSource.get(soundId, -1);
 		if (sourceId != -1) {
-			AL10.alSource3f(sourceId, AL10.AL_POSITION, MathUtils.cos((pan - 1) * MathUtils.PI / 2), 0,
-				MathUtils.sin((pan + 1) * MathUtils.PI / 2));
+			AL10.alSource3f(sourceId, AL10.AL_POSITION, MathUtils.cos((pan - 1) * MathUtils.HALF_PI), 0,
+				MathUtils.sin((pan + 1) * MathUtils.HALF_PI));
 			AL10.alSourcef(sourceId, AL10.AL_GAIN, volume);
 		}
 	}

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALMusic.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALMusic.java
@@ -154,8 +154,8 @@ public abstract class OpenALMusic implements Music {
 		this.pan = pan;
 		if (audio.noDevice) return;
 		if (sourceID == -1) return;
-		alSource3f(sourceID, AL_POSITION, MathUtils.cos((pan - 1) * MathUtils.PI / 2), 0,
-			MathUtils.sin((pan + 1) * MathUtils.PI / 2));
+		alSource3f(sourceID, AL_POSITION, MathUtils.cos((pan - 1) * MathUtils.HALF_PI), 0,
+			MathUtils.sin((pan + 1) * MathUtils.HALF_PI));
 		alSourcef(sourceID, AL_GAIN, volume);
 	}
 

--- a/gdx/src/com/badlogic/gdx/math/Interpolation.java
+++ b/gdx/src/com/badlogic/gdx/math/Interpolation.java
@@ -110,13 +110,13 @@ public abstract class Interpolation {
 
 	static public final Interpolation sineIn = new Interpolation() {
 		public float apply (float a) {
-			return 1 - MathUtils.cos(a * MathUtils.PI / 2);
+			return 1 - MathUtils.cos(a * MathUtils.HALF_PI);
 		}
 	};
 
 	static public final Interpolation sineOut = new Interpolation() {
 		public float apply (float a) {
-			return MathUtils.sin(a * MathUtils.PI / 2);
+			return MathUtils.sin(a * MathUtils.HALF_PI);
 		}
 	};
 

--- a/gdx/src/com/badlogic/gdx/math/MathUtils.java
+++ b/gdx/src/com/badlogic/gdx/math/MathUtils.java
@@ -32,8 +32,8 @@ public final class MathUtils {
 	// ---
 	static public final float FLOAT_ROUNDING_ERROR = 0.000001f; // 32 bits
 	static public final float PI = (float) Math.PI;
-	static public final float PI2 = (float) (Math.PI * 2d);
-	static public final float HALF_PI = (float) (Math.PI / 2d);
+	static public final float PI2 = PI * 2;
+	static public final float HALF_PI = PI / 2;
 
 	static public final float E = (float) Math.E;
 

--- a/gdx/src/com/badlogic/gdx/math/MathUtils.java
+++ b/gdx/src/com/badlogic/gdx/math/MathUtils.java
@@ -47,10 +47,10 @@ public final class MathUtils {
 	static private final float degToIndex = SIN_COUNT / degFull;
 
 	/** multiply by this to convert from radians to degrees */
-	static public final float radiansToDegrees = (float) (180d / Math.PI);
+	static public final float radiansToDegrees = 180 / PI;
 	static public final float radDeg = radiansToDegrees;
 	/** multiply by this to convert from degrees to radians */
-	static public final float degreesToRadians = (float) (Math.PI / 180d);
+	static public final float degreesToRadians = PI / 180;
 	static public final float degRad = degreesToRadians;
 
 	static private class Sin {

--- a/gdx/src/com/badlogic/gdx/math/MathUtils.java
+++ b/gdx/src/com/badlogic/gdx/math/MathUtils.java
@@ -31,25 +31,26 @@ public final class MathUtils {
 
 	// ---
 	static public final float FLOAT_ROUNDING_ERROR = 0.000001f; // 32 bits
-	static public final float PI = 3.1415927f;
-	static public final float PI2 = PI * 2;
+	static public final float PI = (float) Math.PI;
+	static public final float PI2 = (float) (Math.PI * 2d);
+	static public final float HALF_PI = (float) (Math.PI / 2d);
 
-	static public final float E = 2.7182818f;
+	static public final float E = (float) Math.E;
 
 	static private final int SIN_BITS = 14; // 16KB. Adjust for accuracy.
 	static private final int SIN_MASK = ~(-1 << SIN_BITS);
 	static private final int SIN_COUNT = SIN_MASK + 1;
 
-	static private final float radFull = PI * 2;
+	static private final float radFull = PI2;
 	static private final float degFull = 360;
 	static private final float radToIndex = SIN_COUNT / radFull;
 	static private final float degToIndex = SIN_COUNT / degFull;
 
 	/** multiply by this to convert from radians to degrees */
-	static public final float radiansToDegrees = 180f / PI;
+	static public final float radiansToDegrees = (float) (180d / Math.PI);
 	static public final float radDeg = radiansToDegrees;
 	/** multiply by this to convert from degrees to radians */
-	static public final float degreesToRadians = PI / 180;
+	static public final float degreesToRadians = (float) (Math.PI / 180d);
 	static public final float degRad = degreesToRadians;
 
 	static private class Sin {
@@ -72,7 +73,7 @@ public final class MathUtils {
 	/** Returns the cosine in radians from a lookup table. For optimal precision, use radians between -PI2 and PI2 (both
 	 * inclusive). */
 	static public float cos (float radians) {
-		return Sin.table[(int)((radians + PI / 2) * radToIndex) & SIN_MASK];
+		return Sin.table[(int)((radians + HALF_PI) * radToIndex) & SIN_MASK];
 	}
 
 	/** Returns the sine in degrees from a lookup table. For optimal precision, use radians between -360 and 360 (both
@@ -93,9 +94,9 @@ public final class MathUtils {
 	 * degrees), largest error of 0.00488 radians (0.2796 degrees). */
 	static public float atan2 (float y, float x) {
 		if (x == 0f) {
-			if (y > 0f) return PI / 2;
+			if (y > 0f) return HALF_PI;
 			if (y == 0f) return 0f;
-			return -PI / 2;
+			return -HALF_PI;
 		}
 		final float atan, z = y / x;
 		if (Math.abs(z) < 1f) {
@@ -103,7 +104,7 @@ public final class MathUtils {
 			if (x < 0f) return atan + (y < 0f ? -PI : PI);
 			return atan;
 		}
-		atan = PI / 2 - z / (z * z + 0.28f);
+		atan = HALF_PI - z / (z * z + 0.28f);
 		return y < 0f ? atan - PI : atan;
 	}
 

--- a/gdx/src/com/badlogic/gdx/math/MathUtils.java
+++ b/gdx/src/com/badlogic/gdx/math/MathUtils.java
@@ -47,7 +47,7 @@ public final class MathUtils {
 	static private final float degToIndex = SIN_COUNT / degFull;
 
 	/** multiply by this to convert from radians to degrees */
-	static public final float radiansToDegrees = 180 / PI;
+	static public final float radiansToDegrees = 180f / PI;
 	static public final float radDeg = radiansToDegrees;
 	/** multiply by this to convert from degrees to radians */
 	static public final float degreesToRadians = PI / 180;

--- a/gdx/test/com/badlogic/gdx/math/Vector2Test.java
+++ b/gdx/test/com/badlogic/gdx/math/Vector2Test.java
@@ -28,11 +28,11 @@ public class Vector2Test {
 
 	@Test
 	public void testAngleRad() {
-		assertEquals(- MathUtils.PI / 2f, new Vector2(0, -1f).angleRad(), MathUtils.FLOAT_ROUNDING_ERROR);
+		assertEquals(- MathUtils.HALF_PI, new Vector2(0, -1f).angleRad(), MathUtils.FLOAT_ROUNDING_ERROR);
 	}
 
 	@Test
 	public void testAngleRadRelative() {
-		assertEquals(- MathUtils.PI / 2f, new Vector2(0, -1f).angleRad(Vector2.X), MathUtils.FLOAT_ROUNDING_ERROR);
+		assertEquals(- MathUtils.HALF_PI, new Vector2(0, -1f).angleRad(Vector2.X), MathUtils.FLOAT_ROUNDING_ERROR);
 	}
 }


### PR DESCRIPTION
Minor cosmetic improvements to some of the `MathUtils` public constants not to use hardcoded values. All constants have the same value as before.

I've also added a new constant `MathUtils.HALF_PI` which doesn't introduce extra floating precision in comparison to using `MathUtils.PI / 2f` but it's a common enough value to have it there.

NOTE: I had originally changed `radiansToDegrees` and `degreesToRadians` to improve the float precision error but, even if technically the value is closer to the real one, when working with floats for everything (when using `MathUtils` API), conversions that you'd expect to be exact such as `MathUtils.PI / 6f  * radiansToDegrees = 30`  ended up having a precision error like `30.000001`.