### PR TITLE
Add FRAMEBUFFER_BINDING support to GwtGL20.

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtGL20.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtGL20.java
@@ -22,15 +22,12 @@ import java.nio.FloatBuffer;
 import java.nio.HasArrayBufferView;
 import java.nio.IntBuffer;
 import java.nio.ShortBuffer;
-import java.util.HashMap;
-import java.util.Map;
 
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.utils.GdxRuntimeException;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.JavaScriptObject;
-import com.google.gwt.core.client.JsArray;
 import com.google.gwt.typedarrays.client.Uint8ArrayNative;
 import com.google.gwt.typedarrays.shared.Float32Array;
 import com.google.gwt.typedarrays.shared.Int16Array;
@@ -77,6 +74,14 @@ public class GwtGL20 implements GL20 {
 			var value = this[key];
 			delete this[key];
 			return value;
+		}-*/;
+
+		public native int getKey(T value) /*-{
+			for (i = 0; i < this.length; i++) {
+		           if (value === this[i]) {
+		               return i;
+		           }
+		       }
 		}-*/;
 	}
 
@@ -632,6 +637,14 @@ public class GwtGL20 implements GL20 {
 			params.put(1, array.get(1));
 			params.put(2, array.get(2));
 			params.put(3, array.get(3));
+			params.flip();
+		} else if(pname == GL20.GL_FRAMEBUFFER_BINDING) {
+			WebGLFramebuffer fbo = gl.getParametero(pname);
+			if(fbo == null) {
+				params.put(0);
+			} else {
+				params.put(frameBuffers.getKey(fbo));
+			}
 			params.flip();
 		} else
 			throw new GdxRuntimeException("glGetInteger not supported by GWT WebGL backend");


### PR DESCRIPTION
`GwtGL20` only supports a subset of values being passed to `glGetIntegerv`. This PR adds `FRAMEBUFFER_BINDING`, which is useful if one wants to nest framebuffers inside of each other. This closes #4688.

The implementation is a bit more complex, since, unlike desktop OpenGL, WebGL does not return an integer, but rather a FrameBuffer object. Consequently, a look up is used to determine the ID of that framebuffer.

<details>
 <summary><b><I>Click to show an executable example</i></b></summary>

What is supposed to happen: A green triangle is rendered; the console output should be `A: 0`, `B: 1`, `C: 2`, `D: 0` as those are the framebuffers bound at that moment.

```java
public class FrameBufferTest2 extends GdxTest {
	FrameBuffer fbo1, fbo2;
	ShapeRenderer shapeRenderer;

	boolean enableFbo1 = true;
	boolean enableFbo2 = true;

	private static final IntBuffer intBuff = ByteBuffer
			.allocateDirect(16 * Integer.BYTES).order(ByteOrder.nativeOrder())
			.asIntBuffer();

	@Override
	public void render () {
		Gdx.gl20.glClearColor(1f, 1f, 1f, 1);
		Gdx.gl20.glClear(GL20.GL_COLOR_BUFFER_BIT);

		if (Gdx.input.isKeyJustPressed(Input.Keys.N))
			enableFbo1 = !enableFbo1;
		if (Gdx.input.isKeyJustPressed(Input.Keys.M))
			enableFbo2 = !enableFbo2;

		Gdx.gl.glGetIntegerv(GL20.GL_FRAMEBUFFER_BINDING, intBuff);
		Gdx.app.log("FrameBufferTest2", "A: " + intBuff.get(0));

		if(enableFbo1)
			fbo1.begin();

		Gdx.gl.glGetIntegerv(GL20.GL_FRAMEBUFFER_BINDING, intBuff);
		Gdx.app.log("FrameBufferTest2", "B: " + intBuff.get(0));

		if(enableFbo1)
			fbo1.end();

		if(enableFbo2)
			fbo2.begin();

		Gdx.gl.glGetIntegerv(GL20.GL_FRAMEBUFFER_BINDING, intBuff);
		Gdx.app.log("FrameBufferTest2", "C: " + intBuff.get(0));

		if(enableFbo2)
			fbo2.end();

		//green triangle
		shapeRenderer.begin(ShapeRenderer.ShapeType.Filled);
		shapeRenderer.setColor(Color.GREEN);
		shapeRenderer.triangle(20, 120, 60, 160, 100, 120);
		shapeRenderer.end();

		Gdx.gl.glGetIntegerv(GL20.GL_FRAMEBUFFER_BINDING, intBuff);
		Gdx.app.log("FrameBufferTest2", "D: " + intBuff.get(0));
	}

	@Override
	public void create () {
		this.shapeRenderer = new ShapeRenderer();
		this.shapeRenderer.getProjectionMatrix().setToOrtho2D(0, 0, 256, 256);
		//this.shapeRenderer.updateMatrices();

		fbo1 = new FrameBuffer
				(Format.RGB565,
						HdpiUtils.toBackBufferX(256),
						HdpiUtils.toBackBufferY(256), false);
		fbo2 = new FrameBuffer
				(Format.RGB565,
						HdpiUtils.toBackBufferX(256),
						HdpiUtils.toBackBufferY(256), false);
	}

	@Override
	public void dispose () {
		fbo1.dispose();
		fbo2.dispose();
		shapeRenderer.dispose();
	}
}
```

</details>