### PR TITLE
Net: New method downloadPixmapFromHttpUrl

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/graphics/Pixmap.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/graphics/Pixmap.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import com.badlogic.gdx.backends.gwt.GwtFileHandle;
+import com.badlogic.gdx.backends.gwt.preloader.AssetDownloader;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.utils.BufferUtils;
 import com.badlogic.gdx.utils.Disposable;
@@ -101,7 +102,26 @@ public class Pixmap implements Disposable {
 		this(((GwtFileHandle)file).preloader.images.get(file.path()));
 		if (imageElement == null) throw new GdxRuntimeException("Couldn't load image '" + file.path() + "', file does not exist");
 	}
-	
+
+	public static void downloadFromUrl(String url, final DownloadPixmapResponseListener responseListener) {
+		new AssetDownloader().loadImage(url, null, "anonymous", new AssetDownloader.AssetLoaderListener<ImageElement>() {
+			@Override
+			public void onProgress(double amount) {
+				// nothing to do
+			}
+
+			@Override
+			public void onFailure() {
+				responseListener.downloadFailed(new Exception("Failed to download image"));
+			}
+
+			@Override
+			public void onSuccess(ImageElement result) {
+				responseListener.downloadComplete(new Pixmap(result));
+			}
+		});
+	}
+
 	public Context2d getContext() {
 		ensureCanvasExists();
 		return context;
@@ -569,5 +589,9 @@ public class Pixmap implements Disposable {
 	private enum DrawType {
 		FILL, STROKE
 	}
-	
+
+	public interface DownloadPixmapResponseListener {
+		void downloadComplete(Pixmap pixmap);
+		void downloadFailed(Throwable t);
+	}
 }

--- a/tests/gdx-tests/res/com/badlogic/gdx/GdxTests.gwt.xml
+++ b/tests/gdx-tests/res/com/badlogic/gdx/GdxTests.gwt.xml
@@ -11,7 +11,6 @@
 		<exclude name="**/BulletTestCollection.java"/> <!-- native -->
 		<exclude name="**/ContactListenerTest.java"/> <!-- String.format, Reflection -->
 		<exclude name="**/CullTest.java"/> <!-- GL ES 1.0 -->
-		<exclude name="**/DownloadTest.java"/> <!-- Incompatible Pixmap ctor -->
 		<exclude name="**/KTXTest.java"/> <!-- use ECT1 which is native -->
 		<exclude name="**/ETC1Test.java"/> <!-- native -->
 		<exclude name="**/FFTTest.java"/> <!-- native -->

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/DownloadTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/DownloadTest.java
@@ -1,51 +1,38 @@
 package com.badlogic.gdx.tests;
 
 import com.badlogic.gdx.Gdx;
-import com.badlogic.gdx.Net.HttpMethods;
-import com.badlogic.gdx.Net.HttpRequest;
-import com.badlogic.gdx.Net.HttpResponse;
-import com.badlogic.gdx.Net.HttpResponseListener;
-import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.Texture;
-import com.badlogic.gdx.graphics.g2d.PixmapPacker;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.graphics.glutils.PixmapTextureData;
 import com.badlogic.gdx.tests.utils.GdxTest;
+import com.badlogic.gdx.utils.Queue;
 
 public class DownloadTest extends GdxTest {
 	Texture texture;
 	SpriteBatch batch;
+	Queue<String> urls = new Queue<>();
 
 	@Override
 	public void create () {
+		urls.addLast("https://www.google.at/images/srpr/logo11w.png");
+		urls.addLast("https://placekitten.com/200/300");
+		urls.addLast("https://i.imgur.com/snfjsWx.png");
+
 		batch = new SpriteBatch();
-		HttpRequest request = new HttpRequest(HttpMethods.GET);
-		request.setUrl("https://www.google.at/images/srpr/logo11w.png");
-		Gdx.net.sendHttpRequest(request, new HttpResponseListener() {
+		Pixmap.downloadFromUrl(urls.removeFirst(), new Pixmap.DownloadPixmapResponseListener() {
 			@Override
-			public void handleHttpResponse (HttpResponse httpResponse) {
-				final byte[] bytes = httpResponse.getResult();
-				
-				Gdx.app.postRunnable(new Runnable() {
-					@Override
-					public void run () {
-						Pixmap pixmap = new Pixmap(bytes, 0, bytes.length);
-						texture = new Texture(new PixmapTextureData(pixmap, pixmap.getFormat(), false, false, true));	
-					}
-				});		
+			public void downloadComplete(Pixmap pixmap) {
+				texture = new Texture(new PixmapTextureData(pixmap, pixmap.getFormat(), false, false, true));
 			}
-			
+
 			@Override
-			public void failed (Throwable t) {
-				t.printStackTrace();
-				Gdx.app.log("EmptyDownloadTest", "Failed", t);
-			}
-			
-			@Override
-			public void cancelled () {
-				Gdx.app.log("EmptyDownloadTest", "Cancelled");
+			public void downloadFailed(Throwable t) {
+				Gdx.app.log("EmptyDownloadTest", "Failed, trying next", t);
+				if (urls.notEmpty()) {
+					Pixmap.downloadFromUrl(urls.removeFirst(), this);
+				}
 			}
 		});
 	}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtTestWrapper.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtTestWrapper.java
@@ -532,6 +532,10 @@ public class GwtTestWrapper extends GdxTest {
 				return new FrameBufferTest();
 			}
 		}, new Instancer() {
+		public GdxTest instance () {
+			return new DownloadTest();
+		}
+		}, new Instancer() {
 			public GdxTest instance () {
 				return new FramebufferToTextureTest();
 			}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
@@ -132,6 +132,7 @@ public class GdxTests {
 		DeltaTimeTest.class,
 		DirtyRenderingTest.class,
 		DisplayModeTest.class,
+		DownloadTest.class,
 		DragAndDropTest.class,
 		ETC1Test.class,
 //		EarClippingTriangulatorTest.class,


### PR DESCRIPTION
Downloading an image from HTTP is easy on JVM platforms, but it is difficult - especially for beginners - to do on GWT. Ironically, GWT backend fetches all images needed for the game from an url before the game starts, so everything needed is already implemented. 

Thus, the new method downloadPixmapFromHttpUrl is on the one hand just a convinience method, on the other hand desperately requested.

Please check the DownloadTest. On GWT, it will throw an expected failure for the first URL to test error handling and will download the next image in the queue.