### PR TITLE
Make the WebGLRenderingContext public

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtGL20.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtGL20.java
@@ -94,7 +94,7 @@ public class GwtGL20 implements GL20 {
 	Int16Array shortBuffer = TypedArrays.createInt16Array(2000 * 6);
 	float[] floatArray = new float[16000];
 
-	final WebGLRenderingContext gl;
+	public final WebGLRenderingContext gl;
 
 	protected GwtGL20 (WebGLRenderingContext gl) {
 		this.gl = gl;


### PR DESCRIPTION
There are some methods like `texImage2D (int target, int level, int internalformat, int format, int type, VideoElement video)` which are not exposed with GwtGL20.