### PR TITLE
Fixes collision detection with the function overlapConvexPolygons

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,5 @@
 [1.9.12]
+- Fixes Issue #5048. The function Intersector.overlapConvexPolygons now should return the right minimum translation vector values.
 - Update to MobiVM 2.3.10
 - API Change: Removed Pool constructor with preFill parameter in favor of using Pool#fill() method. See #6117
 - API Addition: Slider can now be configured to only trigger on certain mouse button clicks (Slider#setButton(int)).


### PR DESCRIPTION
Hello everyone, this should fix #5048 

Sorry for not adding a non graphical test but the magic happens in the SAT Algorithm. If you are familiar with the algorithm the placement and the orientation of the minimum translation vector happens on the one dimensional axis.
The magic happens when we project the axis of the max and min points of the polygon and based on the scalar value (dot product) of this values i calculate the direction of the minimum translation vector. You can see this with the red line in the graphical Test.

TL;DR i added no functional Test because of math magic. It is hard to predict the assert value so a graphical test with debug output says more than 1mio asserts.

Also you see in the code and in the graphical test i also handle edge cases like when one polygon contains another.