### PR TITLE
- Fixes Issue #5048. The function Intersector.overlapConvexPolygons now should return the right minimum translation vector values.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,5 @@
 [1.9.12]
+- Fixes Issue #5048. The function Intersector.overlapConvexPolygons now should return the right minimum translation vector values.
 - Update to MobiVM 2.3.10
 - API Change: Removed Pool constructor with preFill parameter in favor of using Pool#fill() method. See #6117
 - API Addition: Slider can now be configured to only trigger on certain mouse button clicks (Slider#setButton(int)).

--- a/gdx/src/com/badlogic/gdx/math/Intersector.java
+++ b/gdx/src/com/badlogic/gdx/math/Intersector.java
@@ -1025,7 +1025,7 @@ public final class Intersector {
 		return closestX + closestY < c.radius * c.radius;
 	}
 
-	/** Check whether specified counter-clockwise wound convex polygons overlap.
+	/** Check whether specified convex polygons overlap (clockwise or counter-clockwise wound doesn't matter).
 	 * @param p1 The first polygon.
 	 * @param p2 The second polygon.
 	 * @return Whether polygons overlap. */
@@ -1033,7 +1033,7 @@ public final class Intersector {
 		return overlapConvexPolygons(p1, p2, null);
 	}
 
-	/** Check whether specified counter-clockwise wound convex polygons overlap. If they do, optionally obtain a Minimum
+	/** Check whether convex polygons overlap (clockwise or counter-clockwise wound doesn't matter). If they do, optionally obtain a Minimum
 	 * Translation Vector indicating the minimum magnitude vector required to push the polygon p1 out of collision with polygon p2.
 	 * @param p1 The first polygon.
 	 * @param p2 The second polygon.
@@ -1048,7 +1048,7 @@ public final class Intersector {
 		return overlapConvexPolygons(verts1, 0, verts1.length, verts2, 0, verts2.length, mtv);
 	}
 
-	/** Check whether polygons defined by the given counter-clockwise wound vertex arrays overlap. If they do, optionally obtain a
+	/** Check whether polygons defined by the given vertex arrays overlap (clockwise or counter-clockwise wound doesn't matter). If they do, optionally obtain a
 	 * Minimum Translation Vector indicating the minimum magnitude vector required to push the polygon defined by verts1 out of the
 	 * collision with the polygon defined by verts2.
 	 * @param verts1 Vertices of the first polygon.
@@ -1082,6 +1082,7 @@ public final class Intersector {
 	}
 
 	/**
+	 * Implementation of the separating axis theorem (SAT) algorithm
 	 * @param verts1        the verts1
 	 * @param offset1       offset of verts1
 	 * @param count1        count of verts1

--- a/gdx/src/com/badlogic/gdx/math/Intersector.java
+++ b/gdx/src/com/badlogic/gdx/math/Intersector.java
@@ -1049,22 +1049,26 @@ public final class Intersector {
 	}
 
 	/** Check whether polygons defined by the given counter-clockwise wound vertex arrays overlap. If they do, optionally obtain a
-	 * Minimum Translation Vector indicating the minimum magnitude vector required to push the polygon defined by shapeA out of the
-	 * collision with the polygon defined by shapeB.
-	 * @param shapeA Vertices of the first polygon.
-	 * @param shapeB Vertices of the second polygon.
+	 * Minimum Translation Vector indicating the minimum magnitude vector required to push the polygon defined by verts1 out of the
+	 * collision with the polygon defined by verts2.
+	 * @param verts1 Vertices of the first polygon.
+	 * @param offset1 the offset of the verts1 array
+	 * @param count1 the amount that is added to the offset1
+	 * @param verts2 Vertices of the second polygon.
+	 * @param offset2 the offset of the verts2 array
+	 * @param count2 the amount that is added to the offset2
 	 * @param mtv A Minimum Translation Vector to fill in the case of a collision, or null (optional).
 	 * @return Whether polygons overlap. */
-	public static boolean overlapConvexPolygons (float[] shapeA, int offsetA, int countA, float[] shapeB, int offsetB, int countB,
+	public static boolean overlapConvexPolygons (float[] verts1, int offset1, int count1, float[] verts2, int offset2, int count2,
 		MinimumTranslationVector mtv) {
 		boolean overlaps;
 		if (mtv != null) {
 			mtv.depth = Float.MAX_VALUE;
 			mtv.normal.setZero();
 		}
-		overlaps = overlapsOnAxisOfShape(shapeB, offsetB, countB, shapeA, offsetA, countA, mtv, true);
+		overlaps = overlapsOnAxisOfShape(verts2, offset2, count2, verts1, offset1, count1, mtv, true);
 		if (overlaps) {
-			overlaps = overlapsOnAxisOfShape(shapeA, offsetA, countA, shapeB, offsetB, countB, mtv, false);
+			overlaps = overlapsOnAxisOfShape(verts1, offset1, count1, verts2, offset2, count2, mtv, false);
 		}
 
 		if (!overlaps) {
@@ -1078,25 +1082,25 @@ public final class Intersector {
 	}
 
 	/**
-	 * @param shapeA        the shapeA
-	 * @param offsetA       offset of shapeA
-	 * @param countA        count of shapeA
-	 * @param shapeB        the shapeB
-	 * @param offsetB       offset of shapeB
-	 * @param countB        count of shapeB
+	 * @param verts1        the verts1
+	 * @param offset1       offset of verts1
+	 * @param count1        count of verts1
+	 * @param verts2        the verts2
+	 * @param offset2       offset of verts2
+	 * @param count2        count of verts2
 	 * @param mtv           the minimum translation vector
-	 * @param shapesShifted states if shape a and b are shifted. Important for calculating the axis translation for shapeA.
+	 * @param shapesShifted states if shape a and b are shifted. Important for calculating the axis translation for verts1.
 	 * @return
 	 */
-	private static boolean overlapsOnAxisOfShape(float[] shapeA, int offsetA, int countA, float[] shapeB, int offsetB, int countB, MinimumTranslationVector mtv, boolean shapesShifted) {
-		int endA = offsetA + countA;
-		int endB = offsetB + countB;
+	private static boolean overlapsOnAxisOfShape(float[] verts1, int offset1, int count1, float[] verts2, int offset2, int count2, MinimumTranslationVector mtv, boolean shapesShifted) {
+		int endA = offset1 + count1;
+		int endB = offset2 + count2;
 		//get axis of polygon A
-		for (int i = offsetA; i < endA; i += 2) {
-			float x1 = shapeA[i];
-			float y1 = shapeA[i + 1];
-			float x2 = shapeA[(i + 2) % countA];
-			float y2 = shapeA[(i + 3) % countA];
+		for (int i = offset1; i < endA; i += 2) {
+			float x1 = verts1[i];
+			float y1 = verts1[i + 1];
+			float x2 = verts1[(i + 2) % count1];
+			float y2 = verts1[(i + 3) % count1];
 
 			//Get the Axis for the 2 vertices
 			float axisX = y1 - y2;
@@ -1109,8 +1113,8 @@ public final class Intersector {
 			float minA = Float.MAX_VALUE;
 			float maxA = -Float.MAX_VALUE;
 			//project shape a on axis
-			for (int v = offsetA; v < endA; v += 2) {
-				float p = shapeA[v] * axisX + shapeA[v + 1] * axisY;
+			for (int v = offset1; v < endA; v += 2) {
+				float p = verts1[v] * axisX + verts1[v + 1] * axisY;
 				minA = Math.min(minA, p);
 				maxA = Math.max(maxA, p);
 			}
@@ -1119,8 +1123,8 @@ public final class Intersector {
 			float maxB = -Float.MAX_VALUE;
 
 			//project shape b on axis
-			for (int v = offsetB; v < endB; v += 2) {
-				float p = shapeB[v] * axisX + shapeB[v + 1] * axisY;
+			for (int v = offset2; v < endB; v += 2) {
+				float p = verts2[v] * axisX + verts2[v + 1] * axisY;
 				minB = Math.min(minB, p);
 				maxB = Math.max(maxB, p);
 			}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/IntersectorOverlapConvexPolygonsTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/IntersectorOverlapConvexPolygonsTest.java
@@ -18,14 +18,14 @@ public class IntersectorOverlapConvexPolygonsTest extends GdxTest {
     private OrthographicCamera camera;
     private ShapeRenderer shapeRenderer;
 
-    private float triangleWidth = 10f;
-    private float triangleHeight = 10f;
-    //2 triangle polygons intersect at 0,10 - 10,10 will return the wrong direction
-    private float[] vertsTriangle1 = {0f, 0f, triangleWidth, 0f, triangleWidth, triangleHeight};
-    private float[] vertsTriangle2 = {0f, 0f, triangleWidth*2, 0f, triangleWidth*2, triangleHeight*2};
+    private float shapeWidth = 10f;
+    private float shapeHeight = 10f;
+    //the vertices of the 2 shapes. Feel free to play with the values. It must be a convex Polygon.
+    private float[] vertsShape1 = {0f, 0f, shapeWidth, 0f, shapeWidth, shapeHeight};
+    private float[] vertsShape2 = {0f, 0f, shapeWidth *2, 0f, shapeWidth *2, shapeHeight *2,0, shapeHeight};
 
-    private Polygon triangle1 = new Polygon();
-    private Polygon triangle2 = new Polygon();
+    private Polygon shape1 = new Polygon();
+    private Polygon shape2 = new Polygon();
 
     private Intersector.MinimumTranslationVector mtv = new Intersector.MinimumTranslationVector();
 
@@ -40,10 +40,10 @@ public class IntersectorOverlapConvexPolygonsTest extends GdxTest {
         shapeRenderer = new ShapeRenderer();
         shapeRenderer.setAutoShapeType(true);
         //set inital position
-        triangle1.setVertices(vertsTriangle1);
-        triangle2.setVertices(vertsTriangle2);
-        triangle1.setPosition(0, 0);
-        triangle2.setPosition(10, 0);
+        shape1.setVertices(vertsShape1);
+        shape2.setVertices(vertsShape2);
+        shape1.setPosition(0, 0);
+        shape2.setPosition(10, 0);
     }
 
     @Override
@@ -54,21 +54,21 @@ public class IntersectorOverlapConvexPolygonsTest extends GdxTest {
 
     private void update(float deltaTime) {
         if (Gdx.input.isKeyJustPressed(Input.Keys.SPACE)) {
-            Intersector.overlapConvexPolygons(triangle1, triangle2, mtv);
-            float x = triangle1.getX() + (mtv.normal.x * mtv.depth);
-            float y = triangle1.getY() + (mtv.normal.y * mtv.depth);
-            triangle1.setPosition(x, y);
+            Intersector.overlapConvexPolygons(shape1, shape2, mtv);
+            float x = shape1.getX() + (mtv.normal.x * mtv.depth);
+            float y = shape1.getY() + (mtv.normal.y * mtv.depth);
+            shape1.setPosition(x, y);
             Gdx.app.debug(TAG, mtv.normal + " " + mtv.depth);
         }
         if (Gdx.input.isButtonPressed(Input.Buttons.LEFT)) {
             mouseCoords.set(Gdx.input.getX(), Gdx.input.getY(), 0);
             camera.unproject(mouseCoords);
-            triangle1.setPosition(mouseCoords.x, mouseCoords.y);
-            boolean overlaps = Intersector.overlapConvexPolygons(triangle1, triangle2, mtv);
+            shape1.setPosition(mouseCoords.x, mouseCoords.y);
+            boolean overlaps = Intersector.overlapConvexPolygons(shape1, shape2, mtv);
             Gdx.app.debug(TAG, mtv.normal + " " + mtv.depth + " overlaps: " + overlaps + " " + mouseCoords);
         } else if (Gdx.input.isButtonJustPressed(Input.Buttons.RIGHT)) {
-            triangle1.rotate(90);
-            boolean overlaps = Intersector.overlapConvexPolygons(triangle1, triangle2, mtv);
+            shape1.rotate(90);
+            boolean overlaps = Intersector.overlapConvexPolygons(shape1, shape2, mtv);
             Gdx.app.debug(TAG, mtv.normal + " " + mtv.depth + " overlaps: " + overlaps);
         }
     }
@@ -82,13 +82,21 @@ public class IntersectorOverlapConvexPolygonsTest extends GdxTest {
         shapeRenderer.setProjectionMatrix(camera.combined);
         shapeRenderer.begin(ShapeRenderer.ShapeType.Line);
         shapeRenderer.setColor(Color.GOLD);
-        shapeRenderer.polygon(triangle1.getTransformedVertices());
+        shapeRenderer.polygon(shape1.getTransformedVertices());
         shapeRenderer.setColor(Color.CYAN);
-        shapeRenderer.polygon(triangle2.getTransformedVertices());
+        shapeRenderer.polygon(shape2.getTransformedVertices());
+        //Translate the axis to position 0/0 and show the direction as red line
         shapeRenderer.setColor(Color.RED);
-        shapeRenderer.line(mtv.normal.x, mtv.normal.y, mtv.normal.x * 10, mtv.normal.y * 10);
+        shapeRenderer.line(0, 0, (mtv.normal.x * 100)-mtv.normal.x, (mtv.normal.y * 100)-mtv.normal.y);
+        //Translate the axis to position 0/0 and show the opposite direction as dark red line
+        shapeRenderer.setColor(Color.DARK_GRAY);
+        shapeRenderer.line(0, 0, (mtv.normal.x * -100)-mtv.normal.x, (mtv.normal.y * -100)-mtv.normal.y);
+        //Translate the axis to position 0/0 and show the depth as green line
+        shapeRenderer.setColor(Color.GREEN);
+        shapeRenderer.line(0, 0, (mtv.normal.x * mtv.depth)-mtv.normal.x, (mtv.normal.y * mtv.depth)-mtv.normal.y);
         shapeRenderer.set(ShapeRenderer.ShapeType.Filled);
-        shapeRenderer.circle((mtv.normal.x), (mtv.normal.y), 0.5f);
+        //Show origin at 0,0 as green dot
+        shapeRenderer.circle(0, 0, 0.2f);
         shapeRenderer.end();
     }
 }

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/IntersectorOverlapConvexPolygonsTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/IntersectorOverlapConvexPolygonsTest.java
@@ -1,0 +1,94 @@
+package com.badlogic.gdx.tests;
+
+import com.badlogic.gdx.Application;
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Input;
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.OrthographicCamera;
+import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
+import com.badlogic.gdx.math.Intersector;
+import com.badlogic.gdx.math.Polygon;
+import com.badlogic.gdx.math.Vector3;
+import com.badlogic.gdx.tests.utils.GdxTest;
+
+public class IntersectorOverlapConvexPolygonsTest extends GdxTest {
+
+    private static final String TAG = IntersectorOverlapConvexPolygonsTest.class.getSimpleName();
+    private OrthographicCamera camera;
+    private ShapeRenderer shapeRenderer;
+
+    private float triangleWidth = 10f;
+    private float triangleHeight = 10f;
+    //2 triangle polygons intersect at 0,10 - 10,10 will return the wrong direction
+    private float[] vertsTriangle1 = {0f, 0f, triangleWidth, 0f, triangleWidth, triangleHeight};
+    private float[] vertsTriangle2 = {0f, 0f, triangleWidth*2, 0f, triangleWidth*2, triangleHeight*2};
+
+    private Polygon triangle1 = new Polygon();
+    private Polygon triangle2 = new Polygon();
+
+    private Intersector.MinimumTranslationVector mtv = new Intersector.MinimumTranslationVector();
+
+    private Vector3 mouseCoords = new Vector3();
+
+    @Override
+    public void create() {
+        Gdx.app.setLogLevel(Application.LOG_DEBUG);
+        camera = new OrthographicCamera();
+        camera.setToOrtho(false);
+        camera.position.set(0, 0, 0);
+        shapeRenderer = new ShapeRenderer();
+        shapeRenderer.setAutoShapeType(true);
+        //set inital position
+        triangle1.setVertices(vertsTriangle1);
+        triangle2.setVertices(vertsTriangle2);
+        triangle1.setPosition(0, 0);
+        triangle2.setPosition(10, 0);
+    }
+
+    @Override
+    public void resize(int width, int height) {
+        camera.viewportWidth = 80;
+        camera.viewportHeight = 60;
+    }
+
+    private void update(float deltaTime) {
+        if (Gdx.input.isKeyJustPressed(Input.Keys.SPACE)) {
+            Intersector.overlapConvexPolygons(triangle1, triangle2, mtv);
+            float x = triangle1.getX() + (mtv.normal.x * mtv.depth);
+            float y = triangle1.getY() + (mtv.normal.y * mtv.depth);
+            triangle1.setPosition(x, y);
+            Gdx.app.debug(TAG, mtv.normal + " " + mtv.depth);
+        }
+        if (Gdx.input.isButtonPressed(Input.Buttons.LEFT)) {
+            mouseCoords.set(Gdx.input.getX(), Gdx.input.getY(), 0);
+            camera.unproject(mouseCoords);
+            triangle1.setPosition(mouseCoords.x, mouseCoords.y);
+            boolean overlaps = Intersector.overlapConvexPolygons(triangle1, triangle2, mtv);
+            Gdx.app.debug(TAG, mtv.normal + " " + mtv.depth + " overlaps: " + overlaps + " " + mouseCoords);
+        } else if (Gdx.input.isButtonJustPressed(Input.Buttons.RIGHT)) {
+            triangle1.rotate(90);
+            boolean overlaps = Intersector.overlapConvexPolygons(triangle1, triangle2, mtv);
+            Gdx.app.debug(TAG, mtv.normal + " " + mtv.depth + " overlaps: " + overlaps);
+        }
+    }
+
+    @Override
+    public void render() {
+        update(Gdx.graphics.getDeltaTime());
+        camera.update();
+        Gdx.gl.glClearColor(0f, 0f, 0f, 0f);
+        Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
+        shapeRenderer.setProjectionMatrix(camera.combined);
+        shapeRenderer.begin(ShapeRenderer.ShapeType.Line);
+        shapeRenderer.setColor(Color.GOLD);
+        shapeRenderer.polygon(triangle1.getTransformedVertices());
+        shapeRenderer.setColor(Color.CYAN);
+        shapeRenderer.polygon(triangle2.getTransformedVertices());
+        shapeRenderer.setColor(Color.RED);
+        shapeRenderer.line(mtv.normal.x, mtv.normal.y, mtv.normal.x * 10, mtv.normal.y * 10);
+        shapeRenderer.set(ShapeRenderer.ShapeType.Filled);
+        shapeRenderer.circle((mtv.normal.x), (mtv.normal.y), 0.5f);
+        shapeRenderer.end();
+    }
+}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/IntersectorOverlapConvexPolygonsTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/IntersectorOverlapConvexPolygonsTest.java
@@ -18,8 +18,8 @@ public class IntersectorOverlapConvexPolygonsTest extends GdxTest {
     private OrthographicCamera camera;
     private ShapeRenderer shapeRenderer;
 
-    private float shapeWidth = 10f;
-    private float shapeHeight = 10f;
+    private float shapeWidth = 1f;
+    private float shapeHeight = 1f;
     //the vertices of the 2 shapes. Feel free to play with the values. It must be a convex Polygon.
     private float[] vertsShape1 = {0f, 0f, shapeWidth, 0f, shapeWidth, shapeHeight};
     private float[] vertsShape2 = {0f, 0f, shapeWidth *2, 0f, shapeWidth *2, shapeHeight *2,0, shapeHeight};
@@ -38,18 +38,17 @@ public class IntersectorOverlapConvexPolygonsTest extends GdxTest {
         camera.setToOrtho(false);
         camera.position.set(0, 0, 0);
         shapeRenderer = new ShapeRenderer();
-        shapeRenderer.setAutoShapeType(true);
         //set inital position
         shape1.setVertices(vertsShape1);
         shape2.setVertices(vertsShape2);
         shape1.setPosition(0, 0);
-        shape2.setPosition(10, 0);
+        shape2.setPosition(1, 0);
     }
 
     @Override
     public void resize(int width, int height) {
-        camera.viewportWidth = 80;
-        camera.viewportHeight = 60;
+        camera.viewportWidth = 8;
+        camera.viewportHeight = 6;
     }
 
     private void update(float deltaTime) {
@@ -85,18 +84,15 @@ public class IntersectorOverlapConvexPolygonsTest extends GdxTest {
         shapeRenderer.polygon(shape1.getTransformedVertices());
         shapeRenderer.setColor(Color.CYAN);
         shapeRenderer.polygon(shape2.getTransformedVertices());
-        //Translate the axis to position 0/0 and show the direction as red line
+        //Show axis starting at position 0/0 in pointing direction
         shapeRenderer.setColor(Color.RED);
-        shapeRenderer.line(0, 0, (mtv.normal.x * 100)-mtv.normal.x, (mtv.normal.y * 100)-mtv.normal.y);
-        //Translate the axis to position 0/0 and show the opposite direction as dark red line
+        shapeRenderer.line(0, 0, mtv.normal.x * 100, mtv.normal.y * 100);
+        //Show axis starting at position 0/0 in opposite direction
         shapeRenderer.setColor(Color.DARK_GRAY);
-        shapeRenderer.line(0, 0, (mtv.normal.x * -100)-mtv.normal.x, (mtv.normal.y * -100)-mtv.normal.y);
-        //Translate the axis to position 0/0 and show the depth as green line
+        shapeRenderer.line(0, 0, mtv.normal.x * -100, mtv.normal.y * -100);
+        //Show depth on axis in pointing direction
         shapeRenderer.setColor(Color.GREEN);
-        shapeRenderer.line(0, 0, (mtv.normal.x * mtv.depth)-mtv.normal.x, (mtv.normal.y * mtv.depth)-mtv.normal.y);
-        shapeRenderer.set(ShapeRenderer.ShapeType.Filled);
-        //Show origin at 0,0 as green dot
-        shapeRenderer.circle(0, 0, 0.2f);
+        shapeRenderer.line(0, 0, mtv.normal.x * mtv.depth, mtv.normal.y * mtv.depth);
         shapeRenderer.end();
     }
 }

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
@@ -167,6 +167,7 @@ public class GdxTests {
 		InputTest.class,
 		IntegerBitmapFontTest.class,
 		InterpolationTest.class,
+		IntersectorOverlapConvexPolygonsTest.class,
 		InverseKinematicsTest.class,
 		IsometricTileTest.class,
 		KinematicBodyTest.class,


### PR DESCRIPTION
Hello everyone, this should fix #5048

Sorry for not adding a non graphical test but the magic happens in the SAT Algorithm. If you are familiar with the algorithm the placement and the orientation of the minimum translation vector happens on the one dimensional axis.
The magic happens when we project the axis of the max and min points of the polygon and based on the scalar value (dot product) of this values i calculate the direction of the minimum translation vector. You can see this with the red line in the graphical Test.

TL;DR i added no functional Test because of math magic. It is hard to predict the assert value so a graphical test with debug output says more than 1mio asserts.

Also you see in the code and in the graphical test i also handle edge cases like when one polygon contains another.