### PR TITLE
Fix sound and music not playing because of changed file names

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtFileHandle.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtFileHandle.java
@@ -56,6 +56,11 @@ public class GwtFileHandle extends FileHandle {
 		this.file = fixSlashes(path);
 	}
 
+	/** @return The full url to an asset, e.g. http://localhost:8080/assets/data/shotgun-e5f56587d6f025bff049632853ae4ff9.ogg */
+	public String getAssetUrl() {
+		return preloader.baseUrl + preloader.assetNames.get(file, file);
+	}
+
 	public String path () {
 		return file;
 	}

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/preloader/Preloader.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/preloader/Preloader.java
@@ -53,6 +53,7 @@ public class Preloader {
 	public ObjectMap<String, String> texts = new ObjectMap<String, String>();
 	public ObjectMap<String, Blob> binaries = new ObjectMap<String, Blob>();
 	private ObjectMap<String, Asset> stillToFetchAssets = new ObjectMap<String, Asset>();
+	public ObjectMap<String, String> assetNames = new ObjectMap<String, String>();
 
 	public static class Asset {
 		public Asset(String file, String url, AssetType type, long size, String mimeType) {
@@ -159,6 +160,7 @@ public class Preloader {
 						size = 0;
 					}
 					Asset asset = new Asset(assetPathOrig.trim(), assetPathMd5.trim(), type, size, assetMimeType);
+					assetNames.put(asset.file, asset.url);
                     if (assetPreload || asset.file.startsWith("com/badlogic/"))
                         assets.add(asset);
                     else

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/webaudio/WebAudioAPIManager.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/webaudio/WebAudioAPIManager.java
@@ -20,12 +20,10 @@ import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.LifecycleListener;
 import com.badlogic.gdx.audio.Music;
 import com.badlogic.gdx.audio.Sound;
-import com.badlogic.gdx.backends.gwt.GwtApplicationConfiguration;
+import com.badlogic.gdx.backends.gwt.GwtFileHandle;
 import com.badlogic.gdx.backends.gwt.preloader.AssetDownloader;
-import com.badlogic.gdx.backends.gwt.GwtApplication;
 import com.badlogic.gdx.files.FileHandle;
 import com.google.gwt.core.client.JavaScriptObject;
-import com.google.gwt.dom.client.CanvasElement;
 import com.google.gwt.media.client.Audio;
 import com.google.gwt.typedarrays.shared.ArrayBuffer;
 import com.google.gwt.typedarrays.shared.Int8Array;
@@ -163,7 +161,7 @@ public class WebAudioAPIManager implements LifecycleListener {
 	public Sound createSound (FileHandle fileHandle) {
 		final WebAudioAPISound newSound = new WebAudioAPISound(audioContext, globalVolumeNode, audioControlGraphPool);
 
-		String url = ((GwtApplication)Gdx.app).getBaseUrl() + fileHandle.path();
+		String url = ((GwtFileHandle) fileHandle).getAssetUrl();
 
 		XMLHttpRequest request = XMLHttpRequest.create();
 		request.setOnReadyStateChange(new ReadyStateChangeHandler() {
@@ -192,7 +190,7 @@ public class WebAudioAPIManager implements LifecycleListener {
 	}
 
 	public Music createMusic (FileHandle fileHandle) {
-		String url = ((GwtApplication)Gdx.app).getBaseUrl() + fileHandle.path();
+		String url = ((GwtFileHandle) fileHandle).getAssetUrl();
 
 		Audio audio = Audio.createIfSupported();
 		audio.setSrc(url);


### PR DESCRIPTION
With #4314 the file names contain the hash. This breaks the web audio implementation because it loaded the files with the original file names