### PR TITLE
Make Bresenham2 actually implement Bresenham's algorithm

### DIFF
--- a/gdx/src/com/badlogic/gdx/math/Bresenham2.java
+++ b/gdx/src/com/badlogic/gdx/math/Bresenham2.java
@@ -76,10 +76,11 @@ public class Bresenham2 {
 		}
 		if (h < 0)
 			dy1 = -1;
-		else if (h > 0) dy1 = 1;
+		else if (h > 0)
+			dy1 = 1;
 		int longest = Math.abs(w);
 		int shortest = Math.abs(h);
-		if (longest <= shortest) {
+		if (longest < shortest) {
 			longest = Math.abs(h);
 			shortest = Math.abs(w);
 			if (h < 0)
@@ -87,14 +88,16 @@ public class Bresenham2 {
 			else if (h > 0) dy2 = 1;
 			dx2 = 0;
 		}
-		int numerator = longest >> 1;
+		int shortest2 = shortest << 1;
+		int longest2 = longest << 1;
+		int numerator = 0;
 		for (int i = 0; i <= longest; i++) {
 			GridPoint2 point = pool.obtain();
 			point.set(startX, startY);
 			output.add(point);
-			numerator += shortest;
+			numerator += shortest2;
 			if (numerator > longest) {
-				numerator -= longest;
+				numerator -= longest2;
 				startX += dx1;
 				startY += dy1;
 			} else {

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/Bresenham2Test.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/Bresenham2Test.java
@@ -20,31 +20,92 @@ import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Pixmap;
-import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.Pixmap.Format;
+import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.math.Bresenham2;
 import com.badlogic.gdx.math.GridPoint2;
-import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.tests.utils.GdxTest;
+import com.badlogic.gdx.utils.Array;
 
 public class Bresenham2Test extends GdxTest {
 	SpriteBatch batch;
 	Texture result;
+	Pixmap pixmap;
+	Bresenham2 bresenham;
+	Array<GridPoint2> line;
+	int lastX;
+	int lastY;
+	
+	/**
+	 * If any of the green pixels this draws are still visible after Bresenham2's line is drawn,
+	 * then the implementation in Bresenham2 is wrong.
+	 * <br>
+	 * This is almost exactly taken from http://rosettacode.org/wiki/Bitmap/Bresenham%27s_line_algorithm#Java ;
+	 * only the Swing/AWT code was changed to use Pixmap here. The Rosetta Code version doesn't use
+	 * pooling for its points, so the algorithm in Bresenham2 should be more efficient, but this can
+	 * be used as a reference implementation that's probably been picked over and run many times.
+	 * @param x1 start x
+	 * @param y1 start y
+	 * @param x2 end x
+	 * @param y2 end y
+	 */
+	public void drawRosettaCodeLine(int x1, int y1, int x2, int y2){
+		pixmap.setColor(Color.GREEN);
+		
+		int d = 0;
+
+		int dx = Math.abs(x2 - x1);
+		int dy = Math.abs(y2 - y1);
+
+		int dx2 = 2 * dx; // slope scaling factors to
+		int dy2 = 2 * dy; // avoid floating point
+
+		int ix = x1 < x2 ? 1 : -1; // increment direction
+		int iy = y1 < y2 ? 1 : -1;
+
+		int x = x1;
+		int y = y1;
+
+		if (dx >= dy) {
+			while (true) {
+				pixmap.drawPixel(x, y);
+				if (x == x2)
+					break;
+				x += ix;
+				d += dy2;
+				if (d > dx) {
+					y += iy;
+					d -= dx2;
+				}
+			}
+		} else {
+			while (true) {
+				pixmap.drawPixel(x, y);
+				if (y == y2)
+					break;
+				y += iy;
+				d += dx2;
+				if (d > dy) {
+					x += ix;
+					d -= dy2;
+				}
+			}
+		}
+
+	}
 
 	@Override
 	public void create () {
-		Pixmap pixmap = new Pixmap(512, 512, Format.RGBA8888);
+		pixmap = new Pixmap(160, 120, Format.RGBA8888);
 		pixmap.setColor(Color.WHITE);
-
-		Bresenham2 bresenham = new Bresenham2();
-		for (GridPoint2 point : bresenham.line(0, 0, 512, 512))
-			pixmap.drawPixel(point.x, point.y);
-		for (GridPoint2 point : bresenham.line(512, 0, 0, 512))
-			pixmap.drawPixel(point.x, point.y);
-		for (GridPoint2 point : bresenham.line(0, 0, 512, 256))
-			pixmap.drawPixel(point.x, point.y);
-		for (GridPoint2 point : bresenham.line(512, 0, 0, 256))
+		
+		lastX = -1;
+		lastY = -1;
+		drawRosettaCodeLine(79, 59, 80, 60);
+		bresenham = new Bresenham2();
+		line = bresenham.line(79, 59, 80, 60);
+		for (GridPoint2 point : line)
 			pixmap.drawPixel(point.x, point.y);
 
 		result = new Texture(pixmap);
@@ -54,8 +115,21 @@ public class Bresenham2Test extends GdxTest {
 	@Override
 	public void render () {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		int x = Gdx.input.getX() >> 2, y = Gdx.input.getY() >> 2;
+		if((lastX != x || lastY != y) && x >= 0 && x < 160 && y >= 0 && y < 120) {
+			lastX = x;
+			lastY = y;
+			pixmap.setColor(Color.BLACK);
+			pixmap.fill();
+			drawRosettaCodeLine(79, 59, x, y);
+			pixmap.setColor(Color.WHITE);
+			line = bresenham.line(79, 59, x, y);
+			for (GridPoint2 point : line)
+				pixmap.drawPixel(point.x, point.y);
+			result.draw(pixmap, 0, 0);
+		}
 		batch.begin();
-		batch.draw(result, 0, 0);
+		batch.draw(result, 0, 0, 640, 480);
 		batch.end();
 	}
 }


### PR DESCRIPTION
Before, it implemented something else, and couldn't complete some common lines, like any 2-point diagonal line. The Bresenham2 test is now much more robust, and can be used to preview any line from the center of a 160x120 area to anywhere in that area. If green is ever visible in the test's line, that means there's some discrepancy between the actual algorithm and what Bresenham2 implements; so far I haven't seen any green and this can connect all lines. This fixes #5012 .