### PR TITLE
Gdx Setup minor Gradle fixes

### DIFF
--- a/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/core/build.gradle
+++ b/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/core/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: "%LANG%"
-
 sourceCompatibility = 1.7
 [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
 

--- a/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/desktop/build.gradle
+++ b/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/desktop/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: "%LANG%"
-
 sourceCompatibility = 1.7
 sourceSets.main.java.srcDirs = [ "src/" ]
 sourceSets.main.resources.srcDirs = ["../%ASSET_PATH%"]

--- a/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/desktop/build.gradle
+++ b/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/desktop/build.gradle
@@ -10,7 +10,7 @@ task run(dependsOn: classes, type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     standardInput = System.in
     workingDir = project.assetsDir
-    ignoreExitValue true
+    ignoreExitValue = true
 }
 
 task debug(dependsOn: classes, type: JavaExec) {
@@ -18,7 +18,7 @@ task debug(dependsOn: classes, type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     standardInput = System.in
     workingDir = project.assetsDir
-    ignoreExitValue true
+    ignoreExitValue = true
     debug = true
 }
 

--- a/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/desktop/build.gradle
+++ b/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/desktop/build.gradle
@@ -10,7 +10,7 @@ task run(dependsOn: classes, type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     standardInput = System.in
     workingDir = project.assetsDir
-    ignoreExitValue = true
+    ignoreExitValue true
 }
 
 task debug(dependsOn: classes, type: JavaExec) {
@@ -18,7 +18,7 @@ task debug(dependsOn: classes, type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     standardInput = System.in
     workingDir = project.assetsDir
-    ignoreExitValue = true
+    ignoreExitValue true
     debug = true
 }
 

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/Language.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/Language.java
@@ -1,7 +1,7 @@
 package com.badlogic.gdx.setup;
 
 public enum Language {
-	JAVA ("java", "", "", "", "java-library;java-library;android;java-library,robovm;java-library,gwt,war", true) ,
+	JAVA ("java", "", "", "", "java-library;java-library;com.android.application;java-library,robovm;java-library,gwt,war", true) ,
 	KOTLIN ("kotlin", "ext.kotlinVersion = '1.3.41'",
 			"classpath \"org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion\"", 
 			"api \"org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion\"",


### PR DESCRIPTION
A couple of minor improvements to the Gradle scripts generated by Gdx Setup.

1. On `core` and `desktop` modules, `build.gradle` generated scripts contained the line `apply plugin: "%LANG%"` which is unnecessary as this plugin is already defined per module on root `build.gradle`. Also, in the case of Java it was adding `apply plugin: java` instead of `apply plugin: java-library`.

2. Replaced deprecated `apply plugin: "android"` by `apply plugin: "com.android.application"`.