### PR TITLE
Update RoboVM to 2.3.10 stable version

### DIFF
--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/DependencyBank.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/DependencyBank.java
@@ -25,7 +25,7 @@ public class DependencyBank {
 	static String libgdxVersion = "1.9.11";
 	//Temporary snapshot version, we need a more dynamic solution for pointing to the latest nightly
 	static String libgdxNightlyVersion = "1.9.12-SNAPSHOT";
-	static String roboVMVersion = "2.3.10-SNAPSHOT";
+	static String roboVMVersion = "2.3.10";
 	static String buildToolsVersion = "29.0.2";
 	static String androidAPILevel = "29";
 	static String gwtVersion = "2.8.2";

--- a/fetch.xml
+++ b/fetch.xml
@@ -2,62 +2,20 @@
 <project name="fetch-natives" default="all">
 	<property name="domain" value="http://libgdx.badlogicgames.com/nightlies/dist"/>
 
-    <property name="robovm-snapshoturl" value="https://oss.sonatype.org/content/repositories/snapshots/com/mobidevelop/robovm"/>
-
     <property name="robovm" value="https://oss.sonatype.org/content/repositories/releases/com/mobidevelop/robovm"/>
 
-    <property name="robovm-version" value="2.3.10-SNAPSHOT"/>
+    <property name="robovm-version" value="2.3.10"/>
 
     <property name="lwjgl" value="https://oss.sonatype.org/content/repositories/releases/org/lwjgl"/>
     <property name="lwjgl-version" value="3.2.3"/>
-
-    <!--    Begin robovm snapshot hacks-->
-    <exec executable="/bin/bash" outputproperty="robovm-snapshot.cacerts">
-        <arg value="extractLatestSnapshot.sh"/>
-        <arg value="robovm-cacerts-full"/>
-        <arg value="${robovm-snapshoturl}/robovm-cacerts-full/${robovm-version}/"/>
-    </exec>
-
-    <exec executable="/bin/bash" outputproperty="robovm-snapshot.cocoatouch">
-        <arg value="extractLatestSnapshot.sh"/>
-        <arg value="robovm-cocoatouch"/>
-        <arg value="${robovm-snapshoturl}/robovm-cocoatouch/${robovm-version}/"/>
-    </exec>
-
-    <exec executable="/bin/bash" outputproperty="robovm-snapshot.objc">
-        <arg value="extractLatestSnapshot.sh"/>
-        <arg value="robovm-objc"/>
-        <arg value="${robovm-snapshoturl}/robovm-objc/${robovm-version}/"/>
-    </exec>
-
-    <exec executable="/bin/bash" outputproperty="robovm-snapshot.rt">
-        <arg value="extractLatestSnapshot.sh"/>
-        <arg value="robovm-rt"/>
-        <arg value="${robovm-snapshoturl}/robovm-rt/${robovm-version}/"/>
-    </exec>
-
-
-    <echo message="Robovm Snapshots extracted
-        ${line.separator}${robovm-snapshot.cacerts}
-        ${line.separator}${robovm-snapshot.cocoatouch}
-        ${line.separator}${robovm-snapshot.objc}
-        ${line.separator}${robovm-snapshot.rt}">
-    </echo>
-
+    
     <target name="fetch-robovm">
         <mkdir dir="backends/gdx-backend-robovm/libs/"/>
         <parallel>
-            <!--            Release-->
-            <!--            <get src="${robovm}/robovm-cacerts-full/${robovm-version}/robovm-cacerts-full-${robovm-version}.jar" dest="backends/gdx-backend-robovm/libs/robovm-cacerts-full.jar"/>-->
-            <!--            <get src="${robovm}/robovm-cocoatouch/${robovm-version}/robovm-cocoatouch-${robovm-version}.jar" dest="backends/gdx-backend-robovm/libs/robovm-cocoatouch.jar"/>-->
-            <!--            <get src="${robovm}/robovm-objc/${robovm-version}/robovm-objc-${robovm-version}.jar" dest="backends/gdx-backend-robovm/libs/robovm-objc.jar"/>-->
-            <!--            <get src="${robovm}/robovm-rt/${robovm-version}/robovm-rt-${robovm-version}.jar" dest="backends/gdx-backend-robovm/libs/robovm-rt.jar"/>-->
-
-            <!--            Snapshots-->
-            <get src="${robovm-snapshot.cacerts}" dest="backends/gdx-backend-robovm/libs/robovm-cacerts-full.jar"/>
-            <get src="${robovm-snapshot.cocoatouch}" dest="backends/gdx-backend-robovm/libs/robovm-cocoatouch.jar"/>
-            <get src="${robovm-snapshot.objc}" dest="backends/gdx-backend-robovm/libs/robovm-objc.jar"/>
-            <get src="${robovm-snapshot.rt}" dest="backends/gdx-backend-robovm/libs/robovm-rt.jar"/>
+            <get src="${robovm}/robovm-cacerts-full/${robovm-version}/robovm-cacerts-full-${robovm-version}.jar" dest="backends/gdx-backend-robovm/libs/robovm-cacerts-full.jar"/>
+            <get src="${robovm}/robovm-cocoatouch/${robovm-version}/robovm-cocoatouch-${robovm-version}.jar" dest="backends/gdx-backend-robovm/libs/robovm-cocoatouch.jar"/>
+            <get src="${robovm}/robovm-objc/${robovm-version}/robovm-objc-${robovm-version}.jar" dest="backends/gdx-backend-robovm/libs/robovm-objc.jar"/>
+            <get src="${robovm}/robovm-rt/${robovm-version}/robovm-rt-${robovm-version}.jar" dest="backends/gdx-backend-robovm/libs/robovm-rt.jar"/>
         </parallel>
     </target>
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -20,7 +20,7 @@ ext {
     testnatives = [:]
 }
 
-versions.robovm = "2.3.10-SNAPSHOT"
+versions.robovm = "2.3.10"
 versions.gwt = "2.8.2"
 versions.gwtPlugin = "1.0.9"
 versions.jglwf = "1.1"

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <gwt.version>2.8.2</gwt.version>
     <lwjgl.version>2.9.3</lwjgl.version>
     <lwjgl3.version>3.2.3</lwjgl3.version>
-    <robovm.version>2.3.10-SNAPSHOT</robovm.version>
+    <robovm.version>2.3.10</robovm.version>
   </properties>
 
   <modules>


### PR DESCRIPTION
Remove the temporary workaround to support RoboVM Snapshot versions and set version to 2.3.10.