### PR TITLE
GWT: Use Gretty for serving files in superdev mode

### DIFF
--- a/backends/gdx-backends-gwt/build.gradle
+++ b/backends/gdx-backends-gwt/build.gradle
@@ -18,4 +18,9 @@ dependencies {
     compile libraries.gwt
 }
 
+configurations.all {
+    // gwt-dev pulls in apache-jsp (Tomcat), but we don't need it and it messes with gretty
+    exclude group: 'org.eclipse.jetty', module: 'apache-jsp'
+}
+
 sourceSets.main.java.exclude "**/System.java"

--- a/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/html/build.gradle
+++ b/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/html/build.gradle
@@ -15,30 +15,39 @@ gwt {
 }
 
 import org.wisepersist.gradle.plugins.gwt.GwtSuperDev
+import org.akhikhl.gretty.AppBeforeIntegrationTestTask
 
-def HttpFileServer server = null
-def httpFilePort = 8080
+gretty.httpPort = 8080
+gretty.resourceBase = project.buildDir.path + "/gwt/draftOut"
+gretty.contextPath = "/"
+gretty.portPropertiesFileName = "TEMP_PORTS.properties"
 
 task startHttpServer () {
     dependsOn draftCompileGwt
 
-    String output = project.buildDir.path + "/gwt/draftOut"
-
-    doLast {
+    doFirst {
         copy {
             from "webapp"
-            into output
+            into gretty.resourceBase
         }
 
         copy {
             from "war"
-            into output
+            into gretty.resourceBase
         }
-
-        server = new SimpleHttpFileServerFactory().start(new File(output), httpFilePort)
-
-        println "Server started in directory " + server.getContentRoot() + ", http://localhost:" + server.getPort()
     }
+}
+
+task beforeRun(type: AppBeforeIntegrationTestTask, dependsOn: startHttpServer) {
+    // The next line allows ports to be reused instead of
+    // needing a process to be manually terminated.
+    file("build/TEMP_PORTS.properties").delete()
+    // Somewhat of a hack; uses Gretty's support for wrapping a task in
+    // a start and then stop of a Jetty server that serves files while
+    // also running the SuperDev code server.
+    integrationTestTask 'superDev'
+
+    interactive false
 }
 
 task superDev (type: GwtSuperDev) {
@@ -47,7 +56,6 @@ task superDev (type: GwtSuperDev) {
         gwt.modules = gwt.devModules
     }
 }
-
 
 task dist(dependsOn: [clean, compileGwt]) {
     doLast {

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/BuildScriptHelper.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/BuildScriptHelper.java
@@ -43,6 +43,7 @@ public class BuildScriptHelper {
 		write(wr, "dependencies {");
 		if (projects.contains(ProjectType.HTML)) {
 			write(wr, "classpath '" + DependencyBank.gwtPluginImport + "'");
+			write(wr, "classpath '" + DependencyBank.grettyPluginImport + "'");
 		}
 		if (projects.contains(ProjectType.ANDROID)) {
 			write(wr, "classpath '" + DependencyBank.androidPluginImport + "'");

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/DependencyBank.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/DependencyBank.java
@@ -40,7 +40,8 @@ public class DependencyBank {
 	static String libGDXReleaseUrl = "https://oss.sonatype.org/content/repositories/releases/";
 
 	//Project plugins
-	static String gwtPluginImport = "org.wisepersist:gwt-gradle-plugin:1.0.9";
+	static String gwtPluginImport = "org.wisepersist:gwt-gradle-plugin:1.0.13";
+	static String grettyPluginImport = "org.gretty:gretty:3.0.2";
 	static String androidPluginImport = "com.android.tools.build:gradle:3.4.1";
 	static String roboVMPluginImport = "com.mobidevelop.robovm:robovm-gradle-plugin:" + roboVMVersion;
 

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/Language.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/Language.java
@@ -1,7 +1,7 @@
 package com.badlogic.gdx.setup;
 
 public enum Language {
-	JAVA ("java", "", "", "", "java-library;java-library;com.android.application;java-library,robovm;java-library,gwt,war", true) ,
+	JAVA ("java", "", "", "", "java-library;java-library;com.android.application;java-library,robovm;java-library,gwt,war,org.gretty", true) ,
 	KOTLIN ("kotlin", "ext.kotlinVersion = '1.3.41'",
 			"classpath \"org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion\"", 
 			"api \"org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion\"",

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -23,6 +23,7 @@ ext {
 versions.robovm = "2.3.10"
 versions.gwt = "2.8.2"
 versions.gwtPlugin = "1.0.9"
+versions.gretty = "3.0.2"
 versions.jglwf = "1.1"
 versions.lwjgl = "2.9.3"
 versions.lwjgl3 = "3.2.3"

--- a/tests/gdx-tests-gwt/build.gradle
+++ b/tests/gdx-tests-gwt/build.gradle
@@ -17,16 +17,21 @@
 buildscript {
     dependencies {
         classpath "org.wisepersist:gwt-gradle-plugin:${versions.gwtPlugin}"
+        classpath "org.gretty:gretty:${versions.gretty}"
     }
 }
 
 apply plugin: 'war'
 apply plugin: 'gwt'
+apply plugin: 'org.gretty'
 
 import org.wisepersist.gradle.plugins.gwt.GwtSuperDev
+import org.akhikhl.gretty.AppBeforeIntegrationTestTask
 
-def HttpFileServer server = null
-def httpFilePort = 8080
+gretty.httpPort = 8080
+gretty.resourceBase = project.buildDir.path + "/gwt/draftOut"
+gretty.contextPath = "/"
+gretty.portPropertiesFileName = "TEMP_PORTS.properties"
 
 dependencies {
     compile project(":tests:gdx-tests")
@@ -51,23 +56,29 @@ gwt {
 task startHttpServer () {
     dependsOn draftCompileGwt
 
-    String output = project.buildDir.path + "/gwt/draftOut"
-
-    doLast {
+    doFirst {
         copy {
             from "webapp"
-            into output
+            into gretty.resourceBase
         }
 
         copy {
             from "war"
-            into output
+            into gretty.resourceBase
         }
-
-        server = new SimpleHttpFileServerFactory().start(new File(output), httpFilePort)
-
-        println "Server started in directory " + server.getContentRoot() + ", http://localhost:" + server.getPort()
     }
+}
+
+task beforeRun(type: AppBeforeIntegrationTestTask, dependsOn: startHttpServer) {
+    // The next line allows ports to be reused instead of
+    // needing a process to be manually terminated.
+    file("build/TEMP_PORTS.properties").delete()
+    // Somewhat of a hack; uses Gretty's support for wrapping a task in
+    // a start and then stop of a Jetty server that serves files while
+    // also running the SuperDev code server.
+    integrationTestTask 'superDev'
+
+    interactive false
 }
 
 task superDev (type: GwtSuperDev) {


### PR DESCRIPTION
Since Jetty plugin was removed, we use Gradle's SimpleFileHttpServer to serve the assets in superdev mode.

This has unfortunately some drawbacks:
* Files without extension aren't served, causing older projects (including our test project) to fail in superdev mode
* The server is not killed when super dev process is stopped, so task manager has to be your regular friend while developing
* SimpileFileServer is very simple (hence the name) and does not support caching or default file mechanisms

This PR changes our tests and the template project to use Gretty (Gradle Jetty Plugin), as we used Jetty before. The problems listed above are fixed with this.

I know from the history @Tom-Ski tried to integrate Gretty before, but eventually removed it. I suppose it was because Gretty fails to run out of the box in our environment. This is because gwt-dev pulls in at least some parts of Tomcat causing conflicts. This can be avoided by adding an exclusion on the gwt backend project, which I did.