### PR TITLE
Lwjgl backends call correct LWJGL function for vectorized input

### DIFF
--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGL30.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGL30.java
@@ -480,7 +480,7 @@ class LwjglGL30 extends LwjglGL20 implements com.badlogic.gdx.graphics.GL30 {
 
 	@Override
 	public void glGetActiveUniformBlockiv (int program, int uniformBlockIndex, int pname, IntBuffer params) {
-		params.put(GL31.glGetActiveUniformBlocki(program, uniformBlockIndex, pname));
+		GL31.glGetActiveUniformBlock(program, uniformBlockIndex, pname, params);
 	}
 
 	@Override

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3GL30.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3GL30.java
@@ -482,7 +482,7 @@ class Lwjgl3GL30 extends Lwjgl3GL20 implements com.badlogic.gdx.graphics.GL30 {
 
 	@Override
 	public void glGetActiveUniformBlockiv (int program, int uniformBlockIndex, int pname, IntBuffer params) {
-		params.put(GL31.glGetActiveUniformBlocki(program, uniformBlockIndex, pname));
+		GL31.glGetActiveUniformBlockiv(program, uniformBlockIndex, pname, params);
 	}
 
 	@Override


### PR DESCRIPTION
Related Issue https://github.com/libgdx/libgdx/issues/6203

glGetActiveUniformiv was calling the `i` (single output) version at all times. I swapped the function calls for the vectorized version.

I've tested the Lwjgl3 backend and it works.
Haven't tried the Lwjgl2 backend yet (but I would assume it's fine)