### PR TITLE
ShaderProvider extends Disposable

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g3d/utils/ShaderProvider.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/utils/ShaderProvider.java
@@ -16,21 +16,18 @@
 
 package com.badlogic.gdx.graphics.g3d.utils;
 
-import com.badlogic.gdx.graphics.g3d.Material;
 import com.badlogic.gdx.graphics.g3d.Renderable;
 import com.badlogic.gdx.graphics.g3d.Shader;
-import com.badlogic.gdx.graphics.glutils.ShaderProgram;
+import com.badlogic.gdx.utils.Disposable;
 
 /** Returns {@link Shader} instances for a {@link Renderable} on request. Also responsible for disposing of any created
- * {@link ShaderProgram} instances on a call to {@link #dispose()}.
+ * {@link Shader} instances on a call to {@link Disposable#dispose()}.
  * @author badlogic */
-public interface ShaderProvider {
+public interface ShaderProvider extends Disposable {
 	/** Returns a {@link Shader} for the given {@link Renderable}. The RenderInstance may already contain a Shader, in which case
 	 * the provider may decide to return that.
 	 * @param renderable the Renderable
 	 * @return the Shader to be used for the RenderInstance */
 	Shader getShader (Renderable renderable);
 
-	/** Disposes all resources created by the provider */
-	public void dispose ();
 }


### PR DESCRIPTION
Since `ShaderProvider` interface does already contain declaration of the `public void dispose()`, it makes sense to allow working with these instances same as with `Disposable` ones.

Also, `import` declarations, which are never used, have been removed here.