### PR TITLE
Add method to calculate intersection point between three planes

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -47,6 +47,7 @@
 - API Change: Table#round uses ceil/floor and is applied during layout, rather than afterward.
 - Fixed blurry NinePatch rendering when using a single center region.
 - API Change: Upon changing the window size with the lwjgl3 backend, the window is centered on the monitor.
+- Added Intersector#intersectPlanes to calculate the point intersected by three planes
 
 [1.9.11]
 - Update to MobiVM 2.3.8

--- a/CHANGES
+++ b/CHANGES
@@ -47,7 +47,7 @@
 - API Change: Table#round uses ceil/floor and is applied during layout, rather than afterward.
 - Fixed blurry NinePatch rendering when using a single center region.
 - API Change: Upon changing the window size with the lwjgl3 backend, the window is centered on the monitor.
-- Added Intersector#intersectPlanes to calculate the point intersected by three planes
+- Added Intersector#intersectPlanes to calculate the point intersected by three planes, see https://github.com/libgdx/libgdx/pull/6217
 
 [1.9.11]
 - Update to MobiVM 2.3.8

--- a/gdx/src/com/badlogic/gdx/math/Intersector.java
+++ b/gdx/src/com/badlogic/gdx/math/Intersector.java
@@ -408,8 +408,7 @@ public final class Intersector {
 	}
 
 	/**
-	 * Code from MonoGame.BoundingFrustum.IntersectionPoint (MIT License)
-	 * https://github.com/MonoGame/MonoGame/blob/master/MonoGame.Framework/BoundingFrustum.cs#L529
+	 * Intersect three {@link Plane}, returning the intersection point in intersection if any.
 	 *
 	 * @param a The plane a
 	 * @param b The plane b

--- a/gdx/src/com/badlogic/gdx/math/Intersector.java
+++ b/gdx/src/com/badlogic/gdx/math/Intersector.java
@@ -407,15 +407,8 @@ public final class Intersector {
 		return -1;
 	}
 
-	/**
-	 * Intersect three {@link Plane}, returning the intersection point in intersection if any.
-	 *
-	 * @param a The plane a
-	 * @param b The plane b
-	 * @param c The plane c
-	 * @param intersection The point where the three planes intersect
-	 * @return Whether an intersection point exists.
-	 */
+	/** Returns true if the three {@link Plane planes} intersect, setting the point of intersection in {@code intersection}, if any.
+	 * @param intersection The point where the three planes intersect */
 	public static boolean intersectPlanes (Plane a, Plane b, Plane c, Vector3 intersection) {
 		tmp1.set(a.normal).crs(b.normal);
 		tmp2.set(b.normal).crs(c.normal);

--- a/gdx/src/com/badlogic/gdx/math/Intersector.java
+++ b/gdx/src/com/badlogic/gdx/math/Intersector.java
@@ -408,35 +408,30 @@ public final class Intersector {
 	}
 
 	/**
-	 * Code from MonoGame.BoundingFrustum.IntersectionPoint
+	 * Code from MonoGame.BoundingFrustum.IntersectionPoint (MIT License)
 	 * https://github.com/MonoGame/MonoGame/blob/master/MonoGame.Framework/BoundingFrustum.cs#L529
 	 *
 	 * @param a The plane a
 	 * @param b The plane b
 	 * @param c The plane c
 	 * @param intersection The point where the three planes intersect
-	 * @return Whether an intersection is present.
+	 * @return Whether an intersection point exists.
 	 */
 	public static boolean intersectPlanes (Plane a, Plane b, Plane c, Vector3 intersection) {
-		tmp1.set(a.normal);
-		tmp1.crs(b.normal);
-
-		tmp2.set(b.normal);
-		tmp2.crs(c.normal);
-
-		tmp3.set(c.normal);
-		tmp3.crs(a.normal);
+		tmp1.set(a.normal).crs(b.normal);
+		tmp2.set(b.normal).crs(c.normal);
+		tmp3.set(c.normal).crs(a.normal);
 
 		float f = -a.normal.dot(tmp2);
 		if (Math.abs(f) < MathUtils.FLOAT_ROUNDING_ERROR) {
 			return false;
 		}
 
-		Vector3 v1 = (tmp2.scl(a.d));
-		Vector3 v2 = (tmp3.scl(b.d));
-		Vector3 v3 = (tmp1.scl(c.d));
+		tmp1.scl(c.d);
+		tmp2.scl(a.d);
+		tmp3.scl(b.d);
 
-		intersection.set(v1.x + v2.x + v3.x, v1.y + v2.y + v3.y, v1.z + v2.z + v3.z);
+		intersection.set(tmp1.x + tmp2.x + tmp3.x, tmp1.y + tmp2.y + tmp3.y, tmp1.z + tmp2.z + tmp3.z);
 		intersection.scl(1 / f);
 		return true;
 	}

--- a/gdx/src/com/badlogic/gdx/math/Intersector.java
+++ b/gdx/src/com/badlogic/gdx/math/Intersector.java
@@ -407,6 +407,40 @@ public final class Intersector {
 		return -1;
 	}
 
+	/**
+	 * Code from MonoGame.BoundingFrustum.IntersectionPoint
+	 * https://github.com/MonoGame/MonoGame/blob/master/MonoGame.Framework/BoundingFrustum.cs#L529
+	 *
+	 * @param a The plane a
+	 * @param b The plane b
+	 * @param c The plane c
+	 * @param intersection The point where the three planes intersect
+	 * @return Whether an intersection is present.
+	 */
+	public static boolean intersectPlanes (Plane a, Plane b, Plane c, Vector3 intersection) {
+		tmp1.set(a.normal);
+		tmp1.crs(b.normal);
+
+		tmp2.set(b.normal);
+		tmp2.crs(c.normal);
+
+		tmp3.set(c.normal);
+		tmp3.crs(a.normal);
+
+		float f = -a.normal.dot(tmp2);
+		if (Math.abs(f) < MathUtils.FLOAT_ROUNDING_ERROR) {
+			return false;
+		}
+
+		Vector3 v1 = (tmp2.scl(a.d));
+		Vector3 v2 = (tmp3.scl(b.d));
+		Vector3 v3 = (tmp1.scl(c.d));
+
+		intersection.set(v1.x + v2.x + v3.x, v1.y + v2.y + v3.y, v1.z + v2.z + v3.z);
+		intersection.scl(1 / f);
+		return true;
+	}
+
 	private static final Plane p = new Plane(new Vector3(), 0);
 	private static final Vector3 i = new Vector3();
 

--- a/gdx/test/com/badlogic/gdx/math/IntersectorTest.java
+++ b/gdx/test/com/badlogic/gdx/math/IntersectorTest.java
@@ -5,6 +5,7 @@ import com.badlogic.gdx.math.Intersector.SplitTriangle;
 
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -138,5 +139,51 @@ public class IntersectorTest {
 		assertTrue(intersects);
 		assertTrue(mtv.normal.equals(new Vector2(0, 1f)) || mtv.normal.equals(new Vector2(0f, -1f)));
 		assertTrue(mtv.depth == 4f);
+	}
+
+	@Test
+	public void testIntersectPlanes () {
+		final int NEAR = 0;
+		final int FAR = 1;
+		final int LEFT = 2;
+		final int RIGHT = 3;
+		final int TOP = 4;
+		final int BOTTOM = 5;
+
+		/*camera = new PerspectiveCamera(60, 1280, 720);
+		camera.direction.set(0, 0, 1);
+		camera.near = 0.1f;
+		camera.far = 100f;
+		camera.update();
+		Plane[] planes = camera.frustum.planes;*/
+
+		Plane[] planes = new Plane[6];
+		planes[NEAR] = new Plane(new Vector3(0.0f,0.0f,1.0f), -0.1f);
+		planes[FAR] = new Plane(new Vector3(0.0f,-0.0f,-1.0f), 99.99771f);
+		planes[LEFT] = new Plane(new Vector3(-0.69783056f,0.0f,0.71626294f), -9.3877316E-7f);
+		planes[RIGHT] = new Plane(new Vector3(0.6978352f,0.0f,0.71625835f), -0.0f);
+		planes[TOP] = new Plane(new Vector3(0.0f,-0.86602545f,0.5f), -0.0f);
+		planes[BOTTOM] = new Plane(new Vector3(-0.0f,0.86602545f,0.5f), -0.0f);
+
+		Vector3 intersection = new Vector3();
+		Intersector.intersectPlanes(planes[TOP], planes[FAR], planes[LEFT], intersection);
+		assertEquals(102.63903f, intersection.x, 0.1f);
+		assertEquals(57.7337f, intersection.y, 0.1f);
+		assertEquals(100, intersection.z, 0.1f);
+
+		Intersector.intersectPlanes(planes[TOP], planes[FAR], planes[RIGHT], intersection);
+		assertEquals(-102.63903f, intersection.x, 0.1f);
+		assertEquals(57.7337f, intersection.y, 0.1f);
+		assertEquals(100, intersection.z, 0.1f);
+
+		Intersector.intersectPlanes(planes[BOTTOM], planes[FAR], planes[LEFT], intersection);
+		assertEquals(102.63903f, intersection.x, 0.1f);
+		assertEquals(-57.7337f, intersection.y, 0.1f);
+		assertEquals(100, intersection.z, 0.1f);
+
+		Intersector.intersectPlanes(planes[BOTTOM], planes[FAR], planes[RIGHT], intersection);
+		assertEquals(-102.63903f, intersection.x, 0.1f);
+		assertEquals(-57.7337f, intersection.y, 0.1f);
+		assertEquals(100, intersection.z, 0.1f);
 	}
 }

--- a/gdx/test/com/badlogic/gdx/math/IntersectorTest.java
+++ b/gdx/test/com/badlogic/gdx/math/IntersectorTest.java
@@ -156,7 +156,6 @@ public class IntersectorTest {
 		camera.far = 100f;
 		camera.update();
 		Plane[] planes = camera.frustum.planes;*/
-
 		Plane[] planes = new Plane[6];
 		planes[NEAR] = new Plane(new Vector3(0.0f,0.0f,1.0f), -0.1f);
 		planes[FAR] = new Plane(new Vector3(0.0f,-0.0f,-1.0f), 99.99771f);


### PR DESCRIPTION
This PR simply adds a method to calculate the intersection point between three planes.

Returns false if there is no intersection or the intersection is not a point.
Returns true if there is an intersection point.

This post might help to illustrate the math behind it: http://geomalgorithms.com/a05-_intersect-1.html

I need this code (among other reasons) to prove with images that the PR #6086 is not breaking anything and is doing the same calculation as before.

**Tags**
- Non breaking changes
- Math

Closes #6214 