### PR TITLE
Added Input:setCursorHidden(). Resolves #5546

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/DefaultAndroidInput.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/DefaultAndroidInput.java
@@ -940,6 +940,16 @@ public class DefaultAndroidInput implements AndroidInput {
 	public boolean isCursorCatched () {
 		return false;
 	}
+    
+    @Override
+    public void setCursorHidden (boolean hidden) {
+    
+    }
+    
+    @Override
+    public boolean isCursorHidden () {
+        return false;
+    }
 
 	@Override
 	public int getDeltaX () {

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/DefaultAndroidInput.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/DefaultAndroidInput.java
@@ -940,16 +940,16 @@ public class DefaultAndroidInput implements AndroidInput {
 	public boolean isCursorCatched () {
 		return false;
 	}
-    
-    @Override
-    public void setCursorHidden (boolean hidden) {
-    
-    }
-    
-    @Override
-    public boolean isCursorHidden () {
-        return false;
-    }
+
+	@Override
+	public void setCursorHidden (boolean hidden) {
+
+	}
+
+	@Override
+	public boolean isCursorHidden () {
+		return false;
+	}
 
 	@Override
 	public int getDeltaX () {

--- a/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/mock/input/MockInput.java
+++ b/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/mock/input/MockInput.java
@@ -264,6 +264,16 @@ public class MockInput implements Input {
 	public boolean isCursorCatched() {
 		return false;
 	}
+    
+    @Override
+    public void setCursorHidden (boolean hidden) {
+    
+    }
+    
+    @Override
+    public boolean isCursorHidden () {
+        return false;
+    }
 
 	@Override
 	public void setCursorPosition(int x, int y) {

--- a/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/mock/input/MockInput.java
+++ b/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/mock/input/MockInput.java
@@ -264,16 +264,16 @@ public class MockInput implements Input {
 	public boolean isCursorCatched() {
 		return false;
 	}
-    
-    @Override
-    public void setCursorHidden (boolean hidden) {
-    
-    }
-    
-    @Override
-    public boolean isCursorHidden () {
-        return false;
-    }
+
+	@Override
+	public void setCursorHidden (boolean hidden) {
+
+	}
+
+	@Override
+	public boolean isCursorHidden () {
+		return false;
+	}
 
 	@Override
 	public void setCursorPosition(int x, int y) {

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/DefaultLwjglInput.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/DefaultLwjglInput.java
@@ -1054,6 +1054,16 @@ final public class DefaultLwjglInput implements LwjglInput {
 	public boolean isCursorCatched () {
 		return Mouse.isGrabbed();
 	}
+    
+    @Override
+    public void setCursorHidden (boolean hidden) {
+    
+    }
+    
+    @Override
+    public boolean isCursorHidden () {
+        return false;
+    }
 
 	@Override
 	public int getDeltaX () {

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/DefaultLwjglInput.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/DefaultLwjglInput.java
@@ -1054,16 +1054,16 @@ final public class DefaultLwjglInput implements LwjglInput {
 	public boolean isCursorCatched () {
 		return Mouse.isGrabbed();
 	}
-    
-    @Override
-    public void setCursorHidden (boolean hidden) {
-    
-    }
-    
-    @Override
-    public boolean isCursorHidden () {
-        return false;
-    }
+
+	@Override
+	public void setCursorHidden (boolean hidden) {
+
+	}
+
+	@Override
+	public boolean isCursorHidden () {
+	return false;
+	}
 
 	@Override
 	public int getDeltaX () {

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglAWTInput.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglAWTInput.java
@@ -916,6 +916,16 @@ public class LwjglAWTInput implements Input, MouseMotionListener, MouseListener,
 	public boolean isCursorCatched () {
 		return catched;
 	}
+    
+    @Override
+    public void setCursorHidden (boolean hidden) {
+        setCursorCatched(hidden);
+    }
+    
+    @Override
+    public boolean isCursorHidden () {
+        return isCursorCatched();
+    }
 
 	@Override
 	public int getDeltaX () {

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglAWTInput.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglAWTInput.java
@@ -916,16 +916,16 @@ public class LwjglAWTInput implements Input, MouseMotionListener, MouseListener,
 	public boolean isCursorCatched () {
 		return catched;
 	}
-    
-    @Override
-    public void setCursorHidden (boolean hidden) {
-        setCursorCatched(hidden);
-    }
-    
-    @Override
-    public boolean isCursorHidden () {
-        return isCursorCatched();
-    }
+
+	@Override
+	public void setCursorHidden (boolean hidden) {
+	setCursorCatched(hidden);
+	}
+
+	@Override
+	public boolean isCursorHidden () {
+	return isCursorCatched();
+	}
 
 	@Override
 	public int getDeltaX () {

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/DefaultLwjgl3Input.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/DefaultLwjgl3Input.java
@@ -366,16 +366,16 @@ public class DefaultLwjgl3Input implements Lwjgl3Input {
 	public boolean isCursorCatched() {
 		return GLFW.glfwGetInputMode(window.getWindowHandle(), GLFW.GLFW_CURSOR) == GLFW.GLFW_CURSOR_DISABLED;
 	}
-    
-    @Override
-    public void setCursorHidden(boolean hidden) {
-        GLFW.glfwSetInputMode(window.getWindowHandle(), GLFW.GLFW_CURSOR, hidden ? GLFW.GLFW_CURSOR_HIDDEN : GLFW.GLFW_CURSOR_NORMAL);
-    }
-    
-    @Override
-    public boolean isCursorHidden() {
-        return GLFW.glfwGetInputMode(window.getWindowHandle(), GLFW.GLFW_CURSOR) == GLFW.GLFW_CURSOR_HIDDEN;
-    }
+
+	@Override
+	public void setCursorHidden(boolean hidden) {
+		GLFW.glfwSetInputMode(window.getWindowHandle(), GLFW.GLFW_CURSOR, hidden ? GLFW.GLFW_CURSOR_HIDDEN : GLFW.GLFW_CURSOR_NORMAL);
+	}
+
+	@Override
+	public boolean isCursorHidden() {
+		return GLFW.glfwGetInputMode(window.getWindowHandle(), GLFW.GLFW_CURSOR) == GLFW.GLFW_CURSOR_HIDDEN;
+	}
 
 	@Override
 	public void setCursorPosition(int x, int y) {

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/DefaultLwjgl3Input.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/DefaultLwjgl3Input.java
@@ -366,6 +366,16 @@ public class DefaultLwjgl3Input implements Lwjgl3Input {
 	public boolean isCursorCatched() {
 		return GLFW.glfwGetInputMode(window.getWindowHandle(), GLFW.GLFW_CURSOR) == GLFW.GLFW_CURSOR_DISABLED;
 	}
+    
+    @Override
+    public void setCursorHidden(boolean hidden) {
+        GLFW.glfwSetInputMode(window.getWindowHandle(), GLFW.GLFW_CURSOR, hidden ? GLFW.GLFW_CURSOR_HIDDEN : GLFW.GLFW_CURSOR_NORMAL);
+    }
+    
+    @Override
+    public boolean isCursorHidden() {
+        return GLFW.glfwGetInputMode(window.getWindowHandle(), GLFW.GLFW_CURSOR) == GLFW.GLFW_CURSOR_HIDDEN;
+    }
 
 	@Override
 	public void setCursorPosition(int x, int y) {

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/DefaultIOSInput.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/DefaultIOSInput.java
@@ -640,16 +640,16 @@ public class DefaultIOSInput implements IOSInput {
 	public boolean isCursorCatched () {
 		return false;
 	}
-    
-    @Override
-    public void setCursorHidden (boolean hidden) {
-    
-    }
-    
-    @Override
-    public boolean isCursorHidden () {
-        return false;
-    }
+
+	@Override
+	public void setCursorHidden (boolean hidden) {
+
+	}
+
+	@Override
+	public boolean isCursorHidden () {
+		return false;
+	}
 
 	@Override
 	public void setCursorPosition (int x, int y) {

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/DefaultIOSInput.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/DefaultIOSInput.java
@@ -640,6 +640,16 @@ public class DefaultIOSInput implements IOSInput {
 	public boolean isCursorCatched () {
 		return false;
 	}
+    
+    @Override
+    public void setCursorHidden (boolean hidden) {
+    
+    }
+    
+    @Override
+    public boolean isCursorHidden () {
+        return false;
+    }
 
 	@Override
 	public void setCursorPosition (int x, int y) {

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/DefaultGwtInput.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/DefaultGwtInput.java
@@ -533,6 +533,16 @@ public class DefaultGwtInput implements GwtInput {
 	public boolean isCursorCatched () {
 		return isCursorCatchedJSNI(canvas);
 	}
+    
+    @Override
+    public void setCursorHidden (boolean hidden) {
+        setCursorCatched(hidden);
+    }
+    
+    @Override
+    public boolean isCursorHidden () {
+        return isCursorCatched();
+    }
 
 	@Override
 	public void setCursorPosition (int x, int y) {

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/DefaultGwtInput.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/DefaultGwtInput.java
@@ -533,16 +533,16 @@ public class DefaultGwtInput implements GwtInput {
 	public boolean isCursorCatched () {
 		return isCursorCatchedJSNI(canvas);
 	}
-    
-    @Override
-    public void setCursorHidden (boolean hidden) {
-        setCursorCatched(hidden);
-    }
-    
-    @Override
-    public boolean isCursorHidden () {
-        return isCursorCatched();
-    }
+
+	@Override
+	public void setCursorHidden (boolean hidden) {
+		setCursorCatched(hidden);
+	}
+
+	@Override
+	public boolean isCursorHidden () {
+		return isCursorCatched();
+	}
 
 	@Override
 	public void setCursorPosition (int x, int y) {

--- a/gdx/src/com/badlogic/gdx/Input.java
+++ b/gdx/src/com/badlogic/gdx/Input.java
@@ -818,6 +818,14 @@ public interface Input {
 
 	/** @return whether the mouse cursor is catched. */
 	public boolean isCursorCatched ();
+    
+    /** Only viable on the LWJGL3 backend. Will hide the mouse cursor, however the mouse cursor will not be confined to
+     * the window.
+     * @param hidden whether to hide or not to hide the mouse cursor */
+    public void setCursorHidden (boolean hidden);
+    
+    /** @return whether the mouse cursor is hidden. */
+    public boolean isCursorHidden ();
 
 	/** Only viable on the desktop. Will set the mouse cursor location to the given window coordinates (origin top-left corner).
 	 * @param x the x-position

--- a/gdx/src/com/badlogic/gdx/Input.java
+++ b/gdx/src/com/badlogic/gdx/Input.java
@@ -818,14 +818,14 @@ public interface Input {
 
 	/** @return whether the mouse cursor is catched. */
 	public boolean isCursorCatched ();
-    
-    /** Only viable on the LWJGL3 backend. Will hide the mouse cursor, however the mouse cursor will not be confined to
-     * the window.
-     * @param hidden whether to hide or not to hide the mouse cursor */
-    public void setCursorHidden (boolean hidden);
-    
-    /** @return whether the mouse cursor is hidden. */
-    public boolean isCursorHidden ();
+
+	/** Only viable on the LWJGL3 backend. Will hide the mouse cursor, however the mouse cursor will not be confined to
+	 * the window.
+	 * @param hidden whether to hide or not to hide the mouse cursor */
+	public void setCursorHidden (boolean hidden);
+
+	/** @return whether the mouse cursor is hidden. */
+	public boolean isCursorHidden ();
 
 	/** Only viable on the desktop. Will set the mouse cursor location to the given window coordinates (origin top-left corner).
 	 * @param x the x-position

--- a/gdx/src/com/badlogic/gdx/input/RemoteInput.java
+++ b/gdx/src/com/badlogic/gdx/input/RemoteInput.java
@@ -559,6 +559,16 @@ public class RemoteInput implements Runnable, Input {
 	public boolean isCursorCatched () {
 		return false;
 	}
+    
+    @Override
+    public void setCursorHidden (boolean hidden) {
+    
+    }
+    
+    @Override
+    public boolean isCursorHidden () {
+        return false;
+    }
 
 	@Override
 	public int getDeltaX () {

--- a/gdx/src/com/badlogic/gdx/input/RemoteInput.java
+++ b/gdx/src/com/badlogic/gdx/input/RemoteInput.java
@@ -559,16 +559,16 @@ public class RemoteInput implements Runnable, Input {
 	public boolean isCursorCatched () {
 		return false;
 	}
-    
-    @Override
-    public void setCursorHidden (boolean hidden) {
-    
-    }
-    
-    @Override
-    public boolean isCursorHidden () {
-        return false;
-    }
+
+	@Override
+	public void setCursorHidden (boolean hidden) {
+
+	}
+
+	@Override
+	public boolean isCursorHidden () {
+		return false;
+	}
 
 	@Override
 	public int getDeltaX () {

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtTestWrapper.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtTestWrapper.java
@@ -405,16 +405,16 @@ public class GwtTestWrapper extends GdxTest {
 		public boolean isCursorCatched () {
 			return input.isCursorCatched();
 		}
-        
-        @Override
-        public void setCursorHidden (boolean hidden) {
-            input.setCursorHidden(hidden);
-        }
-        
-        @Override
-        public boolean isCursorHidden () {
-            return input.isCursorHidden();
-        }
+
+		@Override
+		public void setCursorHidden (boolean hidden) {
+			input.setCursorHidden(hidden);
+		}
+
+		@Override
+		public boolean isCursorHidden () {
+			return input.isCursorHidden();
+		}
 
 		@Override
 		public void setCursorPosition (int x, int y) {

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtTestWrapper.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtTestWrapper.java
@@ -405,6 +405,16 @@ public class GwtTestWrapper extends GdxTest {
 		public boolean isCursorCatched () {
 			return input.isCursorCatched();
 		}
+        
+        @Override
+        public void setCursorHidden (boolean hidden) {
+            input.setCursorHidden(hidden);
+        }
+        
+        @Override
+        public boolean isCursorHidden () {
+            return input.isCursorHidden();
+        }
 
 		@Override
 		public void setCursorPosition (int x, int y) {


### PR DESCRIPTION
Please see #5546. Catching the cursor and hiding the cursor are two separate goals. Catching cursor makes the cursor invisible _and_ keeps the cursor locked to the window. Hiding the cursor will only make the cursor invisible and not restrict the positioning of the mouse. There are use cases for this such as rendering animated mouse cursors in game.

The previous technique to hide the mouse (and the technique that is still valid for LWJGL2) is to set the cursor to a completely transparent image. This does not work on LWJGL3 per the mentioned issue (verified on Windows 10). The modern technique is to use `GLFW.GLFW_CURSOR_HIDDEN` which has no such issues.

I have implemented this feature with `Gdx.input.setCursorHidden(true)`. I am somewhat at odds with myself in regards to adding to the Input interface. This is really only applicable to LWJGL3, but the option would be visible on all platforms. However, there is precedent with this considering `setCursorCatched()`. I do not want to add it as a configuration option because users may want to Hide/Unhide during runtime. Adding the method to Input will allow others in the future to emulate the behavior on other platforms if they see fit.