### PR TITLE
Fixed TextField tab traversal on HTML5.

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextField.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextField.java
@@ -886,7 +886,10 @@ public class TextField extends Widget implements Disableable {
 
 			if (!hasKeyboardFocus()) return false;
 
-			if (checkFocusTraversal(keycode)) next(UIUtils.shift());
+			if (checkFocusTraversal(keycode)) {
+				next(UIUtils.shift());
+				return true;
+			}
 			
 			boolean repeat = false;
 			boolean ctrl = UIUtils.ctrl();

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextField.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextField.java
@@ -885,8 +885,8 @@ public class TextField extends Widget implements Disableable {
 			if (focused) Timer.schedule(blinkTask, blinkTime, blinkTime);
 
 			if (!hasKeyboardFocus()) return false;
-            
-            if (checkFocusTraversal(keycode)) next(UIUtils.shift());
+
+			if (checkFocusTraversal(keycode)) next(UIUtils.shift());
 			
 			boolean repeat = false;
 			boolean ctrl = UIUtils.ctrl();
@@ -1018,15 +1018,15 @@ public class TextField extends Widget implements Disableable {
 			return focusTraversal && (character == TAB
 				|| ((character == CARRIAGE_RETURN || character == NEWLINE) && (UIUtils.isAndroid || UIUtils.isIos)));
 		}
-        
-        /** Checks if focus traversal should be triggered. The default implementation uses {@link TextField#focusTraversal} and the
-         * typed keyCode, depending on the OS.
-         * @param keycode The keyCode that triggered a possible focus traversal.
-         * @return true if the focus should change to the {@link TextField#next(boolean) next} input field. */
-        protected boolean checkFocusTraversal (int keycode) {
-            return focusTraversal && (keycode == Keys.TAB
-                    || (keycode == Keys.ENTER && (UIUtils.isAndroid || UIUtils.isIos)));
-        }
+
+		/** Checks if focus traversal should be triggered. The default implementation uses {@link TextField#focusTraversal} and the
+		 * typed keyCode, depending on the OS.
+		 * @param keycode The keyCode that triggered a possible focus traversal.
+		 * @return true if the focus should change to the {@link TextField#next(boolean) next} input field. */
+		protected boolean checkFocusTraversal (int keycode) {
+			return focusTraversal && (keycode == Keys.TAB
+					|| (keycode == Keys.ENTER && (UIUtils.isAndroid || UIUtils.isIos)));
+		}
 
 		public boolean keyTyped (InputEvent event, char character) {
 			if (disabled) return false;

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextField.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextField.java
@@ -885,7 +885,9 @@ public class TextField extends Widget implements Disableable {
 			if (focused) Timer.schedule(blinkTask, blinkTime, blinkTime);
 
 			if (!hasKeyboardFocus()) return false;
-
+            
+            if (checkFocusTraversal(keycode)) next(UIUtils.shift());
+			
 			boolean repeat = false;
 			boolean ctrl = UIUtils.ctrl();
 			boolean jump = ctrl && !passwordMode;
@@ -1016,6 +1018,15 @@ public class TextField extends Widget implements Disableable {
 			return focusTraversal && (character == TAB
 				|| ((character == CARRIAGE_RETURN || character == NEWLINE) && (UIUtils.isAndroid || UIUtils.isIos)));
 		}
+        
+        /** Checks if focus traversal should be triggered. The default implementation uses {@link TextField#focusTraversal} and the
+         * typed keyCode, depending on the OS.
+         * @param keycode The keyCode that triggered a possible focus traversal.
+         * @return true if the focus should change to the {@link TextField#next(boolean) next} input field. */
+        protected boolean checkFocusTraversal (int keycode) {
+            return focusTraversal && (keycode == Keys.TAB
+                    || (keycode == Keys.ENTER && (UIUtils.isAndroid || UIUtils.isIos)));
+        }
 
 		public boolean keyTyped (InputEvent event, char character) {
 			if (disabled) return false;
@@ -1035,9 +1046,7 @@ public class TextField extends Widget implements Disableable {
 
 			if (UIUtils.isMac && Gdx.input.isKeyPressed(Keys.SYM)) return true;
 
-			if (checkFocusTraversal(character))
-				next(UIUtils.shift());
-			else {
+			if (!checkFocusTraversal(character)) {
 				boolean enter = character == CARRIAGE_RETURN || character == NEWLINE;
 				boolean delete = character == DELETE;
 				boolean backspace = character == BACKSPACE;


### PR DESCRIPTION
Tab traversal along TextFields in HTML5 does not work for a number of reasons. The first obvious reason is that the browser reserves the key for navigation. That is easily resolved by adding the following to the script block of the index.html:
```
window.onkeydown = function(event) {
  if(event.keyCode == 9) {
    event.preventDefault();
    return false;
  }
};
```

It's the responsibility of the user to handle this code and is not the point of this PR. This operation is covered in the [wiki](https://github.com/libgdx/libgdx/wiki/HTML5-Backend-and-GWT-Specifics#preventing-keys-from-triggering-scrolling-and-other-browser-functions). However, by doing the above you break the ability of TextField to detect Tab keys. This is because the detection is in the keyTyped method. If we move the detection to keyDown, it works across all the backends.

I would appreciate some testing on iOS/Android if anyone is available.