### PR TITLE
Fix shader providers overflow and depth shader skinning configuration

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -47,6 +47,7 @@
 - API Change: Table#round uses ceil/floor and is applied during layout, rather than afterward.
 - Fixed blurry NinePatch rendering when using a single center region.
 - API Change: Upon changing the window size with the lwjgl3 backend, the window is centered on the monitor.
+- Fixed DepthShaderProvider no longer creates one DepthShader per bones count. Now it creates only one skinned variant and one non-skinned variant based on DepthShader/Config numBones.
 
 [1.9.11]
 - Update to MobiVM 2.3.8

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/DepthShader.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/DepthShader.java
@@ -125,15 +125,7 @@ public class DepthShader extends DefaultShader {
 				return false;
 		}
 		final boolean skinned = ((renderable.meshPart.mesh.getVertexAttributes().getMask() & Usage.BoneWeight) == Usage.BoneWeight);
-		if (skinned != (numBones > 0)) return false;
-		if (!skinned) return true;
-		int w = 0;
-		final int n = renderable.meshPart.mesh.getVertexAttributes().size();
-		for (int i = 0; i < n; i++) {
-			final VertexAttribute attr = renderable.meshPart.mesh.getVertexAttributes().get(i);
-			if (attr.usage == Usage.BoneWeight) w |= (1 << attr.unit);
-		}
-		return w == weights;
+		return skinned == (weights > 0);
 	}
 	
 	@Override

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/utils/BaseShaderProvider.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/utils/BaseShaderProvider.java
@@ -20,6 +20,7 @@ import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.g3d.Renderable;
 import com.badlogic.gdx.graphics.g3d.Shader;
 import com.badlogic.gdx.utils.Array;
+import com.badlogic.gdx.utils.GdxRuntimeException;
 
 public abstract class BaseShaderProvider implements ShaderProvider {
 	protected Array<Shader> shaders = new Array<Shader>();
@@ -32,6 +33,7 @@ public abstract class BaseShaderProvider implements ShaderProvider {
 			if (shader.canRender(renderable)) return shader;
 		}
 		final Shader shader = createShader(renderable);
+		if (!shader.canRender(renderable)) throw new GdxRuntimeException("unable to provide a shader for this renderable");
 		shader.init();
 		shaders.add(shader);
 		return shader;


### PR DESCRIPTION
Few issues i tried to fix with the less breaking changes as possible :

* Sometimes, a shader created with a given configuration (renderable), cannot render the same configuration (canRender method). This causes an overflow of shader creation at each drawing making shaders list growing indefinitely. Now, an exception is thrown.
* Depth shader configured with maxBones=0 is one of those case : it can't render a skinned mesh even if it has been created with a skinned renderable.
* While i was fixing it, i saw that a new DepthShader is created depending on renderable bones count. DefaultShaderProvider doesn't care about bones count, it provides 2 variants : one with skinning, one without. I changed depth shader to use the same approach. Several models with different bones count means a lot of shaders and switches. 

The downside of this last change is for some case like : 1 model with 100 bones and a lot of models with only 1 or 2 bones. One shader switch might be better than sending 100 uniform matrices per renderable. I didn't benchmarked it to see how bad it could be. Note that devs could customize this by subclassing DepthShaderProvider.