### PR TITLE
Added support ios split screen. Fixes #5814

### DIFF
--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSApplication.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSApplication.java
@@ -119,7 +119,7 @@ public class IOSApplication implements Application {
 		this.uiApp = uiApp;
 
 		// enable or disable screen dimming
-		UIApplication.getSharedApplication().setIdleTimerDisabled(config.preventScreenDimming);
+		uiApp.setIdleTimerDisabled(config.preventScreenDimming);
 
 		Gdx.app.debug("IOSApplication", "iOS version: " + UIDevice.getCurrentDevice().getSystemVersion());
 		Gdx.app.debug("IOSApplication", "Running in " + (Bro.IS_64BIT ? "64-bit" : "32-bit") + " mode");
@@ -127,6 +127,10 @@ public class IOSApplication implements Application {
 		// iOS counts in "points" instead of pixels. Points are logical pixels
 		pixelsPerPoint = (float)UIScreen.getMainScreen().getNativeScale();
 		Gdx.app.debug("IOSApplication", "Pixels per point: " + pixelsPerPoint);
+
+		this.uiWindow = new UIWindow(UIScreen.getMainScreen().getBounds());
+		this.uiWindow.makeKeyAndVisible();
+		uiApp.getDelegate().setWindow(uiWindow);
 
 		// setup libgdx
 		this.input = createInput();
@@ -145,9 +149,7 @@ public class IOSApplication implements Application {
 
 		this.input.setupPeripherals();
 
-		this.uiWindow = new UIWindow(UIScreen.getMainScreen().getBounds());
 		this.uiWindow.setRootViewController(this.graphics.viewController);
-		this.uiWindow.makeKeyAndVisible();
 		Gdx.app.debug("IOSApplication", "created");
 		return true;
 	}
@@ -183,28 +185,12 @@ public class IOSApplication implements Application {
 	/** @see IOSScreenBounds for detailed explanation
 	 * @return logical dimensions of space we draw to, adjusted for device orientation */
 	protected IOSScreenBounds computeBounds () {
-		final CGRect screenBounds = UIScreen.getMainScreen().getBounds();
+		CGRect screenBounds = uiWindow.getBounds();
 		final CGRect statusBarFrame = uiApp.getStatusBarFrame();
-		final UIInterfaceOrientation statusBarOrientation = uiApp.getStatusBarOrientation();
-
-		double statusBarHeight = Math.min(statusBarFrame.getWidth(), statusBarFrame.getHeight());
+		double statusBarHeight = statusBarFrame.getHeight();
 
 		double screenWidth = screenBounds.getWidth();
 		double screenHeight = screenBounds.getHeight();
-
-		// Make sure that the orientation is consistent with ratios. Should be, but may not be on older iOS versions
-		switch (statusBarOrientation) {
-		case LandscapeLeft:
-		case LandscapeRight:
-			if (screenHeight > screenWidth) {
-				debug("IOSApplication", "Switching reported width and height (original was w=" + screenWidth + " h="
-							+ screenHeight + ")");
-				double tmp = screenHeight;
-				// noinspection SuspiciousNameCombination
-				screenHeight = screenWidth;
-				screenWidth = tmp;
-			}
-		}
 
 		if (statusBarHeight != 0.0) {
 			debug("IOSApplication", "Status bar is visible (height = " + statusBarHeight + ")");


### PR DESCRIPTION
Fixes #5814 

To support iOS Split screen, the only required change is to calculate the graphics bounds using the iOS window object instead of the screen. Any app that doesn't want to support split screen just has to add the `UIRequiresFullScreen` flag to their `Info.plist`.

In addition to changing that, there's several things related to it that have been improved.
1. Window is now created and set before libGDX is setup and creates Graphics. This way, when Graphics are created and `computeBounds()` called, `window` is not null.
2. The `window` property on `AppDelegate` is now explicitely set with the main window we set key by calling `uiApp.getDelegate().setWindow(uiWindow)`. In libGDX we keep a reference to this window on `IOSApplication` (called `uiWindow`) but on standard iOS apps it is kept on the `AppDelegate` (in our case `IOSLauncher`) that can access it by calling `getWindow()`. Before this change, calling `getWindow()` from `IOSLauncher` returned `null`. Some more info on the differences between app window and app delegate windows here: https://stackoverflow.com/questions/21698482/what-is-the-difference-between-uiapplication-sharedapplication-delegate-window-a.
3. There was some code that was added for backwards compatibility for iOS 7- before windows bound sizes and status bar were made device orientation dependent (https://stackoverflow.com/questions/24150359/is-uiscreen-mainscreen-bounds-size-becoming-orientation-dependent-in-ios8). Now that the minimum supported iOS version is 8 we can get rid of them. 