### PR TITLE
Return iOS Insets in logical pixels

### DIFF
--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
@@ -551,18 +551,11 @@ public class IOSGraphics extends NSObject implements Graphics, GLKViewDelegate, 
 		safeInsetBottom = 0;
 
 		if (Foundation.getMajorSystemVersion() >= 11) {
-			UIView view = UIApplication.getSharedApplication().getKeyWindow().getRootViewController().getView();
-			UIEdgeInsets edgeInsets = view.getSafeAreaInsets();
-
-			double top = edgeInsets.getTop() * view.getContentScaleFactor();
-			double bottom = edgeInsets.getBottom() * view.getContentScaleFactor();
-			double left = edgeInsets.getLeft() * view.getContentScaleFactor();
-			double right = edgeInsets.getRight() * view.getContentScaleFactor();
-
-			safeInsetTop = (int) top;
-			safeInsetLeft = (int) left;
-			safeInsetRight = (int) right;
-			safeInsetBottom = (int) bottom;
+			UIEdgeInsets edgeInsets = viewController.getView().getSafeAreaInsets();
+			safeInsetTop = (int) edgeInsets.getTop();
+			safeInsetLeft = (int) edgeInsets.getLeft();
+			safeInsetRight = (int) edgeInsets.getRight();
+			safeInsetBottom = (int) edgeInsets.getBottom();
 		}
 	}
 

--- a/gdx/src/com/badlogic/gdx/Graphics.java
+++ b/gdx/src/com/badlogic/gdx/Graphics.java
@@ -154,22 +154,22 @@ public interface Graphics {
 	public int getBackBufferHeight ();
 
 	/**
-	 * @return the inset from the left which avoids display cutouts in pixels
+	 * @return the inset from the left which avoids display cutouts in logical pixels
 	 */
 	int getSafeInsetLeft();
 
 	/**
-	 * @return the inset from the top which avoids display cutouts in pixels
+	 * @return the inset from the top which avoids display cutouts in logical pixels
 	 */
 	int getSafeInsetTop();
 
 	/**
-	 * @return the inset from the bottom which avoids display cutouts or floating gesture bars, in pixels
+	 * @return the inset from the bottom which avoids display cutouts or floating gesture bars, in logical pixels
 	 */
 	int getSafeInsetBottom();
 
 	/**
-	 * @return the inset from the right which avoids display cutouts in pixels
+	 * @return the inset from the right which avoids display cutouts in logical pixels
 	 */
 	int getSafeInsetRight();
 


### PR DESCRIPTION
Insets API was still returning physical pixels after the changes on https://github.com/libgdx/libgdx/pull/3709. Made the Insets API consistent by returning logical pixels.