### PR TITLE
glDrawBuffers no longer ignores bufsize (n) argument

### DIFF
--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGL30.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGL30.java
@@ -179,7 +179,10 @@ class LwjglGL30 extends LwjglGL20 implements com.badlogic.gdx.graphics.GL30 {
 
 	@Override
 	public void glDrawBuffers (int n, IntBuffer bufs) {
+		int limit = bufs.limit();
+		bufs.limit(n);
 		GL20.glDrawBuffers(bufs);
+		bufs.limit(limit);
 	}
 
 	@Override

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3GL30.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3GL30.java
@@ -181,7 +181,10 @@ class Lwjgl3GL30 extends Lwjgl3GL20 implements com.badlogic.gdx.graphics.GL30 {
 
 	@Override
 	public void glDrawBuffers (int n, IntBuffer bufs) {
+		int limit = bufs.limit();
+		bufs.limit(n);
 		GL20.glDrawBuffers(bufs);
+		bufs.limit(limit);
 	}
 
 	@Override


### PR DESCRIPTION
fixes https://github.com/libgdx/libgdx/issues/6230

Previously in LWJGL backends `glDrawbuffers` would rely on the `remaining()` of the `IntBuffer` passed in, ignoring the bufsize argument (`n`). This would possibly cause errors when users would expect (`n`) to limit the number of args passed to opengl from the buffer.

Now the buffer is limited by (`n`) properly

I've tested this with framebuffers on my own project and they work.