### PR TITLE
Fix #6228. Removed delta smoothing on Android backend

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,7 @@
 - [BREAKING CHANGE] iOS: Changed how Retina/hdpi handled on iOS. See #3709.
 - [BREAKING CHANGE] API Change: InputProcessor scrolled method now receives scroll amount for X and Y. Changed type to float to support devices which report fractional scroll amounts. Updated InputEvent in scene2d accordingly: added scrollAmountX, scrollAmountY attributes and corresponding setters and getters. See #6154.
 - [BREAKING CHANGE] API Change: Vector2 angleRad(Vector2) now correctly returns counter-clockwise angles. See #5428
+- [BREAKING CHANGE] Android: getDeltaTime() now returns the raw delta time instead of a smoothed one. See #6228.
 - Fixed vertices returned by Decal.getVertices() not being updated
 - Fixes Issue #5048. The function Intersector.overlapConvexPolygons now should return the right minimum translation vector values.
 - Update to MobiVM 2.3.10

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphics.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphics.java
@@ -76,7 +76,6 @@ public class AndroidGraphics implements Graphics, Renderer {
 	protected long frameId = -1;
 	protected int frames = 0;
 	protected int fps;
-	protected WindowedMean mean = new WindowedMean(5);
 
 	volatile boolean created = false;
 	volatile boolean running = false;
@@ -304,7 +303,6 @@ public class AndroidGraphics implements Graphics, Renderer {
 		Display display = app.getWindowManager().getDefaultDisplay();
 		this.width = display.getWidth();
 		this.height = display.getHeight();
-		this.mean = new WindowedMean(5);
 		this.lastFrameTime = System.nanoTime();
 
 		gl.glViewport(0, 0, this.width, this.height);
@@ -406,15 +404,14 @@ public class AndroidGraphics implements Graphics, Renderer {
 	@Override
 	public void onDrawFrame (javax.microedition.khronos.opengles.GL10 gl) {
 		long time = System.nanoTime();
-		deltaTime = (time - lastFrameTime) / 1000000000.0f;
-		lastFrameTime = time;
-
 		// After pause deltaTime can have somewhat huge value that destabilizes the mean, so let's cut it off
 		if (!resume) {
-			mean.addValue(deltaTime);
+			deltaTime = (time - lastFrameTime) / 1000000000.0f;
 		} else {
 			deltaTime = 0;
 		}
+		lastFrameTime = time;
+
 
 		boolean lrunning = false;
 		boolean lpause = false;
@@ -514,7 +511,7 @@ public class AndroidGraphics implements Graphics, Renderer {
 	/** {@inheritDoc} */
 	@Override
 	public float getDeltaTime () {
-		return mean.getMean() == 0 ? deltaTime : mean.getMean();
+		return deltaTime;
 	}
 
 	@Override
@@ -720,7 +717,6 @@ public class AndroidGraphics implements Graphics, Renderer {
 			this.isContinuous = enforceContinuousRendering || isContinuous;
 			int renderMode = this.isContinuous ? GLSurfaceView.RENDERMODE_CONTINUOUSLY : GLSurfaceView.RENDERMODE_WHEN_DIRTY;
 			view.setRenderMode(renderMode);
-			mean.clear();
 		}
 	}
 

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphicsLiveWallpaper.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphicsLiveWallpaper.java
@@ -111,15 +111,13 @@ public final class AndroidGraphicsLiveWallpaper extends AndroidGraphics {
 	@Override
 	public void onDrawFrame (javax.microedition.khronos.opengles.GL10 gl) {
 		long time = System.nanoTime();
-		deltaTime = (time - lastFrameTime) / 1000000000.0f;
-		lastFrameTime = time;
-
 		// After pause deltaTime can have somewhat huge value that destabilizes the mean, so let's cut it off
 		if (!resume) {
-			mean.addValue(deltaTime);
+			deltaTime = (time - lastFrameTime) / 1000000000.0f;
 		} else {
 			deltaTime = 0;
 		}
+		lastFrameTime = time;
 
 		boolean lrunning = false;
 		boolean lpause = false;

--- a/gdx/src/com/badlogic/gdx/Graphics.java
+++ b/gdx/src/com/badlogic/gdx/Graphics.java
@@ -180,10 +180,12 @@ public interface Graphics {
 	 * @return the id of the current frame */
 	public long getFrameId ();
 
-	/** @return the time span between the current frame and the last frame in seconds. Might be smoothed over n frames. */
+	/** @return the time span between the current frame and the last frame in seconds. */
 	public float getDeltaTime ();
 
-	/** @return the time span between the current frame and the last frame in seconds, without smoothing **/
+	/** @return the time span between the current frame and the last frame in seconds, without smoothing 
+	 * @deprecated use {@link #getDeltaTime()} instead. */
+	@Deprecated
 	public float getRawDeltaTime ();
 
 	/** @return the average number of frames per second */


### PR DESCRIPTION
Fixes #6228.

- `getRawDelta()` has been deprecated as, at least for now, it's a duplicate of `getDelta()`.
- the line `mean.clear()` on `setContinuousRendering()` can be safely removed because it was added to fix an issue caused by the smoothing (https://code.google.com/archive/p/libgdx/issues/962).