### PR TITLE
Fix Intersector#pointLineSide documentation.

### DIFF
--- a/gdx/src/com/badlogic/gdx/math/Intersector.java
+++ b/gdx/src/com/badlogic/gdx/math/Intersector.java
@@ -92,8 +92,8 @@ public final class Intersector {
 		return true;
 	}
 
-	/** Determines on which side of the given line the point is. Returns -1 if the point is on the left side of the line, 0 if the
-	 * point is on the line and 1 if the point is on the right side of the line. Left and right are relative to the lines direction
+	/** Determines on which side of the given line the point is. Returns 1 if the point is on the left side of the line, 0 if the
+	 * point is on the line and -1 if the point is on the right side of the line. Left and right are relative to the lines direction
 	 * which is linePoint1 to linePoint2. */
 	public static int pointLineSide (Vector2 linePoint1, Vector2 linePoint2, Vector2 point) {
 		return (int)Math.signum(


### PR DESCRIPTION
Closes #3622. As detailed in that issue, `Intersector.pointLineSide` returns the wrong side. Simple example:

```
Vector2 start = new Vector2(0, 0);
Vector2 end = new Vector2(0, 10f);
Vector2 point = new Vector2(-1, 10f); // clearly left of the line

int side = Intersector.pointLineSide(start, end, point);
System.out.println(side);
```

Instead of changing the actual implementation, which could break code relying on it, I just fixed the documentation.