### PR TITLE
Support specifying which onscreen keyboard type to use

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/DefaultAndroidInput.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/DefaultAndroidInput.java
@@ -614,8 +614,11 @@ public class DefaultAndroidInput implements AndroidInput {
 				InputMethodManager manager = (InputMethodManager)context.getSystemService(Context.INPUT_METHOD_SERVICE);
 				if (visible) {
 					View view = ((AndroidGraphics)app.getGraphics()).getView();
-					((GLSurfaceView20)view).onscreenKeyboardType = type == null ? OnscreenKeyboardType.Default : type;
-					manager.restartInput(view);
+					OnscreenKeyboardType tmp = type == null ? OnscreenKeyboardType.Default : type;
+					if(((GLSurfaceView20)view).onscreenKeyboardType != tmp) {
+						((GLSurfaceView20) view).onscreenKeyboardType = tmp;
+						manager.restartInput(view);
+					}
 
 					view.setFocusable(true);
 					view.setFocusableInTouchMode(true);

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/DefaultAndroidInput.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/DefaultAndroidInput.java
@@ -32,8 +32,8 @@ import android.os.Vibrator;
 import android.view.MotionEvent;
 import android.view.Surface;
 import android.view.View;
-import android.view.View.OnKeyListener;
 import android.view.View.OnGenericMotionListener;
+import android.view.View.OnKeyListener;
 import android.view.WindowManager;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
@@ -42,6 +42,7 @@ import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Graphics.DisplayMode;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.InputProcessor;
+import com.badlogic.gdx.backends.android.surfaceview.GLSurfaceView20;
 import com.badlogic.gdx.utils.IntSet;
 import com.badlogic.gdx.utils.Pool;
 
@@ -603,11 +604,19 @@ public class DefaultAndroidInput implements AndroidInput {
 
 	@Override
 	public void setOnscreenKeyboardVisible (final boolean visible) {
+		setOnscreenKeyboardVisible(visible, OnscreenKeyboardType.Default);
+	}
+
+	@Override
+	public void setOnscreenKeyboardVisible (final boolean visible, final OnscreenKeyboardType type) {
 		handle.post(new Runnable() {
 			public void run () {
 				InputMethodManager manager = (InputMethodManager)context.getSystemService(Context.INPUT_METHOD_SERVICE);
 				if (visible) {
 					View view = ((AndroidGraphics)app.getGraphics()).getView();
+					((GLSurfaceView20)view).onscreenKeyboardType = type == null ? OnscreenKeyboardType.Default : type;
+					manager.restartInput(view);
+
 					view.setFocusable(true);
 					view.setFocusableInTouchMode(true);
 					manager.showSoftInput(((AndroidGraphics)app.getGraphics()).getView(), 0);

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/surfaceview/GLSurfaceView20.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/surfaceview/GLSurfaceView20.java
@@ -29,6 +29,7 @@ import android.view.KeyEvent;
 import android.view.inputmethod.BaseInputConnection;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputConnection;
+import com.badlogic.gdx.Input.OnscreenKeyboardType;
 
 /** A simple GLSurfaceView sub-class that demonstrates how to perform OpenGL ES 2.0 rendering into a GL Surface. Note the following
  * important details:
@@ -47,6 +48,7 @@ public class GLSurfaceView20 extends GLSurfaceView {
 
 	final ResolutionStrategy resolutionStrategy;
 	static int targetGLESVersion;
+	public OnscreenKeyboardType onscreenKeyboardType = OnscreenKeyboardType.Default;
 
 	public GLSurfaceView20 (Context context, ResolutionStrategy resolutionStrategy, int targetGLESVersion) {
 		super(context);
@@ -78,7 +80,15 @@ public class GLSurfaceView20 extends GLSurfaceView {
 		// add this line, the IME can show the selectable words when use chinese input method editor.
 		if (outAttrs != null) {
 			outAttrs.imeOptions = outAttrs.imeOptions | EditorInfo.IME_FLAG_NO_EXTRACT_UI;
-			outAttrs.inputType = InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD | InputType.TYPE_NULL;
+
+			switch(onscreenKeyboardType){
+				default: outAttrs.inputType = InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD; break;
+				case NumberPad: outAttrs.inputType = InputType.TYPE_CLASS_NUMBER; break;
+				case PhonePad: outAttrs.inputType = InputType.TYPE_CLASS_PHONE; break;
+				case Email: outAttrs.inputType = InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS; break;
+				case Password: outAttrs.inputType = InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD; break;
+				case URI: outAttrs.inputType = InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_URI; break;
+			}
 		}
 
 		BaseInputConnection connection = new BaseInputConnection(this, false) {

--- a/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/mock/input/MockInput.java
+++ b/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/mock/input/MockInput.java
@@ -156,6 +156,11 @@ public class MockInput implements Input {
 	}
 
 	@Override
+	public void setOnscreenKeyboardVisible(boolean visible, OnscreenKeyboardType type) {
+
+	}
+
+	@Override
 	public void vibrate(int milliseconds) {
 
 	}

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/DefaultLwjglInput.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/DefaultLwjglInput.java
@@ -298,6 +298,11 @@ final public class DefaultLwjglInput implements LwjglInput {
 	}
 
 	@Override
+	public void setOnscreenKeyboardVisible(boolean visible, OnscreenKeyboardType type) {
+
+	}
+
+	@Override
 	public void setCatchBackKey (boolean catchBack) {
 
 	}

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglAWTInput.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglAWTInput.java
@@ -448,6 +448,11 @@ public class LwjglAWTInput implements Input, MouseMotionListener, MouseListener,
 	}
 
 	@Override
+	public void setOnscreenKeyboardVisible(boolean visible, OnscreenKeyboardType type) {
+
+	}
+
+	@Override
 	public void mouseDragged (MouseEvent e) {
 		synchronized (this) {
 			TouchEvent event = usedTouchEvents.obtain();

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/DefaultLwjgl3Input.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/DefaultLwjgl3Input.java
@@ -866,9 +866,13 @@ public class DefaultLwjgl3Input implements Lwjgl3Input {
 	public Orientation getNativeOrientation() {
 		return Orientation.Landscape;
 	}
-	
+
 	@Override
 	public void setOnscreenKeyboardVisible(boolean visible) {
+	}
+
+	@Override
+	public void setOnscreenKeyboardVisible(boolean visible, OnscreenKeyboardType type) {
 	}
 
 	@Override

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/DefaultIOSInput.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/DefaultIOSInput.java
@@ -459,9 +459,25 @@ public class DefaultIOSInput implements IOSInput {
 
 	@Override
 	public void setOnscreenKeyboardVisible (boolean visible) {
+		setOnscreenKeyboardVisible(visible, OnscreenKeyboardType.Default);
+	}
+
+	@Override
+	public void setOnscreenKeyboardVisible (boolean visible, OnscreenKeyboardType type) {
 		if (textfield == null) createDefaultTextField();
 		softkeyboardActive = visible;
 		if (visible) {
+			UIKeyboardType preferredInputType;
+			if(type == null) type = OnscreenKeyboardType.Default;
+			switch(type){
+				case Password: //no equivalent in UIKeyboardType?
+				default: preferredInputType = UIKeyboardType.Default; break;
+				case NumberPad: preferredInputType = UIKeyboardType.NumberPad; break;
+				case PhonePad: preferredInputType = UIKeyboardType.PhonePad; break;
+				case Email: preferredInputType = UIKeyboardType.EmailAddress; break;
+				case URI: preferredInputType = UIKeyboardType.URL; break;
+			}
+			textfield.setKeyboardType(preferredInputType);
 			textfield.becomeFirstResponder();
 			textfield.setDelegate(textDelegate);
 		} else {

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/DefaultGwtInput.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/DefaultGwtInput.java
@@ -305,6 +305,10 @@ public class DefaultGwtInput implements GwtInput {
 	}
 
 	@Override
+	public void setOnscreenKeyboardVisible(boolean visible, OnscreenKeyboardType type) {
+	}
+
+	@Override
 	public void vibrate (int milliseconds) {
 	}
 

--- a/gdx/src/com/badlogic/gdx/Input.java
+++ b/gdx/src/com/badlogic/gdx/Input.java
@@ -682,10 +682,20 @@ public interface Input {
 	 * @param text The message presented to the user. */
 	public void getTextInput (TextInputListener listener, String title, String text, String hint);
 
-	/** Sets the on-screen keyboard visible if available.
+	/** Sets the on-screen keyboard visible if available. Will use the Default keyboard type.
 	 * 
 	 * @param visible visible or not */
 	public void setOnscreenKeyboardVisible (boolean visible);
+
+	/** Sets the on-screen keyboard visible if available.
+	 *
+	 * @param visible visible or not
+	 * @param type which type of keyboard we wish to display. Can be null when hiding */
+	public void setOnscreenKeyboardVisible (boolean visible, OnscreenKeyboardType type);
+
+	public enum OnscreenKeyboardType {
+		Default, NumberPad, PhonePad, Email, Password, URI
+	}
 
 	/** Vibrates for the given amount of time. Note that you'll need the permission
 	 * <code> <uses-permission android:name="android.permission.VIBRATE" /></code> in your manifest file in order for this to work.

--- a/gdx/src/com/badlogic/gdx/input/RemoteInput.java
+++ b/gdx/src/com/badlogic/gdx/input/RemoteInput.java
@@ -458,6 +458,10 @@ public class RemoteInput implements Runnable, Input {
 	}
 
 	@Override
+	public void setOnscreenKeyboardVisible(boolean visible, OnscreenKeyboardType type) {
+	}
+
+	@Override
 	public void vibrate (int milliseconds) {
 
 	}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/OnscreenKeyboardTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/OnscreenKeyboardTest.java
@@ -18,6 +18,7 @@ package com.badlogic.gdx.tests;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.InputProcessor;
+import com.badlogic.gdx.Input.OnscreenKeyboardType;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
@@ -28,22 +29,25 @@ public class OnscreenKeyboardTest extends GdxTest implements InputProcessor {
 	BitmapFont font;
 	String text;
 	SpriteBatch batch;
+	OnscreenKeyboardType type = OnscreenKeyboardType.Default;
 
 	public void create () {
 		batch = new SpriteBatch();
 		font = new BitmapFont();
 		text = "";
 		Gdx.input.setInputProcessor(this);
-// Gdx.input.setOnscreenKeyboardVisible(true);
 	}
 
 	public void render () {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		batch.begin();
-		font.draw(batch, "input: " + text, 0, Gdx.graphics.getHeight());
+		font.draw(batch, "input ["+type+"]: " + text, 0, Gdx.graphics.getHeight());
 		batch.end();
 
-		if (Gdx.input.justTouched()) Gdx.input.setOnscreenKeyboardVisible(true);
+		if (Gdx.input.justTouched()) {
+			type = OnscreenKeyboardType.values()[(type.ordinal()+1) % OnscreenKeyboardType.values().length];
+			Gdx.input.setOnscreenKeyboardVisible(true, type);
+		}
 	}
 
 	@Override

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtTestWrapper.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtTestWrapper.java
@@ -300,6 +300,11 @@ public class GwtTestWrapper extends GdxTest {
 		}
 
 		@Override
+		public void setOnscreenKeyboardVisible(boolean visible, OnscreenKeyboardType type) {
+			input.setOnscreenKeyboardVisible(visible, type);
+		}
+
+		@Override
 		public void vibrate (int milliseconds) {
 			input.vibrate(milliseconds);
 		}


### PR DESCRIPTION
Is mainly useful for the ability to open the numeric/phone keyboards directly.

Current implementation adds Default, NumberPad, PhonePad, Email, Password, URI options which are mapped back to Android/iOS types.

Android Password/URI types do not visually change anything on my device, but I do not know if this is keyboard dependent. Password type may also prevent autocomplete data from learning passwords.

iOS code is untested. I am not sure if the current setKeyboardType call is sufficient enough to actually change the keyboard.

Github wont let me reopen #5201 because I force pushed.

I have been running a version of this internally on Android for years, and have recieved a handful of reports that the keyboard will occasionally get stuck on the incorrect type. This is fairly rare, and I haven't been able to figure out the cause.

Reopening at the request of @MrStahlfelge 