### PR TITLE
Fixes libGDX Gradle build error

### DIFF
--- a/gdx/build.gradle
+++ b/gdx/build.gradle
@@ -41,7 +41,7 @@ test {
 
 // Workaround needed for IDEA to have resources on classpath when running tests (like gdx-tests-lwjgl3)
 task copyIdeaResources(type: Copy) {
-    from "${projectDir}/src/main/resources"
+    from "${projectDir}/res"
     into "${buildDir}/classes/java/main/"
 }
 processResources.dependsOn copyIdeaResources

--- a/gdx/build.gradle
+++ b/gdx/build.gradle
@@ -21,10 +21,6 @@ targetCompatibility = 1.7
 
 sourceSets.main.java.srcDirs = ["src"]
 sourceSets.main.resources.srcDirs = ["res"]
-// Workaround the Idea limitation that only takes output folder for classpath resolution when running
-// from other modules (such as /tests)
-sourceSets.main.output.resourcesDir = file("$buildDir/classes/java/main")
-
 sourceSets.test.java.srcDirs = ["test"]
 
 compileJava {
@@ -42,3 +38,10 @@ test {
         events "passed", "skipped", "failed", "standardOut", "standardError"
     }
 }
+
+// Workaround needed for IDEA to have resources on classpath when running tests (like gdx-tests-lwjgl3)
+task copyIdeaResources(type: Copy) {
+    from "${projectDir}/src/main/resources"
+    into "${buildDir}/classes/java/main/"
+}
+processResources.dependsOn copyIdeaResources


### PR DESCRIPTION
Building libGDX project with Gradle was failing (just run `gradlew clean build` to test) due to a bad workaround I added to fix Android and Desktop tests not running on IDEA (https://github.com/libgdx/libgdx/commit/a30ecf0c1f41f9f2e6a7403520e0bdcd7f4bcb72).

This alternative workaround fixes the Gradle issue and keeps IDEA happy (thanks to PokeMMO).