### PR TITLE
Set back buffer configs for any window

### DIFF
--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
@@ -425,15 +425,13 @@ public class Lwjgl3Application implements Lwjgl3ApplicationBase {
 		GLFW.glfwWindowHint(GLFW.GLFW_MAXIMIZED, config.windowMaximized ? GLFW.GLFW_TRUE : GLFW.GLFW_FALSE);
 		GLFW.glfwWindowHint(GLFW.GLFW_AUTO_ICONIFY, config.autoIconify ? GLFW.GLFW_TRUE : GLFW.GLFW_FALSE);
 
-		if(sharedContextWindow == 0) {
-			GLFW.glfwWindowHint(GLFW.GLFW_RED_BITS, config.r);
-			GLFW.glfwWindowHint(GLFW.GLFW_GREEN_BITS, config.g);
-			GLFW.glfwWindowHint(GLFW.GLFW_BLUE_BITS, config.b);
-			GLFW.glfwWindowHint(GLFW.GLFW_ALPHA_BITS, config.a);
-			GLFW.glfwWindowHint(GLFW.GLFW_STENCIL_BITS, config.stencil);
-			GLFW.glfwWindowHint(GLFW.GLFW_DEPTH_BITS, config.depth);
-			GLFW.glfwWindowHint(GLFW.GLFW_SAMPLES, config.samples);
-		}
+		GLFW.glfwWindowHint(GLFW.GLFW_RED_BITS, config.r);
+		GLFW.glfwWindowHint(GLFW.GLFW_GREEN_BITS, config.g);
+		GLFW.glfwWindowHint(GLFW.GLFW_BLUE_BITS, config.b);
+		GLFW.glfwWindowHint(GLFW.GLFW_ALPHA_BITS, config.a);
+		GLFW.glfwWindowHint(GLFW.GLFW_STENCIL_BITS, config.stencil);
+		GLFW.glfwWindowHint(GLFW.GLFW_DEPTH_BITS, config.depth);
+		GLFW.glfwWindowHint(GLFW.GLFW_SAMPLES, config.samples);
 
 		if (config.useGL30) {
 			GLFW.glfwWindowHint(GLFW.GLFW_CONTEXT_VERSION_MAJOR, config.gles30ContextMajorVersion);


### PR DESCRIPTION
As point out in #6207, I can't see any downside to enable back buffer for all created windows rather then the only first one.
This commit will fix the MSAA issue for multiple windows and allow users to set custom back buffer configuration for any window.

I've tested this in some environments and I haven't noticed any unexpected behavior, also, I can't find online any reason why this was made in the past, please check it.

Thanks