### PR TITLE
fix GLFrameBufferBuilder visibility

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/glutils/GLFrameBuffer.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/GLFrameBuffer.java
@@ -439,7 +439,7 @@ public abstract class GLFrameBuffer<T extends GLTexture> implements Disposable {
 		}
 	}
 
-	protected static abstract class GLFrameBufferBuilder<U extends GLFrameBuffer<? extends GLTexture>> {
+	public static abstract class GLFrameBufferBuilder<U extends GLFrameBuffer<? extends GLTexture>> {
 		protected int width, height;
 
 		protected Array<FrameBufferTextureAttachmentSpec> textureAttachmentSpecs = new Array<FrameBufferTextureAttachmentSpec>();


### PR DESCRIPTION
GLFrameBufferBuilder methods return itself for chaining but visibility was protected so the return type couldn't be used. Following example code now compile :
```java
FrameBuffer fbo = new FrameBufferBuilder(w, h)
.addColorTextureAttachment(GL30.GL_RGBA8, GL30.GL_RGBA, GL30.GL_UNSIGNED_BYTE)
.addDepthTextureAttachment(GL30.GL_DEPTH_COMPONENT, GL30.GL_UNSIGNED_SHORT)
.build();
```

This change also allows GLFrameBufferBuilder subclassing as a side effect, not sure it's so bad.

I saw 3 ways to fix this : 
* change return type to void, which would remove builder design pattern.
* messing with generics to return concrete type, which would overcomplexify code and would be a breaking change.
* simply change class visibility (what i did)