### PR TITLE
Alternative asynchronous sound  Android Audio implementation

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -51,6 +51,7 @@
 - API Change: Upon changing the window size with the lwjgl3 backend, the window is centered on the monitor.
 - Fixed DepthShaderProvider no longer creates one DepthShader per bones count. Now it creates only one skinned variant and one non-skinned variant based on DepthShader/Config numBones.
 - API Addition: Added Intersector#intersectPlanes to calculate the point intersected by three planes, see https://github.com/libgdx/libgdx/pull/6217
+- API Addition: Added alternative Android Audio implementation for performant sound. See https://github.com/libgdx/libgdx/pull/6233.
 
 [1.9.11]
 - Update to MobiVM 2.3.8

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AsynchronousAndroidAudio.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AsynchronousAndroidAudio.java
@@ -5,6 +5,13 @@ import android.os.Handler;
 import android.os.HandlerThread;
 import com.badlogic.gdx.audio.Sound;
 
+/** A performance oriented implementation of the {@link AndroidAudio} interface.
+ * 
+ * Sounds are played on a separate thread. This avoids waiting for sound ids on methods that can 
+ * potentially lock main thread for considerable amount of time, especially when playing several
+ * sounds at the same time. The limitation of this approach is that methods that require a sound id
+ * are not supported.
+*/
 public class AsynchronousAndroidAudio extends DefaultAndroidAudio {
 
 	private final HandlerThread handlerThread;

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AsynchronousAndroidAudio.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AsynchronousAndroidAudio.java
@@ -1,0 +1,37 @@
+package com.badlogic.gdx.backends.android;
+
+import android.content.Context;
+import android.os.Handler;
+import android.os.HandlerThread;
+import com.badlogic.gdx.audio.Sound;
+
+public class AsynchronousAndroidAudio extends DefaultAndroidAudio {
+
+	private final HandlerThread handlerThread;
+	private final Handler handler;
+
+	public AsynchronousAndroidAudio (Context context, AndroidApplicationConfiguration config) {
+		super(context, config);
+		if (!config.disableAudio) {
+			handlerThread = new HandlerThread("libGDX Sound Management");
+			handlerThread.start();
+			handler = new Handler(handlerThread.getLooper());
+		} else {
+			handler = null;
+			handlerThread = null;
+		}
+	}
+
+	@Override
+	public void dispose () {
+		super.dispose();
+		if (handlerThread != null) {
+			handlerThread.quit();
+		}
+	}
+
+	@Override
+	protected Sound postProcessSound (AndroidSound sound) {
+		return new AsynchronousSound(sound, handler);
+	}
+}

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AsynchronousAndroidAudio.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AsynchronousAndroidAudio.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.os.Handler;
 import android.os.HandlerThread;
 import com.badlogic.gdx.audio.Sound;
+import com.badlogic.gdx.files.FileHandle;
 
 /** A performance oriented implementation of the {@link AndroidAudio} interface.
  * 
@@ -38,7 +39,8 @@ public class AsynchronousAndroidAudio extends DefaultAndroidAudio {
 	}
 
 	@Override
-	protected Sound postProcessSound (AndroidSound sound) {
+	public Sound newSound (FileHandle file) {
+		Sound sound = super.newSound(file);
 		return new AsynchronousSound(sound, handler);
 	}
 }

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AsynchronousSound.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AsynchronousSound.java
@@ -3,9 +3,8 @@ package com.badlogic.gdx.backends.android;
 import android.os.Handler;
 import com.badlogic.gdx.audio.Sound;
 
-
 public class AsynchronousSound implements Sound {
-	
+
 	private final AndroidSound sound;
 	private final Handler handler;
 
@@ -18,7 +17,7 @@ public class AsynchronousSound implements Sound {
 	public long play () {
 		handler.post(new Runnable() {
 			@Override
-			public void run() {
+			public void run () {
 				sound.play();
 			}
 		});
@@ -29,7 +28,7 @@ public class AsynchronousSound implements Sound {
 	public long play (final float volume) {
 		handler.post(new Runnable() {
 			@Override
-			public void run() {
+			public void run () {
 				sound.play(volume);
 			}
 		});
@@ -40,7 +39,7 @@ public class AsynchronousSound implements Sound {
 	public long play (final float volume, final float pitch, final float pan) {
 		handler.post(new Runnable() {
 			@Override
-			public void run() {
+			public void run () {
 				sound.play(volume, pitch, pan);
 			}
 		});
@@ -51,7 +50,7 @@ public class AsynchronousSound implements Sound {
 	public long loop () {
 		handler.post(new Runnable() {
 			@Override
-			public void run() {
+			public void run () {
 				sound.loop();
 			}
 		});
@@ -62,7 +61,7 @@ public class AsynchronousSound implements Sound {
 	public long loop (final float volume) {
 		handler.post(new Runnable() {
 			@Override
-			public void run() {
+			public void run () {
 				sound.loop(volume);
 			}
 		});
@@ -73,7 +72,7 @@ public class AsynchronousSound implements Sound {
 	public long loop (final float volume, final float pitch, final float pan) {
 		handler.post(new Runnable() {
 			@Override
-			public void run() {
+			public void run () {
 				sound.loop(volume, pitch, pan);
 			}
 		});

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AsynchronousSound.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AsynchronousSound.java
@@ -5,10 +5,10 @@ import com.badlogic.gdx.audio.Sound;
 
 public class AsynchronousSound implements Sound {
 
-	private final AndroidSound sound;
+	private final Sound sound;
 	private final Handler handler;
 
-	public AsynchronousSound (AndroidSound sound, Handler handler) {
+	public AsynchronousSound (Sound sound, Handler handler) {
 		this.sound = sound;
 		this.handler = handler;
 	}

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AsynchronousSound.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AsynchronousSound.java
@@ -1,0 +1,137 @@
+package com.badlogic.gdx.backends.android;
+
+import android.os.Handler;
+import com.badlogic.gdx.audio.Sound;
+
+
+public class AsynchronousSound implements Sound {
+	
+	private final AndroidSound sound;
+	private final Handler handler;
+
+	public AsynchronousSound (AndroidSound sound, Handler handler) {
+		this.sound = sound;
+		this.handler = handler;
+	}
+
+	@Override
+	public long play () {
+		handler.post(new Runnable() {
+			@Override
+			public void run() {
+				sound.play();
+			}
+		});
+		return 0;
+	}
+
+	@Override
+	public long play (final float volume) {
+		handler.post(new Runnable() {
+			@Override
+			public void run() {
+				sound.play(volume);
+			}
+		});
+		return 0;
+	}
+
+	@Override
+	public long play (final float volume, final float pitch, final float pan) {
+		handler.post(new Runnable() {
+			@Override
+			public void run() {
+				sound.play(volume, pitch, pan);
+			}
+		});
+		return 0;
+	}
+
+	@Override
+	public long loop () {
+		handler.post(new Runnable() {
+			@Override
+			public void run() {
+				sound.loop();
+			}
+		});
+		return 0;
+	}
+
+	@Override
+	public long loop (final float volume) {
+		handler.post(new Runnable() {
+			@Override
+			public void run() {
+				sound.loop(volume);
+			}
+		});
+		return 0;
+	}
+
+	@Override
+	public long loop (final float volume, final float pitch, final float pan) {
+		handler.post(new Runnable() {
+			@Override
+			public void run() {
+				sound.loop(volume, pitch, pan);
+			}
+		});
+		return 0;
+	}
+
+	@Override
+	public void stop () {
+		sound.stop();
+	}
+
+	@Override
+	public void pause () {
+		sound.pause();
+	}
+
+	@Override
+	public void resume () {
+		sound.resume();
+	}
+
+	@Override
+	public void dispose () {
+		sound.dispose();
+	}
+
+	@Override
+	public void stop (long soundId) {
+		throw new UnsupportedOperationException("Asynchronous audio doesn't support sound id based operations.");
+	}
+
+	@Override
+	public void pause (long soundId) {
+		throw new UnsupportedOperationException("Asynchronous audio doesn't support sound id based operations.");
+	}
+
+	@Override
+	public void resume (long soundId) {
+		throw new UnsupportedOperationException("Asynchronous audio doesn't support sound id based operations.");
+	}
+
+	@Override
+	public void setLooping (long soundId, boolean looping) {
+		throw new UnsupportedOperationException("Asynchronous audio doesn't support sound id based operations.");
+	}
+
+	@Override
+	public void setPitch (long soundId, float pitch) {
+		throw new UnsupportedOperationException("Asynchronous audio doesn't support sound id based operations.");
+	}
+
+	@Override
+	public void setVolume (long soundId, float volume) {
+		throw new UnsupportedOperationException("Asynchronous audio doesn't support sound id based operations.");
+	}
+
+	@Override
+	public void setPan (long soundId, float pan, float volume) {
+		throw new UnsupportedOperationException("Asynchronous audio doesn't support sound id based operations.");
+	}
+}

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/DefaultAndroidAudio.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/DefaultAndroidAudio.java
@@ -200,15 +200,9 @@ public class DefaultAndroidAudio implements AndroidAudio {
 				throw new GdxRuntimeException("Error loading audio file: " + file, ex);
 			}
 		}
-		Sound sound = postProcessSound(androidSound);
-		return sound;
+		return androidSound;
 	}
 	
-	/** Overwrite to do some post processing on the sound right after instantiation. */
-	protected Sound postProcessSound(AndroidSound sound) {
-		return sound;
-	}
-
 	/** {@inheritDoc} */
 	@Override
 	public AudioRecorder newAudioRecorder (int samplingRate, boolean isMono) {

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/DefaultAndroidAudio.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/DefaultAndroidAudio.java
@@ -204,6 +204,7 @@ public class DefaultAndroidAudio implements AndroidAudio {
 		return sound;
 	}
 	
+	/** Overwrite to do some post processing on the sound right after instantiation. */
 	protected Sound postProcessSound(AndroidSound sound) {
 		return sound;
 	}

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/DefaultAndroidAudio.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/DefaultAndroidAudio.java
@@ -42,7 +42,7 @@ import java.util.List;
 /** An implementation of the {@link Audio} interface for Android.
  * 
  * @author mzechner */
-public final class DefaultAndroidAudio implements AndroidAudio {
+public class DefaultAndroidAudio implements AndroidAudio {
 	private final SoundPool soundPool;
 	private final AudioManager manager;
 	private final List<AndroidMusic> musics = new ArrayList<AndroidMusic>();
@@ -182,24 +182,30 @@ public final class DefaultAndroidAudio implements AndroidAudio {
 		if (soundPool == null) {
 			throw new GdxRuntimeException("Android audio is not enabled by the application config.");
 		}
+		AndroidSound androidSound;
 		AndroidFileHandle aHandle = (AndroidFileHandle)file;
 		if (aHandle.type() == FileType.Internal) {
 			try {
 				AssetFileDescriptor descriptor = aHandle.getAssetFileDescriptor();
-				AndroidSound sound = new AndroidSound(soundPool, manager, soundPool.load(descriptor, 1));
+				androidSound = new AndroidSound(soundPool, manager, soundPool.load(descriptor, 1));
 				descriptor.close();
-				return sound;
 			} catch (IOException ex) {
 				throw new GdxRuntimeException("Error loading audio file: " + file
 					+ "\nNote: Internal audio files must be placed in the assets directory.", ex);
 			}
 		} else {
 			try {
-				return new AndroidSound(soundPool, manager, soundPool.load(aHandle.file().getPath(), 1));
+				androidSound = new AndroidSound(soundPool, manager, soundPool.load(aHandle.file().getPath(), 1));
 			} catch (Exception ex) {
 				throw new GdxRuntimeException("Error loading audio file: " + file, ex);
 			}
 		}
+		Sound sound = postProcessSound(androidSound);
+		return sound;
+	}
+	
+	protected Sound postProcessSound(AndroidSound sound) {
+		return sound;
 	}
 
 	/** {@inheritDoc} */


### PR DESCRIPTION
This PR adds an alternative audio implementation (`AsynchronousAndroidAudio`) aimed at improving sound performance.

Current sound implementation has a very poor performance in scenarios in which several sounds are played at the same time. This is caused by the main thread being locked each time a method that returns a "sound id" such as `float play()` is called. For some reason, Android takes much longer to return a sound id in these scenarios and no configuration of the `SoundPool` seems to fix it.

The proposed approach is to play the sounds on a separate thread. The drawback of this approach is that operations that use `soundId` are no longer supported but that's not a big deal in most scenarios. I personally use this implementations in all my games and the results are great.

For an app to use this alternative implementation it just needs to override `createAudio()` on `AndroidApplication` and return a new `AsynchronousAndroidAudio` instance.

There are no profiling measurements or tests linked on this PR atm. I did a lot long time ago for my implementations and, if really necessary, I can try to provide some but I'd rather confirm the interest on this first.

**This issue has been reported plenty of times on the forums, Discord and SO and is one of the most reported and recurrent issues on Android backend.**