### PR TITLE
Fix wrong reported density on iOS

### DIFF
--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSApplication.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSApplication.java
@@ -29,6 +29,7 @@ import org.robovm.apple.uikit.UIApplication;
 import org.robovm.apple.uikit.UIApplicationDelegateAdapter;
 import org.robovm.apple.uikit.UIApplicationLaunchOptions;
 import org.robovm.apple.uikit.UIDevice;
+import org.robovm.apple.uikit.UIUserInterfaceIdiom;
 import org.robovm.apple.uikit.UIInterfaceOrientation;
 import org.robovm.apple.uikit.UIPasteboard;
 import org.robovm.apple.uikit.UIScreen;

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSApplication.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSApplication.java
@@ -168,6 +168,17 @@ public class IOSApplication implements Application {
 		 return new DefaultIOSInput(this);
 	}
 
+	/** Returns device ppi using a best guess approach when device is unknown. Overwrite to customize strategy. */
+	protected int guessUnknownPpi() {
+		int ppi;
+		if (UIDevice.getCurrentDevice().getUserInterfaceIdiom() == UIUserInterfaceIdiom.Pad)
+			ppi = 132 * (int) pixelsPerPoint;
+		else
+			ppi = 164 * (int) pixelsPerPoint;
+		error("IOSApplication", "Device PPI unknown. PPI value has been guessed to " + ppi + " but may be wrong");
+		return ppi;
+	}
+
 	/** Return the UI view controller of IOSApplication
 	 * @return the view controller of IOSApplication */
 	public UIViewController getUIViewController () {

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
@@ -287,7 +287,7 @@ public class IOSGraphics extends NSObject implements Graphics, GLKViewDelegate, 
 		IOSDevice device = config.knownDevices.get(machineString);
 		if (device == null) app.error(tag, "Machine ID: " + machineString + " not found, please report to LibGDX");
 		int ppi = device != null ? device.ppi : 163;
-		density = device != null ? device.ppi/160f : app.pixelsPerPoint;
+		density = app.pixelsPerPoint;
 		ppiX = ppi;
 		ppiY = ppi;
 		ppcX = ppiX / 2.54f;

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
@@ -43,7 +43,6 @@ import org.robovm.apple.glkit.GLKViewDrawableMultisample;
 import org.robovm.apple.glkit.GLKViewDrawableStencilFormat;
 import org.robovm.apple.opengles.EAGLContext;
 import org.robovm.apple.opengles.EAGLRenderingAPI;
-import org.robovm.apple.uikit.UIApplication;
 import org.robovm.apple.uikit.UIEdgeInsets;
 import org.robovm.apple.uikit.UIEvent;
 import org.robovm.apple.uikit.UIInterfaceOrientation;
@@ -51,7 +50,6 @@ import org.robovm.apple.uikit.UIInterfaceOrientationMask;
 import org.robovm.apple.uikit.UIPress;
 import org.robovm.apple.uikit.UIPressesEvent;
 import org.robovm.apple.uikit.UIRectEdge;
-import org.robovm.apple.uikit.UIView;
 import org.robovm.objc.Selector;
 import org.robovm.objc.annotation.BindSelector;
 import org.robovm.objc.annotation.Method;
@@ -285,9 +283,9 @@ public class IOSGraphics extends NSObject implements Graphics, GLKViewDelegate, 
 
 		String machineString = HWMachine.getMachineString();
 		IOSDevice device = config.knownDevices.get(machineString);
-		if (device == null) app.error(tag, "Machine ID: " + machineString + " not found, please report to LibGDX");
-		int ppi = device != null ? device.ppi : 163;
 		density = app.pixelsPerPoint;
+		if (device == null) app.error(tag, "Machine ID: " + machineString + " not found, please report to LibGDX");
+		int ppi = device != null ? device.ppi : app.guessUnknownPpi();
 		ppiX = ppi;
 		ppiY = ppi;
 		ppcX = ppiX / 2.54f;


### PR DESCRIPTION
Density not only was being calculated using `IOSDevice` information (which is risky in case there's a mistake) but it was using Android's 160 dpi value which reported wrong density values on iOS (326 ppi / 160dpi = 2,0375 when it should be 326ppi / 163dpi = 2).

We already obtain points per pixel programatically (API available since iOS 8), there's not reason to depend on `IOSDevice` information afaict.