### PR TITLE
Support specifying which keyboard type to use for getTextInput

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/DefaultAndroidInput.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/DefaultAndroidInput.java
@@ -228,17 +228,19 @@ public class DefaultAndroidInput implements AndroidInput {
 	}
 
 	@Override
-	public void getTextInput(final TextInputListener listener, final String title, final String text, final String hint, final OnscreenKeyboardType type) {
+	public void getTextInput(final TextInputListener listener, final String title, final String text, final String hint, final OnscreenKeyboardType keyboardType) {
 		handle.post(new Runnable() {
 			public void run () {
 				AlertDialog.Builder alert = new AlertDialog.Builder(context);
 				alert.setTitle(title);
 				final EditText input = new EditText(context);
-				input.setInputType(getAndroidInputType(type));
+				if (keyboardType != OnscreenKeyboardType.Default) {
+					input.setInputType(getAndroidInputType(keyboardType));
+				}
 				input.setHint(hint);
 				input.setText(text);				
 				input.setSingleLine();
-				if (type == OnscreenKeyboardType.Password) {
+				if (keyboardType == OnscreenKeyboardType.Password) {
 					input.setTransformationMethod(new PasswordTransformationMethod());
 				}
 				alert.setView(input);

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/DefaultAndroidInput.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/DefaultAndroidInput.java
@@ -30,6 +30,7 @@ import android.os.Handler;
 import android.os.VibrationEffect;
 import android.os.Vibrator;
 import android.text.InputType;
+import android.text.method.PasswordTransformationMethod;
 import android.view.MotionEvent;
 import android.view.Surface;
 import android.view.View;
@@ -237,6 +238,9 @@ public class DefaultAndroidInput implements AndroidInput {
 				input.setHint(hint);
 				input.setText(text);				
 				input.setSingleLine();
+				if (type == OnscreenKeyboardType.Password) {
+					input.setTransformationMethod(new PasswordTransformationMethod());
+				}
 				alert.setView(input);
 				alert.setPositiveButton(context.getString(android.R.string.ok), new DialogInterface.OnClickListener() {
 					public void onClick (DialogInterface dialog, int whichButton) {

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/DefaultAndroidInput.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/DefaultAndroidInput.java
@@ -29,6 +29,7 @@ import android.os.Build;
 import android.os.Handler;
 import android.os.VibrationEffect;
 import android.os.Vibrator;
+import android.text.InputType;
 import android.view.MotionEvent;
 import android.view.Surface;
 import android.view.View;
@@ -221,12 +222,18 @@ public class DefaultAndroidInput implements AndroidInput {
 	}
 
 	@Override
-	public void getTextInput (final TextInputListener listener, final String title, final String text, final String hint) {
+	public void getTextInput (TextInputListener listener, String title, String text, String hint) {
+		getTextInput(listener, title, text, hint, OnscreenKeyboardType.Default);
+	}
+
+	@Override
+	public void getTextInput(final TextInputListener listener, final String title, final String text, final String hint, final OnscreenKeyboardType type) {
 		handle.post(new Runnable() {
 			public void run () {
 				AlertDialog.Builder alert = new AlertDialog.Builder(context);
 				alert.setTitle(title);
 				final EditText input = new EditText(context);
+				input.setInputType(getAndroidInputType(type));
 				input.setHint(hint);
 				input.setText(text);				
 				input.setSingleLine();
@@ -265,6 +272,31 @@ public class DefaultAndroidInput implements AndroidInput {
 				alert.show();
 			}
 		});
+	}
+
+	public static int getAndroidInputType(OnscreenKeyboardType type) {
+		int inputType;
+		switch (type) {
+			case NumberPad:
+				inputType = InputType.TYPE_CLASS_NUMBER;
+				break;
+			case PhonePad:
+				inputType = InputType.TYPE_CLASS_PHONE;
+				break;
+			case Email:
+				inputType = InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS;
+				break;
+			case Password:
+				inputType = InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD;
+				break;
+			case URI:
+				inputType = InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_URI;
+				break;
+			default:
+				inputType = InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD;
+				break;
+		}
+		return inputType;
 	}
 
 	@Override

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/surfaceview/GLSurfaceView20.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/surfaceview/GLSurfaceView20.java
@@ -22,7 +22,6 @@ import android.content.Context;
 import android.graphics.PixelFormat;
 import android.opengl.GLSurfaceView;
 import android.os.SystemClock;
-import android.text.InputType;
 import android.util.Log;
 import android.view.KeyCharacterMap;
 import android.view.KeyEvent;
@@ -30,6 +29,7 @@ import android.view.inputmethod.BaseInputConnection;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputConnection;
 import com.badlogic.gdx.Input.OnscreenKeyboardType;
+import com.badlogic.gdx.backends.android.DefaultAndroidInput;
 
 /** A simple GLSurfaceView sub-class that demonstrates how to perform OpenGL ES 2.0 rendering into a GL Surface. Note the following
  * important details:
@@ -80,15 +80,7 @@ public class GLSurfaceView20 extends GLSurfaceView {
 		// add this line, the IME can show the selectable words when use chinese input method editor.
 		if (outAttrs != null) {
 			outAttrs.imeOptions = outAttrs.imeOptions | EditorInfo.IME_FLAG_NO_EXTRACT_UI;
-
-			switch(onscreenKeyboardType){
-				default: outAttrs.inputType = InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD; break;
-				case NumberPad: outAttrs.inputType = InputType.TYPE_CLASS_NUMBER; break;
-				case PhonePad: outAttrs.inputType = InputType.TYPE_CLASS_PHONE; break;
-				case Email: outAttrs.inputType = InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS; break;
-				case Password: outAttrs.inputType = InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD; break;
-				case URI: outAttrs.inputType = InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_URI; break;
-			}
+			outAttrs.inputType = DefaultAndroidInput.getAndroidInputType(onscreenKeyboardType);
 		}
 
 		BaseInputConnection connection = new BaseInputConnection(this, false) {

--- a/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/mock/input/MockInput.java
+++ b/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/mock/input/MockInput.java
@@ -151,6 +151,11 @@ public class MockInput implements Input {
 	}
 
 	@Override
+	public void getTextInput(TextInputListener listener, String title, String text, String hint, OnscreenKeyboardType type) {
+
+	}
+
+	@Override
 	public void setOnscreenKeyboardVisible(boolean visible) {
 
 	}

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/DefaultLwjglInput.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/DefaultLwjglInput.java
@@ -119,7 +119,13 @@ final public class DefaultLwjglInput implements LwjglInput {
 		return 0;
 	}
 
-	public void getTextInput (final TextInputListener listener, final String title, final String text, final String hint) {
+	@Override
+	public void getTextInput(TextInputListener listener, String title, String text, String hint) {
+		getTextInput(listener, title, text, hint, OnscreenKeyboardType.Default);
+	}
+
+	@Override
+	public void getTextInput (final TextInputListener listener, final String title, final String text, final String hint, OnscreenKeyboardType type) {
 		SwingUtilities.invokeLater(new Runnable() {
 			@Override
 			public void run () {

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglAWTInput.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglAWTInput.java
@@ -160,7 +160,13 @@ public class LwjglAWTInput implements Input, MouseMotionListener, MouseListener,
 		return 0;
 	}
 
-	public void getTextInput (final TextInputListener listener, final String title, final String text, final String hint) {
+	@Override
+	public void getTextInput(TextInputListener listener, String title, String text, String hint) {
+		getTextInput(listener, title, text, hint, OnscreenKeyboardType.Default);
+	}
+
+	@Override
+	public void getTextInput (final TextInputListener listener, final String title, final String text, final String hint, OnscreenKeyboardType type) {
 		SwingUtilities.invokeLater(new Runnable() {
 			@Override
 			public void run () {

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/DefaultLwjgl3Input.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/DefaultLwjgl3Input.java
@@ -316,6 +316,11 @@ public class DefaultLwjgl3Input implements Lwjgl3Input {
 
 	@Override
 	public void getTextInput(TextInputListener listener, String title, String text, String hint) {
+		getTextInput(listener, title, text, hint, OnscreenKeyboardType.Default);
+	}
+
+	@Override
+	public void getTextInput(TextInputListener listener, String title, String text, String hint, OnscreenKeyboardType type) {
 		// FIXME getTextInput does nothing
 		listener.canceled();
 	}

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/DefaultIOSInput.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/DefaultIOSInput.java
@@ -406,7 +406,12 @@ public class DefaultIOSInput implements IOSInput {
 
 	@Override
 	public void getTextInput(TextInputListener listener, String title, String text, String hint) {
-		UIAlertController uiAlertController = buildUIAlertController(listener, title, text, hint);
+		getTextInput(listener, title, text, hint, OnscreenKeyboardType.Default);
+	}
+
+	@Override
+	public void getTextInput(TextInputListener listener, String title, String text, String hint, OnscreenKeyboardType type) {
+		UIAlertController uiAlertController = buildUIAlertController(listener, title, text, hint, type);
 		app.getUIViewController().presentViewController(uiAlertController, true, null);
 	}	
 
@@ -469,22 +474,37 @@ public class DefaultIOSInput implements IOSInput {
 		if (visible) {
 			UIKeyboardType preferredInputType;
 			if(type == null) type = OnscreenKeyboardType.Default;
-			switch(type){
-				case Password: //no equivalent in UIKeyboardType?
-				default: preferredInputType = UIKeyboardType.Default; break;
-				case NumberPad: preferredInputType = UIKeyboardType.NumberPad; break;
-				case PhonePad: preferredInputType = UIKeyboardType.PhonePad; break;
-				case Email: preferredInputType = UIKeyboardType.EmailAddress; break;
-				case URI: preferredInputType = UIKeyboardType.URL; break;
-			}
-			textfield.setKeyboardType(preferredInputType);
+			textfield.setKeyboardType(getIosInputType(type));
 			textfield.becomeFirstResponder();
 			textfield.setDelegate(textDelegate);
 		} else {
 			textfield.resignFirstResponder();
 		}
 	}
-	
+
+	protected UIKeyboardType getIosInputType(OnscreenKeyboardType type) {
+		UIKeyboardType preferredInputType;
+		switch (type) {
+			case NumberPad:
+				preferredInputType = UIKeyboardType.NumberPad;
+				break;
+			case PhonePad:
+				preferredInputType = UIKeyboardType.PhonePad;
+				break;
+			case Email:
+				preferredInputType = UIKeyboardType.EmailAddress;
+				break;
+			case URI:
+				preferredInputType = UIKeyboardType.URL;
+				break;
+			case Password: //no equivalent in UIKeyboardType?
+			default:
+				preferredInputType = UIKeyboardType.Default;
+				break;
+		}
+		return preferredInputType;
+	}
+
 	/**
 	 * Set the keyboard to close when the UITextField return key is pressed
 	 * @param shouldClose Whether or not the keyboard should clsoe on return key press
@@ -517,14 +537,16 @@ public class DefaultIOSInput implements IOSInput {
 	 * @param listener Text input listener
 	 * @param title Dialog title
 	 * @param text Text for text field
+	 * @param type
 	 * @return UIAlertController */
-	private UIAlertController buildUIAlertController(final TextInputListener listener, String title, final String text, final String placeholder) {
+	private UIAlertController buildUIAlertController(final TextInputListener listener, String title, final String text, final String placeholder, final OnscreenKeyboardType type) {
 		final UIAlertController uiAlertController = new UIAlertController(title, text, UIAlertControllerStyle.Alert);
 		uiAlertController.addTextField(new VoidBlock1<UITextField>() {
 			@Override
 			public void invoke(UITextField uiTextField) {
 				uiTextField.setPlaceholder(placeholder);
 				uiTextField.setText(text);
+				uiTextField.setKeyboardType(getIosInputType(type));
 			}
 		});
 		uiAlertController.addAction(new UIAlertAction("Ok", UIAlertActionStyle.Default, new VoidBlock1<UIAlertAction>() {

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/DefaultIOSInput.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/DefaultIOSInput.java
@@ -547,6 +547,10 @@ public class DefaultIOSInput implements IOSInput {
 				uiTextField.setPlaceholder(placeholder);
 				uiTextField.setText(text);
 				uiTextField.setKeyboardType(getIosInputType(type));
+				if (type == OnscreenKeyboardType.Password) {
+					uiTextField.setSecureTextEntry(true);
+				}
+
 			}
 		});
 		uiAlertController.addAction(new UIAlertAction("Ok", UIAlertActionStyle.Default, new VoidBlock1<UIAlertAction>() {

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/DefaultGwtInput.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/DefaultGwtInput.java
@@ -280,7 +280,13 @@ public class DefaultGwtInput implements GwtInput {
 		return justPressedKeys[key];
 	}
 
-	public void getTextInput (TextInputListener listener, String title, String text, String hint) {
+	@Override
+	public void getTextInput(TextInputListener listener, String title, String text, String hint) {
+		getTextInput(listener, title, text, hint, OnscreenKeyboardType.Default);
+	}
+
+	@Override
+	public void getTextInput (TextInputListener listener, String title, String text, String hint, OnscreenKeyboardType type) {
 		TextInputDialogBox dialog = new TextInputDialogBox(title, text, hint);
 		final TextInputListener capturedListener = listener;
 		dialog.setListener(new TextInputDialogListener() {

--- a/gdx/src/com/badlogic/gdx/Input.java
+++ b/gdx/src/com/badlogic/gdx/Input.java
@@ -674,13 +674,23 @@ public interface Input {
 	public boolean isKeyJustPressed (int key);
 
 	/** System dependent method to input a string of text. A dialog box will be created with the given title and the given text as a
-	 * message for the user. Once the dialog has been closed the provided {@link TextInputListener} will be called on the rendering
-	 * thread.
+	 * message for the user. Will use the Default keyboard type.
+	 * Once the dialog has been closed the provided {@link TextInputListener} will be called on the rendering thread.
 	 * 
 	 * @param listener The TextInputListener.
 	 * @param title The title of the text input dialog.
 	 * @param text The message presented to the user. */
 	public void getTextInput (TextInputListener listener, String title, String text, String hint);
+
+	/** System dependent method to input a string of text. A dialog box will be created with the given title and the given text as a
+	 * message for the user. Once the dialog has been closed the provided {@link TextInputListener} will be called on the rendering
+	 * thread.
+	 *
+	 * @param listener The TextInputListener.
+	 * @param title The title of the text input dialog.
+	 * @param text The message presented to the user.
+	 * @param type which type of keyboard we wish to display */
+	public void getTextInput (TextInputListener listener, String title, String text, String hint, OnscreenKeyboardType type);
 
 	/** Sets the on-screen keyboard visible if available. Will use the Default keyboard type.
 	 * 

--- a/gdx/src/com/badlogic/gdx/input/RemoteInput.java
+++ b/gdx/src/com/badlogic/gdx/input/RemoteInput.java
@@ -454,6 +454,11 @@ public class RemoteInput implements Runnable, Input {
 	}
 
 	@Override
+	public void getTextInput(TextInputListener listener, String title, String text, String hint, OnscreenKeyboardType type) {
+		Gdx.app.getInput().getTextInput(listener, title, text, hint, type);
+	}
+
+	@Override
 	public void setOnscreenKeyboardVisible (boolean visible) {
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TextInputDialogTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TextInputDialogTest.java
@@ -17,6 +17,7 @@
 package com.badlogic.gdx.tests;
 
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Input;
 import com.badlogic.gdx.Input.TextInputListener;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
@@ -43,7 +44,7 @@ public class TextInputDialogTest extends GdxTest {
 			public void canceled () {
 				message = "cancled by user";
 			}
-		}, "enter something funny", "funny", "something funny");
+		}, "enter something funny", "funny", "something funny", Input.OnscreenKeyboardType.Default);
 	}
 
 	public void render () {

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtTestWrapper.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtTestWrapper.java
@@ -295,6 +295,11 @@ public class GwtTestWrapper extends GdxTest {
 		}
 
 		@Override
+		public void getTextInput(TextInputListener listener, String title, String text, String hint, OnscreenKeyboardType type) {
+			input.getTextInput(listener, title, text, hint, type);
+		}
+
+		@Override
 		public void setOnscreenKeyboardVisible (boolean visible) {
 			input.setOnscreenKeyboardVisible(visible);
 		}


### PR DESCRIPTION
This is a follow-up to #6235 and adds support for different keyboard types on iOS and Android for `getTextInput` method.