### PR TITLE
Add a skip-flag for GH Actions.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   macos:
+    if: "!contains(github.event.head_commit.message, 'ci skip')"
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
@@ -33,6 +34,7 @@ jobs:
         run: ant -f build-mac-ios.xml
 
   linux:
+    if: "!contains(github.event.head_commit.message, 'ci skip')"
     runs-on: ubuntu-latest
     env:
       ORG_GRADLE_PROJECT_GITHUB_USERNAME: ""


### PR DESCRIPTION
This change allows skipping the Github Actions CI by adding "[ci skip]" to the commit message. This was a feature in the previously used Travis CI and is useful for README or documentation changes.

It is based on [this](https://github.community/t/github-actions-does-not-respect-skip-ci/17325/9) Github community post.