### PR TITLE
Revert 6118 "Cache Box2D Fixture filter data to avoid JNI overhead"

### DIFF
--- a/extensions/gdx-box2d/gdx-box2d/src/com/badlogic/gdx/physics/box2d/Filter.java
+++ b/extensions/gdx-box2d/gdx-box2d/src/com/badlogic/gdx/physics/box2d/Filter.java
@@ -28,10 +28,4 @@ public class Filter {
 	/** Collision groups allow a certain group of objects to never collide (negative) or always collide (positive). Zero means no
 	 * collision group. Non-zero group filtering always wins against the mask bits. */
 	public short groupIndex = 0;
-
-	public void set(Filter filter) {
-		categoryBits = filter.categoryBits;
-		maskBits = filter.maskBits;
-		groupIndex = filter.groupIndex;
-	}
 }

--- a/extensions/gdx-box2d/gdx-box2d/src/com/badlogic/gdx/physics/box2d/Fixture.java
+++ b/extensions/gdx-box2d/gdx-box2d/src/com/badlogic/gdx/physics/box2d/Fixture.java
@@ -31,9 +31,6 @@ public class Fixture {
 	/** the address of the fixture **/
 	protected long addr;
 
-	/** the fixture filter data, initialized lazily **/
-	private Filter filter;
-
 	/** the shape, initialized lazy **/
 	protected Shape shape;
 
@@ -144,9 +141,6 @@ public class Fixture {
 	 * awake. This automatically calls Refilter. */
 	public void setFilterData (Filter filter) {
 		jniSetFilterData(addr, filter.categoryBits, filter.maskBits, filter.groupIndex);
-		if (this.filter == null)
-			this.filter = new Filter();
-		this.filter.set(filter);
 	}
 
 	private native void jniSetFilterData (long addr, short categoryBits, short maskBits, short groupIndex); /*
@@ -160,18 +154,14 @@ public class Fixture {
 
 	/** Get the contact filtering data. */
 	private final short[] tmp = new short[3];
-	private final Filter tmpFilter = new Filter();
+	private final Filter filter = new Filter();
 
 	public Filter getFilterData () {
-		if (filter == null) {
-			jniGetFilterData(addr, tmp);
-			filter = new Filter();
-			filter.maskBits = tmp[0];
-			filter.categoryBits = tmp[1];
-			filter.groupIndex = tmp[2];
-		}
-		tmpFilter.set(filter);
-		return tmpFilter;
+		jniGetFilterData(addr, tmp);
+		filter.maskBits = tmp[0];
+		filter.categoryBits = tmp[1];
+		filter.groupIndex = tmp[2];
+		return filter;
 	}
 
 	private native void jniGetFilterData (long addr, short[] filter); /*


### PR DESCRIPTION
Unfortunately this change has unintended consequences on Box2D making collision logic unreliable. 

I pushed a live app with libGDX 1.9.12 and have received several user reports about objects traversing walls in some cases.

I was able to reproduce incorrect collision resolution by changing the filter data of an existing object by calling `setFilterData` but there may be other scenarios. My guess is that this is caused because the filter data is not applied immediately when calling `setFilterData` as stated on this comment:
```
/** Set the contact filtering data. This will not update contacts until the next time step when either parent body is active and
	 * awake. This automatically calls Refilter. */
```
causing a mismatch between Box2D internal state and libGDX state.

**EDIT: The cause of the issue is probably because libGDX pools the `Fixture`s in `World` and the `reset()` doesn't set the filter back to default.**

**@Tom-Ski @NathanSweet This is a bad issue. I think we whould release a patch version as currently Box2D is broken.**