### PR TITLE
 Cache Box2D Fixture filter data to avoid JNI overhead V2

### DIFF
--- a/extensions/gdx-box2d/gdx-box2d/src/com/badlogic/gdx/physics/box2d/Filter.java
+++ b/extensions/gdx-box2d/gdx-box2d/src/com/badlogic/gdx/physics/box2d/Filter.java
@@ -28,4 +28,10 @@ public class Filter {
 	/** Collision groups allow a certain group of objects to never collide (negative) or always collide (positive). Zero means no
 	 * collision group. Non-zero group filtering always wins against the mask bits. */
 	public short groupIndex = 0;
+
+	public void set(Filter filter) {
+		categoryBits = filter.categoryBits;
+		maskBits = filter.maskBits;
+		groupIndex = filter.groupIndex;
+	}
 }

--- a/extensions/gdx-box2d/gdx-box2d/src/com/badlogic/gdx/physics/box2d/Fixture.java
+++ b/extensions/gdx-box2d/gdx-box2d/src/com/badlogic/gdx/physics/box2d/Fixture.java
@@ -164,6 +164,8 @@ public class Fixture {
 	/** Get the contact filtering data. */
 	private final short[] tmp = new short[3];
 
+	/** Get the contact filtering data. Modifying the returned {@code Filter} without calling {@link #setFilterData} can result in
+	 * unpredictable behaviour. */
 	public Filter getFilterData () {
 		if (dirtyFilter) {
 			jniGetFilterData(addr, tmp);

--- a/extensions/gdx-box2d/gdx-box2d/src/com/badlogic/gdx/physics/box2d/Fixture.java
+++ b/extensions/gdx-box2d/gdx-box2d/src/com/badlogic/gdx/physics/box2d/Fixture.java
@@ -37,6 +37,12 @@ public class Fixture {
 	/** user specified data **/
 	protected Object userData;
 
+	/** the fixture filter data **/
+	private final Filter filter = new Filter();
+	
+	/** flag to indicate if filter data needs to be updated with a JNI call **/
+	private boolean dirtyFilter = true;
+
 	/** Constructs a new fixture
 	 * @param addr the address of the fixture */
 	protected Fixture (Body body, long addr) {
@@ -49,6 +55,7 @@ public class Fixture {
 		this.addr = addr;
 		this.shape = null;
 		this.userData = null;
+		this.dirtyFilter = true;
 	}
 
 	/** Get the type of the child shape. You can use this to down cast to the concrete shape.
@@ -141,6 +148,8 @@ public class Fixture {
 	 * awake. This automatically calls Refilter. */
 	public void setFilterData (Filter filter) {
 		jniSetFilterData(addr, filter.categoryBits, filter.maskBits, filter.groupIndex);
+		this.filter.set(filter);
+		dirtyFilter = false;
 	}
 
 	private native void jniSetFilterData (long addr, short categoryBits, short maskBits, short groupIndex); /*
@@ -154,13 +163,15 @@ public class Fixture {
 
 	/** Get the contact filtering data. */
 	private final short[] tmp = new short[3];
-	private final Filter filter = new Filter();
 
 	public Filter getFilterData () {
-		jniGetFilterData(addr, tmp);
-		filter.maskBits = tmp[0];
-		filter.categoryBits = tmp[1];
-		filter.groupIndex = tmp[2];
+		if (dirtyFilter) {
+			jniGetFilterData(addr, tmp);
+			filter.maskBits = tmp[0];
+			filter.categoryBits = tmp[1];
+			filter.groupIndex = tmp[2];
+			dirtyFilter = false;
+		}
 		return filter;
 	}
 


### PR DESCRIPTION
This is an attempt to fix the issues caused by #6118 described in #6261.

Instead of setting `filter` to `null` on `Fixture` `reset()` which would cause an allocation every time a `Fixture` is obtained (`reset()` is called after `obtain()` in this case), I've opted to go for a no memory allocation approach by using a boolean flag to indicate if `filter` data is dirty. The drawback of this approach is that `getFilterData()` now returns the `Filter` reference used by `Fixture` meaning that, if  it's changed without calling `setFilterData()`, it will cause inconsistent behaviour. This also means the change may break backwards compatibility.

The approach suggested by @NathanSweet on #6118 asking if it was possible to remove `jniGetFilterData()` alltogether would require some hacks because fixtures can be created using a `FixtureDef` directly (see `Body#createFixture (FixtureDef def)`) in which case the `Filter` instance would not have the information provided.

I've tested it on my games and haven't found any issue.

