### PR TITLE
Fix getDensity() on iOS to be consistent with the rest of backends

### DIFF
--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
@@ -283,9 +283,9 @@ public class IOSGraphics extends NSObject implements Graphics, GLKViewDelegate, 
 
 		String machineString = HWMachine.getMachineString();
 		IOSDevice device = config.knownDevices.get(machineString);
-		density = app.pixelsPerPoint;
 		if (device == null) app.error(tag, "Machine ID: " + machineString + " not found, please report to LibGDX");
 		int ppi = device != null ? device.ppi : app.guessUnknownPpi();
+		density = ppi / 160f;
 		ppiX = ppi;
 		ppiY = ppi;
 		ppcX = ppiX / 2.54f;


### PR DESCRIPTION
#6245 changes on `getDensity()` were not following `Graphics` API which specifies:

```
	/** This is a scaling factor for the Density Independent Pixel unit, following the same conventions as
	 * android.util.DisplayMetrics#density, where one DIP is one pixel on an approximately 160 dpi screen. Thus on a 160dpi screen
	 * this density value will be 1; on a 120 dpi screen it would be .75; etc.
	 *
```

As a separate PR we can add a new interface method to easily get the amount of physical pixels per logical pixel, maybe promoting the already present on iOS `getBackBufferScale()`.