### PR TITLE
HeadlessApplication use nanotime for render interval

### DIFF
--- a/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/HeadlessApplication.java
+++ b/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/HeadlessApplication.java
@@ -118,7 +118,8 @@ public class HeadlessApplication implements Application {
 				final long n = TimeUtils.nanoTime();
 				if (t > n) {
 					try {
-						Thread.sleep((t - n) / 1000000);
+						long sleep = t - n;
+						Thread.sleep(sleep / 1000000, (int) (sleep % 1000000));
 					} catch (InterruptedException e) {}
 					t = TimeUtils.nanoTime() + renderInterval;
 				} else

--- a/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/HeadlessApplication.java
+++ b/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/HeadlessApplication.java
@@ -121,7 +121,7 @@ public class HeadlessApplication implements Application {
 						long sleep = t - n;
 						Thread.sleep(sleep / 1000000, (int) (sleep % 1000000));
 					} catch (InterruptedException e) {}
-					t = TimeUtils.nanoTime() + renderInterval;
+					t = t + renderInterval;
 				} else
 					t = n + renderInterval;
 				

--- a/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/mock/graphics/MockGraphics.java
+++ b/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/mock/graphics/MockGraphics.java
@@ -93,7 +93,7 @@ public class MockGraphics implements Graphics {
 
 	@Override
 	public float getRawDeltaTime() {
-		return 0;
+		return deltaTime;
 	}
 
 	@Override


### PR DESCRIPTION
Also report raw delta time instead of 0 (wrong). 

Fixes #4742