### PR TITLE
GWT use setCatchKey to prevent browser's default behaviour

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,5 @@
 [1.9.13]
-- GWT: Key codes set with Gwt.input.setCatchKey prevent default browser behaviour
+- GWT: Key codes set with Gdx.input.setCatchKey prevent default browser behaviour
 
 [1.9.12]
 - [BREAKING CHANGE] iOS: Changed how Retina/hdpi handled on iOS. See #3709.

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+[1.9.13]
+- GWT: Key codes set with Gwt.input.setCatchKey prevent default browser behaviour
+
 [1.9.12]
 - [BREAKING CHANGE] iOS: Changed how Retina/hdpi handled on iOS. See #3709.
 - [BREAKING CHANGE] API Change: InputProcessor scrolled method now receives scroll amount for X and Y. Changed type to float to support devices which report fractional scroll amounts. Updated InputEvent in scene2d accordingly: added scrollAmountX, scrollAmountY attributes and corresponding setters and getters. See #6154.

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/DefaultGwtInput.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/DefaultGwtInput.java
@@ -55,6 +55,7 @@ public class DefaultGwtInput implements GwtInput {
 	boolean hasFocus = true;
 	GwtAccelerometer accelerometer;
 	GwtGyroscope gyroscope;
+	private IntSet keysToCatch = new IntSet();
 
 	public DefaultGwtInput (CanvasElement canvas, GwtApplicationConfiguration config) {
 		this.canvas = canvas;
@@ -102,6 +103,9 @@ public class DefaultGwtInput implements GwtInput {
 			}
 		}
 		hookEvents();
+
+		// backwards compatibility: backspace was caught in older versions
+		keysToCatch.add(Keys.BACKSPACE);
 	}
 
 	@Override
@@ -352,30 +356,36 @@ public class DefaultGwtInput implements GwtInput {
 
 	@Override
 	public void setCatchBackKey (boolean catchBack) {
+		setCatchKey(Keys.BACK, catchBack);
 	}
 
 	@Override
 	public boolean isCatchBackKey () {
-		return false;
+		return keysToCatch.contains(Keys.BACK);
 	}
 
 	@Override
 	public void setCatchMenuKey (boolean catchMenu) {
+		setCatchKey(Keys.MENU, catchMenu);
 	}
 
 	@Override
 	public boolean isCatchMenuKey () {
-		return false;
+		return keysToCatch.contains(Keys.MENU);
 	}
 
 	@Override
 	public void setCatchKey (int keycode, boolean catchKey) {
-
+		if (!catchKey) {
+			keysToCatch.remove(keycode);
+		} else if (catchKey) {
+			keysToCatch.add(keycode);
+		}
 	}
 
 	@Override
 	public boolean isCatchKey (int keycode) {
-		return false;
+		return keysToCatch.contains(keycode);
 	}
 
 	@Override
@@ -735,8 +745,10 @@ public class DefaultGwtInput implements GwtInput {
 			if (e.getType().equals("keydown")) {
 				// Gdx.app.log("DefaultGwtInput", "keydown");
 				int code = keyForCode(e.getKeyCode());
-				if (code == 67) {
+				if (isCatchKey(code)) {
 					e.preventDefault();
+				}
+				if (code == Keys.BACKSPACE) {
 					if (processor != null) {
 						processor.keyDown(code);
 						processor.keyTyped('\b');
@@ -764,6 +776,9 @@ public class DefaultGwtInput implements GwtInput {
 			if (e.getType().equals("keyup")) {
 				// Gdx.app.log("DefaultGwtInput", "keyup");
 				int code = keyForCode(e.getKeyCode());
+				if (isCatchKey(code)) {
+					e.preventDefault();
+				}
 				if (pressedKeys[code]) {
 					pressedKeySet.remove(code);
 					pressedKeyCount--;
@@ -878,7 +893,7 @@ public class DefaultGwtInput implements GwtInput {
 	}
 
 	/** borrowed from PlayN, thanks guys **/
-	private static int keyForCode (int keyCode) {
+	protected int keyForCode (int keyCode) {
 		switch (keyCode) {
 		case KeyCodes.KEY_ALT:
 			return Keys.ALT_LEFT;

--- a/gdx/src/com/badlogic/gdx/Input.java
+++ b/gdx/src/com/badlogic/gdx/Input.java
@@ -788,10 +788,11 @@ public interface Input {
 	public boolean isCatchMenuKey ();
 
 	/**
-	 * Sets whether the given key on Android should be caught. No effect on other platforms.
-	 * All keys that are not caught may be handled by other apps or background processes. For example, media or volume
-	 * buttons are handled by background media players if present. If you use these keys to control your game, they
-	 * must be catched to prevent unintended behaviour.
+	 * Sets whether the given key on Android or GWT should be caught. No effect on other platforms.
+	 * All keys that are not caught may be handled by other apps or background processes on Android, or may
+	 * trigger default browser behaviour on GWT. For example, media or volume buttons are handled by
+	 * background media players if present, or Space key triggers a scroll. All keys you need to control your
+	 * game should be caught to prevent unintended behaviour.
 	 *
 	 * @param keycode  keycode to catch
 	 * @param catchKey whether to catch the given keycode


### PR DESCRIPTION
Typically, every libGDX HTML project has to tweak around with index.html to prevent browser's default behaviour on certain key presses (F1, Alt, Space, Arrow Keys and stuff).

We already have `setCatchKey` to prevent system or background app behaviour on key presses, but this is only implemented on Android so far. This PR adds the ability to use the setCatchKey methods to prevent browser default behaviour on GWT.

Additionally, this changes `keyForCode` from private static to protected. Since we now can override the input processing class, it makes sense to have this method overridable as well.