### PR TITLE
Simplifiications to Proguard config

### DIFF
--- a/extensions/gdx-controllers/gdx-controllers-android/src/com/badlogic/gdx/controllers/android/AndroidControllers.java
+++ b/extensions/gdx-controllers/gdx-controllers-android/src/com/badlogic/gdx/controllers/android/AndroidControllers.java
@@ -57,12 +57,7 @@ public class AndroidControllers implements LifecycleListener, ControllerManager,
 		
 		// use InputManager on Android +4.1 to receive (dis-)connect events
 		if(Gdx.app.getVersion() >= 16) {
-			try {
-				String className = "com.badlogic.gdx.controllers.android.ControllerLifeCycleListener";
-				Class.forName(className).getConstructor(AndroidControllers.class).newInstance(this);
-			} catch(Exception e) {
-				Gdx.app.log(TAG, "Couldn't register controller life-cycle listener");
-			}
+			new ControllerLifeCycleListener(this);
 		}
 	}
 	

--- a/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/android/proguard-rules.pro
+++ b/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/android/proguard-rules.pro
@@ -27,6 +27,10 @@
 -dontwarn com.badlogic.gdx.jnigen.BuildTarget*
 -dontwarn com.badlogic.gdx.graphics.g2d.freetype.FreetypeBuild
 
+# Required if using Gdx-Controllers extension
+-keep class com.badlogic.gdx.controllers.android.AndroidControllers
+
+# Required if using Box2D extension
 -keepclassmembers class com.badlogic.gdx.physics.box2d.World {
    boolean contactFilter(long, long);
    void    beginContact(long);

--- a/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/android/proguard-rules.pro
+++ b/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/android/proguard-rules.pro
@@ -21,18 +21,11 @@
 
 -verbose
 
--dontwarn android.support.**
 -dontwarn com.badlogic.gdx.backends.android.AndroidFragmentApplication
 -dontwarn com.badlogic.gdx.utils.GdxBuild
 -dontwarn com.badlogic.gdx.physics.box2d.utils.Box2DBuild
 -dontwarn com.badlogic.gdx.jnigen.BuildTarget*
 -dontwarn com.badlogic.gdx.graphics.g2d.freetype.FreetypeBuild
-
--keep class com.badlogic.gdx.controllers.android.AndroidControllers
-
--keepclassmembers class com.badlogic.gdx.backends.android.AndroidInput* {
-   <init>(com.badlogic.gdx.Application, android.content.Context, java.lang.Object, com.badlogic.gdx.backends.android.AndroidApplicationConfiguration);
-}
 
 -keepclassmembers class com.badlogic.gdx.physics.box2d.World {
    boolean contactFilter(long, long);


### PR DESCRIPTION
Removed some unnecessary Proguard rules:
- `dontwarn android.support` rule is default on Android `proguard-android.txt` platform file, no need to add it again (and with migration to AndroidX I don't think is relevant for us anyway).
- `AndroidControllers` rule is not needed after removing reflection code
- `AndroidInput` rule is not needed either (legacy reflection), actually that class is now an Interface, the old one was renamed to `DefaultAndroidInput`.