### PR TITLE
Add hasContents to Clipboard interface, to reduce clipboard notifications on iOS 14

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidClipboard.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidClipboard.java
@@ -23,10 +23,15 @@ import com.badlogic.gdx.utils.Clipboard;
 
 public class AndroidClipboard implements Clipboard {
 
-	private android.content.ClipboardManager clipboard;
+	private final android.content.ClipboardManager clipboard;
 
 	public AndroidClipboard (Context context) {
 		clipboard = (android.content.ClipboardManager)context.getSystemService(Context.CLIPBOARD_SERVICE);
+	}
+
+	@Override
+	public boolean hasContents () {
+		return clipboard.hasPrimaryClip();
 	}
 
 	@Override

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglClipboard.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglClipboard.java
@@ -30,6 +30,12 @@ import com.badlogic.gdx.utils.Clipboard;
  * @author mzechner */
 public class LwjglClipboard implements Clipboard, ClipboardOwner {
 	@Override
+	public boolean hasContents () {
+		String contents = getContents();
+		return contents != null && !contents.isEmpty();
+	}
+
+	@Override
 	public String getContents () {
 		try {
 			java.awt.datatransfer.Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Clipboard.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Clipboard.java
@@ -16,8 +16,6 @@
 
 package com.badlogic.gdx.backends.lwjgl3;
 
-import java.awt.Toolkit;
-
 import org.lwjgl.glfw.GLFW;
 
 import com.badlogic.gdx.Gdx;
@@ -26,6 +24,12 @@ import com.badlogic.gdx.utils.Clipboard;
 /** Clipboard implementation for desktop that uses the system clipboard via GLFW.
  * @author mzechner */
 public class Lwjgl3Clipboard implements Clipboard {
+	@Override
+	public boolean hasContents () {
+		String contents = getContents();
+		return contents != null && !contents.isEmpty();
+	}
+
 	@Override
 	public String getContents () {		
 		return GLFW.glfwGetClipboardString(((Lwjgl3Graphics)Gdx.graphics).getWindow().getWindowHandle());

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSApplication.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSApplication.java
@@ -21,6 +21,7 @@ import java.io.File;
 import com.badlogic.gdx.ApplicationLogger;
 import com.badlogic.gdx.backends.iosrobovm.objectal.OALIOSAudio;
 import org.robovm.apple.coregraphics.CGRect;
+import org.robovm.apple.foundation.Foundation;
 import org.robovm.apple.foundation.NSMutableDictionary;
 import org.robovm.apple.foundation.NSObject;
 import org.robovm.apple.foundation.NSProcessInfo;
@@ -435,7 +436,12 @@ public class IOSApplication implements Application {
 
 			@Override
 			public boolean hasContents () {
-				return UIPasteboard.getGeneralPasteboard().hasStrings();
+				if (Foundation.getMajorSystemVersion() >= 10) {
+					return UIPasteboard.getGeneralPasteboard().hasStrings();
+				}
+
+				String contents = getContents();
+				return contents != null && !contents.isEmpty();
 			}
 
 			@Override

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSApplication.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSApplication.java
@@ -434,6 +434,11 @@ public class IOSApplication implements Application {
 			}
 
 			@Override
+			public boolean hasContents () {
+				return UIPasteboard.getGeneralPasteboard().hasStrings();
+			}
+
+			@Override
 			public String getContents () {
 				return UIPasteboard.getGeneralPasteboard().getString();
 			}

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtClipboard.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtClipboard.java
@@ -24,9 +24,15 @@ public class GwtClipboard implements Clipboard {
 	private boolean requestedWritePermissions = false;
 	private boolean hasWritePermissions = true;
 
-	private ClipboardWriteHandler writeHandler = new ClipboardWriteHandler();
+	private final ClipboardWriteHandler writeHandler = new ClipboardWriteHandler();
 
 	private String content = "";
+
+	@Override
+	public boolean hasContents () {
+		String contents = getContents();
+		return contents != null && !contents.isEmpty();
+	}
 
 	@Override
 	public String getContents () {

--- a/gdx/src/com/badlogic/gdx/utils/Clipboard.java
+++ b/gdx/src/com/badlogic/gdx/utils/Clipboard.java
@@ -19,6 +19,12 @@ package com.badlogic.gdx.utils;
 /** A very simple clipboard interface for text content.
  * @author mzechner */
 public interface Clipboard {
+	/** Check if the clipboard has contents.
+	 * Recommended to use over getContents() for privacy reasons, if you only want to check if there's something on the clipboard.
+	 * For instance, calling getContents() on iOS shows a privacy notification since iOS 14, while hasContents() does not.
+	 * @return true, if the clipboard has contents */
+	public boolean hasContents ();
+
 	/** gets the current content of the clipboard if it contains text
 	 * for WebGL app, getting the system clipboard is currently not supported. It works only inside the app
 	 * @return the clipboard content or null */

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ClipboardTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ClipboardTest.java
@@ -31,6 +31,7 @@ public class ClipboardTest extends GdxTest {
 	TextArea textArea;
 	TextButton buttonCopy;
 	TextButton buttonPaste;
+	TextButton buttonHasContents;
 
 	@Override
 	public void create() {
@@ -39,6 +40,7 @@ public class ClipboardTest extends GdxTest {
 		textArea = new TextArea("", skin);
 		buttonCopy = new TextButton("Copy", skin);
 		buttonPaste = new TextButton("Paste", skin);
+		buttonHasContents = new TextButton("Has Contents: " + Gdx.app.getClipboard().hasContents(), skin);
 
 		textArea.setSize(Gdx.graphics.getWidth() / 3f, Gdx.graphics.getHeight() / 3f);
 
@@ -48,6 +50,8 @@ public class ClipboardTest extends GdxTest {
 				Gdx.graphics.getHeight() / 4f - buttonCopy.getHeight() / 2f);
 		buttonPaste.setPosition(3 * Gdx.graphics.getWidth() / 4f - buttonPaste.getWidth() / 2f,
 				Gdx.graphics.getHeight() / 4f - buttonPaste.getHeight() / 2f);
+		buttonHasContents.setPosition(Gdx.graphics.getWidth() / 2f - buttonHasContents.getWidth() / 2f,
+				Gdx.graphics.getHeight() / 4f - buttonHasContents.getHeight() / 2f);
 
 		buttonCopy.addListener(new ChangeListener() {
 			@Override
@@ -61,10 +65,17 @@ public class ClipboardTest extends GdxTest {
 				textArea.setText(Gdx.app.getClipboard().getContents());
 			}
 		});
+		buttonHasContents.addListener(new ChangeListener() {
+			@Override
+			public void changed(ChangeEvent event, Actor actor) {
+				buttonHasContents.setText("Has Contents: " + Gdx.app.getClipboard().hasContents());
+			}
+		});
 
 		stage.addActor(textArea);
 		stage.addActor(buttonCopy);
 		stage.addActor(buttonPaste);
+		stage.addActor(buttonHasContents);
 
 		Gdx.input.setInputProcessor(stage);
 	}


### PR DESCRIPTION
Apple has added a new banner alert to iOS 14 that lets users know if an app is pasting from the clipboard and therefore able to read the clipboard’s contents ([More information](https://9to5mac.com/2020/06/24/ios-14-clipboard-notifications/))

I've added a `boolean hasContents()` method to the `Clipboard` interface and adjusted the iOS and Android implementations, so that the actual clipboard content is not read by the app when calling this method.

