### PR TITLE
Use platform default color bit depth on Android and iOS

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplicationConfiguration.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplicationConfiguration.java
@@ -29,7 +29,7 @@ import com.badlogic.gdx.backends.android.surfaceview.ResolutionStrategy;
  * @author mzechner */
 public class AndroidApplicationConfiguration {
 	/** number of bits per color channel **/
-	public int r = 5, g = 6, b = 5, a = 0;
+	public int r = 8, g = 8, b = 8, a = 0;
 
 	/** number of bits for depth and stencil buffer **/
 	public int depth = 16, stencil = 0;

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphics.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphics.java
@@ -90,7 +90,7 @@ public class AndroidGraphics implements Graphics, Renderer {
 	private float density = 1;
 
 	protected final AndroidApplicationConfiguration config;
-	private BufferFormat bufferFormat = new BufferFormat(5, 6, 5, 0, 16, 0, 0, false);
+	private BufferFormat bufferFormat = new BufferFormat(8, 8, 8, 0, 16, 0, 0, false);
 	private boolean isContinuous = true;
 
 	public AndroidGraphics (AndroidApplicationBase application, AndroidApplicationConfiguration config,

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/surfaceview/GLSurfaceView20.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/surfaceview/GLSurfaceView20.java
@@ -120,7 +120,7 @@ public class GLSurfaceView20 extends GLSurfaceView {
 	private void init (boolean translucent, int depth, int stencil) {
 
 		/*
-		 * By default, GLSurfaceView() creates a RGB_565 opaque surface. If we want a translucent one, we should change the
+		 * By default, GLSurfaceView() creates a RGB_888 opaque surface. If we want a translucent one, we should change the
 		 * surface's format here, using PixelFormat.TRANSLUCENT for GL Surfaces is interpreted as any 32-bit surface with alpha by
 		 * SurfaceFlinger.
 		 */
@@ -137,7 +137,7 @@ public class GLSurfaceView20 extends GLSurfaceView {
 		 * We need to choose an EGLConfig that matches the format of our surface exactly. This is going to be done in our custom
 		 * config chooser. See ConfigChooser class definition below.
 		 */
-		setEGLConfigChooser(translucent ? new ConfigChooser(8, 8, 8, 8, depth, stencil) : new ConfigChooser(5, 6, 5, 0, depth,
+		setEGLConfigChooser(translucent ? new ConfigChooser(8, 8, 8, 8, depth, stencil) : new ConfigChooser(8, 8, 8, 0, depth,
 			stencil));
 
 		/* Set the renderer responsible for frame rendering */

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSApplicationConfiguration.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSApplicationConfiguration.java
@@ -32,8 +32,8 @@ public class IOSApplicationConfiguration {
 	/** whether or not landscape orientation is supported. */
 	public boolean orientationLandscape = true;
 
-	/** the color format, RGB565 is the default **/
-	public GLKViewDrawableColorFormat colorFormat = GLKViewDrawableColorFormat.RGB565;
+	/** the color format, RGBA8888 is the default **/
+	public GLKViewDrawableColorFormat colorFormat = GLKViewDrawableColorFormat.RGBA8888;
 
 	/** the depth buffer format, Format16 is default **/
 	public GLKViewDrawableDepthFormat depthFormat = GLKViewDrawableDepthFormat._16;


### PR DESCRIPTION
After a post from user "tann" on Discord #android channel we've realised some inconsistencies on the libGDX default color format (RGB565) and the platform defaults on Android (RGB888) and iOS (RGBA8888).

### Android
It is currently set to RGB565 because that was the default of `GLSurfaceView` before but, currently (not sure since when), it's RGB888 (https://developer.android.com/reference/android/opengl/GLSurfaceView.html).

> By default GLSurfaceView will create a PixelFormat.RGB_888 format surface.

I've kept RGB565 as fallback in case the provided color format configuration is not supported by the device. This is the safest approach as, in the rare case a device did not support RGB888 it would fallback to previous default but it's not necessarily the best one. It depends if there are actually devices in the wild (with min SDK 14+) that don't support RGB888, if there aren't, we should default to RGB888. Unfortunately I haven't been able to find that information.

Regarding the changes a couple of comments:
- The change in the `BufferFormat` on `AndroidGraphics` is aesthetic. A new instance with the appropriate configurations is assigned to `bufferFormat`, I'm not sure if instantitating it on declaration is needed at all but I've kept it just in case.
- Something similar happens on `GLSurfaceView20` `init()` method changes. Even if we set the color format there (either RGB888 or RGBA8888) it doesn't matter because we set it manually afterwards in every case later on (check for example `AndroidGraphics.createGLSurfaceView()`):

```
GLSurfaceView20 view = new GLSurfaceView20(application.getContext(), resolutionStrategy, config.useGL30 ? 3 : 2);
if (configChooser != null)
	view.setEGLConfigChooser(configChooser);
else
	view.setEGLConfigChooser(config.r, config.g, config.b, config.a, config.depth, config.stencil);
```

**Known issues and Tests**
1. Using RGB565 has some known issues on especific devices such as reported here https://github.com/libgdx/libgdx/issues/5993. I've also personally observed issues when running an OpenGL gradient on a Nexus 7 2013 which displays bad banding and artifacts that get fixed using RGB888.
2. Current default RGB565 causes dithering to be applied, especially visible when zooming in on any libGDX game with default settings.
3. @cypherdare says he's been using RGBA8888 on his apps for 5 years without any issue.

### iOS
On iOS the current default is RGBA8888 (https://developer.apple.com/documentation/glkit/glkview/1615587-drawablecolorformat).

iOS is weird because the color format seems to be ignored when running on a device (it always looks like RGB888) but it is correctly applied on Simulator. I've confirmed this and has been reported on the forums before: https://badlogicgames.com/forum/viewtopic.php?f=11&t=29129. I don't know the reason for this and the change will not have any impact on apps running on device but at least we improve consistency between Simulator and Device.

