### PR TITLE
Fix TextField tab traversal on HTML5

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/DefaultGwtInput.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/DefaultGwtInput.java
@@ -774,7 +774,12 @@ public class DefaultGwtInput implements GwtInput {
 			if (e.getType().equals("keypress")) {
 				// Gdx.app.log("DefaultGwtInput", "keypress");
 				char c = (char)e.getCharCode();
-				if (processor != null) processor.keyTyped(c);
+				// usually, browsers don't send a keypress event for tab, so we emulate it in
+				// keyup event. Just in case this changes in the future, we sort this out here
+				// to avoid sending the event twice.
+				if (c != '\t') {
+					if (processor != null) processor.keyTyped(c);
+				}
 			}
 
 			if (e.getType().equals("keyup")) {
@@ -782,6 +787,11 @@ public class DefaultGwtInput implements GwtInput {
 				int code = keyForCode(e.getKeyCode(), getKeyLocationJSNI(e));
 				if (isCatchKey(code)) {
 					e.preventDefault();
+				}
+				if (processor != null && code == Keys.TAB) {
+					// js does not raise keypress event for tab, so emulate this here for
+					// platform-independant behaviour
+					processor.keyTyped('\t');
 				}
 				if (pressedKeys[code]) {
 					pressedKeySet.remove(code);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TextAreaTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TextAreaTest.java
@@ -17,6 +17,7 @@
 package com.badlogic.gdx.tests;
 
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Input;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.scenes.scene2d.Stage;
@@ -50,6 +51,8 @@ public class TextAreaTest extends GdxTest {
 		textField.setHeight(30);
 		stage.addActor(textArea);
 		stage.addActor(textField);
+
+		Gdx.input.setCatchKey(Input.Keys.TAB, true);
 	}
 
 	@Override


### PR DESCRIPTION
This is another way to fix problem #6219  TextField tab traversal on GWT.

The problem is caused by the behaviour of web browsers to not send a keypress event for Tab key. Instead of changing the core component to listen for keydown/keyup, this PR emulates the keypress event on GWT when the keyup event is raised by the browser. This way, we've got the same behaviour on HTML5 as on other platforms.

TextAreaTest can be used to test that this works as intended.