### PR TITLE
Add support for hardware keys F13 to F24

### DIFF
--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/DefaultLwjglInput.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/DefaultLwjglInput.java
@@ -577,6 +577,18 @@ final public class DefaultLwjglInput implements LwjglInput {
 			return Input.Keys.F11;
 		case Keyboard.KEY_F12:
 			return Input.Keys.F12;
+		case Keyboard.KEY_F13:
+			return Input.Keys.F13;
+		case Keyboard.KEY_F14:
+			return Input.Keys.F14;
+		case Keyboard.KEY_F15:
+			return Input.Keys.F15;
+		case Keyboard.KEY_F16:
+			return Input.Keys.F16;
+		case Keyboard.KEY_F17:
+			return Input.Keys.F17;
+		case Keyboard.KEY_F18:
+			return Input.Keys.F18;
 		case Keyboard.KEY_COLON:
 			return Input.Keys.COLON;
 		case Keyboard.KEY_NUMPAD0:
@@ -781,6 +793,18 @@ final public class DefaultLwjglInput implements LwjglInput {
 			return Keyboard.KEY_F11;
 		case Input.Keys.F12:
 			return Keyboard.KEY_F12;
+		case Input.Keys.F13:
+			return Keyboard.KEY_F13;
+		case Input.Keys.F14:
+			return Keyboard.KEY_F14;
+		case Input.Keys.F15:
+			return Keyboard.KEY_F15;
+		case Input.Keys.F16:
+			return Keyboard.KEY_F16;
+		case Input.Keys.F17:
+			return Keyboard.KEY_F17;
+		case Input.Keys.F18:
+			return Keyboard.KEY_F18;
 		case Input.Keys.COLON:
 			return Keyboard.KEY_COLON;
 		case Input.Keys.NUMPAD_0:

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglAWTInput.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglAWTInput.java
@@ -797,6 +797,30 @@ public class LwjglAWTInput implements Input, MouseMotionListener, MouseListener,
 			return Input.Keys.F11;
 		case java.awt.event.KeyEvent.VK_F12:
 			return Input.Keys.F12;
+		case java.awt.event.KeyEvent.VK_F13:
+			return Input.Keys.F13;
+		case java.awt.event.KeyEvent.VK_F14:
+			return Input.Keys.F14;
+		case java.awt.event.KeyEvent.VK_F15:
+			return Input.Keys.F15;
+		case java.awt.event.KeyEvent.VK_F16:
+			return Input.Keys.F16;
+		case java.awt.event.KeyEvent.VK_F17:
+			return Input.Keys.F17;
+		case java.awt.event.KeyEvent.VK_F18:
+			return Input.Keys.F18;
+		case java.awt.event.KeyEvent.VK_F19:
+			return Input.Keys.F19;
+		case java.awt.event.KeyEvent.VK_F20:
+			return Input.Keys.F20;
+		case java.awt.event.KeyEvent.VK_F21:
+			return Input.Keys.F21;
+		case java.awt.event.KeyEvent.VK_F22:
+			return Input.Keys.F22;
+		case java.awt.event.KeyEvent.VK_F23:
+			return Input.Keys.F23;
+		case java.awt.event.KeyEvent.VK_F24:
+			return Input.Keys.F24;
 		case java.awt.event.KeyEvent.VK_COLON:
 			return Input.Keys.COLON;
 		case java.awt.event.KeyEvent.VK_NUMPAD0:

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/DefaultLwjgl3Input.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/DefaultLwjgl3Input.java
@@ -537,17 +537,29 @@ public class DefaultLwjgl3Input implements Lwjgl3Input {
 		case GLFW.GLFW_KEY_F12:
 			return Input.Keys.F12;
 		case GLFW.GLFW_KEY_F13:
+			return Input.Keys.F13;
 		case GLFW.GLFW_KEY_F14:
+			return Input.Keys.F14;
 		case GLFW.GLFW_KEY_F15:
+			return Input.Keys.F15;
 		case GLFW.GLFW_KEY_F16:
+			return Input.Keys.F16;
 		case GLFW.GLFW_KEY_F17:
+			return Input.Keys.F17;
 		case GLFW.GLFW_KEY_F18:
+			return Input.Keys.F18;
 		case GLFW.GLFW_KEY_F19:
+			return Input.Keys.F19;
 		case GLFW.GLFW_KEY_F20:
+			return Input.Keys.F20;
 		case GLFW.GLFW_KEY_F21:
+			return Input.Keys.F21;
 		case GLFW.GLFW_KEY_F22:
+			return Input.Keys.F22;
 		case GLFW.GLFW_KEY_F23:
+			return Input.Keys.F23;
 		case GLFW.GLFW_KEY_F24:
+			return Input.Keys.F24;
 		case GLFW.GLFW_KEY_F25:
 			return Input.Keys.UNKNOWN;
 		case GLFW.GLFW_KEY_NUM_LOCK:
@@ -755,6 +767,30 @@ public class DefaultLwjgl3Input implements Lwjgl3Input {
 			return GLFW.GLFW_KEY_F11;
 		case Input.Keys.F12:
 			return GLFW.GLFW_KEY_F12;
+		case Input.Keys.F13:
+			return GLFW.GLFW_KEY_F13;
+		case Input.Keys.F14:
+			return GLFW.GLFW_KEY_F14;
+		case Input.Keys.F15:
+			return GLFW.GLFW_KEY_F15;
+		case Input.Keys.F16:
+			return GLFW.GLFW_KEY_F16;
+		case Input.Keys.F17:
+			return GLFW.GLFW_KEY_F17;
+		case Input.Keys.F18:
+			return GLFW.GLFW_KEY_F18;
+		case Input.Keys.F19:
+			return GLFW.GLFW_KEY_F19;
+		case Input.Keys.F20:
+			return GLFW.GLFW_KEY_F20;
+		case Input.Keys.F21:
+			return GLFW.GLFW_KEY_F21;
+		case Input.Keys.F22:
+			return GLFW.GLFW_KEY_F22;
+		case Input.Keys.F23:
+			return GLFW.GLFW_KEY_F23;
+		case Input.Keys.F24:
+			return GLFW.GLFW_KEY_F24;
 		case Keys.NUM_LOCK:
 			return GLFW.GLFW_KEY_NUM_LOCK;
 		case Input.Keys.NUMPAD_0:

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/DefaultIOSInput.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/DefaultIOSInput.java
@@ -1089,6 +1089,30 @@ public class DefaultIOSInput implements IOSInput {
 				return Keys.F11;
 			case KeyboardF12:
 				return Keys.F12;
+			case KeyboardF13:
+				return Keys.F13;
+			case KeyboardF14:
+				return Keys.F14;
+			case KeyboardF15:
+				return Keys.F15;
+			case KeyboardF16:
+				return Keys.F16;
+			case KeyboardF17:
+				return Keys.F17;
+			case KeyboardF18:
+				return Keys.F18;
+			case KeyboardF19:
+				return Keys.F19;
+			case KeyboardF20:
+				return Keys.F20;
+			case KeyboardF21:
+				return Keys.F21;
+			case KeyboardF22:
+				return Keys.F22;
+			case KeyboardF23:
+				return Keys.F23;
+			case KeyboardF24:
+				return Keys.F24;
 			case KeyboardPause:
 				return Keys.MEDIA_PLAY_PAUSE;
 			case KeyboardInsert:

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/DefaultGwtInput.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/DefaultGwtInput.java
@@ -1081,6 +1081,30 @@ public class DefaultGwtInput implements GwtInput {
 			return Keys.F11;
 		case KEY_F12:
 			return Keys.F12;
+		case KEY_F13:
+			return Keys.F13;
+		case KEY_F14:
+			return Keys.F14;
+		case KEY_F15:
+			return Keys.F15;
+		case KEY_F16:
+			return Keys.F16;
+		case KEY_F17:
+			return Keys.F17;
+		case KEY_F18:
+			return Keys.F18;
+		case KEY_F19:
+			return Keys.F19;
+		case KEY_F20:
+			return Keys.F20;
+		case KEY_F21:
+			return Keys.F21;
+		case KEY_F22:
+			return Keys.F22;
+		case KEY_F23:
+			return Keys.F23;
+		case KEY_F24:
+			return Keys.F24;
 		case KEY_NUM_LOCK:
 			return Keys.NUM_LOCK;
 		case KEY_SCROLL_LOCK:
@@ -1183,6 +1207,18 @@ public class DefaultGwtInput implements GwtInput {
 	private static final int KEY_F10 = 121;
 	private static final int KEY_F11 = 122;
 	private static final int KEY_F12 = 123;
+	private static final int KEY_F13 = 124;
+	private static final int KEY_F14 = 125;
+	private static final int KEY_F15 = 126;
+	private static final int KEY_F16 = 127;
+	private static final int KEY_F17 = 128;
+	private static final int KEY_F18 = 129;
+	private static final int KEY_F19 = 130;
+	private static final int KEY_F20 = 131;
+	private static final int KEY_F21 = 132;
+	private static final int KEY_F22 = 133;
+	private static final int KEY_F23 = 134;
+	private static final int KEY_F24 = 135;
 	private static final int KEY_NUM_LOCK = 144;
 	private static final int KEY_SCROLL_LOCK = 145;
 	private static final int KEY_SEMICOLON = 186;

--- a/gdx/src/com/badlogic/gdx/Input.java
+++ b/gdx/src/com/badlogic/gdx/Input.java
@@ -252,18 +252,18 @@ public interface Input {
 		public static final int F10 = 253;
 		public static final int F11 = 254;
 		public static final int F12 = 255;
-		public static final int F13	= 183;
-		public static final int F14	= 184;
-		public static final int F15	= 185;
-		public static final int F16	= 186;
-		public static final int F17	= 187;
-		public static final int F18	= 188;
-		public static final int F19	= 189;
-		public static final int F20	= 190;
-		public static final int F21	= 191;
-		public static final int F22	= 192;
-		public static final int F23	= 193;
-		public static final int F24	= 194;
+		public static final int F13 = 183;
+		public static final int F14 = 184;
+		public static final int F15 = 185;
+		public static final int F16 = 186;
+		public static final int F17 = 187;
+		public static final int F18 = 188;
+		public static final int F19 = 189;
+		public static final int F20 = 190;
+		public static final int F21 = 191;
+		public static final int F22 = 192;
+		public static final int F23 = 193;
+		public static final int F24 = 194;
 
 		public static final int MAX_KEYCODE = 255;
 

--- a/gdx/src/com/badlogic/gdx/Input.java
+++ b/gdx/src/com/badlogic/gdx/Input.java
@@ -252,6 +252,18 @@ public interface Input {
 		public static final int F10 = 253;
 		public static final int F11 = 254;
 		public static final int F12 = 255;
+		public static final int F13	= 183;
+		public static final int F14	= 184;
+		public static final int F15	= 185;
+		public static final int F16	= 186;
+		public static final int F17	= 187;
+		public static final int F18	= 188;
+		public static final int F19	= 189;
+		public static final int F20	= 190;
+		public static final int F21	= 191;
+		public static final int F22	= 192;
+		public static final int F23	= 193;
+		public static final int F24	= 194;
 
 		public static final int MAX_KEYCODE = 255;
 
@@ -542,6 +554,30 @@ public interface Input {
 				return "F11";
 			case F12:
 				return "F12";
+			case F13:
+				return "F13";
+			case F14:
+				return "F14";
+			case F15:
+				return "F15";
+			case F16:
+				return "F16";
+			case F17:
+				return "F17";
+			case F18:
+				return "F18";
+			case F19:
+				return "F19";
+			case F20:
+				return "F20";
+			case F21:
+				return "F21";
+			case F22:
+				return "F22";
+			case F23:
+				return "F23";
+			case F24:
+				return "F24";
 			case NUMPAD_DIVIDE:
 				return "Num /";
 			case NUMPAD_MULTIPLY:


### PR DESCRIPTION
This adds keybindings for F13 to F24 as requested in #5389 

I couldn't test this because I have not such a keyboard. I derived the necessary keybindings from the given constants in the backends. For GWT and Android, there were no constants defined in code. [This page](https://source.android.com/devices/input/keyboard-devices) lists them for Android, [this one](https://keycode.info/) for JS. Lwjgl2 only supports F13 to F18, I did not forget the other ones. :)