### PR TITLE
fix/improve WebGL 1.0 backend

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtGL20.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtGL20.java
@@ -497,6 +497,7 @@ public class GwtGL20 implements GL20 {
 			int id = this.buffers.add(buffer);
 			buffers.put(id);
 		}
+		buffers.flip();
 	}
 
 	@Override
@@ -517,6 +518,7 @@ public class GwtGL20 implements GL20 {
 			int id = this.frameBuffers.add(fb);
 			framebuffers.put(id);
 		}
+		framebuffers.flip();
 	}
 
 	@Override
@@ -532,6 +534,7 @@ public class GwtGL20 implements GL20 {
 			int id = this.renderBuffers.add(rb);
 			renderbuffers.put(id);
 		}
+		renderbuffers.flip();
 	}
 
 	@Override
@@ -547,6 +550,7 @@ public class GwtGL20 implements GL20 {
 			int id = this.textures.add(texture);
 			textures.put(id);
 		}
+		textures.flip();
 	}
 
 
@@ -554,7 +558,9 @@ public class GwtGL20 implements GL20 {
 	public String glGetActiveAttrib (int program, int index, IntBuffer size, IntBuffer type) {
 		WebGLActiveInfo activeAttrib = gl.getActiveAttrib(programs.get(program), index);
 		size.put(activeAttrib.getSize());
+		size.flip();
 		type.put(activeAttrib.getType());
+		type.flip();
 		return activeAttrib.getName();
 	}
 
@@ -562,7 +568,9 @@ public class GwtGL20 implements GL20 {
 	public String glGetActiveUniform (int program, int index, IntBuffer size, IntBuffer type) {
 		WebGLActiveInfo activeUniform = gl.getActiveUniform(programs.get(program), index);
 		size.put(activeUniform.getSize());
+		size.flip();
 		type.put(activeUniform.getType());
+		type.flip();
 		return activeUniform.getName();
 	}
 
@@ -597,9 +605,10 @@ public class GwtGL20 implements GL20 {
 	@Override
 	public void glGetFloatv (int pname, FloatBuffer params) {
 		if (pname == GL20.GL_DEPTH_CLEAR_VALUE || pname == GL20.GL_LINE_WIDTH || pname == GL20.GL_POLYGON_OFFSET_FACTOR
-				|| pname == GL20.GL_POLYGON_OFFSET_UNITS || pname == GL20.GL_SAMPLE_COVERAGE_VALUE)
+				|| pname == GL20.GL_POLYGON_OFFSET_UNITS || pname == GL20.GL_SAMPLE_COVERAGE_VALUE) {
 			params.put(0, gl.getParameterf(pname));
-		else
+			params.flip();
+		} else
 			throw new GdxRuntimeException("glGetFloat not supported by GWT WebGL backend");
 	}
 
@@ -629,9 +638,10 @@ public class GwtGL20 implements GL20 {
 				|| pname == GL20.GL_STENCIL_BACK_WRITEMASK || pname == GL20.GL_STENCIL_BITS || pname == GL20.GL_STENCIL_CLEAR_VALUE
 				|| pname == GL20.GL_STENCIL_FAIL || pname == GL20.GL_STENCIL_FUNC || pname == GL20.GL_STENCIL_PASS_DEPTH_FAIL
 				|| pname == GL20.GL_STENCIL_PASS_DEPTH_PASS || pname == GL20.GL_STENCIL_REF || pname == GL20.GL_STENCIL_VALUE_MASK
-				|| pname == GL20.GL_STENCIL_WRITEMASK || pname == GL20.GL_SUBPIXEL_BITS || pname == GL20.GL_UNPACK_ALIGNMENT)
+				|| pname == GL20.GL_STENCIL_WRITEMASK || pname == GL20.GL_SUBPIXEL_BITS || pname == GL20.GL_UNPACK_ALIGNMENT) {
 			params.put(0, gl.getParameteri(pname));
-		else if (pname == GL20.GL_VIEWPORT) {
+			params.flip();
+		} else if (pname == GL20.GL_VIEWPORT) {
 			Int32Array array = gl.getParameterv(pname);
 			params.put(0, array.get(0));
 			params.put(1, array.get(1));
@@ -664,6 +674,7 @@ public class GwtGL20 implements GL20 {
 		} else {
 			params.put(gl.getProgramParameteri(programs.get(program), pname));
 		}
+		params.flip();
 	}
 
 	@Override
@@ -686,6 +697,7 @@ public class GwtGL20 implements GL20 {
 			int result = gl.getShaderParameteri(shaders.get(shader), pname);
 			params.put(result);
 		}
+		params.flip();
 	}
 
 	@Override
@@ -828,6 +840,7 @@ public class GwtGL20 implements GL20 {
 
 		// read bytes to ArrayBufferView
 		gl.readPixels(x, y, width, height, format, type, buffer);
+		pixels.flip();
 	}
 
 	@Override


### PR DESCRIPTION
These changes was inspired by #5763. I prefer to split changes from original PR. More will come later.

Current GwtGL20 missing some buffer flips and ByteBuffer support for some methods.