### PR TITLE
GLES 3.0 glMapBufferRange implementation and PBO example

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGL30.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGL30.java
@@ -245,10 +245,10 @@ public class AndroidGL30 extends AndroidGL20 implements GL30 {
 		GLES30.glFramebufferTextureLayer(target, attachment, texture, level, layer);
 	}
 
-// @Override
-// public java.nio.Buffer glMapBufferRange(int target, int offset, int length, int access) {
-// return GLES30.glMapBufferRange(target, offset, length, access);
-// }
+	@Override
+	public java.nio.Buffer glMapBufferRange (int target, int offset, int length, int access) {
+		return GLES30.glMapBufferRange(target, offset, length, access);
+	}
 
 	@Override
 	public void glFlushMappedBufferRange (int target, int offset, int length) {

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGL20.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGL20.java
@@ -595,7 +595,7 @@ class LwjglGL20 implements com.badlogic.gdx.graphics.GL20 {
 	public void glTexImage2D (int target, int level, int internalformat, int width, int height, int border, int format, int type,
 		Buffer pixels) {
 		if (pixels == null)
-			GL11.glTexImage2D(target, level, internalformat, width, height, border, format, type, (ByteBuffer)null);
+			GL11.glTexImage2D(target, level, internalformat, width, height, border, format, type, 0L);
 		else if (pixels instanceof ByteBuffer)
 			GL11.glTexImage2D(target, level, internalformat, width, height, border, format, type, (ByteBuffer)pixels);
 		else if (pixels instanceof ShortBuffer)

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGL30.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGL30.java
@@ -323,6 +323,11 @@ class LwjglGL30 extends LwjglGL20 implements com.badlogic.gdx.graphics.GL30 {
 	}
 
 	@Override
+	public java.nio.Buffer glMapBufferRange (int target, int offset, int length, int access) {
+		return GL30.glMapBufferRange(target, offset, length, access, null);
+	}
+
+	@Override
 	public void glFlushMappedBufferRange (int target, int offset, int length) {
 		GL30.glFlushMappedBufferRange(target, offset, length);
 	}

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3GL30.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3GL30.java
@@ -325,6 +325,11 @@ class Lwjgl3GL30 extends Lwjgl3GL20 implements com.badlogic.gdx.graphics.GL30 {
 	}
 
 	@Override
+	public java.nio.Buffer glMapBufferRange (int target, int offset, int length, int access) {
+		return GL30.glMapBufferRange(target, offset, length, access, null);
+	}
+
+	@Override
 	public void glFlushMappedBufferRange (int target, int offset, int length) {
 		GL30.glFlushMappedBufferRange(target, offset, length);
 	}

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGLES30.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGLES30.java
@@ -73,6 +73,8 @@ public class IOSGLES30 extends IOSGLES20 implements GL30 {
 
     public native void glFramebufferTextureLayer(int target, int attachment, int texture, int level, int layer);
 
+	public native java.nio.Buffer glMapBufferRange (int target, int offset, int length, int access);
+
     public native void glFlushMappedBufferRange(int target, int offset, int length);
 
     public native void glBindVertexArray(int array);

--- a/gdx/jni/iosgl/iosgl30.cpp
+++ b/gdx/jni/iosgl/iosgl30.cpp
@@ -417,6 +417,23 @@ JNIEXPORT void JNICALL Java_com_badlogic_gdx_backends_iosrobovm_IOSGLES30_glFram
     glFramebufferTextureLayer(target, attachment, texture, level, layer);
 }
 
+
+/*
+ * Class:     com_badlogic_gdx_backends_iosrobovm_IOSGLES30
+ * Method:    glMapBufferRange
+ * Signature: (IIII)Ljava/nio/Buffer;
+ */
+JNIEXPORT jobject JNICALL Java_com_badlogic_gdx_backends_iosrobovm_IOSGLES30_glMapBufferRange
+  (JNIEnv *env, jobject, jint target, jint offset, jint length, jint access) {
+	GLvoid* buf = glMapBufferRange(target, offset, length, access);
+	jobject returnBuffer = (jobject)0;
+	if (buf) {
+		returnBuffer = env->NewDirectByteBuffer(buf, length);
+	}
+	return returnBuffer;
+}
+
+
 /*
  * Class:     com_badlogic_gdx_backends_iosrobovm_IOSGLES30
  * Method:    glFlushMappedBufferRange

--- a/gdx/jni/iosgl/iosgl30.h
+++ b/gdx/jni/iosgl/iosgl30.h
@@ -14,6 +14,7 @@ extern "C" {
  */
 JNIEXPORT void JNICALL Java_com_badlogic_gdx_backends_iosrobovm_IOSGLES30_init
   (JNIEnv *, jclass);
+
 /*
  * Class:     com_badlogic_gdx_backends_iosrobovm_IOSGLES30
  * Method:    glReadBuffer
@@ -245,6 +246,15 @@ JNIEXPORT void JNICALL Java_com_badlogic_gdx_backends_iosrobovm_IOSGLES30_glRend
  */
 JNIEXPORT void JNICALL Java_com_badlogic_gdx_backends_iosrobovm_IOSGLES30_glFramebufferTextureLayer
   (JNIEnv *, jobject, jint, jint, jint, jint, jint);
+
+
+/*
+ * Class:     com_badlogic_gdx_backends_iosrobovm_IOSGLES30
+ * Method:    glMapBufferRange
+ * Signature: (IIII)Ljava/nio/Buffer;
+ */
+JNIEXPORT jobject JNICALL Java_com_badlogic_gdx_backends_iosrobovm_IOSGLES30_glMapBufferRange
+  (JNIEnv *, jobject, jint, jint, jint, jint);
 
 /*
  * Class:     com_badlogic_gdx_backends_iosrobovm_IOSGLES30

--- a/gdx/src/com/badlogic/gdx/graphics/GL30.java
+++ b/gdx/src/com/badlogic/gdx/graphics/GL30.java
@@ -611,14 +611,9 @@ public interface GL30 extends GL20 {
 
 	public void glFramebufferTextureLayer (int target, int attachment, int texture, int level, int layer);
 
-// // C function GLvoid * glMapBufferRange ( GLenum target, GLintptr offset, GLsizeiptr length, GLbitfield access )
-//
-// public java.nio.Buffer glMapBufferRange(
-// int target,
-// int offset,
-// int length,
-// int access
-// );
+	// C function GLvoid * glMapBufferRange ( GLenum target, GLintptr offset, GLsizeiptr length, GLbitfield access )
+
+	public java.nio.Buffer glMapBufferRange (int target, int offset, int length, int access);
 
 	// C function void glFlushMappedBufferRange ( GLenum target, GLintptr offset, GLsizeiptr length )
 

--- a/gdx/src/com/badlogic/gdx/graphics/profiling/GL30Interceptor.java
+++ b/gdx/src/com/badlogic/gdx/graphics/profiling/GL30Interceptor.java
@@ -1430,6 +1430,14 @@ public class GL30Interceptor extends GLInterceptor implements GL30 {
 	}
 
 	@Override
+	public Buffer glMapBufferRange (int target, int offset, int length, int access) {
+		calls++;
+		Buffer result = gl30.glMapBufferRange(target, offset, length, access);
+		check();
+		return result;
+	}
+
+	@Override
 	public void glFlushMappedBufferRange (int target, int offset, int length) {
 		calls++;
 		gl30.glFlushMappedBufferRange(target, offset, length);

--- a/tests/gdx-tests-lwjgl3/src/com/badlogic/gdx/tests/lwjgl3/Lwjgl3TestStarter.java
+++ b/tests/gdx-tests-lwjgl3/src/com/badlogic/gdx/tests/lwjgl3/Lwjgl3TestStarter.java
@@ -26,6 +26,7 @@ import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Graphics;
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3WindowConfiguration;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.glutils.ShaderProgram;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.InputEvent;
 import com.badlogic.gdx.scenes.scene2d.Stage;
@@ -60,7 +61,11 @@ public class Lwjgl3TestStarter {
 		
 		Lwjgl3ApplicationConfiguration config = new Lwjgl3ApplicationConfiguration();
 		config.setWindowedMode(640, 480);
+
 		if(options.gl30){
+			ShaderProgram.prependVertexCode = "#version 140\n#define varying out\n#define attribute in\n";
+			ShaderProgram.prependFragmentCode = "#version 140\n#define varying in\n#define texture2D texture\n#define gl_FragColor fragColor\nout vec4 fragColor;\n";
+
 			config.useOpenGL3(true, 3, 2);
 		}
 

--- a/tests/gdx-tests/res/com/badlogic/gdx/GdxTests.gwt.xml
+++ b/tests/gdx-tests/res/com/badlogic/gdx/GdxTests.gwt.xml
@@ -28,6 +28,7 @@
 		<exclude name="**/NetAPITest.java"/> <!-- abuses FileHandle() -->
 		<exclude name="**/NoncontinuousRenderingTest.java"/> <!-- Noncontinuous rendering not supported -->
 		<exclude name="**/PingPongSocketExample.java"/> <!-- networking -->
+		<exclude name="**/PixelBufferObjectTest.java"/> <!-- threading -->
 		<exclude name="**/PixmapPackerIOTest.java"/> <!-- gdx-tools -->
 		<exclude name="**/PngTest.java"/> <!-- Not compatible -->
 		<exclude name="**/RemoteTest.java"/> <!-- networking -->

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gles3/PixelBufferObjectTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gles3/PixelBufferObjectTest.java
@@ -1,0 +1,102 @@
+package com.badlogic.gdx.tests.gles3;
+
+import java.nio.Buffer;
+import java.nio.ByteBuffer;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.GL30;
+import com.badlogic.gdx.graphics.Pixmap;
+import com.badlogic.gdx.graphics.Pixmap.Format;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.tests.utils.GdxTest;
+import com.badlogic.gdx.tests.utils.GdxTestConfig;
+import com.badlogic.gdx.utils.BufferUtils;
+
+@GdxTestConfig(requireGL30=true)
+public class PixelBufferObjectTest extends GdxTest {
+
+	private SpriteBatch batch;
+	private Texture texture;
+	protected Lock lock;
+	protected Pixmap pixmap;
+	protected int pixmapSizeBytes;
+	protected boolean pixmapReady;
+	protected boolean textureReady;
+	protected boolean pboTransferComplete;
+	protected Buffer mappedBuffer;
+	protected int pboHandle;
+	
+	@Override
+	public void create () {
+		batch = new SpriteBatch();
+		lock = new ReentrantLock();
+		lock.lock();
+		
+		new Thread(new Runnable() {
+			@Override
+			public void run () {
+				// load the pixmap in order to get header information
+				pixmap = new Pixmap(Gdx.files.internal("data/badlogic.jpg"));
+				pixmapSizeBytes = pixmap.getWidth() * pixmap.getHeight() * 3;
+				pixmapReady = true;
+				
+				// wait for PBO initialization (need to be done in GLThread)
+				lock.lock();
+				
+				// Transfer data from pixmap to PBO
+				ByteBuffer data = pixmap.getPixels();
+				data.rewind();
+				BufferUtils.copy(data, mappedBuffer, pixmapSizeBytes);
+				pboTransferComplete = true;
+			}
+		}).start();
+	}
+	
+	@Override
+	public void render() {
+		// first step: once we get pixmap size, we can create both texture and PBO
+		if(pixmapReady && texture == null){
+			texture = new Texture(pixmap.getWidth(), pixmap.getHeight(), pixmap.getFormat());
+			
+			pboHandle = Gdx.gl.glGenBuffer();
+			Gdx.gl.glBindBuffer(GL30.GL_PIXEL_UNPACK_BUFFER, pboHandle);
+			Gdx.gl.glBufferData(GL30.GL_PIXEL_UNPACK_BUFFER, pixmapSizeBytes, null, GL30.GL_STREAM_DRAW);
+			
+			mappedBuffer = Gdx.gl30.glMapBufferRange(GL30.GL_PIXEL_UNPACK_BUFFER, 0, pixmapSizeBytes, GL30.GL_MAP_WRITE_BIT | GL30.GL_MAP_UNSYNCHRONIZED_BIT);
+			Gdx.gl.glBindBuffer(GL30.GL_PIXEL_UNPACK_BUFFER, 0);
+
+			lock.unlock();
+		}
+		// second step: once async transfer is complete, we can transfer to the texture and cleanup
+		if(!textureReady && pboTransferComplete){
+			
+			// transfer data to texture (GL Thread)
+			Gdx.gl.glBindBuffer(GL30.GL_PIXEL_UNPACK_BUFFER, pboHandle);
+			Gdx.gl30.glUnmapBuffer(GL30.GL_PIXEL_UNPACK_BUFFER);
+			
+			Gdx.gl.glBindTexture (GL20.GL_TEXTURE_2D, texture.getTextureObjectHandle());
+			Gdx.gl.glTexImage2D(GL20.GL_TEXTURE_2D, 0, pixmap.getGLInternalFormat(), pixmap.getWidth(), pixmap.getHeight(), 0, pixmap.getGLFormat(), pixmap.getGLType(), null);
+			Gdx.gl.glBindTexture(GL20.GL_TEXTURE_2D, 0);
+			
+			Gdx.gl.glBindBuffer(GL30.GL_PIXEL_UNPACK_BUFFER, 0);
+			
+			// cleanup
+			mappedBuffer = null;
+			Gdx.gl.glDeleteBuffer(pboHandle);
+			pboHandle = 0;
+			pixmap.dispose();
+			pixmap = null;
+			textureReady = true;
+		}
+		// last step: texture is ready to be used.
+		if(textureReady){
+			batch.begin();
+			batch.draw(texture, 0, 0, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+			batch.end();
+		}
+	}
+}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
@@ -78,6 +78,7 @@ import com.badlogic.gdx.tests.g3d.utils.DefaultTextureBinderTest;
 import com.badlogic.gdx.tests.gles2.HelloTriangle;
 import com.badlogic.gdx.tests.gles2.SimpleVertexShader;
 import com.badlogic.gdx.tests.gles3.InstancedRenderingTest;
+import com.badlogic.gdx.tests.gles3.PixelBufferObjectTest;
 import com.badlogic.gdx.tests.net.NetAPITest;
 import com.badlogic.gdx.tests.superkoalio.SuperKoalio;
 import com.badlogic.gdx.utils.ObjectMap;
@@ -201,6 +202,7 @@ public class GdxTests {
 		ParticleEmitterTest.class,
 		ParticleEmittersTest.class,
 		ParticleEmitterChangeSpriteTest.class,
+		PixelBufferObjectTest.class,
 		PixelsPerInchTest.class,
 		PixmapBlendingTest.class,
 		PixmapPackerTest.class,


### PR DESCRIPTION
This PR is open for discussion (i'll keep it as draft until we're all set).

I investigated deeply to know why glMapBufferRange was commented from the beginning. Some reasons could be found [in original PR comments](https://github.com/libgdx/libgdx/pull/2527#issuecomment-74588121).

In short, WebGL 2.0 doesn't provide this method for [performance and security reasons when writing to a mapped buffer](https://stackoverflow.com/questions/43530082/how-can-i-upload-a-texture-in-webgl2-using-a-pixel-buffer-object). For read only buffers there is a replacement method (getBufferSubData). So we could provide a limited implementation (read only) for the WebGL 2.0 backend later.

PBO (PixelBufferObject) is one of the use cases using glMapBufferRange. PBO is basically useful to asynchronously transfer pixels from CPU to GPU and vice versa.
I'm currently working on TransformFeedback which is another use case when you want to retrieve transformed data CPU side, that's why i did this PR.

I only tested Desktop (linux) Lwjgl2 and Lwjgl3 backends, it needs to be tested on Android and iOS (i don't have required hardware).