### PR TITLE
Update intersectRayBoundsFast to handle degenerated boxes

### DIFF
--- a/gdx/src/com/badlogic/gdx/math/Intersector.java
+++ b/gdx/src/com/badlogic/gdx/math/Intersector.java
@@ -621,25 +621,29 @@ public final class Intersector {
 		final float divY = 1f / ray.direction.y;
 		final float divZ = 1f / ray.direction.z;
 
-		float minx = ((center.x - dimensions.x * 0.5f) - ray.origin.x) * divX;
-		float maxx = ((center.x + dimensions.x * 0.5f) - ray.origin.x) * divX;
+		final float halfDimX = Math.max(dimensions.x, MathUtils.FLOAT_ROUNDING_ERROR) * 0.5f;
+		final float halfDimY = Math.max(dimensions.y, MathUtils.FLOAT_ROUNDING_ERROR) * 0.5f;
+		final float halfDimZ = Math.max(dimensions.z, MathUtils.FLOAT_ROUNDING_ERROR) * 0.5f;
+
+		float minx = ((center.x - halfDimX) - ray.origin.x) * divX;
+		float maxx = ((center.x + halfDimX) - ray.origin.x) * divX;
 		if (minx > maxx) {
 			final float t = minx;
 			minx = maxx;
 			maxx = t;
 		}
 
-		float miny = ((center.y - dimensions.y * 0.5f) - ray.origin.y) * divY;
-		float maxy = ((center.y + dimensions.y * 0.5f) - ray.origin.y) * divY;
+		float miny = ((center.y - halfDimY) - ray.origin.y) * divY;
+		float maxy = ((center.y + halfDimY) - ray.origin.y) * divY;
 		if (miny > maxy) {
 			final float t = miny;
 			miny = maxy;
 			maxy = t;
 		}
 
-		float minz = ((center.z - dimensions.z * 0.5f) - ray.origin.z) * divZ;
-		float maxz = ((center.z + dimensions.z * 0.5f) - ray.origin.z) * divZ;
-		if (minz > maxz) {
+		float minz = ((center.z - halfDimZ) - ray.origin.z) * divZ;
+		float maxz = ((center.z + halfDimZ) - ray.origin.z) * divZ;
+		if (minz >= maxz) {
 			final float t = minz;
 			minz = maxz;
 			maxz = t;

--- a/gdx/test/com/badlogic/gdx/math/IntersectorTest.java
+++ b/gdx/test/com/badlogic/gdx/math/IntersectorTest.java
@@ -3,6 +3,8 @@ package com.badlogic.gdx.math;
 
 import com.badlogic.gdx.math.Intersector.SplitTriangle;
 
+import com.badlogic.gdx.math.collision.BoundingBox;
+import com.badlogic.gdx.math.collision.Ray;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -184,5 +186,16 @@ public class IntersectorTest {
 		assertEquals(-102.63903f, intersection.x, 0.1f);
 		assertEquals(-57.7337f, intersection.y, 0.1f);
 		assertEquals(100, intersection.z, 0.1f);
+	}
+
+	@Test
+	public void testIntersectRayAABBDegenerated() {
+		Vector3 bottomLeft = new Vector3(3f, 3f, 0f);
+		Vector3 topRight = new Vector3(4f, 4f, 0f);
+		//Bounding box from (3,3) to (4,4)
+		BoundingBox boundingBox = new BoundingBox(bottomLeft, topRight);
+		//Ray from (0,0), direction (1,1)
+		Ray ray = new Ray(Vector3.Zero, new Vector3(1f, 1f, 0f).nor());
+		assertTrue(Intersector.intersectRayBoundsFast(ray, boundingBox));
 	}
 }


### PR DESCRIPTION
The fix here is to set a minimal dimension when the value is zero.
It adds a few more operations (because of Math.max) but also removes three multiplications.

Closes #5128