### PR TITLE
add cubemaps to the management, fixes #5047

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/Cubemap.java
+++ b/gdx/src/com/badlogic/gdx/graphics/Cubemap.java
@@ -95,6 +95,7 @@ public class Cubemap extends GLTexture {
 		super(GL20.GL_TEXTURE_CUBE_MAP);
 		this.data = data;
 		load(data);
+		if (data.isManaged()) addManagedCubemap(Gdx.app, this);
 	}
 
 	/** Construct a Cubemap with the specified texture files for the sides, does not generate mipmaps. */
@@ -137,13 +138,7 @@ public class Cubemap extends GLTexture {
 	/** Construct a Cubemap with the specified {@link TextureData}'s for the sides */
 	public Cubemap (TextureData positiveX, TextureData negativeX, TextureData positiveY, TextureData negativeY,
 		TextureData positiveZ, TextureData negativeZ) {
-		super(GL20.GL_TEXTURE_CUBE_MAP);
-		minFilter = TextureFilter.Nearest;
-		magFilter = TextureFilter.Nearest;
-		uWrap = TextureWrap.ClampToEdge;
-		vWrap = TextureWrap.ClampToEdge;
-		data = new FacedCubemapData(positiveX, negativeX, positiveY, negativeY, positiveZ, negativeZ);
-		load(data);
+		this(new FacedCubemapData(positiveX, negativeX, positiveY, negativeY, positiveZ, negativeZ));
 	}
 
 	/** Sets the sides of this cubemap to the specified {@link CubemapData}. */


### PR DESCRIPTION
I refactored a constructor in order to have a common root constructor, filters and wrapping options was already the same as the default one in GLTexture.