### PR TITLE
GWT: Initial call to set viewport size fails for resizable application

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtGraphics.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtGraphics.java
@@ -90,7 +90,7 @@ public class GwtGraphics implements Graphics {
 		attributes.setPreserveDrawingBuffer(config.preserveDrawingBuffer);
 
 		context = WebGLRenderingContext.getContext(canvas, attributes);
-		context.viewport(0, 0, config.width, config.height);
+		context.viewport(0, 0, getWidth(), getHeight());
 		this.gl = config.useDebugGL ? new GwtGL20Debug(context) : new GwtGL20(context);
 
 		String versionString = gl.glGetString(GL20.GL_VERSION);


### PR DESCRIPTION
d3cbe98eb72ec68bdd8c8630034b50166e8da4f8 introduced resizable applications with no configured with and height, therefore `config.width` and `configh.height` being 0.
The initial call to set the viewport size still based on this constants, causing this call to set an invalid size for resizable applications. This was not noticed because our tests and most games use an own viewport, but of all things, our starter template generated by gdx-setup fails to render correctly without this fix.