### PR TITLE
Cast to Buffer

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/ZipResourceFile.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/ZipResourceFile.java
@@ -25,6 +25,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.RandomAccessFile;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.MappedByteBuffer;
@@ -139,7 +140,7 @@ public class ZipResourceFile {
 		/**
 		 * Calculates the offset of the start of the Zip file entry within the
 		 * Zip file.
-		 * 
+		 *
 		 * @return the offset, in bytes from the start of the file of the entry
 		 */
 		public long getOffset() {
@@ -148,7 +149,7 @@ public class ZipResourceFile {
 
 		/**
 		 * isUncompressed
-		 * 
+		 *
 		 * @return true if the file is stored in uncompressed form
 		 */
 		public boolean isUncompressed() {
@@ -218,7 +219,7 @@ public class ZipResourceFile {
 	 * MediaPlayer. It also allows for the class to be used in a content
 	 * provider that can feed video players. The file must be stored
 	 * (non-compressed) in the Zip file for this to work.
-	 * 
+	 *
 	 * @param assetPath
 	 * @return the asset file descriptor for the file, or null if the file isn't
 	 *         present or is stored compressed
@@ -235,7 +236,7 @@ public class ZipResourceFile {
 	 * getInputStream returns an AssetFileDescriptor.AutoCloseInputStream
 	 * associated with the asset that is contained in the Zip file, or a
 	 * standard ZipInputStream if necessary to uncompress the file
-	 * 
+	 *
 	 * @param assetPath
 	 * @return an input stream for the named asset path, or null if not found
 	 * @throws IOException
@@ -399,9 +400,9 @@ public class ZipResourceFile {
 
 			/* get the CDE filename */
 
-			directoryMap.position(currentOffset + kCDELen);
+			((Buffer) directoryMap).position(currentOffset + kCDELen);
 			directoryMap.get(tempBuf, 0, fileNameLen);
-			directoryMap.position(0);
+			((Buffer) directoryMap).position(0);
 
 			/* UTF-8 on Android */
 			String str = new String(tempBuf, 0, fileNameLen);
@@ -421,7 +422,7 @@ public class ZipResourceFile {
 					+ kCDELocalOffset) & 0xffffffffL;
 
 			// set the offsets
-			buf.clear();
+			((Buffer) buf).clear();
 			ze.setOffsetFromFile(f, buf);
 
 			// put file into hash

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGL20.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGL20.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -36,7 +36,7 @@ import com.badlogic.gdx.utils.GdxRuntimeException;
 
 /** An implementation of the {@link GL20} interface based on LWJGL. Note that LWJGL shaders and OpenGL ES shaders will not be 100%
  * compatible. Some glGetXXX methods are not implemented.
- * 
+ *
  * @author mzechner */
 class LwjglGL20 implements com.badlogic.gdx.graphics.GL20 {
 	private ByteBuffer buffer = null;
@@ -53,14 +53,14 @@ class LwjglGL20 implements com.badlogic.gdx.graphics.GL20 {
 
 	private FloatBuffer toFloatBuffer (float v[], int offset, int count) {
 		ensureBufferCapacity(count << 2);
-		floatBuffer.clear();
+		((Buffer) floatBuffer).clear();
 		com.badlogic.gdx.utils.BufferUtils.copy(v, floatBuffer, count, offset);
 		return floatBuffer;
 	}
 
 	private IntBuffer toIntBuffer (int v[], int offset, int count) {
 		ensureBufferCapacity(count << 2);
-		intBuffer.clear();
+		((Buffer) intBuffer).clear();
 		com.badlogic.gdx.utils.BufferUtils.copy(v, offset, count, intBuffer);
 		return intBuffer;
 	}

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGL30.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGL30.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -41,7 +41,7 @@ import com.badlogic.gdx.utils.GdxRuntimeException;
 
 class LwjglGL30 extends LwjglGL20 implements com.badlogic.gdx.graphics.GL30 {
 	@Override
-	public void glReadBuffer (int mode) {		
+	public void glReadBuffer (int mode) {
 		GL11.glReadBuffer(mode);
 	}
 
@@ -180,9 +180,9 @@ class LwjglGL30 extends LwjglGL20 implements com.badlogic.gdx.graphics.GL30 {
 	@Override
 	public void glDrawBuffers (int n, IntBuffer bufs) {
 		int limit = bufs.limit();
-		bufs.limit(n);
+		((Buffer) bufs).limit(n);
 		GL20.glDrawBuffers(bufs);
-		bufs.limit(limit);
+		((Buffer) bufs).limit(limit);
 	}
 
 	@Override
@@ -410,7 +410,7 @@ class LwjglGL30 extends LwjglGL20 implements com.badlogic.gdx.graphics.GL30 {
 	public void glVertexAttribI4ui (int index, int x, int y, int z, int w) {
 		GL30.glVertexAttribI4ui(index, x, y, z, w);
 	}
-	
+
 	@Override
 	public void glGetUniformuiv (int program, int location, IntBuffer params) {
 		GL30.glGetUniformu(program, location, params);
@@ -509,7 +509,7 @@ class LwjglGL30 extends LwjglGL20 implements com.badlogic.gdx.graphics.GL30 {
 	@Override
 	public void glDrawElementsInstanced (int mode, int count, int type, int indicesOffset, int instanceCount) {
 		GL31.glDrawElementsInstanced(mode, count, type, indicesOffset, instanceCount);
-		
+
 	}
 
 	@Override
@@ -584,7 +584,7 @@ class LwjglGL30 extends LwjglGL20 implements com.badlogic.gdx.graphics.GL30 {
 	@Override
 	public void glGetSamplerParameterfv (int sampler, int pname, FloatBuffer params) {
 		GL33.glGetSamplerParameter(sampler, pname, params);
-		
+
 	}
 
 	@Override

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGraphics.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGraphics.java
@@ -18,6 +18,7 @@ package com.badlogic.gdx.backends.lwjgl;
 
 import java.awt.Canvas;
 import java.awt.Toolkit;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 
 import com.badlogic.gdx.Application;
@@ -250,7 +251,7 @@ public class LwjglGraphics implements Graphics {
 						pixmap = rgba;
 					}
 					icons[i] = ByteBuffer.allocateDirect(pixmap.getPixels().limit());
-					icons[i].put(pixmap.getPixels()).flip();
+					((Buffer) icons[i].put(pixmap.getPixels())).flip();
 					pixmap.dispose();
 				}
 				Display.setIcon(icons);

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/audio/OpenALAudioDevice.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/audio/OpenALAudioDevice.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,6 +16,7 @@
 
 package com.badlogic.gdx.backends.lwjgl.audio;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
 
@@ -98,8 +99,8 @@ public class OpenALAudioDevice implements AudioDevice {
 			for (int i = 0; i < bufferCount; i++) {
 				int bufferID = buffers.get(i);
 				int written = Math.min(bufferSize, length);
-				tempBuffer.clear();
-				tempBuffer.put(data, offset, written).flip();
+				((Buffer) tempBuffer).clear();
+				((Buffer) tempBuffer.put(data, offset, written)).flip();
 				alBufferData(bufferID, format, tempBuffer, sampleRate);
 				alSourceQueueBuffers(sourceID, bufferID);
 				length -= written;
@@ -107,7 +108,7 @@ public class OpenALAudioDevice implements AudioDevice {
 				queuedBuffers++;
 			}
 			// Queue rest of buffers, empty.
-			tempBuffer.clear().flip();
+			((Buffer) tempBuffer).clear().flip();
 			for (int i = queuedBuffers; i < bufferCount; i++) {
 				int bufferID = buffers.get(i);
 				alBufferData(bufferID, format, tempBuffer, sampleRate);
@@ -136,8 +137,8 @@ public class OpenALAudioDevice implements AudioDevice {
 				if (bufferID == AL_INVALID_VALUE) break;
 				renderedSeconds += secondsPerBuffer;
 
-				tempBuffer.clear();
-				tempBuffer.put(data, offset, written).flip();
+				((Buffer) tempBuffer).clear();
+				((Buffer) tempBuffer.put(data, offset, written)).flip();
 				alBufferData(bufferID, format, tempBuffer, sampleRate);
 
 				alSourceQueueBuffers(sourceID, bufferID);

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/audio/OpenALLwjglAudio.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/audio/OpenALLwjglAudio.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,6 +16,7 @@
 
 package com.badlogic.gdx.backends.lwjgl.audio;
 
+import java.nio.Buffer;
 import java.nio.FloatBuffer;
 
 import org.lwjgl.BufferUtils;
@@ -86,11 +87,14 @@ public class OpenALLwjglAudio implements LwjglAudio {
 		sourceToSoundId = new IntMap<Long>();
 
 		FloatBuffer orientation = (FloatBuffer)BufferUtils.createFloatBuffer(6)
-			.put(new float[] {0.0f, 0.0f, -1.0f, 0.0f, 1.0f, 0.0f}).flip();
+			.put(new float[] {0.0f, 0.0f, -1.0f, 0.0f, 1.0f, 0.0f});
+		((Buffer) orientation).flip();
 		alListener(AL_ORIENTATION, orientation);
-		FloatBuffer velocity = (FloatBuffer)BufferUtils.createFloatBuffer(3).put(new float[] {0.0f, 0.0f, 0.0f}).flip();
+		FloatBuffer velocity = (FloatBuffer)BufferUtils.createFloatBuffer(3).put(new float[] {0.0f, 0.0f, 0.0f});
+		((Buffer) velocity).flip();
 		alListener(AL_VELOCITY, velocity);
-		FloatBuffer position = (FloatBuffer)BufferUtils.createFloatBuffer(3).put(new float[] {0.0f, 0.0f, 0.0f}).flip();
+		FloatBuffer position = (FloatBuffer)BufferUtils.createFloatBuffer(3).put(new float[] {0.0f, 0.0f, 0.0f});
+		((Buffer) position).flip();
 		alListener(AL_POSITION, position);
 
 		recentSounds = new OpenALSound[simultaneousSources];

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/audio/OpenALMusic.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/audio/OpenALMusic.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,6 +16,7 @@
 
 package com.badlogic.gdx.backends.lwjgl.audio;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
 
@@ -245,7 +246,7 @@ public abstract class OpenALMusic implements Music {
 	}
 
 	private boolean fill (int bufferID) {
-		tempBuffer.clear();
+		((Buffer) tempBuffer).clear();
 		int length = read(tempBytes);
 		if (length <= 0) {
 			if (isLooping) {
@@ -262,7 +263,7 @@ public abstract class OpenALMusic implements Music {
 		float currentBufferSeconds = maxSecondsPerBuffer * (float)length / (float)bufferSize;
 		renderedSecondsQueue.insert(0, previousLoadedSeconds + currentBufferSeconds);
 
-		tempBuffer.put(tempBytes, 0, length).flip();
+		((Buffer) tempBuffer.put(tempBytes, 0, length)).flip();
 		alBufferData(bufferID, format, tempBuffer, sampleRate);
 		return true;
 	}

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/audio/OpenALSound.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/audio/OpenALSound.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,6 +16,7 @@
 
 package com.badlogic.gdx.backends.lwjgl.audio;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
@@ -41,7 +42,7 @@ public class OpenALSound implements Sound {
 		ByteBuffer buffer = ByteBuffer.allocateDirect(bytes);
 		buffer.order(ByteOrder.nativeOrder());
 		buffer.put(pcm, 0, bytes);
-		buffer.flip();
+		((Buffer) buffer).flip();
 
 		if (bufferID == -1) {
 			bufferID = alGenBuffers();

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3GL20.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3GL20.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -49,19 +49,19 @@ class Lwjgl3GL20 implements com.badlogic.gdx.graphics.GL20 {
 
 	private FloatBuffer toFloatBuffer (float v[], int offset, int count) {
 		ensureBufferCapacity(count << 2);
-		floatBuffer.clear();
-		floatBuffer.limit(count);
+		((Buffer) floatBuffer).clear();
+		((Buffer) floatBuffer).limit(count);
 		floatBuffer.put(v,  offset, count);
-		floatBuffer.position(0);
+		((Buffer) floatBuffer).position(0);
 		return floatBuffer;
 	}
 
 	private IntBuffer toIntBuffer (int v[], int offset, int count) {
 		ensureBufferCapacity(count << 2);
-		intBuffer.clear();
-		intBuffer.limit(count);
+		((Buffer) intBuffer).clear();
+		((Buffer) intBuffer).limit(count);
 		intBuffer.put(v, offset, count);
-		intBuffer.position(0);
+		((Buffer) intBuffer).position(0);
 		return intBuffer;
 	}
 
@@ -797,7 +797,7 @@ class Lwjgl3GL20 implements com.badlogic.gdx.graphics.GL20 {
 
 	public void glVertexAttribPointer (int indx, int size, int type, boolean normalized, int stride, Buffer buffer) {
 		if (buffer instanceof ByteBuffer) {
-			if (type == GL_BYTE)				
+			if (type == GL_BYTE)
 				GL20.glVertexAttribPointer(indx, size, type, normalized, stride, (ByteBuffer)buffer);
 			else if (type == GL_UNSIGNED_BYTE)
 				GL20.glVertexAttribPointer(indx, size, type, normalized, stride, (ByteBuffer)buffer);

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3GL30.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3GL30.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -41,7 +41,7 @@ import com.badlogic.gdx.utils.GdxRuntimeException;
 
 class Lwjgl3GL30 extends Lwjgl3GL20 implements com.badlogic.gdx.graphics.GL30 {
 	@Override
-	public void glReadBuffer (int mode) {		
+	public void glReadBuffer (int mode) {
 		GL11.glReadBuffer(mode);
 	}
 
@@ -182,9 +182,9 @@ class Lwjgl3GL30 extends Lwjgl3GL20 implements com.badlogic.gdx.graphics.GL30 {
 	@Override
 	public void glDrawBuffers (int n, IntBuffer bufs) {
 		int limit = bufs.limit();
-		bufs.limit(n);
+		((Buffer) bufs).limit(n);
 		GL20.glDrawBuffers(bufs);
-		bufs.limit(limit);
+		((Buffer) bufs).limit(limit);
 	}
 
 	@Override
@@ -412,7 +412,7 @@ class Lwjgl3GL30 extends Lwjgl3GL20 implements com.badlogic.gdx.graphics.GL30 {
 	public void glVertexAttribI4ui (int index, int x, int y, int z, int w) {
 		GL30.glVertexAttribI4ui(index, x, y, z, w);
 	}
-	
+
 	@Override
 	public void glGetUniformuiv (int program, int location, IntBuffer params) {
 		GL30.glGetUniformuiv(program, location, params);
@@ -511,7 +511,7 @@ class Lwjgl3GL30 extends Lwjgl3GL20 implements com.badlogic.gdx.graphics.GL30 {
 	@Override
 	public void glDrawElementsInstanced (int mode, int count, int type, int indicesOffset, int instanceCount) {
 		GL31.glDrawElementsInstanced(mode, count, type, indicesOffset, instanceCount);
-		
+
 	}
 
 	@Override
@@ -585,7 +585,7 @@ class Lwjgl3GL30 extends Lwjgl3GL20 implements com.badlogic.gdx.graphics.GL30 {
 
 	@Override
 	public void glGetSamplerParameterfv (int sampler, int pname, FloatBuffer params) {
-		GL33.glGetSamplerParameterfv(sampler, pname, params);		
+		GL33.glGetSamplerParameterfv(sampler, pname, params);
 	}
 
 	@Override

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OggInputStream.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OggInputStream.java
@@ -1,17 +1,17 @@
 /**
  * Copyright (c) 2007, Slick 2D
- * 
+ *
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following
  * conditions are met:
- * 
+ *
  * Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
  * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer
  * in the documentation and/or other materials provided with the distribution. Neither the name of the Slick 2D nor the names of
  * its contributors may be used to endorse or promote products derived from this software without specific prior written
  * permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
  * BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
  * SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
@@ -24,6 +24,7 @@ package com.badlogic.gdx.backends.lwjgl3.audio;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
@@ -45,7 +46,7 @@ import com.jcraft.jorbis.Info;
  * @author kevin */
 public class OggInputStream extends InputStream {
 	private final static int BUFFER_SIZE = 512;
-	
+
 	/** The conversion buffer size */
 	private int convsize = BUFFER_SIZE * 4;
 	/** The buffer used to read OGG file */
@@ -92,7 +93,7 @@ public class OggInputStream extends InputStream {
 	private int total;
 
 	/** Create a new stream to decode OGG data
-	 * 
+	 *
 	 * @param input The input stream from which to read the OGG file */
 	public OggInputStream (InputStream input) {
 		this(input, null);
@@ -124,7 +125,7 @@ public class OggInputStream extends InputStream {
 	}
 
 	/** Get the number of bytes on the stream
-	 * 
+	 *
 	 * @return The number of the bytes on the stream */
 	public int getLength () {
 		return total;
@@ -155,7 +156,7 @@ public class OggInputStream extends InputStream {
 	}
 
 	/** Get a page and packet from that page
-	 * 
+	 *
 	 * @return True if there was a page available */
 	private boolean getPageAndPacket () {
 		// grab some data at the head of the stream. We want the first page
@@ -431,7 +432,7 @@ public class OggInputStream extends InputStream {
 
 	public int read () {
 		if (readIndex >= pcmBuffer.position()) {
-			pcmBuffer.clear();
+			((Buffer) pcmBuffer).clear();
 			readPCM();
 			readIndex = 0;
 		}

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALAudioDevice.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALAudioDevice.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,6 +16,7 @@
 
 package com.badlogic.gdx.backends.lwjgl3.audio;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
 
@@ -98,8 +99,8 @@ public class OpenALAudioDevice implements AudioDevice {
 			for (int i = 0; i < bufferCount; i++) {
 				int bufferID = buffers.get(i);
 				int written = Math.min(bufferSize, length);
-				tempBuffer.clear();
-				tempBuffer.put(data, offset, written).flip();
+				((Buffer) tempBuffer).clear();
+				((Buffer) tempBuffer.put(data, offset, written)).flip();
 				alBufferData(bufferID, format, tempBuffer, sampleRate);
 				alSourceQueueBuffers(sourceID, bufferID);
 				length -= written;
@@ -107,7 +108,7 @@ public class OpenALAudioDevice implements AudioDevice {
 				queuedBuffers++;
 			}
 			// Queue rest of buffers, empty.
-			tempBuffer.clear().flip();
+			((Buffer) tempBuffer).clear().flip();
 			for (int i = queuedBuffers; i < bufferCount; i++) {
 				int bufferID = buffers.get(i);
 				alBufferData(bufferID, format, tempBuffer, sampleRate);
@@ -136,8 +137,8 @@ public class OpenALAudioDevice implements AudioDevice {
 				if (bufferID == AL_INVALID_VALUE) break;
 				renderedSeconds += secondsPerBuffer;
 
-				tempBuffer.clear();
-				tempBuffer.put(data, offset, written).flip();
+				((Buffer) tempBuffer).clear();
+				((Buffer) tempBuffer.put(data, offset, written)).flip();
 				alBufferData(bufferID, format, tempBuffer, sampleRate);
 
 				alSourceQueueBuffers(sourceID, bufferID);

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALLwjgl3Audio.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALLwjgl3Audio.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -36,6 +36,7 @@ import static org.lwjgl.openal.AL10.alSourceStop;
 import static org.lwjgl.openal.AL10.alSourcei;
 import static org.lwjgl.openal.ALC10.*;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.FloatBuffer;
 import java.nio.IntBuffer;
@@ -120,11 +121,14 @@ public class OpenALLwjgl3Audio implements Lwjgl3Audio {
 		sourceToSoundId = new IntMap<Long>();
 
 		FloatBuffer orientation = (FloatBuffer)BufferUtils.createFloatBuffer(6)
-			.put(new float[] {0.0f, 0.0f, -1.0f, 0.0f, 1.0f, 0.0f}).flip();
+			.put(new float[] {0.0f, 0.0f, -1.0f, 0.0f, 1.0f, 0.0f});
+		((Buffer) orientation).flip();
 		alListenerfv(AL_ORIENTATION, orientation);
-		FloatBuffer velocity = (FloatBuffer)BufferUtils.createFloatBuffer(3).put(new float[] {0.0f, 0.0f, 0.0f}).flip();
+		FloatBuffer velocity = (FloatBuffer)BufferUtils.createFloatBuffer(3).put(new float[] {0.0f, 0.0f, 0.0f});
+		((Buffer) velocity).flip();
 		alListenerfv(AL_VELOCITY, velocity);
-		FloatBuffer position = (FloatBuffer)BufferUtils.createFloatBuffer(3).put(new float[] {0.0f, 0.0f, 0.0f}).flip();
+		FloatBuffer position = (FloatBuffer)BufferUtils.createFloatBuffer(3).put(new float[] {0.0f, 0.0f, 0.0f});
+		((Buffer) position).flip();
 		alListenerfv(AL_POSITION, position);
 
 		recentSounds = new OpenALSound[simultaneousSources];

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALMusic.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALMusic.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,6 +16,7 @@
 
 package com.badlogic.gdx.backends.lwjgl3.audio;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
 
@@ -249,7 +250,7 @@ public abstract class OpenALMusic implements Music {
 	}
 
 	private boolean fill (int bufferID) {
-		tempBuffer.clear();
+		((Buffer) tempBuffer).clear();
 		int length = read(tempBytes);
 		if (length <= 0) {
 			if (isLooping) {
@@ -266,7 +267,7 @@ public abstract class OpenALMusic implements Music {
 		float currentBufferSeconds = maxSecondsPerBuffer * (float)length / (float)bufferSize;
 		renderedSecondsQueue.insert(0, previousLoadedSeconds + currentBufferSeconds);
 
-		tempBuffer.put(tempBytes, 0, length).flip();
+		((Buffer) tempBuffer.put(tempBytes, 0, length)).flip();
 		alBufferData(bufferID, format, tempBuffer, sampleRate);
 		return true;
 	}

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALSound.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALSound.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,6 +16,7 @@
 
 package com.badlogic.gdx.backends.lwjgl3.audio;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
@@ -41,7 +42,7 @@ public class OpenALSound implements Sound {
 		ByteBuffer buffer = ByteBuffer.allocateDirect(bytes);
 		buffer.order(ByteOrder.nativeOrder());
 		buffer.put(pcm, 0, bytes);
-		buffer.flip();
+		((Buffer) buffer).flip();
 
 		if (bufferID == -1) {
 			bufferID = alGenBuffers();

--- a/extensions/gdx-bullet/jni/swig-src/extras/com/badlogic/gdx/physics/bullet/extras/btBulletWorldImporter.java
+++ b/extensions/gdx-bullet/jni/swig-src/extras/com/badlogic/gdx/physics/bullet/extras/btBulletWorldImporter.java
@@ -21,27 +21,29 @@ import com.badlogic.gdx.physics.bullet.dynamics.btDynamicsWorld;
 import com.badlogic.gdx.physics.bullet.dynamics.btContactSolverInfo;
 import com.badlogic.gdx.physics.bullet.collision.btCollisionShape;
 
+import java.nio.Buffer;
+
 public class btBulletWorldImporter extends btWorldImporter {
 	private long swigCPtr;
-	
+
 	protected btBulletWorldImporter(final String className, long cPtr, boolean cMemoryOwn) {
 		super(className, ExtrasJNI.btBulletWorldImporter_SWIGUpcast(cPtr), cMemoryOwn);
 		swigCPtr = cPtr;
 	}
-	
+
 	/** Construct a new btBulletWorldImporter, normally you should not need this constructor it's intended for low-level usage. */
 	public btBulletWorldImporter(long cPtr, boolean cMemoryOwn) {
 		this("btBulletWorldImporter", cPtr, cMemoryOwn);
 		construct();
 	}
-	
+
 	@Override
 	protected void reset(long cPtr, boolean cMemoryOwn) {
 		if (!destroyed)
 			destroy();
 		super.reset(ExtrasJNI.btBulletWorldImporter_SWIGUpcast(swigCPtr = cPtr), cMemoryOwn);
 	}
-	
+
 	public static long getCPtr(btBulletWorldImporter obj) {
 		return (obj == null) ? 0 : obj.swigCPtr;
 	}
@@ -85,7 +87,7 @@ public class btBulletWorldImporter extends btWorldImporter {
 			throw new com.badlogic.gdx.utils.GdxRuntimeException("Incorrect file specified");
 		java.nio.ByteBuffer buff = com.badlogic.gdx.utils.BufferUtils.newUnsafeByteBuffer(len);
 		buff.put(fileHandle.readBytes());
-		buff.position(0);
+		((Buffer) buff).position(0);
 		boolean result = loadFileFromMemory(buff, len);
 		com.badlogic.gdx.utils.BufferUtils.disposeUnsafeByteBuffer(buff);
 		return result;

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/hiero/BMFontUtil.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/hiero/BMFontUtil.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,6 +25,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.nio.Buffer;
 import java.nio.IntBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -172,7 +173,7 @@ public class BMFontUtil {
 				fileName = outputName + (pageIndex + 1) + ".png";
 
 			page.getTexture().bind();
-			buffer.clear();
+			((Buffer) buffer).clear();
 			GL11.glGetTexImage(GL11.GL_TEXTURE_2D, 0, GL12.GL_BGRA, GL11.GL_UNSIGNED_BYTE, buffer);
 			WritableRaster raster = pageImage.getRaster();
 			for (int y = 0; y < height; y++) {

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/hiero/unicodefont/GlyphPage.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/hiero/unicodefont/GlyphPage.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,6 +23,7 @@ import java.awt.font.FontRenderContext;
 import java.awt.image.BufferedImage;
 import java.awt.image.WritableRaster;
 import java.math.BigInteger;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.IntBuffer;
@@ -69,7 +70,7 @@ public class GlyphPage {
 	}
 
 	/** Loads glyphs to the backing texture and sets the image on each loaded glyph. Loaded glyphs are removed from the list.
-	 * 
+	 *
 	 * If this page already has glyphs and maxGlyphsToLoad is -1, then this method will return 0 if all the new glyphs don't fit.
 	 * This reduces texture binds when drawing since glyphs loaded at once are typically displayed together.
 	 * @param glyphs The glyphs to load.
@@ -165,7 +166,7 @@ public class GlyphPage {
 			}
 			fontPixels.position(0);
 			glyphPixels.position(height * glyphRowBytes);
-			glyphPixels.flip();
+			((Buffer) glyphPixels).flip();
 			format = GL11.GL_RGBA;
 		} else {
 			// Draw the glyph to the scratch image using Java2D.

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/hiero/unicodefont/GlyphPage.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/hiero/unicodefont/GlyphPage.java
@@ -152,20 +152,20 @@ public class GlyphPage {
 
 			ByteBuffer fontPixels = fontPixmap.getPixels();
 			byte[] row = new byte[glyphRowBytes];
-			glyphPixels.position(0);
+			((Buffer) glyphPixels).position(0);
 			for (int i = 0; i < padTop; i++)
 				glyphPixels.put(row);
-			glyphPixels.position((height - padBottom) * glyphRowBytes);
+			((Buffer) glyphPixels).position((height - padBottom) * glyphRowBytes);
 			for (int i = 0; i < padBottom; i++)
 				glyphPixels.put(row);
-			glyphPixels.position(padTop * glyphRowBytes);
+			((Buffer) glyphPixels).position(padTop * glyphRowBytes);
 			for (int y = 0, n = g.height; y < n; y++) {
-				fontPixels.position(((g.srcY + y) * fontWidth + g.srcX) * 4);
+				((Buffer) fontPixels).position(((g.srcY + y) * fontWidth + g.srcX) * 4);
 				fontPixels.get(row, padLeftBytes, fontRowBytes);
 				glyphPixels.put(row);
 			}
-			fontPixels.position(0);
-			glyphPixels.position(height * glyphRowBytes);
+			((Buffer) fontPixels).position(0);
+			((Buffer) glyphPixels).position(height * glyphRowBytes);
 			((Buffer) glyphPixels).flip();
 			format = GL11.GL_RGBA;
 		} else {
@@ -206,8 +206,8 @@ public class GlyphPage {
 			hash = bigInt.toString(16);
 		} catch (NoSuchAlgorithmException ex) {
 		}
-		scratchByteBuffer.clear();
-		scratchIntBuffer.clear();
+		((Buffer) scratchByteBuffer).clear();
+		((Buffer) scratchIntBuffer).clear();
 
 		try {
 			for (int i = 0, n = hashes.size(); i < n; i++) {

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/ktx/KTXProcessor.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/ktx/KTXProcessor.java
@@ -4,6 +4,7 @@ package com.badlogic.gdx.tools.ktx;
 import java.io.DataOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.zip.GZIPOutputStream;
 
@@ -362,7 +363,7 @@ public class KTXProcessor {
 		public byte[] getBytes () {
 			if (etcData != null) {
 				byte[] result = new byte[getSize()];
-				etcData.compressedData.position(etcData.dataOffset);
+				((Buffer) etcData.compressedData).position(etcData.dataOffset);
 				etcData.compressedData.get(result);
 				return result;
 			}

--- a/gdx/src/com/badlogic/gdx/graphics/GLTexture.java
+++ b/gdx/src/com/badlogic/gdx/graphics/GLTexture.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -26,6 +26,7 @@ import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.utils.BufferUtils;
 import com.badlogic.gdx.utils.Disposable;
 
+import java.nio.Buffer;
 import java.nio.FloatBuffer;
 
 /** Class representing an OpenGL texture by its target and handle. Keeps track of its state like the TextureFilter and TextureWrap.
@@ -231,8 +232,8 @@ public abstract class GLTexture implements Disposable {
 			return maxAnisotropicFilterLevel;
 		if (Gdx.graphics.supportsExtension("GL_EXT_texture_filter_anisotropic")) {
 			FloatBuffer buffer = BufferUtils.newFloatBuffer(16);
-			buffer.position(0);
-			buffer.limit(buffer.capacity());
+			((Buffer) buffer).position(0);
+			((Buffer) buffer).limit(buffer.capacity());
 			Gdx.gl20.glGetFloatv(GL20.GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT, buffer);
 			return maxAnisotropicFilterLevel = buffer.get(0);
 		}
@@ -255,7 +256,7 @@ public abstract class GLTexture implements Disposable {
 	protected static void uploadImageData (int target, TextureData data) {
 		uploadImageData(target, data, 0);
 	}
-	
+
 	public static void uploadImageData (int target, TextureData data, int miplevel) {
 		if (data == null) {
 			// FIXME: remove texture on target?

--- a/gdx/src/com/badlogic/gdx/graphics/Mesh.java
+++ b/gdx/src/com/badlogic/gdx/graphics/Mesh.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,6 +16,7 @@
 
 package com.badlogic.gdx.graphics;
 
+import java.nio.Buffer;
 import java.nio.FloatBuffer;
 import java.nio.ShortBuffer;
 import java.util.HashMap;
@@ -312,7 +313,7 @@ public class Mesh implements Disposable {
 
 		return this;
 	}
-	
+
 	/** @return Indicates whether this mesh uses instancing. */
 	public boolean isInstanced () {
 		return this.isInstanced;
@@ -388,9 +389,9 @@ public class Mesh implements Disposable {
 			throw new IllegalArgumentException("not enough room in vertices array, has " + vertices.length + " floats, needs "
 				+ count);
 		int pos = getVerticesBuffer().position();
-		getVerticesBuffer().position(srcOffset);
+		((Buffer) getVerticesBuffer()).position(srcOffset);
 		getVerticesBuffer().get(vertices, destOffset, count);
-		getVerticesBuffer().position(pos);
+		((Buffer) getVerticesBuffer()).position(pos);
 		return vertices;
 	}
 
@@ -454,9 +455,9 @@ public class Mesh implements Disposable {
 		if ((indices.length - destOffset) < count)
 			throw new IllegalArgumentException("not enough room in indices array, has " + indices.length + " shorts, needs " + count);
 		int pos = getIndicesBuffer().position();
-		getIndicesBuffer().position(srcOffset);
+		((Buffer) getVerticesBuffer()).position(srcOffset);
 		getIndicesBuffer().get(indices, destOffset, count);
-		getIndicesBuffer().position(pos);
+		((Buffer) getVerticesBuffer()).position(pos);
 	}
 
 	/** @return the number of defined indices */
@@ -616,11 +617,11 @@ public class Mesh implements Disposable {
 				ShortBuffer buffer = indices.getBuffer();
 				int oldPosition = buffer.position();
 				int oldLimit = buffer.limit();
-				buffer.position(offset);
-				buffer.limit(offset + count);
+				((Buffer) buffer).position(offset);
+				((Buffer) buffer).limit(offset + count);
 				Gdx.gl20.glDrawElements(primitiveType, count, GL20.GL_UNSIGNED_SHORT, buffer);
-				buffer.position(oldPosition);
-				buffer.limit(oldLimit);
+				((Buffer) buffer).position(oldPosition);
+				((Buffer) buffer).limit(oldLimit);
 			} else {
 				Gdx.gl20.glDrawArrays(primitiveType, offset, count);
 			}
@@ -660,7 +661,7 @@ public class Mesh implements Disposable {
 	}
 
 	/** Returns the first {@link VertexAttribute} having the given {@link Usage}.
-	 * 
+	 *
 	 * @param usage the Usage.
 	 * @return the VertexAttribute or null if no attribute with that usage was found. */
 	public VertexAttribute getVertexAttribute (int usage) {
@@ -684,7 +685,7 @@ public class Mesh implements Disposable {
 
 	/** Calculates the {@link BoundingBox} of the vertices contained in this mesh. In case no vertices are defined yet a
 	 * {@link GdxRuntimeException} is thrown. This method creates a new BoundingBox instance.
-	 * 
+	 *
 	 * @return the bounding box. */
 	public BoundingBox calculateBoundingBox () {
 		BoundingBox bbox = new BoundingBox();
@@ -694,7 +695,7 @@ public class Mesh implements Disposable {
 
 	/** Calculates the {@link BoundingBox} of the vertices contained in this mesh. In case no vertices are defined yet a
 	 * {@link GdxRuntimeException} is thrown.
-	 * 
+	 *
 	 * @param bbox the bounding box to store the result in. */
 	public void calculateBoundingBox (BoundingBox bbox) {
 		final int numVertices = getNumVertices();
@@ -985,7 +986,7 @@ public class Mesh implements Disposable {
 
 	/** Method to scale the positions in the mesh. Normals will be kept as is. This is a potentially slow operation, use with care.
 	 * It will also create a temporary float[] which will be garbage collected.
-	 * 
+	 *
 	 * @param scaleX scale on x
 	 * @param scaleY scale on y
 	 * @param scaleZ scale on z */
@@ -1029,7 +1030,7 @@ public class Mesh implements Disposable {
 
 	/** Method to transform the positions in the mesh. Normals will be kept as is. This is a potentially slow operation, use with
 	 * care. It will also create a temporary float[] which will be garbage collected.
-	 * 
+	 *
 	 * @param matrix the transformation matrix */
 	public void transform (final Matrix4 matrix) {
 		transform(matrix, 0, getNumVertices());
@@ -1100,7 +1101,7 @@ public class Mesh implements Disposable {
 
 	/** Method to transform the texture coordinates in the mesh. This is a potentially slow operation, use with care. It will also
 	 * create a temporary float[] which will be garbage collected.
-	 * 
+	 *
 	 * @param matrix the transformation matrix */
 	public void transformUV (final Matrix3 matrix) {
 		transformUV(matrix, 0, getNumVertices());

--- a/gdx/src/com/badlogic/gdx/graphics/PixmapIO.java
+++ b/gdx/src/com/badlogic/gdx/graphics/PixmapIO.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,6 +22,7 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.zip.CRC32;
 import java.util.zip.CheckedOutputStream;
@@ -97,8 +98,8 @@ public class PixmapIO {
 				out.writeInt(Format.toGdx2DPixmapFormat(pixmap.getFormat()));
 
 				ByteBuffer pixelBuf = pixmap.getPixels();
-				pixelBuf.position(0);
-				pixelBuf.limit(pixelBuf.capacity());
+				((Buffer) pixelBuf).position(0);
+				((Buffer) pixelBuf).limit(pixelBuf.capacity());
 
 				int remainingBytes = pixelBuf.capacity() % BUFFER_SIZE;
 				int iterations = pixelBuf.capacity() / BUFFER_SIZE;
@@ -113,8 +114,8 @@ public class PixmapIO {
 					out.write(writeBuffer, 0, remainingBytes);
 				}
 
-				pixelBuf.position(0);
-				pixelBuf.limit(pixelBuf.capacity());
+				((Buffer) pixelBuf).position(0);
+				((Buffer) pixelBuf).limit(pixelBuf.capacity());
 				// Gdx.app.log("PixmapIO", "write (" + file.name() + "):" + (System.nanoTime() - start) / 1000000000.0f + ", " +
 				// Thread.currentThread().getName());
 			} catch (Exception e) {
@@ -136,8 +137,8 @@ public class PixmapIO {
 				Pixmap pixmap = new Pixmap(width, height, format);
 
 				ByteBuffer pixelBuf = pixmap.getPixels();
-				pixelBuf.position(0);
-				pixelBuf.limit(pixelBuf.capacity());
+				((Buffer) pixelBuf).position(0);
+				((Buffer) pixelBuf).limit(pixelBuf.capacity());
 
 				synchronized (readBuffer) {
 					int readBytes = 0;
@@ -146,8 +147,8 @@ public class PixmapIO {
 					}
 				}
 
-				pixelBuf.position(0);
-				pixelBuf.limit(pixelBuf.capacity());
+				((Buffer) pixelBuf).position(0);
+				((Buffer) pixelBuf).limit(pixelBuf.capacity());
 				// Gdx.app.log("PixmapIO", "read:" + (System.nanoTime() - start) / 1000000000.0f);
 				return pixmap;
 			} catch (Exception e) {
@@ -159,21 +160,21 @@ public class PixmapIO {
 	}
 
 	/** PNG encoder with compression. An instance can be reused to encode multiple PNGs with minimal allocation.
-	 * 
+	 *
 	 * <pre>
 	 * Copyright (c) 2007 Matthias Mann - www.matthiasmann.de
 	 * Copyright (c) 2014 Nathan Sweet
-	 * 
+	 *
 	 * Permission is hereby granted, free of charge, to any person obtaining a copy
 	 * of this software and associated documentation files (the "Software"), to deal
 	 * in the Software without restriction, including without limitation the rights
 	 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 	 * copies of the Software, and to permit persons to whom the Software is
 	 * furnished to do so, subject to the following conditions:
-	 * 
+	 *
 	 * The above copyright notice and this permission notice shall be included in
 	 * all copies or substantial portions of the Software.
-	 * 
+	 *
 	 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 	 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 	 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -267,7 +268,7 @@ public class PixmapIO {
 			for (int y = 0, h = pixmap.getHeight(); y < h; y++) {
 				int py = flipY ? (h - y - 1) : y;
 				if (rgba8888) {
-					pixels.position(py * lineLen);
+					((Buffer) pixels).position(py * lineLen);
 					pixels.get(curLine, 0, lineLen);
 				} else {
 					for (int px = 0, x = 0; px < pixmap.getWidth(); px++) {
@@ -309,7 +310,7 @@ public class PixmapIO {
 				curLine = prevLine;
 				prevLine = temp;
 			}
-			pixels.position(oldPosition);
+			((Buffer) pixels).position(oldPosition);
 			deflaterOutput.finish();
 			buffer.endChunk(dataOutput);
 

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/SpriteBatch.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/SpriteBatch.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -29,6 +29,8 @@ import com.badlogic.gdx.math.Affine2;
 import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.math.Matrix4;
 import com.badlogic.gdx.utils.NumberUtils;
+
+import java.nio.Buffer;
 
 /** Draws batched quads using indices.
  * @see Batch
@@ -955,8 +957,8 @@ public class SpriteBatch implements Batch {
 		lastTexture.bind();
 		Mesh mesh = this.mesh;
 		mesh.setVertices(vertices, 0, idx);
-		mesh.getIndicesBuffer().position(0);
-		mesh.getIndicesBuffer().limit(count);
+		((Buffer) mesh.getIndicesBuffer()).position(0);
+		((Buffer) mesh.getIndicesBuffer()).limit(count);
 
 		if (blendingDisabled) {
 			Gdx.gl.glDisable(GL20.GL_BLEND);

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/SpriteCache.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/SpriteCache.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,6 +19,7 @@ package com.badlogic.gdx.graphics.g2d;
 import static com.badlogic.gdx.graphics.g2d.Sprite.SPRITE_SIZE;
 import static com.badlogic.gdx.graphics.g2d.Sprite.VERTEX_SIZE;
 
+import java.nio.Buffer;
 import java.nio.FloatBuffer;
 
 import com.badlogic.gdx.ApplicationListener;
@@ -183,12 +184,12 @@ public class SpriteCache implements Disposable {
 		if (currentCache != null) throw new IllegalStateException("endCache must be called before begin.");
 		if (cacheID == caches.size - 1) {
 			Cache oldCache = caches.removeIndex(cacheID);
-			mesh.getVerticesBuffer().limit(oldCache.offset);
+			((Buffer) mesh.getVerticesBuffer()).limit(oldCache.offset);
 			beginCache();
 			return;
 		}
 		currentCache = caches.get(cacheID);
-		mesh.getVerticesBuffer().position(currentCache.offset);
+		((Buffer) mesh.getVerticesBuffer()).position(currentCache.offset);
 	}
 
 	/** Ends the definition of a cache, returning the cache ID to be used with {@link #draw(int)}. */
@@ -205,7 +206,7 @@ public class SpriteCache implements Disposable {
 			for (int i = 0, n = counts.size; i < n; i++)
 				cache.counts[i] = counts.get(i);
 
-			mesh.getVerticesBuffer().flip();
+			((Buffer) mesh.getVerticesBuffer()).flip();
 		} else {
 			// Redefine existing cache.
 			if (cacheCount > cache.maxCount) {
@@ -225,9 +226,9 @@ public class SpriteCache implements Disposable {
 				cache.counts[i] = counts.get(i);
 
 			FloatBuffer vertices = mesh.getVerticesBuffer();
-			vertices.position(0);
+			((Buffer) vertices).position(0);
 			Cache lastCache = caches.get(caches.size - 1);
-			vertices.limit(lastCache.offset + lastCache.maxCount);
+			((Buffer) vertices).limit(lastCache.offset + lastCache.maxCount);
 		}
 
 		currentCache = null;
@@ -240,7 +241,7 @@ public class SpriteCache implements Disposable {
 	/** Invalidates all cache IDs and resets the SpriteCache so new caches can be added. */
 	public void clear () {
 		caches.clear();
-		mesh.getVerticesBuffer().clear().flip();
+		((Buffer) mesh.getVerticesBuffer()).clear().flip();
 	}
 
 	/** Adds the specified vertices to the cache. Each vertex should have 5 elements, one for each of the attributes: x, y, color,
@@ -1009,9 +1010,9 @@ public class SpriteCache implements Disposable {
 	 * uploaded via a mat4 uniform called "u_proj", the transform matrix is uploaded via a uniform called "u_trans", the combined
 	 * transform and projection matrx is is uploaded via a mat4 uniform called "u_projTrans". The texture sampler is passed via a
 	 * uniform called "u_texture".
-	 * 
+	 *
 	 * Call this method with a null argument to use the default shader.
-	 * 
+	 *
 	 * @param shader the {@link ShaderProgram} or null to use the default shader. */
 	public void setShader (ShaderProgram shader) {
 		customShader = shader;

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/Model.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/Model.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -55,17 +55,19 @@ import com.badlogic.gdx.utils.Disposable;
 import com.badlogic.gdx.utils.GdxRuntimeException;
 import com.badlogic.gdx.utils.ObjectMap;
 
+import java.nio.Buffer;
+
 /** A model represents a 3D assets. It stores a hierarchy of nodes. A node has a transform and optionally a graphical part in form
  * of a {@link MeshPart} and {@link Material}. Mesh parts reference subsets of vertices in one of the meshes of the model.
  * Animations can be applied to nodes, to modify their transform (translation, rotation, scale) over time.</p>
- * 
+ *
  * A model can be rendered by creating a {@link ModelInstance} from it. That instance has an additional transform to position the
  * model in the world, and allows modification of materials and nodes without destroying the original model. The original model is
  * the owner of any meshes and textures, all instances created from the model share these resources. Disposing the model will
  * automatically make all instances invalid!</p>
- * 
+ *
  * A model is created from {@link ModelData}, which in turn is loaded by a {@link ModelLoader}.
- * 
+ *
  * @author badlogic, xoppa */
 public class Model implements Disposable {
 	/** the materials of the model, used by nodes that have a graphical representation FIXME not sure if superfluous, allows
@@ -245,7 +247,7 @@ public class Model implements Disposable {
 
 		BufferUtils.copy(modelMesh.vertices, mesh.getVerticesBuffer(), modelMesh.vertices.length, 0);
 		int offset = 0;
-		mesh.getIndicesBuffer().clear();
+		((Buffer) mesh.getIndicesBuffer()).clear();
 		for (ModelMeshPart part : modelMesh.parts) {
 			MeshPart meshPart = new MeshPart();
 			meshPart.id = part.id;
@@ -259,7 +261,7 @@ public class Model implements Disposable {
 			offset += meshPart.size;
 			meshParts.add(meshPart);
 		}
-		mesh.getIndicesBuffer().position(0);
+		((Buffer) mesh.getIndicesBuffer()).position(0);
 		for (MeshPart part : meshParts)
 			part.update();
 	}
@@ -358,7 +360,7 @@ public class Model implements Disposable {
 	 * {@link Node#localTransform} transform is calculated based on the translation, rotation and scale of each Node. Then each
 	 * {@link Node#calculateWorldTransform()} is calculated, based on the parent's world transform and the local transform of each
 	 * Node. Finally, the animation bone matrices are updated accordingly.</p>
-	 * 
+	 *
 	 * This method can be used to recalculate all transforms if any of the Node's local properties (translation, rotation, scale)
 	 * was modified. */
 	public void calculateTransforms () {

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/ETC1.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/ETC1.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,6 +19,7 @@ package com.badlogic.gdx.graphics.glutils;
 import java.io.BufferedInputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
@@ -71,8 +72,8 @@ public class ETC1 {
 				while ((readBytes = in.read(buffer)) != -1) {
 					compressedData.put(buffer, 0, readBytes);
 				}
-				compressedData.position(0);
-				compressedData.limit(compressedData.capacity());
+				((Buffer) compressedData).position(0);
+				((Buffer) compressedData).limit(compressedData.capacity());
 			} catch (Exception e) {
 				throw new GdxRuntimeException("Couldn't load pkm file '" + pkmFile + "'", e);
 			} finally {
@@ -82,7 +83,7 @@ public class ETC1 {
 			width = getWidthPKM(compressedData, 0);
 			height = getHeightPKM(compressedData, 0);
 			dataOffset = PKM_HEADER_SIZE;
-			compressedData.position(dataOffset);
+			((Buffer) compressedData).position(dataOffset);
 			checkNPOT();
 		}
 
@@ -103,8 +104,8 @@ public class ETC1 {
 			DataOutputStream write = null;
 			byte[] buffer = new byte[10 * 1024];
 			int writtenBytes = 0;
-			compressedData.position(0);
-			compressedData.limit(compressedData.capacity());
+			((Buffer) compressedData).position(0);
+			((Buffer) compressedData).limit(compressedData.capacity());
 			try {
 				write = new DataOutputStream(new GZIPOutputStream(file.write(false)));
 				write.writeInt(compressedData.capacity());
@@ -119,8 +120,8 @@ public class ETC1 {
 			} finally {
 				StreamUtils.closeQuietly(write);
 			}
-			compressedData.position(dataOffset);
-			compressedData.limit(compressedData.capacity());
+			((Buffer) compressedData).position(dataOffset);
+			((Buffer) compressedData).limit(compressedData.capacity());
 		}
 
 		/** Releases the native resources of the ETC1Data instance. */
@@ -204,7 +205,7 @@ public class ETC1 {
 	public static native int getCompressedDataSize (int width, int height); /*
 		return etc1_get_encoded_data_size(width, height);
 	*/
-	
+
 
 	/** Writes a PKM header to the {@link ByteBuffer}. Does not modify the position or limit of the ByteBuffer.
 	 * @param header the direct native order {@link ByteBuffer}

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/GLFrameBuffer.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/GLFrameBuffer.java
@@ -16,6 +16,7 @@
 
 package com.badlogic.gdx.graphics.glutils;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.IntBuffer;
@@ -180,7 +181,7 @@ public abstract class GLFrameBuffer<T extends GLTexture> implements Disposable {
 			for (int i = 0; i < colorTextureCounter; i++) {
 				buffer.put(GL30.GL_COLOR_ATTACHMENT0 + i);
 			}
-			buffer.position(0);
+			((Buffer) buffer).position(0);
 			Gdx.gl30.glDrawBuffers(colorTextureCounter, buffer);
 		} else {
 			attachFrameBufferColorTexture(textureAttachments.first());

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/IndexArray.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/IndexArray.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,6 +16,7 @@
 
 package com.badlogic.gdx.graphics.glutils;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.ShortBuffer;
 
@@ -29,7 +30,7 @@ public class IndexArray implements IndexData {
 	private final boolean empty;
 
 	/** Creates a new IndexArray to be used with vertex arrays.
-	 * 
+	 *
 	 * @param maxIndices the maximum number of indices this buffer can hold */
 	public IndexArray (int maxIndices) {
 
@@ -40,8 +41,8 @@ public class IndexArray implements IndexData {
 
 		byteBuffer = BufferUtils.newUnsafeByteBuffer(maxIndices * 2);
 		buffer = byteBuffer.asShortBuffer();
-		buffer.flip();
-		byteBuffer.flip();
+		((Buffer) buffer).flip();
+		((Buffer) byteBuffer).flip();
 	}
 
 	/** @return the number of indices currently stored in this buffer */
@@ -58,46 +59,46 @@ public class IndexArray implements IndexData {
 	 * Sets the indices of this IndexArray, discarding the old indices. The count must equal the number of indices to be copied to
 	 * this IndexArray.
 	 * </p>
-	 * 
+	 *
 	 * <p>
 	 * This can be called in between calls to {@link #bind()} and {@link #unbind()}. The index data will be updated instantly.
 	 * </p>
-	 * 
+	 *
 	 * @param indices the vertex data
 	 * @param offset the offset to start copying the data from
 	 * @param count the number of shorts to copy */
 	public void setIndices (short[] indices, int offset, int count) {
-		buffer.clear();
+		((Buffer) buffer).clear();
 		buffer.put(indices, offset, count);
-		buffer.flip();
-		byteBuffer.position(0);
-		byteBuffer.limit(count << 1);
+		((Buffer) buffer).flip();
+		((Buffer) byteBuffer).position(0);
+		((Buffer) byteBuffer).limit(count << 1);
 	}
-	
+
 	public void setIndices (ShortBuffer indices) {
 		int pos = indices.position();
-		buffer.clear();
-		buffer.limit(indices.remaining());
+		((Buffer) buffer).clear();
+		((Buffer) buffer).limit(indices.remaining());
 		buffer.put(indices);
-		buffer.flip();
-		indices.position(pos);
-		byteBuffer.position(0);
-		byteBuffer.limit(buffer.limit() << 1);
+		((Buffer) buffer).flip();
+		((Buffer) indices).position(pos);
+		((Buffer) byteBuffer).position(0);
+		((Buffer) byteBuffer).limit(buffer.limit() << 1);
 	}
 
 	@Override
 	public void updateIndices (int targetOffset, short[] indices, int offset, int count) {
 		final int pos = byteBuffer.position();
-		byteBuffer.position(targetOffset * 2);
+		((Buffer) byteBuffer).position(targetOffset * 2);
 		BufferUtils.copy(indices, offset, byteBuffer, count);
-		byteBuffer.position(pos);
+		((Buffer) byteBuffer).position(pos);
 	}
 
 	/** <p>
 	 * Returns the underlying ShortBuffer. If you modify the buffer contents they wil be uploaded on the call to {@link #bind()}.
 	 * If you need immediate uploading use {@link #setIndices(short[], int, int)}.
 	 * </p>
-	 * 
+	 *
 	 * @return the underlying short buffer. */
 	public ShortBuffer getBuffer () {
 		return buffer;

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/IndexBufferObject.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/IndexBufferObject.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,6 +16,7 @@
 
 package com.badlogic.gdx.graphics.glutils;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.ShortBuffer;
 
@@ -28,21 +29,21 @@ import com.badlogic.gdx.utils.GdxRuntimeException;
  * In IndexBufferObject wraps OpenGL's index buffer functionality to be used in conjunction with VBOs. This class can be
  * seamlessly used with OpenGL ES 1.x and 2.0.
  * </p>
- * 
+ *
  * <p>
  * Uses indirect Buffers on Android 1.5/1.6 to fix GC invocation due to leaking PlatformAddress instances.
  * </p>
- * 
+ *
  * <p>
  * You can also use this to store indices for vertex arrays. Do not call {@link #bind()} or {@link #unbind()} in this case but
  * rather use {@link #getBuffer()} to use the buffer directly with glDrawElements. You must also create the IndexBufferObject with
  * the second constructor and specify isDirect as true as glDrawElements in conjunction with vertex arrays needs direct buffers.
  * </p>
- * 
+ *
  * <p>
  * VertexBufferObjects must be disposed via the {@link #dispose()} method when no longer needed
  * </p>
- * 
+ *
  * @author mzechner, Thorsten Schleinzer */
 public class IndexBufferObject implements IndexData {
 	final ShortBuffer buffer;
@@ -58,14 +59,14 @@ public class IndexBufferObject implements IndexData {
 	private final boolean empty;
 
 	/** Creates a new static IndexBufferObject to be used with vertex arrays.
-	 * 
+	 *
 	 * @param maxIndices the maximum number of indices this buffer can hold */
 	public IndexBufferObject (int maxIndices) {
 		this(true, maxIndices);
 	}
 
 	/** Creates a new IndexBufferObject.
-	 * 
+	 *
 	 * @param isStatic whether the index buffer is static
 	 * @param maxIndices the maximum number of indices this buffer can hold */
 	public IndexBufferObject (boolean isStatic, int maxIndices) {
@@ -80,8 +81,8 @@ public class IndexBufferObject implements IndexData {
 
 		buffer = byteBuffer.asShortBuffer();
 		ownsBuffer = true;
-		buffer.flip();
-		byteBuffer.flip();
+		((Buffer) buffer).flip();
+		((Buffer) byteBuffer).flip();
 		bufferHandle = Gdx.gl20.glGenBuffer();
 		usage = isStatic ? GL20.GL_STATIC_DRAW : GL20.GL_DYNAMIC_DRAW;
 	}
@@ -112,21 +113,21 @@ public class IndexBufferObject implements IndexData {
 	 * Sets the indices of this IndexBufferObject, discarding the old indices. The count must equal the number of indices to be
 	 * copied to this IndexBufferObject.
 	 * </p>
-	 * 
+	 *
 	 * <p>
 	 * This can be called in between calls to {@link #bind()} and {@link #unbind()}. The index data will be updated instantly.
 	 * </p>
-	 * 
+	 *
 	 * @param indices the vertex data
 	 * @param offset the offset to start copying the data from
 	 * @param count the number of shorts to copy */
 	public void setIndices (short[] indices, int offset, int count) {
 		isDirty = true;
-		buffer.clear();
+		((Buffer) buffer).clear();
 		buffer.put(indices, offset, count);
-		buffer.flip();
-		byteBuffer.position(0);
-		byteBuffer.limit(count << 1);
+		((Buffer) buffer).flip();
+		((Buffer) byteBuffer).position(0);
+		((Buffer) byteBuffer).limit(count << 1);
 
 		if (isBound) {
 			Gdx.gl20.glBufferData(GL20.GL_ELEMENT_ARRAY_BUFFER, byteBuffer.limit(), byteBuffer, usage);
@@ -137,12 +138,12 @@ public class IndexBufferObject implements IndexData {
 	public void setIndices (ShortBuffer indices) {
 		isDirty = true;
 		int pos = indices.position();
-		buffer.clear();
+		((Buffer) buffer).clear();
 		buffer.put(indices);
-		buffer.flip();
-		indices.position(pos);
-		byteBuffer.position(0);
-		byteBuffer.limit(buffer.limit() << 1);
+		((Buffer) buffer).flip();
+		((Buffer) indices).position(pos);
+		((Buffer) byteBuffer).position(0);
+		((Buffer) byteBuffer).limit(buffer.limit() << 1);
 
 		if (isBound) {
 			Gdx.gl20.glBufferData(GL20.GL_ELEMENT_ARRAY_BUFFER, byteBuffer.limit(), byteBuffer, usage);
@@ -154,10 +155,10 @@ public class IndexBufferObject implements IndexData {
 	public void updateIndices (int targetOffset, short[] indices, int offset, int count) {
 		isDirty = true;
 		final int pos = byteBuffer.position();
-		byteBuffer.position(targetOffset * 2);
+		((Buffer) byteBuffer).position(targetOffset * 2);
 		BufferUtils.copy(indices, offset, byteBuffer, count);
-		byteBuffer.position(pos);
-		buffer.position(0);
+		((Buffer) byteBuffer).position(pos);
+		((Buffer) buffer).position(0);
 
 		if (isBound) {
 			Gdx.gl20.glBufferData(GL20.GL_ELEMENT_ARRAY_BUFFER, byteBuffer.limit(), byteBuffer, usage);
@@ -169,7 +170,7 @@ public class IndexBufferObject implements IndexData {
 	 * Returns the underlying ShortBuffer. If you modify the buffer contents they wil be uploaded on the call to {@link #bind()}.
 	 * If you need immediate uploading use {@link #setIndices(short[], int, int)}.
 	 * </p>
-	 * 
+	 *
 	 * @return the underlying short buffer. */
 	public ShortBuffer getBuffer () {
 		isDirty = true;
@@ -182,7 +183,7 @@ public class IndexBufferObject implements IndexData {
 
 		Gdx.gl20.glBindBuffer(GL20.GL_ELEMENT_ARRAY_BUFFER, bufferHandle);
 		if (isDirty) {
-			byteBuffer.limit(buffer.limit() * 2);
+			((Buffer) byteBuffer).limit(buffer.limit() * 2);
 			Gdx.gl20.glBufferData(GL20.GL_ELEMENT_ARRAY_BUFFER, byteBuffer.limit(), byteBuffer, usage);
 			isDirty = false;
 		}

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/IndexBufferObjectSubData.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/IndexBufferObjectSubData.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,6 +16,7 @@
 
 package com.badlogic.gdx.graphics.glutils;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.ShortBuffer;
 
@@ -25,19 +26,19 @@ import com.badlogic.gdx.utils.BufferUtils;
 import com.badlogic.gdx.utils.GdxRuntimeException;
 
 /** <p>
- * IndexBufferObject wraps OpenGL's index buffer functionality to be used in conjunction with VBOs. 
+ * IndexBufferObject wraps OpenGL's index buffer functionality to be used in conjunction with VBOs.
  * </p>
- * 
+ *
  * <p>
  * You can also use this to store indices for vertex arrays. Do not call {@link #bind()} or {@link #unbind()} in this case but
  * rather use {@link #getBuffer()} to use the buffer directly with glDrawElements. You must also create the IndexBufferObject with
  * the second constructor and specify isDirect as true as glDrawElements in conjunction with vertex arrays needs direct buffers.
  * </p>
- * 
+ *
  * <p>
  * VertexBufferObjects must be disposed via the {@link #dispose()} method when no longer needed
  * </p>
- * 
+ *
  * @author mzechner */
 public class IndexBufferObjectSubData implements IndexData {
 	final ShortBuffer buffer;
@@ -49,7 +50,7 @@ public class IndexBufferObjectSubData implements IndexData {
 	final int usage;
 
 	/** Creates a new IndexBufferObject.
-	 * 
+	 *
 	 * @param isStatic whether the index buffer is static
 	 * @param maxIndices the maximum number of indices this buffer can hold */
 	public IndexBufferObjectSubData (boolean isStatic, int maxIndices) {
@@ -58,13 +59,13 @@ public class IndexBufferObjectSubData implements IndexData {
 
 		usage = isStatic ? GL20.GL_STATIC_DRAW : GL20.GL_DYNAMIC_DRAW;
 		buffer = byteBuffer.asShortBuffer();
-		buffer.flip();
-		byteBuffer.flip();
+		((Buffer) buffer).flip();
+		((Buffer) byteBuffer).flip();
 		bufferHandle = createBufferObject();
 	}
 
 	/** Creates a new IndexBufferObject to be used with vertex arrays.
-	 * 
+	 *
 	 * @param maxIndices the maximum number of indices this buffer can hold */
 	public IndexBufferObjectSubData (int maxIndices) {
 		byteBuffer = BufferUtils.newByteBuffer(maxIndices * 2);
@@ -72,8 +73,8 @@ public class IndexBufferObjectSubData implements IndexData {
 
 		usage = GL20.GL_STATIC_DRAW;
 		buffer = byteBuffer.asShortBuffer();
-		buffer.flip();
-		byteBuffer.flip();
+		((Buffer) buffer).flip();
+		((Buffer) byteBuffer).flip();
 		bufferHandle = createBufferObject();
 	}
 
@@ -99,21 +100,21 @@ public class IndexBufferObjectSubData implements IndexData {
 	 * Sets the indices of this IndexBufferObject, discarding the old indices. The count must equal the number of indices to be
 	 * copied to this IndexBufferObject.
 	 * </p>
-	 * 
+	 *
 	 * <p>
 	 * This can be called in between calls to {@link #bind()} and {@link #unbind()}. The index data will be updated instantly.
 	 * </p>
-	 * 
+	 *
 	 * @param indices the vertex data
 	 * @param offset the offset to start copying the data from
 	 * @param count the number of floats to copy */
 	public void setIndices (short[] indices, int offset, int count) {
 		isDirty = true;
-		buffer.clear();
+		((Buffer) buffer).clear();
 		buffer.put(indices, offset, count);
-		buffer.flip();
-		byteBuffer.position(0);
-		byteBuffer.limit(count << 1);
+		((Buffer) buffer).flip();
+		((Buffer) byteBuffer).position(0);
+		((Buffer) byteBuffer).limit(count << 1);
 
 		if (isBound) {
 			Gdx.gl20.glBufferSubData(GL20.GL_ELEMENT_ARRAY_BUFFER, 0, byteBuffer.limit(), byteBuffer);
@@ -124,13 +125,13 @@ public class IndexBufferObjectSubData implements IndexData {
 	public void setIndices (ShortBuffer indices) {
 		int pos = indices.position();
 		isDirty = true;
-		buffer.clear();
+		((Buffer) buffer).clear();
 		buffer.put(indices);
-		buffer.flip();
-		indices.position(pos);
-		byteBuffer.position(0);
-		byteBuffer.limit(buffer.limit() << 1);
-		
+		((Buffer) buffer).flip();
+		((Buffer) indices).position(pos);
+		((Buffer) byteBuffer).position(0);
+		((Buffer) byteBuffer).limit(buffer.limit() << 1);
+
 		if (isBound) {
 			Gdx.gl20.glBufferSubData(GL20.GL_ELEMENT_ARRAY_BUFFER, 0, byteBuffer.limit(), byteBuffer);
 			isDirty = false;
@@ -141,10 +142,10 @@ public class IndexBufferObjectSubData implements IndexData {
 	public void updateIndices (int targetOffset, short[] indices, int offset, int count) {
 		isDirty = true;
 		final int pos = byteBuffer.position();
-		byteBuffer.position(targetOffset * 2);
+		((Buffer) byteBuffer).position(targetOffset * 2);
 		BufferUtils.copy(indices, offset, byteBuffer, count);
-		byteBuffer.position(pos);
-		buffer.position(0);
+		((Buffer) byteBuffer).position(pos);
+		((Buffer) buffer).position(0);
 
 		if (isBound) {
 			Gdx.gl20.glBufferSubData(GL20.GL_ELEMENT_ARRAY_BUFFER, 0, byteBuffer.limit(), byteBuffer);
@@ -152,12 +153,12 @@ public class IndexBufferObjectSubData implements IndexData {
 		}
 	}
 
-	
+
 	/** <p>
 	 * Returns the underlying ShortBuffer. If you modify the buffer contents they wil be uploaded on the call to {@link #bind()}.
 	 * If you need immediate uploading use {@link #setIndices(short[], int, int)}.
 	 * </p>
-	 * 
+	 *
 	 * @return the underlying short buffer. */
 	public ShortBuffer getBuffer () {
 		isDirty = true;
@@ -170,7 +171,7 @@ public class IndexBufferObjectSubData implements IndexData {
 
 		Gdx.gl20.glBindBuffer(GL20.GL_ELEMENT_ARRAY_BUFFER, bufferHandle);
 		if (isDirty) {
-			byteBuffer.limit(buffer.limit() * 2);
+			((Buffer) byteBuffer).limit(buffer.limit() * 2);
 			Gdx.gl20.glBufferSubData(GL20.GL_ELEMENT_ARRAY_BUFFER, 0, byteBuffer.limit(), byteBuffer);
 			isDirty = false;
 		}

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/InstanceBufferObject.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/InstanceBufferObject.java
@@ -55,7 +55,7 @@ public class InstanceBufferObject implements InstanceData {
 		bufferHandle = Gdx.gl20.glGenBuffer();
 
 		ByteBuffer data = BufferUtils.newUnsafeByteBuffer(instanceAttributes.vertexSize * numVertices);
-		data.limit(0);
+		((Buffer) data).limit(0);
 		setBuffer(data, true, instanceAttributes);
 		setUsage(isStatic ? GL20.GL_STATIC_DRAW : GL20.GL_DYNAMIC_DRAW);
 	}
@@ -101,10 +101,10 @@ public class InstanceBufferObject implements InstanceData {
 		this.ownsBuffer = ownsBuffer;
 
 		final int l = byteBuffer.limit();
-		byteBuffer.limit(byteBuffer.capacity());
+		((Buffer) byteBuffer).limit(byteBuffer.capacity());
 		buffer = byteBuffer.asFloatBuffer();
-		byteBuffer.limit(l);
-		buffer.limit(l / 4);
+		((Buffer) byteBuffer).limit(l);
+		((Buffer) buffer).limit(l / 4);
 	}
 
 	private void bufferChanged () {
@@ -119,8 +119,8 @@ public class InstanceBufferObject implements InstanceData {
 	public void setInstanceData (float[] data, int offset, int count) {
 		isDirty = true;
 		BufferUtils.copy(data, byteBuffer, count, offset);
-		buffer.position(0);
-		buffer.limit(count);
+		((Buffer) buffer).position(0);
+		((Buffer) buffer).limit(count);
 		bufferChanged();
 	}
 
@@ -128,8 +128,8 @@ public class InstanceBufferObject implements InstanceData {
 	public void setInstanceData (FloatBuffer data, int count) {
 		isDirty = true;
 		BufferUtils.copy(data, byteBuffer, count);
-		buffer.position(0);
-		buffer.limit(count);
+		((Buffer) buffer).position(0);
+		((Buffer) buffer).limit(count);
 		bufferChanged();
 	}
 
@@ -137,10 +137,10 @@ public class InstanceBufferObject implements InstanceData {
 	public void updateInstanceData (int targetOffset, float[] data, int sourceOffset, int count) {
 		isDirty = true;
 		final int pos = byteBuffer.position();
-		byteBuffer.position(targetOffset * 4);
+		((Buffer) byteBuffer).position(targetOffset * 4);
 		BufferUtils.copy(data, sourceOffset, count, byteBuffer);
-		byteBuffer.position(pos);
-		buffer.position(0);
+		((Buffer) byteBuffer).position(pos);
+		((Buffer) buffer).position(0);
 		bufferChanged();
 	}
 
@@ -148,11 +148,11 @@ public class InstanceBufferObject implements InstanceData {
 	public void updateInstanceData (int targetOffset, FloatBuffer data, int sourceOffset, int count) {
 		isDirty = true;
 		final int pos = byteBuffer.position();
-		byteBuffer.position(targetOffset * 4);
-		data.position(sourceOffset * 4);
+		((Buffer) byteBuffer).position(targetOffset * 4);
+		((Buffer) data).position(sourceOffset * 4);
 		BufferUtils.copy(data, byteBuffer, count);
-		byteBuffer.position(pos);
-		buffer.position(0);
+		((Buffer) byteBuffer).position(pos);
+		((Buffer) buffer).position(0);
 		bufferChanged();
 	}
 
@@ -190,7 +190,7 @@ public class InstanceBufferObject implements InstanceData {
 
 		gl.glBindBuffer(GL20.GL_ARRAY_BUFFER, bufferHandle);
 		if (isDirty) {
-			byteBuffer.limit(buffer.limit() * 4);
+			((Buffer) byteBuffer).limit(buffer.limit() * 4);
 			gl.glBufferData(GL20.GL_ARRAY_BUFFER, byteBuffer.limit(), byteBuffer, usage);
 			isDirty = false;
 		}

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/InstanceBufferObjectSubData.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/InstanceBufferObjectSubData.java
@@ -72,8 +72,8 @@ public class InstanceBufferObjectSubData implements InstanceData {
 		usage = isStatic ? GL20.GL_STATIC_DRAW : GL20.GL_DYNAMIC_DRAW;
 		buffer = byteBuffer.asFloatBuffer();
 		bufferHandle = createBufferObject();
-		buffer.flip();
-		byteBuffer.flip();
+		((Buffer) buffer).flip();
+		((Buffer) byteBuffer).flip();
 	}
 
 	private int createBufferObject () {
@@ -128,14 +128,14 @@ public class InstanceBufferObjectSubData implements InstanceData {
 		isDirty = true;
 		if (isDirect) {
 			BufferUtils.copy(data, byteBuffer, count, offset);
-			buffer.position(0);
-			buffer.limit(count);
+			((Buffer) buffer).position(0);
+			((Buffer) buffer).limit(count);
 		} else {
-			buffer.clear();
+			((Buffer) buffer).clear();
 			buffer.put(data, offset, count);
-			buffer.flip();
-			byteBuffer.position(0);
-			byteBuffer.limit(buffer.limit() << 2);
+			((Buffer) buffer).flip();
+			((Buffer) byteBuffer).position(0);
+			((Buffer) byteBuffer).limit(buffer.limit() << 2);
 		}
 
 		bufferChanged();
@@ -146,14 +146,14 @@ public class InstanceBufferObjectSubData implements InstanceData {
 		isDirty = true;
 		if (isDirect) {
 			BufferUtils.copy(data, byteBuffer, count);
-			buffer.position(0);
-			buffer.limit(count);
+			((Buffer) buffer).position(0);
+			((Buffer) buffer).limit(count);
 		} else {
-			buffer.clear();
+			((Buffer) buffer).clear();
 			buffer.put(data);
-			buffer.flip();
-			byteBuffer.position(0);
-			byteBuffer.limit(buffer.limit() << 2);
+			((Buffer) buffer).flip();
+			((Buffer) byteBuffer).position(0);
+			((Buffer) byteBuffer).limit(buffer.limit() << 2);
 		}
 
 		bufferChanged();
@@ -164,9 +164,9 @@ public class InstanceBufferObjectSubData implements InstanceData {
 		isDirty = true;
 		if (isDirect) {
 			final int pos = byteBuffer.position();
-			byteBuffer.position(targetOffset * 4);
+			((Buffer) byteBuffer).position(targetOffset * 4);
 			BufferUtils.copy(data, sourceOffset, count, byteBuffer);
-			byteBuffer.position(pos);
+			((Buffer) byteBuffer).position(pos);
 		} else
 			throw new GdxRuntimeException("Buffer must be allocated direct."); // Should never happen
 
@@ -178,10 +178,10 @@ public class InstanceBufferObjectSubData implements InstanceData {
 		isDirty = true;
 		if (isDirect) {
 			final int pos = byteBuffer.position();
-			byteBuffer.position(targetOffset * 4);
-			data.position(sourceOffset * 4);
+			((Buffer) byteBuffer).position(targetOffset * 4);
+			((Buffer) data).position(sourceOffset * 4);
 			BufferUtils.copy(data, byteBuffer, count);
-			byteBuffer.position(pos);
+			((Buffer) byteBuffer).position(pos);
 		} else
 			throw new GdxRuntimeException("Buffer must be allocated direct."); // Should never happen
 
@@ -204,7 +204,7 @@ public class InstanceBufferObjectSubData implements InstanceData {
 
 		gl.glBindBuffer(GL20.GL_ARRAY_BUFFER, bufferHandle);
 		if (isDirty) {
-			byteBuffer.limit(buffer.limit() * 4);
+			((Buffer) byteBuffer).limit(buffer.limit() * 4);
 			gl.glBufferData(GL20.GL_ARRAY_BUFFER, byteBuffer.limit(), byteBuffer, usage);
 			isDirty = false;
 		}

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/KTXTextureData.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/KTXTextureData.java
@@ -3,6 +3,7 @@ package com.badlogic.gdx.graphics.glutils;
 
 import java.io.BufferedInputStream;
 import java.io.DataInputStream;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.IntBuffer;
@@ -25,9 +26,9 @@ import com.badlogic.gdx.utils.StreamUtils;
 /** A KTXTextureData holds the data from a KTX (or zipped KTX file, aka ZKTX). That is to say an OpenGL ready texture data. The KTX
  * file format is just a thin wrapper around OpenGL textures and therefore is compatible with most OpenGL texture capabilities
  * like texture compression, cubemapping, mipmapping, etc.
- * 
+ *
  * For example, KTXTextureData can be used for {@link Texture} or {@link Cubemap}.
- * 
+ *
  * @author Vincent Bousquet */
 public class KTXTextureData implements TextureData, CubemapData {
 
@@ -84,8 +85,8 @@ public class KTXTextureData implements TextureData, CubemapData {
 				int readBytes = 0;
 				while ((readBytes = in.read(buffer)) != -1)
 					compressedData.put(buffer, 0, readBytes);
-				compressedData.position(0);
-				compressedData.limit(compressedData.capacity());
+				((Buffer) compressedData).position(0);
+				((Buffer) compressedData).limit(compressedData.capacity());
 			} catch (Exception e) {
 				throw new GdxRuntimeException("Couldn't load zktx file '" + file + "'", e);
 			} finally {
@@ -134,8 +135,8 @@ public class KTXTextureData implements TextureData, CubemapData {
 				int faceLodSizeRounded = (faceLodSize + 3) & ~3;
 				pos += faceLodSizeRounded * numberOfFaces + 4;
 			}
-			compressedData.limit(pos);
-			compressedData.position(0);
+			((Buffer) compressedData).limit(pos);
+			((Buffer) compressedData).position(0);
 			ByteBuffer directBuffer = BufferUtils.newUnsafeByteBuffer(pos);
 			directBuffer.order(compressedData.order());
 			directBuffer.put(compressedData);
@@ -226,16 +227,16 @@ public class KTXTextureData implements TextureData, CubemapData {
 			int pixelWidth = Math.max(1, this.pixelWidth >> level);
 			int pixelHeight = Math.max(1, this.pixelHeight >> level);
 			int pixelDepth = Math.max(1, this.pixelDepth >> level);
-			compressedData.position(pos);
+			((Buffer) compressedData).position(pos);
 			int faceLodSize = compressedData.getInt();
 			int faceLodSizeRounded = (faceLodSize + 3) & ~3;
 			pos += 4;
 			for (int face = 0; face < numberOfFaces; face++) {
-				compressedData.position(pos);
+				((Buffer) compressedData).position(pos);
 				pos += faceLodSizeRounded;
 				if (singleFace != -1 && singleFace != face) continue;
 				ByteBuffer data = compressedData.slice();
-				data.limit(faceLodSizeRounded);
+				((Buffer) data).limit(faceLodSizeRounded);
 				if (textureDimensions == 1) {
 					// if (compressed)
 					// Gdx.gl.glCompressedTexImage1D(target + face, level, glInternalFormat, pixelWidth, 0, faceLodSize,
@@ -327,9 +328,9 @@ public class KTXTextureData implements TextureData, CubemapData {
 			if (level == requestedLevel) {
 				for (int face = 0; face < numberOfFaces; face++) {
 					if (face == requestedFace) {
-						compressedData.position(pos);
+						((Buffer) compressedData).position(pos);
 						ByteBuffer data = compressedData.slice();
-						data.limit(faceLodSizeRounded);
+						((Buffer) data).limit(faceLodSizeRounded);
 						return data;
 					}
 					pos += faceLodSizeRounded;

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/ShaderProgram.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/ShaderProgram.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -41,26 +41,26 @@ import com.badlogic.gdx.utils.ObjectMap;
 /** <p>
  * A shader program encapsulates a vertex and fragment shader pair linked to form a shader program.
  * </p>
- * 
+ *
  * <p>
  * After construction a ShaderProgram can be used to draw {@link Mesh}. To make the GPU use a specific ShaderProgram the programs
  * {@link ShaderProgram#bind()} method must be used which effectively binds the program.
  * </p>
- * 
+ *
  * <p>
  * When a ShaderProgram is bound one can set uniforms, vertex attributes and attributes as needed via the respective methods.
  * </p>
- * 
+ *
  * <p>
  * A ShaderProgram must be disposed via a call to {@link ShaderProgram#dispose()} when it is no longer needed
  * </p>
- * 
+ *
  * <p>
  * ShaderPrograms are managed. In case the OpenGL context is lost all shaders get invalidated and have to be reloaded. This
  * happens on Android when a user switches to another application or receives an incoming call. Managed ShaderPrograms are
  * automatically reloaded when the OpenGL context is recreated so you don't have to do this manually.
  * </p>
- * 
+ *
  * @author mzechner */
 public class ShaderProgram implements Disposable {
 	/** default name for position attributes **/
@@ -147,7 +147,7 @@ public class ShaderProgram implements Disposable {
 	private int refCount = 0;
 
 	/** Constructs a new ShaderProgram and immediately compiles it.
-	 * 
+	 *
 	 * @param vertexShader the vertex shader
 	 * @param fragmentShader the fragment shader */
 
@@ -177,7 +177,7 @@ public class ShaderProgram implements Disposable {
 	}
 
 	/** Loads and compiles the shaders, creates a new program and links the shaders.
-	 * 
+	 *
 	 * @param vertexShader
 	 * @param fragmentShader */
 	private void compileShaders (String vertexShader, String fragmentShader) {
@@ -310,7 +310,7 @@ public class ShaderProgram implements Disposable {
 	}
 
 	/** Sets the uniform with the given name. The {@link ShaderProgram} must be bound for this to work.
-	 * 
+	 *
 	 * @param name the name of the uniform
 	 * @param value the value */
 	public void setUniformi (String name, int value) {
@@ -327,7 +327,7 @@ public class ShaderProgram implements Disposable {
 	}
 
 	/** Sets the uniform with the given name. The {@link ShaderProgram} must be bound for this to work.
-	 * 
+	 *
 	 * @param name the name of the uniform
 	 * @param value1 the first value
 	 * @param value2 the second value */
@@ -345,7 +345,7 @@ public class ShaderProgram implements Disposable {
 	}
 
 	/** Sets the uniform with the given name. The {@link ShaderProgram} must be bound for this to work.
-	 * 
+	 *
 	 * @param name the name of the uniform
 	 * @param value1 the first value
 	 * @param value2 the second value
@@ -364,7 +364,7 @@ public class ShaderProgram implements Disposable {
 	}
 
 	/** Sets the uniform with the given name. The {@link ShaderProgram} must be bound for this to work.
-	 * 
+	 *
 	 * @param name the name of the uniform
 	 * @param value1 the first value
 	 * @param value2 the second value
@@ -384,7 +384,7 @@ public class ShaderProgram implements Disposable {
 	}
 
 	/** Sets the uniform with the given name. The {@link ShaderProgram} must be bound for this to work.
-	 * 
+	 *
 	 * @param name the name of the uniform
 	 * @param value the value */
 	public void setUniformf (String name, float value) {
@@ -401,7 +401,7 @@ public class ShaderProgram implements Disposable {
 	}
 
 	/** Sets the uniform with the given name. The {@link ShaderProgram} must be bound for this to work.
-	 * 
+	 *
 	 * @param name the name of the uniform
 	 * @param value1 the first value
 	 * @param value2 the second value */
@@ -419,7 +419,7 @@ public class ShaderProgram implements Disposable {
 	}
 
 	/** Sets the uniform with the given name. The {@link ShaderProgram} must be bound for this to work.
-	 * 
+	 *
 	 * @param name the name of the uniform
 	 * @param value1 the first value
 	 * @param value2 the second value
@@ -438,7 +438,7 @@ public class ShaderProgram implements Disposable {
 	}
 
 	/** Sets the uniform with the given name. The {@link ShaderProgram} must be bound for this to work.
-	 * 
+	 *
 	 * @param name the name of the uniform
 	 * @param value1 the first value
 	 * @param value2 the second value
@@ -510,7 +510,7 @@ public class ShaderProgram implements Disposable {
 	}
 
 	/** Sets the uniform matrix with the given name. The {@link ShaderProgram} must be bound for this to work.
-	 * 
+	 *
 	 * @param name the name of the uniform
 	 * @param matrix the matrix */
 	public void setUniformMatrix (String name, Matrix4 matrix) {
@@ -518,7 +518,7 @@ public class ShaderProgram implements Disposable {
 	}
 
 	/** Sets the uniform matrix with the given name. The {@link ShaderProgram} must be bound for this to work.
-	 * 
+	 *
 	 * @param name the name of the uniform
 	 * @param matrix the matrix
 	 * @param transpose whether the matrix should be transposed */
@@ -537,7 +537,7 @@ public class ShaderProgram implements Disposable {
 	}
 
 	/** Sets the uniform matrix with the given name. The {@link ShaderProgram} must be bound for this to work.
-	 * 
+	 *
 	 * @param name the name of the uniform
 	 * @param matrix the matrix */
 	public void setUniformMatrix (String name, Matrix3 matrix) {
@@ -545,7 +545,7 @@ public class ShaderProgram implements Disposable {
 	}
 
 	/** Sets the uniform matrix with the given name. The {@link ShaderProgram} must be bound for this to work.
-	 * 
+	 *
 	 * @param name the name of the uniform
 	 * @param matrix the matrix
 	 * @param transpose whether the uniform matrix should be transposed */
@@ -564,27 +564,27 @@ public class ShaderProgram implements Disposable {
 	}
 
 	/** Sets an array of uniform matrices with the given name. The {@link ShaderProgram} must be bound for this to work.
-	 * 
+	 *
 	 * @param name the name of the uniform
 	 * @param buffer buffer containing the matrix data
 	 * @param transpose whether the uniform matrix should be transposed */
 	public void setUniformMatrix3fv (String name, FloatBuffer buffer, int count, boolean transpose) {
 		GL20 gl = Gdx.gl20;
 		checkManaged();
-		buffer.position(0);
+		((Buffer) buffer).position(0);
 		int location = fetchUniformLocation(name);
 		gl.glUniformMatrix3fv(location, count, transpose, buffer);
 	}
 
 	/** Sets an array of uniform matrices with the given name. The {@link ShaderProgram} must be bound for this to work.
-	 * 
+	 *
 	 * @param name the name of the uniform
 	 * @param buffer buffer containing the matrix data
 	 * @param transpose whether the uniform matrix should be transposed */
 	public void setUniformMatrix4fv (String name, FloatBuffer buffer, int count, boolean transpose) {
 		GL20 gl = Gdx.gl20;
 		checkManaged();
-		buffer.position(0);
+		((Buffer) buffer).position(0);
 		int location = fetchUniformLocation(name);
 		gl.glUniformMatrix4fv(location, count, transpose, buffer);
 	}
@@ -600,7 +600,7 @@ public class ShaderProgram implements Disposable {
 	}
 
 	/** Sets the uniform with the given name. The {@link ShaderProgram} must be bound for this to work.
-	 * 
+	 *
 	 * @param name the name of the uniform
 	 * @param values x and y as the first and second values respectively */
 	public void setUniformf (String name, Vector2 values) {
@@ -612,7 +612,7 @@ public class ShaderProgram implements Disposable {
 	}
 
 	/** Sets the uniform with the given name. The {@link ShaderProgram} must be bound for this to work.
-	 * 
+	 *
 	 * @param name the name of the uniform
 	 * @param values x, y and z as the first, second and third values respectively */
 	public void setUniformf (String name, Vector3 values) {
@@ -624,7 +624,7 @@ public class ShaderProgram implements Disposable {
 	}
 
 	/** Sets the uniform with the given name. The {@link ShaderProgram} must be bound for this to work.
-	 * 
+	 *
 	 * @param name the name of the uniform
 	 * @param values r, g, b and a as the first through fourth values respectively */
 	public void setUniformf (String name, Color values) {
@@ -636,7 +636,7 @@ public class ShaderProgram implements Disposable {
 	}
 
 	/** Sets the vertex attribute with the given name. The {@link ShaderProgram} must be bound for this to work.
-	 * 
+	 *
 	 * @param name the attribute name
 	 * @param size the number of components, must be >= 1 and <= 4
 	 * @param type the type, must be one of GL20.GL_BYTE, GL20.GL_UNSIGNED_BYTE, GL20.GL_SHORT,
@@ -659,7 +659,7 @@ public class ShaderProgram implements Disposable {
 	}
 
 	/** Sets the vertex attribute with the given name. The {@link ShaderProgram} must be bound for this to work.
-	 * 
+	 *
 	 * @param name the attribute name
 	 * @param size the number of components, must be >= 1 and <= 4
 	 * @param type the type, must be one of GL20.GL_BYTE, GL20.GL_UNSIGNED_BYTE, GL20.GL_SHORT,
@@ -709,7 +709,7 @@ public class ShaderProgram implements Disposable {
 	}
 
 	/** Disables the vertex attribute with the given name
-	 * 
+	 *
 	 * @param name the vertex attribute name */
 	public void disableVertexAttribute (String name) {
 		GL20 gl = Gdx.gl20;
@@ -726,7 +726,7 @@ public class ShaderProgram implements Disposable {
 	}
 
 	/** Enables the vertex attribute with the given name
-	 * 
+	 *
 	 * @param name the vertex attribute name */
 	public void enableVertexAttribute (String name) {
 		GL20 gl = Gdx.gl20;
@@ -792,7 +792,7 @@ public class ShaderProgram implements Disposable {
 	}
 
 	/** Sets the given attribute
-	 * 
+	 *
 	 * @param name the name of the attribute
 	 * @param value1 the first value
 	 * @param value2 the second value
@@ -808,16 +808,16 @@ public class ShaderProgram implements Disposable {
 	IntBuffer type = BufferUtils.newIntBuffer(1);
 
 	private void fetchUniforms () {
-		params.clear();
+		((Buffer) params).clear();
 		Gdx.gl20.glGetProgramiv(program, GL20.GL_ACTIVE_UNIFORMS, params);
 		int numUniforms = params.get(0);
 
 		uniformNames = new String[numUniforms];
 
 		for (int i = 0; i < numUniforms; i++) {
-			params.clear();
+			((Buffer) params).clear();
 			params.put(0, 1);
-			type.clear();
+			((Buffer) type).clear();
 			String name = Gdx.gl20.glGetActiveUniform(program, i, params, type);
 			int location = Gdx.gl20.glGetUniformLocation(program, name);
 			uniforms.put(name, location);
@@ -828,16 +828,16 @@ public class ShaderProgram implements Disposable {
 	}
 
 	private void fetchAttributes () {
-		params.clear();
+		((Buffer) params).clear();
 		Gdx.gl20.glGetProgramiv(program, GL20.GL_ACTIVE_ATTRIBUTES, params);
 		int numAttributes = params.get(0);
 
 		attributeNames = new String[numAttributes];
 
 		for (int i = 0; i < numAttributes; i++) {
-			params.clear();
+			((Buffer) params).clear();
 			params.put(0, 1);
-			type.clear();
+			((Buffer) type).clear();
 			String name = Gdx.gl20.glGetActiveAttrib(program, i, params, type);
 			int location = Gdx.gl20.glGetAttribLocation(program, name);
 			attributes.put(name, location);

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/VertexArray.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/VertexArray.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,6 +16,7 @@
 
 package com.badlogic.gdx.graphics.glutils;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.FloatBuffer;
 
@@ -28,11 +29,11 @@ import com.badlogic.gdx.utils.BufferUtils;
  * Convenience class for working with OpenGL vertex arrays. It interleaves all data in the order you specified in the constructor
  * via {@link VertexAttribute}.
  * </p>
- * 
+ *
  * <p>
  * This class is not compatible with OpenGL 3+ core profiles. For this {@link VertexBufferObject}s are needed.
  * </p>
- * 
+ *
  * @author mzechner, Dave Clayton <contact@redskyforge.com> */
 public class VertexArray implements VertexData {
 	final VertexAttributes attributes;
@@ -41,7 +42,7 @@ public class VertexArray implements VertexData {
 	boolean isBound = false;
 
 	/** Constructs a new interleaved VertexArray
-	 * 
+	 *
 	 * @param numVertices the maximum number of vertices
 	 * @param attributes the {@link VertexAttribute}s */
 	public VertexArray (int numVertices, VertexAttribute... attributes) {
@@ -49,15 +50,15 @@ public class VertexArray implements VertexData {
 	}
 
 	/** Constructs a new interleaved VertexArray
-	 * 
+	 *
 	 * @param numVertices the maximum number of vertices
 	 * @param attributes the {@link VertexAttributes} */
 	public VertexArray (int numVertices, VertexAttributes attributes) {
 		this.attributes = attributes;
 		byteBuffer = BufferUtils.newUnsafeByteBuffer(this.attributes.vertexSize * numVertices);
 		buffer = byteBuffer.asFloatBuffer();
-		buffer.flip();
-		byteBuffer.flip();
+		((Buffer) buffer).flip();
+		((Buffer) byteBuffer).flip();
 	}
 
 	@Override
@@ -82,16 +83,16 @@ public class VertexArray implements VertexData {
 	@Override
 	public void setVertices (float[] vertices, int offset, int count) {
 		BufferUtils.copy(vertices, byteBuffer, count, offset);
-		buffer.position(0);
-		buffer.limit(count);
+		((Buffer) buffer).position(0);
+		((Buffer) buffer).limit(count);
 	}
 
 	@Override
 	public void updateVertices (int targetOffset, float[] vertices, int sourceOffset, int count) {
 		final int pos = byteBuffer.position();
-		byteBuffer.position(targetOffset * 4);
+		((Buffer) byteBuffer).position(targetOffset * 4);
 		BufferUtils.copy(vertices, sourceOffset, count, byteBuffer);
-		byteBuffer.position(pos);
+		((Buffer) byteBuffer).position(pos);
 	}
 
 	@Override
@@ -102,7 +103,7 @@ public class VertexArray implements VertexData {
 	@Override
 	public void bind (final ShaderProgram shader, final int[] locations) {
 		final int numAttributes = attributes.size();
-		byteBuffer.limit(buffer.limit() * 4);
+		((Buffer) byteBuffer).limit(buffer.limit() * 4);
 		if (locations == null) {
 			for (int i = 0; i < numAttributes; i++) {
 				final VertexAttribute attribute = attributes.get(i);
@@ -111,11 +112,11 @@ public class VertexArray implements VertexData {
 				shader.enableVertexAttribute(location);
 
 				if (attribute.type == GL20.GL_FLOAT) {
-					buffer.position(attribute.offset / 4);
+					((Buffer) buffer).position(attribute.offset / 4);
 					shader.setVertexAttribute(location, attribute.numComponents, attribute.type, attribute.normalized,
 						attributes.vertexSize, buffer);
 				} else {
-					byteBuffer.position(attribute.offset);
+					((Buffer) byteBuffer).position(attribute.offset);
 					shader.setVertexAttribute(location, attribute.numComponents, attribute.type, attribute.normalized,
 						attributes.vertexSize, byteBuffer);
 				}
@@ -128,11 +129,11 @@ public class VertexArray implements VertexData {
 				shader.enableVertexAttribute(location);
 
 				if (attribute.type == GL20.GL_FLOAT) {
-					buffer.position(attribute.offset / 4);
+					((Buffer) buffer).position(attribute.offset / 4);
 					shader.setVertexAttribute(location, attribute.numComponents, attribute.type, attribute.normalized,
 						attributes.vertexSize, buffer);
 				} else {
-					byteBuffer.position(attribute.offset);
+					((Buffer) byteBuffer).position(attribute.offset);
 					shader.setVertexAttribute(location, attribute.numComponents, attribute.type, attribute.normalized,
 						attributes.vertexSize, byteBuffer);
 				}
@@ -142,7 +143,7 @@ public class VertexArray implements VertexData {
 	}
 
 	/** Unbinds this VertexBufferObject.
-	 * 
+	 *
 	 * @param shader the shader */
 	@Override
 	public void unbind (ShaderProgram shader) {
@@ -169,7 +170,7 @@ public class VertexArray implements VertexData {
 	public VertexAttributes getAttributes () {
 		return attributes;
 	}
-	
+
 	@Override
 	public void invalidate () {
 	}

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/VertexBufferObject.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/VertexBufferObject.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,11 +32,11 @@ import com.badlogic.gdx.utils.GdxRuntimeException;
  * <p>
  * If the OpenGL ES context was lost you can call {@link #invalidate()} to recreate a new OpenGL vertex buffer object.
  * <p>
- * The data is bound via glVertexAttribPointer() according to the attribute aliases specified via {@link VertexAttributes} 
+ * The data is bound via glVertexAttribPointer() according to the attribute aliases specified via {@link VertexAttributes}
  * in the constructor.
  * <p>
  * VertexBufferObjects must be disposed via the {@link #dispose()} method when no longer needed
- * 
+ *
  * @author mzechner, Dave Clayton <contact@redskyforge.com> */
 public class VertexBufferObject implements VertexData {
 	private VertexAttributes attributes;
@@ -49,7 +49,7 @@ public class VertexBufferObject implements VertexData {
 	boolean isBound = false;
 
 	/** Constructs a new interleaved VertexBufferObject.
-	 * 
+	 *
 	 * @param isStatic whether the vertex data is static.
 	 * @param numVertices the maximum number of vertices
 	 * @param attributes the {@link VertexAttribute}s. */
@@ -58,7 +58,7 @@ public class VertexBufferObject implements VertexData {
 	}
 
 	/** Constructs a new interleaved VertexBufferObject.
-	 * 
+	 *
 	 * @param isStatic whether the vertex data is static.
 	 * @param numVertices the maximum number of vertices
 	 * @param attributes the {@link VertexAttributes}. */
@@ -66,14 +66,14 @@ public class VertexBufferObject implements VertexData {
 		bufferHandle = Gdx.gl20.glGenBuffer();
 
 		ByteBuffer data = BufferUtils.newUnsafeByteBuffer(attributes.vertexSize * numVertices);
-		data.limit(0);
+		((Buffer) data).limit(0);
 		setBuffer(data, true, attributes);
 		setUsage(isStatic ? GL20.GL_STATIC_DRAW : GL20.GL_DYNAMIC_DRAW);
 	}
-	
+
 	protected VertexBufferObject (int usage, ByteBuffer data, boolean ownsBuffer, VertexAttributes attributes) {
 		bufferHandle = Gdx.gl20.glGenBuffer();
-		
+
 		setBuffer(data, ownsBuffer, attributes);
 		setUsage(usage);
 	}
@@ -113,12 +113,12 @@ public class VertexBufferObject implements VertexData {
 		else
 			throw new GdxRuntimeException("Only ByteBuffer is currently supported");
 		this.ownsBuffer = ownsBuffer;
-		
+
 		final int l = byteBuffer.limit();
-		byteBuffer.limit(byteBuffer.capacity());
+		((Buffer) byteBuffer).limit(byteBuffer.capacity());
 		buffer = byteBuffer.asFloatBuffer();
-		byteBuffer.limit(l);
-		buffer.limit(l / 4);
+		((Buffer) byteBuffer).limit(l);
+		((Buffer) buffer).limit(l / 4);
 	}
 
 	private void bufferChanged () {
@@ -132,8 +132,8 @@ public class VertexBufferObject implements VertexData {
 	public void setVertices (float[] vertices, int offset, int count) {
 		isDirty = true;
 		BufferUtils.copy(vertices, byteBuffer, count, offset);
-		buffer.position(0);
-		buffer.limit(count);
+		((Buffer) buffer).position(0);
+		((Buffer) buffer).limit(count);
 		bufferChanged();
 	}
 
@@ -141,10 +141,10 @@ public class VertexBufferObject implements VertexData {
 	public void updateVertices (int targetOffset, float[] vertices, int sourceOffset, int count) {
 		isDirty = true;
 		final int pos = byteBuffer.position();
-		byteBuffer.position(targetOffset * 4);
+		((Buffer) byteBuffer).position(targetOffset * 4);
 		BufferUtils.copy(vertices, sourceOffset, count, byteBuffer);
-		byteBuffer.position(pos);
-		buffer.position(0);
+		((Buffer) byteBuffer).position(pos);
+		((Buffer) buffer).position(0);
 		bufferChanged();
 	}
 
@@ -174,7 +174,7 @@ public class VertexBufferObject implements VertexData {
 
 		gl.glBindBuffer(GL20.GL_ARRAY_BUFFER, bufferHandle);
 		if (isDirty) {
-			byteBuffer.limit(buffer.limit() * 4);
+			((Buffer) byteBuffer).limit(buffer.limit() * 4);
 			gl.glBufferData(GL20.GL_ARRAY_BUFFER, byteBuffer.limit(), byteBuffer, usage);
 			isDirty = false;
 		}
@@ -206,7 +206,7 @@ public class VertexBufferObject implements VertexData {
 	}
 
 	/** Unbinds this VertexBufferObject.
-	 * 
+	 *
 	 * @param shader the shader */
 	@Override
 	public void unbind (final ShaderProgram shader) {

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/VertexBufferObjectSubData.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/VertexBufferObjectSubData.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,6 +16,7 @@
 
 package com.badlogic.gdx.graphics.glutils;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.FloatBuffer;
 
@@ -31,11 +32,11 @@ import com.badlogic.gdx.utils.GdxRuntimeException;
  * <p>
  * If the OpenGL ES context was lost you can call {@link #invalidate()} to recreate a new OpenGL vertex buffer object.
  * <p>
- * The data is bound via glVertexAttribPointer() according to the attribute aliases specified via {@link VertexAttributes} 
+ * The data is bound via glVertexAttribPointer() according to the attribute aliases specified via {@link VertexAttributes}
  * in the constructor.
  * <p>
  * VertexBufferObjects must be disposed via the {@link #dispose()} method when no longer needed
- * 
+ *
  * @author mzechner */
 public class VertexBufferObjectSubData implements VertexData {
 	final VertexAttributes attributes;
@@ -47,9 +48,9 @@ public class VertexBufferObjectSubData implements VertexData {
 	final int usage;
 	boolean isDirty = false;
 	boolean isBound = false;
-	
+
 	/** Constructs a new interleaved VertexBufferObject.
-	 * 
+	 *
 	 * @param isStatic whether the vertex data is static.
 	 * @param numVertices the maximum number of vertices
 	 * @param attributes the {@link VertexAttributes}. */
@@ -58,7 +59,7 @@ public class VertexBufferObjectSubData implements VertexData {
 	}
 
 	/** Constructs a new interleaved VertexBufferObject.
-	 * 
+	 *
 	 * @param isStatic whether the vertex data is static.
 	 * @param numVertices the maximum number of vertices
 	 * @param attributes the {@link VertexAttribute}s. */
@@ -71,8 +72,8 @@ public class VertexBufferObjectSubData implements VertexData {
 		usage = isStatic ? GL20.GL_STATIC_DRAW : GL20.GL_DYNAMIC_DRAW;
 		buffer = byteBuffer.asFloatBuffer();
 		bufferHandle = createBufferObject();
-		buffer.flip();
-		byteBuffer.flip();
+		((Buffer) buffer).flip();
+		((Buffer) byteBuffer).flip();
 	}
 
 	private int createBufferObject () {
@@ -116,14 +117,14 @@ public class VertexBufferObjectSubData implements VertexData {
 		isDirty = true;
 		if (isDirect) {
 			BufferUtils.copy(vertices, byteBuffer, count, offset);
-			buffer.position(0);
-			buffer.limit(count);
+			((Buffer) buffer).position(0);
+			((Buffer) buffer).limit(count);
 		} else {
-			buffer.clear();
+			((Buffer) buffer).clear();
 			buffer.put(vertices, offset, count);
-			buffer.flip();
-			byteBuffer.position(0);
-			byteBuffer.limit(buffer.limit() << 2);
+			((Buffer) buffer).flip();
+			((Buffer) byteBuffer).position(0);
+			((Buffer) byteBuffer).limit(buffer.limit() << 2);
 		}
 
 		bufferChanged();
@@ -134,9 +135,9 @@ public class VertexBufferObjectSubData implements VertexData {
 		isDirty = true;
 		if (isDirect) {
 			final int pos = byteBuffer.position();
-			byteBuffer.position(targetOffset * 4);
+			((Buffer) byteBuffer).position(targetOffset * 4);
 			BufferUtils.copy(vertices, sourceOffset, count, byteBuffer);
-			byteBuffer.position(pos);
+			((Buffer) byteBuffer).position(pos);
 		} else
 			throw new GdxRuntimeException("Buffer must be allocated direct."); // Should never happen
 
@@ -144,7 +145,7 @@ public class VertexBufferObjectSubData implements VertexData {
 	}
 
 	/** Binds this VertexBufferObject for rendering via glDrawArrays or glDrawElements
-	 * 
+	 *
 	 * @param shader the shader */
 	@Override
 	public void bind (final ShaderProgram shader) {
@@ -157,7 +158,7 @@ public class VertexBufferObjectSubData implements VertexData {
 
 		gl.glBindBuffer(GL20.GL_ARRAY_BUFFER, bufferHandle);
 		if (isDirty) {
-			byteBuffer.limit(buffer.limit() * 4);
+			((Buffer) byteBuffer).limit(buffer.limit() * 4);
 			gl.glBufferData(GL20.GL_ARRAY_BUFFER, byteBuffer.limit(), byteBuffer, usage);
 			isDirty = false;
 		}
@@ -188,7 +189,7 @@ public class VertexBufferObjectSubData implements VertexData {
 	}
 
 	/** Unbinds this VertexBufferObject.
-	 * 
+	 *
 	 * @param shader the shader */
 	@Override
 	public void unbind (final ShaderProgram shader) {

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/VertexBufferObjectWithVAO.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/VertexBufferObjectWithVAO.java
@@ -1,5 +1,6 @@
 package com.badlogic.gdx.graphics.glutils;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.FloatBuffer;
 import java.nio.IntBuffer;
@@ -73,8 +74,8 @@ public class VertexBufferObjectWithVAO implements VertexData {
 		byteBuffer = BufferUtils.newUnsafeByteBuffer(this.attributes.vertexSize * numVertices);
 		buffer = byteBuffer.asFloatBuffer();
 		ownsBuffer = true;
-		buffer.flip();
-		byteBuffer.flip();
+		((Buffer) buffer).flip();
+		((Buffer) byteBuffer).flip();
 		bufferHandle = Gdx.gl20.glGenBuffer();
 		usage = isStatic ? GL20.GL_STATIC_DRAW : GL20.GL_DYNAMIC_DRAW;
 		createVAO();
@@ -87,8 +88,8 @@ public class VertexBufferObjectWithVAO implements VertexData {
 		byteBuffer = unmanagedBuffer;
 		ownsBuffer = false;
 		buffer = byteBuffer.asFloatBuffer();
-		buffer.flip();
-		byteBuffer.flip();
+		((Buffer) buffer).flip();
+		((Buffer) byteBuffer).flip();
 		bufferHandle = Gdx.gl20.glGenBuffer();
 		usage = isStatic ? GL20.GL_STATIC_DRAW : GL20.GL_DYNAMIC_DRAW;
 		createVAO();
@@ -127,8 +128,8 @@ public class VertexBufferObjectWithVAO implements VertexData {
 	public void setVertices (float[] vertices, int offset, int count) {
 		isDirty = true;
 		BufferUtils.copy(vertices, byteBuffer, count, offset);
-		buffer.position(0);
-		buffer.limit(count);
+		((Buffer) buffer).position(0);
+		((Buffer) buffer).limit(count);
 		bufferChanged();
 	}
 
@@ -136,10 +137,10 @@ public class VertexBufferObjectWithVAO implements VertexData {
 	public void updateVertices (int targetOffset, float[] vertices, int sourceOffset, int count) {
 		isDirty = true;
 		final int pos = byteBuffer.position();
-		byteBuffer.position(targetOffset * 4);
+		((Buffer) byteBuffer).position(targetOffset * 4);
 		BufferUtils.copy(vertices, sourceOffset, count, byteBuffer);
-		byteBuffer.position(pos);
-		buffer.position(0);
+		((Buffer) byteBuffer).position(pos);
+		((Buffer) buffer).position(0);
 		bufferChanged();
 	}
 
@@ -227,7 +228,7 @@ public class VertexBufferObjectWithVAO implements VertexData {
 	private void bindData (GL20 gl) {
 		if (isDirty) {
 			gl.glBindBuffer(GL20.GL_ARRAY_BUFFER, bufferHandle);
-			byteBuffer.limit(buffer.limit() * 4);
+			((Buffer) byteBuffer).limit(buffer.limit() * 4);
 			gl.glBufferData(GL20.GL_ARRAY_BUFFER, byteBuffer.limit(), byteBuffer, usage);
 			isDirty = false;
 		}
@@ -277,16 +278,16 @@ public class VertexBufferObjectWithVAO implements VertexData {
 	}
 
 	private void createVAO () {
-		tmpHandle.clear();
+		((Buffer) tmpHandle).clear();
 		Gdx.gl30.glGenVertexArrays(1, tmpHandle);
 		vaoHandle = tmpHandle.get();
 	}
 
 	private void deleteVAO () {
 		if (vaoHandle != -1) {
-			tmpHandle.clear();
+			((Buffer) tmpHandle).clear();
 			tmpHandle.put(vaoHandle);
-			tmpHandle.flip();
+			((Buffer) tmpHandle).flip();
 			Gdx.gl30.glDeleteVertexArrays(1, tmpHandle);
 			vaoHandle = -1;
 		}

--- a/gdx/src/com/badlogic/gdx/utils/ScreenUtils.java
+++ b/gdx/src/com/badlogic/gdx/utils/ScreenUtils.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,6 +16,7 @@
 
 package com.badlogic.gdx.utils;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 
 import com.badlogic.gdx.Gdx;
@@ -29,7 +30,7 @@ import com.badlogic.gdx.math.MathUtils;
 
 /** Class with static helper methods that provide access to the default OpenGL FrameBuffer. These methods can be used to get the
  * entire screen content or a portion thereof.
- * 
+ *
  * @author espitz */
 public final class ScreenUtils {
 
@@ -48,7 +49,7 @@ public final class ScreenUtils {
 	 * {@link Format}. It can be accessed via {@link TextureRegion#getTexture}. This texture is not managed and has to be reloaded
 	 * manually on a context loss. If the width and height specified are larger than the framebuffer dimensions, the Texture will
 	 * be padded accordingly. Pixels that fall outside of the current screen will have RGBA values of 0.
-	 * 
+	 *
 	 * @param x the x position of the framebuffer contents to capture
 	 * @param y the y position of the framebuffer contents to capture
 	 * @param w the width of the framebuffer contents to capture
@@ -83,7 +84,7 @@ public final class ScreenUtils {
 	 * always contain RGBA8888 data. Because of differences in screen and image origins the framebuffer contents should be flipped
 	 * along the Y axis if you intend save them to disk as a bitmap. Flipping is not a cheap operation, so use this functionality
 	 * wisely.
-	 * 
+	 *
 	 * @param flipY whether to flip pixels along Y axis */
 	public static byte[] getFrameBufferPixels (boolean flipY) {
 		final int w = Gdx.graphics.getBackBufferWidth();
@@ -97,7 +98,7 @@ public final class ScreenUtils {
 	 * screen will have RGBA values of 0. Because of differences in screen and image origins the framebuffer contents should be
 	 * flipped along the Y axis if you intend save them to disk as a bitmap. Flipping is not a cheap operation, so use this
 	 * functionality wisely.
-	 * 
+	 *
 	 * @param flipY whether to flip pixels along Y axis */
 	public static byte[] getFrameBufferPixels (int x, int y, int w, int h, boolean flipY) {
 		Gdx.gl.glPixelStorei(GL20.GL_PACK_ALIGNMENT, 1);
@@ -108,11 +109,11 @@ public final class ScreenUtils {
 		if (flipY) {
 			final int numBytesPerLine = w * 4;
 			for (int i = 0; i < h; i++) {
-				pixels.position((h - i - 1) * numBytesPerLine);
+				((Buffer) pixels).position((h - i - 1) * numBytesPerLine);
 				pixels.get(lines, i * numBytesPerLine, numBytesPerLine);
 			}
 		} else {
-			pixels.clear();
+			((Buffer) pixels).clear();
 			pixels.get(lines);
 		}
 		return lines;

--- a/gdx/src/com/badlogic/gdx/utils/StreamUtils.java
+++ b/gdx/src/com/badlogic/gdx/utils/StreamUtils.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,6 +23,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.StringWriter;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 
 /** Provides utility methods to copy streams. */
@@ -73,9 +74,9 @@ public final class StreamUtils {
 		while ((bytesRead = input.read(buffer)) != -1) {
 			BufferUtils.copy(buffer, 0, output, bytesRead);
 			total += bytesRead;
-			output.position(startPosition + total);
+			((Buffer) output).position(startPosition + total);
 		}
-		output.position(startPosition);
+		((Buffer) output).position(startPosition);
 		return total;
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/BufferUtilsTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/BufferUtilsTest.java
@@ -42,81 +42,81 @@ public class BufferUtilsTest extends GdxTest {
 		FloatBuffer fb = BufferUtils.newFloatBuffer(8);
 		DoubleBuffer db = BufferUtils.newDoubleBuffer(8);
 
-		bb.position(4);
+		((Buffer) bb).position(4);
 		BufferUtils.copy(new byte[] {1, 2, 3, 4}, 0, bb, 4);
 		checkInt(bb.get(), 1);
 		checkInt(bb.get(), 2);
 		checkInt(bb.get(), 3);
 		checkInt(bb.get(), 4);
 
-		cb.position(4);
+		((Buffer) cb).position(4);
 		BufferUtils.copy(new char[] {1, 2, 3, 4}, 0, cb, 4);
 		checkInt(cb.get(), 1);
 		checkInt(cb.get(), 2);
 		checkInt(cb.get(), 3);
 		checkInt(cb.get(), 4);
-		cb.position(0);
+		((Buffer) cb).position(0);
 		BufferUtils.copy(new char[] {5, 6, 7, 8}, 1, cb, 3);
 		checkInt(cb.get(), 6);
 		checkInt(cb.get(), 7);
 		checkInt(cb.get(), 8);
 
-		sb.position(4);
+		((Buffer) sb).position(4);
 		BufferUtils.copy(new short[] {1, 2, 3, 4}, 0, sb, 4);
 		checkInt(sb.get(), 1);
 		checkInt(sb.get(), 2);
 		checkInt(sb.get(), 3);
 		checkInt(sb.get(), 4);
-		sb.position(0);
+		((Buffer) sb).position(0);
 		BufferUtils.copy(new short[] {5, 6, 7, 8}, 1, sb, 3);
 		checkInt(sb.get(), 6);
 		checkInt(sb.get(), 7);
 		checkInt(sb.get(), 8);
 
-		ib.position(4);
+		((Buffer) ib).position(4);
 		BufferUtils.copy(new int[] {1, 2, 3, 4}, 0, ib, 4);
 		checkInt(ib.get(), 1);
 		checkInt(ib.get(), 2);
 		checkInt(ib.get(), 3);
 		checkInt(ib.get(), 4);
-		ib.position(0);
+		((Buffer) ib).position(0);
 		BufferUtils.copy(new int[] {5, 6, 7, 8}, 1, ib, 3);
 		checkInt(ib.get(), 6);
 		checkInt(ib.get(), 7);
 		checkInt(ib.get(), 8);
 
-		lb.position(4);
+		((Buffer) lb).position(4);
 		BufferUtils.copy(new long[] {1, 2, 3, 4}, 0, lb, 4);
 		checkInt(lb.get(), 1);
 		checkInt(lb.get(), 2);
 		checkInt(lb.get(), 3);
 		checkInt(lb.get(), 4);
-		lb.position(0);
+		((Buffer) lb).position(0);
 		BufferUtils.copy(new long[] {5, 6, 7, 8}, 1, lb, 3);
 		checkInt(lb.get(), 6);
 		checkInt(lb.get(), 7);
 		checkInt(lb.get(), 8);
 
-		fb.position(4);
+		((Buffer) fb).position(4);
 		BufferUtils.copy(new float[] {1, 2, 3, 4}, 0, fb, 4);
 		checkFloat(fb.get(), 1);
 		checkFloat(fb.get(), 2);
 		checkFloat(fb.get(), 3);
 		checkFloat(fb.get(), 4);
-		fb.position(0);
+		((Buffer) fb).position(0);
 		BufferUtils.copy(new float[] {5, 6, 7, 8}, 1, fb, 3);
 		checkFloat(fb.get(), 6);
 		checkFloat(fb.get(), 7);
 		checkFloat(fb.get(), 8);
 
 		if (Gdx.app.getType() != ApplicationType.WebGL) { // gwt throws: NYI: Numbers.doubleToRawLongBits
-			db.position(4);
+			((Buffer) db).position(4);
 			BufferUtils.copy(new double[] {1, 2, 3, 4}, 0, db, 4);
 			checkFloat(db.get(), 1);
 			checkFloat(db.get(), 2);
 			checkFloat(db.get(), 3);
 			checkFloat(db.get(), 4);
-			db.position(0);
+			((Buffer) db).position(0);
 			BufferUtils.copy(new double[] {5, 6, 7, 8}, 1, db, 3);
 			checkFloat(db.get(), 6);
 			checkFloat(db.get(), 7);
@@ -124,7 +124,7 @@ public class BufferUtilsTest extends GdxTest {
 		}
 
 		ByteBuffer bb2 = BufferUtils.newByteBuffer(4);
-		bb.position(4);
+		((Buffer) bb).position(4);
 		BufferUtils.copy(bb, bb2, 4);
 		checkInt(bb2.get(), 1);
 		checkInt(bb2.get(), 2);
@@ -352,7 +352,7 @@ public class BufferUtilsTest extends GdxTest {
 		// relative put
 		long start = TimeUtils.nanoTime();
 		for (int j = 0; j < NUM_MB; j++) {
-			db.clear();
+			((Buffer) db).clear();
 			for (int i = 0; i < len; i++)
 				db.put(doubles[i]);
 		}
@@ -361,7 +361,7 @@ public class BufferUtilsTest extends GdxTest {
 		// absolute put
 		start = TimeUtils.nanoTime();
 		for (int j = 0; j < NUM_MB; j++) {
-			db.clear();
+			((Buffer) db).clear();
 			for (int i = 0; i < len; i++)
 				db.put(i, doubles[i]);
 		}
@@ -370,7 +370,7 @@ public class BufferUtilsTest extends GdxTest {
 		// bulk put
 		start = TimeUtils.nanoTime();
 		for (int j = 0; j < NUM_MB; j++) {
-			db.clear();
+			((Buffer) db).clear();
 			db.put(doubles);
 		}
 		Gdx.app.log("BufferUtilsTest", "DoubleBuffer bulk put: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
@@ -378,7 +378,7 @@ public class BufferUtilsTest extends GdxTest {
 		// JNI put
 		start = TimeUtils.nanoTime();
 		for (int j = 0; j < NUM_MB; j++) {
-			db.clear();
+			((Buffer) db).clear();
 			BufferUtils.copy(doubles, 0, db, len);
 		}
 		Gdx.app.log("BufferUtilsTest", "DoubleBuffer bulk put: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/BufferUtilsTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/BufferUtilsTest.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,13 +16,7 @@
 
 package com.badlogic.gdx.tests;
 
-import java.nio.ByteBuffer;
-import java.nio.CharBuffer;
-import java.nio.DoubleBuffer;
-import java.nio.FloatBuffer;
-import java.nio.IntBuffer;
-import java.nio.LongBuffer;
-import java.nio.ShortBuffer;
+import java.nio.*;
 
 import com.badlogic.gdx.Application.ApplicationType;
 import com.badlogic.gdx.Gdx;
@@ -39,7 +33,7 @@ public class BufferUtilsTest extends GdxTest {
 		//Not emulated in gwt
 		//ByteBuffer bytebuffer = BufferUtils.newUnsafeByteBuffer(1000 * 1000);
 		//BufferUtils.disposeUnsafeByteBuffer(bytebuffer);
-		
+
 		ByteBuffer bb = BufferUtils.newByteBuffer(8);
 		CharBuffer cb = BufferUtils.newCharBuffer(8);
 		ShortBuffer sb = BufferUtils.newShortBuffer(8);
@@ -54,7 +48,7 @@ public class BufferUtilsTest extends GdxTest {
 		checkInt(bb.get(), 2);
 		checkInt(bb.get(), 3);
 		checkInt(bb.get(), 4);
-		
+
 		cb.position(4);
 		BufferUtils.copy(new char[] {1, 2, 3, 4}, 0, cb, 4);
 		checkInt(cb.get(), 1);
@@ -66,7 +60,7 @@ public class BufferUtilsTest extends GdxTest {
 		checkInt(cb.get(), 6);
 		checkInt(cb.get(), 7);
 		checkInt(cb.get(), 8);
-		
+
 		sb.position(4);
 		BufferUtils.copy(new short[] {1, 2, 3, 4}, 0, sb, 4);
 		checkInt(sb.get(), 1);
@@ -90,7 +84,7 @@ public class BufferUtilsTest extends GdxTest {
 		checkInt(ib.get(), 6);
 		checkInt(ib.get(), 7);
 		checkInt(ib.get(), 8);
-		
+
 		lb.position(4);
 		BufferUtils.copy(new long[] {1, 2, 3, 4}, 0, lb, 4);
 		checkInt(lb.get(), 1);
@@ -158,7 +152,7 @@ public class BufferUtilsTest extends GdxTest {
 		// relative put
 		long start = TimeUtils.nanoTime();
 		for (int j = 0; j < NUM_MB; j++) {
-			bb.clear();
+			((Buffer) bb).clear();
 			for (int i = 0; i < len; i++)
 				bb.put(bytes[i]);
 		}
@@ -167,7 +161,7 @@ public class BufferUtilsTest extends GdxTest {
 		// absolute put
 		start = TimeUtils.nanoTime();
 		for (int j = 0; j < NUM_MB; j++) {
-			bb.clear();
+			((Buffer) bb).clear();
 			for (int i = 0; i < len; i++)
 				bb.put(i, bytes[i]);
 		}
@@ -176,7 +170,7 @@ public class BufferUtilsTest extends GdxTest {
 		// bulk put
 		start = TimeUtils.nanoTime();
 		for (int j = 0; j < NUM_MB; j++) {
-			bb.clear();
+			((Buffer) bb).clear();
 			bb.put(bytes);
 		}
 		Gdx.app.log("BufferUtilsTest", "ByteBuffer bulk put: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
@@ -184,7 +178,7 @@ public class BufferUtilsTest extends GdxTest {
 		// JNI put
 		start = TimeUtils.nanoTime();
 		for (int j = 0; j < NUM_MB; j++) {
-			bb.clear();
+			((Buffer) bb).clear();
 			BufferUtils.copy(bytes, 0, bb, len);
 		}
 		Gdx.app.log("BufferUtilsTest", "ByteBuffer native bulk put: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
@@ -198,7 +192,7 @@ public class BufferUtilsTest extends GdxTest {
 		// relative put
 		long start = TimeUtils.nanoTime();
 		for (int j = 0; j < NUM_MB; j++) {
-			sb.clear();
+			((Buffer) sb).clear();
 			for (int i = 0; i < len; i++)
 				sb.put(shorts[i]);
 		}
@@ -207,7 +201,7 @@ public class BufferUtilsTest extends GdxTest {
 		// absolute put
 		start = TimeUtils.nanoTime();
 		for (int j = 0; j < NUM_MB; j++) {
-			sb.clear();
+			((Buffer) sb).clear();
 			for (int i = 0; i < len; i++)
 				sb.put(i, shorts[i]);
 		}
@@ -216,7 +210,7 @@ public class BufferUtilsTest extends GdxTest {
 		// bulk put
 		start = TimeUtils.nanoTime();
 		for (int j = 0; j < NUM_MB; j++) {
-			sb.clear();
+			((Buffer) sb).clear();
 			sb.put(shorts);
 		}
 		Gdx.app.log("BufferUtilsTest", "ShortBuffer bulk put: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
@@ -224,7 +218,7 @@ public class BufferUtilsTest extends GdxTest {
 		// JNI put
 		start = TimeUtils.nanoTime();
 		for (int j = 0; j < NUM_MB; j++) {
-			sb.clear();
+			((Buffer) sb).clear();
 			BufferUtils.copy(shorts, 0, sb, len);
 		}
 		Gdx.app.log("BufferUtilsTest", "ShortBuffer native bulk put: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
@@ -238,7 +232,7 @@ public class BufferUtilsTest extends GdxTest {
 		// relative put
 		long start = TimeUtils.nanoTime();
 		for (int j = 0; j < NUM_MB; j++) {
-			ib.clear();
+			((Buffer) ib).clear();
 			for (int i = 0; i < len; i++)
 				ib.put(ints[i]);
 		}
@@ -247,7 +241,7 @@ public class BufferUtilsTest extends GdxTest {
 		// absolute put
 		start = TimeUtils.nanoTime();
 		for (int j = 0; j < NUM_MB; j++) {
-			ib.clear();
+			((Buffer) ib).clear();
 			for (int i = 0; i < len; i++)
 				ib.put(i, ints[i]);
 		}
@@ -256,7 +250,7 @@ public class BufferUtilsTest extends GdxTest {
 		// bulk put
 		start = TimeUtils.nanoTime();
 		for (int j = 0; j < NUM_MB; j++) {
-			ib.clear();
+			((Buffer) ib).clear();
 			ib.put(ints);
 		}
 		Gdx.app.log("BufferUtilsTest", "IntBuffer bulk put: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
@@ -264,7 +258,7 @@ public class BufferUtilsTest extends GdxTest {
 		// JNI put
 		start = TimeUtils.nanoTime();
 		for (int j = 0; j < NUM_MB; j++) {
-			ib.clear();
+			((Buffer) ib).clear();
 			BufferUtils.copy(ints, 0, ib, len);
 		}
 		Gdx.app.log("BufferUtilsTest", "IntBuffer native bulk put: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
@@ -278,7 +272,7 @@ public class BufferUtilsTest extends GdxTest {
 		// relative put
 		long start = TimeUtils.nanoTime();
 		for (int j = 0; j < NUM_MB; j++) {
-			lb.clear();
+			((Buffer) lb).clear();
 			for (int i = 0; i < len; i++)
 				lb.put(longs[i]);
 		}
@@ -287,7 +281,7 @@ public class BufferUtilsTest extends GdxTest {
 		// absolute put
 		start = TimeUtils.nanoTime();
 		for (int j = 0; j < NUM_MB; j++) {
-			lb.clear();
+			((Buffer) lb).clear();
 			for (int i = 0; i < len; i++)
 				lb.put(i, longs[i]);
 		}
@@ -296,7 +290,7 @@ public class BufferUtilsTest extends GdxTest {
 		// bulk put
 		start = TimeUtils.nanoTime();
 		for (int j = 0; j < NUM_MB; j++) {
-			lb.clear();
+			((Buffer) lb).clear();
 			lb.put(longs);
 		}
 		Gdx.app.log("BufferUtilsTest", "LongBuffer bulk put: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
@@ -304,7 +298,7 @@ public class BufferUtilsTest extends GdxTest {
 		// JNI put
 		start = TimeUtils.nanoTime();
 		for (int j = 0; j < NUM_MB; j++) {
-			lb.clear();
+			((Buffer) lb).clear();
 			BufferUtils.copy(longs, 0, lb, len);
 		}
 		Gdx.app.log("BufferUtilsTest", "LongBuffer native bulk put: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
@@ -318,7 +312,7 @@ public class BufferUtilsTest extends GdxTest {
 		// relative put
 		long start = TimeUtils.nanoTime();
 		for (int j = 0; j < NUM_MB; j++) {
-			fb.clear();
+			((Buffer) fb).clear();
 			for (int i = 0; i < len; i++)
 				fb.put(floats[i]);
 		}
@@ -327,7 +321,7 @@ public class BufferUtilsTest extends GdxTest {
 		// absolute put
 		start = TimeUtils.nanoTime();
 		for (int j = 0; j < NUM_MB; j++) {
-			fb.clear();
+			((Buffer) fb).clear();
 			for (int i = 0; i < len; i++)
 				fb.put(i, floats[i]);
 		}
@@ -336,7 +330,7 @@ public class BufferUtilsTest extends GdxTest {
 		// bulk put
 		start = TimeUtils.nanoTime();
 		for (int j = 0; j < NUM_MB; j++) {
-			fb.clear();
+			((Buffer) fb).clear();
 			fb.put(floats);
 		}
 		Gdx.app.log("BufferUtilsTest", "FloatBuffer bulk put: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
@@ -344,7 +338,7 @@ public class BufferUtilsTest extends GdxTest {
 		// JNI put
 		start = TimeUtils.nanoTime();
 		for (int j = 0; j < NUM_MB; j++) {
-			fb.clear();
+			((Buffer) fb).clear();
 			BufferUtils.copy(floats, 0, fb, len);
 		}
 		Gdx.app.log("BufferUtilsTest", "FloatBuffer native bulk put: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
@@ -391,7 +385,7 @@ public class BufferUtilsTest extends GdxTest {
 	}
 
 	private void checkInt (long val1, long val2) {
-		if (val1 != val2) { 
+		if (val1 != val2) {
 			Gdx.app.error("BufferUtilsTest", "checkInt failed: "+val1+" != "+val2);
 			throw new GdxRuntimeException("Error, val1 != val2");
 		}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/VBOWithVAOPerformanceTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/VBOWithVAOPerformanceTest.java
@@ -38,6 +38,7 @@ import com.badlogic.gdx.utils.BufferUtils;
 import com.badlogic.gdx.utils.GdxRuntimeException;
 import com.badlogic.gdx.utils.StringBuilder;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.FloatBuffer;
 import java.nio.IntBuffer;
@@ -367,8 +368,8 @@ public class VBOWithVAOPerformanceTest extends GdxTest {
 		public void setVertices(float[] vertices, int offset, int count) {
 			isDirty = true;
 			BufferUtils.copy(vertices, byteBuffer, count, offset);
-			buffer.position(0);
-			buffer.limit(count);
+			((Buffer) buffer).position(0);
+			((Buffer) buffer).limit(count);
 			bufferChanged();
 		}
 
@@ -393,7 +394,7 @@ public class VBOWithVAOPerformanceTest extends GdxTest {
 			GL30 gl = Gdx.gl30;
 			if (vaoDirty || !gl.glIsVertexArray(vaoHandle)) {
 				//initialize the VAO with our vertex attributes and buffer:
-				tmpHandle.clear();
+				((Buffer) tmpHandle).clear();
 				gl.glGenVertexArrays(1, tmpHandle);
 				vaoHandle = tmpHandle.get(0);
 				gl.glBindVertexArray(vaoHandle);
@@ -443,7 +444,7 @@ public class VBOWithVAOPerformanceTest extends GdxTest {
 		private void bindData(GL20 gl) {
 			if (isDirty) {
 				gl.glBindBuffer(GL20.GL_ARRAY_BUFFER, bufferHandle);
-				byteBuffer.limit(buffer.limit() * 4);
+				((Buffer) byteBuffer).limit(buffer.limit() * 4);
 				gl.glBufferData(GL20.GL_ARRAY_BUFFER, byteBuffer.limit(), byteBuffer, usage);
 				isDirty = false;
 			}
@@ -478,7 +479,7 @@ public class VBOWithVAOPerformanceTest extends GdxTest {
 			BufferUtils.disposeUnsafeByteBuffer(byteBuffer);
 
 			if (gl.glIsVertexArray(vaoHandle)) {
-				tmpHandle.clear();
+				((Buffer) tmpHandle).clear();
 				tmpHandle.put(vaoHandle);
 				tmpHandle.flip();
 				gl.glDeleteVertexArrays(1, tmpHandle);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/VBOWithVAOPerformanceTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/VBOWithVAOPerformanceTest.java
@@ -330,8 +330,8 @@ public class VBOWithVAOPerformanceTest extends GdxTest {
 
 			byteBuffer = BufferUtils.newUnsafeByteBuffer(this.attributes.vertexSize * numVertices);
 			buffer = byteBuffer.asFloatBuffer();
-			buffer.flip();
-			byteBuffer.flip();
+			((Buffer) buffer).flip();
+			((Buffer) byteBuffer).flip();
 			bufferHandle = Gdx.gl20.glGenBuffer();
 			usage = isStatic ? GL20.GL_STATIC_DRAW : GL20.GL_DYNAMIC_DRAW;
 		}
@@ -377,10 +377,10 @@ public class VBOWithVAOPerformanceTest extends GdxTest {
 		public void updateVertices(int targetOffset, float[] vertices, int sourceOffset, int count) {
 			isDirty = true;
 			final int pos = byteBuffer.position();
-			byteBuffer.position(targetOffset * 4);
+			((Buffer) byteBuffer).position(targetOffset * 4);
 			BufferUtils.copy(vertices, sourceOffset, count, byteBuffer);
-			byteBuffer.position(pos);
-			buffer.position(0);
+			((Buffer) byteBuffer).position(pos);
+			((Buffer) buffer).position(0);
 			bufferChanged();
 		}
 
@@ -481,7 +481,7 @@ public class VBOWithVAOPerformanceTest extends GdxTest {
 			if (gl.glIsVertexArray(vaoHandle)) {
 				((Buffer) tmpHandle).clear();
 				tmpHandle.put(vaoHandle);
-				tmpHandle.flip();
+				((Buffer) tmpHandle).flip();
 				gl.glDeleteVertexArrays(1, tmpHandle);
 			}
 		}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/OcclusionBuffer.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/OcclusionBuffer.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,6 +24,7 @@ import com.badlogic.gdx.math.*;
 import com.badlogic.gdx.utils.BufferUtils;
 import com.badlogic.gdx.utils.Disposable;
 
+import java.nio.Buffer;
 import java.nio.FloatBuffer;
 
 /** Software rasterizer used for depth rendering and testing of bounding box triangles. Stores depth values inside a
@@ -190,7 +191,7 @@ public class OcclusionBuffer implements Disposable {
 
 	/** Clears the depth buffer by setting the depth to -1. */
 	public void clear () {
-		buffer.clear();
+		((Buffer) buffer).clear();
 		while (buffer.position() < buffer.capacity())
 			buffer.put(-1);
 	}
@@ -319,14 +320,14 @@ public class OcclusionBuffer implements Disposable {
 		// Find min/max depth values in buffer
 		float minDepth = Float.POSITIVE_INFINITY;
 		float maxDepth = Float.NEGATIVE_INFINITY;
-		buffer.clear();
+		((Buffer) buffer).clear();
 		while (buffer.position() < buffer.capacity()) {
 			float depth = MathUtils.clamp(buffer.get(), 0, Float.POSITIVE_INFINITY);
 			minDepth = Math.min(depth, minDepth);
 			maxDepth = Math.max(depth, maxDepth);
 		}
 		float extent = 1 / (maxDepth - minDepth);
-		buffer.clear();
+		((Buffer) buffer).clear();
 		// Draw to pixmap
 		for (int x = 0; x < bufferWidth; x++) {
 			for (int y = 0; y < bufferHeight; y++) {

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/OcclusionCuller.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/OcclusionCuller.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,6 +24,7 @@ import com.badlogic.gdx.physics.bullet.collision.*;
 import com.badlogic.gdx.utils.BufferUtils;
 import com.badlogic.gdx.utils.Disposable;
 
+import java.nio.Buffer;
 import java.nio.FloatBuffer;
 
 /** Performs the occlusion culling or k-DOP culling using the dynamic bounding volume tree from the Bullet broadphase.
@@ -158,8 +159,8 @@ public abstract class OcclusionCuller implements Disposable {
 	/** @param frustum Set the frustum plane buffers to this frustum */
 	private void setFrustumPlanes (Frustum frustum) {
 		// All frustum planes except 'near' (index 0) should be sent to Bullet.
-		frustumNormals.clear();
-		frustumOffsets.clear();
+		((Buffer) frustumNormals).clear();
+		((Buffer) frustumOffsets).clear();
 		for (int i = 1; i < 6; i++) {
 			Plane plane = frustum.planes[i];
 			// Since the plane normals map to an array of btVector3, all four vector components (x, y, z, w)

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/SoftBodyTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/SoftBodyTest.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -44,6 +44,8 @@ import com.badlogic.gdx.physics.bullet.softbody.btSoftBodyHelpers;
 import com.badlogic.gdx.physics.bullet.softbody.btSoftBodyRigidBodyCollisionConfiguration;
 import com.badlogic.gdx.physics.bullet.softbody.btSoftBodyWorldInfo;
 import com.badlogic.gdx.physics.bullet.softbody.btSoftRigidDynamicsWorld;
+
+import java.nio.Buffer;
 
 /** @author xoppa */
 public class SoftBodyTest extends BaseBulletTest {
@@ -96,10 +98,10 @@ public class SoftBodyTest extends BaseBulletTest {
 			new VertexAttribute(Usage.Normal, 3, ShaderProgram.NORMAL_ATTRIBUTE), new VertexAttribute(Usage.TextureCoordinates, 2,
 				ShaderProgram.TEXCOORD_ATTRIBUTE + "0"));
 		final int vertSize = mesh.getVertexSize() / 4;
-		mesh.getVerticesBuffer().position(0);
-		mesh.getVerticesBuffer().limit(vertCount * vertSize);
-		mesh.getIndicesBuffer().position(0);
-		mesh.getIndicesBuffer().limit(faceCount * 3);
+		((Buffer) mesh.getVerticesBuffer()).position(0);
+		((Buffer) mesh.getVerticesBuffer()).limit(vertCount * vertSize);
+		((Buffer) mesh.getIndicesBuffer()).position(0);
+		((Buffer) mesh.getIndicesBuffer()).limit(faceCount * 3);
 		softBody.getVertices(mesh.getVerticesBuffer(), vertCount, mesh.getVertexSize(), 0);
 		softBody.getIndices(mesh.getIndicesBuffer(), faceCount);
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/HeightField.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/HeightField.java
@@ -1,6 +1,7 @@
 
 package com.badlogic.gdx.tests.g3d;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 
 import com.badlogic.gdx.graphics.Color;
@@ -339,7 +340,7 @@ public class HeightField implements Disposable {
 		System.arraycopy(data, offset, this.data, 0, this.data.length);
 		update();
 	}
-	
+
 	@Override
 	public void dispose () {
 		mesh.dispose();
@@ -360,7 +361,7 @@ public class HeightField implements Disposable {
 		} else {
 			source = new byte[width * height * bytesPerColor];
 			data.get(source);
-			data.position(startPos);
+			((Buffer) data).position(startPos);
 		}
 
 		float[] dest = new float[width * height];

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gles3/InstancedRenderingTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gles3/InstancedRenderingTest.java
@@ -28,6 +28,7 @@ import com.badlogic.gdx.tests.utils.GdxTestConfig;
 import com.badlogic.gdx.utils.BufferUtils;
 import com.badlogic.gdx.utils.GdxRuntimeException;
 
+import java.nio.Buffer;
 import java.nio.FloatBuffer;
 
 @GdxTestConfig(requireGL30=true)
@@ -77,7 +78,7 @@ public class InstancedRenderingTest extends GdxTest {
 					x/(float)INSTANCE_COUNT_SQRT, y/(float)INSTANCE_COUNT_SQRT, 1f, 1f});
 			}
 		}
-		offsets.position(0);
+		((Buffer) offsets).position(0);
 		mesh.setInstanceData(offsets);
 //		mesh.disableInstancedRendering();
 	}


### PR DESCRIPTION
If you compile you android app with a jdk greater than 8 and try to run it on an android device with API level lower than 29 (from my experience) the app crashes. The methods position, limit, flip and clear from buffer subtypes are the problem.

Detailed description is here:
https://stackoverflow.com/a/58435689/7912520

I just applied the suggested fix.

@PokeMMO found an issue on the google issue tracker, but they seem no to care. https://issuetracker.google.com/issues/123015428