### PR TITLE
Improve MathUtils.asin(), acos()

### DIFF
--- a/gdx/src/com/badlogic/gdx/math/MathUtils.java
+++ b/gdx/src/com/badlogic/gdx/math/MathUtils.java
@@ -108,16 +108,40 @@ public final class MathUtils {
 		return y < 0f ? atan - PI : atan;
 	}
 
-	/** Returns acos in radians, less accurate than Math.acos but may be faster. */
-	static public float acos (float a) {
-		return 1.5707963267948966f - (a * (1f + (a *= a) * (-0.141514171442891431f + a * -0.719110791477959357f)))
-			/ (1f + a * (-0.439110389941411144f + a * -0.471306172023844527f));
+	/** Returns acos in radians; less accurate than Math.acos but may be faster. Average error of 0.00002845 radians
+	 * (0.0016300649 degrees), largest error of 0.000067548 radians (0.0038702153 degrees). This implementation does not
+	 * return NaN if given an out-of-range input (Math.acos does return NaN), unless the input is NaN.
+	 * @param a acos is defined only when a is between -1f and 1f, inclusive
+	 * @return between {@code 0} and {@code PI} when a is in the defined range */
+	static public float acos(float a) {
+		float a2 = a * a;  // a squared
+		float a3 = a * a2; // a cubed
+		if (a >= 0f) {
+			return (float) Math.sqrt(1f - a) *
+					(1.5707288f - 0.2121144f * a + 0.0742610f * a2 - 0.0187293f * a3);
+		}
+		else {
+			return 3.14159265358979323846f - (float) Math.sqrt(1f + a) *
+					(1.5707288f + 0.2121144f * a + 0.0742610f * a2 + 0.0187293f * a3);
+		}
 	}
 
-	/** Returns asin in radians, less accurate than Math.asin but may be faster. */
-	static public float asin (float a) {
-		return (a * (1f + (a *= a) * (-0.141514171442891431f + a * -0.719110791477959357f)))
-			/ (1f + a * (-0.439110389941411144f + a * -0.471306172023844527f));
+	/** Returns asin in radians; less accurate than Math.asin but may be faster. Average error of 0.000028447 radians
+	 * (0.0016298931 degrees), largest error of 0.000067592 radians (0.0038727364 degrees). This implementation does not
+	 * return NaN if given an out-of-range input (Math.asin does return NaN), unless the input is NaN.
+	 * @param a asin is defined only when a is between -1f and 1f, inclusive
+	 * @return between {@code -HALF_PI} and {@code HALF_PI} when a is in the defined range */
+	static public float asin(float a) {
+		float a2 = a * a;  // a squared
+		float a3 = a * a2; // a cubed
+		if (a >= 0f) {
+			return 1.5707963267948966f - (float) Math.sqrt(1f - a) *
+					(1.5707288f - 0.2121144f * a + 0.0742610f * a2 - 0.0187293f * a3);
+		}
+		else {
+			return -1.5707963267948966f + (float) Math.sqrt(1f + a) *
+					(1.5707288f + 0.2121144f * a + 0.0742610f * a2 + 0.0187293f * a3);
+		}
 	}
 
 	// ---


### PR DESCRIPTION
The average and largest error are significantly better for this version (2-3 orders of magnitude), and it can be slightly faster. For comparison, this implementation uses one `Math.sqrt()` call (on a float argument and cast to float, which HotSpot optimizes well), whereas the implementation it replaces uses one float division. These seem to have about the same performance cost on modern Intel hardware; it may be different on AMD processors or ARM. In terms of accuracy, there's no comparison; the previous asin() in MathUtils was only usable if the high error near inputs of -1 and 1 wasn't noticeable.

This algorithm was described in a 1955 research study by RAND Corp, "Approximations for Digital Computers." There are other approximations for asin() described, but the first one, on sheet 35, is the fastest. It's also the least precise of the approximations they give, but it's still much more precise than the current one, which is by Dennis Kjaer Christensen.

I did a comparative benchmark for the previous MathUtils (in GDXASinBench), this PR (in ASin35FloatBench, 35 because the approximation was on sheet 35), and Math (MathASinBench). Higher is better; each of these measures ops/second:

```
 ASin35FloatBench score: 94179176.000000 (94.18M 1836.1%)
 GDXASinBench score    : 91518944.000000 (91.52M 1833.2%)
 MathASinBench score   : 38451616.000000 (38.45M 1746.5%)
```

The acos() implementation here is slightly faster than asin(), because it can avoid adding or subtracting PI or HALF_PI in one of its branches. I benchmarked all of these on a 10th-gen i7 hexacore laptop processor, and performance is likely to vary somewhat on much older PCs because of how thoroughly Math.sqrt() gets optimized on recent CPUs.

I also compared the absolute average error, relative average error, and largest single absolute error for both approximations. These were computed for 2048 equally-spaced floats from -1 (inclusive) to 1 (exclusive).
```
 ASin35: absolute error 0.000028447, relative error -0.000000033, max error 0.000067592
 GDX   : absolute error 0.007147891, relative error -0.000007316, max error 0.023241536
 Math  : no error, because we're comparing relative to Math.asin()
```

If anyone has any questions, just ask; the previous approximations for asin() and acos() weren't tested enough by me when I had suggested them a while ago. I knew they were fast, but I didn't know there were faster approximations that had better accuracy.