### PR TITLE
iOS catch exception for unknown keys from hardware keyboard

### DIFF
--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/DefaultIOSInput.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/DefaultIOSInput.java
@@ -699,7 +699,7 @@ public class DefaultIOSInput implements IOSInput {
 			return false;
 		}
 
-		int keyCode = getGdxKeyCode(key.getKeyCode());
+		int keyCode = getGdxKeyCode(key);
 
 		if (keyCode != Keys.UNKNOWN)
 			synchronized (keyEvents) {
@@ -957,7 +957,14 @@ public class DefaultIOSInput implements IOSInput {
 		return 0;
 	}
 
-	protected int getGdxKeyCode(UIKeyboardHIDUsage keyCode) {
+	protected int getGdxKeyCode(UIKey key) {
+		UIKeyboardHIDUsage keyCode;
+		try {
+			keyCode = key.getKeyCode();
+		} catch (IllegalArgumentException e) {
+			return Keys.UNKNOWN;
+		}
+
 		switch (keyCode) {
 			case KeyboardA:
 				return Keys.A;


### PR DESCRIPTION
I have this crash in my logs:

```
java.lang.IllegalArgumentException: No constant with value 669 (0x29d) found in org.robovm.apple.uikit.UIKeyboardHIDUsage
	at org.robovm.rt.bro.ValuedEnum$AsLongMarshaler.toObject(ValuedEnum.java:142)
	at org.robovm.rt.bro.ValuedEnum$AsMachineSizedSIntMarshaler.toObject(ValuedEnum.java:158)
	at org.robovm.apple.uikit.UIKey.$m$keyCode(Native Method)
	at org.robovm.apple.uikit.UIKey.getKeyCode(UIKey.java)
	at com.badlogic.gdx.backends.iosrobovm.DefaultIOSInput.onKey(DefaultIOSInput.java:660)
```

A UIKeyboardHIDUsage with value 669 is currently not present in RoboVM bindings. Even if it is added, the IllegalArgumentException might be thrown when Apple adds another newly supported key and the game is compiled with a RoboVM version still not knowing it. To avoid crashes, this PR catches the thrown exception and maps to Keys.UNKNOWN instead.