### PR TITLE
GWT log failure initializing graphics

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplication.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplication.java
@@ -207,6 +207,7 @@ public abstract class GwtApplication implements EntryPoint, Application {
 			graphics = new GwtGraphics(root, config);
 		} catch (Throwable e) {
 			root.clear();
+			error("GwtApplication", "exception: " + e.getMessage(), e);
 			root.add(getNoWebGLSupportWidget());
 			return;
 		}


### PR DESCRIPTION
On our Discord server, user valdimir asked for help: 

> gwt game on android mobile chrome: first play - success. Second run - appear "Sorry, your browser doesn't seem support WebGL"
> What could be the reason for this strange behavior?

Turned out this output is written out if there is an Exception thrown when initializing GwtGraphics, but there is no easy way to track down the underlying problem because the Exception is sallowed. This PR adds a console log output for debugging purposes.