### PR TITLE
iOS 14 detect connected hardware keyboard reliably

### DIFF
--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/DefaultIOSInput.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/DefaultIOSInput.java
@@ -31,9 +31,11 @@ import com.badlogic.gdx.utils.Pool;
 import org.robovm.apple.audiotoolbox.AudioServices;
 import org.robovm.apple.coregraphics.CGPoint;
 import org.robovm.apple.coregraphics.CGRect;
+import org.robovm.apple.foundation.Foundation;
 import org.robovm.apple.foundation.NSExtensions;
 import org.robovm.apple.foundation.NSObject;
 import org.robovm.apple.foundation.NSRange;
+import org.robovm.apple.gamecontroller.GCKeyboard;
 import org.robovm.apple.uikit.UIAlertAction;
 import org.robovm.apple.uikit.UIAlertActionStyle;
 import org.robovm.apple.uikit.UIAlertController;
@@ -643,7 +645,8 @@ public class DefaultIOSInput implements IOSInput {
 		if (peripheral == Peripheral.Compass) return compassSupported;
 		if (peripheral == Peripheral.OnscreenKeyboard) return true;
 		if (peripheral == Peripheral.Pressure) return pressureSupported;
-		if (peripheral == Peripheral.HardwareKeyboard) return hadHardwareKeyEvent;
+		if (peripheral == Peripheral.HardwareKeyboard)
+			return (Foundation.getMajorSystemVersion() >= 14) ? GCKeyboard.getCoalescedKeyboard() != null : hadHardwareKeyEvent;
 		return false;
 	}
 

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/DefaultIOSInput.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/DefaultIOSInput.java
@@ -646,7 +646,7 @@ public class DefaultIOSInput implements IOSInput {
 		if (peripheral == Peripheral.OnscreenKeyboard) return true;
 		if (peripheral == Peripheral.Pressure) return pressureSupported;
 		if (peripheral == Peripheral.HardwareKeyboard)
-			return (Foundation.getMajorSystemVersion() >= 14) ? GCKeyboard.getCoalescedKeyboard() != null : hadHardwareKeyEvent;
+			return Foundation.getMajorSystemVersion() >= 14 ? GCKeyboard.getCoalescedKeyboard() != null : hadHardwareKeyEvent;
 		return false;
 	}
 

--- a/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/ios/robovm.xml
+++ b/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/ios/robovm.xml
@@ -44,5 +44,6 @@
     <framework>OpenAL</framework>
     <framework>AudioToolbox</framework>
     <framework>AVFoundation</framework>
+    <framework>GameKit</framework>
   </frameworks>
 </config>

--- a/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/ios/robovm.xml
+++ b/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/ios/robovm.xml
@@ -44,6 +44,6 @@
     <framework>OpenAL</framework>
     <framework>AudioToolbox</framework>
     <framework>AVFoundation</framework>
-    <framework>GameKit</framework>
+    <framework>GameController</framework>
   </frameworks>
 </config>

--- a/tests/gdx-tests-iosrobovm/robovm.xml
+++ b/tests/gdx-tests-iosrobovm/robovm.xml
@@ -49,5 +49,6 @@
     <framework>OpenAL</framework>
     <framework>AudioToolbox</framework>
     <framework>AVFoundation</framework>
+    <framework>GameKit</framework>
   </frameworks>
 </config>

--- a/tests/gdx-tests-iosrobovm/robovm.xml
+++ b/tests/gdx-tests-iosrobovm/robovm.xml
@@ -49,6 +49,6 @@
     <framework>OpenAL</framework>
     <framework>AudioToolbox</framework>
     <framework>AVFoundation</framework>
-    <framework>GameKit</framework>
+    <framework>GameController</framework>
   </frameworks>
 </config>


### PR DESCRIPTION
Since iOS 14, there is now a reliable way to detect a connected hardware keyboard. Until now, it is asumed that a keyboard is connected when a key was pressed. Therefore, we cannot detect a keyboard before the first key press which might confuse users, and we can't detect disconnection of the keyboard. Both is fixed with this PR.

The newly used method is part of GameKit framework, which I added to linked frameworks. It could be discussed if improving such a minor feature justifies the addition a new framework. But I am confident that most games out there will add GameKit sooner or later anyway because of GameCenter or other game related features.