### PR TITLE
FrameBuffer#unbind() is no longer static.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+[1.9.14]
+- API Change: Framebuffer.unbind() is no longer static.
+
 [1.9.13]
 - [BREAKING CHANGE] Fixed keycode representations for ESCAPE, END, INSERT and F1 to F12. These keys are working on Android now, but if you hardcoded or saved the values you might need to migrate.
 - [BREAKING CHANGE] TextureAtlas.AtlasRegion and Region splits and pads fields have been removed and moved to name/value pairs, use #findValue("split") and #findValue("pad") instead.

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/FrameBuffer.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/FrameBuffer.java
@@ -94,8 +94,4 @@ public class FrameBuffer extends GLFrameBuffer<Texture> {
 		Gdx.gl20.glFramebufferTexture2D(GL20.GL_FRAMEBUFFER, GL20.GL_COLOR_ATTACHMENT0, GL20.GL_TEXTURE_2D, texture.getTextureObjectHandle(), 0);
 	}
 
-	/** See {@link GLFrameBuffer#unbind()} */
-	public static void unbind () {
-		GLFrameBuffer.unbind();
-	}
 }

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/GLFrameBuffer.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/GLFrameBuffer.java
@@ -314,7 +314,7 @@ public abstract class GLFrameBuffer<T extends GLTexture> implements Disposable {
 	}
 
 	/** Unbinds the framebuffer, all drawing will be performed to the normal framebuffer from here on. */
-	public static void unbind () {
+	public void unbind () {
 		Gdx.gl20.glBindFramebuffer(GL20.GL_FRAMEBUFFER, defaultFramebufferHandle);
 	}
 


### PR DESCRIPTION
This PR removes the static modifier from the `FrameBuffer#unbind()` method. This allows overriding it, which is useful for FrameBuffer implementations that are nestable, i.e. they don't bind the default buffer in `unbind()`, but rather the one bound before. This also brings `unbind()` in line with the `bind()` method.

I'm not sure, whether there are valid use cases, where one would want to bind the default framebuffer again without having a framebuffer instantiated. If that is the case, we could additionally introduce a getter for the `defaultFramebufferHandle` variable. 