### PR TITLE
Fix missing checks for zero key during Values iteration in IntIntMap, IntFloatMap.

### DIFF
--- a/gdx/src/com/badlogic/gdx/math/MathUtils.java
+++ b/gdx/src/com/badlogic/gdx/math/MathUtils.java
@@ -108,16 +108,40 @@ public final class MathUtils {
 		return y < 0f ? atan - PI : atan;
 	}
 
-	/** Returns acos in radians, less accurate than Math.acos but may be faster. */
-	static public float acos (float a) {
-		return 1.5707963267948966f - (a * (1f + (a *= a) * (-0.141514171442891431f + a * -0.719110791477959357f)))
-			/ (1f + a * (-0.439110389941411144f + a * -0.471306172023844527f));
+	/** Returns acos in radians; less accurate than Math.acos but may be faster. Average error of 0.00002845 radians
+	 * (0.0016300649 degrees), largest error of 0.000067548 radians (0.0038702153 degrees). This implementation does not
+	 * return NaN if given an out-of-range input (Math.acos does return NaN), unless the input is NaN.
+	 * @param a acos is defined only when a is between -1f and 1f, inclusive
+	 * @return between {@code 0} and {@code PI} when a is in the defined range */
+	static public float acos(float a) {
+		float a2 = a * a;  // a squared
+		float a3 = a * a2; // a cubed
+		if (a >= 0f) {
+			return (float) Math.sqrt(1f - a) *
+					(1.5707288f - 0.2121144f * a + 0.0742610f * a2 - 0.0187293f * a3);
+		}
+		else {
+			return 3.14159265358979323846f - (float) Math.sqrt(1f + a) *
+					(1.5707288f + 0.2121144f * a + 0.0742610f * a2 + 0.0187293f * a3);
+		}
 	}
 
-	/** Returns asin in radians, less accurate than Math.asin but may be faster. */
-	static public float asin (float a) {
-		return (a * (1f + (a *= a) * (-0.141514171442891431f + a * -0.719110791477959357f)))
-			/ (1f + a * (-0.439110389941411144f + a * -0.471306172023844527f));
+	/** Returns asin in radians; less accurate than Math.asin but may be faster. Average error of 0.000028447 radians
+	 * (0.0016298931 degrees), largest error of 0.000067592 radians (0.0038727364 degrees). This implementation does not
+	 * return NaN if given an out-of-range input (Math.asin does return NaN), unless the input is NaN.
+	 * @param a asin is defined only when a is between -1f and 1f, inclusive
+	 * @return between {@code -HALF_PI} and {@code HALF_PI} when a is in the defined range */
+	static public float asin(float a) {
+		float a2 = a * a;  // a squared
+		float a3 = a * a2; // a cubed
+		if (a >= 0f) {
+			return 1.5707963267948966f - (float) Math.sqrt(1f - a) *
+					(1.5707288f - 0.2121144f * a + 0.0742610f * a2 - 0.0187293f * a3);
+		}
+		else {
+			return -1.5707963267948966f + (float) Math.sqrt(1f + a) *
+					(1.5707288f + 0.2121144f * a + 0.0742610f * a2 + 0.0187293f * a3);
+		}
 	}
 
 	// ---

--- a/gdx/src/com/badlogic/gdx/utils/IntFloatMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/IntFloatMap.java
@@ -642,7 +642,7 @@ public class IntFloatMap implements Iterable<IntFloatMap.Entry> {
 		public float next () {
 			if (!hasNext) throw new NoSuchElementException();
 			if (!valid) throw new GdxRuntimeException("#iterator() cannot be used nested.");
-			float value = map.valueTable[nextIndex];
+			float value = nextIndex == INDEX_ZERO ? map.zeroValue : map.valueTable[nextIndex];
 			currentIndex = nextIndex;
 			findNextIndex();
 			return value;

--- a/gdx/src/com/badlogic/gdx/utils/IntIntMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/IntIntMap.java
@@ -612,7 +612,7 @@ public class IntIntMap implements Iterable<IntIntMap.Entry> {
 		public int next () {
 			if (!hasNext) throw new NoSuchElementException();
 			if (!valid) throw new GdxRuntimeException("#iterator() cannot be used nested.");
-			int value = map.valueTable[nextIndex];
+			int value = nextIndex == INDEX_ZERO ? map.zeroValue : map.valueTable[nextIndex];
 			currentIndex = nextIndex;
 			findNextIndex();
 			return value;


### PR DESCRIPTION
This fixes #6347 ; big thanks to @tomcashman for making the affected code so easy to spot.

In case what this does isn't obvious, IntMap and LongMap correctly check for whether their Values iterators are currently iterating through the "zero value," which is not in the regular array. When iterating over the value for a key that is zero, the iterator is at position `INDEX_ZERO`, which is -1. While IntMap.Values and LongMap.Values don't try to look up INDEX_ZERO in their value table, IntIntMap.Values and IntFloatMap.Values do, which currently causes an index out of bounds exception in 1.9.13. This makes IntIntMap and IntFloatMap match IntMap's correct behavior.