### PR TITLE
Fix keycode for FOWARD_DEL on GWT and iOS

### DIFF
--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/DefaultIOSInput.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/DefaultIOSInput.java
@@ -1132,7 +1132,7 @@ public class DefaultIOSInput implements IOSInput {
 			case KeyboardPageUp:
 				return Keys.PAGE_UP;
 			case KeyboardDeleteForward:
-				return Keys.DEL;
+				return Keys.FORWARD_DEL;
 			case KeyboardEnd:
 				return Keys.END;
 			case KeyboardPageDown:

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/DefaultGwtInput.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/DefaultGwtInput.java
@@ -916,7 +916,7 @@ public class DefaultGwtInput implements GwtInput {
 		case KeyCodes.KEY_CTRL:
 			return location == LOCATION_RIGHT ? Keys.CONTROL_RIGHT : Keys.CONTROL_LEFT;
 		case KeyCodes.KEY_DELETE:
-			return Keys.DEL;
+			return Keys.FORWARD_DEL;
 		case KeyCodes.KEY_DOWN:
 			return Keys.DOWN;
 		case KeyCodes.KEY_END:


### PR DESCRIPTION
Playing around with TextAreaTest, I noticed that pressing forward delete had the same behaviour than pressing backspace.

Cause is a wrong mapping to DEL which is NOT forward del. A check turned out that RoboVM also has a wrong mapping.