### PR TITLE
Introduce an AbstractInput class and consolidate some methods

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/DefaultAndroidInput.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/DefaultAndroidInput.java
@@ -39,13 +39,14 @@ import android.view.View.OnKeyListener;
 import android.view.WindowManager;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
+
+import com.badlogic.gdx.AbstractInput;
 import com.badlogic.gdx.Application;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Graphics.DisplayMode;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.InputProcessor;
 import com.badlogic.gdx.backends.android.surfaceview.GLSurfaceView20;
-import com.badlogic.gdx.utils.IntSet;
 import com.badlogic.gdx.utils.Pool;
 
 import java.util.ArrayList;
@@ -56,7 +57,7 @@ import java.util.List;
  * 
  * @author mzechner */
 /** @author jshapcot */
-public class DefaultAndroidInput implements AndroidInput {
+public class DefaultAndroidInput extends AbstractInput implements AndroidInput {
 
 	static class KeyEvent {
 		static final int KEY_DOWN = 0;
@@ -99,8 +100,7 @@ public class DefaultAndroidInput implements AndroidInput {
 	};
 
 	public static final int NUM_TOUCHES = 20;
-	public static final int SUPPORTED_KEYS = 260;
-	
+
 	ArrayList<OnKeyListener> keyListeners = new ArrayList();
 	ArrayList<KeyEvent> keyEvents = new ArrayList();
 	ArrayList<TouchEvent> touchEvents = new ArrayList();
@@ -113,10 +113,6 @@ public class DefaultAndroidInput implements AndroidInput {
 	int[] realId = new int[NUM_TOUCHES];
 	float[] pressure = new float[NUM_TOUCHES];
 	final boolean hasMultitouch;
-	private int keyCount = 0;
-	private boolean[] keys = new boolean[SUPPORTED_KEYS];
-	private boolean keyJustPressed = false;
-	private boolean[] justPressedKeys = new boolean[SUPPORTED_KEYS];
 	private boolean[] justPressedButtons = new boolean[NUM_TOUCHES];
 	private SensorManager manager;
 	public boolean accelerometerAvailable = false;
@@ -128,7 +124,6 @@ public class DefaultAndroidInput implements AndroidInput {
 	final Context context;
 	protected final AndroidTouchHandler touchHandler;
 	private int sleepTime = 0;
-	private IntSet keysToCatch = new IntSet();
 	protected final Vibrator vibrator;
 	private boolean compassAvailable = false;
 	private boolean rotationVectorAvailable = false;
@@ -189,7 +184,7 @@ public class DefaultAndroidInput implements AndroidInput {
 
 		// this is for backward compatibility: libGDX always caught the circle button, original comment:
 		// circle button on Xperia Play shouldn't need catchBack == true
-		keysToCatch.add(Keys.BUTTON_CIRCLE);
+		setCatchKey(Keys.BUTTON_CIRCLE, true);
 	}
 
 	@Override
@@ -357,28 +352,6 @@ public class DefaultAndroidInput implements AndroidInput {
 	@Override
 	public void setKeyboardAvailable (boolean available) {
 		this.keyboardAvailable = available;
-	}
-
-	@Override
-	public synchronized boolean isKeyPressed (int key) {
-		if (key == Input.Keys.ANY_KEY) {
-			return keyCount > 0;
-		}
-		if (key < 0 || key >= SUPPORTED_KEYS) {
-			return false;
-		}
-		return keys[key];
-	}
-
-	@Override
-	public synchronized boolean isKeyJustPressed (int key) {
-		if (key == Input.Keys.ANY_KEY) {
-			return keyJustPressed;
-		}
-		if (key < 0 || key >= SUPPORTED_KEYS) {
-			return false;
-		}
-		return justPressedKeys[key];
 	}
 
 	@Override
@@ -556,7 +529,7 @@ public class DefaultAndroidInput implements AndroidInput {
 		// additional key events with ACTION_DOWN and a non-zero value for getRepeatCount().
 		// We are only interested in the first key down event here and must ignore all others
 		if (e.getAction() == android.view.KeyEvent.ACTION_DOWN && e.getRepeatCount() > 0)
-			return keysToCatch.contains(keyCode);
+			return isCatchKey(keyCode);
 
 		synchronized (this) {
 			KeyEvent event = null;
@@ -577,7 +550,7 @@ public class DefaultAndroidInput implements AndroidInput {
 			char character = (char)e.getUnicodeChar();
 			// Android doesn't report a unicode char for back space. hrm...
 			if (keyCode == 67) character = '\b';
-			if (e.getKeyCode() < 0 || e.getKeyCode() >= SUPPORTED_KEYS) {
+			if (e.getKeyCode() < 0 || e.getKeyCode() >= Keys.MAX_KEYCODE) {
 				return false;
 			}
 			
@@ -596,9 +569,9 @@ public class DefaultAndroidInput implements AndroidInput {
 				}
 
 				keyEvents.add(event);
-				if (!keys[event.keyCode]) {
-					keyCount++;
-					keys[event.keyCode] = true;
+				if (!pressedKeys[event.keyCode]) {
+					pressedKeyCount++;
+					pressedKeys[event.keyCode] = true;
 				}
 				break;
 			case android.view.KeyEvent.ACTION_UP:
@@ -623,21 +596,21 @@ public class DefaultAndroidInput implements AndroidInput {
 				keyEvents.add(event);
 
 				if (keyCode == Keys.BUTTON_CIRCLE) {
-					if (keys[Keys.BUTTON_CIRCLE]) {
-						keyCount--;
-						keys[Keys.BUTTON_CIRCLE] = false;
+					if (pressedKeys[Keys.BUTTON_CIRCLE]) {
+						pressedKeyCount--;
+						pressedKeys[Keys.BUTTON_CIRCLE] = false;
 					}
 				} else {
-					if (keys[e.getKeyCode()]) {
-						keyCount--;
-						keys[e.getKeyCode()] = false;
+					if (pressedKeys[e.getKeyCode()]) {
+						pressedKeyCount--;
+						pressedKeys[e.getKeyCode()] = false;
 					}
 				}
 			}
 			app.getGraphics().requestRendering();
 		}
 
-		return keysToCatch.contains(keyCode);
+		return isCatchKey(keyCode);
 	}
 
 	@Override
@@ -666,40 +639,6 @@ public class DefaultAndroidInput implements AndroidInput {
 				}
 			}
 		});
-	}
-
-	@Override
-	public void setCatchBackKey (boolean catchBack) {
-		setCatchKey(Keys.BACK, catchBack);
-	}
-
-	@Override
-	public boolean isCatchBackKey() {
-		return keysToCatch.contains(Keys.BACK);
-	}
-
-	@Override
-	public void setCatchMenuKey (boolean catchMenu) {
-		setCatchKey(Keys.MENU, catchMenu);
-	}
-
-	@Override
-	public boolean isCatchMenuKey () {
-		return keysToCatch.contains(Keys.MENU);
-	}
-
-	@Override
-	public void setCatchKey (int keycode, boolean catchKey) {
-		if (!catchKey) {
-			keysToCatch.remove(keycode);
-		} else if (catchKey) {
-			keysToCatch.add(keycode);
-		}
-	}
-
-	@Override
-	public boolean isCatchKey (int keycode) {
-		return keysToCatch.contains(keycode);
 	}
 
 	@Override

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/DefaultAndroidInput.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/DefaultAndroidInput.java
@@ -550,7 +550,7 @@ public class DefaultAndroidInput extends AbstractInput implements AndroidInput {
 			char character = (char)e.getUnicodeChar();
 			// Android doesn't report a unicode char for back space. hrm...
 			if (keyCode == 67) character = '\b';
-			if (e.getKeyCode() < 0 || e.getKeyCode() >= Keys.MAX_KEYCODE) {
+			if (e.getKeyCode() < 0 || e.getKeyCode() > Keys.MAX_KEYCODE) {
 				return false;
 			}
 			

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/DefaultLwjglInput.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/DefaultLwjglInput.java
@@ -705,6 +705,7 @@ final public class DefaultLwjglInput extends AbstractInput implements LwjglInput
 
 						pressedKeyCount++;
 						keyJustPressed = true;
+						pressedKeys[keyCode] = true;
 						justPressedKeys[keyCode] = true;
 						lastKeyCharPressed = keyChar;
 						keyRepeatTimer = keyRepeatInitialTime;
@@ -725,6 +726,7 @@ final public class DefaultLwjglInput extends AbstractInput implements LwjglInput
 					keyEvents.add(event);
 
 					pressedKeyCount--;
+					pressedKeys[keyCode] = false;
 					lastKeyCharPressed = 0;
 				}
 				Gdx.graphics.requestRendering();

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/DefaultLwjglInput.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/DefaultLwjglInput.java
@@ -16,6 +16,7 @@
 
 package com.badlogic.gdx.backends.lwjgl;
 
+import com.badlogic.gdx.AbstractInput;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.InputProcessor;
@@ -48,7 +49,7 @@ import javax.swing.event.DocumentListener;
 /** An implementation of the {@link LwjglInput} interface hooking a LWJGL panel for input.
  * 
  * @author mzechner */
-final public class DefaultLwjglInput implements LwjglInput {
+final public class DefaultLwjglInput extends AbstractInput implements LwjglInput {
 	static public float keyRepeatInitialTime = 0.4f;
 	static public float keyRepeatTime = 0.1f;
 
@@ -57,9 +58,6 @@ final public class DefaultLwjglInput implements LwjglInput {
 	boolean mousePressed = false;
 	int mouseX, mouseY;
 	int deltaX, deltaY;
-	int pressedKeys = 0;
-	boolean keyJustPressed = false;
-	boolean[] justPressedKeys = new boolean[Keys.MAX_KEYCODE + 1];
 	boolean[] justPressedButtons = new boolean[5];
 	boolean justTouched = false;
 	IntSet pressedButtons = new IntSet();
@@ -230,26 +228,6 @@ final public class DefaultLwjglInput implements LwjglInput {
 		return false;
 	}
 
-	public boolean isKeyPressed (int key) {
-		if (!Keyboard.isCreated()) return false;
-
-		if (key == Input.Keys.ANY_KEY)
-			return pressedKeys > 0;
-		else
-			return Keyboard.isKeyDown(getLwjglKeyCode(key));
-	}
-
-	@Override
-	public boolean isKeyJustPressed (int key) {
-		if (key == Input.Keys.ANY_KEY) {
-			return keyJustPressed;
-		}
-		if (key < 0 || key >= justPressedKeys.length) {
-			return false;
-		}
-		return justPressedKeys[key];
-	}
-
 	public boolean isTouched () {
 		boolean button = Mouse.isButtonDown(0) || Mouse.isButtonDown(1) || Mouse.isButtonDown(2);
 		return button;
@@ -298,36 +276,6 @@ final public class DefaultLwjglInput implements LwjglInput {
 	@Override
 	public void setOnscreenKeyboardVisible(boolean visible, OnscreenKeyboardType type) {
 
-	}
-
-	@Override
-	public void setCatchBackKey (boolean catchBack) {
-
-	}
-
-	@Override
-	public boolean isCatchBackKey () {
-		return false;
-	}	
-
-	@Override
-	public void setCatchMenuKey (boolean catchMenu) {
-		
-	}
-	
-	@Override
-	public boolean isCatchMenuKey () {
-		return false;
-	}
-
-	@Override
-	public void setCatchKey (int keycode, boolean catchKey) {
-
-	}
-
-	@Override
-	public boolean isCatchKey (int keycode) {
-		return false;
 	}
 
 	@Override
@@ -391,7 +339,7 @@ final public class DefaultLwjglInput implements LwjglInput {
 		}
 	}
 
-	public static int getGdxKeyCode (int lwjglKeyCode) {
+	protected int getGdxKeyCode (int lwjglKeyCode) {
 		switch (lwjglKeyCode) {
 		case Keyboard.KEY_LBRACKET:
 			return Input.Keys.LEFT_BRACKET;
@@ -624,242 +572,6 @@ final public class DefaultLwjglInput implements LwjglInput {
 		}
 	}
 
-	public static int getLwjglKeyCode (int gdxKeyCode) {
-		switch (gdxKeyCode) {
-		case Input.Keys.APOSTROPHE:
-			return Keyboard.KEY_APOSTROPHE;
-		case Input.Keys.LEFT_BRACKET:
-		case Keys.NUMPAD_LEFT_PAREN:
-			return Keyboard.KEY_LBRACKET;
-		case Keys.NUMPAD_RIGHT_PAREN:
-		case Input.Keys.RIGHT_BRACKET:
-			return Keyboard.KEY_RBRACKET;
-		case Input.Keys.GRAVE:
-			return Keyboard.KEY_GRAVE;
-		case Input.Keys.STAR:
-		case Input.Keys.NUMPAD_MULTIPLY:
-			return Keyboard.KEY_MULTIPLY;
-		case Input.Keys.NUM:
-		case Input.Keys.NUM_LOCK:
-			return Keyboard.KEY_NUMLOCK;
-		case Keys.SCROLL_LOCK:
-			return Keyboard.KEY_SCROLL;
-		case Keys.CAPS_LOCK:
-			return Keyboard.KEY_CAPITAL;
-		case Keys.PRINT_SCREEN:
-			return Keyboard.KEY_SYSRQ;
-		case Keys.PAUSE:
-			return Keyboard.KEY_PAUSE;
-		case Input.Keys.AT:
-			return Keyboard.KEY_AT;
-		case Input.Keys.EQUALS:
-			return Keyboard.KEY_EQUALS;
-		case Input.Keys.SYM:
-			return Keyboard.KEY_LMETA;
-		case Input.Keys.NUM_0:
-			return Keyboard.KEY_0;
-		case Input.Keys.NUM_1:
-			return Keyboard.KEY_1;
-		case Input.Keys.NUM_2:
-			return Keyboard.KEY_2;
-		case Input.Keys.NUM_3:
-			return Keyboard.KEY_3;
-		case Input.Keys.NUM_4:
-			return Keyboard.KEY_4;
-		case Input.Keys.NUM_5:
-			return Keyboard.KEY_5;
-		case Input.Keys.NUM_6:
-			return Keyboard.KEY_6;
-		case Input.Keys.NUM_7:
-			return Keyboard.KEY_7;
-		case Input.Keys.NUM_8:
-			return Keyboard.KEY_8;
-		case Input.Keys.NUM_9:
-			return Keyboard.KEY_9;
-		case Input.Keys.A:
-			return Keyboard.KEY_A;
-		case Input.Keys.B:
-			return Keyboard.KEY_B;
-		case Input.Keys.C:
-			return Keyboard.KEY_C;
-		case Input.Keys.D:
-			return Keyboard.KEY_D;
-		case Input.Keys.E:
-			return Keyboard.KEY_E;
-		case Input.Keys.F:
-			return Keyboard.KEY_F;
-		case Input.Keys.G:
-			return Keyboard.KEY_G;
-		case Input.Keys.H:
-			return Keyboard.KEY_H;
-		case Input.Keys.I:
-			return Keyboard.KEY_I;
-		case Input.Keys.J:
-			return Keyboard.KEY_J;
-		case Input.Keys.K:
-			return Keyboard.KEY_K;
-		case Input.Keys.L:
-			return Keyboard.KEY_L;
-		case Input.Keys.M:
-			return Keyboard.KEY_M;
-		case Input.Keys.N:
-			return Keyboard.KEY_N;
-		case Input.Keys.O:
-			return Keyboard.KEY_O;
-		case Input.Keys.P:
-			return Keyboard.KEY_P;
-		case Input.Keys.Q:
-			return Keyboard.KEY_Q;
-		case Input.Keys.R:
-			return Keyboard.KEY_R;
-		case Input.Keys.S:
-			return Keyboard.KEY_S;
-		case Input.Keys.T:
-			return Keyboard.KEY_T;
-		case Input.Keys.U:
-			return Keyboard.KEY_U;
-		case Input.Keys.V:
-			return Keyboard.KEY_V;
-		case Input.Keys.W:
-			return Keyboard.KEY_W;
-		case Input.Keys.X:
-			return Keyboard.KEY_X;
-		case Input.Keys.Y:
-			return Keyboard.KEY_Y;
-		case Input.Keys.Z:
-			return Keyboard.KEY_Z;
-		case Input.Keys.ALT_LEFT:
-			return Keyboard.KEY_LMENU;
-		case Input.Keys.ALT_RIGHT:
-			return Keyboard.KEY_RMENU;
-		case Input.Keys.BACKSLASH:
-			return Keyboard.KEY_BACKSLASH;
-		case Input.Keys.COMMA:
-			return Keyboard.KEY_COMMA;
-		case Input.Keys.FORWARD_DEL:
-			return Keyboard.KEY_DELETE;
-		case Input.Keys.DPAD_LEFT:
-			return Keyboard.KEY_LEFT;
-		case Input.Keys.DPAD_RIGHT:
-			return Keyboard.KEY_RIGHT;
-		case Input.Keys.DPAD_UP:
-			return Keyboard.KEY_UP;
-		case Input.Keys.DPAD_DOWN:
-			return Keyboard.KEY_DOWN;
-		case Input.Keys.ENTER:
-			return Keyboard.KEY_RETURN;
-		case Input.Keys.HOME:
-			return Keyboard.KEY_HOME;
-		case Input.Keys.END:
-			return Keyboard.KEY_END;
-		case Input.Keys.PAGE_DOWN:
-			return Keyboard.KEY_NEXT;
-		case Input.Keys.PAGE_UP:
-			return Keyboard.KEY_PRIOR;
-		case Input.Keys.INSERT:
-			return Keyboard.KEY_INSERT;
-		case Input.Keys.MINUS:
-			return Keyboard.KEY_MINUS;
-		case Input.Keys.PERIOD:
-			return Keyboard.KEY_PERIOD;
-		case Input.Keys.PLUS:
-		case Input.Keys.NUMPAD_ADD:
-			return Keyboard.KEY_ADD;
-		case Input.Keys.SEMICOLON:
-			return Keyboard.KEY_SEMICOLON;
-		case Input.Keys.SHIFT_LEFT:
-			return Keyboard.KEY_LSHIFT;
-		case Input.Keys.SHIFT_RIGHT:
-			return Keyboard.KEY_RSHIFT;
-		case Input.Keys.SLASH:
-			return Keyboard.KEY_SLASH;
-		case Input.Keys.SPACE:
-			return Keyboard.KEY_SPACE;
-		case Input.Keys.TAB:
-			return Keyboard.KEY_TAB;
-		case Input.Keys.DEL:
-			return Keyboard.KEY_BACK;
-		case Input.Keys.CONTROL_LEFT:
-			return Keyboard.KEY_LCONTROL;
-		case Input.Keys.CONTROL_RIGHT:
-			return Keyboard.KEY_RCONTROL;
-		case Input.Keys.ESCAPE:
-			return Keyboard.KEY_ESCAPE;
-		case Input.Keys.F1:
-			return Keyboard.KEY_F1;
-		case Input.Keys.F2:
-			return Keyboard.KEY_F2;
-		case Input.Keys.F3:
-			return Keyboard.KEY_F3;
-		case Input.Keys.F4:
-			return Keyboard.KEY_F4;
-		case Input.Keys.F5:
-			return Keyboard.KEY_F5;
-		case Input.Keys.F6:
-			return Keyboard.KEY_F6;
-		case Input.Keys.F7:
-			return Keyboard.KEY_F7;
-		case Input.Keys.F8:
-			return Keyboard.KEY_F8;
-		case Input.Keys.F9:
-			return Keyboard.KEY_F9;
-		case Input.Keys.F10:
-			return Keyboard.KEY_F10;
-		case Input.Keys.F11:
-			return Keyboard.KEY_F11;
-		case Input.Keys.F12:
-			return Keyboard.KEY_F12;
-		case Input.Keys.F13:
-			return Keyboard.KEY_F13;
-		case Input.Keys.F14:
-			return Keyboard.KEY_F14;
-		case Input.Keys.F15:
-			return Keyboard.KEY_F15;
-		case Input.Keys.F16:
-			return Keyboard.KEY_F16;
-		case Input.Keys.F17:
-			return Keyboard.KEY_F17;
-		case Input.Keys.F18:
-			return Keyboard.KEY_F18;
-		case Input.Keys.COLON:
-			return Keyboard.KEY_COLON;
-		case Input.Keys.NUMPAD_0:
-			return Keyboard.KEY_NUMPAD0;
-		case Input.Keys.NUMPAD_1:
-			return Keyboard.KEY_NUMPAD1;
-		case Input.Keys.NUMPAD_2:
-			return Keyboard.KEY_NUMPAD2;
-		case Input.Keys.NUMPAD_3:
-			return Keyboard.KEY_NUMPAD3;
-		case Input.Keys.NUMPAD_4:
-			return Keyboard.KEY_NUMPAD4;
-		case Input.Keys.NUMPAD_5:
-			return Keyboard.KEY_NUMPAD5;
-		case Input.Keys.NUMPAD_6:
-			return Keyboard.KEY_NUMPAD6;
-		case Input.Keys.NUMPAD_7:
-			return Keyboard.KEY_NUMPAD7;
-		case Input.Keys.NUMPAD_8:
-			return Keyboard.KEY_NUMPAD8;
-		case Input.Keys.NUMPAD_9:
-			return Keyboard.KEY_NUMPAD9;
-		case Input.Keys.NUMPAD_ENTER:
-			return Keyboard.KEY_NUMPADENTER;
-		case Input.Keys.NUMPAD_DOT:
-			return Keyboard.KEY_DECIMAL;
-		case Input.Keys.NUMPAD_COMMA:
-			return Keyboard.KEY_NUMPADCOMMA;
-		case Input.Keys.NUMPAD_SUBTRACT:
-			return Keyboard.KEY_SUBTRACT;
-		case Input.Keys.NUMPAD_DIVIDE:
-			return Keyboard.KEY_DIVIDE;
-		case Input.Keys.NUMPAD_EQUALS:
-			return Keyboard.KEY_NUMPADEQUALS;
-		default:
-			return Keyboard.KEY_NONE;
-		}
-	}
-
 	@Override
 	public void update () {
 		updateTime();
@@ -991,7 +703,7 @@ final public class DefaultLwjglInput implements LwjglInput {
 						event.timeStamp = timeStamp;
 						keyEvents.add(event);
 
-						pressedKeys++;
+						pressedKeyCount++;
 						keyJustPressed = true;
 						justPressedKeys[keyCode] = true;
 						lastKeyCharPressed = keyChar;
@@ -1012,7 +724,7 @@ final public class DefaultLwjglInput implements LwjglInput {
 					event.timeStamp = Keyboard.getEventNanoseconds();
 					keyEvents.add(event);
 
-					pressedKeys--;
+					pressedKeyCount--;
 					lastKeyCharPressed = 0;
 				}
 				Gdx.graphics.requestRendering();

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglAWTInput.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglAWTInput.java
@@ -54,12 +54,13 @@ import javax.swing.border.EmptyBorder;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 
+import com.badlogic.gdx.AbstractInput;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.InputProcessor;
 import com.badlogic.gdx.utils.IntSet;
 import com.badlogic.gdx.utils.Pool;
 
-public class LwjglAWTInput implements Input, MouseMotionListener, MouseListener, MouseWheelListener, KeyListener {
+public class LwjglAWTInput extends AbstractInput implements MouseMotionListener, MouseListener, MouseWheelListener, KeyListener {
 	class KeyEvent {
 		static final int KEY_DOWN = 0;
 		static final int KEY_UP = 1;
@@ -108,10 +109,6 @@ public class LwjglAWTInput implements Input, MouseMotionListener, MouseListener,
 	int deltaY = 0;
 	boolean touchDown = false;
 	boolean justTouched = false;
-	int keyCount = 0;
-	boolean[] keys = new boolean[Keys.MAX_KEYCODE + 1];
-	boolean keyJustPressed = false;
-	boolean[] justPressedKeys = new boolean[Keys.MAX_KEYCODE + 1];
 	boolean[] justPressedButtons = new boolean[5];
 	IntSet pressedButtons = new IntSet();
 	InputProcessor processor;
@@ -290,12 +287,12 @@ public class LwjglAWTInput implements Input, MouseMotionListener, MouseListener,
 	@Override
 	public synchronized boolean isKeyPressed (int key) {
 		if (key == Input.Keys.ANY_KEY) {
-			return keyCount > 0;
+			return pressedKeyCount > 0;
 		}
 		if (key < 0 || key > 255) {
 			return false;
 		}
-		return keys[key];
+		return pressedKeys[key];
 	}
 
 	@Override
@@ -416,36 +413,6 @@ public class LwjglAWTInput implements Input, MouseMotionListener, MouseListener,
 			keyEvents.clear();
 			touchEvents.clear();
 		}
-	}
-
-	@Override
-	public void setCatchBackKey (boolean catchBack) {
-
-	}
-
-	@Override
-	public boolean isCatchBackKey () {
-		return false;
-	}
-
-	@Override
-	public void setCatchMenuKey (boolean catchMenu) {
-
-	}
-
-	@Override
-	public boolean isCatchMenuKey () {
-		return false;
-	}
-
-	@Override
-	public void setCatchKey (int keycode, boolean catchKey) {
-
-	}
-
-	@Override
-	public boolean isCatchKey (int keycode) {
-		return false;
 	}
 
 	@Override
@@ -599,9 +566,9 @@ public class LwjglAWTInput implements Input, MouseMotionListener, MouseListener,
 			event.type = KeyEvent.KEY_DOWN;
 			event.timeStamp = System.nanoTime();
 			keyEvents.add(event);
-			if (!keys[event.keyCode]) {
-				keyCount++;
-				keys[event.keyCode] = true;
+			if (!pressedKeys[event.keyCode]) {
+				pressedKeyCount++;
+				pressedKeys[event.keyCode] = true;
 			}
 			lwjglAwtCanvas.graphics.requestRendering();
 		}
@@ -616,9 +583,9 @@ public class LwjglAWTInput implements Input, MouseMotionListener, MouseListener,
 			event.type = KeyEvent.KEY_UP;
 			event.timeStamp = System.nanoTime();
 			keyEvents.add(event);
-			if (keys[event.keyCode]) {
-				keyCount--;
-				keys[event.keyCode] = false;
+			if (pressedKeys[event.keyCode]) {
+				pressedKeyCount--;
+				pressedKeys[event.keyCode] = false;
 			}
 			lwjglAwtCanvas.graphics.requestRendering();
 		}
@@ -637,7 +604,7 @@ public class LwjglAWTInput implements Input, MouseMotionListener, MouseListener,
 		}
 	}
 
-	protected static int translateKeyCode (int keyCode) {
+	protected int translateKeyCode (int keyCode) {
 		switch (keyCode) {
 		case java.awt.event.KeyEvent.VK_0:
 			return Input.Keys.NUM_0;

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/DefaultIOSInput.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/DefaultIOSInput.java
@@ -16,6 +16,7 @@
 
 package com.badlogic.gdx.backends.iosrobovm;
 
+import com.badlogic.gdx.AbstractInput;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.InputProcessor;
@@ -62,7 +63,7 @@ import org.robovm.rt.bro.NativeObject;
 import org.robovm.rt.bro.annotation.MachineSizedUInt;
 import org.robovm.rt.bro.annotation.Pointer;
 
-public class DefaultIOSInput implements IOSInput {
+public class DefaultIOSInput extends AbstractInput implements IOSInput {
 	static final int MAX_TOUCHES = 20;
 	private static final int POINTER_NOT_FOUND = -1;
 
@@ -129,12 +130,7 @@ public class DefaultIOSInput implements IOSInput {
 	boolean keyboardCloseOnReturn;
 	boolean softkeyboardActive = false;
 
-	private IntSet keysToCatch = new IntSet();
-	private boolean keyJustPressed = false;
-	private int keyCount = 0;
 	private boolean hadHardwareKeyEvent = false;
-	private final boolean[] keys = new boolean[Keys.MAX_KEYCODE + 1];
-	private final boolean[] justPressedKeys = new boolean[Keys.MAX_KEYCODE + 1];
 
 	public DefaultIOSInput (IOSApplication app) {
 		this.app = app;
@@ -385,28 +381,6 @@ public class DefaultIOSInput implements IOSInput {
 	}
 
 	@Override
-	public boolean isKeyPressed (int key) {
-		if (key == Input.Keys.ANY_KEY) {
-			return keyCount > 0;
-		}
-		if (key < 0 || key > Keys.MAX_KEYCODE) {
-			return false;
-		}
-		return keys[key];
-	}
-
-	@Override
-	public boolean isKeyJustPressed (int key) {
-		if (key == Input.Keys.ANY_KEY) {
-			return keyJustPressed;
-		}
-		if (key < 0 || key > Keys.MAX_KEYCODE) {
-			return false;
-		}
-		return justPressedKeys[key];
-	}
-
-	@Override
 	public void getTextInput(TextInputListener listener, String title, String text, String hint) {
 		getTextInput(listener, title, text, hint, OnscreenKeyboardType.Default);
 	}
@@ -594,40 +568,6 @@ public class DefaultIOSInput implements IOSInput {
 	}
 
 	@Override
-	public void setCatchBackKey (boolean catchBack) {
-		setCatchKey(Keys.BACK, catchBack);
-	}
-
-	@Override
-	public boolean isCatchBackKey() {
-		return keysToCatch.contains(Keys.BACK);
-	}
-
-	@Override
-	public void setCatchMenuKey (boolean catchMenu) {
-		setCatchKey(Keys.MENU, catchMenu);
-	}
-
-	@Override
-	public boolean isCatchMenuKey () {
-		return keysToCatch.contains(Keys.MENU);
-	}
-
-	@Override
-	public void setCatchKey (int keycode, boolean catchKey) {
-		if (!catchKey) {
-			keysToCatch.remove(keycode);
-		} else if (catchKey) {
-			keysToCatch.add(keycode);
-		}
-	}
-
-	@Override
-	public boolean isCatchKey (int keycode) {
-		return keysToCatch.contains(keycode);
-	}
-
-	@Override
 	public void setInputProcessor (InputProcessor processor) {
 		this.inputProcessor = processor;
 	}
@@ -744,14 +684,14 @@ public class DefaultIOSInput implements IOSInput {
 						keyEvents.add(event);
 					}
 
-					if (keys[keyCode]) {
-						keyCount--;
-						keys[keyCode] = false;
+					if (pressedKeys[keyCode]) {
+						pressedKeyCount--;
+						pressedKeys[keyCode] = false;
 					}
 				} else {
-					if (!keys[event.keyCode]) {
-						keyCount++;
-						keys[event.keyCode] = true;
+					if (!pressedKeys[event.keyCode]) {
+						pressedKeyCount++;
+						pressedKeys[event.keyCode] = true;
 					}
 				}
 

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/DefaultGwtInput.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/DefaultGwtInput.java
@@ -16,6 +16,7 @@
 
 package com.badlogic.gdx.backends.gwt;
 
+import com.badlogic.gdx.AbstractInput;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.InputProcessor;
 import com.badlogic.gdx.backends.gwt.widgets.TextInputDialogBox;
@@ -32,7 +33,7 @@ import com.google.gwt.dom.client.NativeEvent;
 import com.google.gwt.dom.client.Touch;
 import com.google.gwt.event.dom.client.KeyCodes;
 
-public class DefaultGwtInput implements GwtInput {
+public class DefaultGwtInput extends AbstractInput implements GwtInput {
 	static final int MAX_TOUCHES = 20;
 	boolean justTouched = false;
 	private IntMap<Integer> touchMap = new IntMap<Integer>(20);
@@ -42,11 +43,7 @@ public class DefaultGwtInput implements GwtInput {
 	private int[] deltaX = new int[MAX_TOUCHES];
 	private int[] deltaY = new int[MAX_TOUCHES];
 	IntSet pressedButtons = new IntSet();
-	int pressedKeyCount = 0;
 	IntSet pressedKeySet = new IntSet();
-	boolean[] pressedKeys = new boolean[Keys.MAX_KEYCODE + 1];
-	boolean keyJustPressed = false;
-	boolean[] justPressedKeys = new boolean[Keys.MAX_KEYCODE + 1];
 	boolean[] justPressedButtons = new boolean[5];
 	InputProcessor processor;
 	long currentEventTimeStamp;
@@ -55,7 +52,6 @@ public class DefaultGwtInput implements GwtInput {
 	boolean hasFocus = true;
 	GwtAccelerometer accelerometer;
 	GwtGyroscope gyroscope;
-	private IntSet keysToCatch = new IntSet();
 
 	public DefaultGwtInput (CanvasElement canvas, GwtApplicationConfiguration config) {
 		this.canvas = canvas;
@@ -105,7 +101,7 @@ public class DefaultGwtInput implements GwtInput {
 		hookEvents();
 
 		// backwards compatibility: backspace was caught in older versions
-		keysToCatch.add(Keys.BACKSPACE);
+		setCatchKey(Keys.BACKSPACE, true);
 	}
 
 	@Override
@@ -263,28 +259,6 @@ public class DefaultGwtInput implements GwtInput {
 	}
 
 	@Override
-	public boolean isKeyPressed (int key) {
-		if (key == Keys.ANY_KEY) {
-			return pressedKeyCount > 0;
-		}
-		if (key < 0 || key > 255) {
-			return false;
-		}
-		return pressedKeys[key];
-	}
-
-	@Override
-	public boolean isKeyJustPressed (int key) {
-		if (key == Keys.ANY_KEY) {
-			return keyJustPressed;
-		}
-		if (key < 0 || key > 255) {
-			return false;
-		}
-		return justPressedKeys[key];
-	}
-
-	@Override
 	public void getTextInput(TextInputListener listener, String title, String text, String hint) {
 		getTextInput(listener, title, text, hint, OnscreenKeyboardType.Default);
 	}
@@ -352,40 +326,6 @@ public class DefaultGwtInput implements GwtInput {
 	@Override
 	public long getCurrentEventTime () {
 		return currentEventTimeStamp;
-	}
-
-	@Override
-	public void setCatchBackKey (boolean catchBack) {
-		setCatchKey(Keys.BACK, catchBack);
-	}
-
-	@Override
-	public boolean isCatchBackKey () {
-		return keysToCatch.contains(Keys.BACK);
-	}
-
-	@Override
-	public void setCatchMenuKey (boolean catchMenu) {
-		setCatchKey(Keys.MENU, catchMenu);
-	}
-
-	@Override
-	public boolean isCatchMenuKey () {
-		return keysToCatch.contains(Keys.MENU);
-	}
-
-	@Override
-	public void setCatchKey (int keycode, boolean catchKey) {
-		if (!catchKey) {
-			keysToCatch.remove(keycode);
-		} else if (catchKey) {
-			keysToCatch.add(keycode);
-		}
-	}
-
-	@Override
-	public boolean isCatchKey (int keycode) {
-		return keysToCatch.contains(keycode);
 	}
 
 	@Override

--- a/gdx/res/com/badlogic/gdx.gwt.xml
+++ b/gdx/res/com/badlogic/gdx.gwt.xml
@@ -4,6 +4,7 @@
 	    
 	<!--  -->
 		<include name="AbstractGraphics.java"/>
+		<include name="AbstractInput.java"/>
 		<include name="Application.java"/>
 		<include name="ApplicationAdapter.java"/>
 		<include name="ApplicationListener.java"/>

--- a/gdx/src/com/badlogic/gdx/AbstractInput.java
+++ b/gdx/src/com/badlogic/gdx/AbstractInput.java
@@ -1,0 +1,74 @@
+package com.badlogic.gdx;
+
+import com.badlogic.gdx.utils.IntSet;
+
+public abstract class AbstractInput implements Input {
+
+    final protected boolean[] pressedKeys;
+    final protected boolean[] justPressedKeys;
+    private final IntSet keysToCatch = new IntSet();
+    protected int pressedKeyCount = 0;
+    protected boolean keyJustPressed = false;
+
+    public AbstractInput() {
+        pressedKeys = new boolean[Keys.MAX_KEYCODE + 1];
+        justPressedKeys = new boolean[Keys.MAX_KEYCODE + 1];
+    }
+
+    @Override
+    public boolean isKeyPressed(int key) {
+        if (key == Input.Keys.ANY_KEY) {
+            return pressedKeyCount > 0;
+        }
+        if (key < 0 || key > Keys.MAX_KEYCODE) {
+            return false;
+        }
+        return pressedKeys[key];
+    }
+
+    @Override
+    public boolean isKeyJustPressed(int key) {
+        if (key == Input.Keys.ANY_KEY) {
+            return keyJustPressed;
+        }
+        if (key < 0 || key > Keys.MAX_KEYCODE) {
+            return false;
+        }
+        return justPressedKeys[key];
+    }
+
+    @Override
+    public boolean isCatchBackKey() {
+        return keysToCatch.contains(Keys.BACK);
+    }
+
+    @Override
+    public void setCatchBackKey(boolean catchBack) {
+        setCatchKey(Keys.BACK, catchBack);
+    }
+
+    @Override
+    public boolean isCatchMenuKey() {
+        return keysToCatch.contains(Keys.MENU);
+    }
+
+    @Override
+    public void setCatchMenuKey(boolean catchMenu) {
+        setCatchKey(Keys.MENU, catchMenu);
+    }
+
+    @Override
+    public void setCatchKey(int keycode, boolean catchKey) {
+        if (!catchKey) {
+            keysToCatch.remove(keycode);
+        } else {
+            keysToCatch.add(keycode);
+        }
+    }
+
+    @Override
+    public boolean isCatchKey(int keycode) {
+        return keysToCatch.contains(keycode);
+    }
+
+}

--- a/gdx/src/com/badlogic/gdx/AbstractInput.java
+++ b/gdx/src/com/badlogic/gdx/AbstractInput.java
@@ -4,8 +4,8 @@ import com.badlogic.gdx.utils.IntSet;
 
 public abstract class AbstractInput implements Input {
 
-    final protected boolean[] pressedKeys;
-    final protected boolean[] justPressedKeys;
+    protected final boolean[] pressedKeys;
+    protected final boolean[] justPressedKeys;
     private final IntSet keysToCatch = new IntSet();
     protected int pressedKeyCount = 0;
     protected boolean keyJustPressed = false;


### PR DESCRIPTION
After we introduced an abstract graphics class, this PR introduces an abstract input class which aims to consolidate code that is implemented on all (or most) platforms.
We start with pressed key and caught key handlings.

This fixes some minor inconsistencies (keycodes going to 260 on Android, 255 on other platforms). We have a minor behaviour change, too: Setting caught keys will report them as caught when checked with `isCatchKey` (which is not really important, but good imo) even on platforms that have no behaviour change when keys are set to be caught.

With this PR, we also get rid of the two-sided mappings for keycodes on Lwjgl and Lwjgl3 which had inconsistencies as well. And the static methods for key mapping are converted to protected to make overriding in game projects possible.

Testing with SuperKoalio recommended.