### PR TITLE
Android raise touchup events when touched array is reset on pause

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidTouchHandler.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidTouchHandler.java
@@ -23,6 +23,8 @@ import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input.Buttons;
 import com.badlogic.gdx.backends.android.DefaultAndroidInput.TouchEvent;
 
+import java.util.Arrays;
+
 /** Multitouch handler for devices running Android >= 2.0. If device is capable of (fake) multitouch this will report additional
  * pointers.
  * 
@@ -33,9 +35,9 @@ public class AndroidTouchHandler {
 		int pointerIndex = (event.getAction() & MotionEvent.ACTION_POINTER_INDEX_MASK) >> MotionEvent.ACTION_POINTER_INDEX_SHIFT;
 		int pointerId = event.getPointerId(pointerIndex);
 
-		int x = 0, y = 0;
-		int realPointerIndex = 0;
-		int button = Buttons.LEFT;
+		int x, y;
+		int realPointerIndex;
+		int button;
 
 		long timeStamp = System.nanoTime();
 		synchronized (input) {
@@ -161,5 +163,14 @@ public class AndroidTouchHandler {
 
 	public boolean supportsMultitouch (Context activity) {
 		return activity.getPackageManager().hasSystemFeature("android.hardware.touchscreen.multitouch");
+	}
+
+	void cancelTouchState(DefaultAndroidInput input) {
+		long timeStamp = System.nanoTime();
+		for (int i = 0; i < input.realId.length; i++) {
+			if (input.button[i] != -1 && input.touched[i])
+				postTouchEvent(input, TouchEvent.TOUCH_UP, input.touchX[i], input.touchY[i], i, input.button[i], timeStamp);
+		}
+		Arrays.fill(input.touched, false);
 	}
 }

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/DefaultAndroidInput.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/DefaultAndroidInput.java
@@ -1047,7 +1047,7 @@ public class DefaultAndroidInput implements AndroidInput {
 		Arrays.fill(realId, -1);
 
 		// erase touched state. this also sucks donkeyballs...
-		Arrays.fill(touched, false);
+		touchHandler.cancelTouchState(this);
 	}
 
 	@Override
@@ -1062,11 +1062,7 @@ public class DefaultAndroidInput implements AndroidInput {
 
 	@Override
 	public void onDreamingStopped () {
-		unregisterSensorListeners();
-		// erase pointer ids. this sucks donkeyballs...
-		Arrays.fill(realId, -1);
-		// erase touched state. this also sucks donkeyballs...
-		Arrays.fill(touched, false);
+		onPause();
 	}
 
 	/** Our implementation of SensorEventListener. Because Android doesn't like it when we register more than one Sensor to a single

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/InputTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/InputTest.java
@@ -86,7 +86,7 @@ public class InputTest extends GdxTest implements InputProcessor {
 
 	@Override
 	public boolean touchDown (int x, int y, int pointer, int button) {
-		Gdx.app.log("Input Test", "touch down: " + x + ", " + y + ", button: " + getButtonString(button));
+		Gdx.app.log("Input Test", "touch down: " + x + ", " + y + ", button: " + getButtonString(button) + ", pointer: " + pointer);
 		return false;
 	}
 
@@ -98,7 +98,7 @@ public class InputTest extends GdxTest implements InputProcessor {
 
 	@Override
 	public boolean touchUp (int x, int y, int pointer, int button) {
-		Gdx.app.log("Input Test", "touch up: " + x + ", " + y + ", button: " + getButtonString(button));
+		Gdx.app.log("Input Test", "touch up: " + x + ", " + y + ", button: " + getButtonString(button) + ", pointer: " + pointer);
 		return false;
 	}
 


### PR DESCRIPTION
This fixes #4866

When game was sent to background, the touched array was reset, but no touchup events were raised. Thus, listeners and scene2d buttons hung in a clicked state.

Best to test with Scene2dTest and InputTest.