### PR TITLE
Fix crash during Json serialization of IntIntMap (and probably others) after iteration

### DIFF
--- a/gdx/src/com/badlogic/gdx/math/MathUtils.java
+++ b/gdx/src/com/badlogic/gdx/math/MathUtils.java
@@ -108,16 +108,40 @@ public final class MathUtils {
 		return y < 0f ? atan - PI : atan;
 	}
 
-	/** Returns acos in radians, less accurate than Math.acos but may be faster. */
-	static public float acos (float a) {
-		return 1.5707963267948966f - (a * (1f + (a *= a) * (-0.141514171442891431f + a * -0.719110791477959357f)))
-			/ (1f + a * (-0.439110389941411144f + a * -0.471306172023844527f));
+	/** Returns acos in radians; less accurate than Math.acos but may be faster. Average error of 0.00002845 radians
+	 * (0.0016300649 degrees), largest error of 0.000067548 radians (0.0038702153 degrees). This implementation does not
+	 * return NaN if given an out-of-range input (Math.acos does return NaN), unless the input is NaN.
+	 * @param a acos is defined only when a is between -1f and 1f, inclusive
+	 * @return between {@code 0} and {@code PI} when a is in the defined range */
+	static public float acos(float a) {
+		float a2 = a * a;  // a squared
+		float a3 = a * a2; // a cubed
+		if (a >= 0f) {
+			return (float) Math.sqrt(1f - a) *
+					(1.5707288f - 0.2121144f * a + 0.0742610f * a2 - 0.0187293f * a3);
+		}
+		else {
+			return 3.14159265358979323846f - (float) Math.sqrt(1f + a) *
+					(1.5707288f + 0.2121144f * a + 0.0742610f * a2 + 0.0187293f * a3);
+		}
 	}
 
-	/** Returns asin in radians, less accurate than Math.asin but may be faster. */
-	static public float asin (float a) {
-		return (a * (1f + (a *= a) * (-0.141514171442891431f + a * -0.719110791477959357f)))
-			/ (1f + a * (-0.439110389941411144f + a * -0.471306172023844527f));
+	/** Returns asin in radians; less accurate than Math.asin but may be faster. Average error of 0.000028447 radians
+	 * (0.0016298931 degrees), largest error of 0.000067592 radians (0.0038727364 degrees). This implementation does not
+	 * return NaN if given an out-of-range input (Math.asin does return NaN), unless the input is NaN.
+	 * @param a asin is defined only when a is between -1f and 1f, inclusive
+	 * @return between {@code -HALF_PI} and {@code HALF_PI} when a is in the defined range */
+	static public float asin(float a) {
+		float a2 = a * a;  // a squared
+		float a3 = a * a2; // a cubed
+		if (a >= 0f) {
+			return 1.5707963267948966f - (float) Math.sqrt(1f - a) *
+					(1.5707288f - 0.2121144f * a + 0.0742610f * a2 - 0.0187293f * a3);
+		}
+		else {
+			return -1.5707963267948966f + (float) Math.sqrt(1f + a) *
+					(1.5707288f + 0.2121144f * a + 0.0742610f * a2 + 0.0187293f * a3);
+		}
 	}
 
 	// ---

--- a/gdx/src/com/badlogic/gdx/utils/ArrayMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/ArrayMap.java
@@ -36,9 +36,9 @@ public class ArrayMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 	public int size;
 	public boolean ordered;
 
-	private Entries entries1, entries2;
-	private Values values1, values2;
-	private Keys keys1, keys2;
+	private transient Entries entries1, entries2;
+	private transient Values values1, values2;
+	private transient Keys keys1, keys2;
 
 	/** Creates an ordered map with a capacity of 16. */
 	public ArrayMap () {

--- a/gdx/src/com/badlogic/gdx/utils/IntFloatMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/IntFloatMap.java
@@ -65,9 +65,9 @@ public class IntFloatMap implements Iterable<IntFloatMap.Entry> {
 	 * hash. */
 	protected int mask;
 
-	private Entries entries1, entries2;
-	private Values values1, values2;
-	private Keys keys1, keys2;
+	private transient Entries entries1, entries2;
+	private transient Values values1, values2;
+	private transient Keys keys1, keys2;
 
 	/** Creates a new map with an initial capacity of 51 and a load factor of 0.8. */
 	public IntFloatMap () {

--- a/gdx/src/com/badlogic/gdx/utils/IntFloatMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/IntFloatMap.java
@@ -642,7 +642,7 @@ public class IntFloatMap implements Iterable<IntFloatMap.Entry> {
 		public float next () {
 			if (!hasNext) throw new NoSuchElementException();
 			if (!valid) throw new GdxRuntimeException("#iterator() cannot be used nested.");
-			float value = map.valueTable[nextIndex];
+			float value = nextIndex == INDEX_ZERO ? map.zeroValue : map.valueTable[nextIndex];
 			currentIndex = nextIndex;
 			findNextIndex();
 			return value;

--- a/gdx/src/com/badlogic/gdx/utils/IntIntMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/IntIntMap.java
@@ -64,9 +64,9 @@ public class IntIntMap implements Iterable<IntIntMap.Entry> {
 	 * hash. */
 	protected int mask;
 
-	private Entries entries1, entries2;
-	private Values values1, values2;
-	private Keys keys1, keys2;
+	private transient Entries entries1, entries2;
+	private transient Values values1, values2;
+	private transient Keys keys1, keys2;
 
 	/** Creates a new map with an initial capacity of 51 and a load factor of 0.8. */
 	public IntIntMap () {

--- a/gdx/src/com/badlogic/gdx/utils/IntIntMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/IntIntMap.java
@@ -612,7 +612,7 @@ public class IntIntMap implements Iterable<IntIntMap.Entry> {
 		public int next () {
 			if (!hasNext) throw new NoSuchElementException();
 			if (!valid) throw new GdxRuntimeException("#iterator() cannot be used nested.");
-			int value = map.valueTable[nextIndex];
+			int value = nextIndex == INDEX_ZERO ? map.zeroValue : map.valueTable[nextIndex];
 			currentIndex = nextIndex;
 			findNextIndex();
 			return value;

--- a/gdx/src/com/badlogic/gdx/utils/IntMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/IntMap.java
@@ -65,9 +65,9 @@ public class IntMap<V> implements Iterable<IntMap.Entry<V>> {
 	 * hash. */
 	protected int mask;
 
-	private Entries entries1, entries2;
-	private Values values1, values2;
-	private Keys keys1, keys2;
+	private transient Entries entries1, entries2;
+	private transient Values values1, values2;
+	private transient Keys keys1, keys2;
 
 	/** Creates a new map with an initial capacity of 51 and a load factor of 0.8. */
 	public IntMap () {

--- a/gdx/src/com/badlogic/gdx/utils/IntSet.java
+++ b/gdx/src/com/badlogic/gdx/utils/IntSet.java
@@ -60,7 +60,7 @@ public class IntSet {
 	 * hash. */
 	protected int mask;
 
-	private IntSetIterator iterator1, iterator2;
+	private transient IntSetIterator iterator1, iterator2;
 
 	/** Creates a new set with an initial capacity of 51 and a load factor of 0.8. */
 	public IntSet () {

--- a/gdx/src/com/badlogic/gdx/utils/LongMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/LongMap.java
@@ -65,9 +65,9 @@ public class LongMap<V> implements Iterable<LongMap.Entry<V>> {
 	 * hash. */
 	protected int mask;
 
-	private Entries entries1, entries2;
-	private Values values1, values2;
-	private Keys keys1, keys2;
+	private transient Entries entries1, entries2;
+	private transient Values values1, values2;
+	private transient Keys keys1, keys2;
 
 	/** Creates a new map with an initial capacity of 51 and a load factor of 0.8. */
 	public LongMap () {

--- a/gdx/src/com/badlogic/gdx/utils/ObjectFloatMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/ObjectFloatMap.java
@@ -62,9 +62,9 @@ public class ObjectFloatMap<K> implements Iterable<ObjectFloatMap.Entry<K>> {
 	 * hash. */
 	protected int mask;
 
-	Entries entries1, entries2;
-	Values values1, values2;
-	Keys keys1, keys2;
+	transient Entries entries1, entries2;
+	transient Values values1, values2;
+	transient Keys keys1, keys2;
 
 	/** Creates a new map with an initial capacity of 51 and a load factor of 0.8. */
 	public ObjectFloatMap () {

--- a/gdx/src/com/badlogic/gdx/utils/ObjectIntMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/ObjectIntMap.java
@@ -62,9 +62,9 @@ public class ObjectIntMap<K> implements Iterable<ObjectIntMap.Entry<K>> {
 	 * hash. */
 	protected int mask;
 
-	Entries entries1, entries2;
-	Values values1, values2;
-	Keys keys1, keys2;
+	transient Entries entries1, entries2;
+	transient Values values1, values2;
+	transient Keys keys1, keys2;
 
 	/** Creates a new map with an initial capacity of 51 and a load factor of 0.8. */
 	public ObjectIntMap () {

--- a/gdx/src/com/badlogic/gdx/utils/ObjectLongMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/ObjectLongMap.java
@@ -62,9 +62,9 @@ public class ObjectLongMap<K> implements Iterable<ObjectLongMap.Entry<K>> {
 	 * hash. */
 	protected int mask;
 
-	Entries entries1, entries2;
-	Values values1, values2;
-	Keys keys1, keys2;
+	transient Entries entries1, entries2;
+	transient Values values1, values2;
+	transient Keys keys1, keys2;
 
 	/** Creates a new map with an initial capacity of 51 and a load factor of 0.8. */
 	public ObjectLongMap () {

--- a/gdx/src/com/badlogic/gdx/utils/ObjectMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/ObjectMap.java
@@ -64,9 +64,9 @@ public class ObjectMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 	 * hash. */
 	protected int mask;
 
-	Entries entries1, entries2;
-	Values values1, values2;
-	Keys keys1, keys2;
+	transient Entries entries1, entries2;
+	transient Values values1, values2;
+	transient Keys keys1, keys2;
 
 	/** Creates a new map with an initial capacity of 51 and a load factor of 0.8. */
 	public ObjectMap () {

--- a/gdx/src/com/badlogic/gdx/utils/ObjectSet.java
+++ b/gdx/src/com/badlogic/gdx/utils/ObjectSet.java
@@ -61,7 +61,7 @@ public class ObjectSet<T> implements Iterable<T> {
 	 * hash. */
 	protected int mask;
 
-	private ObjectSetIterator iterator1, iterator2;
+	private transient ObjectSetIterator iterator1, iterator2;
 
 	/** Creates a new set with an initial capacity of 51 and a load factor of 0.8. */
 	public ObjectSet () {

--- a/gdx/src/com/badlogic/gdx/utils/OrderedSet.java
+++ b/gdx/src/com/badlogic/gdx/utils/OrderedSet.java
@@ -42,7 +42,7 @@ import java.util.NoSuchElementException;
  * @author Tommy Ettinger */
 public class OrderedSet<T> extends ObjectSet<T> {
 	final Array<T> items;
-	OrderedSetIterator iterator1, iterator2;
+	transient OrderedSetIterator iterator1, iterator2;
 
 	public OrderedSet () {
 		items = new Array();

--- a/gdx/src/com/badlogic/gdx/utils/Queue.java
+++ b/gdx/src/com/badlogic/gdx/utils/Queue.java
@@ -38,7 +38,7 @@ public class Queue<T> implements Iterable<T> {
 	/** Number of elements in the queue. */
 	public int size = 0;
 
-	private QueueIterable iterable;
+	private transient QueueIterable iterable;
 
 	/** Creates a new Queue which can hold 16 values without needing to resize backing array. */
 	public Queue () {

--- a/gdx/src/com/badlogic/gdx/utils/SortedIntList.java
+++ b/gdx/src/com/badlogic/gdx/utils/SortedIntList.java
@@ -21,7 +21,7 @@ package com.badlogic.gdx.utils;
  * @param <E> */
 public class SortedIntList<E> implements Iterable<SortedIntList.Node<E>> {
 	private NodePool<E> nodePool = new NodePool<E>(); // avoid allocating nodes
-	private Iterator iterator;
+	private transient Iterator iterator;
 	int size = 0;
 
 	Node<E> first;

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/JsonTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/JsonTest.java
@@ -2,13 +2,8 @@
 package com.badlogic.gdx.tests;
 
 import com.badlogic.gdx.tests.utils.GdxTest;
-import com.badlogic.gdx.utils.Array;
-import com.badlogic.gdx.utils.ArrayMap;
-import com.badlogic.gdx.utils.Json;
+import com.badlogic.gdx.utils.*;
 import com.badlogic.gdx.utils.JsonWriter.OutputType;
-import com.badlogic.gdx.utils.LongMap;
-import com.badlogic.gdx.utils.ObjectFloatMap;
-import com.badlogic.gdx.utils.ObjectMap;
 import com.badlogic.gdx.utils.reflect.ArrayReflection;
 
 import java.util.ArrayList;
@@ -62,7 +57,73 @@ public class JsonTest extends GdxTest {
 		test.stringFloatMap.put("point one", 0.1f);
 		test.stringFloatMap.put("point double oh seven", 0.007f);
 		test.someEnum = SomeEnum.b;
+
+		// IntIntMap can be written, but only as a normal object, not as a kind of map.
+		test.intsToIntsUnboxed = new IntIntMap();
+		test.intsToIntsUnboxed.put(102, 14);
+		test.intsToIntsUnboxed.put(107, 1);
+		test.intsToIntsUnboxed.put(10, 2);
+		test.intsToIntsUnboxed.put(2, 1);
+		test.intsToIntsUnboxed.put(7, 3);
+		test.intsToIntsUnboxed.put(101, 63);
+		test.intsToIntsUnboxed.put(4, 2);
+		test.intsToIntsUnboxed.put(106, 4);
+		test.intsToIntsUnboxed.put(1, 1);
+		test.intsToIntsUnboxed.put(103, 2);
+		test.intsToIntsUnboxed.put(6, 2);
+		test.intsToIntsUnboxed.put(3, 1);
+		test.intsToIntsUnboxed.put(105, 6);
+		test.intsToIntsUnboxed.put(8, 2);
+		// The above "should" print like this:
+		// {size:14,keyTable:[0,0,102,0,0,0,0,0,107,0,0,10,0,0,0,2,0,0,0,0,7,0,0,0,0,0,101,0,0,0,4,0,106,0,0,0,0,0,0,1,0,0,103,0,0,6,0,0,0,0,0,0,0,0,3,0,0,105,0,0,8,0,0,0],valueTable:[0,0,14,0,0,0,0,0,1,0,0,2,0,0,0,1,0,0,0,0,3,0,0,0,0,0,63,0,0,0,2,0,4,0,0,0,0,0,0,1,0,0,2,0,0,2,0,0,0,0,0,0,0,0,1,0,0,6,0,0,2,0,0,0]}
+		// This is potentially correct, but also quite large considering the contents.
+		// It would be nice to have IntIntMap look like IntMap<Integer> does, below.
+
+		// IntMap gets special treatment and is written as a kind of map.
+		test.intsToIntsBoxed = new IntMap<Integer>();
+		test.intsToIntsBoxed.put(102, 14);
+		test.intsToIntsBoxed.put(107, 1);
+		test.intsToIntsBoxed.put(10, 2);
+		test.intsToIntsBoxed.put(2, 1);
+		test.intsToIntsBoxed.put(7, 3);
+		test.intsToIntsBoxed.put(101, 63);
+		test.intsToIntsBoxed.put(4, 2);
+		test.intsToIntsBoxed.put(106, 4);
+		test.intsToIntsBoxed.put(1, 1);
+		test.intsToIntsBoxed.put(103, 2);
+		test.intsToIntsBoxed.put(6, 2);
+		test.intsToIntsBoxed.put(3, 1);
+		test.intsToIntsBoxed.put(105, 6);
+		test.intsToIntsBoxed.put(8, 2);
+		// The above should print like this:
+		// {102:14,107:1,10:2,2:1,7:3,101:63,4:2,106:4,1:1,103:2,6:2,3:1,105:6,8:2}
+
 		roundTrip(test);
+		int sum = 0;
+		// iterate over an IntIntMap so one of its Entries is instantiated
+		for(IntIntMap.Entry e : test.intsToIntsUnboxed) {
+			sum += e.value + 1;
+		}
+		// also iterate over an Array, which does not have any problems
+		String concat = "";
+		for(String s : test.stringArray) {
+			concat += s;
+		}
+		// by round-tripping again, we verify that the Entries is correctly skipped
+		roundTrip(test);
+		int sum2 = 0;
+		// check and make sure that no entries are skipped over or incorrectly added
+		for(IntIntMap.Entry e : test.intsToIntsUnboxed) {
+			sum2 += e.value + 1;
+		}
+		String concat2 = "";
+		// also check the Array again
+		for(String s : test.stringArray) {
+			concat2 += s;
+		}
+
+		System.out.println("before: " + sum + ", after: " + sum2);
+		System.out.println("before: " + concat + ", after: " + concat2);
 
 		test.someEnum = null;
 		roundTrip(test);
@@ -215,6 +276,8 @@ public class JsonTest extends GdxTest {
 		public LongMap<String> longMap;
 		public ObjectFloatMap<String> stringFloatMap;
 		public SomeEnum someEnum;
+		public IntMap<Integer> intsToIntsBoxed;
+		public IntIntMap intsToIntsUnboxed;
 
 		public boolean equals (Object obj) {
 			if (this == obj) return true;
@@ -271,6 +334,31 @@ public class JsonTest extends GdxTest {
 			if (stringArray != other.stringArray) {
 				if (stringArray == null || other.stringArray == null) return false;
 				if (!stringArray.equals(other.stringArray)) return false;
+			}
+
+			if (objectArray != other.objectArray) {
+				if (objectArray == null || other.objectArray == null) return false;
+				if (!objectArray.equals(other.objectArray)) return false;
+			}
+
+			if (longMap != other.longMap) {
+				if (longMap == null || other.longMap == null) return false;
+				if (!longMap.equals(other.longMap)) return false;
+			}
+
+			if (stringFloatMap != other.stringFloatMap) {
+				if (stringFloatMap == null || other.stringFloatMap == null) return false;
+				if (!stringFloatMap.equals(other.stringFloatMap)) return false;
+			}
+
+			if (intsToIntsBoxed != other.intsToIntsBoxed) {
+				if (intsToIntsBoxed == null || other.intsToIntsBoxed == null) return false;
+				if (!intsToIntsBoxed.equals(other.intsToIntsBoxed)) return false;
+			}
+
+			if (intsToIntsUnboxed != other.intsToIntsUnboxed) {
+				if (intsToIntsUnboxed == null || other.intsToIntsUnboxed == null) return false;
+				if (!intsToIntsUnboxed.equals(other.intsToIntsUnboxed)) return false;
 			}
 
 			if (byteField != other.byteField) return false;


### PR DESCRIPTION
This is a bit of an odd one, but it's not too complex. Some of the data structures in libGDX have special handling in Json, like IntMap, ObjectIntMap, and LongMap; these output like normal JSON maps, with only the present keys and present values written. Other data structures, like IntIntMap, IntFloatMap, and ObjectLongMap do not have such special handling, and output JSON like this for a 14-item IntIntMap:
```
{size:14,keyTable:[0,0,102,0,0,0,0,0,107,0,0,10,0,0,0,2,0,0,0,0,7,0,0,0,0,0,101,0,0,0,4,0,106,0,0,0,0,0,0,1,0,0,103,0,0,6,0,0,0,0,0,0,0,0,3,0,0,105,0,0,8,0,0,0],valueTable:[0,0,14,0,0,0,0,0,1,0,0,2,0,0,0,1,0,0,0,0,3,0,0,0,0,0,63,0,0,0,2,0,4,0,0,0,0,0,0,1,0,0,2,0,0,2,0,0,0,0,0,0,0,0,1,0,0,6,0,0,2,0,0,0]}
```

instead of what the same data in an IntMap<Integer> looks like:
```
{102:14,107:1,10:2,2:1,7:3,101:63,4:2,106:4,1:1,103:2,6:2,3:1,105:6,8:2}
```

These data structures without special handling currently attempt to serialize all fields, because none are marked `transient`. Since this is all of the fields, that includes `Entries`, `Keys`, and `Values` instances, which involve a circular reference to their containing collection. That causes a stack overflow when serializing any of these data structures after a method like `iterator()`, `entries()`, `keys()`, or `values()`, assuming `Collections.allocateIterators` is false.

This fixes the stack overflow by marking the temporary Entries, Keys, Values, and some Iterable/Iterator objects that get reused by libGDX data structures as `transient`. It only changes some Iterable/Iterators because some of those classes already got special treatment, and so marking their iterators as `transient` isn't required. A better approach would be to repeat the special treatment IntMap and ObjectIntMap get for the other data structures in libGDX, but I had written code to do that and it was removed without replacement. Even if we do treat IntIntMap like IntMap, this change should still be useful in case someone uses a third-party serialization format that doesn't understand libGDX internals.