### PR TITLE
Hiero: If a font lacks 'x', fall back to Arial and place a note.

### DIFF
--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/hiero/Hiero.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/hiero/Hiero.java
@@ -73,7 +73,6 @@ import javax.swing.JTextPane;
 import javax.swing.JWindow;
 import javax.swing.KeyStroke;
 import javax.swing.ScrollPaneConstants;
-import javax.swing.SpinnerModel;
 import javax.swing.SpinnerNumberModel;
 import javax.swing.SwingUtilities;
 import javax.swing.border.EmptyBorder;
@@ -84,6 +83,7 @@ import javax.swing.event.DocumentListener;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
 
+import com.badlogic.gdx.utils.GdxRuntimeException;
 import org.lwjgl.opengl.GL11;
 
 import com.badlogic.gdx.ApplicationAdapter;
@@ -436,7 +436,14 @@ public class Hiero extends JFrame {
 			public void valueChanged (ListSelectionEvent evt) {
 				if (evt.getValueIsAdjusting()) return;
 				prefs.put("system.font", (String)fontList.getSelectedValue());
-				updateFont();
+				try {
+					updateFont();
+				} catch (GdxRuntimeException ex) {
+					prefs.remove("system.font");
+					fontList.setSelectedValue("Arial", true);
+					updateFont();
+					sampleTextPane.setText("Selected font does not have the necessary 'x' character; falling back to Arial. \n" + sampleTextPane.getText());
+				}
 			}
 		});
 


### PR DESCRIPTION
At least some of the font generators in Hiero require the 'x' character to be present in a font to use it, but Hiero also remembers the last-selected font for the next startup, and doesn't forget it if it's invalid. This PR makes Hiero forget the selection of the invalid font (removing its name from Preferences), sets the selected font to Arial (which should be available anywhere, since Hiero already fell back to it as a backup in one other place), and writes out a note in the sample text that says that Arial was selected and why (missing 'x'). The note can be easily removed just by pressing the ASCII, NeHe, or Extended buttons, but it lets the user know why Arial was selected instead of some emoji-only font or something. This fixes #6359 , as far as I can tell. It also means there isn't a large stack trace posted where most users can't see it, and the note in the sample text gives some indication of why the selection changed.