### PR TITLE
Add HdpiMode option to iOS backend

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -10,6 +10,7 @@
 - API change: ScreenUtils#getFrameBufferPixmap is deprecated in favor to new method Pixmap#createFromFrameBuffer.
 - API Addition: Added overridable createFiles() methods to backend application classes to allow initializing custom module implementations.
 - API Addition: Add a Graphics#setForegroundFPS() method.
+- API addition: iOS: Added HdpiMode option to IOSApplicationConfiguration to allow users to set whether they want to work in logical or raw pixels (default logical).
 
 [1.9.13]
 - [BREAKING CHANGE] Fixed keycode representations for ESCAPE, END, INSERT and F1 to F12. These keys are working on Android now, but if you hardcoded or saved the values you might need to migrate.

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,6 @@
 [1.9.15]
 - Scene2d.ui: Added new ParticleEffectActor to use particle effects on Stage
+- API addition: iOS: Added HdpiMode option to IOSApplicationConfiguration to allow users to set whether they want to work in logical or raw pixels (default logical).
 
 [1.9.14]
 - [BREAKING CHANGE] iOS: IOSUIViewController has been moved to its own separate class 
@@ -10,7 +11,6 @@
 - API change: ScreenUtils#getFrameBufferPixmap is deprecated in favor to new method Pixmap#createFromFrameBuffer.
 - API Addition: Added overridable createFiles() methods to backend application classes to allow initializing custom module implementations.
 - API Addition: Add a Graphics#setForegroundFPS() method.
-- API addition: iOS: Added HdpiMode option to IOSApplicationConfiguration to allow users to set whether they want to work in logical or raw pixels (default logical).
 
 [1.9.13]
 - [BREAKING CHANGE] Fixed keycode representations for ESCAPE, END, INSERT and F1 to F12. These keys are working on Android now, but if you hardcoded or saved the values you might need to migrate.

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/DefaultIOSInput.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/DefaultIOSInput.java
@@ -796,16 +796,15 @@ public class DefaultIOSInput extends AbstractInput implements IOSInput {
 		for (int i = 0; i < length; i++) {
 			long touchHandle = NSArrayExtensions.objectAtIndex$(array, i);
 			UITouch touch = UI_TOUCH_WRAPPER.wrap(touchHandle);
-			final int locX, locY;
+			int locX, locY;
 			// Get and map the location to our drawing space
 			{
 				CGPoint loc = touch.getLocationInView(app.graphics.view);
+				locX = (int) (loc.getX() - screenBounds.x);
+				locY = (int) (loc.getY() - screenBounds.y);
 				if (config.hdpiMode == HdpiMode.Pixels) {
-					locX = (int) ((loc.getX() * app.pixelsPerPoint) - (screenBounds.x * app.pixelsPerPoint));
-					locY = (int) ((loc.getY() * app.pixelsPerPoint) - (screenBounds.y * app.pixelsPerPoint));
-				} else {
-					locX = (int) (loc.getX() - screenBounds.x);
-					locY = (int) (loc.getY() - screenBounds.y);
+					locX = (int) (locX * app.pixelsPerPoint);
+					locY = (int) (locY * app.pixelsPerPoint);
 				}
 				// app.debug("IOSInput","pos= "+loc+"  bounds= "+bounds+" x= "+locX+" locY= "+locY);
 			}

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/DefaultIOSInput.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/DefaultIOSInput.java
@@ -23,6 +23,7 @@ import com.badlogic.gdx.backends.iosrobovm.custom.UIAcceleration;
 import com.badlogic.gdx.backends.iosrobovm.custom.UIAccelerometer;
 import com.badlogic.gdx.backends.iosrobovm.custom.UIAccelerometerDelegate;
 import com.badlogic.gdx.backends.iosrobovm.custom.UIAccelerometerDelegateAdapter;
+import com.badlogic.gdx.graphics.glutils.HdpiMode;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.GdxRuntimeException;
 import com.badlogic.gdx.utils.Pool;
@@ -799,8 +800,13 @@ public class DefaultIOSInput extends AbstractInput implements IOSInput {
 			// Get and map the location to our drawing space
 			{
 				CGPoint loc = touch.getLocationInView(app.graphics.view);
-				locX = (int)(loc.getX() - screenBounds.x);
-				locY = (int)(loc.getY() - screenBounds.y);
+				if (config.hdpiMode == HdpiMode.Pixels) {
+					locX = (int) ((loc.getX() * app.pixelsPerPoint) - (screenBounds.x * app.pixelsPerPoint));
+					locY = (int) ((loc.getY() * app.pixelsPerPoint) - (screenBounds.y * app.pixelsPerPoint));
+				} else {
+					locX = (int) (loc.getX() - screenBounds.x);
+					locY = (int) (loc.getY() - screenBounds.y);
+				}
 				// app.debug("IOSInput","pos= "+loc+"  bounds= "+bounds+" x= "+locX+" locY= "+locY);
 			}
 

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/DefaultIOSInput.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/DefaultIOSInput.java
@@ -803,8 +803,8 @@ public class DefaultIOSInput extends AbstractInput implements IOSInput {
 				locX = (int) (loc.getX() - screenBounds.x);
 				locY = (int) (loc.getY() - screenBounds.y);
 				if (config.hdpiMode == HdpiMode.Pixels) {
-					locX = (int) (locX * app.pixelsPerPoint);
-					locY = (int) (locY * app.pixelsPerPoint);
+					locX *= app.pixelsPerPoint;
+					locY *= app.pixelsPerPoint;
 				}
 				// app.debug("IOSInput","pos= "+loc+"  bounds= "+bounds+" x= "+locX+" locY= "+locY);
 			}

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSApplicationConfiguration.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSApplicationConfiguration.java
@@ -16,6 +16,9 @@
 
 package com.badlogic.gdx.backends.iosrobovm;
 
+import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.glutils.HdpiMode;
+import com.badlogic.gdx.graphics.glutils.HdpiUtils;
 import com.badlogic.gdx.utils.ObjectMap;
 
 import org.robovm.apple.glkit.GLKViewDrawableColorFormat;
@@ -86,6 +89,16 @@ public class IOSApplicationConfiguration {
 
 	/** whether to use audio or not. Default is <code>true</code> **/
 	public boolean useAudio = true;
+
+	/**
+	 * This setting allows you to specify whether you want to work in logical or raw pixel units.
+	 * See {@link HdpiMode} for more information. Note that some OpenGL
+	 * functions like {@link GL20#glViewport(int, int, int, int)} and
+	 * {@link GL20#glScissor(int, int, int, int)} require raw pixel units. Use
+	 * {@link HdpiUtils} to help with the conversion if HdpiMode is set to
+	 * {@link HdpiMode#Logical}. Defaults to {@link HdpiMode#Logical}.
+	 */
+	public HdpiMode hdpiMode = HdpiMode.Logical;
 
 	ObjectMap<String, IOSDevice> knownDevices = IOSDevice.populateWithKnownDevices();
 

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
@@ -27,6 +27,7 @@ import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.GL30;
 import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.glutils.GLVersion;
+import com.badlogic.gdx.graphics.glutils.HdpiMode;
 import com.badlogic.gdx.utils.Array;
 
 import org.robovm.apple.coregraphics.CGRect;
@@ -57,6 +58,7 @@ public class IOSGraphics extends AbstractGraphics {
 	GL30 gl30;
 	IOSScreenBounds screenBounds;
 	int safeInsetLeft, safeInsetTop, safeInsetBottom, safeInsetRight;
+	int safeInsetRawLeft, safeInsetRawTop, safeInsetRawBottom, safeInsetRawRight;
 	long lastFrameTime;
 	float deltaTime;
 	long framesStart;
@@ -223,8 +225,15 @@ public class IOSGraphics extends AbstractGraphics {
 		gl20.glViewport(IOSGLES20.x, IOSGLES20.y, IOSGLES20.width, IOSGLES20.height);
 
 		if (!created) {
-			final int width = screenBounds.width;
-			final int height = screenBounds.height;
+			final int width;
+			final int height;
+			if (config.hdpiMode == HdpiMode.Pixels) {
+				width = screenBounds.backBufferWidth;
+				height = screenBounds.backBufferHeight;
+			} else {
+				width = screenBounds.width;
+				height = screenBounds.height;
+			}
 			gl20.glViewport(0, 0, width, height);
 
 			String versionString = gl20.glGetString(GL20.GL_VERSION);
@@ -319,11 +328,17 @@ public class IOSGraphics extends AbstractGraphics {
 
 	@Override
 	public int getWidth () {
+		if (config.hdpiMode == HdpiMode.Pixels) {
+			return getBackBufferWidth();
+		}
 		return screenBounds.width;
 	}
 
 	@Override
 	public int getHeight () {
+		if (config.hdpiMode == HdpiMode.Pixels) {
+			return getBackBufferHeight();
+		}
 		return screenBounds.height;
 	}
 
@@ -433,6 +448,10 @@ public class IOSGraphics extends AbstractGraphics {
 		safeInsetLeft = 0;
 		safeInsetRight = 0;
 		safeInsetBottom = 0;
+		safeInsetRawTop = 0;
+		safeInsetRawLeft = 0;
+		safeInsetRawRight = 0;
+		safeInsetRawBottom = 0;
 
 		if (Foundation.getMajorSystemVersion() >= 11) {
 			UIEdgeInsets edgeInsets = viewController.getView().getSafeAreaInsets();
@@ -440,26 +459,42 @@ public class IOSGraphics extends AbstractGraphics {
 			safeInsetLeft = (int) edgeInsets.getLeft();
 			safeInsetRight = (int) edgeInsets.getRight();
 			safeInsetBottom = (int) edgeInsets.getBottom();
+			safeInsetRawTop = (int) (edgeInsets.getTop() * app.pixelsPerPoint);
+			safeInsetRawLeft = (int) (edgeInsets.getLeft() * app.pixelsPerPoint);
+			safeInsetRawRight = (int) (edgeInsets.getRight() * app.pixelsPerPoint);
+			safeInsetRawBottom = (int) (edgeInsets.getBottom() * app.pixelsPerPoint);
 		}
 	}
 
 	@Override
 	public int getSafeInsetLeft() {
+		if (config.hdpiMode == HdpiMode.Pixels) {
+			return safeInsetRawLeft;
+		}
 		return safeInsetLeft;
 	}
 
 	@Override
 	public int getSafeInsetTop() {
+		if (config.hdpiMode == HdpiMode.Pixels) {
+		    return safeInsetRawTop;
+		}
 		return safeInsetTop;
 	}
 
 	@Override
 	public int getSafeInsetBottom() {
+		if (config.hdpiMode == HdpiMode.Pixels) {
+			return safeInsetRawBottom;
+		}
 		return safeInsetBottom;
 	}
 
 	@Override
 	public int getSafeInsetRight() {
+		if (config.hdpiMode == HdpiMode.Pixels) {
+			return safeInsetRawRight;
+		}
 		return safeInsetRight;
 	}
 

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
@@ -58,7 +58,6 @@ public class IOSGraphics extends AbstractGraphics {
 	GL30 gl30;
 	IOSScreenBounds screenBounds;
 	int safeInsetLeft, safeInsetTop, safeInsetBottom, safeInsetRight;
-	int safeInsetRawLeft, safeInsetRawTop, safeInsetRawBottom, safeInsetRawRight;
 	long lastFrameTime;
 	float deltaTime;
 	long framesStart;
@@ -330,16 +329,18 @@ public class IOSGraphics extends AbstractGraphics {
 	public int getWidth () {
 		if (config.hdpiMode == HdpiMode.Pixels) {
 			return getBackBufferWidth();
+		} else {
+			return screenBounds.width;
 		}
-		return screenBounds.width;
 	}
 
 	@Override
 	public int getHeight () {
 		if (config.hdpiMode == HdpiMode.Pixels) {
 			return getBackBufferHeight();
+		} else {
+			return screenBounds.height;
 		}
-		return screenBounds.height;
 	}
 
 	@Override
@@ -448,10 +449,6 @@ public class IOSGraphics extends AbstractGraphics {
 		safeInsetLeft = 0;
 		safeInsetRight = 0;
 		safeInsetBottom = 0;
-		safeInsetRawTop = 0;
-		safeInsetRawLeft = 0;
-		safeInsetRawRight = 0;
-		safeInsetRawBottom = 0;
 
 		if (Foundation.getMajorSystemVersion() >= 11) {
 			UIEdgeInsets edgeInsets = viewController.getView().getSafeAreaInsets();
@@ -459,42 +456,32 @@ public class IOSGraphics extends AbstractGraphics {
 			safeInsetLeft = (int) edgeInsets.getLeft();
 			safeInsetRight = (int) edgeInsets.getRight();
 			safeInsetBottom = (int) edgeInsets.getBottom();
-			safeInsetRawTop = (int) (edgeInsets.getTop() * app.pixelsPerPoint);
-			safeInsetRawLeft = (int) (edgeInsets.getLeft() * app.pixelsPerPoint);
-			safeInsetRawRight = (int) (edgeInsets.getRight() * app.pixelsPerPoint);
-			safeInsetRawBottom = (int) (edgeInsets.getBottom() * app.pixelsPerPoint);
+			if (config.hdpiMode == HdpiMode.Pixels) {
+				safeInsetTop *= app.pixelsPerPoint;
+				safeInsetLeft *= app.pixelsPerPoint;
+				safeInsetRight *= app.pixelsPerPoint;
+				safeInsetBottom *= app.pixelsPerPoint;
+			}
 		}
 	}
 
 	@Override
 	public int getSafeInsetLeft() {
-		if (config.hdpiMode == HdpiMode.Pixels) {
-			return safeInsetRawLeft;
-		}
 		return safeInsetLeft;
 	}
 
 	@Override
 	public int getSafeInsetTop() {
-		if (config.hdpiMode == HdpiMode.Pixels) {
-		    return safeInsetRawTop;
-		}
 		return safeInsetTop;
 	}
 
 	@Override
 	public int getSafeInsetBottom() {
-		if (config.hdpiMode == HdpiMode.Pixels) {
-			return safeInsetRawBottom;
-		}
 		return safeInsetBottom;
 	}
 
 	@Override
 	public int getSafeInsetRight() {
-		if (config.hdpiMode == HdpiMode.Pixels) {
-			return safeInsetRawRight;
-		}
 		return safeInsetRight;
 	}
 

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSUIViewController.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSUIViewController.java
@@ -81,9 +81,9 @@ public class IOSUIViewController extends GLKViewController {
 			graphics.makeCurrent();
 			graphics.updateSafeInsets();
 			if (graphics.config.hdpiMode == HdpiMode.Pixels) {
-				app.listener.resize(newBounds.width, newBounds.height);
-			} else {
 				app.listener.resize(newBounds.backBufferWidth, newBounds.backBufferHeight);
+			} else {
+				app.listener.resize(newBounds.width, newBounds.height);
 			}
 		}
 

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSUIViewController.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSUIViewController.java
@@ -1,5 +1,6 @@
 package com.badlogic.gdx.backends.iosrobovm;
 
+import com.badlogic.gdx.graphics.glutils.HdpiMode;
 import org.robovm.apple.foundation.NSSet;
 import org.robovm.apple.glkit.GLKViewController;
 import org.robovm.apple.uikit.UIInterfaceOrientation;
@@ -79,7 +80,11 @@ public class IOSUIViewController extends GLKViewController {
 		if (graphics.created && (newBounds.width != oldBounds.width || newBounds.height != oldBounds.height)) {
 			graphics.makeCurrent();
 			graphics.updateSafeInsets();
-			app.listener.resize(newBounds.width, newBounds.height);
+			if (graphics.config.hdpiMode == HdpiMode.Pixels) {
+				app.listener.resize(newBounds.width, newBounds.height);
+			} else {
+				app.listener.resize(newBounds.backBufferWidth, newBounds.backBufferHeight);
+			}
 		}
 
 	}


### PR DESCRIPTION
This change adds a HdpiMode option to the iOS backend's IOSApplicationConfiguration, which is used to calculate pixel coordinates for input and return heights and widths in raw pixels on the `getWidth()` etc calls. Safe areas are also returned in raw pixel sizes. The default is left as Logical pixels, the current iOS behaviour.

The rationale behind this is that some LibGDX games - including my own - use pixel scaling for things like UI positioning, texture tiling, and font generation. Porting to the new "logical pixels" system proved to be very difficult. This gives developers the same option they have on the LWJGL3 backend, and more closely matches the Android backend which to my knowledge always uses raw pixels. I've tested it with my own game and it seems to work.