### PR TITLE
Add a Pool#discard(T) method.

### DIFF
--- a/gdx/src/com/badlogic/gdx/utils/Pool.java
+++ b/gdx/src/com/badlogic/gdx/utils/Pool.java
@@ -25,7 +25,7 @@ abstract public class Pool<T> {
 	/** The highest number of free objects. Can be reset any time. */
 	public int peak;
 
-	private final Array<T> freeObjects;
+	protected final Array<T> freeObjects;
 
 	/** Creates a pool with an initial capacity of 16 and no maximum. */
 	public Pool () {

--- a/gdx/src/com/badlogic/gdx/utils/Pool.java
+++ b/gdx/src/com/badlogic/gdx/utils/Pool.java
@@ -25,7 +25,7 @@ abstract public class Pool<T> {
 	/** The highest number of free objects. Can be reset any time. */
 	public int peak;
 
-	protected final Array<T> freeObjects;
+	private final Array<T> freeObjects;
 
 	/** Creates a pool with an initial capacity of 16 and no maximum. */
 	public Pool () {
@@ -54,7 +54,7 @@ abstract public class Pool<T> {
 	}
 
 	/** Puts the specified object in the pool, making it eligible to be returned by {@link #obtain()}. If the pool already contains
-	 * {@link #max} free objects, the specified object is reset but not added to the pool.
+	 * {@link #max} free objects, the specified object is {@link #discard(Object) discarded} and not added to the pool.
 	 * <p>
 	 * The pool does not check if an object is already freed, so the same object must not be freed multiple times. */
 	public void free (T object) {
@@ -62,8 +62,10 @@ abstract public class Pool<T> {
 		if (freeObjects.size < max) {
 			freeObjects.add(object);
 			peak = Math.max(peak, freeObjects.size);
+			reset(object);
+		} else {
+			discard(object);
 		}
-		reset(object);
 	}
 
 	/** Adds the specified number of new free objects to the pool. Usually called early on as a pre-allocation mechanism but can be
@@ -82,6 +84,11 @@ abstract public class Pool<T> {
 		if (object instanceof Poolable) ((Poolable)object).reset();
 	}
 
+	/** Called when an object is discarded. This is the case when an object is freed, but the maximum capacity of the pool is reached,
+	 * and when the pool is {@link #clear() cleared} */
+	protected void discard (T object) {
+	}
+
 	/** Puts the specified objects in the pool. Null objects within the array are silently ignored.
 	 * <p>
 	 * The pool does not check if an object is already freed, so the same object must not be freed multiple times.
@@ -93,15 +100,22 @@ abstract public class Pool<T> {
 		for (int i = 0, n = objects.size; i < n; i++) {
 			T object = objects.get(i);
 			if (object == null) continue;
-			if (freeObjects.size < max) freeObjects.add(object);
-			reset(object);
+			if (freeObjects.size < max) {
+				freeObjects.add(object);
+				reset(object);
+			} else {
+				discard(object);
+			}
 		}
 		peak = Math.max(peak, freeObjects.size);
 	}
 
-	/** Removes all free objects from this pool. */
+	/** Removes and discards all free objects from this pool. */
 	public void clear () {
-		freeObjects.clear();
+		for (int i = 0; i < freeObjects.size; i++) {
+			T obj = freeObjects.pop();
+			discard(obj);
+		}
 	}
 
 	/** The number of objects available to be obtained. */


### PR DESCRIPTION
I'm using libGDX's `Pool` with disposable objects. When an object is freed, but the maximum capacity of the pool is reached, in addition to discarding the object, I'd like to dispose it. However, simply overriding [`Pool<T>#free(T)`](https://github.com/libgdx/libgdx/blob/f99e6947777c89db8e99f351cb73e975a5d7840c/gdx/src/com/badlogic/gdx/utils/Pool.java#L60-L67) and adding that functionality is not possible, since I can't modify the private Array `freeObjects`.

Alternatively, I could just copy the whole class , but that makes it incompatible with [Pools](https://github.com/libgdx/libgdx/blob/80af4ba653789bc44488b9910e04d668eaa3ca7f/gdx/src/com/badlogic/gdx/utils/Pools.java#L22).

