### PR TITLE
fix TextureArray mipmap generation, fixes #6380

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/glutils/FileTextureArrayData.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/FileTextureArrayData.java
@@ -86,6 +86,9 @@ public class FileTextureArrayData implements TextureArrayData {
 					disposePixmap = true;
 				}
 				Gdx.gl30.glTexSubImage3D(GL30.GL_TEXTURE_2D_ARRAY, 0, 0, 0, i, pixmap.getWidth(), pixmap.getHeight(), 1, pixmap.getGLInternalFormat(), pixmap.getGLType(), pixmap.getPixels());
+				if (useMipMaps) {
+					Gdx.gl20.glGenerateMipmap(GL30.GL_TEXTURE_2D_ARRAY);
+				}
 				if (disposePixmap) pixmap.dispose();
 			}
 		}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/TextureArrayTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/TextureArrayTest.java
@@ -18,6 +18,7 @@ package com.badlogic.gdx.tests.g3d;
 
 import com.badlogic.gdx.Application;
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Mesh;
@@ -27,13 +28,17 @@ import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.TextureArray;
 import com.badlogic.gdx.graphics.VertexAttribute;
 import com.badlogic.gdx.graphics.VertexAttributes;
+import com.badlogic.gdx.graphics.Texture.TextureFilter;
 import com.badlogic.gdx.graphics.g3d.utils.FirstPersonCameraController;
 import com.badlogic.gdx.graphics.glutils.ShaderProgram;
+import com.badlogic.gdx.graphics.profiling.GLErrorListener;
 import com.badlogic.gdx.graphics.profiling.GLProfiler;
 import com.badlogic.gdx.math.Matrix4;
 import com.badlogic.gdx.tests.utils.GdxTest;
+import com.badlogic.gdx.tests.utils.GdxTestConfig;
 
 /** @author Tomski **/
+@GdxTestConfig(requireGL30=true)
 public class TextureArrayTest extends GdxTest {
 
 	TextureArray textureArray;
@@ -66,8 +71,14 @@ public class TextureArrayTest extends GdxTest {
 		cameraController = new FirstPersonCameraController(camera);
 		Gdx.input.setInputProcessor(cameraController);
 
-		textureArray = new TextureArray(texPaths);
+		FileHandle [] texFiles = new FileHandle[texPaths.length];
+		for(int i=0 ; i<texPaths.length ; i++){
+			texFiles[i] = Gdx.files.internal(texPaths[i]);
+		}
+		
+		textureArray = new TextureArray(true, texFiles);
 		textureArray.setWrap(Texture.TextureWrap.Repeat, Texture.TextureWrap.Repeat);
+		textureArray.setFilter(TextureFilter.MipMapLinearLinear, TextureFilter.Linear);
 		shaderProgram = new ShaderProgram(Gdx.files.internal("data/shaders/texturearray.vert"), Gdx.files.internal("data/shaders/texturearray.frag"));
 		System.out.println(shaderProgram.getLog());
 


### PR DESCRIPTION
Mipmap generation was missing.

Note that MipMapGenerator is not used in this context since GL30 is available.