### PR TITLE
implement loading Tiled Point objects

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+[1.9.15]
+- [BREAKING CHANGE] BaseTmxMapLoader no longer parses point objects into zero-sized RectangleMapObject. Instead, points are now represented with PointMapObject
+
 [1.9.14]
 - [BREAKING CHANGE] iOS: IOSUIViewController has been moved to its own separate class 
 - [BREAKING CHANGE] API Change: G3D AnimationDesc#update now returns -1 (instead of 0) if animation not finished.

--- a/gdx/res/com/badlogic/gdx.gwt.xml
+++ b/gdx/res/com/badlogic/gdx.gwt.xml
@@ -300,6 +300,7 @@
 		<include name="maps/objects/PolylineMapObject.java"/>
 		<include name="maps/objects/RectangleMapObject.java"/>
 		<include name="maps/objects/TextureMapObject.java"/>
+        <include name="maps/objects/PointMapObject.java"/>
 	
 	<!-- maps/tiled -->
 		<include name="maps/tiled/AtlasTmxMapLoader.java"/>

--- a/gdx/src/com/badlogic/gdx/maps/objects/PointMapObject.java
+++ b/gdx/src/com/badlogic/gdx/maps/objects/PointMapObject.java
@@ -1,0 +1,29 @@
+package com.badlogic.gdx.maps.objects;
+
+import com.badlogic.gdx.maps.MapObject;
+import com.badlogic.gdx.math.Vector2;
+
+/** @brief Represents 2D points on the map */
+public class PointMapObject extends MapObject {
+
+    private final Vector2 point;
+
+    /** creates a 2D point map object at (0, 0) */
+    public PointMapObject() {
+        this(0, 0);
+    }
+
+    /** Creates a 2D point map object
+     * @param x X coordinate
+     * @param y Y coordinate
+     * */
+    public PointMapObject(float x, float y) {
+        point = new Vector2(x, y);
+    }
+
+    /** @return 2D point on the map as {@link Vector2} */
+    public Vector2 getPoint() {
+        return point;
+    }
+
+}

--- a/gdx/src/com/badlogic/gdx/maps/objects/PointMapObject.java
+++ b/gdx/src/com/badlogic/gdx/maps/objects/PointMapObject.java
@@ -1,29 +1,53 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
 package com.badlogic.gdx.maps.objects;
 
 import com.badlogic.gdx.maps.MapObject;
 import com.badlogic.gdx.math.Vector2;
 
-/** @brief Represents 2D points on the map */
+/**
+ * @brief Represents 2D points on the map
+ */
 public class PointMapObject extends MapObject {
 
-    private final Vector2 point;
+	private final Vector2 point;
 
-    /** creates a 2D point map object at (0, 0) */
-    public PointMapObject() {
-        this(0, 0);
-    }
+	/**
+	 * creates a 2D point map object at (0, 0)
+	 */
+	public PointMapObject () {
+		this(0, 0);
+	}
 
-    /** Creates a 2D point map object
-     * @param x X coordinate
-     * @param y Y coordinate
-     * */
-    public PointMapObject(float x, float y) {
-        point = new Vector2(x, y);
-    }
+	/**
+	 * Creates a 2D point map object
+	 *
+	 * @param x X coordinate
+	 * @param y Y coordinate
+	 */
+	public PointMapObject (float x, float y) {
+		point = new Vector2(x, y);
+	}
 
-    /** @return 2D point on the map as {@link Vector2} */
-    public Vector2 getPoint() {
-        return point;
-    }
+	/**
+	 * @return 2D point on the map as {@link Vector2}
+	 */
+	public Vector2 getPoint () {
+		return point;
+	}
 
 }

--- a/gdx/src/com/badlogic/gdx/maps/tiled/BaseTmxMapLoader.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/BaseTmxMapLoader.java
@@ -11,10 +11,7 @@ import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Texture.TextureFilter;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.maps.*;
-import com.badlogic.gdx.maps.objects.EllipseMapObject;
-import com.badlogic.gdx.maps.objects.PolygonMapObject;
-import com.badlogic.gdx.maps.objects.PolylineMapObject;
-import com.badlogic.gdx.maps.objects.RectangleMapObject;
+import com.badlogic.gdx.maps.objects.*;
 import com.badlogic.gdx.maps.tiled.TiledMapTileLayer.Cell;
 import com.badlogic.gdx.maps.tiled.objects.TiledMapTileMapObject;
 import com.badlogic.gdx.maps.tiled.tiles.AnimatedTiledMapTile;
@@ -354,7 +351,9 @@ public abstract class BaseTmxMapLoader<P extends BaseTmxMapLoader.Parameters> ex
 					object = new PolylineMapObject(polyline);
 				} else if ((child = element.getChildByName("ellipse")) != null) {
 					object = new EllipseMapObject(x, flipY ? y - height : y, width, height);
-				}
+				} else if ((child = element.getChildByName("point")) != null) {
+				    object = new PointMapObject(x, flipY ? y - height : y);
+                }
 			}
 			if (object == null) {
 				String gid = null;

--- a/gdx/src/com/badlogic/gdx/maps/tiled/BaseTmxMapLoader.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/BaseTmxMapLoader.java
@@ -352,8 +352,8 @@ public abstract class BaseTmxMapLoader<P extends BaseTmxMapLoader.Parameters> ex
 				} else if ((child = element.getChildByName("ellipse")) != null) {
 					object = new EllipseMapObject(x, flipY ? y - height : y, width, height);
 				} else if ((child = element.getChildByName("point")) != null) {
-				    object = new PointMapObject(x, flipY ? y - height : y);
-                }
+					object = new PointMapObject(x, flipY ? y - height : y);
+				}
 			}
 			if (object == null) {
 				String gid = null;
@@ -392,7 +392,7 @@ public abstract class BaseTmxMapLoader<P extends BaseTmxMapLoader.Parameters> ex
 				object.getProperties().put("id", id);
 			}
 			object.getProperties().put("x", x);
-			
+
 			if (object instanceof TiledMapTileMapObject) {
 				object.getProperties().put("y", y);
 			} else {

--- a/tests/gdx-tests-android/assets/data/maps/tiled-objects/test-load-mapobjects.tmx
+++ b/tests/gdx-tests-android/assets/data/maps/tiled-objects/test-load-mapobjects.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="16" height="16" tilewidth="32" tileheight="32" nextobjectid="18">
+<map version="1.4" tiledversion="1.4.3" orientation="orthogonal" renderorder="right-down" width="16" height="16" tilewidth="32" tileheight="32" infinite="0" nextlayerid="2" nextobjectid="20">
  <tileset firstgid="1" name="Test" tilewidth="256" tileheight="256" tilecount="3" columns="0">
   <tile id="0">
    <image width="32" height="32" source="Start.bmp"/>
@@ -15,7 +15,7 @@
    <image width="256" height="256" source="../../badlogic.jpg"/>
   </tile>
  </tileset>
- <objectgroup name="Objects">
+ <objectgroup id="1" name="Objects">
   <object id="3" name="Ellipse" x="59.3333" y="335" width="130" height="87">
    <ellipse/>
   </object>
@@ -27,6 +27,9 @@
   <object id="14" gid="1073741825" x="384" y="256" width="64" height="32"/>
   <object id="17" name="Polyline" x="364" y="155">
    <polyline points="0,0 29,-60 57,4 91,-63"/>
+  </object>
+  <object id="18" name="Point" x="333.265" y="218.203">
+   <point/>
   </object>
  </objectgroup>
 </map>

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapObjectLoadingTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapObjectLoadingTest.java
@@ -29,21 +29,12 @@ import com.badlogic.gdx.maps.MapLayer;
 import com.badlogic.gdx.maps.MapObject;
 import com.badlogic.gdx.maps.MapObjects;
 import com.badlogic.gdx.maps.MapProperties;
-import com.badlogic.gdx.maps.objects.CircleMapObject;
-import com.badlogic.gdx.maps.objects.EllipseMapObject;
-import com.badlogic.gdx.maps.objects.PolygonMapObject;
-import com.badlogic.gdx.maps.objects.PolylineMapObject;
-import com.badlogic.gdx.maps.objects.RectangleMapObject;
-import com.badlogic.gdx.maps.objects.TextureMapObject;
+import com.badlogic.gdx.maps.objects.*;
 import com.badlogic.gdx.maps.tiled.TiledMap;
 import com.badlogic.gdx.maps.tiled.TmxMapLoader;
 import com.badlogic.gdx.maps.tiled.objects.TiledMapTileMapObject;
 import com.badlogic.gdx.maps.tiled.tiles.AnimatedTiledMapTile;
-import com.badlogic.gdx.math.Circle;
-import com.badlogic.gdx.math.Ellipse;
-import com.badlogic.gdx.math.Polygon;
-import com.badlogic.gdx.math.Polyline;
-import com.badlogic.gdx.math.Rectangle;
+import com.badlogic.gdx.math.*;
 import com.badlogic.gdx.tests.utils.GdxTest;
 import com.badlogic.gdx.tests.utils.OrthoCamController;
 import com.badlogic.gdx.utils.ScreenUtils;
@@ -92,6 +83,7 @@ public class TiledMapObjectLoadingTest extends GdxTest {
 		loadingStatus += "- PolylineMapObject : " + mapObjects.getByType(PolylineMapObject.class).size + "\n";
 		loadingStatus += "- RectangleMapObject : " + mapObjects.getByType(RectangleMapObject.class).size + "\n";
 		loadingStatus += "- TextureMapObject : " + mapObjects.getByType(TextureMapObject.class).size + "\n";
+        loadingStatus += "- PointMapObject : " + mapObjects.getByType(PointMapObject.class).size + "\n";
 		loadingStatus += "- TiledMapTileMapObject : " + mapObjects.getByType(TiledMapTileMapObject.class).size + "\n";
 	}
 
@@ -148,7 +140,13 @@ public class TiledMapObjectLoadingTest extends GdxTest {
 				Polyline polyline = ((PolylineMapObject)mapObject).getPolyline();
 				shapeRenderer.polyline(polyline.getTransformedVertices());
 				shapeRenderer.end();
-			}
+			} else if (mapObject instanceof PointMapObject) {
+			    shapeRenderer.begin(ShapeRenderer.ShapeType.Filled);
+			    Vector2 point = ((PointMapObject)mapObject).getPoint();
+			    // drawing circle, because shapeRenderer.point is barely visible, if visible at all
+			    shapeRenderer.circle(point.x, point.y, 1f);
+			    shapeRenderer.end();
+            }
 		}
 		batch.begin();
 		font.draw(batch, "FPS: " + Gdx.graphics.getFramesPerSecond() + "\n" + loadingStatus, 20, 500);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapObjectLoadingTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapObjectLoadingTest.java
@@ -1,13 +1,13 @@
 /**
  * *****************************************************************************
  * Copyright 2011 See AUTHORS file.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -49,8 +49,7 @@ public class TiledMapObjectLoadingTest extends GdxTest {
 	private SpriteBatch batch;
 	private String loadingStatus;
 
-	@Override
-	public void create () {
+	@Override public void create () {
 		float w = Gdx.graphics.getWidth();
 		float h = Gdx.graphics.getHeight();
 
@@ -67,13 +66,13 @@ public class TiledMapObjectLoadingTest extends GdxTest {
 		map = new TmxMapLoader().load("data/maps/tiled-objects/test-load-mapobjects.tmx");
 		MapProperties properties = map.getProperties();
 		shapeRenderer = new ShapeRenderer();
-		
+
 		// Test get objects by type (adding circle manually because it doesn't exists in Tiledmap editor)
-		
+
 		loadingStatus = "loading status:\n";
 		MapLayer layer = map.getLayers().get("Objects");
 		MapObjects mapObjects = layer.getObjects();
-		
+
 		mapObjects.add(new CircleMapObject(280, 400, 50));
 
 		loadingStatus += "- MapObject : " + mapObjects.getByType(MapObject.class).size + "\n";
@@ -83,12 +82,11 @@ public class TiledMapObjectLoadingTest extends GdxTest {
 		loadingStatus += "- PolylineMapObject : " + mapObjects.getByType(PolylineMapObject.class).size + "\n";
 		loadingStatus += "- RectangleMapObject : " + mapObjects.getByType(RectangleMapObject.class).size + "\n";
 		loadingStatus += "- TextureMapObject : " + mapObjects.getByType(TextureMapObject.class).size + "\n";
-        loadingStatus += "- PointMapObject : " + mapObjects.getByType(PointMapObject.class).size + "\n";
+		loadingStatus += "- PointMapObject : " + mapObjects.getByType(PointMapObject.class).size + "\n";
 		loadingStatus += "- TiledMapTileMapObject : " + mapObjects.getByType(TiledMapTileMapObject.class).size + "\n";
 	}
 
-	@Override
-	public void render () {
+	@Override public void render () {
 		ScreenUtils.clear(0.55f, 0.55f, 0.55f, 1f);
 		camera.update();
 		shapeRenderer.setProjectionMatrix(camera.combined);
@@ -98,7 +96,8 @@ public class TiledMapObjectLoadingTest extends GdxTest {
 		MapLayer layer = map.getLayers().get("Objects");
 		AnimatedTiledMapTile.updateAnimationBaseTime();
 		for (MapObject mapObject : layer.getObjects()) {
-			if (!mapObject.isVisible()) continue;
+			if (!mapObject.isVisible())
+				continue;
 			if (mapObject instanceof TiledMapTileMapObject) {
 				batch.begin();
 				TiledMapTileMapObject tmtObject = (TiledMapTileMapObject)mapObject;
@@ -110,8 +109,7 @@ public class TiledMapObjectLoadingTest extends GdxTest {
 				float xPos = tmtObject.getX();
 				float yPos = tmtObject.getY();
 				textureRegion.flip(tmtObject.isFlipHorizontally(), tmtObject.isFlipVertically());
-				batch.draw(textureRegion, xPos, yPos, tmtObject.getOriginX() * scaleX, tmtObject.getOriginY() * scaleY,
-					textureRegion.getRegionWidth() * scaleX, textureRegion.getRegionHeight() * scaleY, 1f, 1f, rotation);
+				batch.draw(textureRegion, xPos, yPos, tmtObject.getOriginX() * scaleX, tmtObject.getOriginY() * scaleY, textureRegion.getRegionWidth() * scaleX, textureRegion.getRegionHeight() * scaleY, 1f, 1f, rotation);
 				// We flip back to the original state.
 				textureRegion.flip(tmtObject.isFlipHorizontally(), tmtObject.isFlipVertically());
 				batch.end();
@@ -141,20 +139,19 @@ public class TiledMapObjectLoadingTest extends GdxTest {
 				shapeRenderer.polyline(polyline.getTransformedVertices());
 				shapeRenderer.end();
 			} else if (mapObject instanceof PointMapObject) {
-			    shapeRenderer.begin(ShapeRenderer.ShapeType.Filled);
-			    Vector2 point = ((PointMapObject)mapObject).getPoint();
-			    // drawing circle, because shapeRenderer.point is barely visible, if visible at all
-			    shapeRenderer.circle(point.x, point.y, 1f);
-			    shapeRenderer.end();
-            }
+				shapeRenderer.begin(ShapeRenderer.ShapeType.Filled);
+				Vector2 point = ((PointMapObject)mapObject).getPoint();
+				// drawing circle, because shapeRenderer.point is barely visible, if visible at all
+				shapeRenderer.circle(point.x, point.y, 1f);
+				shapeRenderer.end();
+			}
 		}
 		batch.begin();
 		font.draw(batch, "FPS: " + Gdx.graphics.getFramesPerSecond() + "\n" + loadingStatus, 20, 500);
 		batch.end();
 	}
 
-	@Override
-	public void dispose () {
+	@Override public void dispose () {
 		map.dispose();
 		shapeRenderer.dispose();
 	}


### PR DESCRIPTION
This pull request adds Tiled Point objects (https://doc.mapeditor.org/en/stable/reference/tmx-map-format/#point).

 As of now, TmxMapLoader parses points into rectangles with zero width/height. This behavior is probably fine as it is, but one could argue that it's counter-intuitive and non-explicit, so, here we are.
 
 It's also a breaking change for all the people who rely on that their points are parsed into zero-sized rectangles. So, if this PR has any value, I'm open to suggestions on how to work around that.
 
 TiledMapObjectLoadingTest is updated to reflect a new type of objects.