### PR TITLE
Add a ParticleEffectActor

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ParticleEffectActor.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ParticleEffectActor.java
@@ -62,8 +62,9 @@ public class ParticleEffectActor extends Actor implements Disposable {
 
     public void start() {
         isRunning = true;
-        if (resetOnStart)
-            particleEffect.reset();
+        if (resetOnStart) {
+            particleEffect.reset(false);
+        }
         particleEffect.start();
     }
 

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ParticleEffectActor.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ParticleEffectActor.java
@@ -18,6 +18,7 @@ public class ParticleEffectActor extends Actor implements Disposable {
     protected boolean isRunning;
     protected boolean ownsEffect;
     private boolean resetOnStart;
+    private boolean autoRemove;
 
     public ParticleEffectActor(ParticleEffect particleEffect, boolean resetOnStart) {
         super();
@@ -58,6 +59,10 @@ public class ParticleEffectActor extends Actor implements Disposable {
         // don't do particleEffect.update() here - the correct position is set  just while we
         // are in draw() method. We save the delta here to update in draw()
         lastDelta += delta;
+
+        if (autoRemove && particleEffect.isComplete()) {
+            remove();
+        }
     }
 
     public void start() {
@@ -72,8 +77,18 @@ public class ParticleEffectActor extends Actor implements Disposable {
         return resetOnStart;
     }
 
-    public void setResetOnStart(boolean resetOnStart) {
+    public ParticleEffectActor setResetOnStart(boolean resetOnStart) {
         this.resetOnStart = resetOnStart;
+        return this;
+    }
+
+    public boolean isAutoRemove() {
+        return autoRemove;
+    }
+
+    public ParticleEffectActor setAutoRemove(boolean autoRemove) {
+        this.autoRemove = autoRemove;
+        return this;
     }
 
     public boolean isRunning() {

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ParticleEffectActor.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ParticleEffectActor.java
@@ -1,0 +1,96 @@
+package com.badlogic.gdx.scenes.scene2d.ui;
+
+import com.badlogic.gdx.files.FileHandle;
+import com.badlogic.gdx.graphics.g2d.Batch;
+import com.badlogic.gdx.graphics.g2d.ParticleEffect;
+import com.badlogic.gdx.graphics.g2d.TextureAtlas;
+import com.badlogic.gdx.scenes.scene2d.Actor;
+
+/**
+ * ParticleEffectActor holds an {@link ParticleEffect} to use in Scene2d applications.
+ * The particle effect is positioned in the centered in the ParticleEffectActor. Its bounding box
+ * is not limited to the size of this actor.
+ */
+public class ParticleEffectActor extends Actor {
+    private final ParticleEffect particleEffect;
+    float lastDelta;
+    boolean isComplete;
+    private boolean resetOnStart;
+
+    public ParticleEffectActor(ParticleEffect particleEffect, boolean resetOnStart) {
+        super();
+        this.particleEffect = particleEffect;
+        this.resetOnStart = resetOnStart;
+    }
+
+    public ParticleEffectActor(FileHandle particleFile, TextureAtlas atlas) {
+        super();
+        particleEffect = new ParticleEffect();
+        particleEffect.load(particleFile, atlas);
+    }
+
+    public ParticleEffectActor(FileHandle particleFile, FileHandle imagesDir) {
+        super();
+        particleEffect = new ParticleEffect();
+        particleEffect.load(particleFile, imagesDir);
+    }
+
+    @Override
+    public void draw(Batch batch, float parentAlpha) {
+        particleEffect.setPosition(getX() + getWidth() / 2, getY() + getHeight() / 2);
+        if (lastDelta > 0) {
+            particleEffect.update(lastDelta);
+            lastDelta = 0;
+        }
+        if (!isComplete) {
+            particleEffect.draw(batch);
+            isComplete = particleEffect.isComplete();
+        }
+    }
+
+    @Override
+    public void act(float delta) {
+        super.act(delta);
+        // don't do particleEffect.update() here - the correct position is set  just while we
+        // are in draw() method. We save the delta here to update in draw()
+        lastDelta = delta;
+    }
+
+    public void start() {
+        isComplete = false;
+        if (resetOnStart)
+            particleEffect.reset();
+        particleEffect.start();
+    }
+
+    public boolean isResetOnStart() {
+        return resetOnStart;
+    }
+
+    public void setResetOnStart(boolean resetOnStart) {
+        this.resetOnStart = resetOnStart;
+    }
+
+    public ParticleEffect getEffect() {
+        return this.particleEffect;
+    }
+
+    @Override
+    protected void scaleChanged() {
+        super.scaleChanged();
+        particleEffect.scaleEffect(getScaleX(), getScaleY(), getScaleY());
+    }
+
+    public void cancel() {
+        isComplete = true;
+    }
+
+    public void allowCompletion() {
+        particleEffect.allowCompletion();
+    }
+
+    public void dispose() {
+        particleEffect.dispose();
+    }
+
+}

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ParticleEffectActor.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ParticleEffectActor.java
@@ -14,7 +14,7 @@ import com.badlogic.gdx.scenes.scene2d.Actor;
 public class ParticleEffectActor extends Actor {
     private final ParticleEffect particleEffect;
     float lastDelta;
-    boolean isComplete;
+    private boolean isComplete = true;
     private boolean resetOnStart;
 
     public ParticleEffectActor(ParticleEffect particleEffect, boolean resetOnStart) {
@@ -65,6 +65,10 @@ public class ParticleEffectActor extends Actor {
 
     public boolean isResetOnStart() {
         return resetOnStart;
+    }
+
+    public boolean isComplete() {
+        return isComplete;
     }
 
     public void setResetOnStart(boolean resetOnStart) {

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ParticleEffectActor.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ParticleEffectActor.java
@@ -5,16 +5,17 @@ import com.badlogic.gdx.graphics.g2d.Batch;
 import com.badlogic.gdx.graphics.g2d.ParticleEffect;
 import com.badlogic.gdx.graphics.g2d.TextureAtlas;
 import com.badlogic.gdx.scenes.scene2d.Actor;
+import com.badlogic.gdx.utils.Disposable;
 
 /**
  * ParticleEffectActor holds an {@link ParticleEffect} to use in Scene2d applications.
  * The particle effect is positioned in the centered in the ParticleEffectActor. Its bounding box
  * is not limited to the size of this actor.
  */
-public class ParticleEffectActor extends Actor {
+public class ParticleEffectActor extends Actor implements Disposable {
     private final ParticleEffect particleEffect;
-    float lastDelta;
-    private boolean isComplete = true;
+    protected float lastDelta;
+    protected boolean isRunning;
     private boolean resetOnStart;
 
     public ParticleEffectActor(ParticleEffect particleEffect, boolean resetOnStart) {
@@ -42,9 +43,9 @@ public class ParticleEffectActor extends Actor {
             particleEffect.update(lastDelta);
             lastDelta = 0;
         }
-        if (!isComplete) {
+        if (isRunning) {
             particleEffect.draw(batch);
-            isComplete = particleEffect.isComplete();
+            isRunning = !particleEffect.isComplete();
         }
     }
 
@@ -53,11 +54,11 @@ public class ParticleEffectActor extends Actor {
         super.act(delta);
         // don't do particleEffect.update() here - the correct position is set  just while we
         // are in draw() method. We save the delta here to update in draw()
-        lastDelta = delta;
+        lastDelta += delta;
     }
 
     public void start() {
-        isComplete = false;
+        isRunning = true;
         if (resetOnStart)
             particleEffect.reset();
         particleEffect.start();
@@ -67,8 +68,8 @@ public class ParticleEffectActor extends Actor {
         return resetOnStart;
     }
 
-    public boolean isComplete() {
-        return isComplete;
+    public boolean isRunning() {
+        return isRunning;
     }
 
     public void setResetOnStart(boolean resetOnStart) {
@@ -86,13 +87,14 @@ public class ParticleEffectActor extends Actor {
     }
 
     public void cancel() {
-        isComplete = true;
+        isRunning = true;
     }
 
     public void allowCompletion() {
         particleEffect.allowCompletion();
     }
 
+    @Override
     public void dispose() {
         particleEffect.dispose();
     }

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ParticleEffectActor.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ParticleEffectActor.java
@@ -9,13 +9,14 @@ import com.badlogic.gdx.utils.Disposable;
 
 /**
  * ParticleEffectActor holds an {@link ParticleEffect} to use in Scene2d applications.
- * The particle effect is positioned in the centered in the ParticleEffectActor. Its bounding box
+ * The particle effect is positioned at 0, 0 in the ParticleEffectActor. Its bounding box
  * is not limited to the size of this actor.
  */
 public class ParticleEffectActor extends Actor implements Disposable {
     private final ParticleEffect particleEffect;
     protected float lastDelta;
     protected boolean isRunning;
+    protected boolean ownsEffect;
     private boolean resetOnStart;
 
     public ParticleEffectActor(ParticleEffect particleEffect, boolean resetOnStart) {
@@ -28,17 +29,19 @@ public class ParticleEffectActor extends Actor implements Disposable {
         super();
         particleEffect = new ParticleEffect();
         particleEffect.load(particleFile, atlas);
+        ownsEffect = true;
     }
 
     public ParticleEffectActor(FileHandle particleFile, FileHandle imagesDir) {
         super();
         particleEffect = new ParticleEffect();
         particleEffect.load(particleFile, imagesDir);
+        ownsEffect = true;
     }
 
     @Override
     public void draw(Batch batch, float parentAlpha) {
-        particleEffect.setPosition(getX() + getWidth() / 2, getY() + getHeight() / 2);
+        particleEffect.setPosition(getX(), getY());
         if (lastDelta > 0) {
             particleEffect.update(lastDelta);
             lastDelta = 0;
@@ -68,12 +71,12 @@ public class ParticleEffectActor extends Actor implements Disposable {
         return resetOnStart;
     }
 
-    public boolean isRunning() {
-        return isRunning;
-    }
-
     public void setResetOnStart(boolean resetOnStart) {
         this.resetOnStart = resetOnStart;
+    }
+
+    public boolean isRunning() {
+        return isRunning;
     }
 
     public ParticleEffect getEffect() {
@@ -96,7 +99,9 @@ public class ParticleEffectActor extends Actor implements Disposable {
 
     @Override
     public void dispose() {
-        particleEffect.dispose();
+        if (ownsEffect) {
+            particleEffect.dispose();
+        }
     }
 
 }


### PR DESCRIPTION
This adds a simple `ParticleEffectActor`. One could discuss if it is useful to show particle effects in Scene2d, but searching on GitHub for ParticleEffectActor shows that there is a need for such an actor in projects. Menus should look good, too, and we have some games completely built on scene2d.

Most ParticleEffectActors out there are inspired by a code from StackOverflow and update the particle effect in `update()` by converting the local coordinates to stage coordinates. This does not work if the ParticleEffectActor is member of a transformed group. The implementation here handles the update in draw(), because only in draw the position is set correctly by the parent.

I am sure this actor will not satisfy everyone's needs and has to be completed in the future. But it is a start.