### PR TITLE
Convert Scaling from an Enum to an Object.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,5 @@
 [1.9.15]
+- [BREAKING CHANGE] API Change: Scaling is now an object instead of an enum. This may change behavior when used with serialization.
 - Scene2d.ui: Added new ParticleEffectActor to use particle effects on Stage
 
 [1.9.14]

--- a/gdx/src/com/badlogic/gdx/utils/Scaling.java
+++ b/gdx/src/com/badlogic/gdx/utils/Scaling.java
@@ -20,93 +20,97 @@ import com.badlogic.gdx.math.Vector2;
 
 /** Various scaling types for fitting one rectangle into another.
  * @author Nathan Sweet */
-public enum Scaling {
+public abstract class Scaling {
 	/** Scales the source to fit the target while keeping the same aspect ratio. This may cause the source to be smaller than the
 	 * target in one direction. */
-	fit,
-	/** Scales the source to fit the target while keeping the same aspect ratio, but the source is not scaled at all if smaller in
-	 * both directions. This may cause the source to be smaller than the target in one or both directions. */
-	contain,
+	public static final Scaling fit = new Scaling() {
+		@Override
+		public Vector2 apply (float sourceWidth, float sourceHeight, float targetWidth, float targetHeight) {
+			float targetRatio = targetHeight / targetWidth;
+			float sourceRatio = sourceHeight / sourceWidth;
+			float scale = targetRatio > sourceRatio ? targetWidth / sourceWidth : targetHeight / sourceHeight;
+			temp.x = sourceWidth * scale;
+			temp.y = sourceHeight * scale;
+			return temp;
+		}
+	};
 	/** Scales the source to fill the target while keeping the same aspect ratio. This may cause the source to be larger than the
 	 * target in one direction. */
-	fill,
-	/** Scales the source to fill the target in the x direction while keeping the same aspect ratio. This may cause the source to
-	 * be smaller or larger than the target in the y direction. */
-	fillX,
-	/** Scales the source to fill the target in the y direction while keeping the same aspect ratio. This may cause the source to
-	 * be smaller or larger than the target in the x direction. */
-	fillY,
-	/** Scales the source to fill the target. This may cause the source to not keep the same aspect ratio. */
-	stretch,
-	/** Scales the source to fill the target in the x direction, without changing the y direction. This may cause the source to not
-	 * keep the same aspect ratio. */
-	stretchX,
-	/** Scales the source to fill the target in the y direction, without changing the x direction. This may cause the source to not
-	 * keep the same aspect ratio. */
-	stretchY,
-	/** The source is not scaled. */
-	none;
-
-	static private final Vector2 temp = new Vector2();
-
-	/** Returns the size of the source scaled to the target. Note the same Vector2 instance is always returned and should never be
-	 * cached. */
-	public Vector2 apply (float sourceWidth, float sourceHeight, float targetWidth, float targetHeight) {
-		switch (this) {
-		case fit: {
-			float targetRatio = targetHeight / targetWidth;
-			float sourceRatio = sourceHeight / sourceWidth;
-			float scale = targetRatio > sourceRatio ? targetWidth / sourceWidth : targetHeight / sourceHeight;
-			temp.x = sourceWidth * scale;
-			temp.y = sourceHeight * scale;
-			break;
-		}
-		case contain: {
-			float targetRatio = targetHeight / targetWidth;
-			float sourceRatio = sourceHeight / sourceWidth;
-			float scale = targetRatio > sourceRatio ? targetWidth / sourceWidth : targetHeight / sourceHeight;
-			if (scale > 1) scale = 1;
-			temp.x = sourceWidth * scale;
-			temp.y = sourceHeight * scale;
-			break;
-		}
-		case fill: {
+	public static final Scaling fill = new Scaling() {
+		@Override
+		public Vector2 apply (float sourceWidth, float sourceHeight, float targetWidth, float targetHeight) {
 			float targetRatio = targetHeight / targetWidth;
 			float sourceRatio = sourceHeight / sourceWidth;
 			float scale = targetRatio < sourceRatio ? targetWidth / sourceWidth : targetHeight / sourceHeight;
 			temp.x = sourceWidth * scale;
 			temp.y = sourceHeight * scale;
-			break;
+			return temp;
 		}
-		case fillX: {
+	};
+	/** Scales the source to fill the target in the x direction while keeping the same aspect ratio. This may cause the source to
+	 * be smaller or larger than the target in the y direction. */
+	public static final Scaling fillX = new Scaling() {
+		@Override
+		public Vector2 apply (float sourceWidth, float sourceHeight, float targetWidth, float targetHeight) {
 			float scale = targetWidth / sourceWidth;
 			temp.x = sourceWidth * scale;
 			temp.y = sourceHeight * scale;
-			break;
+			return temp;
 		}
-		case fillY: {
+	};
+	/** Scales the source to fill the target in the y direction while keeping the same aspect ratio. This may cause the source to
+	 * be smaller or larger than the target in the x direction. */
+	public static final Scaling fillY = new Scaling() {
+		@Override
+		public Vector2 apply (float sourceWidth, float sourceHeight, float targetWidth, float targetHeight) {
 			float scale = targetHeight / sourceHeight;
 			temp.x = sourceWidth * scale;
 			temp.y = sourceHeight * scale;
-			break;
+			return temp;
 		}
-		case stretch:
+	};
+	/** Scales the source to fill the target. This may cause the source to not keep the same aspect ratio. */
+	public static final Scaling stretch = new Scaling() {
+		@Override
+		public Vector2 apply (float sourceWidth, float sourceHeight, float targetWidth, float targetHeight) {
 			temp.x = targetWidth;
 			temp.y = targetHeight;
-			break;
-		case stretchX:
+			return temp;
+		}
+	};
+	/** Scales the source to fill the target in the x direction, without changing the y direction. This may cause the source to not
+	 * keep the same aspect ratio. */
+	public static final Scaling stretchX = new Scaling() {
+		@Override
+		public Vector2 apply (float sourceWidth, float sourceHeight, float targetWidth, float targetHeight) {
 			temp.x = targetWidth;
 			temp.y = sourceHeight;
-			break;
-		case stretchY:
+			return temp;
+		}
+	};
+	/** Scales the source to fill the target in the y direction, without changing the x direction. This may cause the source to not
+	 * keep the same aspect ratio. */
+	public static final Scaling stretchY = new Scaling() {
+		@Override
+		public Vector2 apply (float sourceWidth, float sourceHeight, float targetWidth, float targetHeight) {
 			temp.x = sourceWidth;
 			temp.y = targetHeight;
-			break;
-		case none:
+			return temp;
+		}
+	};
+	/** The source is not scaled. */
+	public static final Scaling none = new Scaling() {
+		@Override
+		public Vector2 apply (float sourceWidth, float sourceHeight, float targetWidth, float targetHeight) {
 			temp.x = sourceWidth;
 			temp.y = sourceHeight;
-			break;
+			return temp;
 		}
-		return temp;
-	}
+	};
+
+	protected static final Vector2 temp = new Vector2();
+
+	/** Returns the size of the source scaled to the target. Note the same Vector2 instance is always returned and should never be
+	 * cached. */
+	public abstract Vector2 apply (float sourceWidth, float sourceHeight, float targetWidth, float targetHeight);
 }


### PR DESCRIPTION
This allows custom Scaling methods.

We have a need for multiple new custom scaling elements, some of which have "fixed" parameters. These wouldn't be very useful for much of libgdx. This change would allow us to add them ourselves.

Scaling doesn't really need to be an Enum, it's never used in any switch statements, it only is to map String names to Scaling objects.

