### PR TITLE
jcenter is shutting down, replace by Gradle Plugins

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,9 +23,9 @@ allprojects {
     buildscript {
         repositories {
             google()
-            jcenter()
             mavenLocal()
             mavenCentral()
+            maven { url 'https://plugins.gradle.org/m2/' }
             maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
         }
         dependencies {
@@ -35,7 +35,6 @@ allprojects {
 
     repositories {
         google()
-        jcenter()
         mavenLocal()
         mavenCentral()
         maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ allprojects {
         google()
         mavenLocal()
         mavenCentral()
+        maven { url 'https://plugins.gradle.org/m2/' }
         maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
     }
 }

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/BuildScriptHelper.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/BuildScriptHelper.java
@@ -36,7 +36,6 @@ public class BuildScriptHelper {
 		write(wr, DependencyBank.mavenCentral);
 		write(wr, "maven { url \"" + DependencyBank.gradlePlugins + "\" }");
 		write(wr, "maven { url \"" + DependencyBank.libGDXSnapshotsUrl + "\" }");
-		write(wr, DependencyBank.jCenter);
 		write(wr, DependencyBank.google);
 		write(wr, "}");
 		//dependencies
@@ -75,7 +74,6 @@ public class BuildScriptHelper {
 		write(wr, "repositories {");
 		write(wr, DependencyBank.mavenLocal);
 		write(wr, DependencyBank.mavenCentral);
-		write(wr, DependencyBank.jCenter);
 		write(wr, DependencyBank.google);
 		write(wr, "maven { url \"" + DependencyBank.libGDXSnapshotsUrl + "\" }");
 		write(wr, "maven { url \"" + DependencyBank.libGDXReleaseUrl + "\" }");

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/DependencyBank.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/DependencyBank.java
@@ -34,7 +34,6 @@ public class DependencyBank {
 	//Repositories
 	static String mavenLocal = "mavenLocal()";
 	static String mavenCentral = "mavenCentral()";
-	static String jCenter = "jcenter()";
 	static String google = "google()";
 	static String gradlePlugins = "https://plugins.gradle.org/m2/";
 	static String libGDXSnapshotsUrl = "https://oss.sonatype.org/content/repositories/snapshots/";


### PR DESCRIPTION
jcenter is shutting down in less than 90 days, so we need to remove it from our build scripts. All dependencies we needed from there are available on Gradle Plugins repo as well.