### PR TITLE
GLES3 added glTexImage2D and glTexSubImage2D with offset parameter

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGL30.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGL30.java
@@ -17,7 +17,6 @@
 package com.badlogic.gdx.backends.android;
 
 import android.annotation.TargetApi;
-import android.opengl.GLES20;
 import android.opengl.GLES30;
 
 import com.badlogic.gdx.graphics.GL30;
@@ -44,7 +43,7 @@ public class AndroidGL30 extends AndroidGL20 implements GL30 {
 	public void glTexImage2D (int target, int level, int internalformat, int width, int height, int border, int format, int type,
 		int offset) {
 		if (offset != 0) throw new GdxRuntimeException("non zero offset is not supported");
-		GLES20.glTexImage2D(target, level, internalformat, width, height, border, format, type, null);
+		GLES30.glTexImage2D(target, level, internalformat, width, height, border, format, type, null);
 	}
 
 	@Override
@@ -66,7 +65,7 @@ public class AndroidGL30 extends AndroidGL20 implements GL30 {
 	public void glTexSubImage2D (int target, int level, int xoffset, int yoffset, int width, int height, int format, int type,
 		int offset) {
 		if (offset != 0) throw new GdxRuntimeException("non zero offset is not supported");
-		GLES20.glTexSubImage2D(target, level, xoffset, yoffset, width, height, format, type, null);
+		GLES30.glTexSubImage2D(target, level, xoffset, yoffset, width, height, format, type, null);
 	}
 
 	@Override

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGL30.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGL30.java
@@ -17,9 +17,11 @@
 package com.badlogic.gdx.backends.android;
 
 import android.annotation.TargetApi;
+import android.opengl.GLES20;
 import android.opengl.GLES30;
 
 import com.badlogic.gdx.graphics.GL30;
+import com.badlogic.gdx.utils.GdxRuntimeException;
 
 @TargetApi(18)
 public class AndroidGL30 extends AndroidGL20 implements GL30 {
@@ -39,6 +41,13 @@ public class AndroidGL30 extends AndroidGL20 implements GL30 {
 	}
 
 	@Override
+	public void glTexImage2D (int target, int level, int internalformat, int width, int height, int border, int format, int type,
+		int offset) {
+		if (offset != 0) throw new GdxRuntimeException("non zero offset is not supported");
+		GLES20.glTexImage2D(target, level, internalformat, width, height, border, format, type, null);
+	}
+
+	@Override
 	public void glTexImage3D (int target, int level, int internalformat, int width, int height, int depth, int border, int format,
 		int type, java.nio.Buffer pixels) {
 		if (pixels == null)
@@ -51,6 +60,13 @@ public class AndroidGL30 extends AndroidGL20 implements GL30 {
 	public void glTexImage3D (int target, int level, int internalformat, int width, int height, int depth, int border, int format,
 		int type, int offset) {
 		GLES30.glTexImage3D(target, level, internalformat, width, height, depth, border, format, type, offset);
+	}
+
+	@Override
+	public void glTexSubImage2D (int target, int level, int xoffset, int yoffset, int width, int height, int format, int type,
+		int offset) {
+		if (offset != 0) throw new GdxRuntimeException("non zero offset is not supported");
+		GLES20.glTexSubImage2D(target, level, xoffset, yoffset, width, height, format, type, null);
 	}
 
 	@Override

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGL30.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGL30.java
@@ -671,5 +671,4 @@ class LwjglGL30 extends LwjglGL20 implements com.badlogic.gdx.graphics.GL30 {
 		int height) {
 		GL43.glInvalidateSubFramebuffer(target, attachments, x, y, width, height);
 	}
-
 }

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGL30.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGL30.java
@@ -63,6 +63,12 @@ class LwjglGL30 extends LwjglGL20 implements com.badlogic.gdx.graphics.GL30 {
 	}
 
 	@Override
+	public void glTexImage2D (int target, int level, int internalformat, int width, int height, int border, int format, int type,
+		int offset) {
+		GL11.glTexImage2D(target, level, internalformat, width, height, border, format, type, offset);
+	}
+
+	@Override
 	public void glTexImage3D (int target, int level, int internalformat, int width, int height, int depth, int border, int format,
 		int type, Buffer pixels) {
 		if (pixels == null)
@@ -86,6 +92,12 @@ class LwjglGL30 extends LwjglGL20 implements com.badlogic.gdx.graphics.GL30 {
 	public void glTexImage3D (int target, int level, int internalformat, int width, int height, int depth, int border, int format,
 		int type, int offset) {
 		GL12.glTexImage3D(target, level, internalformat, width, height, depth, border, format, type, offset);
+	}
+
+	@Override
+	public void glTexSubImage2D (int target, int level, int xoffset, int yoffset, int width, int height, int format, int type,
+		int offset) {
+		GL11.glTexSubImage2D(target, level, xoffset, yoffset, width, height, format, type, offset);
 	}
 
 	@Override
@@ -659,4 +671,5 @@ class LwjglGL30 extends LwjglGL20 implements com.badlogic.gdx.graphics.GL30 {
 		int height) {
 		GL43.glInvalidateSubFramebuffer(target, attachments, x, y, width, height);
 	}
+
 }

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3GL30.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3GL30.java
@@ -63,6 +63,12 @@ class Lwjgl3GL30 extends Lwjgl3GL20 implements com.badlogic.gdx.graphics.GL30 {
 	}
 
 	@Override
+	public void glTexImage2D (int target, int level, int internalformat, int width, int height, int border, int format, int type,
+		int offset) {
+		GL11.glTexImage2D(target, level, internalformat, width, height, border, format, type, offset);
+	}
+
+	@Override
 	public void glTexImage3D (int target, int level, int internalformat, int width, int height, int depth, int border, int format,
 		int type, Buffer pixels) {
 		if (pixels == null)
@@ -86,6 +92,12 @@ class Lwjgl3GL30 extends Lwjgl3GL20 implements com.badlogic.gdx.graphics.GL30 {
 	public void glTexImage3D (int target, int level, int internalformat, int width, int height, int depth, int border, int format,
 		int type, int offset) {
 		GL12.glTexImage3D(target, level, internalformat, width, height, depth, border, format, type, offset);
+	}
+
+	@Override
+	public void glTexSubImage2D (int target, int level, int xoffset, int yoffset, int width, int height, int format, int type,
+		int offset) {
+		GL11.glTexSubImage2D(target, level, xoffset, yoffset, width, height, format, type, offset);
 	}
 
 	@Override
@@ -660,4 +672,5 @@ class Lwjgl3GL30 extends Lwjgl3GL20 implements com.badlogic.gdx.graphics.GL30 {
 		int height) {
 		GL43.glInvalidateSubFramebuffer(target, attachments, x, y, width, height);
 	}
+
 }

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3GL30.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3GL30.java
@@ -672,5 +672,4 @@ class Lwjgl3GL30 extends Lwjgl3GL20 implements com.badlogic.gdx.graphics.GL30 {
 		int height) {
 		GL43.glInvalidateSubFramebuffer(target, attachments, x, y, width, height);
 	}
-
 }

--- a/backends/gdx-backend-robovm-metalangle/src/com/badlogic/gdx/backends/iosrobovm/IOSGLES30.java
+++ b/backends/gdx-backend-robovm-metalangle/src/com/badlogic/gdx/backends/iosrobovm/IOSGLES30.java
@@ -23,6 +23,9 @@ public class IOSGLES30 extends IOSGLES20 implements GL30 {
 
 	public native void glDrawRangeElements (int mode, int start, int end, int count, int type, int offset);
 
+	public native void glTexImage2D (int target, int level, int xoffset, int yoffset, int width, int height, int format, int type,
+		int offset);
+
 	public void glTexImage3D (int target, int level, int internalformat, int width, int height, int depth, int border, int format,
 		int type, Buffer pixels) {
 		if (!shouldConvert16bit) {
@@ -42,6 +45,9 @@ public class IOSGLES30 extends IOSGLES20 implements GL30 {
 
 	public native void glTexImage3D (int target, int level, int internalformat, int width, int height, int depth, int border,
 		int format, int type, int offset);
+
+	public native void glTexSubImage2D (int target, int level, int xoffset, int yoffset, int width, int height, int format,
+		int type, int offset);
 
 	public void glTexSubImage3D (int target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth,
 		int format, int type, Buffer pixels) {

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGLES30.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGLES30.java
@@ -22,7 +22,8 @@ public class IOSGLES30 extends IOSGLES20 implements GL30 {
 
 	public native void glDrawRangeElements (int mode, int start, int end, int count, int type, int offset);
 
-	public native void glTexImage2D (int target, int level, int xoffset, int yoffset, int width, int height, int format, int type, int offset);
+	public native void glTexImage2D (int target, int level, int xoffset, int yoffset, int width, int height, int format, int type,
+		int offset);
 
 	public void glTexImage3D (int target, int level, int internalformat, int width, int height, int depth, int border, int format,
 		int type, Buffer pixels) {
@@ -45,7 +46,8 @@ public class IOSGLES30 extends IOSGLES20 implements GL30 {
 	public native void glTexImage3D (int target, int level, int internalformat, int width, int height, int depth, int border,
 		int format, int type, int offset);
 
-	public native void glTexSubImage2D (int target, int level, int xoffset, int yoffset, int width, int height, int format, int type, int offset);
+	public native void glTexSubImage2D (int target, int level, int xoffset, int yoffset, int width, int height, int format,
+		int type, int offset);
 
 	public void glTexSubImage3D (int target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth,
 		int format, int type, Buffer pixels) {

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGLES30.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGLES30.java
@@ -22,6 +22,8 @@ public class IOSGLES30 extends IOSGLES20 implements GL30 {
 
 	public native void glDrawRangeElements (int mode, int start, int end, int count, int type, int offset);
 
+	public native void glTexImage2D (int target, int level, int xoffset, int yoffset, int width, int height, int format, int type, int offset);
+
 	public void glTexImage3D (int target, int level, int internalformat, int width, int height, int depth, int border, int format,
 		int type, Buffer pixels) {
 		if (!shouldConvert16bit) {
@@ -42,6 +44,8 @@ public class IOSGLES30 extends IOSGLES20 implements GL30 {
 
 	public native void glTexImage3D (int target, int level, int internalformat, int width, int height, int depth, int border,
 		int format, int type, int offset);
+
+	public native void glTexSubImage2D (int target, int level, int xoffset, int yoffset, int width, int height, int format, int type, int offset);
 
 	public void glTexSubImage3D (int target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth,
 		int format, int type, Buffer pixels) {

--- a/gdx/jni/iosgl/iosgl30.cpp
+++ b/gdx/jni/iosgl/iosgl30.cpp
@@ -148,7 +148,7 @@ JNIEXPORT void JNICALL Java_com_badlogic_gdx_backends_iosrobovm_IOSGLES30_glDraw
 JNIEXPORT void JNICALL Java_com_badlogic_gdx_backends_iosrobovm_IOSGLES30_glTexImage2D
   (JNIEnv *env, jobject, jint target, jint level, jint internalformat, jint width, jint height, jint border, jint format, jint type, jint offset)
 {
-	glTexImage2D( target, level, internalformat, width, height, border, format, type, (void *)&offset );
+	glTexImage2D( target, level, internalformat, width, height, border, format, type, (void*)offset);
 }
 
 /*
@@ -180,7 +180,7 @@ JNIEXPORT void JNICALL Java_com_badlogic_gdx_backends_iosrobovm_IOSGLES30_glTexI
 JNIEXPORT void JNICALL Java_com_badlogic_gdx_backends_iosrobovm_IOSGLES30_glTexSubImage2D
   (JNIEnv *env, jobject, jint target, jint level, jint xoffset, jint yoffset, jint width, jint height, jint format, jint type, jint offset)
 {
-	glTexSubImage2D( target, level, xoffset, yoffset, width, height, format, type, (void *)&offset );
+	glTexSubImage2D( target, level, xoffset, yoffset, width, height, format, type, (void*)offset);
 }
 
 /*

--- a/gdx/jni/iosgl/iosgl30.cpp
+++ b/gdx/jni/iosgl/iosgl30.cpp
@@ -142,6 +142,17 @@ JNIEXPORT void JNICALL Java_com_badlogic_gdx_backends_iosrobovm_IOSGLES30_glDraw
 
 /*
  * Class:     com_badlogic_gdx_backends_iosrobovm_IOSGLES30
+ * Method:    glTexImage2D
+ * Signature: (IIIIIIIII)V
+ */
+JNIEXPORT void JNICALL Java_com_badlogic_gdx_backends_iosrobovm_IOSGLES30_glTexImage2D
+  (JNIEnv *env, jobject, jint target, jint level, jint internalformat, jint width, jint height, jint border, jint format, jint type, jint offset)
+{
+	glTexImage2D( target, level, internalformat, width, height, border, format, type, (void *)&offset );
+}
+
+/*
+ * Class:     com_badlogic_gdx_backends_iosrobovm_IOSGLES30
  * Method:    glTexImage3DJNI
  * Signature: (IIIIIIIIILjava/nio/Buffer;)V
  */
@@ -159,6 +170,17 @@ JNIEXPORT void JNICALL Java_com_badlogic_gdx_backends_iosrobovm_IOSGLES30_glTexI
 JNIEXPORT void JNICALL Java_com_badlogic_gdx_backends_iosrobovm_IOSGLES30_glTexImage3D__IIIIIIIIII
   (JNIEnv *env, jobject, jint target, jint level, jint internalformat, jint width, jint height, jint depth, jint border, jint format, jint type, jint offset) {
     glTexImage3D(target, level, internalformat, width, height, depth, border, format, type, (void*)offset);
+}
+
+/*
+ * Class:     com_badlogic_gdx_backends_iosrobovm_IOSGLES30
+ * Method:    glTexSubImage2D
+ * Signature: (IIIIIIIIJ)V
+ */
+JNIEXPORT void JNICALL Java_com_badlogic_gdx_backends_iosrobovm_IOSGLES30_glTexSubImage2D
+  (JNIEnv *env, jobject, jint target, jint level, jint xoffset, jint yoffset, jint width, jint height, jint format, jint type, jint offset)
+{
+	glTexSubImage2D( target, level, xoffset, yoffset, width, height, format, type, (void *)&offset );
 }
 
 /*

--- a/gdx/jni/iosgl/iosgl30.h
+++ b/gdx/jni/iosgl/iosgl30.h
@@ -41,6 +41,17 @@ JNIEXPORT void JNICALL Java_com_badlogic_gdx_backends_iosrobovm_IOSGLES30_glDraw
 
 /*
  * Class:     com_badlogic_gdx_backends_iosrobovm_IOSGLES30
+ * Method:    glTexSubImage2D
+ * Signature: (IIIIIIIIJ)V
+ */
+JNIEXPORT void JNICALL Java_com_badlogic_gdx_backends_iosrobovm_IOSGLES30_glTexSubImage2D
+  (JNIEnv *env, jobject, jint target, jint level, jint xoffset, jint yoffset, jint width, jint height, jint format, jint type, jint offset)
+{
+	glTexSubImage2D( target, level, xoffset, yoffset, width, height, format, type, (void *)&offset );
+}
+
+/*
+ * Class:     com_badlogic_gdx_backends_iosrobovm_IOSGLES30
  * Method:    glTexImage3DJNI
  * Signature: (IIIIIIIIILjava/nio/Buffer;)V
  */
@@ -54,6 +65,14 @@ JNIEXPORT void JNICALL Java_com_badlogic_gdx_backends_iosrobovm_IOSGLES30_glTexI
  */
 JNIEXPORT void JNICALL Java_com_badlogic_gdx_backends_iosrobovm_IOSGLES30_glTexImage3D__IIIIIIIIII
   (JNIEnv *, jobject, jint, jint, jint, jint, jint, jint, jint, jint, jint, jint);
+
+/*
+ * Class:     com_badlogic_gdx_backends_iosrobovm_IOSGLES30
+ * Method:    glTexSubImage2D
+ * Signature: (IIIIIIIII)V
+ */
+JNIEXPORT void JNICALL Java_com_badlogic_gdx_backends_iosrobovm_IOSGLES30_glTexSubImage2D
+  (JNIEnv *, jobject, jint, jint, jint, jint, jint, jint, jint, jint, jint);
 
 /*
  * Class:     com_badlogic_gdx_backends_iosrobovm_IOSGLES30

--- a/gdx/jni/iosgl/iosgl30.h
+++ b/gdx/jni/iosgl/iosgl30.h
@@ -41,21 +41,18 @@ JNIEXPORT void JNICALL Java_com_badlogic_gdx_backends_iosrobovm_IOSGLES30_glDraw
 
 /*
  * Class:     com_badlogic_gdx_backends_iosrobovm_IOSGLES30
- * Method:    glTexSubImage2D
- * Signature: (IIIIIIIIJ)V
+ * Method:    glTexImage2D
+ * Signature: (IIIIIIIII)V
  */
-JNIEXPORT void JNICALL Java_com_badlogic_gdx_backends_iosrobovm_IOSGLES30_glTexSubImage2D
-  (JNIEnv *env, jobject, jint target, jint level, jint xoffset, jint yoffset, jint width, jint height, jint format, jint type, jint offset)
-{
-	glTexSubImage2D( target, level, xoffset, yoffset, width, height, format, type, (void *)&offset );
-}
+JNIEXPORT void JNICALL Java_com_badlogic_gdx_backends_iosrobovm_IOSGLES30_glTexImage2D
+  (JNIEnv *, jobject, jint, jint, jint, jint, jint, jint, jint, jint, jint);
 
 /*
  * Class:     com_badlogic_gdx_backends_iosrobovm_IOSGLES30
  * Method:    glTexImage3DJNI
  * Signature: (IIIIIIIIILjava/nio/Buffer;)V
  */
-JNIEXPORT void JNICALL Java_com_badlogic_gdx_backends_iosrobovm_IOSGLES30_glTexImage3DJNI__IIIIIIIIILjava_nio_Buffer_2
+JNIEXPORT void JNICALL Java_com_badlogic_gdx_backends_iosrobovm_IOSGLES30_glTexImage3DJNI
   (JNIEnv *, jobject, jint, jint, jint, jint, jint, jint, jint, jint, jint, jobject);
 
 /*
@@ -63,7 +60,7 @@ JNIEXPORT void JNICALL Java_com_badlogic_gdx_backends_iosrobovm_IOSGLES30_glTexI
  * Method:    glTexImage3D
  * Signature: (IIIIIIIIII)V
  */
-JNIEXPORT void JNICALL Java_com_badlogic_gdx_backends_iosrobovm_IOSGLES30_glTexImage3D__IIIIIIIIII
+JNIEXPORT void JNICALL Java_com_badlogic_gdx_backends_iosrobovm_IOSGLES30_glTexImage3D
   (JNIEnv *, jobject, jint, jint, jint, jint, jint, jint, jint, jint, jint, jint);
 
 /*
@@ -79,7 +76,7 @@ JNIEXPORT void JNICALL Java_com_badlogic_gdx_backends_iosrobovm_IOSGLES30_glTexS
  * Method:    glTexSubImage3DJNI
  * Signature: (IIIIIIIIIILjava/nio/Buffer;)V
  */
-JNIEXPORT void JNICALL Java_com_badlogic_gdx_backends_iosrobovm_IOSGLES30_glTexSubImage3DJNI__IIIIIIIIIILjava_nio_Buffer_2
+JNIEXPORT void JNICALL Java_com_badlogic_gdx_backends_iosrobovm_IOSGLES30_glTexSubImage3DJNI
   (JNIEnv *, jobject, jint, jint, jint, jint, jint, jint, jint, jint, jint, jint, jobject);
 
 /*
@@ -87,7 +84,7 @@ JNIEXPORT void JNICALL Java_com_badlogic_gdx_backends_iosrobovm_IOSGLES30_glTexS
  * Method:    glTexSubImage3D
  * Signature: (IIIIIIIIIII)V
  */
-JNIEXPORT void JNICALL Java_com_badlogic_gdx_backends_iosrobovm_IOSGLES30_glTexSubImage3D__IIIIIIIIIII
+JNIEXPORT void JNICALL Java_com_badlogic_gdx_backends_iosrobovm_IOSGLES30_glTexSubImage3D
   (JNIEnv *, jobject, jint, jint, jint, jint, jint, jint, jint, jint, jint, jint, jint);
 
 /*
@@ -265,7 +262,6 @@ JNIEXPORT void JNICALL Java_com_badlogic_gdx_backends_iosrobovm_IOSGLES30_glRend
  */
 JNIEXPORT void JNICALL Java_com_badlogic_gdx_backends_iosrobovm_IOSGLES30_glFramebufferTextureLayer
   (JNIEnv *, jobject, jint, jint, jint, jint, jint);
-
 
 /*
  * Class:     com_badlogic_gdx_backends_iosrobovm_IOSGLES30

--- a/gdx/src/com/badlogic/gdx/graphics/GL30.java
+++ b/gdx/src/com/badlogic/gdx/graphics/GL30.java
@@ -344,6 +344,9 @@ public interface GL30 extends GL20 {
 
 	public void glDrawRangeElements (int mode, int start, int end, int count, int type, int offset);
 
+	public void glTexImage2D (int target, int level, int internalformat, int width, int height, int border, int format, int type,
+		int offset);
+
 	// C function void glTexImage3D ( GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height, GLsizei
 // depth, GLint border, GLenum format, GLenum type, const GLvoid *pixels )
 
@@ -355,6 +358,9 @@ public interface GL30 extends GL20 {
 
 	public void glTexImage3D (int target, int level, int internalformat, int width, int height, int depth, int border, int format,
 		int type, int offset);
+
+	public void glTexSubImage2D (int target, int level, int xoffset, int yoffset, int width, int height, int format, int type,
+		int offset);
 
 	// C function void glTexSubImage3D ( GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset, GLsizei width,
 // GLsizei height, GLsizei depth, GLenum format, GLenum type, const GLvoid *pixels )

--- a/gdx/src/com/badlogic/gdx/graphics/profiling/GL30Interceptor.java
+++ b/gdx/src/com/badlogic/gdx/graphics/profiling/GL30Interceptor.java
@@ -334,6 +334,14 @@ public class GL30Interceptor extends GLInterceptor implements GL30 {
 	}
 
 	@Override
+	public void glTexImage2D (int target, int level, int internalformat, int width, int height, int border, int format, int type,
+		int offset) {
+		calls++;
+		gl30.glTexImage2D(target, level, internalformat, width, height, border, format, type, offset);
+		check();
+	}
+
+	@Override
 	public void glTexParameterf (int target, int pname, float param) {
 		calls++;
 		gl30.glTexParameterf(target, pname, param);
@@ -345,6 +353,14 @@ public class GL30Interceptor extends GLInterceptor implements GL30 {
 		Buffer pixels) {
 		calls++;
 		gl30.glTexSubImage2D(target, level, xoffset, yoffset, width, height, format, type, pixels);
+		check();
+	}
+
+	@Override
+	public void glTexSubImage2D (int target, int level, int xoffset, int yoffset, int width, int height, int format, int type,
+		int offset) {
+		calls++;
+		gl30.glTexSubImage2D(target, level, xoffset, yoffset, width, height, format, type, offset);
 		check();
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gles3/PixelBufferObjectTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gles3/PixelBufferObjectTest.java
@@ -1,4 +1,3 @@
-
 package com.badlogic.gdx.tests.gles3;
 
 import java.nio.Buffer;
@@ -16,89 +15,133 @@ import com.badlogic.gdx.tests.utils.GdxTest;
 import com.badlogic.gdx.tests.utils.GdxTestConfig;
 import com.badlogic.gdx.utils.BufferUtils;
 
-@GdxTestConfig(requireGL30 = true)
+@GdxTestConfig(requireGL30=true)
 public class PixelBufferObjectTest extends GdxTest {
 
-	private SpriteBatch batch;
-	private Texture texture;
-	protected Lock lock;
-	protected Pixmap pixmap;
-	protected int pixmapSizeBytes;
-	protected boolean pixmapReady;
-	protected boolean textureReady;
-	protected boolean pboTransferComplete;
-	protected Buffer mappedBuffer;
-	protected int pboHandle;
+	static class PBOUpload {
+		private Texture texture;
+		protected Lock lock;
+		protected Pixmap pixmap;
+		protected int pixmapSizeBytes;
+		protected boolean pixmapReady;
+		protected boolean textureReady;
+		protected boolean pboTransferComplete;
+		protected Buffer mappedBuffer;
+		protected int pboHandle;
+		private final boolean useSubImage;
+		
+		public PBOUpload (boolean useSubImage) {
+			super();
+			this.useSubImage = useSubImage;
+		}
 
+		public void start(){
+			lock = new ReentrantLock();
+			lock.lock();
+			
+			new Thread(new Runnable() {
+				@Override
+				public void run () {
+					// load the pixmap in order to get header information
+					pixmap = new Pixmap(Gdx.files.internal("data/badlogic.jpg"));
+					pixmapSizeBytes = pixmap.getWidth() * pixmap.getHeight() * 3;
+					pixmapReady = true;
+					
+					// wait for PBO initialization (need to be done in GLThread)
+					lock.lock();
+					
+					// Transfer data from pixmap to PBO
+					ByteBuffer data = pixmap.getPixels();
+					data.rewind();
+					BufferUtils.copy(data, mappedBuffer, pixmapSizeBytes);
+					pboTransferComplete = true;
+				}
+			}).start();
+		}
+		
+		public void update(){
+		// first step: once we get pixmap size, we can create both texture and PBO
+			if(pixmapReady && texture == null){
+				texture = new Texture(pixmap.getWidth(), pixmap.getHeight(), pixmap.getFormat());
+				
+				pboHandle = Gdx.gl.glGenBuffer();
+				Gdx.gl.glBindBuffer(GL30.GL_PIXEL_UNPACK_BUFFER, pboHandle);
+				Gdx.gl.glBufferData(GL30.GL_PIXEL_UNPACK_BUFFER, pixmapSizeBytes, null, GL30.GL_STREAM_DRAW);
+				
+				mappedBuffer = Gdx.gl30.glMapBufferRange(GL30.GL_PIXEL_UNPACK_BUFFER, 0, pixmapSizeBytes, GL30.GL_MAP_WRITE_BIT | GL30.GL_MAP_UNSYNCHRONIZED_BIT);
+				Gdx.gl.glBindBuffer(GL30.GL_PIXEL_UNPACK_BUFFER, 0);
+
+				lock.unlock();
+			}
+			// second step: once async transfer is complete, we can transfer to the texture and cleanup
+			if(!textureReady && pboTransferComplete){
+				
+				// transfer data to texture (GL Thread)
+				Gdx.gl.glBindBuffer(GL30.GL_PIXEL_UNPACK_BUFFER, pboHandle);
+				Gdx.gl30.glUnmapBuffer(GL30.GL_PIXEL_UNPACK_BUFFER);
+				
+				Gdx.gl.glBindTexture (GL20.GL_TEXTURE_2D, texture.getTextureObjectHandle());
+				
+				// for testing purpose: use glTexSubImage2D or glTexImage2D
+				if(useSubImage){
+					Gdx.gl30.glTexSubImage2D(GL20.GL_TEXTURE_2D, 0, 0, 0, pixmap.getWidth(), pixmap.getHeight(), pixmap.getGLFormat(), pixmap.getGLType(), 0);
+				}else{
+					Gdx.gl30.glTexImage2D(GL20.GL_TEXTURE_2D, 0, pixmap.getGLInternalFormat(), pixmap.getWidth(), pixmap.getHeight(), 0, pixmap.getGLFormat(), pixmap.getGLType(), 0);
+				}
+				
+				Gdx.gl.glBindTexture(GL20.GL_TEXTURE_2D, 0);
+				
+				Gdx.gl.glBindBuffer(GL30.GL_PIXEL_UNPACK_BUFFER, 0);
+				
+				// cleanup
+				mappedBuffer = null;
+				Gdx.gl.glDeleteBuffer(pboHandle);
+				pboHandle = 0;
+				pixmap.dispose();
+				pixmap = null;
+				textureReady = true;
+			}
+		}
+		
+		public boolean isTextureReady(){
+			return textureReady;
+		}
+		
+		public Texture getTexture(){
+			return texture;
+		}
+	}
+	
+	private SpriteBatch batch;
+	private PBOUpload demo1, demo2;
+	
 	@Override
 	public void create () {
 		batch = new SpriteBatch();
-		lock = new ReentrantLock();
-		lock.lock();
-
-		new Thread(new Runnable() {
-			@Override
-			public void run () {
-				// load the pixmap in order to get header information
-				pixmap = new Pixmap(Gdx.files.internal("data/badlogic.jpg"));
-				pixmapSizeBytes = pixmap.getWidth() * pixmap.getHeight() * 3;
-				pixmapReady = true;
-
-				// wait for PBO initialization (need to be done in GLThread)
-				lock.lock();
-
-				// Transfer data from pixmap to PBO
-				ByteBuffer data = pixmap.getPixels();
-				data.rewind();
-				BufferUtils.copy(data, mappedBuffer, pixmapSizeBytes);
-				pboTransferComplete = true;
-			}
-		}).start();
+		
+		demo1 = new PBOUpload(false);
+		demo1.start();
+		demo2 = new PBOUpload(true);
+		demo2.start();
+		
 	}
-
+	
 	@Override
-	public void render () {
-		// first step: once we get pixmap size, we can create both texture and PBO
-		if (pixmapReady && texture == null) {
-			texture = new Texture(pixmap.getWidth(), pixmap.getHeight(), pixmap.getFormat());
-
-			pboHandle = Gdx.gl.glGenBuffer();
-			Gdx.gl.glBindBuffer(GL30.GL_PIXEL_UNPACK_BUFFER, pboHandle);
-			Gdx.gl.glBufferData(GL30.GL_PIXEL_UNPACK_BUFFER, pixmapSizeBytes, null, GL30.GL_STREAM_DRAW);
-
-			mappedBuffer = Gdx.gl30.glMapBufferRange(GL30.GL_PIXEL_UNPACK_BUFFER, 0, pixmapSizeBytes,
-				GL30.GL_MAP_WRITE_BIT | GL30.GL_MAP_UNSYNCHRONIZED_BIT);
-			Gdx.gl.glBindBuffer(GL30.GL_PIXEL_UNPACK_BUFFER, 0);
-
-			lock.unlock();
+	public void render() {
+		demo1.update();
+		demo2.update();
+		
+		batch.begin();
+		if(demo1.isTextureReady()){
+			batch.draw(demo1.getTexture(), 
+				0, 0, 
+				Gdx.graphics.getWidth()/2, Gdx.graphics.getHeight()/2);
 		}
-		// second step: once async transfer is complete, we can transfer to the texture and cleanup
-		if (!textureReady && pboTransferComplete) {
-
-			// transfer data to texture (GL Thread)
-			Gdx.gl.glBindBuffer(GL30.GL_PIXEL_UNPACK_BUFFER, pboHandle);
-			Gdx.gl30.glUnmapBuffer(GL30.GL_PIXEL_UNPACK_BUFFER);
-
-			Gdx.gl.glBindTexture(GL20.GL_TEXTURE_2D, texture.getTextureObjectHandle());
-			Gdx.gl.glTexImage2D(GL20.GL_TEXTURE_2D, 0, pixmap.getGLInternalFormat(), pixmap.getWidth(), pixmap.getHeight(), 0,
-				pixmap.getGLFormat(), pixmap.getGLType(), null);
-			Gdx.gl.glBindTexture(GL20.GL_TEXTURE_2D, 0);
-
-			Gdx.gl.glBindBuffer(GL30.GL_PIXEL_UNPACK_BUFFER, 0);
-
-			// cleanup
-			mappedBuffer = null;
-			Gdx.gl.glDeleteBuffer(pboHandle);
-			pboHandle = 0;
-			pixmap.dispose();
-			pixmap = null;
-			textureReady = true;
+		if(demo2.isTextureReady()){
+			batch.draw(demo2.getTexture(), 
+				Gdx.graphics.getWidth()/2, 0, 
+				Gdx.graphics.getWidth()/2, Gdx.graphics.getHeight()/2);
 		}
-		// last step: texture is ready to be used.
-		if (textureReady) {
-			batch.begin();
-			batch.draw(texture, 0, 0, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
-			batch.end();
-		}
+		batch.end();
 	}
 }

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gles3/PixelBufferObjectTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gles3/PixelBufferObjectTest.java
@@ -1,3 +1,4 @@
+
 package com.badlogic.gdx.tests.gles3;
 
 import java.nio.Buffer;
@@ -15,7 +16,7 @@ import com.badlogic.gdx.tests.utils.GdxTest;
 import com.badlogic.gdx.tests.utils.GdxTestConfig;
 import com.badlogic.gdx.utils.BufferUtils;
 
-@GdxTestConfig(requireGL30=true)
+@GdxTestConfig(requireGL30 = true)
 public class PixelBufferObjectTest extends GdxTest {
 
 	static class PBOUpload {
@@ -29,16 +30,16 @@ public class PixelBufferObjectTest extends GdxTest {
 		protected Buffer mappedBuffer;
 		protected int pboHandle;
 		private final boolean useSubImage;
-		
+
 		public PBOUpload (boolean useSubImage) {
 			super();
 			this.useSubImage = useSubImage;
 		}
 
-		public void start(){
+		public void start () {
 			lock = new ReentrantLock();
 			lock.lock();
-			
+
 			new Thread(new Runnable() {
 				@Override
 				public void run () {
@@ -46,10 +47,10 @@ public class PixelBufferObjectTest extends GdxTest {
 					pixmap = new Pixmap(Gdx.files.internal("data/badlogic.jpg"));
 					pixmapSizeBytes = pixmap.getWidth() * pixmap.getHeight() * 3;
 					pixmapReady = true;
-					
+
 					// wait for PBO initialization (need to be done in GLThread)
 					lock.lock();
-					
+
 					// Transfer data from pixmap to PBO
 					ByteBuffer data = pixmap.getPixels();
 					data.rewind();
@@ -58,41 +59,44 @@ public class PixelBufferObjectTest extends GdxTest {
 				}
 			}).start();
 		}
-		
-		public void update(){
-		// first step: once we get pixmap size, we can create both texture and PBO
-			if(pixmapReady && texture == null){
+
+		public void update () {
+			// first step: once we get pixmap size, we can create both texture and PBO
+			if (pixmapReady && texture == null) {
 				texture = new Texture(pixmap.getWidth(), pixmap.getHeight(), pixmap.getFormat());
-				
+
 				pboHandle = Gdx.gl.glGenBuffer();
 				Gdx.gl.glBindBuffer(GL30.GL_PIXEL_UNPACK_BUFFER, pboHandle);
 				Gdx.gl.glBufferData(GL30.GL_PIXEL_UNPACK_BUFFER, pixmapSizeBytes, null, GL30.GL_STREAM_DRAW);
-				
-				mappedBuffer = Gdx.gl30.glMapBufferRange(GL30.GL_PIXEL_UNPACK_BUFFER, 0, pixmapSizeBytes, GL30.GL_MAP_WRITE_BIT | GL30.GL_MAP_UNSYNCHRONIZED_BIT);
+
+				mappedBuffer = Gdx.gl30.glMapBufferRange(GL30.GL_PIXEL_UNPACK_BUFFER, 0, pixmapSizeBytes,
+					GL30.GL_MAP_WRITE_BIT | GL30.GL_MAP_UNSYNCHRONIZED_BIT);
 				Gdx.gl.glBindBuffer(GL30.GL_PIXEL_UNPACK_BUFFER, 0);
 
 				lock.unlock();
 			}
 			// second step: once async transfer is complete, we can transfer to the texture and cleanup
-			if(!textureReady && pboTransferComplete){
-				
+			if (!textureReady && pboTransferComplete) {
+
 				// transfer data to texture (GL Thread)
 				Gdx.gl.glBindBuffer(GL30.GL_PIXEL_UNPACK_BUFFER, pboHandle);
 				Gdx.gl30.glUnmapBuffer(GL30.GL_PIXEL_UNPACK_BUFFER);
-				
-				Gdx.gl.glBindTexture (GL20.GL_TEXTURE_2D, texture.getTextureObjectHandle());
-				
+
+				Gdx.gl.glBindTexture(GL20.GL_TEXTURE_2D, texture.getTextureObjectHandle());
+
 				// for testing purpose: use glTexSubImage2D or glTexImage2D
-				if(useSubImage){
-					Gdx.gl30.glTexSubImage2D(GL20.GL_TEXTURE_2D, 0, 0, 0, pixmap.getWidth(), pixmap.getHeight(), pixmap.getGLFormat(), pixmap.getGLType(), 0);
-				}else{
-					Gdx.gl30.glTexImage2D(GL20.GL_TEXTURE_2D, 0, pixmap.getGLInternalFormat(), pixmap.getWidth(), pixmap.getHeight(), 0, pixmap.getGLFormat(), pixmap.getGLType(), 0);
+				if (useSubImage) {
+					Gdx.gl30.glTexSubImage2D(GL20.GL_TEXTURE_2D, 0, 0, 0, pixmap.getWidth(), pixmap.getHeight(), pixmap.getGLFormat(),
+						pixmap.getGLType(), 0);
+				} else {
+					Gdx.gl30.glTexImage2D(GL20.GL_TEXTURE_2D, 0, pixmap.getGLInternalFormat(), pixmap.getWidth(), pixmap.getHeight(),
+						0, pixmap.getGLFormat(), pixmap.getGLType(), 0);
 				}
-				
+
 				Gdx.gl.glBindTexture(GL20.GL_TEXTURE_2D, 0);
-				
+
 				Gdx.gl.glBindBuffer(GL30.GL_PIXEL_UNPACK_BUFFER, 0);
-				
+
 				// cleanup
 				mappedBuffer = null;
 				Gdx.gl.glDeleteBuffer(pboHandle);
@@ -102,45 +106,42 @@ public class PixelBufferObjectTest extends GdxTest {
 				textureReady = true;
 			}
 		}
-		
-		public boolean isTextureReady(){
+
+		public boolean isTextureReady () {
 			return textureReady;
 		}
-		
-		public Texture getTexture(){
+
+		public Texture getTexture () {
 			return texture;
 		}
 	}
-	
+
 	private SpriteBatch batch;
 	private PBOUpload demo1, demo2;
-	
+
 	@Override
 	public void create () {
 		batch = new SpriteBatch();
-		
+
 		demo1 = new PBOUpload(false);
 		demo1.start();
 		demo2 = new PBOUpload(true);
 		demo2.start();
-		
+
 	}
-	
+
 	@Override
-	public void render() {
+	public void render () {
 		demo1.update();
 		demo2.update();
-		
+
 		batch.begin();
-		if(demo1.isTextureReady()){
-			batch.draw(demo1.getTexture(), 
-				0, 0, 
-				Gdx.graphics.getWidth()/2, Gdx.graphics.getHeight()/2);
+		if (demo1.isTextureReady()) {
+			batch.draw(demo1.getTexture(), 0, 0, Gdx.graphics.getWidth() / 2, Gdx.graphics.getHeight() / 2);
 		}
-		if(demo2.isTextureReady()){
-			batch.draw(demo2.getTexture(), 
-				Gdx.graphics.getWidth()/2, 0, 
-				Gdx.graphics.getWidth()/2, Gdx.graphics.getHeight()/2);
+		if (demo2.isTextureReady()) {
+			batch.draw(demo2.getTexture(), Gdx.graphics.getWidth() / 2, 0, Gdx.graphics.getWidth() / 2,
+				Gdx.graphics.getHeight() / 2);
 		}
 		batch.end();
 	}


### PR DESCRIPTION
This should fix regression introduced in #6309.

Backends status : 
* LWJGL 2 and 3: tested
* IOS: not tested, i'm not confident with my C++ code, @Tom-Ski feel free to fix it if needed.
* Android: not tested, apparently it requires native Android to call related methods but it worked in the previous PR by passing null buffer.
* WebGL: N/A, i checked specifications, WebGL2 have the related methods [texImage2D](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texImage2D) and [texSubImage2D](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texSubImage2D), we could implement them in the future.