### PR TITLE
Make PolygonSpriteBatch and SpriteBatch overridable

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g2d/PolygonSpriteBatch.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/PolygonSpriteBatch.java
@@ -58,12 +58,12 @@ import com.badlogic.gdx.math.Matrix4;
 public class PolygonSpriteBatch implements PolygonBatch {
 	private Mesh mesh;
 
-	private final float[] vertices;
-	private final short[] triangles;
-	private int vertexIndex, triangleIndex;
-	private Texture lastTexture;
-	private float invTexWidth = 0, invTexHeight = 0;
-	private boolean drawing;
+	protected final float[] vertices;
+	protected final short[] triangles;
+	protected int vertexIndex, triangleIndex;
+	protected Texture lastTexture;
+	protected float invTexWidth = 0, invTexHeight = 0;
+	protected boolean drawing;
 
 	private final Matrix4 transformMatrix = new Matrix4();
 	private final Matrix4 projectionMatrix = new Matrix4();
@@ -80,7 +80,7 @@ public class PolygonSpriteBatch implements PolygonBatch {
 	private boolean ownsShader;
 
 	private final Color color = new Color(1, 1, 1, 1);
-	float colorPacked = Color.WHITE_FLOAT_BITS;
+	protected float colorPacked = Color.WHITE_FLOAT_BITS;
 
 	/** Number of render calls since the last {@link #begin()}. **/
 	public int renderCalls = 0;

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/SpriteBatch.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/SpriteBatch.java
@@ -42,12 +42,12 @@ public class SpriteBatch implements Batch {
 
 	private Mesh mesh;
 
-	final float[] vertices;
-	int idx = 0;
-	Texture lastTexture = null;
-	float invTexWidth = 0, invTexHeight = 0;
+	protected final float[] vertices;
+	protected int idx = 0;
+	protected Texture lastTexture = null;
+	protected float invTexWidth = 0, invTexHeight = 0;
 
-	boolean drawing = false;
+	protected boolean drawing = false;
 
 	private final Matrix4 transformMatrix = new Matrix4();
 	private final Matrix4 projectionMatrix = new Matrix4();
@@ -64,7 +64,7 @@ public class SpriteBatch implements Batch {
 	private boolean ownsShader;
 
 	private final Color color = new Color(1, 1, 1, 1);
-	float colorPacked = Color.WHITE_FLOAT_BITS;
+	protected float colorPacked = Color.WHITE_FLOAT_BITS;
 
 	/** Number of render calls since the last {@link #begin()}. **/
 	public int renderCalls = 0;


### PR DESCRIPTION
I'd like to extend `PolygonSpriteBatch` to add features from `CpuSpriteBatch`, after tried some solutions I finally have a version that works good, however I need it as a drop-in replacement of `PolygonSpriteBatch`, but I can't extend it directly because there are some private fields I need. I've also some troubles with GWT because the tricky method I've used to get everything working. So, this commit expose these fields in subclasses.

Thanks!