### PR TITLE
Remove unnecessary arch in robovm.xml

### DIFF
--- a/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/ios/robovm.xml
+++ b/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/ios/robovm.xml
@@ -2,7 +2,6 @@
   <executableName>${app.executable}</executableName>
   <mainClass>${app.mainclass}</mainClass>
   <os>ios</os>
-  <arch>thumbv7</arch>
   <target>ios</target>
   <iosInfoPList>Info.plist.xml</iosInfoPList>
   <treeShaker>conservative</treeShaker>

--- a/tests/gdx-tests-iosrobovm/robovm.xml
+++ b/tests/gdx-tests-iosrobovm/robovm.xml
@@ -2,7 +2,6 @@
   <executableName>${app.executable}</executableName>
   <mainClass>${app.mainclass}</mainClass>
   <os>ios</os>
-  <arch>thumbv7</arch>
   <target>ios</target>
   <iosInfoPList>Info.plist.xml</iosInfoPList>
   <treeShaker>conservative</treeShaker>


### PR DESCRIPTION
Setting `arch` in config is not necessary and can be misleading. It defaults to `auto` (which chooses architecture automatically depending on the current host CPU architecture) but in practice it is always overriden both when using the plugin or the command line.