### PR TITLE
Rename gdx-box2d projects in gradle to match maven

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -23,8 +23,10 @@ include ":backends:gdx-backend-lwjgl3"
 include ":backends:gdx-backend-robovm"
 include ":backends:gdx-backends-gwt"
 
-include ":extensions:gdx-box2d:gdx-box2d"
-include ":extensions:gdx-box2d:gdx-box2d-gwt"
+include(":extensions:gdx-box2d")
+project(":extensions:gdx-box2d").name = "gdx-box2d-parent"
+include ":extensions:gdx-box2d-parent:gdx-box2d"
+include ":extensions:gdx-box2d-parent:gdx-box2d-gwt"
 include ":extensions:gdx-bullet"
 include ":extensions:gdx-freetype"
 include ":extensions:gdx-setup"
@@ -39,4 +41,3 @@ include ":tests:gdx-tests-lwjgl"
 include ":tests:gdx-tests-lwjgl3"
 
 rootProject.name = "libgdx"
-project(":extensions:gdx-box2d").name = "gdx-box2d-parent"

--- a/settings.gradle
+++ b/settings.gradle
@@ -39,4 +39,4 @@ include ":tests:gdx-tests-lwjgl"
 include ":tests:gdx-tests-lwjgl3"
 
 rootProject.name = "libgdx"
-project(":extensions:gdx-box2d:gdx-box2d").name = "gdx-box2d-core"
+project(":extensions:gdx-box2d").name = "gdx-box2d-parent"

--- a/tests/gdx-tests-android/build.gradle
+++ b/tests/gdx-tests-android/build.gradle
@@ -26,7 +26,7 @@ apply from: "obb.gradle"
 dependencies {
 	implementation project(":tests:gdx-tests")
 	implementation project(":gdx")
-	implementation project(":extensions:gdx-box2d:gdx-box2d-core")
+	implementation project(":extensions:gdx-box2d:gdx-box2d")
 	implementation project(":extensions:gdx-bullet")
 	implementation project(":extensions:gdx-freetype")
 	implementation project(":backends:gdx-backend-android")

--- a/tests/gdx-tests-android/build.gradle
+++ b/tests/gdx-tests-android/build.gradle
@@ -26,7 +26,7 @@ apply from: "obb.gradle"
 dependencies {
 	implementation project(":tests:gdx-tests")
 	implementation project(":gdx")
-	implementation project(":extensions:gdx-box2d:gdx-box2d")
+	implementation project(":extensions:gdx-box2d-parent:gdx-box2d")
 	implementation project(":extensions:gdx-bullet")
 	implementation project(":extensions:gdx-freetype")
 	implementation project(":backends:gdx-backend-android")
@@ -46,7 +46,7 @@ android {
 			res.srcDirs = ['res']
 			assets.srcDirs = ['assets']
 			jniLibs.srcDirs = ['libs']
-		}		
+		}
 	}
 
 	defaultConfig {

--- a/tests/gdx-tests-gwt/build.gradle
+++ b/tests/gdx-tests-gwt/build.gradle
@@ -36,7 +36,7 @@ gretty.portPropertiesFileName = "TEMP_PORTS.properties"
 dependencies {
     compile project(":tests:gdx-tests")
     compile project(":backends:gdx-backends-gwt")
-    compile project(":extensions:gdx-box2d:gdx-box2d-gwt")
+    compile project(":extensions:gdx-box2d-parent:gdx-box2d-gwt")
 }
 
 gwt {
@@ -110,7 +110,7 @@ task addSource {
     doLast {
         sourceSets.main.compileClasspath += files(project(':tests:gdx-tests').sourceSets.main.allJava.srcDirs)
         sourceSets.main.compileClasspath += files(project(':backends:gdx-backends-gwt').sourceSets.main.allJava.srcDirs)
-        sourceSets.main.compileClasspath += files(project(':extensions:gdx-box2d:gdx-box2d-gwt').sourceSets.main.allJava.srcDirs)
+        sourceSets.main.compileClasspath += files(project(':extensions:gdx-box2d-parent:gdx-box2d-gwt').sourceSets.main.allJava.srcDirs)
         sourceSets.main.compileClasspath += files(project(':gdx').sourceSets.main.allJava.srcDirs)
         sourceSets.main.compileClasspath += files(sourceSets.main.resources.srcDirs)
     }

--- a/tests/gdx-tests/build.gradle
+++ b/tests/gdx-tests/build.gradle
@@ -16,7 +16,7 @@
 
 dependencies {
     compile project(":gdx")
-    compile project(":extensions:gdx-box2d:gdx-box2d")
+    compile project(":extensions:gdx-box2d-parent:gdx-box2d")
     compile project(":extensions:gdx-bullet")
     compile project(":extensions:gdx-freetype")
     compileOnly project(":extensions:gdx-tools")

--- a/tests/gdx-tests/build.gradle
+++ b/tests/gdx-tests/build.gradle
@@ -16,7 +16,7 @@
 
 dependencies {
     compile project(":gdx")
-    compile project(":extensions:gdx-box2d:gdx-box2d-core")
+    compile project(":extensions:gdx-box2d:gdx-box2d")
     compile project(":extensions:gdx-bullet")
     compile project(":extensions:gdx-freetype")
     compileOnly project(":extensions:gdx-tools")


### PR DESCRIPTION
https://github.com/libgdx/libgdx/commit/446e26910cd30fbcda8518d979f75c43bcf44c82 renamed the subproject to "gdx-box2d-core" which does not match the maven/artifact id. This was done to prevent the issue caused by having two projects named the same. We should instead rename the parent project to "gdx-box2d-parent" like it [is in maven](https://github.com/libgdx/libgdx/blob/master/extensions/gdx-box2d/pom.xml).

This is necessary to be able to publish from gradle eventually™

Addresses an issue brought up in #6369