### PR TITLE
Exclude apache-jsp from gwt-tests.

### DIFF
--- a/tests/gdx-tests-gwt/build.gradle
+++ b/tests/gdx-tests-gwt/build.gradle
@@ -21,6 +21,11 @@ buildscript {
     }
 }
 
+configurations.all {
+    // gwt-dev pulls in apache-jsp (Tomcat), but we don't need it and it messes with gretty
+    exclude group: 'org.eclipse.jetty', module: 'apache-jsp'
+}
+
 apply plugin: 'war'
 apply plugin: 'gwt'
 apply plugin: 'org.gretty'


### PR DESCRIPTION
Gretty pulls it in too, so it's not enough to have it on other classes.

Not sure why it isnt an issue for everyone, but https://mvnrepository.com/artifact/org.gretty/gretty-runner-jetty93/2.3.0 clearly lists it as a dependency.