### PR TITLE
Clean up MathUtils.random() for generating longs

### DIFF
--- a/gdx/src/com/badlogic/gdx/utils/SharedLibraryLoader.java
+++ b/gdx/src/com/badlogic/gdx/utils/SharedLibraryLoader.java
@@ -71,7 +71,7 @@ public class SharedLibraryLoader {
 	}
 	
 	static String randomUUID() {
-		UUID uuid = new UUID(MathUtils.random(Long.MAX_VALUE), MathUtils.random(Long.MAX_VALUE));		
+		UUID uuid = new UUID(MathUtils.random.nextLong(), MathUtils.random.nextLong());
 		return uuid.toString();
 	}
 

--- a/gdx/test/com/badlogic/gdx/math/MathUtilsTest.java
+++ b/gdx/test/com/badlogic/gdx/math/MathUtilsTest.java
@@ -48,4 +48,15 @@ public class MathUtilsTest {
 		assertEquals(200f, MathUtils.map(10f, 20f, 100f, 200f, 20f), 0.01f);
 		assertEquals(300f, MathUtils.map(10f, 20f, 100f, 200f, 30f), 0.01f);
 	}
+
+	@Test
+	public void testRandomLong() {
+		long r;
+		for (int i = 0; i < 512; i++) {
+			assertTrue((r = MathUtils.random(1L, 5L)) >= 1L && r <= 5L);
+			assertTrue((r = MathUtils.random(6L, 1L)) >= 1L && r <= 6L);
+			assertTrue((r = MathUtils.random(-1L, -7L)) <= -1L && r >= -7L);
+			assertTrue((r = MathUtils.random(-8L, -1L)) <= -1L && r >= -8L);
+		}
+	}
 }


### PR DESCRIPTION
This one's an especially intricate piece of code, and the bug it fixes is sorta non-obvious. Before, if you called `MathUtils.nextLong(Long.MAX_VALUE)` many times, you would never get a number with a `1` bit in any of the bottom 10 bits. This is obviously not random; the lack of odd numbers might be the most easily noticeable. That happens because the old code used a double (with 52 bits of mantissa) to generate a random long (with 64 bits). The ensuing precision loss affects all large-enough ranges. The fix is to use Rafael Baptista's technique for getting the upper 64 bits of a 64x64-to-128-bit multiply, treating the inputs as unsigned. It still works for negative bounds, like before, and is inclusive. The lower-bounded long generation is also updated (the regular random(long) calls it), and though it sometimes needs to cover greater ranges than what random(long) has to cover, it still appears to work (certainly better than before).

I also fixed a usage of MathUtils.random(long), in SharedLibraryLoader, where only positive longs were generated when probably all longs were intended. I commented on the commit that affected that class, which is affected much worse without this PR, but no one replied.

The RandomXS128 algorithm, although it is flawed and a little slower than it needs to be, is unchanged here. Only the improper use of double generation to produce longs is changed.