### PR TITLE
Enable LWJGL 3's autoIconify by default.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,10 +1,10 @@
 [1.9.15]
 - [BREAKING CHANGE] Requires Java 7 or above
 - [BREAKING CHANGE] API Change: Scaling is now an object instead of an enum. This may change behavior when used with serialization.
+- [BREAKING CHANGE] Lwjgl3WindowConfiguration#autoIconify is enabled by default.
 - Scene2d.ui: Added new ParticleEffectActor to use particle effects on Stage
 - API addition: iOS: Added HdpiMode option to IOSApplicationConfiguration to allow users to set whether they want to work in logical or raw pixels (default logical).
 - Fix for #6377 Gdx.net.openURI not working with targetSdk 30
-- Lwjgl3WindowConfiguration#autoIconify is enabled by default.
 
 [1.9.14]
 - [BREAKING CHANGE] iOS: IOSUIViewController has been moved to its own separate class 

--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@
 - Scene2d.ui: Added new ParticleEffectActor to use particle effects on Stage
 - API addition: iOS: Added HdpiMode option to IOSApplicationConfiguration to allow users to set whether they want to work in logical or raw pixels (default logical).
 - Fix for #6377 Gdx.net.openURI not working with targetSdk 30
+- Lwjgl3WindowConfiguration#autoIconify is enabled by default.
 
 [1.9.14]
 - [BREAKING CHANGE] iOS: IOSUIViewController has been moved to its own separate class 

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3WindowConfiguration.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3WindowConfiguration.java
@@ -34,7 +34,7 @@ public class Lwjgl3WindowConfiguration {
 	boolean windowDecorated = true;
 	boolean windowMaximized = false;
 	Lwjgl3Graphics.Lwjgl3Monitor maximizedMonitor;
-	boolean autoIconify = false;
+	boolean autoIconify = true;
 	FileType windowIconFileType;
 	String[] windowIconPaths;
 	Lwjgl3WindowListener windowListener;


### PR DESCRIPTION
This PR enables LWJGL 3's `autoIconify` config option by default. All the relevant information can be found here: https://github.com/libgdx/libgdx/issues/4785#issuecomment-744140507.