### PR TITLE
Unfocus children in Group#clearChildren()

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@
 - Scene2d.ui: Added new ParticleEffectActor to use particle effects on Stage
 - API addition: iOS: Added HdpiMode option to IOSApplicationConfiguration to allow users to set whether they want to work in logical or raw pixels (default logical).
 - Fix for #6377 Gdx.net.openURI not working with targetSdk 30
+- API addition: Added Group#clearChildren(boolean unfocus).
 
 [1.9.14]
 - [BREAKING CHANGE] iOS: IOSUIViewController has been moved to its own separate class 

--- a/CHANGES
+++ b/CHANGES
@@ -1,10 +1,10 @@
 [1.9.15]
 - [BREAKING CHANGE] Requires Java 7 or above
 - [BREAKING CHANGE] API Change: Scaling is now an object instead of an enum. This may change behavior when used with serialization.
+- [BREAKING CHANGE] Group#clearChildren() now unfocuses the actors. Added Group#clearChildren(boolean unfocus) for when this isn't wanted. #6423
 - Scene2d.ui: Added new ParticleEffectActor to use particle effects on Stage
 - API addition: iOS: Added HdpiMode option to IOSApplicationConfiguration to allow users to set whether they want to work in logical or raw pixels (default logical).
 - Fix for #6377 Gdx.net.openURI not working with targetSdk 30
-- API addition: Added Group#clearChildren(boolean unfocus).
 - Api Addition: Added a Pool#discard(T) method.
 
 [1.9.14]

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/Group.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/Group.java
@@ -54,7 +54,7 @@ public class Group extends Actor implements Cullable {
 	/** Draws the group and its children. The default implementation calls {@link #applyTransform(Batch, Matrix4)} if needed, then
 	 * {@link #drawChildren(Batch, float)}, then {@link #resetTransform(Batch)} if needed. */
 	public void draw (Batch batch, float parentAlpha) {
-		if (transform) applyTransform(batch, computeTransform());
+		if (transform) applyTransform(batch, computeTransformc());
 		drawChildren(batch, parentAlpha);
 		if (transform) resetTransform(batch);
 	}
@@ -349,9 +349,9 @@ public class Group extends Actor implements Cullable {
 		return actor;
 	}
 
-	/** Removes all actors from this group. Calls {@link #clearChildren(boolean)} with false. */
+	/** Removes all actors from this group and unfocuses them. Calls {@link #clearChildren(boolean)} with true. */
 	public void clearChildren () {
-		clearChildren(false);
+		clearChildren(true);
 	}
 
 	/** Removes all actors from this group. */

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/Group.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/Group.java
@@ -54,7 +54,7 @@ public class Group extends Actor implements Cullable {
 	/** Draws the group and its children. The default implementation calls {@link #applyTransform(Batch, Matrix4)} if needed, then
 	 * {@link #drawChildren(Batch, float)}, then {@link #resetTransform(Batch)} if needed. */
 	public void draw (Batch batch, float parentAlpha) {
-		if (transform) applyTransform(batch, computeTransformc());
+		if (transform) applyTransform(batch, computeTransform());
 		drawChildren(batch, parentAlpha);
 		if (transform) resetTransform(batch);
 	}

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/Group.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/Group.java
@@ -349,11 +349,20 @@ public class Group extends Actor implements Cullable {
 		return actor;
 	}
 
-	/** Removes all actors from this group. */
+	/** Removes all actors from this group. Calls {@link #clearChildren(boolean)} with false. */
 	public void clearChildren () {
+		clearChildren(false);
+	}
+
+	/** Removes all actors from this group. */
+	public void clearChildren (boolean unfocus) {
 		Actor[] actors = children.begin();
 		for (int i = 0, n = children.size; i < n; i++) {
 			Actor child = actors[i];
+			if (unfocus) {
+				Stage stage = getStage();
+				if (stage != null) stage.unfocus(child);
+			}
 			child.setStage(null);
 			child.setParent(null);
 		}


### PR DESCRIPTION
`Group.removeActor(Actor child, boolean unfocus)` gives the option to unfocus the removed child.
`Group.removeActor(Actor child)` unfocuses the removed child (calls `removeActor(child, true)`).

For some reason, `Group.clearChildren()` currently does not unfocus the children. This looks wrong.
This PR adds a `clearChildren(boolean unfocus)` method.

Now the question is: do you want `clearChildren()` (no arguments) to unfocus like `removeActor(child)` does, or do you want `clearChildren()` to not unfocus to avoid potentially breaking apps which may rely on the fact that clearChildren() never unfocused until now? I'm all for breaking apps, but 🤷.