### PR TITLE
Get js heap size on gwt

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplication.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplication.java
@@ -39,7 +39,6 @@ import com.google.gwt.animation.client.AnimationScheduler.AnimationCallback;
 import com.google.gwt.core.client.EntryPoint;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.JavaScriptObject;
-import com.google.gwt.core.client.UnsafeNativeLong;
 import com.google.gwt.dom.client.CanvasElement;
 import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Element;
@@ -436,14 +435,17 @@ public abstract class GwtApplication implements EntryPoint, Application {
 		return 0;
 	}
 
-	@Override
-	@UnsafeNativeLong
-	public native long getJavaHeap () /*-{
+	public native double usedJSHeapSize () /*-{
 		if ("memory" in $wnd.performance) {
 			return $wnd.performance.memory.usedJSHeapSize;
 		}
 		return 0;
 	}-*/;
+
+	@Override
+	public long getJavaHeap () {
+		return (long) usedJSHeapSize();
+	}
 
 	@Override
 	public long getNativeHeap () {

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplication.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplication.java
@@ -39,6 +39,7 @@ import com.google.gwt.animation.client.AnimationScheduler.AnimationCallback;
 import com.google.gwt.core.client.EntryPoint;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.core.client.UnsafeNativeLong;
 import com.google.gwt.dom.client.CanvasElement;
 import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Element;
@@ -436,13 +437,17 @@ public abstract class GwtApplication implements EntryPoint, Application {
 	}
 
 	@Override
-	public long getJavaHeap () {
+	@UnsafeNativeLong
+	public native long getJavaHeap () /*-{
+		if ("memory" in $wnd.performance) {
+			return $wnd.performance.memory.usedJSHeapSize;
+		}
 		return 0;
-	}
+	}-*/;
 
 	@Override
 	public long getNativeHeap () {
-		return 0;
+		return getJavaHeap();
 	}
 
 	@Override

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplication.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplication.java
@@ -444,7 +444,7 @@ public abstract class GwtApplication implements EntryPoint, Application {
 
 	@Override
 	public long getJavaHeap () {
-		return (long) usedJSHeapSize();
+		return (long)usedJSHeapSize();
 	}
 
 	@Override


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/Performance/memory

I'm not totally sure if it's safe to use `UnsafeNativeLong`.

> The compiler will then allow you to pass a long into and out of JavaScript. It will still be an opaque data type, however, so the only thing you will be able to do with it will be to pass it back to Java.

from http://www.gwtproject.org/doc/latest/DevGuideCodingBasicsJSNI.html

An alternative would be to convert it to a string and then parse it to a long back.
