### PR TITLE
Fix #6427. Add Gradle plugins repo to gdx setup project template

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ allprojects {
             google()
             mavenLocal()
             mavenCentral()
-            maven { url 'https://plugins.gradle.org/m2/' }
+            gradlePluginPortal()
             maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
         }
         dependencies {
@@ -37,7 +37,7 @@ allprojects {
         google()
         mavenLocal()
         mavenCentral()
-        maven { url 'https://plugins.gradle.org/m2/' }
+        gradlePluginPortal()
         maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ apply from: "gradle/dependencies.gradle"
 
 allprojects {
     group = 'com.badlogicgames.gdx'
-    version = '1.9.13-SNAPSHOT'
+    version = '1.9.15-SNAPSHOT'
 
     buildscript {
         repositories {

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/BuildScriptHelper.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/BuildScriptHelper.java
@@ -75,6 +75,7 @@ public class BuildScriptHelper {
 		write(wr, DependencyBank.mavenLocal);
 		write(wr, DependencyBank.mavenCentral);
 		write(wr, DependencyBank.google);
+		write(wr, "maven { url \"" + DependencyBank.gradlePlugins + "\" }");
 		write(wr, "maven { url \"" + DependencyBank.libGDXSnapshotsUrl + "\" }");
 		write(wr, "maven { url \"" + DependencyBank.libGDXReleaseUrl + "\" }");
 		write(wr, "}");

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/BuildScriptHelper.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/BuildScriptHelper.java
@@ -34,7 +34,7 @@ public class BuildScriptHelper {
 		write(wr, "repositories {");
 		write(wr, DependencyBank.mavenLocal);
 		write(wr, DependencyBank.mavenCentral);
-		write(wr, "maven { url \"" + DependencyBank.gradlePlugins + "\" }");
+		write(wr, DependencyBank.gradlePlugins);
 		write(wr, "maven { url \"" + DependencyBank.libGDXSnapshotsUrl + "\" }");
 		write(wr, DependencyBank.google);
 		write(wr, "}");
@@ -75,7 +75,7 @@ public class BuildScriptHelper {
 		write(wr, DependencyBank.mavenLocal);
 		write(wr, DependencyBank.mavenCentral);
 		write(wr, DependencyBank.google);
-		write(wr, "maven { url \"" + DependencyBank.gradlePlugins + "\" }");
+		write(wr, DependencyBank.gradlePlugins);
 		write(wr, "maven { url \"" + DependencyBank.libGDXSnapshotsUrl + "\" }");
 		write(wr, "maven { url \"" + DependencyBank.libGDXReleaseUrl + "\" }");
 		write(wr, "}");

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/DependencyBank.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/DependencyBank.java
@@ -35,7 +35,7 @@ public class DependencyBank {
 	static String mavenLocal = "mavenLocal()";
 	static String mavenCentral = "mavenCentral()";
 	static String google = "google()";
-	static String gradlePlugins = "https://plugins.gradle.org/m2/";
+	static String gradlePlugins = "gradlePluginPortal()";
 	static String libGDXSnapshotsUrl = "https://oss.sonatype.org/content/repositories/snapshots/";
 	static String libGDXReleaseUrl = "https://oss.sonatype.org/content/repositories/releases/";
 


### PR DESCRIPTION
- Fixes #6427
- Replaces Gradle plugin repo by `gradlePluginPortal()`.
- I've also updated the Gdx Setup version to be in sync with libGDX.