### PR TITLE
Fix wrong Tree batch color when icons are present

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Tree.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Tree.java
@@ -45,6 +45,7 @@ import com.badlogic.gdx.utils.Null;
  * @author Nathan Sweet */
 public class Tree<N extends Node, V> extends WidgetGroup {
 	static private final Vector2 tmp = new Vector2();
+	static private final Color tmpColor = new Color();
 
 	TreeStyle style;
 	final Array<N> rootNodes = new Array();
@@ -305,9 +306,11 @@ public class Tree<N extends Node, V> extends WidgetGroup {
 
 				if (node.icon != null) {
 					float iconY = y + actorY + Math.round((height - node.icon.getMinHeight()) / 2);
-					batch.setColor(actor.getColor());
+					tmpColor.set(batch.getColor());
+					Color colorActor = actor.getColor();
+					batch.setColor(colorActor.r, colorActor.g, colorActor.b, colorActor.a * tmpColor.a);
 					drawIcon(node, node.icon, batch, iconX, iconY);
-					batch.setColor(1, 1, 1, 1);
+					batch.setColor(tmpColor);
 				}
 
 				if (node.children.size > 0) {


### PR DESCRIPTION
When icons are provided in a `Tree.Node` batch color is not correctly set. It lost parent alpha and, after drawing the icon, batch is forced to `WHITE` color instead to restore the original one. This is what happens when trying to fade out a container that has a `Tree` inside.
![tree-batch-color](https://user-images.githubusercontent.com/5543339/109399681-8faabb00-7944-11eb-9a6d-252a971ca901.gif)
 
Thanks