### PR TITLE
fix some tests

### DIFF
--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ExternalMusicTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ExternalMusicTest.java
@@ -24,7 +24,7 @@ import com.badlogic.gdx.tests.utils.GdxTest;
 /** Tests playing back audio from the external storage.
  * @author mzechner */
 public class ExternalMusicTest extends GdxTest {
-
+	Music music;
 	@Override
 	public void create () {
 		// copy an internal mp3 to the external storage
@@ -33,12 +33,14 @@ public class ExternalMusicTest extends GdxTest {
 		src.copyTo(dst);
 
 		// create a music instance and start playback
-		Music music = Gdx.audio.newMusic(dst);
+		music = Gdx.audio.newMusic(dst);
 		music.play();
 	}
 
 	@Override
 	public void dispose () {
+		music.stop();
+		music.dispose();
 		// delete the copy on the external storage
 		Gdx.files.external("8.12.mp3").delete();
 	}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/FloatTextureTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/FloatTextureTest.java
@@ -29,7 +29,9 @@ import com.badlogic.gdx.graphics.glutils.FrameBuffer;
 import com.badlogic.gdx.graphics.glutils.ShaderProgram;
 import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.tests.utils.GdxTest;
+import com.badlogic.gdx.tests.utils.GdxTestConfig;
 
+@GdxTestConfig(requireGL30=true)
 public class FloatTextureTest extends GdxTest {
 	FrameBuffer fb;
 	FloatFrameBuffer ffb;

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TextureDownloadTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TextureDownloadTest.java
@@ -68,7 +68,7 @@ public class TextureDownloadTest extends GdxTest {
 			@Override
 			public void run () {
 				byte[] bytes = new byte[200 * 1024]; // assuming the content is not bigger than 200kb.
-				int numBytes = download(bytes, "http://www.badlogicgames.com/wordpress/wp-content/uploads/2012/01/badlogic-new.png");
+				int numBytes = download(bytes, "https://www.badlogicgames.com/wordpress/wp-content/uploads/2012/01/badlogic-new.png");
 				if (numBytes != 0) {
 					// load the pixmap, make it a power of two if necessary (not needed for GL ES 2.0!)
 					Pixmap pixmap = new Pixmap(bytes, 0, numBytes);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/net/NetAPITest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/net/NetAPITest.java
@@ -105,19 +105,19 @@ public class NetAPITest extends GdxTest implements HttpResponseListener {
 					String httpMethod = Net.HttpMethods.GET;
 					String requestContent = null;
 					if (clickedButton == btnDownloadImage)
-						url = "http://i.imgur.com/vxomF.jpg";
+						url = "https://i.imgur.com/vxomF.jpg";
 					else if (clickedButton == btnDownloadText)
-						url = "http://www.apache.org/licenses/LICENSE-2.0.txt";
+						url = "https://www.apache.org/licenses/LICENSE-2.0.txt";
 					else if (clickedButton == btnDownloadLarge)
-						url = "http://libgdx.badlogicgames.com/releases/libgdx-1.2.0.zip";
+						url = "https://libgdx.badlogicgames.com/releases/libgdx-1.2.0.zip";
 					else if (clickedButton == btnDownloadError)
-						url = "http://www.badlogicgames.com/doesnotexist";
+						url = "https://www.badlogicgames.com/doesnotexist";
 					else if (clickedButton == btnOpenUri) {
-						Gdx.net.openURI("http://libgdx.badlogicgames.com/");
+						Gdx.net.openURI("https://libgdx.badlogicgames.com/");
 						return;
 					}
 					else {
-						url = "http://posttestserver.com/post.php?dump";
+						url = "https://httpbin.org/post";
 						httpMethod = Net.HttpMethods.POST;
 						requestContent = "name1=value1&name2=value2";
 					}


### PR DESCRIPTION
Hi, i  run gdx test for get some ideas (and it work !)

TextureDownloadTest and NetApiTest was broken cause url.

I get error on FloatTextureTest , i add @GdxTestConfig(requireGL30=true) . Can you check plz, i have 0 knowlegde on GL
```java
Exception in thread "main" com.badlogic.gdx.utils.GdxRuntimeException: Float texture FrameBuffer Attachment not available on GLES 2.0
	at com.badlogic.gdx.graphics.glutils.GLFrameBuffer.checkValidBuilder(GLFrameBuffer.java:284)
	at com.badlogic.gdx.graphics.glutils.GLFrameBuffer.build(GLFrameBuffer.java:116)
	at com.badlogic.gdx.graphics.glutils.FloatFrameBuffer.<init>(FloatFrameBuffer.java:53)
	at com.badlogic.gdx.tests.FloatTextureTest.create(FloatTextureTest.java:45)
	at com.badlogic.gdx.backends.lwjgl3.Lwjgl3Window.initializeListener(Lwjgl3Window.java:433)
	at com.badlogic.gdx.backends.lwjgl3.Lwjgl3Window.update(Lwjgl3Window.java:381)
	at com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application.loop(Lwjgl3Application.java:143)
	at com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application.<init>(Lwjgl3Application.java:116)
	at com.badlogic.gdx.tests.lwjgl3.Lwjgl3TestStarter.main(Lwjgl3TestStarter.java:67)

```
