### PR TITLE
Bind the array buffer when calling bind on VertexBufferObjectWithVAO *DO NOT MERGE*

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/graphics/glutils/VertexBufferObjectWithVAO.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/graphics/glutils/VertexBufferObjectWithVAO.java
@@ -137,6 +137,7 @@ public class VertexBufferObjectWithVAO implements VertexData {
 		GL30 gl = Gdx.gl30;
 
 		gl.glBindVertexArray(vaoHandle);
+		gl.glBindBuffer(gl.GL_ARRAY_BUFFER, bufferHandle);
 
 		bindAttributes(shader, locations);
 

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/VertexBufferObjectWithVAO.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/VertexBufferObjectWithVAO.java
@@ -248,6 +248,7 @@ public class VertexBufferObjectWithVAO implements VertexData {
 	public void unbind (final ShaderProgram shader, final int[] locations) {
 		GL30 gl = Gdx.gl30;
 		gl.glBindVertexArray(0);
+		gl.glBindBuffer(gl.GL_ARRAY_BUFFER, 0);
 		isBound = false;
 	}
 


### PR DESCRIPTION
OS: Windows 10 x64
GPU: AMD RX 580
Driver: 21.2.2
GL: 3.3

I get: GL_INVALID_OPERATION after calling: ``shader.setVertexAttribute`` , binding the array buffer get rid of the error

I'm not sure if that's the right way to fix the error i'm getting, so this shouldn't get merged, i'm probably just wrong

cc:

@xoppa @mgsx-dev