### PR TITLE
enable GL errors in tests via commandLine argument, and fix a test

### DIFF
--- a/tests/gdx-tests-lwjgl/src/com/badlogic/gdx/tests/lwjgl/LwjglTestStarter.java
+++ b/tests/gdx-tests-lwjgl/src/com/badlogic/gdx/tests/lwjgl/LwjglTestStarter.java
@@ -43,6 +43,7 @@ import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.glutils.ShaderProgram;
 import com.badlogic.gdx.tests.utils.CommandLineOptions;
 import com.badlogic.gdx.tests.utils.GdxTest;
+import com.badlogic.gdx.tests.utils.GdxTestWrapper;
 import com.badlogic.gdx.tests.utils.GdxTests;
 
 public class LwjglTestStarter extends JFrame {
@@ -84,7 +85,7 @@ public class LwjglTestStarter extends JFrame {
 			ShaderProgram.prependVertexCode = "";
 			ShaderProgram.prependFragmentCode = "";			
 		}
-		new LwjglApplication(test, config);
+		new LwjglApplication(new GdxTestWrapper(test, options.logGLErrors), config);
 		return true;
 	}
 

--- a/tests/gdx-tests-lwjgl3/src/com/badlogic/gdx/tests/lwjgl3/Lwjgl3TestStarter.java
+++ b/tests/gdx-tests-lwjgl3/src/com/badlogic/gdx/tests/lwjgl3/Lwjgl3TestStarter.java
@@ -34,6 +34,7 @@ import com.badlogic.gdx.scenes.scene2d.ui.Table;
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
 import com.badlogic.gdx.tests.utils.CommandLineOptions;
+import com.badlogic.gdx.tests.utils.GdxTestWrapper;
 import com.badlogic.gdx.tests.utils.GdxTests;
 import com.badlogic.gdx.utils.ScreenUtils;
 import com.badlogic.gdx.utils.viewport.ScreenViewport;
@@ -107,7 +108,7 @@ public class Lwjgl3TestStarter {
 						winConfig.setWindowedMode(640, 480);
 						winConfig.setWindowPosition(((Lwjgl3Graphics)Gdx.graphics).getWindow().getPositionX() + 40,
 							((Lwjgl3Graphics)Gdx.graphics).getWindow().getPositionY() + 40);
-						((Lwjgl3Application)Gdx.app).newWindow(test, winConfig);
+						((Lwjgl3Application)Gdx.app).newWindow(new GdxTestWrapper(test, options.logGLErrors), winConfig);
 						System.out.println("Started test: " + testName);
 						prefs.putString("LastTest", testName);
 						prefs.flush();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/VertexBufferObjectShaderTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/VertexBufferObjectShaderTest.java
@@ -25,12 +25,16 @@ import com.badlogic.gdx.graphics.VertexAttributes;
 import com.badlogic.gdx.graphics.glutils.IndexBufferObject;
 import com.badlogic.gdx.graphics.glutils.ShaderProgram;
 import com.badlogic.gdx.graphics.glutils.VertexBufferObject;
+import com.badlogic.gdx.graphics.glutils.VertexBufferObjectWithVAO;
+import com.badlogic.gdx.graphics.glutils.VertexData;
+import com.badlogic.gdx.graphics.profiling.GLErrorListener;
+import com.badlogic.gdx.graphics.profiling.GLProfiler;
 import com.badlogic.gdx.tests.utils.GdxTest;
 
 public class VertexBufferObjectShaderTest extends GdxTest {
 	Texture texture;
 	ShaderProgram shader;
-	VertexBufferObject vbo;
+	VertexData vbo;
 	IndexBufferObject indices;
 
 	@Override
@@ -48,7 +52,6 @@ public class VertexBufferObjectShaderTest extends GdxTest {
 		Gdx.gl.glClearColor(0.7f, 0, 0, 1);
 		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 
-		gl.glEnable(GL20.GL_TEXTURE_2D);
 		shader.bind();
 		shader.setUniformi("u_texture", 0);
 		texture.bind();
@@ -87,9 +90,16 @@ public class VertexBufferObjectShaderTest extends GdxTest {
 		//@on
 
 		shader = new ShaderProgram(vertexShader, fragmentShader);
-		vbo = new VertexBufferObject(true, 3, new VertexAttribute(VertexAttributes.Usage.Position, 2, "a_position"),
-			new VertexAttribute(VertexAttributes.Usage.TextureCoordinates, 2, "a_texCoords"), new VertexAttribute(
-				VertexAttributes.Usage.ColorPacked, 4, "a_color"));
+		if(Gdx.gl30 != null){
+			vbo = new VertexBufferObjectWithVAO(true, 3, new VertexAttribute(VertexAttributes.Usage.Position, 2, "a_position"),
+				new VertexAttribute(VertexAttributes.Usage.TextureCoordinates, 2, "a_texCoords"), new VertexAttribute(
+					VertexAttributes.Usage.ColorPacked, 4, "a_color"));
+		}else{
+			
+			vbo = new VertexBufferObject(true, 3, new VertexAttribute(VertexAttributes.Usage.Position, 2, "a_position"),
+				new VertexAttribute(VertexAttributes.Usage.TextureCoordinates, 2, "a_texCoords"), new VertexAttribute(
+					VertexAttributes.Usage.ColorPacked, 4, "a_color"));
+		}
 		float[] vertices = new float[] {-1, -1, 0, 0, Color.toFloatBits(1f, 0f, 0f, 1f), 0, 1, 0.5f, 1.0f,
 			Color.toFloatBits(0f, 1f, 0f, 1f), 1, -1, 1, 0, Color.toFloatBits(0f, 0f, 1f, 1f)};
 		vbo.setVertices(vertices, 0, vertices.length);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/CommandLineOptions.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/CommandLineOptions.java
@@ -10,17 +10,20 @@ import com.badlogic.gdx.utils.Array;
  * 
  * options:
  * --gl30 enable GLES 3.2 (default is GLES 2.0)
+ * --glErrors enable GLProfiler and log any GL errors. (default is disabled)
  */
 public class CommandLineOptions {
 	
 	public String startupTestName = null;
 	public boolean gl30 = false;
+	public boolean logGLErrors = false;
 	
 	public CommandLineOptions (String [] argv) {
 		Array<String> args = new Array<String>(argv);
 		for(String arg : args){
 			if(arg.startsWith("-")){
 				if(arg.equals("--gl30")) gl30 = true;
+				else if(arg.equals("--glErrors")) logGLErrors = true;
 				else System.err.println("skip unrecognized option " + arg);
 			}else{
 				startupTestName = arg;

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTestWrapper.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTestWrapper.java
@@ -1,0 +1,60 @@
+package com.badlogic.gdx.tests.utils;
+
+import com.badlogic.gdx.ApplicationListener;
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.profiling.GLErrorListener;
+import com.badlogic.gdx.graphics.profiling.GLProfiler;
+
+public class GdxTestWrapper implements ApplicationListener
+{
+	private ApplicationListener app;
+	private boolean logGLErrors;
+
+	public GdxTestWrapper (ApplicationListener delegates, boolean logGLErrors) {
+		super();
+		this.app = delegates;
+		this.logGLErrors = logGLErrors;
+	}
+
+	@Override
+	public void create () {
+		if(logGLErrors){
+			Gdx.app.log("GLProfiler", "profiler enabled");
+			GLProfiler profiler = new GLProfiler(Gdx.graphics);
+			profiler.setListener(new GLErrorListener() {
+				@Override
+				public void onError (int error) {
+					Gdx.app.error("GLProfiler", "error " + error);
+				}
+			});
+			profiler.enable();
+		}
+		app.create();
+	}
+
+	@Override
+	public void resize (int width, int height) {
+		app.resize(width, height);
+	}
+
+	@Override
+	public void render () {
+		app.render();
+	}
+
+	@Override
+	public void pause () {
+		app.pause();
+	}
+
+	@Override
+	public void resume () {
+		app.resume();
+	}
+
+	@Override
+	public void dispose () {
+		app.dispose();
+	}
+	
+}


### PR DESCRIPTION
Now we can enable GL errors logging when running tests, helpful for debugging.

i also fixed the VertexBufferObjectShaderTest : 
- VertexBufferObjectWithVAO must be used when gl30 is enabled
- `gl.glEnable(GL20.GL_TEXTURE_2D)` is only valid with fixed function pipeline (which is not the case with libGDX).