### PR TITLE
Add copy of macosx natives for box2d maven build

### DIFF
--- a/extensions/gdx-box2d/gdx-box2d/jni/maven/pom.xml
+++ b/extensions/gdx-box2d/gdx-box2d/jni/maven/pom.xml
@@ -38,6 +38,7 @@
                                 <resource><directory>${basedir}/../../libs/linux64</directory></resource>
                                 <resource><directory>${basedir}/../../libs/linuxarm32</directory></resource>
                                 <resource><directory>${basedir}/../../libs/linuxarm64</directory></resource>
+                                <resource><directory>${basedir}/../../libs/macosx64</directory></resource>
                                 <resource><directory>${basedir}/../../libs/windows32</directory></resource>
                                 <resource><directory>${basedir}/../../libs/windows64</directory></resource>
                             </resources>


### PR DESCRIPTION
Looks like this was just missed when switching over to Github Actions. Current snapshots are missing the macosx dylib.