### PR TITLE
Fix #6464: BaseTmxLoader now imports default property "Type" properly.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -11,6 +11,7 @@
 - Fix for #6377 Gdx.net.openURI not working with targetSdk 30
 - Api Addition: Added a Pool#discard(T) method.
 - Architecture support: Linux ARM and AARCH64 support has been added. The gdx-xxx-natives.jar files now contain native libraries of these architectures as well.
+- Fix for #6464: BaseTmxMapLoader now imports default property "Type" properly.
 
 
 [1.9.14]

--- a/CHANGES
+++ b/CHANGES
@@ -12,6 +12,7 @@
 - Api Addition: Added a Pool#discard(T) method.
 - Architecture support: Linux ARM and AARCH64 support has been added. The gdx-xxx-natives.jar files now contain native libraries of these architectures as well.
 - Fix for #6464: BaseTmxMapLoader now imports default property "Type" properly.
+- TiledMap: Default properties in tmx files get loaded with \tname now when a custom property exists with the same name.
 
 
 [1.9.14]

--- a/gdx/src/com/badlogic/gdx/maps/tiled/BaseTmxMapLoader.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/BaseTmxMapLoader.java
@@ -641,6 +641,10 @@ public abstract class BaseTmxMapLoader<P extends BaseTmxMapLoader.Parameters> ex
 		if (probability != null) {
 			tile.getProperties().put("probability", probability);
 		}
+		String type = tileElement.getAttribute("type", null);
+		if (type != null) {
+			tile.getProperties().put("type", type);
+		}
 		Element properties = tileElement.getChildByName("properties");
 		if (properties != null) {
 			loadProperties(tile.getProperties(), properties);

--- a/gdx/src/com/badlogic/gdx/maps/tiled/BaseTmxMapLoader.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/BaseTmxMapLoader.java
@@ -417,6 +417,11 @@ public abstract class BaseTmxMapLoader<P extends BaseTmxMapLoader.Parameters> ex
 				String name = property.getAttribute("name", null);
 				String value = property.getAttribute("value", null);
 				String type = property.getAttribute("type", null);
+
+				if (properties.containsKey(name)) {
+				    properties.put("\t" + name, properties.get(name));
+				}
+
 				if (value == null) {
 					value = property.getText();
 				}


### PR DESCRIPTION
Fix for #6464 

Only downside to that is that this could break some maps which use a custom "type" property.