### PR TITLE
Removes deprecated method calling and unnecessary casting

### DIFF
--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/Animation3DTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/Animation3DTest.java
@@ -34,7 +34,6 @@ import com.badlogic.gdx.graphics.g3d.model.Animation;
 import com.badlogic.gdx.graphics.g3d.model.Node;
 import com.badlogic.gdx.graphics.g3d.utils.AnimationController;
 import com.badlogic.gdx.graphics.g3d.utils.DepthShaderProvider;
-import com.badlogic.gdx.graphics.g3d.utils.MeshBuilder;
 import com.badlogic.gdx.graphics.g3d.utils.MeshPartBuilder;
 import com.badlogic.gdx.graphics.g3d.utils.ModelBuilder;
 import com.badlogic.gdx.math.Matrix4;
@@ -83,7 +82,8 @@ public class Animation3DTest extends BaseG3dHudTest {
 		builder.node().id = "floor";
 		MeshPartBuilder part = builder.part("floor", GL20.GL_TRIANGLES, Usage.Position | Usage.TextureCoordinates | Usage.Normal,
 			new Material("concrete"));
-		((MeshBuilder)part).ensureRectangles(1600);
+		part.ensureVertices(4 * 1600);
+		part.ensureRectangleIndices(1600);
 		for (float x = -200f; x < 200f; x += 10f) {
 			for (float z = -200f; z < 200f; z += 10f) {
 				part.rect(x, 0, z + 10f, x + 10f, 0, z + 10f, x + 10f, 0, z, x, 0, z, 0, 1, 0);


### PR DESCRIPTION
Hi!

There is a deprecated method calling in the Animation3DTest. I removed it and the remained unnecessary casting.