### PR TITLE
Fix #6486

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/DefaultDisplayRotationHelper.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/DefaultDisplayRotationHelper.java
@@ -1,0 +1,48 @@
+package com.badlogic.gdx.backends.android;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.hardware.display.DisplayManager;
+
+@SuppressLint("NewApi")
+public class DefaultDisplayRotationHelper implements DisplayRotationHelper, DisplayManager.DisplayListener {
+
+	private boolean refreshNeeded;
+	private final Context mContext;
+
+	public DefaultDisplayRotationHelper (Context context) {
+		mContext = context;
+	}
+
+	public void onSurfaceChanged () {
+		refreshNeeded = true;
+	}
+
+	public void onResume () {
+		mContext.getSystemService(DisplayManager.class).registerDisplayListener(this, null);
+	}
+
+	public void onPause () {
+		mContext.getSystemService(DisplayManager.class).unregisterDisplayListener(this);
+	}
+
+	@Override
+	public void onDisplayAdded (int displayId) {
+	}
+
+	@Override
+	public void onDisplayRemoved (int displayId) {
+	}
+
+	@Override
+	public void onDisplayChanged (int displayId) {
+		refreshNeeded = true;
+	}
+
+	public boolean getAndResetRefreshNeeded () {
+		boolean isRefreshNeeded = refreshNeeded;
+		refreshNeeded = false;
+		return isRefreshNeeded;
+	}
+
+}

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/DisplayRotationHelper.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/DisplayRotationHelper.java
@@ -1,0 +1,12 @@
+package com.badlogic.gdx.backends.android;
+
+public interface DisplayRotationHelper {
+
+	boolean getAndResetRefreshNeeded ();
+
+	void onSurfaceChanged ();
+
+	void onResume ();
+
+	void onPause ();
+}

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/LegacyDisplayRotationHelper.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/LegacyDisplayRotationHelper.java
@@ -1,0 +1,26 @@
+package com.badlogic.gdx.backends.android;
+
+public class LegacyDisplayRotationHelper implements DisplayRotationHelper {
+
+	private boolean refreshNeeded;
+	
+	@Override
+	public boolean getAndResetRefreshNeeded () {
+		boolean isRefreshNeeded = refreshNeeded;
+		refreshNeeded = false;
+		return isRefreshNeeded;
+	}
+
+	@Override
+	public void onSurfaceChanged () {
+		refreshNeeded = true;
+	}
+
+	@Override
+	public void onResume () {
+	}
+
+	@Override
+	public void onPause () {
+	}
+}


### PR DESCRIPTION
This is a draft proposal to fix #6486.

Changes that require updating ppi, updating insets and calling the resize listener may be triggered both by `onSurfaceChanged()` and by `onDisplayChanged` (such as a 180º orientation change). The DisplayOrientationChange object keeps a boolean that gets evaluated once per frame and updates as necessary. In order to support older APIs there are 2 implementations.

Some more testing is required, for the moment I'll keep in draft. If feedback is positive and seems like a good idea I'll add proper javadocs and run more tests.