### PR TITLE
improved PointSpriteParticleBatch options

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -12,6 +12,8 @@
 - Api Addition: Added a Pool#discard(T) method.
 - Architecture support: Linux ARM and AARCH64 support has been added. The gdx-xxx-natives.jar files now contain native libraries of these architectures as well.
 - API Addition: Desktop Sound now returns number of channels and sample rate.
+- API Addition: PointSpriteParticleBatch blending is now configurable.
+- TOOLS Features: Blending mode and sort mode can be changed in Flame particle 3D editor.
 
 [1.9.14]
 - [BREAKING CHANGE] iOS: IOSUIViewController has been moved to its own separate class 

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/AlignModeWrapper.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/AlignModeWrapper.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogic.gdx.tools.flame;
+
+import com.badlogic.gdx.graphics.g3d.particles.ParticleShader.AlignMode;
+
+enum AlignModeWrapper {
+	Screen(AlignMode.Screen, "Screen"), ViewPoint(AlignMode.ViewPoint, "View Point");
+
+	public static AlignModeWrapper find (AlignMode alignMode) {
+		for (AlignModeWrapper wrapper : values()) {
+			if (wrapper.mode == alignMode) return wrapper;
+		}
+		return null;
+	}
+
+	public String desc;
+	public AlignMode mode;
+
+	AlignModeWrapper (AlignMode mode, String desc) {
+		this.mode = mode;
+		this.desc = desc;
+	}
+
+	@Override
+	public String toString () {
+		return desc;
+	}
+}

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/BlendFunction.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/BlendFunction.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogic.gdx.tools.flame;
+
+import com.badlogic.gdx.graphics.GL20;
+
+enum BlendFunction {
+	ZERO(GL20.GL_ZERO),
+	ONE(GL20.GL_ONE),
+	SRC_ALPHA(GL20.GL_SRC_ALPHA),
+	SRC_COLOR(GL20.GL_SRC_COLOR),
+	DST_ALPHA(GL20.GL_DST_ALPHA),
+	DST_COLOR(GL20.GL_DST_COLOR),
+	ONE_MINUS_SRC_COLOR(GL20.GL_ONE_MINUS_SRC_COLOR),
+	ONE_MINUS_SRC_ALPHA(GL20.GL_ONE_MINUS_SRC_ALPHA),
+	ONE_MINUS_DST_COLOR(GL20.GL_ONE_MINUS_DST_COLOR),
+	ONE_MINUS_DST_ALPHA(GL20.GL_ONE_MINUS_DST_ALPHA);
+
+	public int blend;
+
+	private BlendFunction (int blend) {
+		this.blend = blend;
+	}
+
+	public static BlendFunction find (int function) {
+		for (BlendFunction func : values()) {
+			if (func.blend == function) return func;
+		}
+		return null;
+	}
+}

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/FlameMain.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/FlameMain.java
@@ -265,6 +265,7 @@ public class FlameMain extends JFrame implements AssetErrorListener {
 				addRow(editorPropertiesPanel, new DrawPanel(FlameMain.this, "Draw", ""));
 				addRow(editorPropertiesPanel, new TextureLoaderPanel(FlameMain.this, "Texture", ""));
 				addRow(editorPropertiesPanel, new BillboardBatchPanel(FlameMain.this, renderer.billboardBatch), 1, 1);
+				addRow(editorPropertiesPanel, new PointSpriteBatchPanel(FlameMain.this, renderer.pointSpriteBatch), 1, 1);
 				editorPropertiesPanel.repaint();
 				
 				//Controller props
@@ -351,7 +352,7 @@ public class FlameMain extends JFrame implements AssetErrorListener {
 
 	protected JPanel getPanel (ParticleBatch renderer) {
 		if(renderer instanceof PointSpriteParticleBatch){
-			return new EmptyPanel(this, "Point Sprite Batch", "It renders particles as point sprites.");
+			return new PointSpriteBatchPanel(this, (PointSpriteParticleBatch) renderer);
 		}
 		if(renderer instanceof BillboardParticleBatch){
 			return new BillboardBatchPanel(this, (BillboardParticleBatch) renderer);

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/PointSpriteBatchPanel.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/PointSpriteBatchPanel.java
@@ -1,3 +1,19 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
 package com.badlogic.gdx.tools.flame;
 
 import java.awt.GridBagConstraints;
@@ -12,52 +28,32 @@ import javax.swing.JLabel;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 
+import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.g3d.particles.ParticleShader.AlignMode;
 import com.badlogic.gdx.graphics.g3d.particles.ParticleSorter;
-import com.badlogic.gdx.graphics.g3d.particles.batches.BillboardParticleBatch;
+import com.badlogic.gdx.graphics.g3d.particles.batches.PointSpriteParticleBatch;
 
-/** @author Inferno */
-public class BillboardBatchPanel extends EditorPanel<BillboardParticleBatch> {
-	JComboBox alignCombo;
-	JCheckBox useGPUBox;
+public class PointSpriteBatchPanel extends EditorPanel<PointSpriteParticleBatch> {
+
 	JComboBox sortCombo;
 	JComboBox srcBlendFunction, destBlendFunction;
 
-	public BillboardBatchPanel (FlameMain particleEditor3D, BillboardParticleBatch renderer) {
-		super(particleEditor3D, "Billboard Batch", "Renderer used to draw billboards particles.");
+	public PointSpriteBatchPanel (FlameMain particleEditor3D, PointSpriteParticleBatch renderer) {
+		super(particleEditor3D, "Point sprite Batch", "Renderer used to draw point sprite particles.");
 		initializeComponents(renderer);
 		setValue(renderer);
 	}
 
-	private void initializeComponents (BillboardParticleBatch renderer) {
-		//Align
-		alignCombo = new JComboBox();
-		alignCombo.setModel(new DefaultComboBoxModel(AlignModeWrapper.values()));
-		alignCombo.setSelectedItem(AlignModeWrapper.find(renderer.getAlignMode()));
-		alignCombo.addActionListener(new ActionListener() {
-			public void actionPerformed (ActionEvent event) {
-				AlignModeWrapper align = (AlignModeWrapper)alignCombo.getSelectedItem();
-				editor.getBillboardBatch().setAlignMode(align.mode);
-			}
-		});
-		
-		//Cpu/Gpu
-		useGPUBox = new JCheckBox();
-		useGPUBox.setSelected(renderer.isUseGPU());
-		useGPUBox.addChangeListener(new ChangeListener() {
-			public void stateChanged (ChangeEvent event) {
-				editor.getBillboardBatch().setUseGpu(useGPUBox.isSelected());
-			}
-		}); 
-		
-		//Sort
+	private void initializeComponents (PointSpriteParticleBatch renderer) {
+
+		// Sort
 		sortCombo = new JComboBox();
 		sortCombo.setModel(new DefaultComboBoxModel(SortMode.values()));
 		sortCombo.setSelectedItem(SortMode.find(renderer.getSorter()));
 		sortCombo.addActionListener(new ActionListener() {
 			public void actionPerformed (ActionEvent event) {
 				SortMode mode = (SortMode)sortCombo.getSelectedItem();
-				editor.getBillboardBatch().setSorter(mode.sorter);
+				editor.getPointSpriteBatch().setSorter(mode.sorter);
 			}
 		});
 
@@ -68,7 +64,7 @@ public class BillboardBatchPanel extends EditorPanel<BillboardParticleBatch> {
 		srcBlendFunction.addActionListener(new ActionListener() {
 			public void actionPerformed (ActionEvent event) {
 				BlendFunction blend = (BlendFunction)srcBlendFunction.getSelectedItem();
-				editor.getBillboardBatch().getBlendingAttribute().sourceFunction = blend.blend;
+				editor.getPointSpriteBatch().getBlendingAttribute().sourceFunction = blend.blend;
 			}
 		});
 
@@ -79,24 +75,16 @@ public class BillboardBatchPanel extends EditorPanel<BillboardParticleBatch> {
 		destBlendFunction.addActionListener(new ActionListener() {
 			public void actionPerformed (ActionEvent event) {
 				BlendFunction blend = (BlendFunction)destBlendFunction.getSelectedItem();
-				editor.getBillboardBatch().getBlendingAttribute().destFunction = blend.blend;
+				editor.getPointSpriteBatch().getBlendingAttribute().destFunction = blend.blend;
 			}
 		});
 
 		int i = 0;
-		Insets insets = new Insets(6, 0, 0, 0);
-		contentPanel.add(new JLabel("Align"),
-			new GridBagConstraints(0, i, 1, 1, 0, 0, GridBagConstraints.WEST, GridBagConstraints.NONE, insets, 0, 0));
-		contentPanel.add(alignCombo,
-			new GridBagConstraints(1, i++, 1, 1, 1, 0, GridBagConstraints.WEST, GridBagConstraints.NONE, insets, 0, 0));
-		contentPanel.add(new JLabel("Use GPU"),
-			new GridBagConstraints(0, i, 1, 1, 0, 0, GridBagConstraints.WEST, GridBagConstraints.NONE, insets, 0, 0));
-		contentPanel.add(useGPUBox,
-			new GridBagConstraints(1, i++, 1, 1, 1, 0, GridBagConstraints.WEST, GridBagConstraints.NONE, insets, 0, 0));
+		Insets insets = new Insets(3, 0, 0, 0);
 		contentPanel.add(new JLabel("Sort"),
 			new GridBagConstraints(0, i, 1, 1, 0, 0, GridBagConstraints.WEST, GridBagConstraints.NONE, insets, 0, 0));
 		contentPanel.add(sortCombo,
-			new GridBagConstraints(1, i++, 1, 1, 0, 0, GridBagConstraints.WEST, GridBagConstraints.NONE, insets, 0, 0));
+			new GridBagConstraints(1, i++, 1, 1, 1, 0, GridBagConstraints.WEST, GridBagConstraints.NONE, insets, 0, 0));
 		contentPanel.add(new JLabel("Blending Src"),
 			new GridBagConstraints(0, i, 1, 1, 0, 0, GridBagConstraints.WEST, GridBagConstraints.NONE, insets, 0, 0));
 		contentPanel.add(srcBlendFunction,
@@ -104,7 +92,7 @@ public class BillboardBatchPanel extends EditorPanel<BillboardParticleBatch> {
 		contentPanel.add(new JLabel("Blending Dest"),
 			new GridBagConstraints(0, i, 1, 1, 0, 0, GridBagConstraints.WEST, GridBagConstraints.NONE, insets, 0, 0));
 		contentPanel.add(destBlendFunction,
-			new GridBagConstraints(1, i++, 1, 1, 0, 0, GridBagConstraints.WEST, GridBagConstraints.NONE,insets, 0, 0));
+			new GridBagConstraints(1, i++, 1, 1, 0, 0, GridBagConstraints.WEST, GridBagConstraints.NONE, insets, 0, 0));
 	}
 
 }

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/SortMode.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/SortMode.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogic.gdx.tools.flame;
+
+import com.badlogic.gdx.graphics.g3d.particles.ParticleSorter;
+
+enum SortMode {
+	None("None", new ParticleSorter.None()), Distance("Distance", new ParticleSorter.Distance());
+
+	public static SortMode find (ParticleSorter sorter) {
+		Class type = sorter.getClass();
+		for (SortMode wrapper : values()) {
+			if (wrapper.sorter.getClass() == type) return wrapper;
+		}
+		return null;
+	}
+
+	public String desc;
+	public ParticleSorter sorter;
+
+	SortMode (String desc, ParticleSorter sorter) {
+		this.sorter = sorter;
+		this.desc = desc;
+	}
+
+	@Override
+	public String toString () {
+		return desc;
+	}
+}

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/particles/batches/PointSpriteParticleBatch.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/particles/batches/PointSpriteParticleBatch.java
@@ -68,6 +68,8 @@ public class PointSpriteParticleBatch extends BufferedParticleBatch<PointSpriteC
 
 	private float[] vertices;
 	Renderable renderable;
+	protected BlendingAttribute blendingAttribute;
+	protected DepthTestAttribute depthTestAttribute;
 
 	public PointSpriteParticleBatch () {
 		this(1000);
@@ -78,9 +80,21 @@ public class PointSpriteParticleBatch extends BufferedParticleBatch<PointSpriteC
 	}
 	
 	public PointSpriteParticleBatch (int capacity, ParticleShader.Config shaderConfig) {
+		this(capacity, shaderConfig, null, null);
+	}
+
+	public PointSpriteParticleBatch (int capacity, ParticleShader.Config shaderConfig, BlendingAttribute blendingAttribute,
+		DepthTestAttribute depthTestAttribute) {
 		super(PointSpriteControllerRenderData.class);
 
 		if (!pointSpritesEnabled) enablePointSprites();
+
+		this.blendingAttribute = blendingAttribute;
+		this.depthTestAttribute = depthTestAttribute;
+
+		if (this.blendingAttribute == null)
+			this.blendingAttribute = new BlendingAttribute(GL20.GL_ONE, GL20.GL_ONE_MINUS_SRC_ALPHA, 1f);
+		if (this.depthTestAttribute == null) this.depthTestAttribute = new DepthTestAttribute(GL20.GL_LEQUAL, false);
 
 		allocRenderable();
 		ensureCapacity(capacity);
@@ -99,8 +113,7 @@ public class PointSpriteParticleBatch extends BufferedParticleBatch<PointSpriteC
 		renderable = new Renderable();
 		renderable.meshPart.primitiveType = GL20.GL_POINTS;
 		renderable.meshPart.offset = 0;
-		renderable.material = new Material(new BlendingAttribute(GL20.GL_ONE, GL20.GL_ONE_MINUS_SRC_ALPHA, 1f),
-			new DepthTestAttribute(GL20.GL_LEQUAL, false), TextureAttribute.createDiffuse((Texture)null));
+		renderable.material = new Material(blendingAttribute, depthTestAttribute, TextureAttribute.createDiffuse((Texture)null));
 	}
 
 	public void setTexture (Texture texture) {
@@ -111,6 +124,10 @@ public class PointSpriteParticleBatch extends BufferedParticleBatch<PointSpriteC
 	public Texture getTexture () {
 		TextureAttribute attribute = (TextureAttribute)renderable.material.get(TextureAttribute.Diffuse);
 		return attribute.textureDescription.texture;
+	}
+
+	public BlendingAttribute getBlendingAttribute () {
+		return blendingAttribute;
 	}
 
 	@Override


### PR DESCRIPTION
PointSpriteParticleBatch can be configured the same way as BillboardParticleBatch (blending and depth test).
I created a new panel in Flame for that renderer, moved shared enums to separate classes and refactor shared methods.