### PR TITLE
check bones count when creating shaders

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/DefaultShader.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/DefaultShader.java
@@ -548,6 +548,10 @@ public class DefaultShader extends BaseShader {
 		if (!config.ignoreUnimplemented && (implementedFlags & attributesMask) != attributesMask)
 			throw new GdxRuntimeException("Some attributes not implemented yet (" + attributesMask + ")");
 
+		if (renderable.bones != null && renderable.bones.length > config.numBones) {
+			throw new GdxRuntimeException("too many bones: " + renderable.bones.length + ", max configured: " + config.numBones);
+		}
+
 		// Global uniforms
 		u_projTrans = register(Inputs.projTrans, Setters.projTrans);
 		u_viewTrans = register(Inputs.viewTrans, Setters.viewTrans);

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/DepthShader.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/DepthShader.java
@@ -28,6 +28,7 @@ import com.badlogic.gdx.graphics.g3d.attributes.FloatAttribute;
 import com.badlogic.gdx.graphics.g3d.attributes.TextureAttribute;
 import com.badlogic.gdx.graphics.g3d.utils.RenderContext;
 import com.badlogic.gdx.graphics.glutils.ShaderProgram;
+import com.badlogic.gdx.utils.GdxRuntimeException;
 
 public class DepthShader extends DefaultShader {
 	public static class Config extends DefaultShader.Config {
@@ -91,6 +92,11 @@ public class DepthShader extends DefaultShader {
 	public DepthShader (final Renderable renderable, final Config config, final ShaderProgram shaderProgram) {
 		super(renderable, config, shaderProgram);
 		final Attributes attributes = combineAttributes(renderable);
+
+		if (renderable.bones != null && renderable.bones.length > config.numBones) {
+			throw new GdxRuntimeException("too many bones: " + renderable.bones.length + ", max configured: " + config.numBones);
+		}
+
 		this.numBones = renderable.bones == null ? 0 : config.numBones;
 		int w = 0;
 		final int n = renderable.meshPart.mesh.getVertexAttributes().size();


### PR DESCRIPTION
It's a common pitfall to have more bones in a model than what is configured (default is 12). In this case, you only see a model partially rendered without any obvious clue why (especially beginners).