### PR TITLE
check bones count when selecting shader

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/DefaultShader.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/DefaultShader.java
@@ -725,6 +725,7 @@ public class DefaultShader extends BaseShader {
 
 	@Override
 	public boolean canRender (final Renderable renderable) {
+		if (renderable.bones != null && renderable.bones.length > config.numBones) return false;
 		final long renderableMask = combineAttributeMasks(renderable);
 		return (attributesMask == (renderableMask | optionalAttributes))
 			&& (vertexMask == renderable.meshPart.mesh.getVertexAttributes().getMaskWithSizePacked()) && (renderable.environment != null) == lighting;

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/DepthShader.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/DepthShader.java
@@ -123,6 +123,7 @@ public class DepthShader extends DefaultShader {
 
 	@Override
 	public boolean canRender (Renderable renderable) {
+		if (renderable.bones != null && renderable.bones.length > numBones) return false;
 		final Attributes attributes = combineAttributes(renderable);
 		if (attributes.has(BlendingAttribute.Type)) {
 			if ((attributesMask & BlendingAttribute.Type) != BlendingAttribute.Type)


### PR DESCRIPTION
I missed something in #6496 (sorry about that) : A shader could be reused for another renderable which could have too many bones.