### PR TITLE
Stop generated .gitignore ignoring essential Eclipse metadata files

### DIFF
--- a/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/gitignore
+++ b/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/gitignore
@@ -33,8 +33,6 @@ com_crashlytics_export_strings.xml
 
 ## Eclipse
 
-.classpath
-.project
 .metadata/
 /android/bin/
 /core/bin/
@@ -45,7 +43,6 @@ com_crashlytics_export_strings.xml
 *.bak
 *.swp
 *~.nib
-.settings/
 .loadpath
 .externalToolBuilders/
 *.launch


### PR DESCRIPTION
By default, the generated `.gitignore` ignores two essential Eclipse files: `.project`, and `.classpath`.

`.project` define a project name (user edited) and what types of builds are permitted.

`.classpath` defines the location of runtime libraries and how to execute specific builds.

`.settings/` defines specific IDE switches, e.g. how Eclipse's JDT operates, which compiler version to target, etc.

I'm proposing these changes because after a restart of Eclipse, all of a sudden I couldn't run JUnit tests in my project. Turns out both the `.project` and `.classpath` had changed and I had no idea, because they weren't version controlled.