### PR TITLE
Vectors change check in nor() before normalise

### DIFF
--- a/gdx/src/com/badlogic/gdx/math/Vector2.java
+++ b/gdx/src/com/badlogic/gdx/math/Vector2.java
@@ -113,7 +113,7 @@ public class Vector2 implements Serializable, Vector<Vector2> {
 	@Override
 	public Vector2 nor () {
 		 final float len2 = len2();
-		 if (MathUtils.isZero(len2) || MathUtils.isEqual(len2, 1f))
+		 if (MathUtils.isEqual(len2, 1f) || MathUtils.isZero(len2))
 			  return this;
 		 return this.scl(1 / len());
 	}

--- a/gdx/src/com/badlogic/gdx/math/Vector2.java
+++ b/gdx/src/com/badlogic/gdx/math/Vector2.java
@@ -115,7 +115,7 @@ public class Vector2 implements Serializable, Vector<Vector2> {
 		 final float len2 = len2();
 		 if (MathUtils.isEqual(len2, 1f) || MathUtils.isZero(len2))
 			  return this;
-		 return this.scl(1 / len());
+		 return this.scl(1f / (float)Math.sqrt(len2));
 	}
 
 	@Override

--- a/gdx/src/com/badlogic/gdx/math/Vector2.java
+++ b/gdx/src/com/badlogic/gdx/math/Vector2.java
@@ -112,12 +112,10 @@ public class Vector2 implements Serializable, Vector<Vector2> {
 
 	@Override
 	public Vector2 nor () {
-		float len = len();
-		if (len != 0) {
-			x /= len;
-			y /= len;
-		}
-		return this;
+		 final float len2 = len2();
+		 if (MathUtils.isZero(len2) || MathUtils.isEqual(len2, 1f))
+			  return this;
+		 return this.scl(1 / len());
 	}
 
 	@Override

--- a/gdx/src/com/badlogic/gdx/math/Vector3.java
+++ b/gdx/src/com/badlogic/gdx/math/Vector3.java
@@ -299,8 +299,9 @@ public class Vector3 implements Serializable, Vector<Vector3> {
 	@Override
 	public Vector3 nor () {
 		final float len2 = this.len2();
-		if (len2 == 0f || len2 == 1f) return this;
-		return this.scl(1f / (float)Math.sqrt(len2));
+		if(MathUtils.isZero(len2) || MathUtils.isEqual(len2,1f))
+			 return this;
+		return this.scl(1f / len());
 	}
 
 	/** @return The dot product between the two vectors */

--- a/gdx/src/com/badlogic/gdx/math/Vector3.java
+++ b/gdx/src/com/badlogic/gdx/math/Vector3.java
@@ -301,7 +301,7 @@ public class Vector3 implements Serializable, Vector<Vector3> {
 		final float len2 = this.len2();
 		if(MathUtils.isEqual(len2, 1f) || MathUtils.isZero(len2))
 			 return this;
-		return this.scl(1f / len());
+		 return this.scl(1f / (float)Math.sqrt(len2));
 	}
 
 	/** @return The dot product between the two vectors */

--- a/gdx/src/com/badlogic/gdx/math/Vector3.java
+++ b/gdx/src/com/badlogic/gdx/math/Vector3.java
@@ -299,7 +299,7 @@ public class Vector3 implements Serializable, Vector<Vector3> {
 	@Override
 	public Vector3 nor () {
 		final float len2 = this.len2();
-		if(MathUtils.isZero(len2) || MathUtils.isEqual(len2,1f))
+		if(MathUtils.isEqual(len2, 1f) || MathUtils.isZero(len2))
 			 return this;
 		return this.scl(1f / len());
 	}

--- a/gdx/test/com/badlogic/gdx/math/Vector2Test.java
+++ b/gdx/test/com/badlogic/gdx/math/Vector2Test.java
@@ -2,6 +2,7 @@
 package com.badlogic.gdx.math;
 
 import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
@@ -35,4 +36,20 @@ public class Vector2Test {
 	public void testAngleRadRelative() {
 		assertEquals(- MathUtils.HALF_PI, new Vector2(0, -1f).angleRad(Vector2.X), MathUtils.FLOAT_ROUNDING_ERROR);
 	}
+
+	 /** Test if check before use len() in nor method work */
+	 @Test
+	 public void testNorCheck () {
+		  Vector2 v1 = new Vector2(15.832937f, 44.702236f).nor();
+		  assertFalse(v1.len2() == 1f);
+		  assertTrue(MathUtils.isEqual(v1.len2(), 1f));
+	 }
+
+	 @Test
+	 public void testNorNoArthimeticException () {
+		  Vector2 v = new Vector2(Float.MIN_VALUE, Float.MIN_VALUE);
+		  Vector2 vNor = v.cpy().nor();
+		  assertEquals(v, vNor);
+	 }
+
 }

--- a/gdx/test/com/badlogic/gdx/math/Vector3Test.java
+++ b/gdx/test/com/badlogic/gdx/math/Vector3Test.java
@@ -15,4 +15,19 @@ public class Vector3Test {
 	public void testFromString () {
 		assertEquals(new Vector3(-5f, 42.00055f, 44444.32f), new Vector3().fromString("(-5,42.00055,44444.32)"));
 	}
+
+	 /** Test if check before use len() in nor method work */
+	 @Test
+	 public void testNorCheck () {
+		  Vector3 v = new Vector3(34.616817f,97.90621f,19.677162f).nor();
+		  assertFalse(v.len2() == 1f);
+		  assertTrue(MathUtils.isEqual(v.len2(), 1f));
+	 }
+
+	 @Test
+	 public void testNorNoArthimeticException () {
+		  Vector3 v = new Vector3(Float.MIN_VALUE, Float.MIN_VALUE, Float.MIN_VALUE);
+		  Vector3 vNor = v.cpy().nor();
+		  assertEquals(v, vNor);
+	 }
 }


### PR DESCRIPTION
Hi !
This commit change for Vector2/Vector3 the check for see if Vector is already normalised.

I add 2 tests 
 - for check than len2 method can return number close to 1f and nor() needs to check with MathUtils.isEqual(len2,1f)
 - Check if Arthimetic exception can appears with nor(). (i think its useless, i see in testing that float variable divide by zero, dont throw Arthimetic but an infinite float.

Im not really sure about the tests pertinence.
Thanks for reading.