### PR TITLE
fix audio voice stealing

### DIFF
--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/audio/OpenALLwjglAudio.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/audio/OpenALLwjglAudio.java
@@ -141,12 +141,11 @@ public class OpenALLwjglAudio implements LwjglAudio {
 			int sourceId = idleSources.get(i);
 			int state = alGetSourcei(sourceId, AL_SOURCE_STATE);
 			if (state != AL_PLAYING && state != AL_PAUSED) {
+				Long oldSoundId = sourceToSoundId.remove(sourceId);
+				if (oldSoundId != null) soundIdToSource.remove(oldSoundId);
 				if (isMusic) {
 					idleSources.removeIndex(i);
 				} else {
-					Long oldSoundId = sourceToSoundId.remove(sourceId);
-					if (oldSoundId != null) soundIdToSource.remove(oldSoundId);
-
 					long soundId = nextSoundId++;
 					sourceToSoundId.put(sourceId, soundId);
 					soundIdToSource.put(soundId, sourceId);

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALLwjgl3Audio.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALLwjgl3Audio.java
@@ -174,12 +174,11 @@ public class OpenALLwjgl3Audio implements Lwjgl3Audio {
 			int sourceId = idleSources.get(i);
 			int state = alGetSourcei(sourceId, AL_SOURCE_STATE);
 			if (state != AL_PLAYING && state != AL_PAUSED) {
+				Long oldSoundId = sourceToSoundId.remove(sourceId);
+				if (oldSoundId != null) soundIdToSource.remove(oldSoundId);
 				if (isMusic) {
 					idleSources.removeIndex(i);
 				} else {
-					Long oldSoundId = sourceToSoundId.remove(sourceId);
-					if (oldSoundId != null) soundIdToSource.remove(oldSoundId);
-
 					long soundId = nextSoundId++;
 					sourceToSoundId.put(sourceId, soundId);
 					soundIdToSource.put(soundId, sourceId);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/conformance/AudioSoundAndMusicIsolationTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/conformance/AudioSoundAndMusicIsolationTest.java
@@ -1,0 +1,39 @@
+package com.badlogic.gdx.tests.conformance;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.audio.Music;
+import com.badlogic.gdx.audio.Sound;
+import com.badlogic.gdx.math.MathUtils;
+import com.badlogic.gdx.Files.FileType;
+import com.badlogic.gdx.tests.utils.GdxTest;
+
+/**
+ * Test case to validate an issue where soundID is in dirty state and controls a source
+ * used by a music.
+ * @author mgsx
+ */
+public class AudioSoundAndMusicIsolationTest extends GdxTest
+{
+	private Sound sound;
+	private Music music;
+	private float time;
+	private long soundID;
+
+	@Override
+	public void create () {
+		sound = Gdx.audio.newSound(Gdx.files.getFileHandle("data/shotgun.ogg", FileType.Internal));
+		music = Gdx.audio.newMusic(Gdx.files.internal("data/8.12.loop.wav"));
+		
+		soundID = sound.play();
+	}
+	
+	@Override
+	public void render () {
+		time += Gdx.graphics.getDeltaTime();
+		if(time > 5 && !music.isPlaying()){
+			music.play();
+		}
+		// after 5 seconds, sound is finished but this code affect music volume instead.
+		sound.setVolume(soundID, MathUtils.sinDeg(time * 360) * .5f + .5f);
+	}
+}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
@@ -38,6 +38,7 @@ import java.util.List;
 
 import com.badlogic.gdx.tests.*;
 import com.badlogic.gdx.tests.bench.TiledMapBench;
+import com.badlogic.gdx.tests.conformance.AudioSoundAndMusicIsolationTest;
 import com.badlogic.gdx.tests.conformance.DisplayModeTest;
 import com.badlogic.gdx.tests.examples.MoveSpriteExample;
 import com.badlogic.gdx.tests.extensions.FreeTypeAtlasTest;
@@ -103,6 +104,7 @@ public class GdxTests {
 		AtlasIssueTest.class,
 		AudioDeviceTest.class,
 		AudioRecorderTest.class,
+		AudioSoundAndMusicIsolationTest.class,
 		Basic3DSceneTest.class,
 		Basic3DTest.class,
 		Benchmark3DTest.class,


### PR DESCRIPTION
When a sound is finished, a new music playback didn't remove entry in sound/source maps. In this case, any change using the soundID (volume, pan, pitch) applies to the music instead.

I included a test case in order to validate the issue, let me know if you don't want this test in libgdx repo or if you prefer that i move it somewhere else...