### PR TITLE
fetch jnigen loader jar and add it to gdx classpath

### DIFF
--- a/fetch.xml
+++ b/fetch.xml
@@ -7,6 +7,9 @@
 
     <property name="robovm-version" value="2.3.12"/>
 
+    <property name="jnigen" value="https://oss.sonatype.org/content/repositories/releases/com/badlogicgames/gdx"/>
+    <property name="jnigen-version" value="2.2.0"/>
+
     <property name="lwjgl" value="https://oss.sonatype.org/content/repositories/releases/org/lwjgl"/>
     <property name="lwjgl-version" value="3.2.3"/>
     
@@ -82,6 +85,8 @@
     <target name="fetch-gdx">
         <get src="${gdx-natives}" dest="./"/>   
         <unzip src="natives.zip" dest="./"/>  
+
+        <get src="${jnigen}/gdx-jnigen-loader/${jnigen-version}/gdx-jnigen-loader-${jnigen-version}.jar" dest="gdx/libs/gdx-jnigen-loader.jar"/>
 
         <!-- copy all natives to android tests -->
 		<copy todir="tests/gdx-tests-android/libs/armeabi-v7a">

--- a/gdx/.classpath
+++ b/gdx/.classpath
@@ -10,5 +10,6 @@
 	<classpathentry kind="src" path="test"/>
 	<classpathentry kind="lib" path="libs/junit-4.11.jar"/>
 	<classpathentry kind="lib" path="libs/hamcrest-core-1.3.jar"/>
+	<classpathentry exported="true" kind="lib" path="libs/gdx-jnigen-loader.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>


### PR DESCRIPTION
While #6369 is not merged we still use git tracked eclipse files and jnigen-loader was missing, so i temporarily added it back for Eclipse users.