### PR TITLE
Polygon add method setVertex

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,7 @@
 - API Addition: ObjLoader now supports ambientColor, ambientTexture, transparencyTexture, specularTexture and shininessTexture
 - API Addition: PointSpriteParticleBatch blending is now configurable.
 - TOOLS Features: Blending mode and sort mode can be changed in Flame particle 3D editor.
+- API Addition : Polygon have method setVertex (int vertexNum, float x, float y)
 
 [1.10.0]
 - [BREAKING CHANGE] Android armeabi support has been removed. To migrate your projects: remove any dependency with natives-armeabi qualifier from your gradle build file, this apply to gdx-platform, gdx-bullet-platform, gdx-freetype-platform and gdx-box2d-platform.

--- a/CHANGES
+++ b/CHANGES
@@ -2,7 +2,7 @@
 - API Addition: ObjLoader now supports ambientColor, ambientTexture, transparencyTexture, specularTexture and shininessTexture
 - API Addition: PointSpriteParticleBatch blending is now configurable.
 - TOOLS Features: Blending mode and sort mode can be changed in Flame particle 3D editor.
-- API Addition : Polygon have method setVertex (int vertexNum, float x, float y)
+- API Addition : Polygon have method setVertex (int index, float x, float y)
 
 [1.10.0]
 - [BREAKING CHANGE] Android armeabi support has been removed. To migrate your projects: remove any dependency with natives-armeabi qualifier from your gradle build file, this apply to gdx-platform, gdx-bullet-platform, gdx-freetype-platform and gdx-box2d-platform.

--- a/gdx/src/com/badlogic/gdx/math/Polygon.java
+++ b/gdx/src/com/badlogic/gdx/math/Polygon.java
@@ -121,12 +121,13 @@ public class Polygon implements Shape2D {
 
 	 /** Set vertex position
 	  *
-	  * @param vertexNum min=0, max=(vertices/2)-1
+	  * @param index min=0, max=vertices.length/2-1
 	  * @throws IllegalArgumentException if vertex doesnt exist */
-	 public void setVertex (int vertexNum, float x, float y) {
-		  if (vertexNum > localVertices.length / 2 -1) throw new IllegalArgumentException("the vertex " + vertexNum + "doesn't exist");
-		  localVertices[2 * vertexNum] = x;
-		  localVertices[2 * vertexNum + 1] = y;
+	 public void setVertex (int index, float x, float y) {
+		  if (index < 0 || index > localVertices.length / 2 - 1)
+				throw new IllegalArgumentException("the vertex " + index + " doesn't exist");
+		  localVertices[2 * index] = x;
+		  localVertices[2 * index + 1] = y;
 		  dirty = true;
 	 }
 

--- a/gdx/src/com/badlogic/gdx/math/Polygon.java
+++ b/gdx/src/com/badlogic/gdx/math/Polygon.java
@@ -119,6 +119,17 @@ public class Polygon implements Shape2D {
 		dirty = true;
 	}
 
+	 /** Set vertex position
+	  *
+	  * @param vertexNum min=0, max=(vertices/2)-1
+	  * @throws IllegalArgumentException if vertex doesnt exist */
+	 public void setVertex (int vertexNum, float x, float y) {
+		  if (vertexNum > localVertices.length / 2 -1) throw new IllegalArgumentException("the vertex " + vertexNum + "doesn't exist");
+		  localVertices[2 * vertexNum] = x;
+		  localVertices[2 * vertexNum + 1] = y;
+		  dirty = true;
+	 }
+
 	/** Translates the polygon's position by the specified horizontal and vertical amounts. */
 	public void translate (float x, float y) {
 		this.x += x;


### PR DESCRIPTION
Hi, 
Actually in Polygon , the only method to change a vertex is to use 
 ```	
 public void setVertices (float[] vertices) {
		if (vertices.length < 6) throw new IllegalArgumentException("polygons must contain at least 3 points.");
		localVertices = vertices;
		dirty = true;
	} 
 ```	
I think a method is missing for change easily a vertex.


If read pr code you can see,
- a param vertexNum -> i start to 0, so for a triangle values allowed are (0,1,2). 
Maybe its more normal to start at 1.

- I change vertex in localvertices array, but should it consider the value as worldvertices ? And transform with scale and rotation to a localvertices
- It throw IllegalArgumentException if vertices dont exist in polygon.
Its better to let an npe appears?

My use case is not  on polygon class but in my own class `public class Triangle extends Polygon `
And i want to add a method for change one vertex.
An other solution was to change localvertices to protected, but i follow @obigu advices.

Waiting your feedback
Thanks for reading
