### PR TITLE
Remove frameCount from AnimatedTiledMapTile

### DIFF
--- a/gdx/src/com/badlogic/gdx/maps/tiled/tiles/AnimatedTiledMapTile.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/tiles/AnimatedTiledMapTile.java
@@ -41,7 +41,6 @@ public class AnimatedTiledMapTile implements TiledMapTile {
 	private StaticTiledMapTile[] frameTiles;
 
 	private int[] animationIntervals;
-	private int frameCount = 0;
 	private int loopDuration;
 	private static final long initialTimeOffset = TimeUtils.millis();
 
@@ -159,7 +158,6 @@ public class AnimatedTiledMapTile implements TiledMapTile {
 	 * @param frameTiles An array of {@link StaticTiledMapTile}s that make up the animation. */
 	public AnimatedTiledMapTile (float interval, Array<StaticTiledMapTile> frameTiles) {
 		this.frameTiles = new StaticTiledMapTile[frameTiles.size];
-		this.frameCount = frameTiles.size;
 
 		this.loopDuration = frameTiles.size * (int)(interval * 1000f);
 		this.animationIntervals = new int[frameTiles.size];
@@ -175,7 +173,6 @@ public class AnimatedTiledMapTile implements TiledMapTile {
 	 * @param frameTiles An array of {@link StaticTiledMapTile}s that make up the animation. */
 	public AnimatedTiledMapTile (IntArray intervals, Array<StaticTiledMapTile> frameTiles) {
 		this.frameTiles = new StaticTiledMapTile[frameTiles.size];
-		this.frameCount = frameTiles.size;
 
 		this.animationIntervals = intervals.toArray();
 		this.loopDuration = 0;


### PR DESCRIPTION
frameCount in AnimatedTiledMapTile is private and not used anywhere. It also cannot be accessed from outside.