### PR TITLE
Box2D Shape implements Disposable

### DIFF
--- a/extensions/gdx-box2d/gdx-box2d-gwt/src/com/badlogic/gdx/physics/box2d/gwt/emu/com/badlogic/gdx/physics/box2d/Shape.java
+++ b/extensions/gdx-box2d/gdx-box2d-gwt/src/com/badlogic/gdx/physics/box2d/gwt/emu/com/badlogic/gdx/physics/box2d/Shape.java
@@ -16,12 +16,14 @@
 
 package com.badlogic.gdx.physics.box2d;
 
+import com.badlogic.gdx.utils.Disposable;
+
 /** A shape is used for collision detection. You can create a shape however you like. Shapes used for simulation in b2World are
  * created automatically when a b2Fixture is created. Shapes may encapsulate a one or more child shapes.
  * 
  * NOTE: YOU NEED TO DISPOSE SHAPES YOU CREATED YOURSELF AFTER YOU NO LONGER USE THEM! E.g. after calling body.createFixture();
  * @author mzechner */
-public abstract class Shape {
+public abstract class Shape implements Disposable {
 	/** Enum describing the type of a shape
 	 * @author mzechner */
 	public enum Type {
@@ -45,6 +47,7 @@ public abstract class Shape {
 	public abstract void setRadius (float radius);
 
 	/** Needs to be called when the shape is no longer used, e.g. after a fixture was created based on the shape. */
+	@Override
 	public void dispose () {
 	}
 

--- a/extensions/gdx-box2d/gdx-box2d/src/com/badlogic/gdx/physics/box2d/Shape.java
+++ b/extensions/gdx-box2d/gdx-box2d/src/com/badlogic/gdx/physics/box2d/Shape.java
@@ -16,12 +16,14 @@
 
 package com.badlogic.gdx.physics.box2d;
 
+import com.badlogic.gdx.utils.Disposable;
+
 /** A shape is used for collision detection. You can create a shape however you like. Shapes used for simulation in b2World are
  * created automatically when a b2Fixture is created. Shapes may encapsulate a one or more child shapes.
  * 
  * NOTE: YOU NEED TO DISPOSE SHAPES YOU CREATED YOURSELF AFTER YOU NO LONGER USE THEM! E.g. after calling body.createFixture();
  * @author mzechner */
-public abstract class Shape {
+public abstract class Shape implements Disposable {
 	// @off
 	/*JNI
 #include <Box2D/Box2D.h>
@@ -61,6 +63,7 @@ public abstract class Shape {
 	*/
 
 	/** Needs to be called when the shape is no longer used, e.g. after a fixture was created based on the shape. */
+	@Override
 	public void dispose () {
 		jniDispose(addr);
 	}


### PR DESCRIPTION
Hey i see Shape class got this  comment
``` 
* NOTE: YOU NEED TO DISPOSE SHAPES YOU CREATED YOURSELF AFTER YOU NO LONGER USE THEM! E.g. after calling body.createFixture();
 * @author mzechner */
public abstract class Shape implements Disposable {
```
dispose() method is already here.
I check on package except in World class (already impl Disposable) i dont find other occurence of dispose() or jniDispose()

Thanks for reading.