### PR TITLE
Fix #6464: TMX built-in tile property "type" is now supported.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,8 +2,8 @@
 - API Addition: ObjLoader now supports ambientColor, ambientTexture, transparencyTexture, specularTexture and shininessTexture
 - API Addition: PointSpriteParticleBatch blending is now configurable.
 - TOOLS Features: Blending mode and sort mode can be changed in Flame particle 3D editor.
-- API Addition : Polygon have method setVertex (int index, float x, float y)
-- API Addition:
+- API Addition: Polygon have method setVertex (int index, float x, float y).
+- API Addition: TMX built-in tile property "type" is now supported.
 
 [1.10.0]
 - [BREAKING CHANGE] Android armeabi support has been removed. To migrate your projects: remove any dependency with natives-armeabi qualifier from your gradle build file, this apply to gdx-platform, gdx-bullet-platform, gdx-freetype-platform and gdx-box2d-platform.

--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,7 @@
 - API Addition: PointSpriteParticleBatch blending is now configurable.
 - TOOLS Features: Blending mode and sort mode can be changed in Flame particle 3D editor.
 - API Addition : Polygon have method setVertex (int index, float x, float y)
+- API Addition:
 
 [1.10.0]
 - [BREAKING CHANGE] Android armeabi support has been removed. To migrate your projects: remove any dependency with natives-armeabi qualifier from your gradle build file, this apply to gdx-platform, gdx-bullet-platform, gdx-freetype-platform and gdx-box2d-platform.

--- a/gdx/src/com/badlogic/gdx/maps/tiled/BaseTmxMapLoader.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/BaseTmxMapLoader.java
@@ -641,6 +641,10 @@ public abstract class BaseTmxMapLoader<P extends BaseTmxMapLoader.Parameters> ex
 		if (probability != null) {
 			tile.getProperties().put("probability", probability);
 		}
+		String type = tileElement.getAttribute("type", null);
+		if (type != null) {
+			tile.getProperties().put("type", type);
+		}
 		Element properties = tileElement.getChildByName("properties");
 		if (properties != null) {
 			loadProperties(tile.getProperties(), properties);


### PR DESCRIPTION
Previous PR request: https://github.com/libgdx/libgdx/pull/6465

I've found some time and implemented it in the way @mgsx-dev wanted it.

This however turns the PR into a breaking change compared to previously where it wasn't the case.


![image](https://user-images.githubusercontent.com/11274700/118031309-b040b980-b366-11eb-987f-6a182cb635a8.png)