### PR TITLE
Fix asset manager deadlock on dispose and clear

### DIFF
--- a/gdx/src/com/badlogic/gdx/assets/AssetManager.java
+++ b/gdx/src/com/badlogic/gdx/assets/AssetManager.java
@@ -699,43 +699,50 @@ public class AssetManager implements Disposable {
 
 	/** Disposes all assets in the manager and stops all asynchronous loading. */
 	@Override
-	public synchronized void dispose () {
+	public void dispose () {
 		log.debug("Disposing.");
 		clear();
 		executor.dispose();
 	}
 
 	/** Clears and disposes all assets and the preloading queue. */
-	public synchronized void clear () {
-		loadQueue.clear();
-		while (!update()) {
+	public void clear () {
+		synchronized (this) {
+			loadQueue.clear();
 		}
 
-		ObjectIntMap<String> dependencyCount = new ObjectIntMap<String>();
-		while (assetTypes.size > 0) {
-			// for each asset, figure out how often it was referenced
-			dependencyCount.clear();
-			Array<String> assets = assetTypes.keys().toArray();
-			for (String asset : assets) {
-				Array<String> dependencies = assetDependencies.get(asset);
-				if (dependencies == null) continue;
-				for (String dependency : dependencies)
-					dependencyCount.getAndIncrement(dependency, 0, 1);
+		// Lock is temporarily released to yield to blocked executor threads
+		// A pending async task can cause a deadlock if we do not release
+
+		finishLoading();
+
+		synchronized (this) {
+			ObjectIntMap<String> dependencyCount = new ObjectIntMap<String>();
+			while (assetTypes.size > 0) {
+				// for each asset, figure out how often it was referenced
+				dependencyCount.clear();
+				Array<String> assets = assetTypes.keys().toArray();
+				for (String asset : assets) {
+					Array<String> dependencies = assetDependencies.get(asset);
+					if (dependencies == null) continue;
+					for (String dependency : dependencies)
+						dependencyCount.getAndIncrement(dependency, 0, 1);
+				}
+
+				// only dispose of assets that are root assets (not referenced)
+				for (String asset : assets)
+					if (dependencyCount.get(asset, 0) == 0) unload(asset);
 			}
 
-			// only dispose of assets that are root assets (not referenced)
-			for (String asset : assets)
-				if (dependencyCount.get(asset, 0) == 0) unload(asset);
+			this.assets.clear();
+			this.assetTypes.clear();
+			this.assetDependencies.clear();
+			this.loaded = 0;
+			this.toLoad = 0;
+			this.peakTasks = 0;
+			this.loadQueue.clear();
+			this.tasks.clear();
 		}
-
-		this.assets.clear();
-		this.assetTypes.clear();
-		this.assetDependencies.clear();
-		this.loaded = 0;
-		this.toLoad = 0;
-		this.peakTasks = 0;
-		this.loadQueue.clear();
-		this.tasks.clear();
 	}
 
 	/** @return the {@link Logger} used by the {@link AssetManager} */


### PR DESCRIPTION
A deadlock occurs when an asset manager executor thread tries to acquire the lock during a `dispose()` or `clear()` call. This PR alters these methods to only acquire the lock when required (similar to `finishLoading()` having no explicit lock) and yield to the pending async tasks instead.

```
"AssetManager@2033" daemon prio=5 tid=0x17 nid=NA waiting for monitor entry
  java.lang.Thread.State: BLOCKED
	 waiting for main@1 to release lock on <0x81d>
	  at com.badlogic.gdx.assets.AssetManager.get(AssetManager.java:145)
```