### PR TITLE
Implemented a guard against invalid values of getPpiX in AbstractGraphics

### DIFF
--- a/gdx/src/com/badlogic/gdx/AbstractGraphics.java
+++ b/gdx/src/com/badlogic/gdx/AbstractGraphics.java
@@ -9,7 +9,8 @@ public abstract class AbstractGraphics implements Graphics {
 
 	@Override
 	public float getDensity () {
-		return getPpiX() / 160f;
+		float ppiX = getPpiX();
+		return (ppiX > 0 && ppiX <= Float.MAX_VALUE) ? ppiX / 160f : 1f;
 	}
 
 	@Override

--- a/gdx/src/com/badlogic/gdx/Graphics.java
+++ b/gdx/src/com/badlogic/gdx/Graphics.java
@@ -216,7 +216,7 @@ public interface Graphics {
 	 * android.util.DisplayMetrics#density, where one DIP is one pixel on an approximately 160 dpi screen. Thus on a 160dpi screen
 	 * this density value will be 1; on a 120 dpi screen it would be .75; etc.
 	 *
-	 * If no pixels per inch could be determined, this returns a default value of 1.
+	 * If the density could not be determined, this returns a default value of 1.
 	 *
 	 * @return the Density Independent Pixel factor of the display. */
 	float getDensity ();

--- a/gdx/src/com/badlogic/gdx/Graphics.java
+++ b/gdx/src/com/badlogic/gdx/Graphics.java
@@ -216,6 +216,8 @@ public interface Graphics {
 	 * android.util.DisplayMetrics#density, where one DIP is one pixel on an approximately 160 dpi screen. Thus on a 160dpi screen
 	 * this density value will be 1; on a 120 dpi screen it would be .75; etc.
 	 *
+	 * If no pixels per inch could be determined, this returns a default value of 1.
+	 *
 	 * @return the Density Independent Pixel factor of the display. */
 	float getDensity ();
 


### PR DESCRIPTION
Gdx.graphics.getDensity() returns infinity inside VirtualBox #6537

This way, AbstractGraphics' getDensity will always return 1f as a default value (instead of Infinity).
By the way, this is my first Pull Request for LibGDX ✨ 