### PR TITLE
Fix LWJGL3Net#openURI on macOS & JDK >= 16

### DIFF
--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Net.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Net.java
@@ -70,8 +70,8 @@ public class Lwjgl3Net implements Net {
 	public boolean openURI (String URI) {
 		if(SharedLibraryLoader.isMac) {
 			try {
-                (Runtime.getRuntime()).exec("open " + URI);
-                return true;
+				(Runtime.getRuntime()).exec("open " + URI);
+				return true;
 			} catch (IOException e) {
 				return false;
 			}

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Net.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Net.java
@@ -70,8 +70,8 @@ public class Lwjgl3Net implements Net {
 	public boolean openURI (String URI) {
 		if(SharedLibraryLoader.isMac) {
 			try {
-				FileManager.openURL(URI);
-				return true;
+                (Runtime.getRuntime()).exec("open " + URI);
+                return true;
 			} catch (IOException e) {
 				return false;
 			}

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Net.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Net.java
@@ -17,10 +17,8 @@
 package com.badlogic.gdx.backends.lwjgl3;
 
 import java.awt.Desktop;
-import java.io.IOException;
 import java.net.URI;
 
-import com.apple.eio.FileManager;
 import com.badlogic.gdx.Net;
 import com.badlogic.gdx.net.NetJavaImpl;
 import com.badlogic.gdx.net.NetJavaServerSocketImpl;
@@ -70,7 +68,7 @@ public class Lwjgl3Net implements Net {
 	public boolean openURI (String uri) {
 		if(SharedLibraryLoader.isMac) {
 			try {
-				(Runtime.getRuntime()).exec("open " + (new URI(uri)));
+				(new ProcessBuilder("open", uri)).start();
 				return true;
 			} catch (Throwable t) {
 				return false;

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Net.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Net.java
@@ -67,17 +67,17 @@ public class Lwjgl3Net implements Net {
 	}
 
 	@Override
-	public boolean openURI (String URI) {
+	public boolean openURI (String uri) {
 		if(SharedLibraryLoader.isMac) {
 			try {
-				(Runtime.getRuntime()).exec("open " + URI);
+				(Runtime.getRuntime()).exec("open " + (new URI(uri)));
 				return true;
-			} catch (IOException e) {
+			} catch (Throwable t) {
 				return false;
 			}
 		} else {
 			try {
-				Desktop.getDesktop().browse(new URI(URI));
+				Desktop.getDesktop().browse(new URI(uri));
 				return true;
 			} catch (Throwable t) {
 				return false;

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Net.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Net.java
@@ -68,7 +68,7 @@ public class Lwjgl3Net implements Net {
 	public boolean openURI (String uri) {
 		if(SharedLibraryLoader.isMac) {
 			try {
-				(new ProcessBuilder("open", uri)).start();
+				(new ProcessBuilder("open", (new URI(uri).toString()))).start();
 				return true;
 			} catch (Throwable t) {
 				return false;

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/net/NetAPITest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/net/NetAPITest.java
@@ -113,7 +113,7 @@ public class NetAPITest extends GdxTest implements HttpResponseListener {
 					else if (clickedButton == btnDownloadError)
 						url = "https://www.badlogicgames.com/doesnotexist";
 					else if (clickedButton == btnOpenUri) {
-						Gdx.net.openURI("https://libgdx.badlogicgames.com/");
+						Gdx.net.openURI("https://libgdx.com");
 						return;
 					}
 					else {

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/net/OpenBrowserExample.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/net/OpenBrowserExample.java
@@ -24,6 +24,6 @@ import com.badlogic.gdx.tests.utils.GdxTest;
 public class OpenBrowserExample extends GdxTest {
 	@Override
 	public void create () {
-		Gdx.net.openURI("http://libgdx.badlogicgames.com");
+		Gdx.net.openURI("https://libgdx.com");
 	}
 }


### PR DESCRIPTION
This PR changes the method of opening URLs on macOS, since `FileManager.openURL(URI)` is deprecated and will be removed in JDK 17+. See #6542 for more information.