### PR TITLE
Allow skipping natives download during mvn install.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,7 @@
               <phase>prepare-package</phase>
               <goals><goal>run</goal></goals>
               <configuration>
+              <skip>${skipFetchNatives}</skip>
               <target>
                 <ant antfile="${basedir}/fetch.xml">
                   <target name="fetch-gdx" />


### PR DESCRIPTION
Currently there is no way to skip the natives download when running `mvn install`, this change allows you to run `mvn  -DskipFetchNatives=true install`  to skip natives download and use your existing natives.