### PR TITLE
Implemented GL30's sRGB Format

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/Pixmap.java
+++ b/gdx/src/com/badlogic/gdx/graphics/Pixmap.java
@@ -45,27 +45,33 @@ public class Pixmap implements Disposable {
 	 * 
 	 * @author mzechner */
 	public enum Format {
-		Alpha, Intensity, LuminanceAlpha, RGB565, RGBA4444, RGB888, RGBA8888;
+		Alpha, Intensity, LuminanceAlpha, RGB565, RGBA4444, RGB888, RGBA8888, SRGB;
 
 		public static int toGdx2DPixmapFormat (Format format) {
-			if (format == Alpha) return Gdx2DPixmap.GDX2D_FORMAT_ALPHA;
-			if (format == Intensity) return Gdx2DPixmap.GDX2D_FORMAT_ALPHA;
-			if (format == LuminanceAlpha) return Gdx2DPixmap.GDX2D_FORMAT_LUMINANCE_ALPHA;
-			if (format == RGB565) return Gdx2DPixmap.GDX2D_FORMAT_RGB565;
-			if (format == RGBA4444) return Gdx2DPixmap.GDX2D_FORMAT_RGBA4444;
-			if (format == RGB888) return Gdx2DPixmap.GDX2D_FORMAT_RGB888;
-			if (format == RGBA8888) return Gdx2DPixmap.GDX2D_FORMAT_RGBA8888;
-			throw new GdxRuntimeException("Unknown Format: " + format);
+			switch (format) {
+				case Alpha:
+				case Intensity: return Gdx2DPixmap.GDX2D_FORMAT_ALPHA;
+				case LuminanceAlpha: return Gdx2DPixmap.GDX2D_FORMAT_LUMINANCE_ALPHA;
+				case RGB565: return Gdx2DPixmap.GDX2D_FORMAT_RGB565;
+				case RGBA4444: return Gdx2DPixmap.GDX2D_FORMAT_RGBA4444;
+				case RGB888: return Gdx2DPixmap.GDX2D_FORMAT_RGB888;
+				case RGBA8888: return Gdx2DPixmap.GDX2D_FORMAT_RGBA8888;
+				case SRGB: return Gdx2DPixmap.GDX2D_FORMAT_SRGB;
+				default: throw new GdxRuntimeException("Unknown Format: " + format);
+			}
 		}
 
 		public static Format fromGdx2DPixmapFormat (int format) {
-			if (format == Gdx2DPixmap.GDX2D_FORMAT_ALPHA) return Alpha;
-			if (format == Gdx2DPixmap.GDX2D_FORMAT_LUMINANCE_ALPHA) return LuminanceAlpha;
-			if (format == Gdx2DPixmap.GDX2D_FORMAT_RGB565) return RGB565;
-			if (format == Gdx2DPixmap.GDX2D_FORMAT_RGBA4444) return RGBA4444;
-			if (format == Gdx2DPixmap.GDX2D_FORMAT_RGB888) return RGB888;
-			if (format == Gdx2DPixmap.GDX2D_FORMAT_RGBA8888) return RGBA8888;
-			throw new GdxRuntimeException("Unknown Gdx2DPixmap Format: " + format);
+			switch (format) {
+				case Gdx2DPixmap.GDX2D_FORMAT_ALPHA: return Alpha;
+				case Gdx2DPixmap.GDX2D_FORMAT_LUMINANCE_ALPHA: return LuminanceAlpha;
+				case Gdx2DPixmap.GDX2D_FORMAT_RGB565: return RGB565;
+				case Gdx2DPixmap.GDX2D_FORMAT_RGBA4444: return RGBA4444;
+				case Gdx2DPixmap.GDX2D_FORMAT_RGB888: return RGB888;
+				case Gdx2DPixmap.GDX2D_FORMAT_RGBA8888: return RGBA8888;
+				case Gdx2DPixmap.GDX2D_FORMAT_SRGB: return SRGB;
+				default: throw new GdxRuntimeException("Unknown Gdx2DPixmap Format: " + format);
+			}
 		}
 		
 		public static int toGlFormat (Format format) {

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/Gdx2DPixmap.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/Gdx2DPixmap.java
@@ -22,23 +22,25 @@ import java.io.InputStream;
 import java.nio.ByteBuffer;
 
 import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.GL30;
 import com.badlogic.gdx.utils.Disposable;
 import com.badlogic.gdx.utils.GdxRuntimeException;
 
 /** @author mzechner */
 public class Gdx2DPixmap implements Disposable {
-	public static final int GDX2D_FORMAT_ALPHA = 1;
-	public static final int GDX2D_FORMAT_LUMINANCE_ALPHA = 2;
-	public static final int GDX2D_FORMAT_RGB888 = 3;
-	public static final int GDX2D_FORMAT_RGBA8888 = 4;
-	public static final int GDX2D_FORMAT_RGB565 = 5;
-	public static final int GDX2D_FORMAT_RGBA4444 = 6;
+	public static final short GDX2D_FORMAT_ALPHA = 1;
+	public static final short GDX2D_FORMAT_LUMINANCE_ALPHA = 2;
+	public static final short GDX2D_FORMAT_RGB888 = 3;
+	public static final short GDX2D_FORMAT_RGBA8888 = 4;
+	public static final short GDX2D_FORMAT_RGB565 = 5;
+	public static final short GDX2D_FORMAT_RGBA4444 = 6;
+	public static final short GDX2D_FORMAT_SRGB = 7;
 
-	public static final int GDX2D_SCALE_NEAREST = 0;
-	public static final int GDX2D_SCALE_LINEAR = 1;
+	public static final short GDX2D_SCALE_NEAREST = 0;
+	public static final short GDX2D_SCALE_LINEAR = 1;
 
-	public static final int GDX2D_BLEND_NONE = 0;
-	public static final int GDX2D_BLEND_SRC_OVER = 1;
+	public static final short GDX2D_BLEND_NONE = 0;
+	public static final short GDX2D_BLEND_SRC_OVER = 1;
 
 	public static int toGlFormat (int format) {
 		switch (format) {
@@ -52,8 +54,10 @@ public class Gdx2DPixmap implements Disposable {
 		case GDX2D_FORMAT_RGBA8888:
 		case GDX2D_FORMAT_RGBA4444:
 			return GL20.GL_RGBA;
+		case GDX2D_FORMAT_SRGB:
+			return GL30.GL_SRGB8_ALPHA8;
 		default:
-			throw new GdxRuntimeException("unknown format: " + format);
+			throw new GdxRuntimeException("Unknown format: " + format);
 		}
 	}
 
@@ -69,7 +73,7 @@ public class Gdx2DPixmap implements Disposable {
 		case GDX2D_FORMAT_RGBA4444:
 			return GL20.GL_UNSIGNED_SHORT_4_4_4_4;
 		default:
-			throw new GdxRuntimeException("unknown format: " + format);
+			throw new GdxRuntimeException("Unknown format: " + format);
 		}
 	}
 


### PR DESCRIPTION
#5354 Feature request: add sRGB internal format of texture

Work done:

1. Added `SRGB` format support for `Gdx2DPixmap`. This format lives inside of `GL30`.
2. Code cleanup (changed `if-statements` to `switch-statements` for better readability). This should also enable the compiler to optimize better.