### PR TITLE
Remove backslash conversion from asset manager paths

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -20,6 +20,7 @@
 - LWJGL 3 is now the default desktop backend. If you want to port your existing applications, take a look here: https://gist.github.com/crykn/eb37cb4f7a03d006b3a0ecad27292a2d
 - Brought the official and third-party extensions in gdx-setup up to date. Removed some unmaintained ones and added gdx-websockets & jbump.
 - API Fix: Escaped characters in XML attributes are now properly un-escaped
+- Bug Fix: AssetManager backslash conversion removed - fixes use of filenames containing backslashes
 
 [1.10.0]
 - [BREAKING CHANGE] Android armeabi support has been removed. To migrate your projects: remove any dependency with natives-armeabi qualifier from your gradle build file, this apply to gdx-platform, gdx-bullet-platform, gdx-freetype-platform and gdx-box2d-platform.

--- a/gdx/src/com/badlogic/gdx/assets/AssetDescriptor.java
+++ b/gdx/src/com/badlogic/gdx/assets/AssetDescriptor.java
@@ -38,14 +38,14 @@ public class AssetDescriptor<T> {
 	}
 
 	public AssetDescriptor (String fileName, Class<T> assetType, AssetLoaderParameters<T> params) {
-		this.fileName = fileName.replace('\\', '/');
+		this.fileName = fileName;
 		this.type = assetType;
 		this.params = params;
 	}
 
 	/** Creates an AssetDescriptor with an already resolved name. */
 	public AssetDescriptor (FileHandle file, Class<T> assetType, AssetLoaderParameters<T> params) {
-		this.fileName = file.path().replace('\\', '/');
+		this.fileName = file.path();
 		this.file = file;
 		this.type = assetType;
 		this.params = params;

--- a/gdx/src/com/badlogic/gdx/assets/AssetManager.java
+++ b/gdx/src/com/badlogic/gdx/assets/AssetManager.java
@@ -221,9 +221,6 @@ public class AssetManager implements Disposable {
 	/** Removes the asset and all its dependencies, if they are not used by other assets.
 	 * @param fileName the file name */
 	public synchronized void unload (String fileName) {
-		// convert all windows path separators to unix style
-		fileName = fileName.replace('\\', '/');
-
 		// check if it's currently processed (and the first element in the stack, thus not a dependency) and cancel if necessary
 		if (tasks.size > 0) {
 			AssetLoadingTask currentTask = tasks.first();


### PR DESCRIPTION
Removes the asset backslash replacement for more predictable asset paths (see #6554 for discussion and rationale).