### PR TITLE
Made "Type" and "Probability" first-class citizens on a TiledMapTile

### DIFF
--- a/gdx/src/com/badlogic/gdx/maps/tiled/AtlasTmxMapLoader.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/AtlasTmxMapLoader.java
@@ -197,7 +197,7 @@ public class AtlasTmxMapLoader extends BaseTmxMapLoader<AtlasTmxMapLoader.AtlasT
 					AtlasRegion region = atlas.findRegion(regionName);
 					if (region == null)
 						throw new GdxRuntimeException("Tileset atlasRegion not found: " + regionName);
-					addStaticTiledMapTile(tileSet, region, tileId, offsetX, offsetY);
+					addStaticTiledMapTile(tileSet, region, tileId, offsetX, offsetY, tileElement);
 				}
 			}
 		}

--- a/gdx/src/com/badlogic/gdx/maps/tiled/BaseTmxMapLoader.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/BaseTmxMapLoader.java
@@ -606,14 +606,20 @@ public abstract class BaseTmxMapLoader<P extends BaseTmxMapLoader.Parameters> ex
 			Array<AnimatedTiledMapTile> animatedTiles = new Array<AnimatedTiledMapTile>();
 
 			for (Element tileElement : tileElements) {
-				int localtid = tileElement.getIntAttribute("id", 0);
-				TiledMapTile tile = tileSet.getTile(firstgid + localtid);
+				int localid = tileElement.getIntAttribute("id", 0);
+				TiledMapTile tile = tileSet.getTile(firstgid + localid);
 				if (tile != null) {
 					AnimatedTiledMapTile animatedTile = createAnimatedTile(tileSet, tile, tileElement, firstgid);
 					if (animatedTile != null) {
 						animatedTiles.add(animatedTile);
 						tile = animatedTile;
 					}
+
+					// Add tile-level attributes
+					tile.setType(tileElement.getAttribute("type", null));
+					tile.setProbability(Float.parseFloat(tileElement.getAttribute("probability", "1f")));
+
+					// Add properties and object groups
 					addTileProperties(tile, tileElement);
 					addTileObjectGroup(tile, tileElement);
 				}
@@ -674,10 +680,22 @@ public abstract class BaseTmxMapLoader<P extends BaseTmxMapLoader.Parameters> ex
 		return null;
 	}
 
-	protected void addStaticTiledMapTile (TiledMapTileSet tileSet, TextureRegion textureRegion, int tileId, float offsetX,
-		float offsetY) {
+	protected void addStaticTiledMapTile (TiledMapTileSet tileSet, TextureRegion textureRegion,
+										  int tileId, float offsetX, float offsetY) {
+		addStaticTiledMapTile(tileSet, textureRegion, tileId, offsetX, offsetY, null);
+	}
+
+	protected void addStaticTiledMapTile (TiledMapTileSet tileSet, TextureRegion textureRegion,
+										  int tileId, float offsetX, float offsetY, Element tileElement) {
 		TiledMapTile tile = new StaticTiledMapTile(textureRegion);
 		tile.setId(tileId);
+
+		if (tileElement != null) {
+			// Add tile-level attributes
+			tile.setType(tileElement.getAttribute("type", null));
+			tile.setProbability(Float.parseFloat(tileElement.getAttribute("probability", "1f")));
+		}
+
 		tile.setOffsetX(offsetX);
 		tile.setOffsetY(flipY ? -offsetY : offsetY);
 		tileSet.putTile(tileId, tile);

--- a/gdx/src/com/badlogic/gdx/maps/tiled/TiledMapTile.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/TiledMapTile.java
@@ -31,6 +31,14 @@ public interface TiledMapTile {
 
 	public void setId (int id);
 
+	public String getType ();
+
+	public void setType (String type);
+
+	public float getProbability ();
+
+	public void setProbability (float probability);
+
 	/** @return the {@link BlendMode} to use for rendering the tile */
 	public BlendMode getBlendMode ();
 

--- a/gdx/src/com/badlogic/gdx/maps/tiled/TmxMapLoader.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/TmxMapLoader.java
@@ -201,7 +201,7 @@ public class TmxMapLoader extends BaseTmxMapLoader<TmxMapLoader.Parameters> {
 				}
 				TextureRegion texture = imageResolver.getImage(image.path());
 				int tileId = firstgid + tileElement.getIntAttribute("id");
-				addStaticTiledMapTile(tileSet, texture, tileId, offsetX, offsetY);
+				addStaticTiledMapTile(tileSet, texture, tileId, offsetX, offsetY, tileElement);
 			}
 		}
 	}

--- a/gdx/src/com/badlogic/gdx/maps/tiled/tiles/AnimatedTiledMapTile.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/tiles/AnimatedTiledMapTile.java
@@ -32,6 +32,10 @@ public class AnimatedTiledMapTile implements TiledMapTile {
 
 	private int id;
 
+	private String type;
+
+	private float probability;
+
 	private BlendMode blendMode = BlendMode.ALPHA;
 
 	private MapProperties properties;
@@ -54,6 +58,18 @@ public class AnimatedTiledMapTile implements TiledMapTile {
 	public void setId (int id) {
 		this.id = id;
 	}
+
+	@Override
+	public String getType () { return type; }
+
+	@Override
+	public void setType (String type) { this.type = type; }
+
+	@Override
+	public float getProbability () { return probability; }
+
+	@Override
+	public void setProbability (float probability) { this.probability = probability; }
 
 	@Override
 	public BlendMode getBlendMode () {

--- a/gdx/src/com/badlogic/gdx/maps/tiled/tiles/StaticTiledMapTile.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/tiles/StaticTiledMapTile.java
@@ -26,6 +26,10 @@ public class StaticTiledMapTile implements TiledMapTile {
 
 	private int id;
 
+	private String type;
+
+	private float probability;
+
 	private BlendMode blendMode = BlendMode.ALPHA;
 
 	private MapProperties properties;
@@ -47,6 +51,18 @@ public class StaticTiledMapTile implements TiledMapTile {
 	public void setId (int id) {
 		this.id = id;
 	}
+
+	@Override
+	public String getType () { return type; }
+
+	@Override
+	public void setType (String type) { this.type = type; }
+
+	@Override
+	public float getProbability () { return probability; }
+
+	@Override
+	public void setProbability (float probability) { this.probability = probability; }
 
 	@Override
 	public BlendMode getBlendMode () {


### PR DESCRIPTION
This way, one can access them by both `tile.getProperties().get("type")` and `tile.getType()`. This is closer to the truth given the following .tmx snippet:

```xml
<tileset firstgid="1" name="grass-tiles-2-small" tilewidth="32" tileheight="32" tilecount="72" columns="12">
  <image source="grass-tiles-2-small.png" width="384" height="192"/>
  <tile id="13" type="Grass" probability="0.5"/>
</tileset>
```