### PR TITLE
Could com.badlogicgames.gdx:gdx-backend-lwjgl:1.10.1-SNAPSHOT drop off redundant dependencies to loose weight? 

### DIFF
--- a/backends/gdx-backend-lwjgl/pom.xml
+++ b/backends/gdx-backend-lwjgl/pom.xml
@@ -23,6 +23,16 @@
       <groupId>org.lwjgl.lwjgl</groupId>
       <artifactId>lwjgl</artifactId>
       <version>${lwjgl.version}</version>
+      <exclusions> 
+         <exclusion>
+             <groupId>org.lwjgl.lwjgl</groupId> 
+             <artifactId>lwjgl-platform</artifactId>
+          </exclusion>  
+          <exclusion>
+              <groupId>net.java.jutils</groupId>
+              <artifactId>jutils</artifactId>
+          </exclusion>
+       </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
@NathanSweet Hi, I am a user of project **_com.badlogicgames.gdx:gdx-backend-lwjgl:1.10.1-SNAPSHOT_**. I found that its pom file introduced **_15_** dependencies. However, among them, **_4_** libraries (**_26%_**) have not been used by your project (the redundant dependencies are listed below). Reduce these useless dependencies can help prevent conflicts between library versions. MeanWhile, it can minimize the total added size to projects. It can also help enable advanced scenarios for users of your package. 
This PR helps **_com.badlogicgames.gdx:gdx-backend-lwjgl:1.10.1-SNAPSHOT_** lose weight :) I have tested the revised configuration in my local environment. It is safe to remove the unused libraries.

Best regards


## Redundant dependencies----
<pre><code>
org.lwjgl.lwjgl:lwjgl-platform:jar:natives-linux:2.9.3:compile
org.lwjgl.lwjgl:lwjgl-platform:jar:natives-osx:2.9.3:compile
net.java.jutils:jutils:jar:1.0.0:compile
org.lwjgl.lwjgl:lwjgl-platform:jar:natives-windows:2.9.3:compile
</code></pre>