### PR TITLE
Protect Android MediaPlayer from getting into invalid state

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidMusic.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidMusic.java
@@ -78,7 +78,9 @@ public class AndroidMusic implements Music, MediaPlayer.OnCompletionListener {
 	public void pause () { 
 		if (player == null) return;
 		try {
-			player.pause();
+			if (player.isPlaying()) {
+				player.pause();
+			}
 		} catch (IllegalStateException e) {
 			e.printStackTrace();
 		}


### PR DESCRIPTION
On https://github.com/libgdx/libgdx/pull/6472 the check to verify `MediaPlayer` was playing before calling `pause()` was removed but it's actually needed in case `MediaPlayer` is on `Stopped` state to prevent entering `Error` state from which it doesn't recover.

To reproduce the issue just run `MusicTest` and:
1. Play a song
2. Stop it
3. Pause it
4. Try to play it again, it doesn't play (also can check stacktrace)