### PR TITLE
StringBuilder.toStringAndClear()

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@
 - API Addition: Polygon have method setVertex (int index, float x, float y).
 - API Addition: TMX built-in tile property "type" is now supported.
 - API Addition: Octree structure.
+- API Addition: Added StringBuilder#toStringAndClear() method.
 
 [1.10.0]
 - [BREAKING CHANGE] Android armeabi support has been removed. To migrate your projects: remove any dependency with natives-armeabi qualifier from your gradle build file, this apply to gdx-platform, gdx-bullet-platform, gdx-freetype-platform and gdx-box2d-platform.

--- a/gdx/src/com/badlogic/gdx/utils/StringBuilder.java
+++ b/gdx/src/com/badlogic/gdx/utils/StringBuilder.java
@@ -502,6 +502,15 @@ public class StringBuilder implements Appendable, CharSequence {
 		return new String(chars, 0, length);
 	}
 
+	/** Returns the current String representation and clears the StringBuilder.
+	 * 
+	 * @return a String containing the characters in this instance. */
+	public String toStringAndClear () {
+		final String s = toString();
+		clear();
+		return s;
+	}
+
 	/** Returns a {@code CharSequence} of the subsequence from the {@code start} index to the {@code end} index.
 	 * 
 	 * @param start the inclusive start index to begin the subsequence.


### PR DESCRIPTION
Hey guys,

I find myself typing this a lot:

```
    ...
    final String s = stringBuilder.toString();
    stringBuilder.clear();
    return s;
}
```

So I thought maybe somebody else would also like a convenience method for this?

```
    ...
    return stringBuilder.toStringAndClear();
}
```