### PR TITLE
Fix GlyphLayout multiline with color markup

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@
 - API Addition: Polygon have method setVertex (int index, float x, float y).
 - API Addition: TMX built-in tile property "type" is now supported.
 - API Addition: Octree structure.
+- Fix: GlyphLayout with multiline texts with colormarkup uses the correct distance between GlyphLayout#GlyphRuns
 
 [1.10.0]
 - [BREAKING CHANGE] Android armeabi support has been removed. To migrate your projects: remove any dependency with natives-armeabi qualifier from your gradle build file, this apply to gdx-platform, gdx-bullet-platform, gdx-freetype-platform and gdx-box2d-platform.

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/GlyphLayout.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/GlyphLayout.java
@@ -204,7 +204,7 @@ public class GlyphLayout implements Poolable {
 
 						// Wrap.
 						y += down;
-						lastGlyph = null;
+						if (newline) lastGlyph = null;
 						int wrapIndex = fontData.getWrapIndex(run.glyphs, i);
 						if ((wrapIndex == 0 && run.x == 0) // Require at least one glyph per line.
 							|| wrapIndex >= run.glyphs.size) { // Wrap at least the glyph that didn't fit.


### PR DESCRIPTION
Hey guys,

this PR fixes a very specific problem: Wrong GlyphLayout for multi-line texts where a line after the first one several runs because of colormarkup. (Unfortunately this is not very obvious with the fonts provided with libgdx so I used my own BitmapFont for the screenshots where it is really obvious)

After going through the code for three hours I found the issue: While creating the runs in GlyphLayout#setText() "lastGlyph" is set to null even if there is no newline, but just a new run because of a colormarkup tag.

**Unfixed:**
One line: Everything works
![unfixedOneLine](https://user-images.githubusercontent.com/17275393/123272598-302f7700-d502-11eb-80f5-da1672106c5e.PNG)

Several lines: This is not correct. The bug is the distance between the "(" and the "5"
![unfixedTwoLines](https://user-images.githubusercontent.com/17275393/123272602-30c80d80-d502-11eb-9ba9-d266b3e86560.PNG)
![unfixedThreeLines](https://user-images.githubusercontent.com/17275393/123272600-30c80d80-d502-11eb-97c6-744421c40c2e.PNG)


**Fixed:**
The distance between "(" and "5" is correct now also for multiple lines
![fixedOneLine](https://user-images.githubusercontent.com/17275393/123272948-83092e80-d502-11eb-88ed-6292aaf9a109.PNG)
![fixedTwoLines](https://user-images.githubusercontent.com/17275393/123272952-83a1c500-d502-11eb-9386-84dc7497e8ec.PNG)
![fixedThreeLines](https://user-images.githubusercontent.com/17275393/123272951-83a1c500-d502-11eb-8a5f-06a5239ad513.PNG)

