### PR TITLE
GlyphLayout: Fix width of color markup runs

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,7 +5,7 @@
 - API Addition: Polygon have method setVertex (int index, float x, float y).
 - API Addition: TMX built-in tile property "type" is now supported.
 - API Addition: Octree structure.
-- Fix: GlyphLayout with multiline texts with colormarkup uses the correct distance between GlyphLayout#GlyphRuns
+- Fix: GlyphLayout: Several fixes for color markup runs with multi-line or wrapping texts
 
 [1.10.0]
 - [BREAKING CHANGE] Android armeabi support has been removed. To migrate your projects: remove any dependency with natives-armeabi qualifier from your gradle build file, this apply to gdx-platform, gdx-bullet-platform, gdx-freetype-platform and gdx-box2d-platform.

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/GlyphLayout.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/GlyphLayout.java
@@ -145,6 +145,7 @@ public class GlyphLayout implements Poolable {
 							runEnd = start - 1;
 							start += length + 1;
 							nextColor = colorStack.peek();
+							lastGlyph = null; // Only needed for newLine
 						} else if (length == -2) {
 							start++; // Skip first of "[[" escape sequence.
 							continue outer;
@@ -169,7 +170,7 @@ public class GlyphLayout implements Poolable {
 						x -= lastGlyph.fixedWidth ? lastGlyph.xadvance * fontData.scaleX
 							: (lastGlyph.width + lastGlyph.xoffset) * fontData.scaleX - fontData.padRight;
 					}
-					lastGlyph = run.glyphs.peek();
+					if(newline) lastGlyph = run.glyphs.peek(); // Only needed for newLine, not color markup runs
 					run.x = x;
 					run.y = y;
 					if (newline || runEnd == end) adjustLastGlyph(fontData, run);


### PR DESCRIPTION
While I was on the GlyphLayout yesterday I noticed 2 more bugs. One here and the other one will soon follow in another PR.

This PR fixes the width of color markup runs.

**Before:**
![before](https://user-images.githubusercontent.com/17275393/123423610-10f71f00-d5c0-11eb-8041-3f8ea91eb920.PNG)

**After:**
![after](https://user-images.githubusercontent.com/17275393/123423635-1a808700-d5c0-11eb-8e02-a3ba7858cb74.PNG)