### PR TITLE
GlyphLayout: Fix wrapping for color-markup-runs with just one character

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,7 +5,7 @@
 - API Addition: Polygon have method setVertex (int index, float x, float y).
 - API Addition: TMX built-in tile property "type" is now supported.
 - API Addition: Octree structure.
-- Fix: GlyphLayout with multiline texts with colormarkup uses the correct distance between GlyphLayout#GlyphRuns
+- Fix: GlyphLayout: Several fixes for color markup runs with multi-line or wrapping texts
 
 [1.10.0]
 - [BREAKING CHANGE] Android armeabi support has been removed. To migrate your projects: remove any dependency with natives-armeabi qualifier from your gradle build file, this apply to gdx-platform, gdx-bullet-platform, gdx-freetype-platform and gdx-box2d-platform.

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/GlyphLayout.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/GlyphLayout.java
@@ -145,6 +145,7 @@ public class GlyphLayout implements Poolable {
 							runEnd = start - 1;
 							start += length + 1;
 							nextColor = colorStack.peek();
+							lastGlyph = null; // Only needed for newLine
 						} else if (length == -2) {
 							start++; // Skip first of "[[" escape sequence.
 							continue outer;
@@ -169,7 +170,7 @@ public class GlyphLayout implements Poolable {
 						x -= lastGlyph.fixedWidth ? lastGlyph.xadvance * fontData.scaleX
 							: (lastGlyph.width + lastGlyph.xoffset) * fontData.scaleX - fontData.padRight;
 					}
-					lastGlyph = run.glyphs.peek();
+					if(newline) lastGlyph = run.glyphs.peek(); // Only needed for newLine, not color markup runs
 					run.x = x;
 					run.y = y;
 					if (newline || runEnd == end) adjustLastGlyph(fontData, run);

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/GlyphLayout.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/GlyphLayout.java
@@ -165,9 +165,10 @@ public class GlyphLayout implements Poolable {
 						glyphRunPool.free(run);
 						break runEnded;
 					}
-					float[] xAdvances = run.xAdvances.items;
-					if (lastGlyph != null) // Move back the width of the last glyph from the previous run.
-						xAdvances[0] -= runs.peek().xAdvances.peek();
+					if (lastGlyph != null) { // Move back the width of the last glyph from the previous run.
+						x -= lastGlyph.fixedWidth ? lastGlyph.xadvance * fontData.scaleX
+							: (lastGlyph.width + lastGlyph.xoffset) * fontData.scaleX - fontData.padRight;
+					}
 					lastGlyph = run.glyphs.peek();
 					run.x = x;
 					run.y = y;
@@ -175,6 +176,7 @@ public class GlyphLayout implements Poolable {
 					runs.add(run);
 
 					int n = run.xAdvances.size;
+					float[] xAdvances = run.xAdvances.items;
 					if (!wrap || n == 0) { // No wrap or truncate, or no glyphs.
 						if (markupEnabled) { // If disabled any subsequent run is sure to be on the next line.
 							for (int i = 0; i < n; i++)

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/GlyphLayout.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/GlyphLayout.java
@@ -202,7 +202,7 @@ public class GlyphLayout implements Poolable {
 
 						// Wrap.
 						y += down;
-						lastGlyph = null;
+						if (newline) lastGlyph = null;
 						int wrapIndex = fontData.getWrapIndex(run.glyphs, i);
 						if ((wrapIndex == 0 && run.x == 0) // Require at least one glyph per line.
 							|| wrapIndex >= run.glyphs.size) { // Wrap at least the glyph that didn't fit.

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/GlyphLayout.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/GlyphLayout.java
@@ -165,10 +165,9 @@ public class GlyphLayout implements Poolable {
 						glyphRunPool.free(run);
 						break runEnded;
 					}
-					if (lastGlyph != null) { // Move back the width of the last glyph from the previous run.
-						x -= lastGlyph.fixedWidth ? lastGlyph.xadvance * fontData.scaleX
-							: (lastGlyph.width + lastGlyph.xoffset) * fontData.scaleX - fontData.padRight;
-					}
+					float[] xAdvances = run.xAdvances.items;
+					if (lastGlyph != null) // Move back the width of the last glyph from the previous run.
+						xAdvances[0] -= runs.peek().xAdvances.peek();
 					lastGlyph = run.glyphs.peek();
 					run.x = x;
 					run.y = y;
@@ -176,7 +175,6 @@ public class GlyphLayout implements Poolable {
 					runs.add(run);
 
 					int n = run.xAdvances.size;
-					float[] xAdvances = run.xAdvances.items;
 					if (!wrap || n == 0) { // No wrap or truncate, or no glyphs.
 						if (markupEnabled) { // If disabled any subsequent run is sure to be on the next line.
 							for (int i = 0; i < n; i++)
@@ -186,7 +184,7 @@ public class GlyphLayout implements Poolable {
 					}
 
 					// Wrap or truncate.
-					x += xAdvances[0]; // X offset relative to the drawing position. (Color-markup-runs can have just one letter)
+					x += xAdvances[0]; // X offset relative to the drawing position.
 					for (int i = 1; i < n; i++) {
 						Glyph glyph = run.glyphs.get(i - 1);
 						float glyphWidth = (glyph.width + glyph.xoffset) * fontData.scaleX - fontData.padRight;
@@ -204,7 +202,7 @@ public class GlyphLayout implements Poolable {
 
 						// Wrap.
 						y += down;
-						if (newline) lastGlyph = null;
+						lastGlyph = null;
 						int wrapIndex = fontData.getWrapIndex(run.glyphs, i);
 						if ((wrapIndex == 0 && run.x == 0) // Require at least one glyph per line.
 							|| wrapIndex >= run.glyphs.size) { // Wrap at least the glyph that didn't fit.
@@ -274,8 +272,10 @@ public class GlyphLayout implements Poolable {
 		float width = 0;
 		Object[] runsItems = runs.items;
 		int runsSize = runs.size;
+		System.out.println();
 		for (int i = 0; i < runsSize; i++) {
 			GlyphRun run = (GlyphRun)runsItems[i];
+			System.out.println(run);
 			float[] xAdvances = run.xAdvances.items;
 			float runWidth = run.x + xAdvances[0], max = 0; // run.x is needed to ensure floats are rounded same as above.
 			Object[] glyphs = run.glyphs.items;

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/GlyphLayout.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/GlyphLayout.java
@@ -272,10 +272,8 @@ public class GlyphLayout implements Poolable {
 		float width = 0;
 		Object[] runsItems = runs.items;
 		int runsSize = runs.size;
-		System.out.println();
 		for (int i = 0; i < runsSize; i++) {
 			GlyphRun run = (GlyphRun)runsItems[i];
-			System.out.println(run);
 			float[] xAdvances = run.xAdvances.items;
 			float runWidth = run.x + xAdvances[0], max = 0; // run.x is needed to ensure floats are rounded same as above.
 			Object[] glyphs = run.glyphs.items;

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/GlyphLayout.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/GlyphLayout.java
@@ -145,7 +145,6 @@ public class GlyphLayout implements Poolable {
 							runEnd = start - 1;
 							start += length + 1;
 							nextColor = colorStack.peek();
-							lastGlyph = null; // Only needed for newLine
 						} else if (length == -2) {
 							start++; // Skip first of "[[" escape sequence.
 							continue outer;
@@ -170,7 +169,7 @@ public class GlyphLayout implements Poolable {
 						x -= lastGlyph.fixedWidth ? lastGlyph.xadvance * fontData.scaleX
 							: (lastGlyph.width + lastGlyph.xoffset) * fontData.scaleX - fontData.padRight;
 					}
-					if(newline) lastGlyph = run.glyphs.peek(); // Only needed for newLine, not color markup runs
+					lastGlyph = run.glyphs.peek();
 					run.x = x;
 					run.y = y;
 					if (newline || runEnd == end) adjustLastGlyph(fontData, run);
@@ -187,8 +186,8 @@ public class GlyphLayout implements Poolable {
 					}
 
 					// Wrap or truncate.
-					x += xAdvances[0] + xAdvances[1]; // X offset relative to the drawing position + first xAdvance.
-					for (int i = 2; i < n; i++) {
+					x += xAdvances[0]; // X offset relative to the drawing position. (Color-markup-runs can have just one letter)
+					for (int i = 1; i < n; i++) {
 						Glyph glyph = run.glyphs.get(i - 1);
 						float glyphWidth = (glyph.width + glyph.xoffset) * fontData.scaleX - fontData.padRight;
 						if (x + glyphWidth - epsilon <= targetWidth) {

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/BitmapFontTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/BitmapFontTest.java
@@ -112,7 +112,7 @@ public class BitmapFontTest extends GdxTest {
 			// text = "How quickly da[RED]ft jumping zebras vex.";
 			text = "Another font wrap is-sue,  this time with multiple whitespace characters.";
 			// text = "test with AGWlWi      AGWlWi issue";
-			text = "AAA BBB CCC DDD    [RED]EEE";
+			text = "AAA BBB    [RED]EEE[] or ([GREEN]5[] FFF)";
 			if (true) { // Test wrap.
 				layout.setText(font, text, 0, text.length(), font.getColor(), w, Align.center, true, null);
 			} else { // Test truncation.
@@ -125,6 +125,7 @@ public class BitmapFontTest extends GdxTest {
 			renderer.begin(ShapeRenderer.ShapeType.Line);
 			renderer.setColor(0, 1, 0, 1);
 			for (int i = 0, n = layout.runs.size; i < n; i++) {
+				renderer.setColor(i % 2, (i + 1) % 2, i % 2, 1);
 				GlyphRun r = layout.runs.get(i);
 				renderer.rect(10 + r.x, 10 + meowy + r.y, r.width, -font.getLineHeight());
 			}


### PR DESCRIPTION
Hey, I found another issue while I was doing my other GlyphLayout-PR yesterday, here is the fix for that:

Fixed wrapping of color-markup-runs with just one character (everthing works fine if the color-markup-run has more than 1 character).

I also adjusted the BitmapFontTest to include a 1-character color-markup-run and to use different colors for the debug-borders of the different runs.

State before this PR: The line is not wrapped properly if the targetWidth is at the right border of the "5".
![wrappingBug](https://user-images.githubusercontent.com/17275393/123426081-3d606a80-d5c3-11eb-9708-278b421a749f.PNG)

This does not happen any more with this PR, the lines get wrapped properly.
