### PR TITLE
GlyphLayout: Removed redundant lastGlyph (also fixes overlapping GlyphRuns)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,7 @@
 - API Addition: TMX built-in tile property "type" is now supported.
 - API Addition: Octree structure.
 - Fix: GlyphLayout: Several fixes for color markup runs with multi-line or wrapping texts
+- API change: Removed redundant redundant "Glyph lastGlyph" from BitmapFontData#getGlyphs(GlyphRun, CharSequence, int, int) 
 
 [1.10.0]
 - [BREAKING CHANGE] Android armeabi support has been removed. To migrate your projects: remove any dependency with natives-armeabi qualifier from your gradle build file, this apply to gdx-platform, gdx-bullet-platform, gdx-freetype-platform and gdx-box2d-platform.

--- a/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGenerator.java
+++ b/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGenerator.java
@@ -693,9 +693,9 @@ public class FreeTypeFontGenerator implements Disposable {
 			return glyph;
 		}
 
-		public void getGlyphs (GlyphRun run, CharSequence str, int start, int end, Glyph lastGlyph) {
+		public void getGlyphs (GlyphRun run, CharSequence str, int start, int end) {
 			if (packer != null) packer.setPackToTexture(true); // All glyphs added after this are packed directly to the texture.
-			super.getGlyphs(run, str, start, end, lastGlyph);
+			super.getGlyphs(run, str, start, end);
 			if (dirty) {
 				dirty = false;
 				packer.updateTextureRegions(regions, parameter.minFilter, parameter.magFilter, parameter.genMipMaps);

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFont.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFont.java
@@ -814,7 +814,7 @@ public class BitmapFont implements Disposable {
 		}
 
 		/** Returns the glyph for the specified character, or null if no such glyph exists. Note that
-		 * {@link #getGlyphs(GlyphRun, CharSequence, int, int, Glyph)} should be be used to shape a string of characters into a list
+		 * {@link #getGlyphs(GlyphRun, CharSequence, int, int)} should be be used to shape a string of characters into a list
 		 * of glyphs. */
 		public Glyph getGlyph (char ch) {
 			Glyph[] page = glyphs[ch / PAGE_SIZE];
@@ -824,9 +824,8 @@ public class BitmapFont implements Disposable {
 
 		/** Using the specified string, populates the glyphs and positions of the specified glyph run.
 		 * @param str Characters to convert to glyphs. Will not contain newline or color tags. May contain "[[" for an escaped left
-		 *           square bracket.
-		 * @param lastGlyph The glyph immediately before this run, or null if this is run is the first on a line of text. */
-		public void getGlyphs (GlyphRun run, CharSequence str, int start, int end, Glyph lastGlyph) {
+		 *           square bracket. */
+		public void getGlyphs (GlyphRun run, CharSequence str, int start, int end) {
 			int max = end - start;
 			if (max == 0) return;
 			boolean markupEnabled = this.markupEnabled;
@@ -838,6 +837,7 @@ public class BitmapFont implements Disposable {
 			glyphs.ensureCapacity(max);
 			run.xAdvances.ensureCapacity(max + 1);
 
+			Glyph lastGlyph = null;			
 			do {
 				char ch = str.charAt(start++);
 				if (ch == '\r') continue; // Ignore.

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/GlyphLayout.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/GlyphLayout.java
@@ -36,7 +36,7 @@ import com.badlogic.gdx.utils.Pools;
  * When wrapping occurs, whitespace is removed before and after the wrap position. Whitespace is determined by
  * {@link BitmapFontData#isWhitespace(char)}.
  * <p>
- * Glyphs positions are determined by {@link BitmapFontData#getGlyphs(GlyphRun, CharSequence, int, int, Glyph)}.
+ * Glyphs positions are determined by {@link BitmapFontData#getGlyphs(GlyphRun, CharSequence, int, int)}.
  * <p>
  * This class is not thread safe, even if synchronized externally, and must only be used from the game thread.
  * @author Nathan Sweet
@@ -120,7 +120,6 @@ public class GlyphLayout implements Poolable {
 		}
 
 		float x = 0, y = 0, down = fontData.down;
-		Glyph lastGlyph = null;
 		int runStart = start;
 		outer:
 		while (true) {
@@ -160,16 +159,11 @@ public class GlyphLayout implements Poolable {
 					// Store the run that has ended.
 					GlyphRun run = glyphRunPool.obtain();
 					run.color.set(color);
-					fontData.getGlyphs(run, str, runStart, runEnd, lastGlyph);
+					fontData.getGlyphs(run, str, runStart, runEnd);
 					if (run.glyphs.size == 0) {
 						glyphRunPool.free(run);
 						break runEnded;
 					}
-					if (lastGlyph != null) { // Move back the width of the last glyph from the previous run.
-						x -= lastGlyph.fixedWidth ? lastGlyph.xadvance * fontData.scaleX
-							: (lastGlyph.width + lastGlyph.xoffset) * fontData.scaleX - fontData.padRight;
-					}
-					lastGlyph = run.glyphs.peek();
 					run.x = x;
 					run.y = y;
 					if (newline || runEnd == end) adjustLastGlyph(fontData, run);
@@ -204,7 +198,6 @@ public class GlyphLayout implements Poolable {
 
 						// Wrap.
 						y += down;
-						if (newline) lastGlyph = null;
 						int wrapIndex = fontData.getWrapIndex(run.glyphs, i);
 						if ((wrapIndex == 0 && run.x == 0) // Require at least one glyph per line.
 							|| wrapIndex >= run.glyphs.size) { // Wrap at least the glyph that didn't fit.
@@ -261,7 +254,6 @@ public class GlyphLayout implements Poolable {
 						y += down * fontData.blankLineScale;
 					else
 						y += down;
-					lastGlyph = null;
 				}
 
 				runStart = start;
@@ -321,7 +313,7 @@ public class GlyphLayout implements Poolable {
 
 		// Determine truncate string size.
 		GlyphRun truncateRun = glyphRunPool.obtain();
-		fontData.getGlyphs(truncateRun, truncate, 0, truncate.length(), null);
+		fontData.getGlyphs(truncateRun, truncate, 0, truncate.length());
 		float truncateWidth = 0;
 		if (truncateRun.xAdvances.size > 0) {
 			adjustLastGlyph(fontData, truncateRun);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/BitmapFontTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/BitmapFontTest.java
@@ -112,7 +112,7 @@ public class BitmapFontTest extends GdxTest {
 			// text = "How quickly da[RED]ft jumping zebras vex.";
 			text = "Another font wrap is-sue,  this time with multiple whitespace characters.";
 			// text = "test with AGWlWi      AGWlWi issue";
-			text = "AAA BBB    [RED]EEE[] or ([GREEN]5[] FFF)";
+			text = "AAA BBB    [RED]EEE[] or ([GREEN]5[] FFF [YELLOW]Color at the end)";
 			if (true) { // Test wrap.
 				layout.setText(font, text, 0, text.length(), font.getColor(), w, Align.center, true, null);
 			} else { // Test truncation.


### PR DESCRIPTION
Hey guys,

While trying to fix overlapping GlyphRuns I found out that "Glpyh lastGlyph" is not necessary. Can you guys please confirm? Am I missing any edgecases?
I already tried a lot of fonts and I cannot see any problems.

PS: I cannot commit FreeTypeFontGenerator.java without Github thinking it's all new... the only change actually is the removal of "Glyph lastGlyph" from the method getGlyphs(GlyphRun, CharSequence, int, int) within... I tried everything already... Can somebody help or change my PR? Also reverting FreeTypeFontGenerator and committing it again won't help.
Worst case: Please somebody else recreate this PR and merge. Thanks!


![fix](https://user-images.githubusercontent.com/17275393/123513056-3ef56580-d68b-11eb-82bd-483a93820e6b.PNG)