### PR TITLE
 GlyphLayout: Fix crash on empty glyphs

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g2d/GlyphLayout.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/GlyphLayout.java
@@ -226,7 +226,7 @@ public class GlyphLayout implements Poolable {
 								run.glyphs.removeRange(0, wrapIndex - 1);
 								run.xAdvances.removeRange(1, wrapIndex);
 							}
-							xAdvances[0] = -run.glyphs.first().xoffset * fontData.scaleX - fontData.padLeft;
+							xAdvances[0] = getRunOffset(run.glyphs, fontData);
 
 							if (previous != null) { // Previous run is now at the end of a line.
 								// Remove trailing whitespace and adjust last glyph.
@@ -397,7 +397,7 @@ public class GlyphLayout implements Poolable {
 			FloatArray xAdvances1 = second.xAdvances; // Starts empty.
 			xAdvances1.addAll(xAdvances2, 0, firstEnd + 1);
 			xAdvances2.removeRange(1, secondStart); // Leave first entry to be overwritten by next line.
-			xAdvances2.items[0] = -glyphs2.first().xoffset * fontData.scaleX - fontData.padLeft;
+			xAdvances2.items[0] = getRunOffset(glyphs2, fontData);
 			first.xAdvances = xAdvances1;
 			second.xAdvances = xAdvances2;
 		} else {
@@ -422,6 +422,10 @@ public class GlyphLayout implements Poolable {
 		if (last.fixedWidth) return;
 		float width = (last.width + last.xoffset) * fontData.scaleX - fontData.padRight;
 		run.xAdvances.items[run.xAdvances.size - 1] = width;
+	}
+
+	private float getRunOffset (Array<Glyph> glyphs, BitmapFontData fontData) {
+		return glyphs.isEmpty() ? 0 : -glyphs.first().xoffset * fontData.scaleX - fontData.padLeft;
 	}
 
 	private int parseColorMarkup (CharSequence str, int start, int end, Pool<Color> colorPool) {

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/BitmapFontTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/BitmapFontTest.java
@@ -115,7 +115,7 @@ public class BitmapFontTest extends GdxTest {
 			text = "Another font wrap is-sue,  this time with multiple whitespace characters.";
 			// text = "test with AGWlWi AGWlWi issue";
 			text = "AA BB \nEE"; // When wrapping after BB, there should not be a blank line before EE.
-			text = "AA BB [RED]EE[] T [GREEN]e[] V[YELLOW]a bb[] ([CYAN]5[]FFF)";
+			text = "AA BB [RED]EE[] T [GREEN]e[] \n\nV[YELLOW]a bb[] ([CYAN]5[]FFF)";
 			if (true) { // Test wrap.
 				layout.setText(font, text, 0, text.length(), font.getColor(), w, Align.center, true, null);
 			} else { // Test truncation.


### PR DESCRIPTION
@NathanSweet @tommyettinger Please check: Without the check `glyphs.isEmpty()` setText() throws a NullPointerException with the text provided in the test.