### PR TITLE
Moved Android natives loading out of static init block (#5795)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,5 @@
 [1.10.1]
+- [BREAKING CHANGE] Android Moved natives loading out of static init block, see #5795
 - API Addition: ObjLoader now supports ambientColor, ambientTexture, transparencyTexture, specularTexture and shininessTexture
 - API Addition: PointSpriteParticleBatch blending is now configurable.
 - TOOLS Features: Blending mode and sort mode can be changed in Flame particle 3D editor.

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplication.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplication.java
@@ -40,9 +40,6 @@ import com.badlogic.gdx.utils.*;
  * 
  * @author mzechner */
 public class AndroidApplication extends Activity implements AndroidApplicationBase {
-	static {
-		GdxNativesLoader.load();
-	}
 
 	protected AndroidGraphics graphics;
 	protected AndroidInput input;
@@ -115,6 +112,7 @@ public class AndroidApplication extends Activity implements AndroidApplicationBa
 		if (this.getVersion() < MINIMUM_SDK) {
 			throw new GdxRuntimeException("LibGDX requires Android API Level " + MINIMUM_SDK + " or later.");
 		}
+		GdxNativesLoader.load();
 		setApplicationLogger(new AndroidApplicationLogger());
 		graphics = new AndroidGraphics(this, config, config.resolutionStrategy == null ? new FillResolutionStrategy()
 			: config.resolutionStrategy);

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidDaydream.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidDaydream.java
@@ -45,9 +45,6 @@ import com.badlogic.gdx.utils.SnapshotArray;
  * @author mzechner */
 @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
 public class AndroidDaydream extends DreamService implements AndroidApplicationBase {
-	static {
-		GdxNativesLoader.load();
-	}
 
 	protected AndroidGraphics graphics;
 	protected AndroidInput input;
@@ -108,6 +105,7 @@ public class AndroidDaydream extends DreamService implements AndroidApplicationB
 	}
 
 	private void init (ApplicationListener listener, AndroidApplicationConfiguration config, boolean isForView) {
+		GdxNativesLoader.load();
 		setApplicationLogger(new AndroidApplicationLogger());
 		graphics = new AndroidGraphics(this, config, config.resolutionStrategy == null ? new FillResolutionStrategy()
 			: config.resolutionStrategy);

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidFragmentApplication.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidFragmentApplication.java
@@ -33,10 +33,6 @@ public class AndroidFragmentApplication extends Fragment implements AndroidAppli
 		void exit ();
 	}
 
-	static {
-		GdxNativesLoader.load();
-	}
-
 	protected AndroidGraphics graphics;
 	protected AndroidInput input;
 	protected AndroidAudio audio;
@@ -132,6 +128,7 @@ public class AndroidFragmentApplication extends Fragment implements AndroidAppli
 		if (this.getVersion() < MINIMUM_SDK) {
 			throw new GdxRuntimeException("LibGDX requires Android API Level " + MINIMUM_SDK + " or later.");
 		}
+		GdxNativesLoader.load();
 		setApplicationLogger(new AndroidApplicationLogger());
 		graphics = new AndroidGraphics(this, config, config.resolutionStrategy == null ? new FillResolutionStrategy()
 			: config.resolutionStrategy);

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidLiveWallpaper.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidLiveWallpaper.java
@@ -35,9 +35,6 @@ import com.badlogic.gdx.utils.*;
  * 
  * @author mzechner */
 public class AndroidLiveWallpaper implements AndroidApplicationBase {
-	static {
-		GdxNativesLoader.load();
-	}
 
 	protected AndroidLiveWallpaperService service;
 
@@ -64,6 +61,7 @@ public class AndroidLiveWallpaper implements AndroidApplicationBase {
 		if (this.getVersion() < MINIMUM_SDK) {
 			throw new GdxRuntimeException("LibGDX requires Android API Level " + MINIMUM_SDK + " or later.");
 		}
+		GdxNativesLoader.load();
 		setApplicationLogger(new AndroidApplicationLogger());
 		graphics = new AndroidGraphicsLiveWallpaper(this, config, config.resolutionStrategy == null ? new FillResolutionStrategy()
 			: config.resolutionStrategy);

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidLiveWallpaperService.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidLiveWallpaperService.java
@@ -56,9 +56,6 @@ import com.badlogic.gdx.utils.GdxNativesLoader;
  * 
  * @author Jaroslaw Wisniewski <j.wisniewski@appsisle.com> */
 public abstract class AndroidLiveWallpaperService extends WallpaperService {
-	static {
-		GdxNativesLoader.load();
-	}
 
 	static final String TAG = "WallpaperService";
 	static boolean DEBUG = false; // TODO remember to disable this

--- a/gdx/src/com/badlogic/gdx/utils/GdxNativesLoader.java
+++ b/gdx/src/com/badlogic/gdx/utils/GdxNativesLoader.java
@@ -24,10 +24,10 @@ public class GdxNativesLoader {
 	/** Loads the libgdx native libraries if they have not already been loaded. */
 	static public synchronized void load () {
 		if (nativesLoaded) return;
-		nativesLoaded = true;
 
 		if (disableNativesLoading) return;
 
 		new SharedLibraryLoader().load("gdx");
+		nativesLoaded = true;
 	}
 }


### PR DESCRIPTION
fixes #5795 by giving the developer the ability to gracefully handle missing natives, e.g. by catching the SharedLibraryLoadRuntimeException and launching a new activity with an error message.

Note that natives loading was removed entirely from AndroidLiveWallpaperService as that immediately calls into AndoidLiveWallpaper.initialize.

Will print/sign/send the CLA shortly.