### PR TITLE
Make capitalization of "libGDX" consistent with the branding guidelines by replacing some instances of "LibGDX", "Libgdx" and "libgdx", plus some other very minor inconsistencies

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -77,7 +77,7 @@ If you want to poll the brains of other devs, either send a pull request and sta
 
 ### Contributor License Agreement
 
-Libgdx is licensed under the [Apache 2.0 license](http://en.wikipedia.org/wiki/Apache_License). Before we can accept code contributions, we need you to sign our [contributor license agreement](https://github.com/libgdx/libgdx/blob/master/CLA.txt). Just print it out, fill in the blanks and send a copy to [`contact@badlogicgames.com`](mailto:contact@badlogicgames.com?subject=[LibGDX]%20CLA), with the subject `[Libgdx] CLA`.
+libGDX is licensed under the [Apache 2.0 license](http://en.wikipedia.org/wiki/Apache_License). Before we can accept code contributions, we need you to sign our [contributor license agreement](https://github.com/libgdx/libgdx/blob/master/CLA.txt). Just print it out, fill in the blanks and send a copy to [`contact@badlogicgames.com`](mailto:contact@badlogicgames.com?subject=[libGDX]%20CLA), with the subject `[libGDX] CLA`.
 
 Signing the CLA will allow us to use and distribute your code. This is a non-exclusive license, so you retain all rights to your code. It's a fail-safe for us should someone contribute essential code and later decide to take it back.
 
@@ -91,7 +91,7 @@ If you are using IntelliJ IDEA, you can still make use of the eclipse code forma
 
 ### Code Style
 
-LibGDX does not have an official coding standard. We mostly follow the usual [Java style](http://www.oracle.com/technetwork/java/codeconvtoc-136057.html), and so should you.
+libGDX does not have an official coding standard. We mostly follow the usual [Java style](http://www.oracle.com/technetwork/java/codeconvtoc-136057.html), and so should you.
 
 A few things we'd rather not like to see:
 
@@ -111,7 +111,7 @@ If your class is explicitly thread-safe, mention it in the Javadoc. The default 
 
 ### Performance Considerations
 
-LibGDX is meant to run on both desktop and mobile platforms, including browsers (JavaScript!). While the desktop HotSpot VM can take quite a beating in terms of unnecessary allocations, Dalvik and consorts don't.
+libGDX is meant to run on both desktop and mobile platforms, including browsers (JavaScript!). While the desktop HotSpot VM can take quite a beating in terms of unnecessary allocations, Dalvik and consorts don't.
 
 A couple of guidelines:
 
@@ -129,4 +129,4 @@ Most of the libGDX team members are Git novices. As such, we are just learning t
 
 We do open new branches for bigger API changes. If you help out with a new API, make sure your pull request targets that specific branch.
 
-Pull requests for the master repository will be checked by multiple core contributors before inclusion. We may reject your pull request to `master` if we do not deem them to be ready or fitting. Please don't take offense in that case. LibGDX is used by thousands of projects around the world. We need to make sure things stay somewhat sane and stable.
+Pull requests for the master repository will be checked by multiple core contributors before inclusion. We may reject your pull request to `master` if we do not deem them to be ready or fitting. Please don't take offense in that case. libGDX is used by thousands of projects around the world. We need to make sure things stay somewhat sane and stable.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -67,7 +67,7 @@ provide as much detail and context as possible.
 Contributing to libGDX is easy:
 
   * Fork libGDX on [`http://github.com/libgdx/libgdx`](http://github.com/libgdx/libgdx)
-  * Learn how to [Work with the Source](https://github.com/libgdx/libgdx/wiki/Running-demos-%26-tests)
+  * Learn how to [Work with the Source](https://libgdx.com/dev/from-source/)
   * Hack away, and send a pull request on GitHub!
 
 ### API Changes & Additions

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -7,7 +7,7 @@ _Please provide the details of your issue_
 _Even if you think your issue is trivial to reproduce, please supply a [SSCCE](http://sscce.org/) that demonstrates your issue.  This saves time on our end, and makes it much more likely that your issue will be fixed.
 You can find barebones templates [here](https://github.com/libgdx/libgdx/wiki/Getting-help)_
 
-#### Version of LibGDX and/or relevant dependencies
+#### Version of libGDX and/or relevant dependencies
 _Please provide the version(s) affected._
 
 #### Stacktrace

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Discord Chat](https://img.shields.io/discord/348229412858101762?logo=discord)](https://libgdx.com/community/discord/)
 
 ## Cross-platform Game Development Framework
-**[libGDX](https://libgdx.com) is a cross-platform Java game development framework based on OpenGL (ES) that works on Windows, Linux, Mac OS X, Android, iOS and your WebGL enabled browser.** It provides a well-tried and robust environment for rapid prototyping and fast iterations. LibGDX does not force a specific design or coding style on you, it rather gives you the freedom to create a game the way you like it.
+**[libGDX](https://libgdx.com) is a cross-platform Java game development framework based on OpenGL (ES) that works on Windows, Linux, Mac OS X, Android, iOS and your WebGL enabled browser.** It provides a well-tried and robust environment for rapid prototyping and fast iterations. libGDX does not force a specific design or coding style on you, it rather gives you the freedom to create a game the way you like it.
 
 ## Open Source, Feature Packed and Offering a Big Third-Party Ecosystem
 libGDX is licensed under [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.html) meaning you can use it free of charge, without strings attached in commercial and non-commercial projects. We, however, love to get (non-mandatory) credit in case you release a game or app using libGDX! See our [showcase](https://libgdx.com/showcase/) for a selection of some popular libGDX games. libGDX comes with [batteries included](https://libgdx.com/features/) and provides everything required to develop multi-platform 2D and 3D games with Java.

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplication.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplication.java
@@ -110,7 +110,7 @@ public class AndroidApplication extends Activity implements AndroidApplicationBa
 
 	private void init (ApplicationListener listener, AndroidApplicationConfiguration config, boolean isForView) {
 		if (this.getVersion() < MINIMUM_SDK) {
-			throw new GdxRuntimeException("LibGDX requires Android API Level " + MINIMUM_SDK + " or later.");
+			throw new GdxRuntimeException("libGDX requires Android API Level " + MINIMUM_SDK + " or later.");
 		}
 		GdxNativesLoader.load();
 		setApplicationLogger(new AndroidApplicationLogger());

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidFragmentApplication.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidFragmentApplication.java
@@ -126,7 +126,7 @@ public class AndroidFragmentApplication extends Fragment implements AndroidAppli
 	 * @return the GLSurfaceView of the application */
 	public View initializeForView (ApplicationListener listener, AndroidApplicationConfiguration config) {
 		if (this.getVersion() < MINIMUM_SDK) {
-			throw new GdxRuntimeException("LibGDX requires Android API Level " + MINIMUM_SDK + " or later.");
+			throw new GdxRuntimeException("libGDX requires Android API Level " + MINIMUM_SDK + " or later.");
 		}
 		GdxNativesLoader.load();
 		setApplicationLogger(new AndroidApplicationLogger());

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphics.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphics.java
@@ -115,7 +115,7 @@ public class AndroidGraphics extends AbstractGraphics implements Renderer {
 	}
 
 	protected GLSurfaceView20 createGLSurfaceView (AndroidApplicationBase application, final ResolutionStrategy resolutionStrategy) {
-		if (!checkGL20()) throw new GdxRuntimeException("Libgdx requires OpenGL ES 2.0");
+		if (!checkGL20()) throw new GdxRuntimeException("libGDX requires OpenGL ES 2.0");
 
 		EGLConfigChooser configChooser = getEglConfigChooser();
 		GLSurfaceView20 view = new GLSurfaceView20(application.getContext(), resolutionStrategy, config.useGL30 ? 3 : 2);

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphicsLiveWallpaper.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphicsLiveWallpaper.java
@@ -53,7 +53,7 @@ public final class AndroidGraphicsLiveWallpaper extends AndroidGraphics {
 	// getHolder in created GLSurfaceView20 instances
 	@Override
 	protected GLSurfaceView20 createGLSurfaceView (AndroidApplicationBase application, final ResolutionStrategy resolutionStrategy) {
-		if (!checkGL20()) throw new GdxRuntimeException("Libgdx requires OpenGL ES 2.0");
+		if (!checkGL20()) throw new GdxRuntimeException("libGDX requires OpenGL ES 2.0");
 
 		EGLConfigChooser configChooser = getEglConfigChooser();
 		GLSurfaceView20 view = new GLSurfaceView20(application.getContext(), resolutionStrategy) {

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidLiveWallpaper.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidLiveWallpaper.java
@@ -59,7 +59,7 @@ public class AndroidLiveWallpaper implements AndroidApplicationBase {
 
 	public void initialize (ApplicationListener listener, AndroidApplicationConfiguration config) {
 		if (this.getVersion() < MINIMUM_SDK) {
-			throw new GdxRuntimeException("LibGDX requires Android API Level " + MINIMUM_SDK + " or later.");
+			throw new GdxRuntimeException("libGDX requires Android API Level " + MINIMUM_SDK + " or later.");
 		}
 		GdxNativesLoader.load();
 		setApplicationLogger(new AndroidApplicationLogger());

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSApplication.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSApplication.java
@@ -468,7 +468,7 @@ public class IOSApplication implements Application {
 		}
 	}
 
-	/** Add a listener to handle events from the libgdx root view controller
+	/** Add a listener to handle events from the libGDX root view controller
 	 * @param listener The {#link IOSViewControllerListener} to add */
 	public void addViewControllerListener (IOSViewControllerListener listener) {
 		viewControllerListener = listener;

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
@@ -173,7 +173,7 @@ public class IOSGraphics extends AbstractGraphics {
 
 		String machineString = HWMachine.getMachineString();
 		IOSDevice device = config.knownDevices.get(machineString);
-		if (device == null) app.error(tag, "Machine ID: " + machineString + " not found, please report to LibGDX");
+		if (device == null) app.error(tag, "Machine ID: " + machineString + " not found, please report to libGDX");
 		int ppi = device != null ? device.ppi : app.guessUnknownPpi();
 		density = ppi / 160f;
 		ppiX = ppi;

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtClipboard.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtClipboard.java
@@ -18,7 +18,7 @@ package com.badlogic.gdx.backends.gwt;
 
 import com.badlogic.gdx.utils.Clipboard;
 
-/** Basic implementation of clipboard in GWT. Paste only works inside the libgdx application. */
+/** Basic implementation of clipboard in GWT. Paste only works inside the libGDX application. */
 public class GwtClipboard implements Clipboard {
 
 	private boolean requestedWritePermissions = false;

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/utils/Timer.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/utils/Timer.java
@@ -195,7 +195,7 @@ public class Timer {
 		}
 	}
 
-	/** Manages the single timer thread. Stops thread on libgdx application pause and dispose, starts thread on resume.
+	/** Manages the single timer thread. Stops thread on libGDX application pause and dispose, starts thread on resume.
 	 * @author Nathan Sweet */
 	static class TimerThread extends com.google.gwt.user.client.Timer implements Runnable, LifecycleListener {
 		private Application app;

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/utils/Utf8Decoder.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/utils/Utf8Decoder.java
@@ -56,7 +56,7 @@ public class Utf8Decoder {
 	// This table maps bytes to character classes to reduce
 	// the size of the transition table and create bitmasks.
 	private static final byte[] BYTE_TABLE = {
-		// @off - disable libgdx formatter
+		// @off - disable libGDX formatter
 		 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
 		 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
 		 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
@@ -65,19 +65,19 @@ public class Utf8Decoder {
 		 7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,  7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,
 		 8,8,2,2,2,2,2,2,2,2,2,2,2,2,2,2,  2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,
 		10,3,3,3,3,3,3,3,3,3,3,3,3,4,3,3, 11,6,6,6,5,8,8,8,8,8,8,8,8,8,8,8
-		// @on - enable libgdx formatter
+		// @on - enable libGDX formatter
 	};
 
 	// This is a transition table that maps a combination of a
 	// state of the automaton and a character class to a state.
 	private static final byte[] TRANSITION_TABLE = {
-		// @off - disable libgdx formatter
+		// @off - disable libGDX formatter
 		 0,12,24,36,60,96,84,12,12,12,48,72, 12,12,12,12,12,12,12,12,12,12,12,12,
 		12, 0,12,12,12,12,12, 0,12, 0,12,12, 12,24,12,12,12,12,12,24,12,24,12,12,
 		12,12,12,12,12,12,12,24,12,12,12,12, 12,24,12,12,12,12,12,12,12,24,12,12,
 		12,12,12,12,12,12,12,36,12,36,12,12, 12,36,12,12,12,12,12,36,12,36,12,12,
 		12,36,12,12,12,12,12,12,12,12,12,12
-		// @on - enable libgdx formatter
+		// @on - enable libGDX formatter
 	};
 
 	private int codePoint;

--- a/build.xml
+++ b/build.xml
@@ -1,5 +1,5 @@
 <project name="gdx" default="all" basedir=".">
-	<description>libgdx distribution build file</description>
+	<description>libGDX distribution build file</description>
 	<property environment="env" />
 
 	<!-- library version -->
@@ -212,10 +212,11 @@
 	<!-- generates the javadoc for the core api and the application implementations -->
 	<target name="docs" depends="clean">
 		<javadoc destdir="${distDir}/docs/api" author="true" version="true" use="true"
-		windowtitle="libgdx API" doctitle="libgdx API" footer="libgdx API" useexternalfile="true"
+		windowtitle="libGDX API" doctitle="libGDX API" footer="libGDX API"
+			useexternalfile="true"
 		additionalparam="-Xdoclint:none -encoding UTF-8">
 			<header><![CDATA[
-				libgdx API
+				libGDX API
 				<style>
 				body, td, th { font-family:Helvetica, Tahoma, Arial, sans-serif; font-size:10pt }
 				pre, code, tt { font-size:9pt; font-family:Lucida Console, Courier New, sans-serif }

--- a/extensions/gdx-setup/README.md
+++ b/extensions/gdx-setup/README.md
@@ -1,4 +1,4 @@
-Libgdx gradle setup
+libGDX gradle setup
 ===================
 
 Modular setup powered by gradle, allowing any combination of sub projects and official extensions to get you up and running in a few clicks.  Although this tool will handle setup for you, LEARN GRADLE!

--- a/extensions/gdx-setup/res/com/badlogic/gdx/setup/data/extensions.xml
+++ b/extensions/gdx-setup/res/com/badlogic/gdx/setup/data/extensions.xml
@@ -160,7 +160,7 @@
 	</extension>
 	<extension>
 		<name>gdx-kiwi</name>
-		<description>Guava-inspired utilities for LibGDX.</description>
+		<description>Guava-inspired utilities for libGDX.</description>
 		<package>com.github.czyzby.kiwi</package>
 		<version>1.9.1.9.6</version>
 		<compatibility>1.9.6</compatibility>

--- a/extensions/gdx-setup/res/com/badlogic/gdx/setup/data/extensions.xml
+++ b/extensions/gdx-setup/res/com/badlogic/gdx/setup/data/extensions.xml
@@ -160,7 +160,7 @@
 	</extension>
 	<extension>
 		<name>gdx-kiwi</name>
-		<description>Guava-inspired utilities for libGDX.</description>
+		<description>Guava-inspired utilities for libGDX</description>
 		<package>com.github.czyzby.kiwi</package>
 		<version>1.9.1.9.6</version>
 		<compatibility>1.9.6</compatibility>
@@ -182,7 +182,7 @@
 	</extension>
 	<extension>
 		<name>gdx-lml</name>
-		<description>Parser of HTML-like templates into Scene2D actors.</description>
+		<description>Parser of HTML-like templates into Scene2D actors</description>
 		<package>com.github.czyzby.lml</package>
 		<version>1.9.1.9.6</version>
 		<compatibility>1.9.6</compatibility>
@@ -205,7 +205,7 @@
 	</extension>
 	<extension>
 		<name>gdx-lml-vis</name>
-		<description>Parser of HTML-like templates into VisUI actors.</description>
+		<description>Parser of HTML-like templates into VisUI actors</description>
 		<package>com.github.czyzby.lml.vis</package>
 		<version>1.9.1.9.6</version>
 		<compatibility>1.9.6</compatibility>

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/DependencyBank.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/DependencyBank.java
@@ -90,7 +90,7 @@ public class DependencyBank {
 			new String[]{"com.badlogicgames.gdx:gdx-backend-gwt:$gdxVersion", "com.badlogicgames.gdx:gdx:$gdxVersion:sources", "com.badlogicgames.gdx:gdx-backend-gwt:$gdxVersion:sources"},
 			new String[]{"com.badlogic.gdx.backends.gdx_backends_gwt"},
 			
-			"Core Library for LibGDX"
+			"Core Library for libGDX"
 		),
 		BULLET(
 			new String[]{"com.badlogicgames.gdx:gdx-bullet:$gdxVersion"},

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/ExternalExtensionsDialog.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/ExternalExtensionsDialog.java
@@ -120,8 +120,8 @@ public class ExternalExtensionsDialog extends JDialog implements TableModelListe
 
 		topPanel = new JPanel(new GridBagLayout());
 		topPanel.setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5));
-		warningNotice = new JLabel("List of third party extensions for LibGDX");
-		warningNotice2 = new JLabel("These are not maintained by the LibGDX team, please see the support links for info and help");
+		warningNotice = new JLabel("List of third party extensions for libGDX");
+		warningNotice2 = new JLabel("These are not maintained by the libGDX team, please see the support links for info and help");
 		warningNotice.setHorizontalAlignment(JLabel.CENTER);
 		warningNotice2.setHorizontalAlignment(JLabel.CENTER);
 

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetupUI.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetupUI.java
@@ -99,7 +99,7 @@ public class GdxSetupUI extends JFrame {
 	static SetupPreferences prefs = new SetupPreferences();
 
 	public GdxSetupUI () {
-		setTitle("LibGDX Project Generator");
+		setTitle("libGDX Project Generator");
 		setLayout(new BorderLayout());
 		add(ui, BorderLayout.CENTER);
 		setSize(620, 720);

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/bmfont/BitmapFontWriter.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/bmfont/BitmapFontWriter.java
@@ -47,7 +47,7 @@ public class BitmapFontWriter {
 	/** The output format */
 	private static OutputFormat format = OutputFormat.Text;
 
-	/** Sets the AngelCodeFont output format for subsequent writes; can be text (for LibGDX) or XML (for other engines, like
+	/** Sets the AngelCodeFont output format for subsequent writes; can be text (for libGDX) or XML (for other engines, like
 	 * Pixi.js).
 	 * 
 	 * @param fmt the output format to use */
@@ -82,7 +82,7 @@ public class BitmapFontWriter {
 		public int horizontal, vertical;
 	}
 
-	/** The font "info" line; everything except padding and override metrics are ignored by LibGDX's BitmapFont reader, it is otherwise just useful for
+	/** The font "info" line; everything except padding and override metrics are ignored by libGDX's BitmapFont reader, it is otherwise just useful for
 	 * clean and organized output. */
 	public static class FontInfo {
 		/** Face name */
@@ -155,10 +155,10 @@ public class BitmapFontWriter {
 	 * texture page. The glyphs in BitmapFontData have a "page" id, which references the index of the pageRef you specify here.
 	 * 
 	 * The FontInfo parameter is useful for cleaner output; such as including a size and font face name hint. However, it can be
-	 * null to use default values. LibGDX ignores most of the "info" line when reading back fonts, only padding is used. Padding
+	 * null to use default values. libGDX ignores most of the "info" line when reading back fonts, only padding is used. Padding
 	 * also affects the size, location, and offset of the glyphs that are output.
 	 * 
-	 * Likewise, the scaleW and scaleH are only for cleaner output. They are currently ignored by LibGDX's reader. For maximum
+	 * Likewise, the scaleW and scaleH are only for cleaner output. They are currently ignored by libGDX's reader. For maximum
 	 * compatibility with other BMFont tools, you should use the width and height of your texture pages (each page should be the
 	 * same size).
 	 * 

--- a/gdx/src/com/badlogic/gdx/ApplicationLogger.java
+++ b/gdx/src/com/badlogic/gdx/ApplicationLogger.java
@@ -17,7 +17,7 @@
 package com.badlogic.gdx;
 
 /**
- * The ApplicationLogger provides an interface for a LibGDX Application to log messages and exceptions.
+ * The ApplicationLogger provides an interface for a libGDX Application to log messages and exceptions.
  * A default implementations is provided for each backend, custom implementations can be provided and set using
  * {@link Application#setApplicationLogger(ApplicationLogger) }
  */

--- a/gdx/src/com/badlogic/gdx/Preferences.java
+++ b/gdx/src/com/badlogic/gdx/Preferences.java
@@ -21,7 +21,7 @@ import java.util.Map;
 /** <p>
  * A Preference instance is a hash map holding different values. It is stored alongside your application (SharedPreferences on
  * Android, LocalStorage on GWT, on the desktop a Java Preferences file in a ".prefs" directory will be created, and on iOS an
- * NSMutableDictionary will be written to the given file). CAUTION: On the desktop platform, all libgdx applications share the same
+ * NSMutableDictionary will be written to the given file). CAUTION: On the desktop platform, all libGDX applications share the same
  * ".prefs" directory. To avoid collisions use specific names like "com.myname.game1.settings" instead of "settings".
  * </p>
  * 

--- a/gdx/src/com/badlogic/gdx/Version.java
+++ b/gdx/src/com/badlogic/gdx/Version.java
@@ -18,20 +18,20 @@ package com.badlogic.gdx;
 
 import com.badlogic.gdx.utils.GdxRuntimeException;
 
-/** The version of libgdx
+/** The version of libGDX
  * 
  * @author mzechner */
 public class Version {
-	/** the current version of libgdx as a String in the major.minor.revision format **/
+	/** The current version of libGDX as a String in the major.minor.revision format **/
 	public static final String VERSION = "1.10.1";
 
-	/** the current major version of libgdx **/
+	/** The current major version of libGDX **/
 	public static final int MAJOR;
 
-	/** the current minor version of libgdx **/
+	/** The current minor version of libGDX **/
 	public static final int MINOR;
 
-	/** the current revision version of libgdx **/
+	/** The current revision version of libGDX **/
 	public static final int REVISION;
 
 	static {

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/GLVersion.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/GLVersion.java
@@ -87,7 +87,7 @@ public class GLVersion {
 		try {
 			return Integer.parseInt(v);
 		} catch (NumberFormatException nfe) {
-			Gdx.app.error("LibGDX GL", "Error parsing number: " + v +", assuming: " + defaultValue);
+			Gdx.app.error("libGDX GL", "Error parsing number: " + v +", assuming: " + defaultValue);
 			return defaultValue;
 		}
 	}

--- a/gdx/src/com/badlogic/gdx/input/RemoteInput.java
+++ b/gdx/src/com/badlogic/gdx/input/RemoteInput.java
@@ -35,7 +35,7 @@ import com.badlogic.gdx.utils.GdxRuntimeException;
  * 
  * <p>
  * On your Android device you can use the gdx-remote application available on the Google Code page as an APK or in SVN
- * (extensions/gdx-remote). Open it, specify the IP address and the port of the PC your libgdx app is running on and then tap
+ * (extensions/gdx-remote). Open it, specify the IP address and the port of the PC your libGDX app is running on and then tap
  * away.
  * </p>
  * 

--- a/gdx/src/com/badlogic/gdx/maps/tiled/BaseTmxMapLoader.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/BaseTmxMapLoader.java
@@ -43,7 +43,7 @@ public abstract class BaseTmxMapLoader<P extends BaseTmxMapLoader.Parameters> ex
 		public TextureFilter textureMagFilter = TextureFilter.Nearest;
 		/** Whether to convert the objects' pixel position and size to the equivalent in tile space. **/
 		public boolean convertObjectToTileSpace = false;
-		/** Whether to flip all Y coordinates so that Y positive is up. All LibGDX renderers require flipped Y coordinates, and
+		/** Whether to flip all Y coordinates so that Y positive is up. All libGDX renderers require flipped Y coordinates, and
 		 * thus flipY set to true. This parameter is included for non-rendering related purposes of TMX files, or custom renderers. */
 		public boolean flipY = true;
 	}

--- a/gdx/src/com/badlogic/gdx/utils/GdxRuntimeException.java
+++ b/gdx/src/com/badlogic/gdx/utils/GdxRuntimeException.java
@@ -16,7 +16,7 @@
 
 package com.badlogic.gdx.utils;
 
-/** Typed runtime exception used throughout libgdx
+/** Typed runtime exception used throughout libGDX
  * 
  * @author mzechner */
 public class GdxRuntimeException extends RuntimeException {

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
   <version>1.10.1-SNAPSHOT</version>
 
   <name>libGDX Parent</name>
-  <description>Android/Desktop/iOS/HTML5 game development framework.</description>
+  <description>Android/Desktop/iOS/HTML5 game development framework</description>
   <url>http://libgdx.badlogicgames.com</url>
   <issueManagement>
     <url>https://github.com/libgdx/libgdx/issues</url>

--- a/tests/gdx-tests-lwjgl/src/com/badlogic/gdx/tests/lwjgl/LwjglTestStarter.java
+++ b/tests/gdx-tests-lwjgl/src/com/badlogic/gdx/tests/lwjgl/LwjglTestStarter.java
@@ -50,7 +50,7 @@ public class LwjglTestStarter extends JFrame {
 	static CommandLineOptions options;
 
 	public LwjglTestStarter () throws HeadlessException {
-		super("libgdx Tests");
+		super("libGDX Tests");
 		setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
 		setContentPane(new TestList());
 		pack();

--- a/tests/gdx-tests-lwjgl/src/com/badlogic/gdx/tests/lwjgl/LwjglTestStarter.java
+++ b/tests/gdx-tests-lwjgl/src/com/badlogic/gdx/tests/lwjgl/LwjglTestStarter.java
@@ -139,7 +139,7 @@ public class LwjglTestStarter extends JFrame {
 	}
 
 	/**
-	 * Runs a libgdx test.
+	 * Runs a libGDX test.
 	 * 
 	 * If no arguments are provided on the command line, shows a list of tests to choose from.
 	 * If an argument is present, the test with that name will immediately be run.

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/I18NMessageTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/I18NMessageTest.java
@@ -87,7 +87,7 @@ public class I18NMessageTest extends GdxTest {
 	}
 
 	private String getParametricMessage (String header, I18NBundle rb) {
-		return header + " -> " + rb.format("msgWithArgs", "LibGDX", MathUtils.PI, now);
+		return header + " -> " + rb.format("msgWithArgs", "libGDX", MathUtils.PI, now);
 	}
 
 	private void println (String line) {

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/I18NSimpleMessageTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/I18NSimpleMessageTest.java
@@ -89,7 +89,7 @@ public class I18NSimpleMessageTest extends GdxTest {
 	}
 
 	private String getParametricMessage (String header, I18NBundle rb) {
-		return header + " -> " + rb.format("msgWithArgs", "LibGDX", MathUtils.PI, now);
+		return header + " -> " + rb.format("msgWithArgs", "libGDX", MathUtils.PI, now);
 	}
 
 	private void println (String line) {

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ParticleEmitterTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ParticleEmitterTest.java
@@ -141,7 +141,7 @@ public class ParticleEmitterTest extends GdxTest {
 		if (fpsCounter > 3) {
 			fpsCounter = 0;
 			int activeCount = emitters.get(emitterIndex).getActiveCount();
-			Gdx.app.log("libgdx", activeCount + "/" + particleCount + " particles, FPS: " + Gdx.graphics.getFramesPerSecond());
+			Gdx.app.log("libGDX", activeCount + "/" + particleCount + " particles, FPS: " + Gdx.graphics.getFramesPerSecond());
 		}
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ParticleEmittersTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ParticleEmittersTest.java
@@ -113,7 +113,7 @@ public class ParticleEmittersTest extends GdxTest {
 			fpsCounter = 0;
 			String log = effects.size + " particle effects, FPS: " + Gdx.graphics.getFramesPerSecond() + ", Render calls: "
 				+ spriteBatch.renderCalls;
-			Gdx.app.log("libgdx", log);
+			Gdx.app.log("libGDX", log);
 			logLabel.setText(log);
 		}
 		ui.draw();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/UISimpleTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/UISimpleTest.java
@@ -55,7 +55,7 @@ public class UISimpleTest extends GdxTest {
 		pixmap.fill();
 		skin.add("white", new Texture(pixmap));
 
-		// Store the default libgdx font under the name "default".
+		// Store the default libGDX font under the name "default".
 		skin.add("default", new BitmapFont());
 
 		// Configure a TextButtonStyle and name it "default". Skin resources are stored by type, so this doesn't overwrite the font.


### PR DESCRIPTION
> The name “libGDX” always starts with a lower-case `l`, even at the beginning of a sentence. `GDX` is always written in upper-case letters.

https://libgdx.com/brand/

If we're going to go with this, let's at the very least have the README follow it.

Most of these changes are in comments and the likes, so hopefully nothing will break.

This is not a Find & Replace job - I left some things alone, such as historical changelogs and someone's monologue in `AndroidLiveWallpaper.java`.

I agree to the contributor licence, yadda yadda - just forge my signature.