### PR TITLE
Audio: Add pause/resume methods to AudioDevice.

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidAudioDevice.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidAudioDevice.java
@@ -94,4 +94,14 @@ class AndroidAudioDevice implements AudioDevice {
 	public void setVolume (float volume) {
 		track.setStereoVolume(volume, volume);
 	}
+
+	@Override
+	public void pause () {
+		if (track.getPlayState() == AudioTrack.PLAYSTATE_PLAYING) track.pause();
+	}
+
+	@Override
+	public void resume () {
+		if (track.getPlayState() == AudioTrack.PLAYSTATE_PAUSED) track.play();
+	}
 }

--- a/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/mock/audio/MockAudioDevice.java
+++ b/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/mock/audio/MockAudioDevice.java
@@ -51,4 +51,14 @@ public class MockAudioDevice implements AudioDevice {
 	public void setVolume (float volume) {
 
 	}
+
+	@Override
+	public void pause () {
+
+	}
+
+	@Override
+	public void resume () {
+
+	}
 }

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/audio/OpenALAudioDevice.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/audio/OpenALAudioDevice.java
@@ -213,4 +213,14 @@ public class OpenALAudioDevice implements AudioDevice {
 	public int getLatency () {
 		return (int)(secondsPerBuffer * bufferCount * 1000);
 	}
+
+	@Override
+	public void pause () {
+		// A buffer underflow will cause the source to stop.
+	}
+
+	@Override
+	public void resume () {
+		// Automatically resumes when samples are written
+	}
 }

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/audio/OpenALLwjglAudio.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/audio/OpenALLwjglAudio.java
@@ -323,6 +323,14 @@ public class OpenALLwjglAudio implements LwjglAudio {
 			@Override
 			public void dispose () {
 			}
+
+			@Override
+			public void pause () {
+			}
+
+			@Override
+			public void resume () {
+			}
 		};
 		return new OpenALAudioDevice(this, sampleRate, isMono, deviceBufferSize, deviceBufferCount);
 	}

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALAudioDevice.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALAudioDevice.java
@@ -213,4 +213,14 @@ public class OpenALAudioDevice implements AudioDevice {
 	public int getLatency () {
 		return (int)(secondsPerBuffer * bufferCount * 1000);
 	}
+
+	@Override
+	public void pause () {
+		// A buffer underflow will cause the source to stop.
+	}
+
+	@Override
+	public void resume () {
+		// Automatically resumes when samples are written
+	}
 }

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALLwjgl3Audio.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALLwjgl3Audio.java
@@ -347,6 +347,14 @@ public class OpenALLwjgl3Audio implements Lwjgl3Audio {
 			@Override
 			public void dispose () {
 			}
+
+			@Override
+			public void pause () {
+			}
+
+			@Override
+			public void resume () {
+			}
 		};
 		return new OpenALAudioDevice(this, sampleRate, isMono, deviceBufferSize, deviceBufferCount);
 	}

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/mock/MockAudioDevice.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/mock/MockAudioDevice.java
@@ -51,4 +51,14 @@ public class MockAudioDevice implements AudioDevice {
 	public void setVolume (float volume) {
 
 	}
+
+	@Override
+	public void pause () {
+
+	}
+
+	@Override
+	public void resume () {
+
+	}
 }

--- a/gdx/src/com/badlogic/gdx/audio/AudioDevice.java
+++ b/gdx/src/com/badlogic/gdx/audio/AudioDevice.java
@@ -50,4 +50,10 @@ public interface AudioDevice extends Disposable {
 
 	/** Sets the volume in the range [0,1]. */
 	public void setVolume (float volume);
+
+	/** Pauses the audio device if supported */
+	public void pause ();
+
+	/** Unpauses the audio device if supported */
+	public void resume ();
 }


### PR DESCRIPTION
* Only really useful for Android to save resources when not playing any audio.

A playing AudioDevice will cause Android's audioserver to run constantly, even when the AudioDevice is not being fed any samples. Closing and recreating a new AudioDevice is not cheap, but pausing is.