### PR TITLE
Give SelectBox.SelectBoxList public access for convenience

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/SelectBox.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/SelectBox.java
@@ -397,7 +397,7 @@ public class SelectBox<T> extends Widget implements Disableable {
 	}
 
 	/** @author Nathan Sweet */
-	static class SelectBoxList<T> extends ScrollPane {
+	static public class SelectBoxList<T> extends ScrollPane {
 		private final SelectBox<T> selectBox;
 		int maxListCount;
 		private final Vector2 stagePosition = new Vector2();
@@ -557,6 +557,11 @@ public class SelectBox<T> extends Widget implements Disableable {
 				oldStage.removeListener(list.getKeyListener());
 			}
 			super.setStage(stage);
+		}
+		
+		public SelectBox<T> getSelectBox()
+		{
+			return selectBox;
 		}
 	}
 


### PR DESCRIPTION
There are cases where checking if an actor is a `SelectBox.SelectBoxList` and getting the `SelectBox` associated to it is highly useful. For instance, if you want to detect clicking outside of a menu, you would generally check if the hit actor was a descendant of the menu.

For the case of `SelectBox.SelectBoxList`, this is not possible because it is a free actor added directly onto the stage. There should be a way to retrieve the `SelectBox` associated to the list so one can check if it is part of a menu or not.

We can currently achieve this with reflection, making the whole thing slow and inconvenient:

```
if(actor.getClass().getSimpleName().equals("SelectBoxList"))
{
	try
	{
		Field fieldHandle = newFocus.getClass().getDeclaredField("selectBox");

		if(!fieldHandle.isAccessible())
			fieldHandle.setAccessible(true);

		SelectBox<?> selectBox = (SelectBox<?>)fieldHandle.get(newFocus);

		if(selectBox.isDescendantOf(menu))
		{
			// is a descendant
		}
	}
	catch(NoSuchFieldException | IllegalAccessException ex)
	{
		throw new RuntimeException(ex);
	}
}
```
