### PR TITLE
Fix NPE in Type#getDeclaredAnnotation

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gwtref/gen/ReflectionCacheSourceCreator.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gwtref/gen/ReflectionCacheSourceCreator.java
@@ -610,7 +610,10 @@ public class ReflectionCacheSourceCreator {
 
 			Annotation[] annotations = c.getDeclaredAnnotations();
 			if (annotations != null && annotations.length > 0) {
-				pb(varName + ".annotations = " + getAnnotations(annotations) + ";");
+				String annotations1 = getAnnotations(annotations);
+				if ( !"null".equals(annotations1) ) { // avoid nulling the default empty array for annotations.
+					pb(varName + ".annotations = " + annotations1 + ";");
+				}
 			}
 		} else {
 			pb(varName + ".isAbstract = true;"); // Primitives are _always_ abstract


### PR DESCRIPTION
This PR solves a NPE in `Type#getDeclaredAnnotation()` itself and `Type#getDeclaredAnnotations()` at callsites caused by a small error in the `ReflectionCacheSourceCreator`.

(Spotted one inconsistency related to this I didn't touch, `Method` and all call sites expect a null for an empty `Method.annotations`, `Type`/`Field` and related call sites expect an empty array)

#### Issue details
NPE in `Type#getDeclaredAnnotation` caused by `type.annotations=null` generated in  `ReflectionCacheSourceCreator`.
`ReflectionCacheSourceCreator::getAnnotations` can filter out annotations for various reasons which can produce `null`.

#### Reproduction steps/code
1. Annotate a class in your reflection cache with `@Deprecated` and nothing else.
2. Call `Type#getDeclaredAnnotation` on that class. Observed: NPE

#### Version of libGDX and/or relevant dependencies
1.10.1-SNAPSHOT.

#### Please select the affected platforms
- [X] HTML/GWT
