### PR TITLE
libGDX capitalization (continuation of #6591)

### DIFF
--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetupUI.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetupUI.java
@@ -309,7 +309,7 @@ public class GdxSetupUI extends JFrame {
 		JScrollPane scrollPane = new JScrollPane(textArea);
 		JPanel title = new JPanel();
 		JPanel topBar = new JPanel();
-		JLabel windowLabel = new JLabel("    Libgdx Project Generator");
+		JLabel windowLabel = new JLabel("    libGDX Project Generator");
 		JButton exit;
 		JButton minimize;
 		JLabel logo;


### PR DESCRIPTION
Hello. I made a blunder. In pull request #6591, the setup tool title was changed from "Libgdx Project Generator" to "libGDX Project Generator". However, this only affects the how it's displayed in the taskbar, and probably a few other places - the title within the window remains the same. Turns out the title is defined twice, and I missed the second instance. Apologies for temporarily creating an inconsistency.

In case you're wondering, those spaces preceding it are surely intentional. They're a hacky way of adding left padding to the title, and it looks bad if they're removed.