### PR TITLE
GlyphLayout: Fix wrapping with color tag in whitespace

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g2d/GlyphLayout.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/GlyphLayout.java
@@ -417,11 +417,13 @@ public class GlyphLayout implements Poolable {
 			int droppedGlyphCount = secondStart - firstEnd;
 			if (droppedGlyphCount > 0) {
 				this.glyphCount -= droppedGlyphCount;
-				if (fontData.markupEnabled) {
-					// Many color changes can be hidden in the dropped whitespace, so keep only the previous color entry.
+				if (fontData.markupEnabled && colors.get(colors.size - 2) > this.glyphCount) {
+					// Many color changes can be hidden in the dropped whitespace, so keep only the very last color entry.
+					int lastColor = colors.peek();
 					while (colors.get(colors.size - 2) > this.glyphCount)
 						colors.size -= 2;
 					colors.set(colors.size - 2, this.glyphCount); // Update color change index.
+					colors.set(colors.size - 1, lastColor); // Update color entry.
 				}
 			}
 		}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/BitmapFontTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/BitmapFontTest.java
@@ -115,7 +115,7 @@ public class BitmapFontTest extends GdxTest {
 			// text = "Another font wrap is-sue, this time with multiple whitespace characters.";
 			// text = "test with AGWlWi AGWlWi issue";
 			// text = "AA BB \nEE"; // When wrapping after BB, there should not be a blank line before EE.
-			text = "[BLUE]A[]A BB [#00f000]EE[] T [GREEN]e[]   \r\r[PINK]\n[]\nV[YELLOW]a bb[] ([CYAN]5[]FFFurz)\nV[PURPLE]a[]\nVa\n[PURPLE]V[]a";
+			text = "[BLUE]A[]A BB [#00f000]EE[] T [GREEN]e[]   \r\r[PINK]\n\nV[][YELLOW]a bb[] ([CYAN]5[]FFFurz)\nV[PURPLE]a[]\nVa\n[PURPLE]V[]a";
 			if (true) { // Test wrap.
 				layout.setText(font, text, 0, text.length(), font.getColor(), w, Align.center, true, null);
 			} else { // Test truncation.


### PR DESCRIPTION
Hey guys,

this PR fixes a bug with colors and wrapping if there is a color tag hidden in whitespace.
The updated text in `BitmapFontTest` shows the problem. The "V" should be pink and will be white if the wrapping removes the whitespace.

@NathanSweet @tommyettinger 