### PR TITLE
[GWT] Fix: Reflection cache generator stopped logging types.

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gwtref/gen/ReflectionCacheGenerator.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gwtref/gen/ReflectionCacheGenerator.java
@@ -120,6 +120,7 @@ public class ReflectionCacheGenerator extends Generator {
 		String nestedMsg = "";
 		for (int i = 0; i < nesting; i++)
 			nestedMsg += "  ";
+		nestedMsg += message;
 		logger.log(Type.INFO, nestedMsg);
 	}
 


### PR DESCRIPTION
PR fixes logging in `ReflectionCacheGenerator` which was broken in 90fc8f7
The logging is useful for spotting configuration issues with the reflection cache.

#### Reproduction steps/code
1. Build html target to generate reflection cache and look at the logs. (Any project should do).

Observed: Logging shows empty lines at the beginning (see below).
Expected: List of types included in the reflection cache 
```
[INFO]    Computing all possible rebind results for 'com.badlogic.gwtref.client.IReflectionCache'
[INFO]       Rebinding com.badlogic.gwtref.client.IReflectionCache
[INFO]          Invoking generator com.badlogic.gwtref.gen.ReflectionCacheGenerator
[INFO]             com.badlogic.gwtref.client.IReflectionCache
[INFO]               
[INFO]                 
[INFO]               
[INFO]                 
..
[INFO]            
etc         
```
#### Version of libGDX and/or relevant dependencies
1.10.1-SNAPSHOT