### PR TITLE
Fix HexagonalTiledMapRenderer displaying maps with the wrong stagger index

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -17,6 +17,7 @@
 - API Change: Enable the AL_DIRECT_CHANNELS_SOFT option for Sounds and AudioDevices as well to fix stereo sound
 - API Addition: CameraInputController#setInvertedControls(boolean)
 - API Removal: AnimatedTiledMapTile#frameCount
+- FIX: HexagonalTiledMapRenderer now displays maps with the correct stagger index.
 
 [1.10.0]
 - [BREAKING CHANGE] Android armeabi support has been removed. To migrate your projects: remove any dependency with natives-armeabi qualifier from your gradle build file, this apply to gdx-platform, gdx-bullet-platform, gdx-freetype-platform and gdx-box2d-platform.

--- a/gdx/src/com/badlogic/gdx/maps/tiled/renderers/HexagonalTiledMapRenderer.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/renderers/HexagonalTiledMapRenderer.java
@@ -30,8 +30,8 @@ public class HexagonalTiledMapRenderer extends BatchTiledMapRenderer {
 
 	/** true for X-Axis, false for Y-Axis */
 	private boolean staggerAxisX = true;
-	/** true for even StaggerIndex, false for odd */
-	private boolean staggerIndexEven = false;
+	/** true for even StaggerIndex, true for odd */
+	private boolean staggerIndexOdd = false;
 	/** the parameter defining the shape of the hexagon from tiled. more specifically it represents the length of the sides that
 	 * are parallel to the stagger axis. e.g. with respect to the stagger axis a value of 0 results in a rhombus shape, while a
 	 * value equal to the tile length/height represents a square shape and a value of 0.5 represents a regular hexagon if tile
@@ -70,10 +70,10 @@ public class HexagonalTiledMapRenderer extends BatchTiledMapRenderer {
 
 		String index = map.getProperties().get("staggerindex", String.class);
 		if (index != null) {
-			if (index.equals("even")) {
-				staggerIndexEven = true;
+			if (index.equals("odd")) {
+				staggerIndexOdd = true;
 			} else {
-				staggerIndexEven = false;
+				staggerIndexOdd = false;
 			}
 		}
 
@@ -132,8 +132,8 @@ public class HexagonalTiledMapRenderer extends BatchTiledMapRenderer {
 				(int)((viewBounds.x + viewBounds.width + tileWidthUpperCorner - layerOffsetY) / tileWidthUpperCorner));
 
 			// depending on the stagger index either draw all even before the odd or vice versa
-			final int colA = (staggerIndexEven == (col1 % 2 == 0)) ? col1 + 1 : col1;
-			final int colB = (staggerIndexEven == (col1 % 2 == 0)) ? col1 : col1 + 1;
+			final int colA = (staggerIndexOdd == (col1 % 2 == 0)) ? col1 + 1 : col1;
+			final int colB = (staggerIndexOdd == (col1 % 2 == 0)) ? col1 : col1 + 1;
 
 			for (int row = row2 - 1; row >= row1; row--) {
 				for (int col = colA; col < col2; col += 2) {
@@ -161,7 +161,7 @@ public class HexagonalTiledMapRenderer extends BatchTiledMapRenderer {
 			float shiftX = 0;
 			for (int row = row2 - 1; row >= row1; row--) {
 				// depending on the stagger index either shift for even or uneven indexes
-				if ((row % 2 == 0) == staggerIndexEven)
+				if ((row % 2 == 0) == staggerIndexOdd)
 					shiftX = layerTileWidth50;
 				else
 					shiftX = 0;


### PR DESCRIPTION
When trying to load a hexagonal map via tiledmap, the stagger index is apparently inverted.

It doesn't matter if you save the file in odd or even, gdx loads that property correctly, but renders it inverted.
Therefore, I concluded that the boolean flag is inverted and flipped it around.

# Before:
### Even:
![image](https://user-images.githubusercontent.com/11274700/126612127-0ffde367-f366-49f9-a5b0-2c81fc2f7db0.png)
### Odd:
![image](https://user-images.githubusercontent.com/11274700/126612392-babcf19e-fb22-4f73-9a06-2b526085398e.png)

# After:
### Even:
![image](https://user-images.githubusercontent.com/11274700/126612190-9bc97c4f-143a-4222-9548-3cd645968eb8.png)
### Odd:
![image](https://user-images.githubusercontent.com/11274700/126612354-c3e695d8-0c02-4058-a0ea-4cc22a9bfd6f.png)


A workaround for the current libGDX version would be to do the map in one of the indexes, then save it with the other index. That loads the map correctly in the current version.


Test code:
```java
public class HexMapRenderer extends ScreenAdapter {
    private final TiledMap map;
    private final HexagonalTiledMapRenderer renderer;

    private final Viewport viewport;

    public HexMapRenderer() {
        map = new TmxMapLoader().load("hex/hex.tmx");
        renderer = new HexagonalTiledMapRenderer(map, 1);

        viewport = new ExtendViewport(16 * 32, 9 * 32);
    }

    @Override
    public void render(float delta) {
        viewport.apply();
        renderer.setView((OrthographicCamera) viewport.getCamera());
        renderer.render();
    }

    @Override
    public void resize(int width, int height) {
        viewport.update(width, height);
    }
}
```