### PR TITLE
gdx-setup dialogs

### DIFF
--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/ExternalExtensionsDialog.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/ExternalExtensionsDialog.java
@@ -105,7 +105,7 @@ public class ExternalExtensionsDialog extends JDialog implements TableModelListe
 			}
 		});
 
-		setTitle("Third party external extensions");
+		setTitle("Third-party external extensions");
 		setSize(600, 300);
 		setLocationRelativeTo(null);
 	}
@@ -120,8 +120,8 @@ public class ExternalExtensionsDialog extends JDialog implements TableModelListe
 
 		topPanel = new JPanel(new GridBagLayout());
 		topPanel.setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5));
-		warningNotice = new JLabel("List of third party extensions for libGDX");
-		warningNotice2 = new JLabel("These are not maintained by the libGDX team, please see the support links for info and help");
+		warningNotice = new JLabel("List of third-party extensions for libGDX");
+		warningNotice2 = new JLabel("These are not maintained by the libGDX team. Please see the support links for info and help.");
 		warningNotice.setHorizontalAlignment(JLabel.CENTER);
 		warningNotice2.setHorizontalAlignment(JLabel.CENTER);
 
@@ -260,8 +260,8 @@ public class ExternalExtensionsDialog extends JDialog implements TableModelListe
 		scrollPane.setBackground(new Color(36, 36, 36));
 		scrollPane.getViewport().setBackground(new Color(36, 36, 36));
 
-		warningNotice.setForeground(new Color(255, 20, 20));
-		warningNotice2.setForeground(new Color(255, 20, 20));
+		warningNotice.setForeground(new Color(235, 70, 61));
+		warningNotice2.setForeground(new Color(235, 70, 61));
 	}
 
 	void onOK () {

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/SettingsDialog.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/SettingsDialog.java
@@ -153,7 +153,7 @@ public class SettingsDialog extends JDialog {
 		content.add(settings, new GridBagConstraints(0, 0, 1, 1, 1, 1, NORTH, HORIZONTAL, new Insets(0, 0, 0, 0), 0, 0));
 		content.add(description, new GridBagConstraints(3, 0, 1, 1, 1, 1, NORTH, HORIZONTAL, new Insets(0, 0, 0, 0), 0, 0));
 
-		JLabel mavenLabel = new JLabel("Maven Mirror Url");
+		JLabel mavenLabel = new JLabel("Maven Mirror URL");
 		JLabel mavenDesc = new JLabel("Replaces Maven Central with this repository");
 		mavenTextField = new JTextField(15);
 		mavenTextField.setMinimumSize(mavenTextField.getPreferredSize());
@@ -162,7 +162,7 @@ public class SettingsDialog extends JDialog {
 		JLabel offlineLabel = new JLabel("Offline Mode");
 		JLabel offlineDesc = new JLabel("Don't force download dependencies");
 		JLabel kotlinLabel = new JLabel("Use Kotlin");
-		JLabel kotlinDesc = new JLabel("Use Kotlin as the main language.");
+		JLabel kotlinDesc = new JLabel("Use Kotlin as the main language");
 		offlineBox = new SetupCheckBox();
 		offlineLabel.setForeground(new Color(170, 170, 170));
 		offlineDesc.setForeground(new Color(170, 170, 170));


### PR DESCRIPTION
Some super simple changes to the gdx-setup dialogues. Basically makes the extensions text match the new red, and some other minor things done for consistency sake. Inspired by #6463 and about half of this is to match what it changed - I didn't try it until it was merged.

Currently, diauloug text gets truncated on Linux due to the window size not being wide enough. It's something I'd like to fix, but that would require seeing what the situation is on macOS and confirming it's consistent across distros - or make the daiologes so they can be packed without looking silly (more robust solution but also more work) - so it might not be destined for this pull request.