### PR TITLE
Prevent repeated mipmap generation in FileTextureArrayData

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/glutils/FileTextureArrayData.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/FileTextureArrayData.java
@@ -69,9 +69,11 @@ public class FileTextureArrayData implements TextureArrayData {
 
 	@Override
 	public void consumeTextureArrayData () {
+		boolean containsCustomData = false;
 		for (int i = 0; i < textureDatas.length; i++) {
 			if (textureDatas[i].getType() == TextureData.TextureDataType.Custom) {
 				textureDatas[i].consumeCustomData(GL30.GL_TEXTURE_2D_ARRAY);
+				containsCustomData = true;
 			} else {
 				TextureData texData = textureDatas[i];
 				Pixmap pixmap = texData.consumePixmap();
@@ -91,7 +93,7 @@ public class FileTextureArrayData implements TextureArrayData {
 				if (disposePixmap) pixmap.dispose();
 			}
 		}
-		if (useMipMaps) {
+		if (useMipMaps && !containsCustomData) {
 			Gdx.gl20.glGenerateMipmap(GL30.GL_TEXTURE_2D_ARRAY);
 		}
 	}

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/FileTextureArrayData.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/FileTextureArrayData.java
@@ -88,11 +88,11 @@ public class FileTextureArrayData implements TextureArrayData {
 				}
 				Gdx.gl30.glTexSubImage3D(GL30.GL_TEXTURE_2D_ARRAY, 0, 0, 0, i, pixmap.getWidth(), pixmap.getHeight(), 1,
 					pixmap.getGLInternalFormat(), pixmap.getGLType(), pixmap.getPixels());
-				if (useMipMaps) {
-					Gdx.gl20.glGenerateMipmap(GL30.GL_TEXTURE_2D_ARRAY);
-				}
 				if (disposePixmap) pixmap.dispose();
 			}
+		}
+		if (useMipMaps) {
+			Gdx.gl20.glGenerateMipmap(GL30.GL_TEXTURE_2D_ARRAY);
 		}
 	}
 


### PR DESCRIPTION
The current code repeats the Gdx.gl20.glGenerateMipmap call for every subtexture, although a single call at the end should be sufficient. This becomes a significant performance problem if a texture array contains a large number of elements.