### PR TITLE
Texture Packer page indexes

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,6 @@
 [1.10.1]
 - [BREAKING CHANGE] Android Moved natives loading out of static init block, see #5795
+- [BREAKING CHANGE] Texture Packer: Filenames are now zero-indexed, including the first file (when there are multiple pages) - e.g. pack.png, pack2.png would now be pack0.png, pack1.png
 - API Addition: ObjLoader now supports ambientColor, ambientTexture, transparencyTexture, specularTexture and shininessTexture
 - API Addition: PointSpriteParticleBatch blending is now configurable.
 - TOOLS Features: Blending mode and sort mode can be changed in Flame particle 3D editor.

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/texturepacker/TexturePacker.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/texturepacker/TexturePacker.java
@@ -201,7 +201,7 @@ public class TexturePacker {
 		File packDir = packFileNoExt.getParentFile();
 		String imageName = packFileNoExt.getName();
 
-		int fileIndex = 1;
+		int fileIndex = 0;
 		for (int p = 0, pn = pages.size; p < pn; p++) {
 			Page page = pages.get(p);
 
@@ -233,9 +233,9 @@ public class TexturePacker {
 			page.imageHeight = height;
 
 			File outputFile;
-			while (true) {
+			do {
 				String name = imageName;
-				if (fileIndex > 1) {
+				if (pages.size > 1) {
 					// Last character is a digit or a digit + 'x'.
 					char last = name.charAt(name.length() - 1);
 					if (Character.isDigit(last)
@@ -246,8 +246,7 @@ public class TexturePacker {
 				}
 				fileIndex++;
 				outputFile = new File(packDir, name + "." + settings.outputFormat);
-				if (!outputFile.exists()) break;
-			}
+			} while (outputFile.exists());
 			new FileHandle(outputFile).parent().mkdirs();
 			page.imageName = outputFile.getName();
 
@@ -704,9 +703,8 @@ public class TexturePacker {
 			if (getClass() != obj.getClass()) return false;
 			Rect other = (Rect)obj;
 			if (name == null) {
-				if (other.name != null) return false;
-			} else if (!name.equals(other.name)) return false;
-			return true;
+				return other.name == null;
+			} else return name.equals(other.name);
 		}
 
 		@Override
@@ -719,7 +717,7 @@ public class TexturePacker {
 		}
 	}
 
-	static public enum Resampling {
+	public enum Resampling {
 		nearest(RenderingHints.VALUE_INTERPOLATION_NEAREST_NEIGHBOR), //
 		bilinear(RenderingHints.VALUE_INTERPOLATION_BILINEAR), //
 		bicubic(RenderingHints.VALUE_INTERPOLATION_BICUBIC);
@@ -802,10 +800,10 @@ public class TexturePacker {
 		return false;
 	}
 
-	static public interface Packer {
-		public Array<Page> pack (Array<Rect> inputRects);
+	public interface Packer {
+		Array<Page> pack(Array<Rect> inputRects);
 
-		public Array<Page> pack (ProgressListener progress, Array<Rect> inputRects);
+		Array<Page> pack(ProgressListener progress, Array<Rect> inputRects);
 	}
 
 	static final class InputImage {

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/texturepacker/TexturePackerFileProcessor.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/texturepacker/TexturePackerFileProcessor.java
@@ -38,9 +38,9 @@ import com.badlogic.gdx.utils.ObjectMap;
 public class TexturePackerFileProcessor extends FileProcessor {
 	private final Settings defaultSettings;
 	private final ProgressListener progress;
-	private ObjectMap<File, Settings> dirToSettings = new ObjectMap();
-	private Json json = new Json();
-	private String packFileName;
+	private final ObjectMap<File, Settings> dirToSettings = new ObjectMap();
+	private final Json json = new Json();
+	private final String packFileName;
 	private File root;
 	ArrayList<File> ignoreDirs = new ArrayList();
 	boolean countOnly;


### PR DESCRIPTION
Don't be deceived by the number of changed lines. Only lines 204 and 238 in `TexturePacker.java` actually change any functionality. But those lines make this a breaking change! At least, I think it does - the linked issue was labelled as breaking.

It aims to fix #6239 by adding an index to the first texture page. Just like previously, an index isn't added if the atlas is only one page long.

No-one asked for this, but I also made the index start at 0 instead of 1. My reasoning behind this is it's easier to iterate over your textures and all that this way - no need to have `+ 1` all over the place.

There's also a little bit of tidy-up to reduce warnings about redundancy and whatnot, but it's a very minimal effort.

P.S. I actually have git set up a bit better now - there'll be no more "Frosty-J and Frosty-J committed" business.