### PR TITLE
Protection against NullPointerException in destroyBody()

### DIFF
--- a/extensions/gdx-box2d/gdx-box2d/src/com/badlogic/gdx/physics/box2d/World.java
+++ b/extensions/gdx-box2d/gdx-box2d/src/com/badlogic/gdx/physics/box2d/World.java
@@ -327,7 +327,8 @@ b2ContactFilter defaultFilter;
 		Array<Fixture> fixtureList = body.getFixtureList();
 		while(fixtureList.size > 0) {
 			Fixture fixtureToDelete = fixtureList.removeIndex(0);
- 			this.fixtures.remove(fixtureToDelete.addr).setUserData(null);
+			fixtureToDelete.setUserData(null);
+ 			this.fixtures.remove(fixtureToDelete.addr);
  			freeFixtures.free(fixtureToDelete);
  		}
 		


### PR DESCRIPTION
Going through the crash reports on one of my games I've come across this very rare one: 

```
at Fatal Exception: java.lang.NullPointerException
java.lang.NullPointerException at com.badlogic.gdx.physics.box2d.World.destroyBody(World.java:330) 
```

`this.fixtures.remove(fixtureToDelete.addr)` can potentially return `null` throwing an exception that should not be fatal. I've gone through my code and I don't know how this may happen but this fix prevents the crash regardless. It also makes it consistent with `Body#destroyFixture()` implementation.