### PR TITLE
gdx-setup UI: Fix Box2D being included by default

### DIFF
--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetupUI.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetupUI.java
@@ -125,7 +125,6 @@ public class GdxSetupUI extends JFrame {
 		builder = new ProjectBuilder(new DependencyBank());
 		modules.add(ProjectType.CORE);
 		dependencies.add(builder.bank.getDependency(ProjectDependency.GDX));
-		dependencies.add(builder.bank.getDependency(ProjectDependency.BOX2D));
 	}
 
 	void generate () {

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetupUI.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetupUI.java
@@ -573,7 +573,7 @@ public class GdxSetupUI extends JFrame {
 				while (depCounter < ProjectDependency.values().length) {
 					if (ProjectDependency.values()[depCounter] != null) {
 						final ProjectDependency projDep = ProjectDependency.values()[depCounter];
-						if (projDep.equals(ProjectDependency.GDX) || projDep.equals(ProjectDependency.TOOLS)) {
+						if (projDep.equals(ProjectDependency.GDX)) {
 							depCounter++;
 							continue;
 						}
@@ -601,7 +601,7 @@ public class GdxSetupUI extends JFrame {
 					}
 				}
 				
-				for (int left = ((depCounter - 1) % 5); left > 2; left--) {
+				for (int left = ((depCounter - 1) % 5); left > 1; left--) {
 					extensionPanel.add(Box.createHorizontalBox());
 				}
 

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetupUI.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetupUI.java
@@ -574,7 +574,7 @@ public class GdxSetupUI extends JFrame {
 				while (depCounter < ProjectDependency.values().length) {
 					if (ProjectDependency.values()[depCounter] != null) {
 						final ProjectDependency projDep = ProjectDependency.values()[depCounter];
-						if (projDep.equals(ProjectDependency.GDX)) {
+						if (projDep.equals(ProjectDependency.GDX) || projDep.equals(ProjectDependency.TOOLS)) {
 							depCounter++;
 							continue;
 						}
@@ -602,7 +602,7 @@ public class GdxSetupUI extends JFrame {
 					}
 				}
 				
-				for (int left = ((depCounter - 1) % 5); left > 1; left--) {
+				for (int left = ((depCounter - 1) % 5); left > 2; left--) {
 					extensionPanel.add(Box.createHorizontalBox());
 				}
 


### PR DESCRIPTION
In #6463, the Box2D checkbox was set to be unselected by default, but this was only a visual change. With this pull request, now it should only be included if the user actually selects the checkbox.

This originally had stuff for removing gdx-tools from the UI, as it's unsupported in LWJGL3 so its checkbox does nothing, but following discussions on Discord that's no longer the case until we get a clearer picture on the state of gdx-tools and LWJGL3.