### PR TITLE
Fix LWJGL 3 borderless fullscreen.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -22,6 +22,7 @@
 - API Fix: Escaped characters in XML attributes are now properly un-escaped
 - Bug Fix: AssetManager backslash conversion removed - fixes use of filenames containing backslashes
 - gdx-setup now places the assets directory in project root instead of android or core. See advanced settings (UI) or arguments (command line) if you don't want it in root.
+- API Fix: Resolved issues with LWJGL 3 and borderless fullscreen
 
 [1.10.0]
 - [BREAKING CHANGE] Android armeabi support has been removed. To migrate your projects: remove any dependency with natives-armeabi qualifier from your gradle build file, this apply to gdx-platform, gdx-bullet-platform, gdx-freetype-platform and gdx-box2d-platform.

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
@@ -488,8 +488,8 @@ public class Lwjgl3Application implements Lwjgl3ApplicationBase {
 				IntBuffer areaHeight = BufferUtils.createIntBuffer(1);
 				GLFW.glfwGetMonitorWorkarea(monitorHandle, areaXPos, areaYPos, areaWidth, areaHeight);
 
-				GLFW.glfwSetWindowPos(windowHandle, areaXPos.get(0) + areaWidth.get(0) / 2 - windowWidth / 2,
-					areaYPos.get(0) + areaHeight.get(0) / 2 - windowHeight / 2);
+				GLFW.glfwSetWindowPos(windowHandle, Math.max(0, areaXPos.get(0) + areaWidth.get(0) / 2 - windowWidth / 2),
+					Math.max(0, areaYPos.get(0) + areaHeight.get(0) / 2 - windowHeight / 2));
 			} else {
 				GLFW.glfwSetWindowPos(windowHandle, config.windowX, config.windowY);
 			}

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Graphics.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Graphics.java
@@ -394,13 +394,19 @@ public class Lwjgl3Graphics extends AbstractGraphics implements Disposable {
 	public boolean setWindowedMode (int width, int height) {
 		window.getInput().resetPollingStates();
 		if (!isFullscreen()) {
-			if (width != logicalWidth || height != logicalHeight) { // Center window
+			int newX = 0, newY = 0;
+			boolean centerWindow = false;
+			if (width != logicalWidth || height != logicalHeight) {
+				centerWindow = true;
 				Lwjgl3Monitor monitor = (Lwjgl3Monitor)getMonitor();
 				GLFW.glfwGetMonitorWorkarea(monitor.monitorHandle, tmpBuffer, tmpBuffer2, tmpBuffer3, tmpBuffer4);
-				window.setPosition(Math.max(0, tmpBuffer.get(0) + (tmpBuffer3.get(0) - width) / 2),
-					Math.max(0, tmpBuffer2.get(0) + (tmpBuffer4.get(0) - height) / 2));
+				newX = Math.max(0, tmpBuffer.get(0) + (tmpBuffer3.get(0) - width) / 2);
+				newY = Math.max(0, tmpBuffer2.get(0) + (tmpBuffer4.get(0) - height) / 2);
 			}
 			GLFW.glfwSetWindowSize(window.getWindowHandle(), width, height);
+			if (centerWindow) {
+				window.setPosition(newX, newY); // on macOS the centering has to happen _after_ the new window size was set
+			}
 		} else {
 			if (displayModeBeforeFullscreen == null) {
 				storeCurrentWindowPositionAndDisplayMode();

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Graphics.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Graphics.java
@@ -394,23 +394,24 @@ public class Lwjgl3Graphics extends AbstractGraphics implements Disposable {
 	public boolean setWindowedMode (int width, int height) {
 		window.getInput().resetPollingStates();
 		if (!isFullscreen()) {
-			if (width != logicalWidth || height != logicalHeight) {
-				// Center window
+			if (width != logicalWidth || height != logicalHeight) { // Center window
 				Lwjgl3Monitor monitor = (Lwjgl3Monitor)getMonitor();
 				GLFW.glfwGetMonitorWorkarea(monitor.monitorHandle, tmpBuffer, tmpBuffer2, tmpBuffer3, tmpBuffer4);
-				window.setPosition(tmpBuffer.get(0) + (tmpBuffer3.get(0) - width) / 2,
-					tmpBuffer2.get(0) + (tmpBuffer4.get(0) - height) / 2);
+				window.setPosition(Math.max(0, tmpBuffer.get(0) + (tmpBuffer3.get(0) - width) / 2),
+					Math.max(0, tmpBuffer2.get(0) + (tmpBuffer4.get(0) - height) / 2));
 			}
 			GLFW.glfwSetWindowSize(window.getWindowHandle(), width, height);
 		} else {
 			if (displayModeBeforeFullscreen == null) {
 				storeCurrentWindowPositionAndDisplayMode();
 			}
-			if (width != windowWidthBeforeFullscreen || height != windowHeightBeforeFullscreen) {
+			if (width != windowWidthBeforeFullscreen || height != windowHeightBeforeFullscreen) { // Center window
 				Lwjgl3Monitor monitor = (Lwjgl3Monitor)getMonitor();
 				GLFW.glfwGetMonitorWorkarea(monitor.monitorHandle, tmpBuffer, tmpBuffer2, tmpBuffer3, tmpBuffer4);
-				GLFW.glfwSetWindowMonitor(window.getWindowHandle(), 0, tmpBuffer.get(0) + (tmpBuffer3.get(0) - width) / 2,
-					tmpBuffer2.get(0) + (tmpBuffer4.get(0) - height) / 2, width, height, displayModeBeforeFullscreen.refreshRate);
+				GLFW.glfwSetWindowMonitor(window.getWindowHandle(), 0,
+					Math.max(0, tmpBuffer.get(0) + (tmpBuffer3.get(0) - width) / 2),
+					Math.max(0, tmpBuffer2.get(0) + (tmpBuffer4.get(0) - height) / 2), width, height,
+					displayModeBeforeFullscreen.refreshRate);
 			} else {
 				GLFW.glfwSetWindowMonitor(window.getWindowHandle(), 0, windowPosXBeforeFullscreen, windowPosYBeforeFullscreen, width,
 					height, displayModeBeforeFullscreen.refreshRate);


### PR DESCRIPTION
The following code snippet is supposed to create a borderless fullscreen window:

```java
Gdx.graphics.setUndecorated(true);
Graphics.DisplayMode displayMode = Gdx.graphics.getDisplayMode();
Gdx.graphics.setWindowedMode(displayMode.width, displayMode.height);
```

However, while [testing some things for #6646](https://github.com/libgdx/libgdx/issues/6646#issuecomment-918095556), we discovered that on some systems the taskbar on Windows just stays visible, while on other systems the taskbar may be no longer visible, but is still clickable (i.e. clicking the lower part of the window just triggers taskbar shortcuts, etc.). To some extent, the bug was introduced in #6178, but even before then, in 1.9.11, this happened when the window was placed on a different monitor than the primary one. 

This PR fixes all of that, i.e. it makes borderless fullscreen (as can be achieved by the snippet above) working (again) with the LWJGL 3 backend. Tested on Windows as well as on macOS (where apparently the `glfwSetWindowPos` call has to happen after the `glfwSetWindowSize` one, or the window position doesn't take the menu bar into account).