### PR TITLE
Fix #6643 and improvements to iOS supported orientations logic

### DIFF
--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/DefaultIOSInput.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/DefaultIOSInput.java
@@ -606,13 +606,7 @@ public class DefaultIOSInput extends AbstractInput implements IOSInput {
 
 	@Override
 	public Orientation getNativeOrientation () {
-		switch (app.uiApp.getStatusBarOrientation()) {
-		case LandscapeLeft:
-		case LandscapeRight:
-			return Orientation.Landscape;
-		default:
-			return Orientation.Portrait;
-		}
+		return Orientation.Portrait;
 	}
 
 	@Override

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSUIViewController.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSUIViewController.java
@@ -4,14 +4,13 @@ package com.badlogic.gdx.backends.iosrobovm;
 import com.badlogic.gdx.graphics.glutils.HdpiMode;
 import org.robovm.apple.foundation.NSSet;
 import org.robovm.apple.glkit.GLKViewController;
+import org.robovm.apple.uikit.UIDevice;
 import org.robovm.apple.uikit.UIInterfaceOrientation;
 import org.robovm.apple.uikit.UIInterfaceOrientationMask;
 import org.robovm.apple.uikit.UIPress;
 import org.robovm.apple.uikit.UIPressesEvent;
 import org.robovm.apple.uikit.UIRectEdge;
-import org.robovm.objc.Selector;
-import org.robovm.objc.annotation.BindSelector;
-import org.robovm.rt.bro.annotation.Callback;
+import org.robovm.apple.uikit.UIUserInterfaceIdiom;
 
 public class IOSUIViewController extends GLKViewController {
 	final IOSApplication app;
@@ -40,10 +39,13 @@ public class IOSUIViewController extends GLKViewController {
 	public UIInterfaceOrientationMask getSupportedInterfaceOrientations () {
 		long mask = 0;
 		if (app.config.orientationLandscape) {
-			mask |= ((1 << UIInterfaceOrientation.LandscapeLeft.value()) | (1 << UIInterfaceOrientation.LandscapeRight.value()));
+			mask |= (1L << UIInterfaceOrientation.LandscapeLeft.value()) | (1L << UIInterfaceOrientation.LandscapeRight.value());
 		}
 		if (app.config.orientationPortrait) {
-			mask |= ((1 << UIInterfaceOrientation.Portrait.value()) | (1 << UIInterfaceOrientation.PortraitUpsideDown.value()));
+			mask |= 1L << UIInterfaceOrientation.Portrait.value();
+			if (UIDevice.getCurrentDevice().getUserInterfaceIdiom() == UIUserInterfaceIdiom.Pad) {
+				mask |= 1L << UIInterfaceOrientation.PortraitUpsideDown.value();
+			}
 		}
 		return new UIInterfaceOrientationMask(mask);
 	}
@@ -51,18 +53,6 @@ public class IOSUIViewController extends GLKViewController {
 	@Override
 	public boolean shouldAutorotate () {
 		return true;
-	}
-
-	public boolean shouldAutorotateToInterfaceOrientation (UIInterfaceOrientation orientation) {
-		// we return "true" if we support the orientation
-		switch (orientation) {
-		case LandscapeLeft:
-		case LandscapeRight:
-			return app.config.orientationLandscape;
-		default:
-			// assume portrait
-			return app.config.orientationPortrait;
-		}
 	}
 
 	@Override
@@ -99,13 +89,6 @@ public class IOSUIViewController extends GLKViewController {
 	@Override
 	public boolean prefersHomeIndicatorAutoHidden () {
 		return app.config.hideHomeIndicator;
-	}
-
-	@Callback
-	@BindSelector("shouldAutorotateToInterfaceOrientation:")
-	private static boolean shouldAutorotateToInterfaceOrientation (IOSUIViewController self, Selector sel,
-		UIInterfaceOrientation orientation) {
-		return self.shouldAutorotateToInterfaceOrientation(orientation);
 	}
 
 	@Override


### PR DESCRIPTION
Fixed #6643.

Also removed deprecated(on iOS6) method to handle supported orientation `shouldAutorotateToInterfaceOrientation` and improved the one that replaces it, `getSupportedInterfaceOrientations()`, to distinguish between iPad OS and iOS (following official docs recommendation only to add PortraitUpsideDown to iPad. (https://developer.apple.com/documentation/uikit/uiviewcontroller/1621435-supportedinterfaceorientations).