### PR TITLE
Improve iOS Music loading

### DIFF
--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSMusic.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSMusic.java
@@ -26,10 +26,13 @@ import com.badlogic.gdx.backends.iosrobovm.objectal.OALAudioTrack;
 /** @author Niklas Therning */
 public class IOSMusic implements Music {
 	private final OALAudioTrack track;
+	private final String filePath;
+	private boolean initialized;
 	OnCompletionListener onCompletionListener;
 
-	public IOSMusic (OALAudioTrack track) {
+	public IOSMusic (OALAudioTrack track, String filePath) {
 		this.track = track;
+		this.filePath = filePath;
 		this.track.setDelegate(new AVAudioPlayerDelegateAdapter() {
 			@Override
 			public void didFinishPlaying (NSObject player, boolean success) {
@@ -51,7 +54,17 @@ public class IOSMusic implements Music {
 		if (track.isPaused()) {
 			track.setPaused(false);
 		} else if (!track.isPlaying()) {
-			track.play();
+			// Check https://github.com/kstenerud/ObjectAL-for-iPhone/blob/master/ObjectAL/ObjectAL/AudioTrack/OALAudioTrack.m
+			// OALAudioTrack needs to execute preloadURL() once to store the file path. From then on we avoid
+			// calling it again to avoid instantiating a new AVAudioPlayer every time.
+			if (!initialized) {
+				initialized = track.playFile(filePath);
+				if (!initialized) {
+					Gdx.app.error("IOSMusic", "Unable to initialize music " + filePath);
+				}
+			} else {
+				track.play();
+			}
 		}
 	}
 
@@ -116,6 +129,12 @@ public class IOSMusic implements Music {
 	@Override
 	public void setOnCompletionListener (OnCompletionListener listener) {
 		this.onCompletionListener = listener;
+	}
+
+	/** Calling this method preloads audio buffers and acquires the audio hardware necessary for playback. Can be noticeable on
+	 * latency critical scenarios. Call with some time before {@link #play()}. */
+	public boolean preload () {
+		return initialized = track.preloadFile(filePath);
 	}
 
 }

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/objectal/OALAudioTrack.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/objectal/OALAudioTrack.java
@@ -47,6 +47,9 @@ public class OALAudioTrack extends NSObject {
 	@Method
 	public native boolean play ();
 
+	@Method
+	public native boolean playFile (String filePath);
+
 	@Property
 	public native boolean isPaused ();
 

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/objectal/OALIOSAudio.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/objectal/OALIOSAudio.java
@@ -62,11 +62,9 @@ public class OALIOSAudio implements IOSAudio {
 		String path = fileHandle.file().getPath().replace('\\', '/');
 		OALAudioTrack track = OALAudioTrack.create();
 		if (track != null) {
-			if (track.preloadFile(path)) {
-				return new IOSMusic(track);
-			}
+			return new IOSMusic(track, path);
 		}
-		throw new GdxRuntimeException("Error opening music file at " + path);
+		throw new GdxRuntimeException("Error creating music audio track");
 	}
 
 }


### PR DESCRIPTION
I was seeing the following crashes on iOS on games where I load several `Music` tracks using `AssetManager`:

```
9 more Caused by: com.badlogic.gdx.utils.GdxRuntimeException: com.badlogic.gdx.utils.GdxRuntimeException: Error opening music file at /private/var/containers/Bundle/Application/B750969F-4D4E-48D1-9AD1-DB576A12AE1A/IOSLauncher.app/music/song.mp3 at com.badlogic.gdx.utils.async.AsyncResult.get(AsyncResult.java:46) at com.badlogic.gdx.assets.AssetLoadingTask.handleAsyncLoader(AssetLoadingTask.java:117) ... 12 more Caused by: com.badlogic.gdx.utils.GdxRuntimeException: Error opening music file at /private/var/containers/Bundle/Application/B750969F-4D4E-48D1-9AD1-DB576A12AE1A/IOSLauncher.app/music/song.mp3 at com.badlogic.gdx.backends.iosrobovm.objectal.OALIOSAudio
```

The reason is `track.preloadFile(path)`returning `false` on `newMusic()`:

```
@Override
	public Music newMusic (FileHandle fileHandle) {
		String path = fileHandle.file().getPath().replace('\\', '/');
		OALAudioTrack track = OALAudioTrack.create();
		if (track != null) {
			if (track.preloadFile(path)) {
				return new IOSMusic(track);
			}
		}
		throw new GdxRuntimeException("Error opening music file at " + path);
	}
```
One reason it may return `false` is that the app is on background (at least a reasonable  percentage of the errors on Firebase console show as the app being on background). It is possible the async task runs just after the app is set to background and the call returns `false`. In any case, I will explain why failing to `preLoad()` should not be a fatal error. 

iOS MobiVM audio uses `ObjectAL`  library (https://github.com/kstenerud/ObjectAL-for-iPhone) which internally uses `OpenAL` for sounds and `AVAudioEngine` for music.

Checking the `OALAudioTrack` native implementation (https://github.com/kstenerud/ObjectAL-for-iPhone/blob/master/ObjectAL/ObjectAL/AudioTrack/OALAudioTrack.m) we can see that, amongst some other things, `preloadFile` ends up calling `prepareToPlay()` on `AVAudioPlayer` (https://developer.apple.com/documentation/avfaudio/avaudioplayer/1386886-preparetoplay). `prepareToPlay()` is an optional method as the docs explain: 

> Calling this method preloads audio buffers and acquires the audio hardware necessary for playback. This method activates the audio session, so pass false to setActive(_:) if immediate playback isn’t necessary.

> The system calls this method when using the method play(), but calling it in advance minimizes the delay between calling play() and the start of sound output.


Just considering this, there would be 2 approaches
1. We don't throw the `GdxRuntimeException` but keep the call to `preloadFile()`.
2. We ditch the `preloadFile()` call alltogether.

I think we should go for option 2 and ditch it for several reasons:
- `prepareToPlay()` is currently called on ALL loaded music tracks independently if they are going to be played. That's not how the API is supposed to be used and doesn't seem a good way to use the device resources.
- `prepareToPlay()` is only called for the FIRST time that music is played. After it has ended or stopped, next play will be executed without the preparation.
- The latency is not noticeable in standard music use in my tests. To provide extra control to latency sensitive apps I have added a `preload()` method to `IOSMusic`. 

There's some added complexity introduced by `ObjectAL` implementation choices (or limitations) that makes the solution a bit more convoluted. `OALAudioTrack` gives 2 options to play a sound. 
- You can first preload it providing the URL/path and from then on you can call `play()` and `stop()` with no need to specify the sound file path again as long as you keep playing the same file (as we do in libGDX). 
- Or, you can simply call `playFromFile(String)`. The downside of this call is that it's less efficient than `play()` because it unnecessarily instantes a new `AVAudioPlayer` each call (even when the file is the same every time) as well as some other stuff.

So, final proposed solution is not to preLoad the files on `newMusic()` and let the preloading be made automatically first time the music is played as well as the file path set (with `playFromFile(String)`). If a user really needs that extra latency improvement, it can manually call `preload()` before `play()` to get the best performance.

**I recommend using `MusicTest` if somebody wants to test**