### PR TITLE
TMX built-in Point Object support.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -23,6 +23,7 @@
 - API Fix: Escaped characters in XML attributes are now properly un-escaped
 - Bug Fix: AssetManager backslash conversion removed - fixes use of filenames containing backslashes
 - gdx-setup now places the assets directory in project root instead of android or core. See advanced settings (UI) or arguments (command line) if you don't want it in root.
+- API Addition: TMX built-in Point Object is now supported.
 
 [1.10.0]
 - [BREAKING CHANGE] Android armeabi support has been removed. To migrate your projects: remove any dependency with natives-armeabi qualifier from your gradle build file, this apply to gdx-platform, gdx-bullet-platform, gdx-freetype-platform and gdx-box2d-platform.

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,6 @@
 [1.10.1]
 - [BREAKING CHANGE] Android Moved natives loading out of static init block, see #5795
+- [BREAKING CHANGE] TMX Point Objects may break projects using RectangleMapObjects as points with width and height set to 0, see #6655
 - iOS: Update to MobiVM 2.3.14
 - API Addition: ObjLoader now supports ambientColor, ambientTexture, transparencyTexture, specularTexture and shininessTexture
 - API Addition: PointSpriteParticleBatch blending is now configurable.

--- a/gdx/res/com/badlogic/gdx.gwt.xml
+++ b/gdx/res/com/badlogic/gdx.gwt.xml
@@ -300,7 +300,8 @@
 		<include name="maps/objects/PolylineMapObject.java"/>
 		<include name="maps/objects/RectangleMapObject.java"/>
 		<include name="maps/objects/TextureMapObject.java"/>
-	
+		<include name="maps/objects/PointMapObject.java"/>
+
 	<!-- maps/tiled -->
 		<include name="maps/tiled/AtlasTmxMapLoader.java"/>
 		<include name="maps/tiled/BaseTmxMapLoader.java"/>

--- a/gdx/src/com/badlogic/gdx/maps/objects/PointMapObject.java
+++ b/gdx/src/com/badlogic/gdx/maps/objects/PointMapObject.java
@@ -1,3 +1,18 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
 
 package com.badlogic.gdx.maps.objects;
 

--- a/gdx/src/com/badlogic/gdx/maps/objects/PointMapObject.java
+++ b/gdx/src/com/badlogic/gdx/maps/objects/PointMapObject.java
@@ -1,0 +1,36 @@
+
+package com.badlogic.gdx.maps.objects;
+
+import com.badlogic.gdx.maps.MapObject;
+
+/** @brief Represents a point map object */
+public class PointMapObject extends MapObject {
+
+	private float x;
+	private float y;
+
+	/** @return point X */
+	public float getX () {
+		return x;
+	}
+
+	/** @return point Y */
+	public float getY () {
+		return y;
+	}
+
+	/** Creates a point object at (0, 0) */
+	public PointMapObject () {
+		this(0f, 0f);
+	}
+
+	/** Creates a point object with the given X and Y coordinates.
+	 *
+	 * @param x the point x
+	 * @param y the point y */
+	public PointMapObject (float x, float y) {
+		super();
+		this.x = x;
+		this.y = y;
+	}
+}

--- a/gdx/src/com/badlogic/gdx/maps/tiled/BaseTmxMapLoader.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/BaseTmxMapLoader.java
@@ -15,6 +15,7 @@ import com.badlogic.gdx.maps.objects.EllipseMapObject;
 import com.badlogic.gdx.maps.objects.PolygonMapObject;
 import com.badlogic.gdx.maps.objects.PolylineMapObject;
 import com.badlogic.gdx.maps.objects.RectangleMapObject;
+import com.badlogic.gdx.maps.objects.PointMapObject;
 import com.badlogic.gdx.maps.tiled.TiledMapTileLayer.Cell;
 import com.badlogic.gdx.maps.tiled.objects.TiledMapTileMapObject;
 import com.badlogic.gdx.maps.tiled.tiles.AnimatedTiledMapTile;
@@ -356,6 +357,8 @@ public abstract class BaseTmxMapLoader<P extends BaseTmxMapLoader.Parameters> ex
 					object = new PolylineMapObject(polyline);
 				} else if ((child = element.getChildByName("ellipse")) != null) {
 					object = new EllipseMapObject(x, flipY ? y - height : y, width, height);
+				} else if ((child = element.getChildByName("point")) != null) {
+					object = new PointMapObject(x, y);
 				}
 			}
 			if (object == null) {

--- a/tests/gdx-tests-android/assets/data/maps/tiled-objects/test-load-mapobjects.tmx
+++ b/tests/gdx-tests-android/assets/data/maps/tiled-objects/test-load-mapobjects.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="16" height="16" tilewidth="32" tileheight="32" nextobjectid="18">
+<map version="1.5" tiledversion="1.7.2" orientation="orthogonal" renderorder="right-down" width="16" height="16" tilewidth="32" tileheight="32" infinite="0" nextlayerid="2" nextobjectid="19">
  <tileset firstgid="1" name="Test" tilewidth="256" tileheight="256" tilecount="3" columns="0">
   <tile id="0">
    <image width="32" height="32" source="Start.bmp"/>
@@ -15,7 +15,7 @@
    <image width="256" height="256" source="../../badlogic.jpg"/>
   </tile>
  </tileset>
- <objectgroup name="Objects">
+ <objectgroup id="1" name="Objects">
   <object id="3" name="Ellipse" x="59.3333" y="335" width="130" height="87">
    <ellipse/>
   </object>
@@ -27,6 +27,9 @@
   <object id="14" gid="1073741825" x="384" y="256" width="64" height="32"/>
   <object id="17" name="Polyline" x="364" y="155">
    <polyline points="0,0 29,-60 57,4 91,-63"/>
+  </object>
+  <object id="18" name="Point" x="211.611" y="142.838">
+   <point/>
   </object>
  </objectgroup>
 </map>

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapObjectLoadingTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapObjectLoadingTest.java
@@ -29,12 +29,7 @@ import com.badlogic.gdx.maps.MapLayer;
 import com.badlogic.gdx.maps.MapObject;
 import com.badlogic.gdx.maps.MapObjects;
 import com.badlogic.gdx.maps.MapProperties;
-import com.badlogic.gdx.maps.objects.CircleMapObject;
-import com.badlogic.gdx.maps.objects.EllipseMapObject;
-import com.badlogic.gdx.maps.objects.PolygonMapObject;
-import com.badlogic.gdx.maps.objects.PolylineMapObject;
-import com.badlogic.gdx.maps.objects.RectangleMapObject;
-import com.badlogic.gdx.maps.objects.TextureMapObject;
+import com.badlogic.gdx.maps.objects.*;
 import com.badlogic.gdx.maps.tiled.TiledMap;
 import com.badlogic.gdx.maps.tiled.TmxMapLoader;
 import com.badlogic.gdx.maps.tiled.objects.TiledMapTileMapObject;
@@ -91,6 +86,7 @@ public class TiledMapObjectLoadingTest extends GdxTest {
 		loadingStatus += "- PolygonMapObject : " + mapObjects.getByType(PolygonMapObject.class).size + "\n";
 		loadingStatus += "- PolylineMapObject : " + mapObjects.getByType(PolylineMapObject.class).size + "\n";
 		loadingStatus += "- RectangleMapObject : " + mapObjects.getByType(RectangleMapObject.class).size + "\n";
+		loadingStatus += "- PointMapObject : " + mapObjects.getByType(PointMapObject.class).size + "\n";
 		loadingStatus += "- TextureMapObject : " + mapObjects.getByType(TextureMapObject.class).size + "\n";
 		loadingStatus += "- TiledMapTileMapObject : " + mapObjects.getByType(TiledMapTileMapObject.class).size + "\n";
 	}
@@ -147,6 +143,11 @@ public class TiledMapObjectLoadingTest extends GdxTest {
 				shapeRenderer.begin(ShapeRenderer.ShapeType.Line);
 				Polyline polyline = ((PolylineMapObject)mapObject).getPolyline();
 				shapeRenderer.polyline(polyline.getTransformedVertices());
+				shapeRenderer.end();
+			} else if (mapObject instanceof PointMapObject) {
+				shapeRenderer.begin(ShapeRenderer.ShapeType.Filled);
+				PointMapObject point = (PointMapObject)mapObject;
+				shapeRenderer.circle(point.getX(), point.getY(), 2f);
 				shapeRenderer.end();
 			}
 		}


### PR DESCRIPTION
## Info:

* With tiled, you can add point objects that consist in a simple 2D coordinate, and currently, it's not supported by libgdx.

![image](https://user-images.githubusercontent.com/52864251/134013405-e0c81618-ab27-4dd5-93b7-8e705f975126.png)

## Implementation:

* Added an object that holds the x and y values called PointMapObject.
  * The implementation is based on the RectangleMapObject to keep the same code design.
* While loading the map objects, check if it contains a child called "point" and adds it.