### PR TITLE
Make new libGDX HTML projects default to disabling the context menu

### DIFF
--- a/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/html/war/index
+++ b/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/html/war/index
@@ -24,7 +24,7 @@
                 evt.preventDefault();
                 evt.stopPropagation();
               }
-			  document.addEventListener('contextmenu', event => event.preventDefault());
+              document.addEventListener('contextmenu', event => event.preventDefault());
               document.getElementById('embed-html').addEventListener('mousedown', handleMouseDown, false);
               document.getElementById('embed-html').addEventListener('mouseup', handleMouseUp, false);
        </script>

--- a/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/html/war/index
+++ b/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/html/war/index
@@ -24,6 +24,7 @@
                 evt.preventDefault();
                 evt.stopPropagation();
               }
+			  document.addEventListener('contextmenu', event => event.preventDefault());
               document.getElementById('embed-html').addEventListener('mousedown', handleMouseDown, false);
               document.getElementById('embed-html').addEventListener('mouseup', handleMouseUp, false);
        </script>


### PR DESCRIPTION
The menu that pops up when you right click in the browser is incredibly intrusive when making HTML / web browser games.

Disabling it by default, I believe, is sensible because:

1. More people will ask how to disable it, than how to enable it.
2. Re-enabling it is simpler than disabling it. _(find and commenting out a line, compared to finding what the line is to add and where)_


This PR should also be followed up with @tommyettinger, who maintains lift-off. I believe if this gets merged, he should also make the change

**Alternatives**

To implement this, another thing I came across was

`<body oncontextmenu="return false">`

which, although being incredibly effective, does not achieve the same thing when we imagine telling a beginner which line to get rid of. _(They have to know html and know not to mess up the brackets or quotes)_

**Testing**

I manually built gdx-setup, built a project, built the html component, and ensured I couldn't right click to open the context menu. While this isn't an effective test, this isn't exactly a sweeping change.

**Conclusion**

I posted this in #libgdx-contributions on discord, and got reasonably good feedback. Let me know if there's anything I missed.

