### PR TITLE
Linux: Shared libraries are now built on Ubuntu 18.04

### DIFF
--- a/.github/workflows/build-pullrequest.yml
+++ b/.github/workflows/build-pullrequest.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build-java:
     if: "!contains(github.event.head_commit.message, 'ci skip')"
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/build-snapshot.yml
+++ b/.github/workflows/build-snapshot.yml
@@ -106,7 +106,7 @@ jobs:
           rm -f ~/.gradle/caches/modules-2/gc.properties
 
   natives-linux:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
         with:
@@ -155,7 +155,7 @@ jobs:
           rm -f ~/.gradle/caches/modules-2/gc.properties
 
   natives-windows:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
         with:
@@ -202,7 +202,7 @@ jobs:
           rm -f ~/.gradle/caches/modules-2/gc.properties
 
   natives-android:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
         with:
@@ -246,7 +246,7 @@ jobs:
           rm -f ~/.gradle/caches/modules-2/gc.properties
 
   pack-natives:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     needs: [natives-macos, natives-linux, natives-windows, natives-ios, natives-android]
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -335,7 +335,7 @@ jobs:
           rm -f ~/.gradle/caches/modules-2/gc.properties
 
   release-snapshot:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     needs: pack-natives
     env:
       MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
@@ -377,7 +377,7 @@ jobs:
 
 
   build-and-upload-runnables:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,6 @@
 [1.10.1]
 - [BREAKING CHANGE] Android Moved natives loading out of static init block, see #5795
+- [BREAKING CHANGE] Linux: Shared libraries are now built on Ubuntu 18.04 (up from Ubuntu 16.04)
 - iOS: Update to MobiVM 2.3.14
 - API Addition: ObjLoader now supports ambientColor, ambientTexture, transparencyTexture, specularTexture and shininessTexture
 - API Addition: PointSpriteParticleBatch blending is now configurable.


### PR DESCRIPTION
Fixes #6657

Breaking change that may make older linux operating systems no longer compatible. More or less matches changes done by lwjgl3, but we do not target a specific gcc/g++ version just use the default provided by bionic's meta packages.

- https://packages.ubuntu.com/bionic/g++
- https://packages.ubuntu.com/bionic/gcc
- https://packages.ubuntu.com/bionic/g++-aarch64-linux-gnu
- https://packages.ubuntu.com/bionic/gcc-aarch64-linux-gnu
- https://packages.ubuntu.com/bionic/gcc-arm-linux-gnueabihf
- https://packages.ubuntu.com/bionic/g++-arm-linux-gnueabihf