### PR TITLE
Update vis-ui website link

### DIFF
--- a/extensions/gdx-setup/res/com/badlogic/gdx/setup/data/extensions.xml
+++ b/extensions/gdx-setup/res/com/badlogic/gdx/setup/data/extensions.xml
@@ -24,7 +24,7 @@
 		<package>com.kotcrab.vis.ui</package>
 		<version>1.4.11</version>
 		<compatibility>1.9.14</compatibility>
-		<website>https://github.com/kotcrab/VisEditor/wiki/VisUI</website>
+		<website>https://github.com/kotcrab/vis-ui</website>
 		<gwtInherits>
 			<inherit>com.kotcrab.vis.vis-ui</inherit>
 		</gwtInherits>


### PR DESCRIPTION
https://github.com/kotcrab/VisEditor/wiki/VisUI is no longer where info about vis-ui is. It's now at https://github.com/kotcrab/vis-ui. Probably not a recent change - I just hadn't paid the links in gdx-setup much notice before. The others seem fine.