### PR TITLE
Fix ParticleEditor freezing and crashing

### DIFF
--- a/.github/workflows/fix-formatting.yml
+++ b/.github/workflows/fix-formatting.yml
@@ -4,7 +4,6 @@ on: [push]
 
 jobs:
   fix-formatting:
-    if: ${{ github.repository_owner != 'libgdx' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/ParticleEditor.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/ParticleEditor.java
@@ -154,25 +154,25 @@ public class ParticleEditor extends JFrame {
 		ParticleEmitter emitter = getEmitter();
 		addRow(new ImagePanel(ParticleEditor.this, "Images", ""));
 		addRow(
-				new CountPanel(ParticleEditor.this, "Count", "Min number of particles at all times, max number of particles allowed."));
+			new CountPanel(ParticleEditor.this, "Count", "Min number of particles at all times, max number of particles allowed."));
 		addRow(new RangedNumericPanel(emitter.getDelay(), "Delay",
-				"Time from beginning of effect to emission start, in milliseconds."));
+			"Time from beginning of effect to emission start, in milliseconds."));
 		addRow(new RangedNumericPanel(emitter.getDuration(), "Duration", "Time particles will be emitted, in milliseconds."));
 		addRow(new ScaledNumericPanel(emitter.getEmission(), "Duration", "Emission", "Number of particles emitted per second."));
 		addRow(new ScaledNumericPanel(emitter.getLife(), "Duration", "Life", "Time particles will live, in milliseconds."));
 		addRow(new ScaledNumericPanel(emitter.getLifeOffset(), "Duration", "Life Offset",
-				"Particle starting life consumed, in milliseconds."));
+			"Particle starting life consumed, in milliseconds."));
 		addRow(new RangedNumericPanel(emitter.getXOffsetValue(), "X Offset",
-				"Amount to offset a particle's starting X location, in world units."));
+			"Amount to offset a particle's starting X location, in world units."));
 		addRow(new RangedNumericPanel(emitter.getYOffsetValue(), "Y Offset",
-				"Amount to offset a particle's starting Y location, in world units."));
+			"Amount to offset a particle's starting Y location, in world units."));
 		addRow(new SpawnPanel(ParticleEditor.this, emitter.getSpawnShape(), "Spawn", "Shape used to spawn particles."));
 		addRow(
-				new ScaledNumericPanel(emitter.getSpawnWidth(), "Duration", "Spawn Width", "Width of the spawn shape, in world units."));
+			new ScaledNumericPanel(emitter.getSpawnWidth(), "Duration", "Spawn Width", "Width of the spawn shape, in world units."));
 		addRow(new ScaledNumericPanel(emitter.getSpawnHeight(), "Duration", "Spawn Height",
-				"Height of the spawn shape, in world units."));
+			"Height of the spawn shape, in world units."));
 		addRow(new ScaledNumericPanel(emitter.getXScale(), "Life", "X Size",
-				"Particle x size, in world units. If Y Size is not active, this also controls the y size"));
+			"Particle x size, in world units. If Y Size is not active, this also controls the y size"));
 		addRow(new ScaledNumericPanel(emitter.getYScale(), "Life", "Y Size", "Particle y size, in world units."));
 		addRow(new ScaledNumericPanel(emitter.getVelocity(), "Life", "Velocity", "Particle speed, in world units per second."));
 		addRow(new ScaledNumericPanel(emitter.getAngle(), "Life", "Angle", "Particle emission angle, in degrees."));
@@ -190,13 +190,13 @@ public class ParticleEditor extends JFrame {
 	void addEditorRow (JPanel row) {
 		row.setBorder(BorderFactory.createMatteBorder(0, 0, 1, 0, java.awt.Color.black));
 		editRowsPanel.add(row, new GridBagConstraints(0, -1, 1, 1, 1, 0, GridBagConstraints.CENTER, GridBagConstraints.HORIZONTAL,
-				new Insets(0, 0, 0, 0), 0, 0));
+			new Insets(0, 0, 0, 0), 0, 0));
 	}
 
 	void addRow (JPanel row) {
 		row.setBorder(BorderFactory.createMatteBorder(0, 0, 1, 0, java.awt.Color.black));
 		rowsPanel.add(row, new GridBagConstraints(0, -1, 1, 1, 1, 0, GridBagConstraints.CENTER, GridBagConstraints.HORIZONTAL,
-				new Insets(0, 0, 0, 0), 0, 0));
+			new Insets(0, 0, 0, 0), 0, 0));
 	}
 
 	public void setVisible (String name, boolean visible) {
@@ -250,11 +250,11 @@ public class ParticleEditor extends JFrame {
 				JPanel propertiesPanel = new JPanel(new GridBagLayout());
 				rightSplit.add(propertiesPanel, JSplitPane.TOP);
 				propertiesPanel.setBorder(new CompoundBorder(BorderFactory.createEmptyBorder(3, 0, 6, 6),
-						BorderFactory.createTitledBorder("Editor Properties")));
+					BorderFactory.createTitledBorder("Editor Properties")));
 				{
 					JScrollPane scroll = new JScrollPane();
 					propertiesPanel.add(scroll, new GridBagConstraints(0, 0, 1, 1, 1, 1, GridBagConstraints.NORTH,
-							GridBagConstraints.BOTH, new Insets(0, 0, 0, 0), 0, 0));
+						GridBagConstraints.BOTH, new Insets(0, 0, 0, 0), 0, 0));
 					scroll.setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 0));
 					{
 						editRowsPanel = new JPanel(new GridBagLayout());
@@ -268,11 +268,11 @@ public class ParticleEditor extends JFrame {
 				JPanel propertiesPanel = new JPanel(new GridBagLayout());
 				rightSplit.add(propertiesPanel, JSplitPane.BOTTOM);
 				propertiesPanel.setBorder(new CompoundBorder(BorderFactory.createEmptyBorder(3, 0, 6, 6),
-						BorderFactory.createTitledBorder("Emitter Properties")));
+					BorderFactory.createTitledBorder("Emitter Properties")));
 				{
 					JScrollPane scroll = new JScrollPane();
 					propertiesPanel.add(scroll, new GridBagConstraints(0, 0, 1, 1, 1, 1, GridBagConstraints.NORTH,
-							GridBagConstraints.BOTH, new Insets(0, 0, 0, 0), 0, 0));
+						GridBagConstraints.BOTH, new Insets(0, 0, 0, 0), 0, 0));
 					scroll.setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 0));
 					{
 						rowsPanel = new JPanel(new GridBagLayout());
@@ -302,7 +302,7 @@ public class ParticleEditor extends JFrame {
 				JPanel emittersPanel = new JPanel(new BorderLayout());
 				leftSplit.add(emittersPanel, JSplitPane.TOP);
 				emittersPanel.setBorder(new CompoundBorder(BorderFactory.createEmptyBorder(0, 6, 6, 0),
-						BorderFactory.createTitledBorder("Effect Emitters")));
+					BorderFactory.createTitledBorder("Effect Emitters")));
 				{
 					effectPanel = new EffectPanel(this);
 					emittersPanel.add(effectPanel);
@@ -356,7 +356,7 @@ public class ParticleEditor extends JFrame {
 			backgroundColor.setColors(new float[] {0f, 0f, 0f});
 
 			font = new BitmapFont(Gdx.files.getFileHandle("default.fnt", FileType.Internal),
-					Gdx.files.getFileHandle("default.png", FileType.Internal), true);
+				Gdx.files.getFileHandle("default.png", FileType.Internal), true);
 			effectPanel.newExampleEmitter("Untitled", true);
 			// if (resources.openFile("/editor-bg.png") != null) bgImage = new Image(gl, "/editor-bg.png");
 
@@ -541,7 +541,7 @@ public class ParticleEditor extends JFrame {
 					String imageName = new File(imagePath.replace('\\', '/')).getName();
 					FileHandle file;
 					if (imagePath.equals(ParticleEditor.DEFAULT_PARTICLE)
-							|| imagePath.equals(ParticleEditor.DEFAULT_PREMULT_PARTICLE)) {
+						|| imagePath.equals(ParticleEditor.DEFAULT_PREMULT_PARTICLE)) {
 						file = Gdx.files.classpath(imagePath);
 					} else {
 						if ((imagePath.contains("/") || imagePath.contains("\\")) && !imageName.contains("..")) {
@@ -572,7 +572,7 @@ public class ParticleEditor extends JFrame {
 		public boolean keyDown (int keycode) {
 			if (keycode == Input.Keys.SPACE) {
 				effect.setPosition(previewImagePanel.valueX.getValue() + previewImagePanel.valueWidth.getValue() / 2f,
-						previewImagePanel.valueY.getValue() + previewImagePanel.valueHeight.getValue() / 2f);
+					previewImagePanel.valueY.getValue() + previewImagePanel.valueHeight.getValue() / 2f);
 			}
 			return false;
 		}

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/ParticleEditor.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/ParticleEditor.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,6 +19,7 @@ package com.badlogic.gdx.tools.particleeditor;
 import java.awt.*;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
+import java.awt.geom.AffineTransform;
 import java.io.File;
 import java.util.HashMap;
 
@@ -34,7 +35,7 @@ import com.badlogic.gdx.Input;
 import com.badlogic.gdx.InputAdapter;
 import com.badlogic.gdx.InputMultiplexer;
 import com.badlogic.gdx.InputProcessor;
-import com.badlogic.gdx.backends.lwjgl.LwjglCanvas;
+import com.badlogic.gdx.backends.lwjgl.LwjglApplication;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.OrthographicCamera;
@@ -58,7 +59,7 @@ public class ParticleEditor extends JFrame {
 	public static final String DEFAULT_PREMULT_PARTICLE = "pre_particle.png";
 
 	public Renderer renderer;
-	LwjglCanvas lwjglCanvas;
+	Canvas lwjglCanvas;
 	JPanel rowsPanel;
 	JPanel editRowsPanel;
 	EffectPanel effectPanel;
@@ -83,7 +84,7 @@ public class ParticleEditor extends JFrame {
 		super("Particle Editor");
 
 		renderer = new Renderer();
-		lwjglCanvas = new LwjglCanvas(renderer);
+
 		addWindowListener(new WindowAdapter() {
 			public void windowClosed (WindowEvent event) {
 				System.exit(0);
@@ -99,77 +100,103 @@ public class ParticleEditor extends JFrame {
 		setVisible(true);
 	}
 
-	void reloadRows () {
-		EventQueue.invokeLater(new Runnable() {
-			public void run () {
-				editRowsPanel.removeAll();
-				addEditorRow(new NumericPanel(pixelsPerMeter, "Pixels per meter", ""));
-				addEditorRow(new NumericPanel(zoomLevel, "Zoom level", ""));
-				addEditorRow(new NumericPanel(deltaMultiplier, "Delta multiplier", ""));
-				addEditorRow(new GradientPanel(backgroundColor, "Background color", "", true));
+	private void createCanvas () {
+		lwjglCanvas = new Canvas() {
+			private final Dimension minSize = new Dimension(1, 1);
+			private float scaleX;
+			private float scaleY;
 
-				previewImagePanel = new PreviewImagePanel(ParticleEditor.this, "Preview Image", "");
-				addEditorRow(previewImagePanel);
+			public final void addNotify () {
+				super.addNotify();
 
-				JPanel gridPanel = new JPanel(new GridLayout());
-				boolean previousSelected = renderGridCheckBox != null && renderGridCheckBox.isSelected();
-				renderGridCheckBox = new JCheckBox("Render Grid", previousSelected);
-				gridPanel.add(renderGridCheckBox, new GridBagConstraints());
-				addEditorRow(gridPanel);
-				addEditorRow(new CustomShadingPanel(ParticleEditor.this, "Shading", "Custom shader and multi-texture preview."));
-
-				rowsPanel.removeAll();
-				ParticleEmitter emitter = getEmitter();
-				addRow(new ImagePanel(ParticleEditor.this, "Images", ""));
-				addRow(new CountPanel(ParticleEditor.this, "Count",
-					"Min number of particles at all times, max number of particles allowed."));
-				addRow(new RangedNumericPanel(emitter.getDelay(), "Delay",
-					"Time from beginning of effect to emission start, in milliseconds."));
-				addRow(new RangedNumericPanel(emitter.getDuration(), "Duration", "Time particles will be emitted, in milliseconds."));
-				addRow(
-					new ScaledNumericPanel(emitter.getEmission(), "Duration", "Emission", "Number of particles emitted per second."));
-				addRow(new ScaledNumericPanel(emitter.getLife(), "Duration", "Life", "Time particles will live, in milliseconds."));
-				addRow(new ScaledNumericPanel(emitter.getLifeOffset(), "Duration", "Life Offset",
-					"Particle starting life consumed, in milliseconds."));
-				addRow(new RangedNumericPanel(emitter.getXOffsetValue(), "X Offset",
-					"Amount to offset a particle's starting X location, in world units."));
-				addRow(new RangedNumericPanel(emitter.getYOffsetValue(), "Y Offset",
-					"Amount to offset a particle's starting Y location, in world units."));
-				addRow(new SpawnPanel(ParticleEditor.this, emitter.getSpawnShape(), "Spawn", "Shape used to spawn particles."));
-				addRow(new ScaledNumericPanel(emitter.getSpawnWidth(), "Duration", "Spawn Width",
-					"Width of the spawn shape, in world units."));
-				addRow(new ScaledNumericPanel(emitter.getSpawnHeight(), "Duration", "Spawn Height",
-					"Height of the spawn shape, in world units."));
-				addRow(new ScaledNumericPanel(emitter.getXScale(), "Life", "X Size",
-					"Particle x size, in world units. If Y Size is not active, this also controls the y size"));
-				addRow(new ScaledNumericPanel(emitter.getYScale(), "Life", "Y Size", "Particle y size, in world units."));
-				addRow(
-					new ScaledNumericPanel(emitter.getVelocity(), "Life", "Velocity", "Particle speed, in world units per second."));
-				addRow(new ScaledNumericPanel(emitter.getAngle(), "Life", "Angle", "Particle emission angle, in degrees."));
-				addRow(new ScaledNumericPanel(emitter.getRotation(), "Life", "Rotation", "Particle rotation, in degrees."));
-				addRow(new ScaledNumericPanel(emitter.getWind(), "Life", "Wind", "Wind strength, in world units per second."));
-				addRow(
-					new ScaledNumericPanel(emitter.getGravity(), "Life", "Gravity", "Gravity strength, in world units per second."));
-				addRow(new GradientPanel(emitter.getTint(), "Tint", "", false));
-				addRow(new PercentagePanel(emitter.getTransparency(), "Life", "Transparency", ""));
-				addRow(new OptionsPanel(ParticleEditor.this, "Options", ""));
-				for (Component component : rowsPanel.getComponents())
-					if (component instanceof EditorPanel) ((EditorPanel)component).update(ParticleEditor.this);
-				rowsPanel.repaint();
+				AffineTransform transform = getGraphicsConfiguration().getDefaultTransform();
+				scaleX = (float)transform.getScaleX();
+				scaleY = (float)transform.getScaleY();
 			}
-		});
+
+			public Dimension getMinimumSize () {
+				return minSize;
+			}
+
+			public int getWidth () {
+				return Math.round(super.getWidth() * scaleX);
+			}
+
+			public int getHeight () {
+				return Math.round(super.getHeight() * scaleY);
+			}
+		};
+
+		lwjglCanvas.setSize(1, 1);
+		lwjglCanvas.setIgnoreRepaint(true);
+
+		new LwjglApplication(renderer, lwjglCanvas);
+	}
+
+	void reloadRows () {
+		editRowsPanel.removeAll();
+		addEditorRow(new NumericPanel(pixelsPerMeter, "Pixels per meter", ""));
+		addEditorRow(new NumericPanel(zoomLevel, "Zoom level", ""));
+		addEditorRow(new NumericPanel(deltaMultiplier, "Delta multiplier", ""));
+		addEditorRow(new GradientPanel(backgroundColor, "Background color", "", true));
+
+		previewImagePanel = new PreviewImagePanel(ParticleEditor.this, "Preview Image", "");
+		addEditorRow(previewImagePanel);
+
+		JPanel gridPanel = new JPanel(new GridLayout());
+		boolean previousSelected = renderGridCheckBox != null && renderGridCheckBox.isSelected();
+		renderGridCheckBox = new JCheckBox("Render Grid", previousSelected);
+		gridPanel.add(renderGridCheckBox, new GridBagConstraints());
+		addEditorRow(gridPanel);
+		addEditorRow(new CustomShadingPanel(ParticleEditor.this, "Shading", "Custom shader and multi-texture preview."));
+
+		rowsPanel.removeAll();
+		ParticleEmitter emitter = getEmitter();
+		addRow(new ImagePanel(ParticleEditor.this, "Images", ""));
+		addRow(
+				new CountPanel(ParticleEditor.this, "Count", "Min number of particles at all times, max number of particles allowed."));
+		addRow(new RangedNumericPanel(emitter.getDelay(), "Delay",
+				"Time from beginning of effect to emission start, in milliseconds."));
+		addRow(new RangedNumericPanel(emitter.getDuration(), "Duration", "Time particles will be emitted, in milliseconds."));
+		addRow(new ScaledNumericPanel(emitter.getEmission(), "Duration", "Emission", "Number of particles emitted per second."));
+		addRow(new ScaledNumericPanel(emitter.getLife(), "Duration", "Life", "Time particles will live, in milliseconds."));
+		addRow(new ScaledNumericPanel(emitter.getLifeOffset(), "Duration", "Life Offset",
+				"Particle starting life consumed, in milliseconds."));
+		addRow(new RangedNumericPanel(emitter.getXOffsetValue(), "X Offset",
+				"Amount to offset a particle's starting X location, in world units."));
+		addRow(new RangedNumericPanel(emitter.getYOffsetValue(), "Y Offset",
+				"Amount to offset a particle's starting Y location, in world units."));
+		addRow(new SpawnPanel(ParticleEditor.this, emitter.getSpawnShape(), "Spawn", "Shape used to spawn particles."));
+		addRow(
+				new ScaledNumericPanel(emitter.getSpawnWidth(), "Duration", "Spawn Width", "Width of the spawn shape, in world units."));
+		addRow(new ScaledNumericPanel(emitter.getSpawnHeight(), "Duration", "Spawn Height",
+				"Height of the spawn shape, in world units."));
+		addRow(new ScaledNumericPanel(emitter.getXScale(), "Life", "X Size",
+				"Particle x size, in world units. If Y Size is not active, this also controls the y size"));
+		addRow(new ScaledNumericPanel(emitter.getYScale(), "Life", "Y Size", "Particle y size, in world units."));
+		addRow(new ScaledNumericPanel(emitter.getVelocity(), "Life", "Velocity", "Particle speed, in world units per second."));
+		addRow(new ScaledNumericPanel(emitter.getAngle(), "Life", "Angle", "Particle emission angle, in degrees."));
+		addRow(new ScaledNumericPanel(emitter.getRotation(), "Life", "Rotation", "Particle rotation, in degrees."));
+		addRow(new ScaledNumericPanel(emitter.getWind(), "Life", "Wind", "Wind strength, in world units per second."));
+		addRow(new ScaledNumericPanel(emitter.getGravity(), "Life", "Gravity", "Gravity strength, in world units per second."));
+		addRow(new GradientPanel(emitter.getTint(), "Tint", "", false));
+		addRow(new PercentagePanel(emitter.getTransparency(), "Life", "Transparency", ""));
+		addRow(new OptionsPanel(ParticleEditor.this, "Options", ""));
+		for (Component component : rowsPanel.getComponents())
+			if (component instanceof EditorPanel) ((EditorPanel)component).update(ParticleEditor.this);
+		rowsPanel.repaint();
 	}
 
 	void addEditorRow (JPanel row) {
 		row.setBorder(BorderFactory.createMatteBorder(0, 0, 1, 0, java.awt.Color.black));
 		editRowsPanel.add(row, new GridBagConstraints(0, -1, 1, 1, 1, 0, GridBagConstraints.CENTER, GridBagConstraints.HORIZONTAL,
-			new Insets(0, 0, 0, 0), 0, 0));
+				new Insets(0, 0, 0, 0), 0, 0));
 	}
 
 	void addRow (JPanel row) {
 		row.setBorder(BorderFactory.createMatteBorder(0, 0, 1, 0, java.awt.Color.black));
 		rowsPanel.add(row, new GridBagConstraints(0, -1, 1, 1, 1, 0, GridBagConstraints.CENTER, GridBagConstraints.HORIZONTAL,
-			new Insets(0, 0, 0, 0), 0, 0));
+				new Insets(0, 0, 0, 0), 0, 0));
 	}
 
 	public void setVisible (String name, boolean visible) {
@@ -202,6 +229,7 @@ public class ParticleEditor extends JFrame {
 		// JMenu fileMenu = new JMenu("File");
 		// menuBar.add(fileMenu);
 		// }
+		createCanvas();
 		splitPane = new JSplitPane();
 		splitPane.setUI(new BasicSplitPaneUI() {
 			public void paint (Graphics g, JComponent jc) {
@@ -222,11 +250,11 @@ public class ParticleEditor extends JFrame {
 				JPanel propertiesPanel = new JPanel(new GridBagLayout());
 				rightSplit.add(propertiesPanel, JSplitPane.TOP);
 				propertiesPanel.setBorder(new CompoundBorder(BorderFactory.createEmptyBorder(3, 0, 6, 6),
-					BorderFactory.createTitledBorder("Editor Properties")));
+						BorderFactory.createTitledBorder("Editor Properties")));
 				{
 					JScrollPane scroll = new JScrollPane();
 					propertiesPanel.add(scroll, new GridBagConstraints(0, 0, 1, 1, 1, 1, GridBagConstraints.NORTH,
-						GridBagConstraints.BOTH, new Insets(0, 0, 0, 0), 0, 0));
+							GridBagConstraints.BOTH, new Insets(0, 0, 0, 0), 0, 0));
 					scroll.setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 0));
 					{
 						editRowsPanel = new JPanel(new GridBagLayout());
@@ -240,11 +268,11 @@ public class ParticleEditor extends JFrame {
 				JPanel propertiesPanel = new JPanel(new GridBagLayout());
 				rightSplit.add(propertiesPanel, JSplitPane.BOTTOM);
 				propertiesPanel.setBorder(new CompoundBorder(BorderFactory.createEmptyBorder(3, 0, 6, 6),
-					BorderFactory.createTitledBorder("Emitter Properties")));
+						BorderFactory.createTitledBorder("Emitter Properties")));
 				{
 					JScrollPane scroll = new JScrollPane();
 					propertiesPanel.add(scroll, new GridBagConstraints(0, 0, 1, 1, 1, 1, GridBagConstraints.NORTH,
-						GridBagConstraints.BOTH, new Insets(0, 0, 0, 0), 0, 0));
+							GridBagConstraints.BOTH, new Insets(0, 0, 0, 0), 0, 0));
 					scroll.setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 0));
 					{
 						rowsPanel = new JPanel(new GridBagLayout());
@@ -267,14 +295,14 @@ public class ParticleEditor extends JFrame {
 			{
 				JPanel spacer = new JPanel(new BorderLayout());
 				leftSplit.add(spacer, JSplitPane.BOTTOM);
-				spacer.add(lwjglCanvas.getCanvas());
+				spacer.add(lwjglCanvas);
 				spacer.setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 4));
 			}
 			{
 				JPanel emittersPanel = new JPanel(new BorderLayout());
 				leftSplit.add(emittersPanel, JSplitPane.TOP);
 				emittersPanel.setBorder(new CompoundBorder(BorderFactory.createEmptyBorder(0, 6, 6, 0),
-					BorderFactory.createTitledBorder("Effect Emitters")));
+						BorderFactory.createTitledBorder("Effect Emitters")));
 				{
 					effectPanel = new EffectPanel(this);
 					emittersPanel.add(effectPanel);
@@ -328,12 +356,13 @@ public class ParticleEditor extends JFrame {
 			backgroundColor.setColors(new float[] {0f, 0f, 0f});
 
 			font = new BitmapFont(Gdx.files.getFileHandle("default.fnt", FileType.Internal),
-				Gdx.files.getFileHandle("default.png", FileType.Internal), true);
+					Gdx.files.getFileHandle("default.png", FileType.Internal), true);
 			effectPanel.newExampleEmitter("Untitled", true);
 			// if (resources.openFile("/editor-bg.png") != null) bgImage = new Image(gl, "/editor-bg.png");
 
 			OrthoCamController orthoCamController = new OrthoCamController(worldCamera);
 			Gdx.input.setInputProcessor(new InputMultiplexer(orthoCamController, this));
+			resize(lwjglCanvas.getWidth(), lwjglCanvas.getHeight());
 		}
 
 		private class OrthoCamController extends InputAdapter {
@@ -512,7 +541,7 @@ public class ParticleEditor extends JFrame {
 					String imageName = new File(imagePath.replace('\\', '/')).getName();
 					FileHandle file;
 					if (imagePath.equals(ParticleEditor.DEFAULT_PARTICLE)
-						|| imagePath.equals(ParticleEditor.DEFAULT_PREMULT_PARTICLE)) {
+							|| imagePath.equals(ParticleEditor.DEFAULT_PREMULT_PARTICLE)) {
 						file = Gdx.files.classpath(imagePath);
 					} else {
 						if ((imagePath.contains("/") || imagePath.contains("\\")) && !imageName.contains("..")) {
@@ -543,7 +572,7 @@ public class ParticleEditor extends JFrame {
 		public boolean keyDown (int keycode) {
 			if (keycode == Input.Keys.SPACE) {
 				effect.setPosition(previewImagePanel.valueX.getValue() + previewImagePanel.valueWidth.getValue() / 2f,
-					previewImagePanel.valueY.getValue() + previewImagePanel.valueHeight.getValue() / 2f);
+						previewImagePanel.valueY.getValue() + previewImagePanel.valueHeight.getValue() / 2f);
 			}
 			return false;
 		}

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextTooltip.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextTooltip.java
@@ -63,7 +63,7 @@ public class TextTooltip extends Tooltip<Label> {
 	protected Label newLabel (String text, LabelStyle style) {
 		return new Label(text, style);
 	}
-	
+
 	public void setStyle (TextTooltipStyle style) {
 		if (style == null) throw new NullPointerException("style cannot be null");
 		container.getActor().setStyle(style.label);


### PR DESCRIPTION
The ParticleEditor crashed if you unfocused it and refocused it. For example, clicking out of the ParticleEditor window and then clicking back in would cause the ParticleEditor to freeze and not respond.

The reason is due to the `LwjglCanvas`. I suspect it has to do with the line `Display.processMessages();`. To fix the issue, in ParticleEditor I used a normal Java AWT Canvas, and created a new LwjglApplication passing the Canvas as an argument. This fixes the issue, as far as I can tell;

Tested on Windows machine, 11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz 

Fixes #6584