### PR TITLE
Fixed opening effect file error on Windows.

### DIFF
--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/FlameMain.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/FlameMain.java
@@ -961,8 +961,11 @@ public class FlameMain extends JFrame implements AssetErrorListener {
 	public ParticleEffect openEffect (File file, boolean replaceCurrentWorkspace) {
 		try {
 
-			ParticleEffect loadedEffect = load(file.getAbsolutePath().replace("\\", "/"), ParticleEffect.class, null,
-				new ParticleEffectLoader.ParticleEffectLoadParameter(particleSystem.getBatches()));
+			ParticleEffect loadedEffect = load(
+					file.getAbsolutePath().replace("\\", "/"),
+					ParticleEffect.class,
+					null,
+					new ParticleEffectLoader.ParticleEffectLoadParameter(particleSystem.getBatches()));
 
 			loadedEffect = loadedEffect.copy();
 			loadedEffect.init();

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/FlameMain.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/FlameMain.java
@@ -998,7 +998,7 @@ public class FlameMain extends JFrame implements AssetErrorListener {
 
 		assetManager.load(resolvedPath, type, params);
 		assetManager.finishLoading();
-		T res = assetManager.get(resolvedPath);
+		T res = assetManager.get(resource);
 		if (currentLoader != null) assetManager.setLoader(type, currentLoader);
 
 		if (exist) EventManager.get().fire(EVT_ASSET_RELOADED, new Object[] {oldAsset, res});

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/FlameMain.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/FlameMain.java
@@ -960,7 +960,8 @@ public class FlameMain extends JFrame implements AssetErrorListener {
 
 	public ParticleEffect openEffect (File file, boolean replaceCurrentWorkspace) {
 		try {
-			ParticleEffect loadedEffect = load(file.getAbsolutePath().replace("\\", "/"), ParticleEffect.class, null,
+			String path = file.getAbsolutePath().replace("\\", "/");
+			ParticleEffect loadedEffect = load(path, ParticleEffect.class, null,
 					new ParticleEffectLoader.ParticleEffectLoadParameter(particleSystem.getBatches()));
 			loadedEffect = loadedEffect.copy();
 			loadedEffect.init();

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/FlameMain.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/FlameMain.java
@@ -960,9 +960,8 @@ public class FlameMain extends JFrame implements AssetErrorListener {
 
 	public ParticleEffect openEffect (File file, boolean replaceCurrentWorkspace) {
 		try {
-			String path = file.getAbsolutePath().replace("\\", "/");
-			ParticleEffect loadedEffect = load(path, ParticleEffect.class, null,
-					new ParticleEffectLoader.ParticleEffectLoadParameter(particleSystem.getBatches()));
+			ParticleEffect loadedEffect = load(file.getAbsolutePath(), ParticleEffect.class, null,
+				new ParticleEffectLoader.ParticleEffectLoadParameter(particleSystem.getBatches()));
 			loadedEffect = loadedEffect.copy();
 			loadedEffect.init();
 			if (replaceCurrentWorkspace) {
@@ -997,7 +996,7 @@ public class FlameMain extends JFrame implements AssetErrorListener {
 		AssetLoader<T, AssetLoaderParameters<T>> currentLoader = assetManager.getLoader(type);
 		if (loader != null) assetManager.setLoader(type, loader);
 
-		assetManager.load(resource, type, params);
+		assetManager.load(resolvedPath, type, params);
 		assetManager.finishLoading();
 		T res = assetManager.get(resolvedPath);
 		if (currentLoader != null) assetManager.setLoader(type, currentLoader);

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/FlameMain.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/FlameMain.java
@@ -960,8 +960,13 @@ public class FlameMain extends JFrame implements AssetErrorListener {
 
 	public ParticleEffect openEffect (File file, boolean replaceCurrentWorkspace) {
 		try {
-			ParticleEffect loadedEffect = load(file.getAbsolutePath(), ParticleEffect.class, null,
-				new ParticleEffectLoader.ParticleEffectLoadParameter(particleSystem.getBatches()));
+
+			ParticleEffect loadedEffect = load(
+					file.getAbsolutePath().replace("\\", "/"),
+					ParticleEffect.class,
+					null,
+					new ParticleEffectLoader.ParticleEffectLoadParameter(particleSystem.getBatches()));
+
 			loadedEffect = loadedEffect.copy();
 			loadedEffect.init();
 			if (replaceCurrentWorkspace) {

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/FlameMain.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/FlameMain.java
@@ -961,11 +961,8 @@ public class FlameMain extends JFrame implements AssetErrorListener {
 	public ParticleEffect openEffect (File file, boolean replaceCurrentWorkspace) {
 		try {
 
-			ParticleEffect loadedEffect = load(
-					file.getAbsolutePath().replace("\\", "/"),
-					ParticleEffect.class,
-					null,
-					new ParticleEffectLoader.ParticleEffectLoadParameter(particleSystem.getBatches()));
+			ParticleEffect loadedEffect = load(file.getAbsolutePath().replace("\\", "/"), ParticleEffect.class, null,
+				new ParticleEffectLoader.ParticleEffectLoadParameter(particleSystem.getBatches()));
 
 			loadedEffect = loadedEffect.copy();
 			loadedEffect.init();

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/FlameMain.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/FlameMain.java
@@ -960,13 +960,8 @@ public class FlameMain extends JFrame implements AssetErrorListener {
 
 	public ParticleEffect openEffect (File file, boolean replaceCurrentWorkspace) {
 		try {
-
-			ParticleEffect loadedEffect = load(
-					file.getAbsolutePath().replace("\\", "/"),
-					ParticleEffect.class,
-					null,
+			ParticleEffect loadedEffect = load(file.getAbsolutePath().replace("\\", "/"), ParticleEffect.class, null,
 					new ParticleEffectLoader.ParticleEffectLoadParameter(particleSystem.getBatches()));
-
 			loadedEffect = loadedEffect.copy();
 			loadedEffect.init();
 			if (replaceCurrentWorkspace) {


### PR DESCRIPTION
Fixed opening effect file error on Windows. When calling "file.getAbsolutePath()" it creates the file location with a backslash. But right after inside the load() we replace in that string all backslashes to a regular slash - thus leading the asset manager not to found the loaded resource.