### PR TITLE
Improve Quaternion Euler Precision

### DIFF
--- a/gdx/src/com/badlogic/gdx/math/Quaternion.java
+++ b/gdx/src/com/badlogic/gdx/math/Quaternion.java
@@ -129,24 +129,24 @@ public class Quaternion implements Serializable {
 	 * @param roll the rotation around the z axis in radians
 	 * @return this quaternion */
 	public Quaternion setEulerAnglesRad (float yaw, float pitch, float roll) {
-		final float hr = roll * 0.5f;
-		final float shr = (float)Math.sin(hr);
-		final float chr = (float)Math.cos(hr);
-		final float hp = pitch * 0.5f;
-		final float shp = (float)Math.sin(hp);
-		final float chp = (float)Math.cos(hp);
-		final float hy = yaw * 0.5f;
-		final float shy = (float)Math.sin(hy);
-		final float chy = (float)Math.cos(hy);
-		final float chy_shp = chy * shp;
-		final float shy_chp = shy * chp;
-		final float chy_chp = chy * chp;
-		final float shy_shp = shy * shp;
+		final double hr = roll * 0.5f;
+		final double shr = Math.sin(hr);
+		final double chr = Math.cos(hr);
+		final double hp = pitch * 0.5f;
+		final double shp = Math.sin(hp);
+		final double chp = Math.cos(hp);
+		final double hy = yaw * 0.5f;
+		final double shy = Math.sin(hy);
+		final double chy = Math.cos(hy);
+		final double chy_shp = chy * shp;
+		final double shy_chp = shy * chp;
+		final double chy_chp = chy * chp;
+		final double shy_shp = shy * shp;
 
-		x = (chy_shp * chr) + (shy_chp * shr); // cos(yaw/2) * sin(pitch/2) * cos(roll/2) + sin(yaw/2) * cos(pitch/2) * sin(roll/2)
-		y = (shy_chp * chr) - (chy_shp * shr); // sin(yaw/2) * cos(pitch/2) * cos(roll/2) - cos(yaw/2) * sin(pitch/2) * sin(roll/2)
-		z = (chy_chp * shr) - (shy_shp * chr); // cos(yaw/2) * cos(pitch/2) * sin(roll/2) - sin(yaw/2) * sin(pitch/2) * cos(roll/2)
-		w = (chy_chp * chr) + (shy_shp * shr); // cos(yaw/2) * cos(pitch/2) * cos(roll/2) + sin(yaw/2) * sin(pitch/2) * sin(roll/2)
+		x = (float)((chy_shp * chr) + (shy_chp * shr)); // cos(yaw/2) * sin(pitch/2) * cos(roll/2) + sin(yaw/2) * cos(pitch/2) * sin(roll/2)
+		y = (float)((shy_chp * chr) - (chy_shp * shr)); // sin(yaw/2) * cos(pitch/2) * cos(roll/2) - cos(yaw/2) * sin(pitch/2) * sin(roll/2)
+		z = (float)((chy_chp * shr) - (shy_shp * chr)); // cos(yaw/2) * cos(pitch/2) * sin(roll/2) - sin(yaw/2) * sin(pitch/2) * cos(roll/2)
+		w = (float)((chy_chp * chr) + (shy_shp * shr)); // cos(yaw/2) * cos(pitch/2) * cos(roll/2) + sin(yaw/2) * sin(pitch/2) * sin(roll/2)
 		return this;
 	}
 
@@ -160,40 +160,40 @@ public class Quaternion implements Serializable {
 	/** Get the roll euler angle in radians, which is the rotation around the z axis. Requires that this quaternion is normalized.
 	 * @return the rotation around the z axis in radians (between -PI and +PI) */
 	public float getRollRad () {
-		final int pole = getGimbalPole();
-		return pole == 0 ? MathUtils.atan2(2f * (w * z + y * x), 1f - 2f * (x * x + z * z))
-			: (float)pole * 2f * MathUtils.atan2(y, w);
+		final double pole = getGimbalPole();
+		return (float)(pole == 0 ? Math.atan2(2.0 * (w * z + y * x), 1.0 - 2.0 * (x * x + z * z))
+			: pole * 2.0 * Math.atan2(y, w));
 	}
 
 	/** Get the roll euler angle in degrees, which is the rotation around the z axis. Requires that this quaternion is normalized.
 	 * @return the rotation around the z axis in degrees (between -180 and +180) */
 	public float getRoll () {
-		return getRollRad() * MathUtils.radiansToDegrees;
+		return (float)Math.toDegrees(getRollRad());
 	}
 
 	/** Get the pitch euler angle in radians, which is the rotation around the x axis. Requires that this quaternion is normalized.
 	 * @return the rotation around the x axis in radians (between -(PI/2) and +(PI/2)) */
 	public float getPitchRad () {
 		final int pole = getGimbalPole();
-		return pole == 0 ? (float)Math.asin(MathUtils.clamp(2f * (w * x - z * y), -1f, 1f)) : (float)pole * MathUtils.PI * 0.5f;
+		return (float)(pole == 0 ? Math.asin(MathUtils.clamp(2.0 * (w * x - z * y), -1.0, 1.0)) : pole * MathUtils.PI * 0.5);
 	}
 
 	/** Get the pitch euler angle in degrees, which is the rotation around the x axis. Requires that this quaternion is normalized.
 	 * @return the rotation around the x axis in degrees (between -90 and +90) */
 	public float getPitch () {
-		return getPitchRad() * MathUtils.radiansToDegrees;
+		return (float)Math.toDegrees(getPitchRad());
 	}
 
 	/** Get the yaw euler angle in radians, which is the rotation around the y axis. Requires that this quaternion is normalized.
 	 * @return the rotation around the y axis in radians (between -PI and +PI) */
 	public float getYawRad () {
-		return getGimbalPole() == 0 ? MathUtils.atan2(2f * (y * w + x * z), 1f - 2f * (y * y + x * x)) : 0f;
+		return (float)(getGimbalPole() == 0 ? Math.atan2(2.0 * (y * w + x * z), 1.0 - 2.0 * (y * y + x * x)) : 0.0);
 	}
 
 	/** Get the yaw euler angle in degrees, which is the rotation around the y axis. Requires that this quaternion is normalized.
 	 * @return the rotation around the y axis in degrees (between -180 and +180) */
 	public float getYaw () {
-		return getYawRad() * MathUtils.radiansToDegrees;
+		return (float)Math.toDegrees(getYawRad());
 	}
 
 	public final static float len2 (final float x, final float y, final float z, final float w) {

--- a/gdx/test/com/badlogic/gdx/math/QuaternionTest.java
+++ b/gdx/test/com/badlogic/gdx/math/QuaternionTest.java
@@ -1,0 +1,23 @@
+
+package com.badlogic.gdx.math;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class QuaternionTest {
+    private static final float epsilon = Float.MIN_NORMAL;
+
+    @Test
+    public void testEulerPrecision () {
+        float yaw = -5f;
+        float pitch = 42.00055f;
+        float roll = 164.32f;
+
+        Quaternion q = new Quaternion().setEulerAngles(yaw, pitch, roll);
+
+        assertEquals(yaw, q.getYaw(), epsilon);
+        assertEquals(pitch, q.getPitch(), epsilon);
+        assertEquals(roll, q.getRoll(), epsilon);
+    }
+}


### PR DESCRIPTION
# Summary
Changes Quaternions to use double precision under the hood when specifically working with Euler angles to improve precision/numerical stability.

## Why?
![bad_euler_angles](https://user-images.githubusercontent.com/372642/140622796-93d33225-4678-4191-bc6d-47fbafa14be6.gif)
_Wobbly/broken editor rotation gizmo._

While working on implementing a gizmo system for my editor I spent quite some time struggling with why rotations would degenerate and eventually break. After double and triple checking my math, I finally noticed that round-tripping an Euler value can change as much as 0.1 degrees!

## Floats vs Doubles
I know we typically prefer floats for performance reasons, but I'd argue that here correctness/precision would be preferred.

## My Workaround
![good_euler_angles](https://user-images.githubusercontent.com/372642/140623002-560cc0e4-ea2d-4166-8a75-600e5786e6ca.gif)
_Nice and stable rotation gizmo._

I've worked around this by using a helper class to get/set euler angles instead of using the Quaternion instance methods. But being a good open source citizen I thought I'd contribute my findings.
