### PR TITLE
Improve MathUtils.atan2() precision.

### DIFF
--- a/gdx/src/com/badlogic/gdx/math/MathUtils.java
+++ b/gdx/src/com/badlogic/gdx/math/MathUtils.java
@@ -94,11 +94,10 @@ public final class MathUtils {
 
 	// ---
 
-	/** A variant on {@link #atan(float)} that does not tolerate infinite inputs for speed reasons.
-	 * This can be given a double parameter, but is otherwise the same as atan(float), and returns
-	 * a float like that method. It uses the same approximation, from sheet 11 of "Approximations
-	 * for Digital Computers." This is mostly meant to be used inside {@link #atan2(float, float)},
-	 * but it may be a tiny bit faster than atan(float) in other code.
+	/** A variant on {@link #atan(float)} that does not tolerate infinite inputs for speed reasons. This can be given a double
+	 * parameter, but is otherwise the same as atan(float), and returns a float like that method. It uses the same approximation,
+	 * from sheet 11 of "Approximations for Digital Computers." This is mostly meant to be used inside
+	 * {@link #atan2(float, float)}, but it may be a tiny bit faster than atan(float) in other code.
 	 * @param i any finite double or float, but more commonly a float
 	 * @return an output from the inverse tangent function, from {@code -HALF_PI} to {@code HALF_PI} inclusive */
 	public static float atanUnchecked (double i) {
@@ -136,13 +135,11 @@ public final class MathUtils {
 		if (x > 0)
 			return atanUnchecked(n);
 		else if (x < 0) {
-			if (y >= 0)
-				return atanUnchecked(n) + PI;
+			if (y >= 0) return atanUnchecked(n) + PI;
 			return atanUnchecked(n) - PI;
 		} else if (y > 0)
 			return x + HALF_PI;
-		else if (y < 0)
-			return x - HALF_PI;
+		else if (y < 0) return x - HALF_PI;
 		return x + y; // returns 0 for 0,0 or NaN if either y or x is NaN
 	}
 
@@ -158,7 +155,7 @@ public final class MathUtils {
 			return (float)Math.sqrt(1f - a) * (1.5707288f - 0.2121144f * a + 0.0742610f * a2 - 0.0187293f * a3);
 		}
 		return 3.14159265358979323846f
-				- (float)Math.sqrt(1f + a) * (1.5707288f + 0.2121144f * a + 0.0742610f * a2 + 0.0187293f * a3);
+			- (float)Math.sqrt(1f + a) * (1.5707288f + 0.2121144f * a + 0.0742610f * a2 + 0.0187293f * a3);
 	}
 
 	/** Returns asin in radians; less accurate than Math.asin but may be faster. Average error of 0.000028447 radians (0.0016298931
@@ -173,8 +170,7 @@ public final class MathUtils {
 			return 1.5707963267948966f
 				- (float)Math.sqrt(1f - a) * (1.5707288f - 0.2121144f * a + 0.0742610f * a2 - 0.0187293f * a3);
 		}
-		return -1.5707963267948966f
-				+ (float)Math.sqrt(1f + a) * (1.5707288f + 0.2121144f * a + 0.0742610f * a2 + 0.0187293f * a3);
+		return -1.5707963267948966f + (float)Math.sqrt(1f + a) * (1.5707288f + 0.2121144f * a + 0.0742610f * a2 + 0.0187293f * a3);
 	}
 
 	/** Arc tangent approximation with very low error, using an algorithm from the 1955 research study "Approximations for Digital

--- a/gdx/src/com/badlogic/gdx/math/MathUtils.java
+++ b/gdx/src/com/badlogic/gdx/math/MathUtils.java
@@ -115,14 +115,13 @@ public final class MathUtils {
 	}
 
 	/** Close approximation of the frequently-used trigonometric method atan2, with higher precision than libGDX's atan2
-	 * approximation. Maximum error is below 0.00009 radians. Takes y and x (in that unusual order) as floats, and returns the
-	 * angle from the origin to that point in radians. It is about 5 times faster than {@link Math#atan2(double, double)} (roughly
-	 * 12 ns instead of roughly 62 ns for Math, on Java 8 HotSpot). It is slightly faster than libGDX' MathUtils approximation of
-	 * the same method; MathUtils seems to have worse average error, though. <br>
+	 * approximation. Average error is 1.057E-6 radians; maximum error is 1.922E-6. Takes y and x (in that unusual order) as
+	 * floats, and returns the angle from the origin to that point in radians. It is about 4 times faster than
+	 * {@link Math#atan2(double, double)} (roughly 15 ns instead of roughly 60 ns for Math, on Java 8 HotSpot). <br>
 	 * Credit for this goes to the 1955 research study "Approximations for Digital Computers," by RAND Corporation. This is sheet
-	 * 9's algorithm, which is the second-fastest and second-least precise. The algorithm on sheet 8 is faster, but only by a very
-	 * small degree, and is considerably less precise. That study provides an {@link #atan(float)} method, and the small code to
-	 * make that work as atan2() was worked out from Wikipedia.
+	 * 11's algorithm, which is the fourth-fastest and fourth-least precise. The algorithms on sheets 8-10 are faster, but only by
+	 * a very small degree, and are considerably less precise. That study provides an {@link #atan(float)} method, and that cleanly
+	 * translates to atan2().
 	 * @param y y-component of the point to find the angle towards; note the parameter order is unusual by convention
 	 * @param x x-component of the point to find the angle towards; note the parameter order is unusual by convention
 	 * @return the angle to the given point, in radians as a float; ranges from -PI to PI */


### PR DESCRIPTION
I had looked around for alternative atan2() approximations a while ago, and somewhat recently found a good series of approximations published in 1955 by RAND Corp. I believe I already used that study for asin() and acos() here. I've ramped up the quality on the approximations here because it can go up quite a bit while still keeping pretty much exactly the same speed as the current MathUtils.atan2(). I also added atan(), because it's quite similar to atan2(). Both max and average error are substantially better here -- my tests show max error was 0.004883076937336028 radians before, and 1.9221310783024137E-6 radians now. Average error goes from 0.0023030318272527724 radians (before) to 1.0570983651010727E-6 radians now. That means in both cases, we go from two zeros (0.00n) to 5 zeros (0.00000n).

There's some part to discuss still, here -- By using a different approximation, we can speed up MathUtils.atan2() to faster than it was before, and still with lower error, but the max and average errors are still pretty close to what's in MathUtils now -- that is, not great. It also isn't drastically faster; it goes from 14.6 ns to 12.4 ns per call. I think that the speed difference is small enough, and the quality difference substantial enough, to maintain the current speed and just improve quality.

I ran spotlessApply, but I don't know if it worked out OK -- Git claimed there were ~2200 files changed, but that they had no content changes.