### PR TITLE
Intersector.intersectPolygons add doc p2 should be clockwise #6679

### DIFF
--- a/gdx/src/com/badlogic/gdx/math/Intersector.java
+++ b/gdx/src/com/badlogic/gdx/math/Intersector.java
@@ -152,6 +152,7 @@ public final class Intersector {
 
 	/** Intersects two convex polygons with clockwise vertices and sets the overlap polygon resulting from the intersection.
 	 * Follows the Sutherland-Hodgman algorithm.
+	 * p2 should be clockwise
 	 * @param p1 The polygon that is being clipped
 	 * @param p2 The clip polygon
 	 * @param overlap The intersection of the two polygons (can be null, if an intersection polygon is not needed)

--- a/gdx/src/com/badlogic/gdx/math/Intersector.java
+++ b/gdx/src/com/badlogic/gdx/math/Intersector.java
@@ -151,8 +151,7 @@ public final class Intersector {
 	private final static Vector2 e = new Vector2();
 
 	/** Intersects two convex polygons with clockwise vertices and sets the overlap polygon resulting from the intersection.
-	 * Follows the Sutherland-Hodgman algorithm.
-	 * p2 should be clockwise
+	 * Follows the Sutherland-Hodgman algorithm. p2 should be clockwise
 	 * @param p1 The polygon that is being clipped
 	 * @param p2 The clip polygon
 	 * @param overlap The intersection of the two polygons (can be null, if an intersection polygon is not needed)


### PR DESCRIPTION
Hey, i work on my issues [#6679](https://github.com/libgdx/libgdx/issues/6679)

i found after test that, the second polygon must be clockwise.

I dont know if its an error in algorithm implementation or algorithm itself need it.
I find an implementation in python  where the two polygons must be clockwise.
When i look the algorithm, a rotation dir is needed,  but it can be ccw too. 

Anyways the method seems work fine, i just add a line of doc for utilisation
Thanks for reading