### PR TITLE
Add Methods for libgdx-freetype Extension

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -25,6 +25,7 @@
 - Bug Fix: AssetManager backslash conversion removed - fixes use of filenames containing backslashes
 - gdx-setup now places the assets directory in project root instead of android or core. See advanced settings (UI) or arguments (command line) if you don't want it in root.
 - API Fix: Resolved issues with LWJGL 3 and borderless fullscreen
+- API Addition: Added FreeTypeFontGenerator#hasCharGlyph method.
 
 [1.10.0]
 - [BREAKING CHANGE] Android armeabi support has been removed. To migrate your projects: remove any dependency with natives-armeabi qualifier from your gradle build file, this apply to gdx-platform, gdx-bullet-platform, gdx-freetype-platform and gdx-box2d-platform.

--- a/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGenerator.java
+++ b/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGenerator.java
@@ -613,6 +613,12 @@ public class FreeTypeFontGenerator implements Disposable {
 		return glyph;
 	}
 
+	/** check the font glyph exists for single UTF-32 code point */
+	public boolean hasGlyph (int charCode) {
+		// 0 stand for undefined character code
+		return face.getCharIndex(charCode) != 0;
+	}
+
 	public String toString () {
 		return name;
 	}


### PR DESCRIPTION
#6702 

This pull request will add methods for the freetype extension.

There is a method: `FreeTypeFontGenerator#hasGlyph(int)`.

This can check whether the font file has certain glyphs.

There're no tests. According to the [documentation](https://freetype.org/freetype2/docs/reference/ft2-base_interface.html#ft_get_char_index) of freetype, this should work on all platforms.