### PR TITLE
Corrected a typo in the JavaDoc for the scene2d Actor class.

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/Actor.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/Actor.java
@@ -956,7 +956,7 @@ public class Actor {
 		drawDebugBounds(shapes);
 	}
 
-	/** Draws a rectange for the bounds of this actor if {@link #getDebug()} is true. */
+	/** Draws a rectangle for the bounds of this actor if {@link #getDebug()} is true. */
 	protected void drawDebugBounds (ShapeRenderer shapes) {
 		if (!debug) return;
 		shapes.set(ShapeType.Line);


### PR DESCRIPTION
Corrected a typo (from 'rectange' to 'rectangle') in the JavaDoc of the scene2d Actor class.