### PR TITLE
GWT: Extract setupMainLoop method

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplication.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplication.java
@@ -77,9 +77,9 @@ public abstract class GwtApplication implements EntryPoint, Application {
 	protected TextArea log = null;
 	private int logLevel = LOG_ERROR;
 	private ApplicationLogger applicationLogger;
-	private Array<Runnable> runnables = new Array<Runnable>();
-	private Array<Runnable> runnablesHelper = new Array<Runnable>();
-	private Array<LifecycleListener> lifecycleListeners = new Array<LifecycleListener>();
+	protected final Array<Runnable> runnables = new Array<Runnable>();
+	protected final Array<Runnable> runnablesHelper = new Array<Runnable>();
+	protected final Array<LifecycleListener> lifecycleListeners = new Array<LifecycleListener>();
 	private int lastWidth;
 	private int lastHeight;
 	Preloader preloader;
@@ -233,6 +233,10 @@ public abstract class GwtApplication implements EntryPoint, Application {
 			throw new RuntimeException(t);
 		}
 
+		setupMainLoop();
+	}
+
+	protected void setupMainLoop () {
 		AnimationScheduler.get().requestAnimationFrame(new AnimationCallback() {
 			@Override
 			public void execute (double timestamp) {


### PR DESCRIPTION
Extracting the method setupMainLoop allows developers to extend GWTApplication and handle the main loop externally.

It might sound very specific but this is how [WebXR works](https://developer.mozilla.org/en-US/docs/Web/API/XRSession/requestAnimationFrame).