### PR TITLE
gwtref: Throw ClassNotFoundException instead of RuntimeException in ReflectionCache.forName

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/utils/reflect/ClassReflection.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/utils/reflect/ClassReflection.java
@@ -30,7 +30,7 @@ public final class ClassReflection {
 		try {
 			return ReflectionCache.forName(name).getClassOfType();
 		} catch (ClassNotFoundException e) {
-			throw new ReflectionException("Class not found: " + name);
+			throw new ReflectionException("Class not found: " + name, e);
 		}
 	}
 

--- a/backends/gdx-backends-gwt/src/com/badlogic/gwtref/client/ReflectionCache.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gwtref/client/ReflectionCache.java
@@ -30,7 +30,7 @@ public class ReflectionCache {
 			type.source = instance1;
 		}
 		if (type == null) {
-			throw new RuntimeException("Couldn't find Type for class '" + name + "'");
+			throw new ClassNotFoundException("Couldn't find Type for class '" + name + "'");
 		}
 		if (type.source == null) {
 			type.source = instance2;


### PR DESCRIPTION
Not tested.

Should fix #6708