### PR TITLE
Lwjgl3Net: Fallback to xdg-open on Linux if Desktop.BROWSE is unavailable

### DIFF
--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Net.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Net.java
@@ -73,14 +73,21 @@ public class Lwjgl3Net implements Net {
 			} catch (Throwable t) {
 				return false;
 			}
-		} else {
+		} else if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {
 			try {
 				Desktop.getDesktop().browse(new URI(uri));
 				return true;
 			} catch (Throwable t) {
 				return false;
 			}
+		} else if (SharedLibraryLoader.isLinux) {
+			try {
+				(new ProcessBuilder("xdg-open", (new URI(uri).toString()))).start();
+				return true;
+			} catch (Throwable t) {
+				return false;
+			}
 		}
+		return false;
 	}
-
 }


### PR DESCRIPTION
When using a libGDX application inside of a linux sandbox container (Snap/Flatpak), Net#openURI will fail to open any url because the Desktop.BROWSE action is unavailable. This is intended behavior of the sandbox. You're supposed to use xdg-portals to access urls in these environments.

The simplest way to workaround this limitation is to call xdg-open for the target uri. There's no guarantee it'll be able to handle your uri if a mime type is undefined for the sandbox, but it'll work most of the time. This binary is standard on freedesktop platforms.
