### PR TITLE
Check if we're on mobile!

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -27,6 +27,7 @@
 - API Fix: Resolved issues with LWJGL 3 and borderless fullscreen
 - API Addition: GeometryUtils,polygons isCCW, ensureClockwise, reverseVertices
 - API Addition: Added FreeTypeFontGenerator#hasCharGlyph method.
+- API Addition: Gdx.app.isMobile() can be used to determine if the user is on a mobile device.
 
 [1.10.0]
 - [BREAKING CHANGE] Android armeabi support has been removed. To migrate your projects: remove any dependency with natives-armeabi qualifier from your gradle build file, this apply to gdx-platform, gdx-bullet-platform, gdx-freetype-platform and gdx-box2d-platform.

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplication.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplication.java
@@ -62,8 +62,11 @@ public class AndroidApplication extends Activity implements AndroidApplicationBa
 	private int wasFocusChanged = -1;
 	private boolean isWaitingForAudio = false;
 
-	/* The device is mobile unless running under the Android Runtime for Chrome (e.g. on a Chromebook). Based on:
-	* https://github.com/google/talkback/blob/f5d564f/utils/src/main/java/com/google/android/accessibility/utils/FeatureSupport.java#L49-L51 */
+	/*
+	 * The device is mobile unless running under the Android Runtime for Chrome (e.g. on a Chromebook). Based on:
+	 * https://github.com/google/talkback/blob/f5d564f/utils/src/main/java/com/google/android/accessibility/utils/FeatureSupport.
+	 * java#L49-L51
+	 */
 	private final boolean mobile = Build.DEVICE != null && !Build.DEVICE.matches(".+_cheets|cheets_.+");
 
 	/** This method has to be called in the {@link Activity#onCreate(Bundle)} method. It sets up all the things necessary to get

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplication.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplication.java
@@ -62,6 +62,10 @@ public class AndroidApplication extends Activity implements AndroidApplicationBa
 	private int wasFocusChanged = -1;
 	private boolean isWaitingForAudio = false;
 
+	/* The device is mobile unless running under the Android Runtime for Chrome (e.g. on a Chromebook). Based on:
+	* https://github.com/google/talkback/blob/f5d564f/utils/src/main/java/com/google/android/accessibility/utils/FeatureSupport.java#L49-L51 */
+	private final boolean mobile = Build.DEVICE != null && !Build.DEVICE.matches(".+_cheets|cheets_.+");
+
 	/** This method has to be called in the {@link Activity#onCreate(Bundle)} method. It sets up all the things necessary to get
 	 * input, render via OpenGL and so on. Uses a default {@link AndroidApplicationConfiguration}.
 	 * 
@@ -322,6 +326,11 @@ public class AndroidApplication extends Activity implements AndroidApplicationBa
 	@Override
 	public int getVersion () {
 		return android.os.Build.VERSION.SDK_INT;
+	}
+
+	@Override
+	public boolean isMobile () {
+		return mobile;
 	}
 
 	@Override

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidDaydream.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidDaydream.java
@@ -62,8 +62,11 @@ public class AndroidDaydream extends DreamService implements AndroidApplicationB
 	protected int logLevel = LOG_INFO;
 	protected ApplicationLogger applicationLogger;
 
-	/* The device is mobile unless running under the Android Runtime for Chrome (e.g. on a Chromebook). Based on:
-	 * https://github.com/google/talkback/blob/f5d564f/utils/src/main/java/com/google/android/accessibility/utils/FeatureSupport.java#L49-L51 */
+	/*
+	 * The device is mobile unless running under the Android Runtime for Chrome (e.g. on a Chromebook). Based on:
+	 * https://github.com/google/talkback/blob/f5d564f/utils/src/main/java/com/google/android/accessibility/utils/FeatureSupport.
+	 * java#L49-L51
+	 */
 	private final boolean mobile = Build.DEVICE != null && !Build.DEVICE.matches(".+_cheets|cheets_.+");
 
 	/** This method has to be called in the Activity#onCreate(Bundle) method. It sets up all the things necessary to get input,

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidDaydream.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidDaydream.java
@@ -62,6 +62,10 @@ public class AndroidDaydream extends DreamService implements AndroidApplicationB
 	protected int logLevel = LOG_INFO;
 	protected ApplicationLogger applicationLogger;
 
+	/* The device is mobile unless running under the Android Runtime for Chrome (e.g. on a Chromebook). Based on:
+	 * https://github.com/google/talkback/blob/f5d564f/utils/src/main/java/com/google/android/accessibility/utils/FeatureSupport.java#L49-L51 */
+	private final boolean mobile = Build.DEVICE != null && !Build.DEVICE.matches(".+_cheets|cheets_.+");
+
 	/** This method has to be called in the Activity#onCreate(Bundle) method. It sets up all the things necessary to get input,
 	 * render via OpenGL and so on. Uses a default {@link AndroidApplicationConfiguration}.
 	 * @param listener the {@link ApplicationListener} implementing the program logic */
@@ -261,6 +265,11 @@ public class AndroidDaydream extends DreamService implements AndroidApplicationB
 	@Override
 	public int getVersion () {
 		return android.os.Build.VERSION.SDK_INT;
+	}
+
+	@Override
+	public boolean isMobile () {
+		return mobile;
 	}
 
 	@Override

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidFragmentApplication.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidFragmentApplication.java
@@ -50,8 +50,11 @@ public class AndroidFragmentApplication extends Fragment implements AndroidAppli
 	protected int logLevel = LOG_INFO;
 	protected ApplicationLogger applicationLogger;
 
-	/* The device is mobile unless running under the Android Runtime for Chrome (e.g. on a Chromebook). Based on:
-	 * https://github.com/google/talkback/blob/f5d564f/utils/src/main/java/com/google/android/accessibility/utils/FeatureSupport.java#L49-L51 */
+	/*
+	 * The device is mobile unless running under the Android Runtime for Chrome (e.g. on a Chromebook). Based on:
+	 * https://github.com/google/talkback/blob/f5d564f/utils/src/main/java/com/google/android/accessibility/utils/FeatureSupport.
+	 * java#L49-L51
+	 */
 	private final boolean mobile = Build.DEVICE != null && !Build.DEVICE.matches(".+_cheets|cheets_.+");
 
 	protected Callbacks callbacks;

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidFragmentApplication.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidFragmentApplication.java
@@ -50,6 +50,10 @@ public class AndroidFragmentApplication extends Fragment implements AndroidAppli
 	protected int logLevel = LOG_INFO;
 	protected ApplicationLogger applicationLogger;
 
+	/* The device is mobile unless running under the Android Runtime for Chrome (e.g. on a Chromebook). Based on:
+	 * https://github.com/google/talkback/blob/f5d564f/utils/src/main/java/com/google/android/accessibility/utils/FeatureSupport.java#L49-L51 */
+	private final boolean mobile = Build.DEVICE != null && !Build.DEVICE.matches(".+_cheets|cheets_.+");
+
 	protected Callbacks callbacks;
 
 	@Override
@@ -268,6 +272,11 @@ public class AndroidFragmentApplication extends Fragment implements AndroidAppli
 	@Override
 	public int getVersion () {
 		return android.os.Build.VERSION.SDK_INT;
+	}
+
+	@Override
+	public boolean isMobile () {
+		return mobile;
 	}
 
 	@Override

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidLiveWallpaper.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidLiveWallpaper.java
@@ -54,6 +54,10 @@ public class AndroidLiveWallpaper implements AndroidApplicationBase {
 	protected ApplicationLogger applicationLogger;
 	protected volatile Color[] wallpaperColors = null;
 
+	/* The device is mobile unless running under the Android Runtime for Chrome (e.g. on a Chromebook). Based on:
+	 * https://github.com/google/talkback/blob/f5d564f/utils/src/main/java/com/google/android/accessibility/utils/FeatureSupport.java#L49-L51 */
+	private final boolean mobile = Build.DEVICE != null && !Build.DEVICE.matches(".+_cheets|cheets_.+");
+
 	public AndroidLiveWallpaper (AndroidLiveWallpaperService service) {
 		this.service = service;
 	}
@@ -219,6 +223,11 @@ public class AndroidLiveWallpaper implements AndroidApplicationBase {
 	@Override
 	public int getVersion () {
 		return android.os.Build.VERSION.SDK_INT;
+	}
+
+	@Override
+	public boolean isMobile () {
+		return mobile;
 	}
 
 	@Override

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidLiveWallpaper.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidLiveWallpaper.java
@@ -54,8 +54,11 @@ public class AndroidLiveWallpaper implements AndroidApplicationBase {
 	protected ApplicationLogger applicationLogger;
 	protected volatile Color[] wallpaperColors = null;
 
-	/* The device is mobile unless running under the Android Runtime for Chrome (e.g. on a Chromebook). Based on:
-	 * https://github.com/google/talkback/blob/f5d564f/utils/src/main/java/com/google/android/accessibility/utils/FeatureSupport.java#L49-L51 */
+	/*
+	 * The device is mobile unless running under the Android Runtime for Chrome (e.g. on a Chromebook). Based on:
+	 * https://github.com/google/talkback/blob/f5d564f/utils/src/main/java/com/google/android/accessibility/utils/FeatureSupport.
+	 * java#L49-L51
+	 */
 	private final boolean mobile = Build.DEVICE != null && !Build.DEVICE.matches(".+_cheets|cheets_.+");
 
 	public AndroidLiveWallpaper (AndroidLiveWallpaperService service) {

--- a/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/HeadlessApplication.java
+++ b/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/HeadlessApplication.java
@@ -196,6 +196,11 @@ public class HeadlessApplication implements Application {
 	}
 
 	@Override
+	public boolean isMobile () {
+		return false;
+	}
+
+	@Override
 	public long getJavaHeap () {
 		return Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
 	}

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglAWTCanvas.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglAWTCanvas.java
@@ -222,6 +222,11 @@ public class LwjglAWTCanvas implements Application {
 		return 0;
 	}
 
+	@Override
+	public boolean isMobile () {
+		return false;
+	}
+
 	void setGlobals () {
 		Gdx.app = this;
 		if (audio != null) Gdx.audio = audio;

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglApplication.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglApplication.java
@@ -323,6 +323,11 @@ public class LwjglApplication implements LwjglApplicationBase {
 		return 0;
 	}
 
+	@Override
+	public boolean isMobile () {
+		return false;
+	}
+
 	public void stop () {
 		running = false;
 		try {

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglCanvas.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglCanvas.java
@@ -209,6 +209,11 @@ public class LwjglCanvas implements LwjglApplicationBase {
 		return 0;
 	}
 
+	@Override
+	public boolean isMobile () {
+		return false;
+	}
+
 	void create () {
 		try {
 			graphics.setupDisplay();

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
@@ -312,6 +312,11 @@ public class Lwjgl3Application implements Lwjgl3ApplicationBase {
 	}
 
 	@Override
+	public boolean isMobile () {
+		return false;
+	}
+
+	@Override
 	public long getJavaHeap () {
 		return Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
 	}

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSApplication.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSApplication.java
@@ -375,6 +375,11 @@ public class IOSApplication implements Application {
 	}
 
 	@Override
+	public boolean isMobile () {
+		return true;
+	}
+
+	@Override
 	public long getJavaHeap () {
 		return Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
 	}

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplication.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplication.java
@@ -88,6 +88,18 @@ public abstract class GwtApplication implements EntryPoint, Application {
 	private Clipboard clipboard;
 	LoadingListener loadingListener;
 
+	private final static boolean mobileDevice;
+	static {
+		// RegEx pattern from detectmobilebrowsers.com (public domain)
+		String pattern = "(android|bb\\d+|meego).+mobile|avantgo|bada\\/|blackberry|blazer|compal|elaine|fennec"
+			+ "|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)"
+			+ "i|palm( os)?|phone|p(ixi|re)\\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\\.(browser|link)"
+			+ "|vodafone|wap|windows ce|xda|xiino|android|ipad|playbook|silk";
+		Pattern p = Pattern.compile(pattern);
+		Matcher m = p.matcher(Window.Navigator.getUserAgent().toLowerCase());
+		mobileDevice = m.matches();
+	}
+
 	/** @return the configuration for the {@link GwtApplication}. */
 	public abstract GwtApplicationConfiguration getConfig ();
 
@@ -440,6 +452,11 @@ public abstract class GwtApplication implements EntryPoint, Application {
 	}
 
 	@Override
+	public boolean isMobile () {
+		return mobileDevice;
+	}
+
+	@Override
 	public long getJavaHeap () {
 		return 0;
 	}
@@ -485,16 +502,10 @@ public abstract class GwtApplication implements EntryPoint, Application {
 		return new DefaultGwtInput(canvas, config);
 	}
 
-	/** @return {@code true} if application runs on a mobile device */
+	/** @return {@code true} if application is running on a mobile device
+	 * @deprecated use {@link #isMobile ()} instead */
 	public static boolean isMobileDevice () {
-		// RegEx pattern from detectmobilebrowsers.com (public domain)
-		String pattern = "(android|bb\\d+|meego).+mobile|avantgo|bada\\/|blackberry|blazer|compal|elaine|fennec"
-			+ "|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)"
-			+ "i|palm( os)?|phone|p(ixi|re)\\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\\.(browser|link)"
-			+ "|vodafone|wap|windows ce|xda|xiino|android|ipad|playbook|silk";
-		Pattern p = Pattern.compile(pattern);
-		Matcher m = p.matcher(Window.Navigator.getUserAgent().toLowerCase());
-		return m.matches();
+		return mobileDevice;
 	}
 
 	/** Contains precomputed information on the user-agent. Useful for dealing with browser and OS behavioral differences. Kindly

--- a/gdx/src/com/badlogic/gdx/Application.java
+++ b/gdx/src/com/badlogic/gdx/Application.java
@@ -162,8 +162,11 @@ public interface Application {
 	/** @return what {@link ApplicationType} this application has, e.g. Android or Desktop */
 	public ApplicationType getType ();
 
-	/** @return the Android API level on Android, the major OS version on iOS (5, 6, 7, ..), or 0 on the desktop. */
+	/** @return the Android API level on Android, the major OS version on iOS (5, 6, 7, ..), or 0 on the desktop */
 	public int getVersion ();
+
+	/** @return {@code true} if the device is a mobile, primarily touchscreen-driven device */
+	public boolean isMobile ();
 
 	/** @return the Java heap memory use in bytes */
 	public long getJavaHeap ();


### PR DESCRIPTION
Frequently I find myself fetching `GwtApplication.isMobileDevice()` and passing it into my main class. `Gdx.app.getType()` is unsuitable for this task, as it doesn't distinguish mobile web from desktop web. It's a bit of a hassle, so here's my proposal for not having to do that anymore. The code's a bit smelly, but hopefully functional - feel free to edit.

`GwtApplication.isMobileDevice()` still exists as to not break existing projects, but has been deprecated. I don't really like having two methods that do effectively the same thing, but don't see a better solution at the moment due to `isMobileDevice()` being `static`.

I've changed  `GwtApplication.isMobileDevice()` to return a `final` boolean rather than query the user agent each time the method is run. This is to ensure tip-top performance if someone calls the method each frame, such as to decide whether to draw touchscreen controls. The other backends use the same approach. It doesn't matter that it doesn't update, as the user agent shouldn't change while the game is running (every mobile browser I've used refreshes the page when switching between mobile/desktop modes).

GWT's regex for the mobile check remains completely overkill, seeing as libGDX isn't compatible with most of those devices/browsers, but I'd rather not touch it and inadvertently break something in the process.

Platform|Is mobile?
-|-
Web|Detects based on user agent like previously
Desktop|Never mobile
Android|Mobile unless running under ARC (e.g. Chromebook)
iOS|Always mobile

***

I'm having trouble properly testing my changes. The IDE doesn't recognise any libGDX classes when using `1.10.1-SNAPSHOT`, despite invalidating caches and deleting `.idea`. `superDev` just results in `User limit of inotify watches reached`. Yeah, not very helpful for you lot, but not something I can fix tonight (raising the system inotify limit didn't change anything).

Mild curiosity: `[ALSOFT] (EE) Failed to set real-time priority for thread: Operation not permitted (1)` gets output twice for LWJGL3 desktop (Linux) on 1.10.1-SNAPSHOT, but the sound still works fine.

And the formatter doesn't understand the concept of hyperlinks.  :(