### PR TITLE
add back default Pool behavior when object is discarded

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -27,6 +27,7 @@
 - API Fix: Resolved issues with LWJGL 3 and borderless fullscreen
 - API Addition: GeometryUtils,polygons isCCW, ensureClockwise, reverseVertices
 - API Addition: Added FreeTypeFontGenerator#hasCharGlyph method.
+- API Fix: Pool discard method now resets object by default. This fixes the known issue about Pool in libGDX 1.10.0.
 
 [1.10.0]
 - [BREAKING CHANGE] Android armeabi support has been removed. To migrate your projects: remove any dependency with natives-armeabi qualifier from your gradle build file, this apply to gdx-platform, gdx-bullet-platform, gdx-freetype-platform and gdx-box2d-platform.
@@ -36,7 +37,7 @@
 - [BREAKING CHANGE] API Change: Scaling is now an object instead of an enum. This may change behavior when used with serialization.
 - [BREAKING CHANGE] Group#clear() and #clearChildren() now unfocus the children. Added clear(boolean) and clearChildren(boolean) for when this isn't wanted. Code that overrides clear()/clearChildren() probably should change to override the (boolean) method. #6423
 - [BREAKING CHANGE] Lwjgl3WindowConfiguration#autoIconify is enabled by default.
-- [BREAKING CHANGE] Pool no longer reset freed objects when pool size is above its retention limit. Pool will discard objects instead. If you want to keep the old behavior, you should override Pool#discard method to reset discarded objects.
+- [KNOWN ISSUE] Pool no longer reset freed objects when pool size is above its retention limit. Pool will discard objects instead. If you want to keep the old behavior, you should override Pool#discard method to reset discarded objects.
 - Scene2d.ui: Added new ParticleEffectActor to use particle effects on Stage
 - API addition: iOS: Added HdpiMode option to IOSApplicationConfiguration to allow users to set whether they want to work in logical or raw pixels (default logical).
 - Fix for #6377 Gdx.net.openURI not working with targetSdk 30

--- a/gdx/src/com/badlogic/gdx/utils/Pool.java
+++ b/gdx/src/com/badlogic/gdx/utils/Pool.java
@@ -87,6 +87,7 @@ abstract public class Pool<T> {
 	/** Called when an object is discarded. This is the case when an object is freed, but the maximum capacity of the pool is
 	 * reached, and when the pool is {@link #clear() cleared} */
 	protected void discard (T object) {
+		reset(object);
 	}
 
 	/** Puts the specified objects in the pool. Null objects within the array are silently ignored.


### PR DESCRIPTION
as discussed in #6723, Pool change from #6379 was a breaking change. This PR add back previous behavior.