### PR TITLE
Fixes some Gradle build issues (GWT Tests, Runnable Tools)

### DIFF
--- a/extensions/gdx-tools/build.gradle
+++ b/extensions/gdx-tools/build.gradle
@@ -35,7 +35,7 @@ ext {
 task dist2DParticles (type: Jar) {
 	from files(sourceSets.main.java.outputDir)
 	from files(sourceSets.main.output.resourcesDir)
-	from {configurations.compile.collect {zipTree(it)}}
+	from {configurations.runtimeClasspath.collect {zipTree(it)}}
 	from files(toolsAssetsDir)
 
 	archiveFileName = "runnable-2D-particles.jar"
@@ -48,7 +48,7 @@ task dist2DParticles (type: Jar) {
 task dist3DParticles (type: Jar) {
 	from files(sourceSets.main.java.outputDir)
 	from files(sourceSets.main.output.resourcesDir)
-	from {configurations.compile.collect {zipTree(it)}}
+	from {configurations.runtimeClasspath.collect {zipTree(it)}}
 	from files(toolsAssetsDir)
 
 	archiveFileName = "runnable-3D-particles.jar"
@@ -61,7 +61,7 @@ task dist3DParticles (type: Jar) {
 task distHiero (type: Jar) {
 	from files(sourceSets.main.java.outputDir)
 	from files(sourceSets.main.output.resourcesDir)
-	from {configurations.compile.collect {zipTree(it)}}
+	from {configurations.runtimeClasspath.collect {zipTree(it)}}
 	from files(toolsAssetsDir)
 
 	archiveFileName = "runnable-hiero.jar"
@@ -74,7 +74,7 @@ task distHiero (type: Jar) {
 task distTexturePacker (type: Jar) {
 	from files(sourceSets.main.java.outputDir)
 	from files(sourceSets.main.output.resourcesDir)
-	from {configurations.compile.collect {zipTree(it)}}
+	from {configurations.runtimeClasspath.collect {zipTree(it)}}
 	from files(toolsAssetsDir)
 
 	archiveFileName = "runnable-texturepacker.jar"

--- a/tests/gdx-tests-gwt/build.gradle
+++ b/tests/gdx-tests-gwt/build.gradle
@@ -120,6 +120,7 @@ task addSource {
 		sourceSets.main.compileClasspath += files(project(':extensions:gdx-box2d-parent:gdx-box2d-gwt').sourceSets.main.allJava.srcDirs)
 		sourceSets.main.compileClasspath += files(project(':extensions:gdx-box2d-parent:gdx-box2d-gwt').sourceSets.main.resources.srcDirs)
 		sourceSets.main.compileClasspath += files(project(':gdx').sourceSets.main.allJava.srcDirs)
+		sourceSets.main.compileClasspath += files(project(':gdx').sourceSets.main.resources.srcDirs)
 		sourceSets.main.compileClasspath += files(sourceSets.main.resources.srcDirs)
 	}
 }


### PR DESCRIPTION
Found some issues that look to be side effects of https://github.com/libgdx/libgdx/pull/6652.

The resources from the main gdx module were not being added as sources for the GWT Tests, which was preventing compile.
Runtime dependencies were not included in the runnable jars for tools (e.g. Hiero couldn't launch due to missing ApplicationListener class).
