### PR TITLE
Add new Pixmap constructor for loading from a ByteBuffer

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/Pixmap.java
+++ b/gdx/src/com/badlogic/gdx/graphics/Pixmap.java
@@ -153,6 +153,30 @@ public class Pixmap implements Disposable {
 		}
 	}
 
+	/** Creates a new Pixmap instance from the given encoded image data. The image can be encoded as JPEG, PNG or BMP. Not
+	 * available on GWT backend.
+	 *
+	 * @param encodedData the encoded image data
+	 * @param offset the offset relative to the base address of encodedData
+	 * @param len the length */
+	public Pixmap (ByteBuffer encodedData, int offset, int len) {
+		try {
+			pixmap = new Gdx2DPixmap(encodedData, offset, len, 0);
+		} catch (IOException e) {
+			throw new GdxRuntimeException("Couldn't load pixmap from image data", e);
+		}
+	}
+
+	/** Creates a new Pixmap instance from the given encoded image data. The image can be encoded as JPEG, PNG or BMP. Not
+	 * available on GWT backend.
+	 *
+	 * Offset is based on the position of the buffer. Length is based on the remaining bytes of the buffer.
+	 *
+	 * @param encodedData the encoded image data */
+	public Pixmap (ByteBuffer encodedData) {
+		this(encodedData, encodedData.position(), encodedData.remaining());
+	}
+
 	/** Creates a new Pixmap instance from the given file. The file must be a Png, Jpeg or Bitmap. Paletted formats are not
 	 * supported.
 	 * 

--- a/gdx/src/com/badlogic/gdx/graphics/Pixmap.java
+++ b/gdx/src/com/badlogic/gdx/graphics/Pixmap.java
@@ -160,6 +160,7 @@ public class Pixmap implements Disposable {
 	 * @param offset the offset relative to the base address of encodedData
 	 * @param len the length */
 	public Pixmap (ByteBuffer encodedData, int offset, int len) {
+		if (!encodedData.isDirect()) throw new GdxRuntimeException("Couldn't load pixmap from non-direct ByteBuffer");
 		try {
 			pixmap = new Gdx2DPixmap(encodedData, offset, len, 0);
 		} catch (IOException e) {

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/Gdx2DPixmap.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/Gdx2DPixmap.java
@@ -94,6 +94,20 @@ public class Gdx2DPixmap implements Disposable {
 		}
 	}
 
+	public Gdx2DPixmap (ByteBuffer encodedData, int offset, int len, int requestedFormat) throws IOException {
+		pixelPtr = load(nativeData, encodedData, offset, len);
+		if (pixelPtr == null) throw new IOException("Error loading pixmap: " + getFailureReason());
+
+		basePtr = nativeData[0];
+		width = (int)nativeData[1];
+		height = (int)nativeData[2];
+		format = (int)nativeData[3];
+
+		if (requestedFormat != 0 && requestedFormat != format) {
+			convert(requestedFormat);
+		}
+	}
+
 	public Gdx2DPixmap (InputStream in, int requestedFormat) throws IOException {
 		ByteArrayOutputStream bytes = new ByteArrayOutputStream(1024);
 		byte[] buffer = new byte[1024];
@@ -285,6 +299,27 @@ public class Gdx2DPixmap implements Disposable {
 		const unsigned char* p_buffer = (const unsigned char*)env->GetPrimitiveArrayCritical(buffer, 0);
 		gdx2d_pixmap* pixmap = gdx2d_load(p_buffer + offset, len);
 		env->ReleasePrimitiveArrayCritical(buffer, (char*)p_buffer, 0);
+
+		if(pixmap==0)
+			return 0;
+
+		jobject pixel_buffer = env->NewDirectByteBuffer((void*)pixmap->pixels, pixmap->width * pixmap->height * gdx2d_bytes_per_pixel(pixmap->format));
+		jlong* p_native_data = (jlong*)env->GetPrimitiveArrayCritical(nativeData, 0);
+		p_native_data[0] = (jlong)pixmap;
+		p_native_data[1] = pixmap->width;
+		p_native_data[2] = pixmap->height;
+		p_native_data[3] = pixmap->format;
+		env->ReleasePrimitiveArrayCritical(nativeData, p_native_data, 0);
+
+		return pixel_buffer;
+	 */
+
+	private static native ByteBuffer load (long[] nativeData, ByteBuffer buffer, int offset, int len); /*MANUAL
+		if(buffer==0)
+			return 0;
+
+		const unsigned char* p_buffer = (const unsigned char*)env->GetDirectBufferAddress(buffer);
+		gdx2d_pixmap* pixmap = gdx2d_load(p_buffer + offset, len);
 
 		if(pixmap==0)
 			return 0;


### PR DESCRIPTION
Removes the need to create a copy if you already have an image in a **direct** ByteBuffer.