### PR TITLE
Remove dead code in OpenALAudioDevice

### DIFF
--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/audio/OpenALAudioDevice.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/audio/OpenALAudioDevice.java
@@ -108,13 +108,6 @@ public class OpenALAudioDevice implements AudioDevice {
 				offset += written;
 				queuedBuffers++;
 			}
-			// Queue rest of buffers, empty.
-			((Buffer)tempBuffer).clear().flip();
-			for (int i = queuedBuffers; i < bufferCount; i++) {
-				int bufferID = buffers.get(i);
-				alBufferData(bufferID, format, tempBuffer, sampleRate);
-				alSourceQueueBuffers(sourceID, bufferID);
-			}
 			alSourcePlay(sourceID);
 			isPlaying = true;
 		}

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALAudioDevice.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALAudioDevice.java
@@ -108,13 +108,6 @@ public class OpenALAudioDevice implements AudioDevice {
 				offset += written;
 				queuedBuffers++;
 			}
-			// Queue rest of buffers, empty.
-			((Buffer)tempBuffer).clear().flip();
-			for (int i = queuedBuffers; i < bufferCount; i++) {
-				int bufferID = buffers.get(i);
-				alBufferData(bufferID, format, tempBuffer, sampleRate);
-				alSourceQueueBuffers(sourceID, bufferID);
-			}
 			alSourcePlay(sourceID);
 			isPlaying = true;
 		}


### PR DESCRIPTION
This piece of code is dead as it never gets executed. The purpose was to fill the remaining buffers with silence and queue them on the source (the algorithm relies on it) but the code above already takes care of this, so these lines can be safely removed.