### PR TITLE
Add NWSEResize, NESWResize, AllResize, and NotAllowed SystemCursors

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -41,6 +41,7 @@
 - API Fix: Move vertex array index buffer limit to backends to fix issue with numIndices parameter
 - API Fix: TexturePacker: Fix wrong Y value when using padding
 - API Fix: Lwjgl3Net: Add fallback to xdg-open on Linux if Desktop.BROWSE is unavailable
+- API Addition: Add NWSEResize, NESWResize, AllResize, and NotAllowed SystemCursors
 
 [1.10.0]
 - [BREAKING CHANGE] Android armeabi support has been removed. To migrate your projects: remove any dependency with natives-armeabi qualifier from your gradle build file, this apply to gdx-platform, gdx-bullet-platform, gdx-freetype-platform and gdx-box2d-platform.

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Cursor.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Cursor.java
@@ -119,6 +119,14 @@ public class Lwjgl3Cursor implements Cursor {
 				handle = GLFW.glfwCreateStandardCursor(GLFW.GLFW_VRESIZE_CURSOR);
 			} else if (systemCursor == SystemCursor.Ibeam) {
 				handle = GLFW.glfwCreateStandardCursor(GLFW.GLFW_IBEAM_CURSOR);
+			} else if (systemCursor == SystemCursor.NWSEResize) {
+				handle = GLFW.glfwCreateStandardCursor(GLFW.GLFW_RESIZE_NWSE_CURSOR);
+			} else if (systemCursor == SystemCursor.NESWResize) {
+				handle = GLFW.glfwCreateStandardCursor(GLFW.GLFW_RESIZE_NESW_CURSOR);
+			} else if (systemCursor == SystemCursor.AllResize) {
+				handle = GLFW.glfwCreateStandardCursor(GLFW.GLFW_RESIZE_ALL_CURSOR);
+			} else if (systemCursor == SystemCursor.NotAllowed) {
+				handle = GLFW.glfwCreateStandardCursor(GLFW.GLFW_NOT_ALLOWED_CURSOR);
 			} else {
 				throw new GdxRuntimeException("Unknown system cursor " + systemCursor);
 			}

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtCursor.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtCursor.java
@@ -74,6 +74,14 @@ public class GwtCursor implements Cursor {
 			return "ns-resize";
 		} else if (systemCursor == SystemCursor.Ibeam) {
 			return "text";
+		} else if (systemCursor == SystemCursor.NWSEResize) {
+			return "nwse-resize";
+		} else if (systemCursor == SystemCursor.NESWResize) {
+			return "nesw-resize";
+		} else if (systemCursor == SystemCursor.AllResize) {
+			return "move";
+		} else if (systemCursor == SystemCursor.NotAllowed) {
+			return "not-allowed";
 		} else {
 			throw new GdxRuntimeException("Unknown system cursor " + systemCursor);
 		}

--- a/gdx/src/com/badlogic/gdx/graphics/Cursor.java
+++ b/gdx/src/com/badlogic/gdx/graphics/Cursor.java
@@ -13,6 +13,6 @@ import com.badlogic.gdx.utils.Disposable;
 public interface Cursor extends Disposable {
 
 	public static enum SystemCursor {
-		Arrow, Ibeam, Crosshair, Hand, HorizontalResize, VerticalResize
+		Arrow, Ibeam, Crosshair, Hand, HorizontalResize, VerticalResize, NWSEResize, NESWResize, AllResize, NotAllowed
 	}
 }

--- a/tests/gdx-tests-gwt/src/com/badlogic/gdx/tests/gwt/client/GwtTestWrapper.java
+++ b/tests/gdx-tests-gwt/src/com/badlogic/gdx/tests/gwt/client/GwtTestWrapper.java
@@ -75,6 +75,7 @@ import com.badlogic.gdx.tests.SpriteBatchShaderTest;
 import com.badlogic.gdx.tests.SpriteCacheOffsetTest;
 import com.badlogic.gdx.tests.SpriteCacheTest;
 import com.badlogic.gdx.tests.StageTest;
+import com.badlogic.gdx.tests.SystemCursorTest;
 import com.badlogic.gdx.tests.TableTest;
 import com.badlogic.gdx.tests.TextAreaTest;
 import com.badlogic.gdx.tests.TextAreaTest2;
@@ -417,6 +418,10 @@ public class GwtTestWrapper extends AbstractTestWrapper {
 			}, new GwtInstancer() {
 				public GdxTest instance () {
 					return new StageTest();
+				}
+			}, new GwtInstancer() {
+				public GdxTest instance () {
+					return new SystemCursorTest();
 				}
 			},
 			// new GwtInstancer() {public GdxTest instance(){return new StagePerformanceTest();}}, // FIXME borks out

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/SystemCursorTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/SystemCursorTest.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogic.gdx.tests;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.Cursor;
+import com.badlogic.gdx.scenes.scene2d.Actor;
+import com.badlogic.gdx.scenes.scene2d.Stage;
+import com.badlogic.gdx.scenes.scene2d.ui.Skin;
+import com.badlogic.gdx.scenes.scene2d.ui.Table;
+import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
+import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
+import com.badlogic.gdx.tests.utils.GdxTest;
+import com.badlogic.gdx.utils.viewport.ScreenViewport;
+
+public class SystemCursorTest extends GdxTest {
+	private Stage stage;
+	private Skin skin;
+
+	@Override
+	public void create () {
+		super.create();
+		stage = new Stage(new ScreenViewport());
+		skin = new Skin(Gdx.files.internal("data/uiskin.json"));
+
+		Gdx.input.setInputProcessor(stage);
+
+		Table table = new Table();
+		table.setFillParent(true);
+		stage.addActor(table);
+
+		for (final Cursor.SystemCursor cursor : Cursor.SystemCursor.values()) {
+			TextButton button = new TextButton(cursor.name(), skin);
+			button.addListener(new ChangeListener() {
+				@Override
+				public void changed (ChangeEvent event, Actor actor) {
+					Gdx.graphics.setSystemCursor(cursor);
+				}
+			});
+			table.add(button).row();
+		}
+	}
+
+	@Override
+	public void render () {
+		super.render();
+		stage.act();
+		stage.draw();
+	}
+
+	@Override
+	public void resize (int width, int height) {
+		super.resize(width, height);
+		stage.getViewport().update(width, height, true);
+	}
+
+	@Override
+	public void dispose () {
+		super.dispose();
+		stage.dispose();
+		skin.dispose();
+	}
+}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
@@ -252,6 +252,7 @@ public class GdxTests {
 		StagePerformanceTest.class,
 		StageTest.class,
 		SuperKoalio.class,
+		SystemCursorTest.class,
 		TableLayoutTest.class,
 		TableTest.class,
 		TangentialAccelerationTest.class,


### PR DESCRIPTION
This PR:
- adds the `NWSEResize`, `NESWResize`, `AllResize`, and `NotAllowed` `SystemCursor`s, which are now available since LWJGL 3.3.0
- adds a `SystemCursorTest`

Tested on LWJGL 3 and GWT.