### PR TITLE
LWJGL3: Add errorStream option to initializeGlfw

### DIFF
--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
@@ -75,10 +75,17 @@ public class Lwjgl3Application implements Lwjgl3ApplicationBase {
 	private static Callback glDebugCallback;
 	private final Sync sync;
 
-	static void initializeGlfw () {
+	public static void initializeGlfw () {
+		initializeGlfw(System.err);
+	}
+
+	public static void initializeGlfw (PrintStream errorStream) {
+		if (errorStream != System.err && errorCallback != null) {
+			throw new GdxRuntimeException("errorCallback already set");
+		}
 		if (errorCallback == null) {
 			Lwjgl3NativesLoader.load();
-			errorCallback = GLFWErrorCallback.createPrint(System.err);
+			errorCallback = GLFWErrorCallback.createPrint(errorStream);
 			GLFW.glfwSetErrorCallback(errorCallback);
 			GLFW.glfwInitHint(GLFW.GLFW_JOYSTICK_HAT_BUTTONS, GLFW.GLFW_FALSE);
 			if (!GLFW.glfwInit()) {

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
@@ -75,17 +75,10 @@ public class Lwjgl3Application implements Lwjgl3ApplicationBase {
 	private static Callback glDebugCallback;
 	private final Sync sync;
 
-	public static void initializeGlfw () {
-		initializeGlfw(System.err);
-	}
-
-	public static void initializeGlfw (PrintStream errorStream) {
-		if (errorStream != System.err && errorCallback != null) {
-			throw new GdxRuntimeException("errorCallback already set");
-		}
+	static void initializeGlfw () {
 		if (errorCallback == null) {
 			Lwjgl3NativesLoader.load();
-			errorCallback = GLFWErrorCallback.createPrint(errorStream);
+			errorCallback = GLFWErrorCallback.createPrint(Lwjgl3ApplicationConfiguration.errorStream);
 			GLFW.glfwSetErrorCallback(errorCallback);
 			GLFW.glfwInitHint(GLFW.GLFW_JOYSTICK_HAT_BUTTONS, GLFW.GLFW_FALSE);
 			if (!GLFW.glfwInit()) {

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3ApplicationConfiguration.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3ApplicationConfiguration.java
@@ -38,6 +38,8 @@ import com.badlogic.gdx.graphics.glutils.HdpiMode;
 import com.badlogic.gdx.graphics.glutils.HdpiUtils;
 
 public class Lwjgl3ApplicationConfiguration extends Lwjgl3WindowConfiguration {
+	public static PrintStream errorStream = System.err;
+
 	boolean disableAudio = false;
 
 	/** The maximum number of threads to use for network requests. Default is {@link Integer#MAX_VALUE}. */


### PR DESCRIPTION
Making this method public will allow a user to call it manually to override the PrintStream used for the error callback.

Due to how we call this early in [Lwjgl3ApplicationConfiguration#L263](https://github.com/libgdx/libgdx/blob/master/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3ApplicationConfiguration.java#L263) we can't really make it a normal `Lwjgl3ApplicationConfiguration` option.

I'm open to feedback or suggestions on how to handle this better.