### PR TITLE
 Allow setting null to a bullet body shape

### DIFF
--- a/extensions/gdx-bullet/jni/swig/collision/btCollisionObject.i
+++ b/extensions/gdx-bullet/jni/swig/collision/btCollisionObject.i
@@ -122,7 +122,9 @@
 		if (collisionShape != null)
 			collisionShape.release();
 		collisionShape = shape;
-		collisionShape.obtain();
+		if(collisionShape != null) {
+			collisionShape.obtain();
+		}
 	}
 	
 	public btCollisionShape getCollisionShape() {


### PR DESCRIPTION
Small fix to allow setting null to a body shape.