### PR TITLE
Move Uberjar creation task out of Android tests.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,21 +90,7 @@ allprojects {
         tasks.withType(Javadoc) {
             options.addStringOption('Xdoclint:none,-missing', '-quiet')
         }
-    }   
-
-    tasks.register('uberJar', Jar) {
-        archiveClassifier = ''
-        archiveVersion = ''
-        duplicatesStrategy = 'warn'
-
-
-        from sourceSets.main.output
-
-        dependsOn configurations.runtimeClasspath
-        from {
-            configurations.runtimeClasspath.findAll { it.name.endsWith('jar') && !it.name.endsWith("gdx-" + project.version + ".jar") && !it.name.contains("platform") }.collect { println it; zipTree(it) }
-        }
-    } 
+    }
 }
 
 configure(subprojects - project(":tests:gdx-tests-android")) {
@@ -131,6 +117,19 @@ configure(subprojects - project(":tests:gdx-tests-android")) {
         groovyGradle {
             target '*.gradle'
             greclipse().configFile new File(rootProject.projectDir.absolutePath, 'eclipse-formatter.xml')
+        }
+    }
+
+    tasks.register('uberJar', Jar) {
+        archiveClassifier = ''
+        archiveVersion = ''
+        duplicatesStrategy = 'warn'
+
+        from sourceSets.main.output
+
+        dependsOn configurations.runtimeClasspath
+        from {
+            configurations.runtimeClasspath.findAll { it.name.endsWith('jar') && !it.name.endsWith("gdx-" + project.version + ".jar") && !it.name.contains("platform") }.collect { println it; zipTree(it) }
         }
     }
 }


### PR DESCRIPTION
This needs some review, but it allows the project to actually be imported by IDEA. I'm not 100% sure this is correct, which is why I'm PRing it. Without this change, @Berstanio and I both encountered the same issue in IDEA 2021.3.1, a MissingPropertyException:

Could not get unknown property 'main' for SourceSet container of type org.gradle.api.internal.tasks.DefaultSourceSetContainer.

In my case there was a line number, which pointed to a line containing `from sourceSets.main.output`, which apparently doesn't work properly with the Android support in IDEA. I moved the Uberjar creation task so it runs for all subprojects except the Android tests, since those should probably produce an APK or app bundle. I've never run the Android tests, so I'm not sure what to expect, but I'll start those up now, and get the PR in so people can actually edit files in their IDE of choice.