### PR TITLE
Add lwjgl3 extensions to publish.gradle

### DIFF
--- a/publish.gradle
+++ b/publish.gradle
@@ -11,6 +11,8 @@ configure([
 	project(":extensions:gdx-box2d-parent:gdx-box2d-gwt"),
 	project(":extensions:gdx-bullet"),
 	project(":extensions:gdx-freetype"),
+	project(":extensions:gdx-lwjgl3-angle"),
+	project(":extensions:gdx-lwjgl3-glfw-awt-macos"),
 	project(":extensions:gdx-tools")
 	])
 {


### PR DESCRIPTION
Was missed when adding the new projects. Normally we would have this match all subprojects, but libgdx's weird structure means specifying is better.