### PR TITLE
Remove inclusion of static libs into final app bunlde for iosrobovm test

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -140,13 +140,6 @@ testnatives.desktop = [
         files("extensions/gdx-freetype/libs/gdx-freetype-natives.jar")
 ]
 
-testnatives.ios = [
-        files("gdx/libs/ios32/"),
-        files("extensions/gdx-box2d/gdx-box2d/libs/ios32/"),
-        files("extensions/gdx-bullet/libs/ios32/"),
-        files("extensions/gdx-freetype/libs/ios32/")
-]
-
 gdxnatives.desktop = [
         files("gdx/libs/gdx-natives.jar")
 ]

--- a/tests/gdx-tests-iosrobovm/build.gradle
+++ b/tests/gdx-tests-iosrobovm/build.gradle
@@ -28,7 +28,6 @@ targetCompatibility = '1.7'
 dependencies {
 	implementation project(":tests:gdx-tests")
 	implementation project(":backends:gdx-backend-robovm")
-	implementation testnatives.ios
 }
 
 ext {


### PR DESCRIPTION
Prior to this the static libs would be included inside the final app bundle which is not a intended behavior.