### PR TITLE
Handle Android's MotionEvent.ACTION_CANCEL touch event as TouchEvent.TOUCH_UP

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidTouchHandler.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidTouchHandler.java
@@ -59,6 +59,7 @@ public class AndroidTouchHandler {
 				break;
 
 			case MotionEvent.ACTION_UP:
+			case MotionEvent.ACTION_CANCEL:
 			case MotionEvent.ACTION_POINTER_UP:
 			case MotionEvent.ACTION_OUTSIDE:
 				realPointerIndex = input.lookUpPointerIndex(pointerId);
@@ -76,18 +77,18 @@ public class AndroidTouchHandler {
 				input.touched[realPointerIndex] = false;
 				input.button[realPointerIndex] = 0;
 				input.pressure[realPointerIndex] = 0;
-				break;
 
-			case MotionEvent.ACTION_CANCEL:
-				for (int i = 0; i < input.realId.length; i++) {
-					input.realId[i] = -1;
-					input.touchX[i] = 0;
-					input.touchY[i] = 0;
-					input.deltaX[i] = 0;
-					input.deltaY[i] = 0;
-					input.touched[i] = false;
-					input.button[i] = 0;
-					input.pressure[i] = 0;
+				if (action == MotionEvent.ACTION_CANCEL) {
+					for (int i = 0; i < input.realId.length; i++) {
+						input.realId[i] = -1;
+						input.touchX[i] = 0;
+						input.touchY[i] = 0;
+						input.deltaX[i] = 0;
+						input.deltaY[i] = 0;
+						input.touched[i] = false;
+						input.button[i] = 0;
+						input.pressure[i] = 0;
+					}
 				}
 				break;
 


### PR DESCRIPTION
Resolves an issue introduced in https://github.com/libgdx/libgdx/pull/5222

We have to map MotionEvent.ACTION_CANCEL to TouchEvent.TOUCH_UP because there's no corresponding event in LibGdx's TouchEvent.

https://developer.android.com/reference/android/view/MotionEvent#ACTION_CANCEL
Android docs for MotionEvent.ACTION_CANCEL:
The current gesture has been aborted. You will not receive any more points in it. You should treat this as an up event, but not perform any action that you normally would.
