### PR TITLE
Tests: Add scroll bar; extend to window edge

### DIFF
--- a/tests/gdx-tests-gwt/src/com/badlogic/gdx/tests/gwt/client/GwtTestStarter.java
+++ b/tests/gdx-tests-gwt/src/com/badlogic/gdx/tests/gwt/client/GwtTestStarter.java
@@ -25,6 +25,7 @@ public class GwtTestStarter extends GwtApplication {
 	public GwtApplicationConfiguration getConfig () {
 		GwtApplicationConfiguration config = new GwtApplicationConfiguration(true);
 		config.useGyroscope = true;
+		config.padHorizontal = 0;
 		config.padVertical = 150;
 		// config.openURLInNewWindow = true;
 		return config;

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/AbstractTestWrapper.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/AbstractTestWrapper.java
@@ -62,6 +62,7 @@ public abstract class AbstractTestWrapper extends GdxTest {
 		container.debug();
 		Table table = new Table();
 		ScrollPane scroll = new ScrollPane(table);
+		scroll.setScrollbarsVisible(true);
 		container.add(scroll).expand().fill();
 		container.setFillParent(true);
 		table.pad(10).defaults().expandX().space(4);


### PR DESCRIPTION
Quick pull request to do a couple small things regarding the tests:

* Add a scroll bar. I found it annoying having to swipe with my mouse, and doing so in the browser caused me to accidentally select the text above the canvas, impeding further swipes.
* GWT: Extend to the window edge. This doesn't cause anything to get lost off the size of the screen.