### PR TITLE
GWT: Turns preloadedAssets method into protected

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplication.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplication.java
@@ -163,7 +163,7 @@ public abstract class GwtApplication implements EntryPoint, Application {
 		preloadAssets();
 	}
 
-	void preloadAssets () {
+	protected void preloadAssets () {
 		final PreloaderCallback callback = getPreloaderCallback();
 		preloader = createPreloader();
 		preloader.preload("assets.txt", new PreloaderCallback() {


### PR DESCRIPTION
This change allows GWT applications to skip the preload step or change the way it's done.