### PR TITLE
gdx-tests-android will fallback to simple project when android-sdk is unavailable

### DIFF
--- a/tests/gdx-tests-android/build.gradle
+++ b/tests/gdx-tests-android/build.gradle
@@ -20,6 +20,34 @@ buildscript {
 	}
 }
 
+def localProperties = new File(rootProject.rootDir, "local.properties")
+def hasAndroidSDKDir = false
+if (localProperties.exists()) {
+    Properties properties = new Properties()
+    localProperties.withInputStream { instr ->
+        properties.load(instr)
+    }
+
+    def sdkDirProp = properties.getProperty('sdk.dir')
+
+    if (sdkDirProp != null) {
+        hasAndroidSDKDir = true;
+    } else {
+        sdkDirProp = properties.getProperty('android.dir')
+        if (sdkDirProp != null) {
+            hasAndroidSDKDir = true;
+        }
+    }
+}
+
+if(!hasAndroidSDKDir && System.getenv("ANDROID_HOME") == null && System.getenv("ANDROID_SDK_ROOT") == null) {
+    logger.warn("==============================================================================================");
+    logger.warn("sdk.dir/ANDROID_HOME/ANDROID_SDK_ROOT are unset, gdx-tests-android will not be properly setup.");
+    logger.warn("==============================================================================================");
+    apply plugin: "java-library"
+    return;
+}
+
 apply plugin: "com.android.application"
 apply from: "obb.gradle"
 


### PR DESCRIPTION
As requested on https://github.com/libgdx/libgdx/commit/facc7780be9b5cecde0a665fc9fb28ecdfa48429

Will simply pretend it's a normal java-library, and allow gradle to function for other projects without an android-sdk.

This was preferable to skipping the include due to further [references to the project](https://github.com/libgdx/libgdx/blob/facc7780be9b5cecde0a665fc9fb28ecdfa48429/build.gradle#L96)