### PR TITLE
GWT: Use canvasId if rootPanel is not defined

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplication.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplication.java
@@ -95,10 +95,6 @@ public abstract class GwtApplication implements EntryPoint, Application {
 		return GWT.getHostPageBaseURL() + "assets/";
 	}
 
-	protected String getRootId () {
-		return "embed-" + GWT.getModuleName();
-	}
-
 	@Override
 	public ApplicationListener getApplicationListener () {
 		return listener;
@@ -116,7 +112,7 @@ public abstract class GwtApplication implements EntryPoint, Application {
 		if (config.rootPanel != null) {
 			this.root = config.rootPanel;
 		} else {
-			Element element = Document.get().getElementById(getRootId());
+			Element element = Document.get().getElementById(this.config.canvasId);
 			int width;
 			int height;
 

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplication.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplication.java
@@ -98,7 +98,7 @@ public abstract class GwtApplication implements EntryPoint, Application {
 	protected String getRootId () {
 		return "embed-" + GWT.getModuleName();
 	}
-	
+
 	@Override
 	public ApplicationListener getApplicationListener () {
 		return listener;

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplication.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplication.java
@@ -95,6 +95,10 @@ public abstract class GwtApplication implements EntryPoint, Application {
 		return GWT.getHostPageBaseURL() + "assets/";
 	}
 
+	protected String getRootId () {
+		return "embed-" + GWT.getModuleName();
+	}
+	
 	@Override
 	public ApplicationListener getApplicationListener () {
 		return listener;
@@ -112,7 +116,7 @@ public abstract class GwtApplication implements EntryPoint, Application {
 		if (config.rootPanel != null) {
 			this.root = config.rootPanel;
 		} else {
-			Element element = Document.get().getElementById("embed-" + GWT.getModuleName());
+			Element element = Document.get().getElementById(getRootId());
 			int width;
 			int height;
 

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplicationConfiguration.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplicationConfiguration.java
@@ -18,6 +18,7 @@ package com.badlogic.gdx.backends.gwt;
 
 import com.badlogic.gdx.Application;
 import com.badlogic.gdx.backends.gwt.GwtGraphics.OrientationLockType;
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.ui.Panel;
 import com.google.gwt.user.client.ui.TextArea;
 
@@ -93,6 +94,7 @@ public class GwtApplicationConfiguration {
 		this.width = width;
 		this.height = height;
 		this.usePhysicalPixels = usePhysicalPixels;
+		this.canvasId = "embed-" + GWT.getModuleName();
 	}
 
 	public boolean isFixedSizeApplication () {


### PR DESCRIPTION
Useful (required) when you embedding the GWT application in an html element that already has an id defined.