### PR TITLE
fixed forced attributes type/normalize in GWT backend

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/graphics/glutils/VertexBufferObject.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/graphics/glutils/VertexBufferObject.java
@@ -157,13 +157,7 @@ public class VertexBufferObject implements VertexData {
 				final int location = shader.getAttributeLocation(attribute.alias);
 				if (location < 0) continue;
 				shader.enableVertexAttribute(location);
-
-				if (attribute.usage == Usage.ColorPacked)
-					shader.setVertexAttribute(location, attribute.numComponents, GL20.GL_UNSIGNED_BYTE, true, attributes.vertexSize,
-						attribute.offset);
-				else
-					shader.setVertexAttribute(location, attribute.numComponents, GL20.GL_FLOAT, false, attributes.vertexSize,
-						attribute.offset);
+				shader.setVertexAttribute(location, attribute.numComponents, attribute.type, attribute.normalized, attributes.vertexSize, attribute.offset);
 			}
 		} else {
 			for (int i = 0; i < numAttributes; i++) {
@@ -171,13 +165,7 @@ public class VertexBufferObject implements VertexData {
 				final int location = locations[i];
 				if (location < 0) continue;
 				shader.enableVertexAttribute(location);
-
-				if (attribute.usage == Usage.ColorPacked)
-					shader.setVertexAttribute(location, attribute.numComponents, GL20.GL_UNSIGNED_BYTE, true, attributes.vertexSize,
-						attribute.offset);
-				else
-					shader.setVertexAttribute(location, attribute.numComponents, GL20.GL_FLOAT, false, attributes.vertexSize,
-						attribute.offset);
+				shader.setVertexAttribute(location, attribute.numComponents, attribute.type, attribute.normalized, attributes.vertexSize, attribute.offset);
 			}
 		}
 		isBound = true;

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/graphics/glutils/VertexBufferObject.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/graphics/glutils/VertexBufferObject.java
@@ -22,7 +22,6 @@ import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.VertexAttribute;
 import com.badlogic.gdx.graphics.VertexAttributes;
-import com.badlogic.gdx.graphics.VertexAttributes.Usage;
 import com.badlogic.gdx.utils.BufferUtils;
 
 /**
@@ -157,7 +156,8 @@ public class VertexBufferObject implements VertexData {
 				final int location = shader.getAttributeLocation(attribute.alias);
 				if (location < 0) continue;
 				shader.enableVertexAttribute(location);
-				shader.setVertexAttribute(location, attribute.numComponents, attribute.type, attribute.normalized, attributes.vertexSize, attribute.offset);
+				shader.setVertexAttribute(location, attribute.numComponents, attribute.type, attribute.normalized,
+					attributes.vertexSize, attribute.offset);
 			}
 		} else {
 			for (int i = 0; i < numAttributes; i++) {
@@ -165,7 +165,8 @@ public class VertexBufferObject implements VertexData {
 				final int location = locations[i];
 				if (location < 0) continue;
 				shader.enableVertexAttribute(location);
-				shader.setVertexAttribute(location, attribute.numComponents, attribute.type, attribute.normalized, attributes.vertexSize, attribute.offset);
+				shader.setVertexAttribute(location, attribute.numComponents, attribute.type, attribute.normalized,
+					attributes.vertexSize, attribute.offset);
 			}
 		}
 		isBound = true;

--- a/tests/gdx-tests-gwt/src/com/badlogic/gdx/tests/gwt/client/GwtTestWrapper.java
+++ b/tests/gdx-tests-gwt/src/com/badlogic/gdx/tests/gwt/client/GwtTestWrapper.java
@@ -49,6 +49,7 @@ import com.badlogic.gdx.tests.LabelScaleTest;
 import com.badlogic.gdx.tests.LabelTest;
 import com.badlogic.gdx.tests.LifeCycleTest;
 import com.badlogic.gdx.tests.MeshShaderTest;
+import com.badlogic.gdx.tests.MeshWithCustomAttributesTest;
 import com.badlogic.gdx.tests.MipMapTest;
 import com.badlogic.gdx.tests.MultitouchTest;
 import com.badlogic.gdx.tests.MusicTest;
@@ -301,6 +302,10 @@ public class GwtTestWrapper extends AbstractTestWrapper {
 			new GwtInstancer() {
 				public GdxTest instance () {
 					return new MeshShaderTest();
+				}
+			}, new GwtInstancer() {
+				public GdxTest instance () {
+					return new MeshWithCustomAttributesTest();
 				}
 			}, new GwtInstancer() {
 				public GdxTest instance () {

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/MeshWithCustomAttributesTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/MeshWithCustomAttributesTest.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogic.gdx.tests;
+
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.Mesh;
+import com.badlogic.gdx.graphics.VertexAttribute;
+import com.badlogic.gdx.graphics.VertexAttributes;
+import com.badlogic.gdx.graphics.glutils.ShaderProgram;
+import com.badlogic.gdx.tests.utils.GdxTest;
+import com.badlogic.gdx.utils.ScreenUtils;
+
+public class MeshWithCustomAttributesTest extends GdxTest {
+	ShaderProgram shader;
+	Mesh mesh;
+
+	@Override
+	public void dispose () {
+		mesh.dispose();
+		shader.dispose();
+	}
+
+	@Override
+	public void render () {
+		ScreenUtils.clear(Color.BLACK, true);
+
+		shader.bind();
+		mesh.render(shader, GL20.GL_TRIANGLES);
+	}
+
+	@Override
+	public void create () {
+		//@off
+		String vertexShader = 
+			  "attribute vec4 a_position;    \n"
+			+ "attribute vec4 a_color;\n"
+			+ "varying vec4 v_color; \n"
+			+ "void main()                  \n"
+			+ "{                            \n"
+			+ "   v_color = a_color; \n"
+			+ "   gl_Position =  a_position;  \n"
+			+ "}                            \n";
+		String fragmentShader = 
+			  "#ifdef GL_ES\n"
+			+ "precision mediump float;\n"
+			+ "#endif\n" 
+			+ "varying vec4 v_color;\n"
+			+ "void main()                                  \n"
+			+ "{                                            \n" 
+			+ "  gl_FragColor = vec4(v_color.rgb, 1.0);\n"
+			+ "}";
+
+		mesh = new Mesh(true, 3, 0, 
+			new VertexAttribute(VertexAttributes.Usage.Position, 2, "a_position"),
+			new VertexAttribute(VertexAttributes.Usage.ColorUnpacked, 4, GL20.GL_UNSIGNED_BYTE, true, "a_color"));
+		
+		float[] vertices = new float[] {
+			-1, -1, Color.toFloatBits(254, 0, 0, 0),
+			 0,  1, Color.toFloatBits(0, 254, 0, 0), 
+			 1, -1, Color.toFloatBits(0, 0, 254, 0)};
+		//@on
+		shader = new ShaderProgram(vertexShader, fragmentShader);
+		mesh.setVertices(vertices);
+	}
+
+}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
@@ -186,6 +186,7 @@ public class GdxTests {
 		MatrixJNITest.class,
 		MeshBuilderTest.class,
 		MeshShaderTest.class,
+		MeshWithCustomAttributesTest.class,
 		MipMapTest.class,
 		ModelTest.class,
 		ModelCacheTest.class,


### PR DESCRIPTION
Vertex attributes type and normalisation was forced (not respected) in GWT backend for no reason which prevent use of custom types (byte, short, etc...).

Context: We faced this issue because gdx-gltf extension now uses unpacked color with normalized unsigned short instead of floats for vertex color (due to recent changes in Blender and GLTF exporter) which breaks with GWT backend. 
