### PR TITLE
Fixes music not looping when setting setLooping() before first play()

### DIFF
--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSMusic.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSMusic.java
@@ -59,7 +59,7 @@ public class IOSMusic implements Music {
 			// OALAudioTrack needs to execute preloadURL() once to store the file path. From then on we avoid
 			// calling it again to avoid instantiating a new AVAudioPlayer every time.
 			if (!initialized) {
-				if (looping)
+				if (!looping)
 					initialized = track.playFile(filePath);
 				else
 					initialized = track.playFile(filePath, -1);

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSMusic.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSMusic.java
@@ -28,6 +28,7 @@ public class IOSMusic implements Music {
 	private final OALAudioTrack track;
 	private final String filePath;
 	private boolean initialized;
+	private boolean looping;
 	OnCompletionListener onCompletionListener;
 
 	public IOSMusic (OALAudioTrack track, String filePath) {
@@ -58,7 +59,10 @@ public class IOSMusic implements Music {
 			// OALAudioTrack needs to execute preloadURL() once to store the file path. From then on we avoid
 			// calling it again to avoid instantiating a new AVAudioPlayer every time.
 			if (!initialized) {
-				initialized = track.playFile(filePath);
+				if (looping)
+					initialized = track.playFile(filePath);
+				else
+					initialized = track.playFile(filePath, -1);
 				if (!initialized) {
 					Gdx.app.error("IOSMusic", "Unable to initialize music " + filePath);
 				}
@@ -88,6 +92,7 @@ public class IOSMusic implements Music {
 	@Override
 	public void setLooping (boolean isLooping) {
 		track.setNumberOfLoops(isLooping ? -1 : 0);
+		looping = isLooping;
 	}
 
 	@Override

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/objectal/OALAudioTrack.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/objectal/OALAudioTrack.java
@@ -50,6 +50,9 @@ public class OALAudioTrack extends NSObject {
 	@Method
 	public native boolean playFile (String filePath);
 
+	@Method(selector = "playFile:loops:")
+	public native boolean playFile (String filePath, int numberOfLoops);
+
 	@Property
 	public native boolean isPaused ();
 


### PR DESCRIPTION
#6654 Introduced an issue causing music not to loop when setting `setLooping(true)` before first `play()`. ObjectAL is a bit weird because the only thing that can't be set beforehand when calling `playFromFile()` is `numberOfLoops` and if not passed is set to 0 instead of taking the value of the property

This is the relevant code on [https://github.com/kstenerud/ObjectAL-for-iPhone/blob/master/ObjectAL/ObjectAL/AudioTrack/OALAudioTrack.m](OALAudioTrack).

```
- (bool) playUrl:(NSURL*) url
{
	return [self playUrl:url loops:0];
}
```

Basically the fix is to store if `looping` has been set in order to pass it on first `play`.
