### PR TITLE
Fix crash if there more than one app launched with ANGLE emulation

### DIFF
--- a/extensions/gdx-lwjgl3-angle/src/com/badlogic/gdx/backends/lwjgl3/angle/ANGLELoader.java
+++ b/extensions/gdx-lwjgl3-angle/src/com/badlogic/gdx/backends/lwjgl3/angle/ANGLELoader.java
@@ -46,8 +46,8 @@ public class ANGLELoader {
 			}
 		}
 	}
-	
-	public static boolean compare(InputStream input1, InputStream input2) throws IOException {
+
+	public static boolean compare (InputStream input1, InputStream input2) throws IOException {
 		int b = 0;
 		while ((b = input1.read()) != -1) {
 			if (b != input2.read()) {
@@ -104,13 +104,13 @@ public class ANGLELoader {
 					}
 					hasCompared = true;
 				}
-				
+
 				// Reset input stream by creating a new stream.
 				if (hasCompared) {
 					closeQuietly(inSrc);
 					inSrc = ANGLELoader.class.getResourceAsStream("/" + sourcePath);
 				}
-				
+
 				out = new FileOutputStream(outFile);
 				byte[] buffer = new byte[4096];
 				while (true) {

--- a/extensions/gdx-lwjgl3-angle/src/com/badlogic/gdx/backends/lwjgl3/angle/ANGLELoader.java
+++ b/extensions/gdx-lwjgl3-angle/src/com/badlogic/gdx/backends/lwjgl3/angle/ANGLELoader.java
@@ -74,7 +74,7 @@ public class ANGLELoader {
 				"Couldn't create ANGLE native library output directory " + outFile.getParentFile().getAbsolutePath());
 			OutputStream out = null;
 			InputStream in = null;
-			
+
 			if (outFile.exists()) {
 				return outFile;
 			}

--- a/extensions/gdx-lwjgl3-angle/src/com/badlogic/gdx/backends/lwjgl3/angle/ANGLELoader.java
+++ b/extensions/gdx-lwjgl3-angle/src/com/badlogic/gdx/backends/lwjgl3/angle/ANGLELoader.java
@@ -47,16 +47,6 @@ public class ANGLELoader {
 		}
 	}
 
-	public static boolean compare (InputStream input1, InputStream input2) throws IOException {
-		int b = 0;
-		while ((b = input1.read()) != -1) {
-			if (b != input2.read()) {
-				return false;
-			}
-		}
-		return input2.read() == -1;
-	}
-
 	static String randomUUID () {
 		return new UUID(random.nextLong(), random.nextLong()).toString();
 	}
@@ -83,42 +73,25 @@ public class ANGLELoader {
 			if (!outFile.getParentFile().exists() && !outFile.getParentFile().mkdirs()) throw new GdxRuntimeException(
 				"Couldn't create ANGLE native library output directory " + outFile.getParentFile().getAbsolutePath());
 			OutputStream out = null;
-			InputStream inSrc = null;
-			InputStream inFile = null;
+			InputStream in = null;
+			
+			if (outFile.exists()) {
+				return outFile;
+			}
 
 			try {
-				inSrc = ANGLELoader.class.getResourceAsStream("/" + sourcePath);
-				boolean hasCompared = false;
-				if (!outFile.canWrite() && outFile.exists()) {
-					inFile = new BufferedInputStream(new FileInputStream(outFile));
-					try {
-						if (compare(inSrc, inFile)) {
-							return outFile;
-						}
-					} finally {
-						closeQuietly(inFile);
-					}
-					hasCompared = true;
-				}
-
-				// Reset input stream by creating a new stream.
-				if (hasCompared) {
-					closeQuietly(inSrc);
-					inSrc = ANGLELoader.class.getResourceAsStream("/" + sourcePath);
-				}
-
 				out = new FileOutputStream(outFile);
+				in = ANGLELoader.class.getResourceAsStream("/" + sourcePath);
 				byte[] buffer = new byte[4096];
 				while (true) {
-					int length = inSrc.read(buffer);
+					int length = in.read(buffer);
 					if (length == -1) break;
 					out.write(buffer, 0, length);
 				}
 				return outFile;
 			} finally {
 				closeQuietly(out);
-				closeQuietly(inSrc);
-				closeQuietly(inFile);
+				closeQuietly(in);
 			}
 		} catch (Throwable t) {
 			throw new GdxRuntimeException("Couldn't load ANGLE shared library " + sourcePath, t);

--- a/extensions/gdx-lwjgl3-angle/src/com/badlogic/gdx/backends/lwjgl3/angle/ANGLELoader.java
+++ b/extensions/gdx-lwjgl3-angle/src/com/badlogic/gdx/backends/lwjgl3/angle/ANGLELoader.java
@@ -54,11 +54,7 @@ public class ANGLELoader {
 				return false;
 			}
 		}
-		if (input2.read() == -1) {
-			return true;
-		} else {
-			return false;
-		}
+		return input2.read() == -1;
 	}
 
 	static String randomUUID () {


### PR DESCRIPTION
By simply checking if the file exists. It should allow to run more than one app and launch the app with RenderDoc.

Note: This change is untested, and I don't how to test it.
Fixes #6804