### PR TITLE
Make `AudioRecorder` request runtime permission

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidAudioRecorder.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidAudioRecorder.java
@@ -16,40 +16,99 @@
 
 package com.badlogic.gdx.backends.android;
 
+import android.Manifest;
+import android.app.Activity;
+import android.content.Context;
+import android.content.pm.PackageManager;
 import android.media.AudioFormat;
 import android.media.AudioRecord;
 import android.media.MediaRecorder;
+import android.os.Build;
 
+import androidx.core.app.ActivityCompat;
+import androidx.core.content.ContextCompat;
+
+import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.audio.AudioRecorder;
-import com.badlogic.gdx.utils.GdxRuntimeException;
+
+import java.util.Arrays;
 
 /** {@link AudioRecorder} implementation for the android system based on AudioRecord
  * @author badlogicgames@gmail.com */
-public class AndroidAudioRecorder implements AudioRecorder {
+public class AndroidAudioRecorder implements AudioRecorder, ActivityCompat.OnRequestPermissionsResultCallback {
 	/** the audio track we read samples from **/
 	private AudioRecord recorder;
 
-	public AndroidAudioRecorder (int samplingRate, boolean isMono) {
-		int channelConfig = isMono ? AudioFormat.CHANNEL_IN_MONO : AudioFormat.CHANNEL_IN_STEREO;
-		int minBufferSize = AudioRecord.getMinBufferSize(samplingRate, channelConfig, AudioFormat.ENCODING_PCM_16BIT);
-		recorder = new AudioRecord(MediaRecorder.AudioSource.MIC, samplingRate, channelConfig, AudioFormat.ENCODING_PCM_16BIT,
-			minBufferSize);
-		if (recorder.getState() != AudioRecord.STATE_INITIALIZED)
-			throw new GdxRuntimeException("Unable to initialize AudioRecorder.\nDo you have the RECORD_AUDIO permission?");
-		recorder.startRecording();
+	private final Context context;
+	private final Activity activity;
+	private static final String permission = Manifest.permission.RECORD_AUDIO;
+	private static final String[] permissions = new String[]{ permission };
+	private static final int REQUEST_CODE = 1;
+
+	public AndroidAudioRecorder (int samplingRate, boolean isMono, Context context) {
+		this(samplingRate, isMono, context, true);
 	}
 
-	@Override
-	public void dispose () {
-		recorder.stop();
-		recorder.release();
+	int channelConfig, minBufferSize, samplingRate;
+
+	public AndroidAudioRecorder (int samplingRate, boolean isMono, Context context, boolean requestPermission) {
+		this.context = context;
+		this.activity = (Activity) context;
+
+		this.samplingRate = samplingRate;
+		channelConfig = isMono ? AudioFormat.CHANNEL_IN_MONO : AudioFormat.CHANNEL_IN_STEREO;
+		minBufferSize = AudioRecord.getMinBufferSize(samplingRate, channelConfig, AudioFormat.ENCODING_PCM_16BIT);
+
+		if (requestPermission) requestPermission();
 	}
 
 	@Override
 	public void read (short[] samples, int offset, int numSamples) {
-		int read = 0;
-		while (read != numSamples) {
-			read += recorder.read(samples, offset + read, numSamples - read);
+		if (recorder != null && recorder.getRecordingState() == AudioRecord.RECORDSTATE_RECORDING) {
+			int read = 0;
+			while (read != numSamples) {
+				read += recorder.read(samples, offset + read, numSamples - read);
+			}
+		} else {
+			Arrays.fill(samples, (short) 0);
+		}
+	}
+
+	@Override
+	public Permissions hasPermission () {
+		if (ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED) {
+			return Permissions.GRANTED;
+		} else if (ActivityCompat.shouldShowRequestPermissionRationale(activity, permission)) {
+			return Permissions.RATIONALE;
+		} else {
+			return Permissions.DENIED;
+		}
+	}
+
+	@Override
+	public Permissions requestPermission () {
+		Permissions permissionStatus = hasPermission();
+		if (Build.VERSION.SDK_INT >= 23 && permissionStatus != Permissions.GRANTED) {
+			ActivityCompat.requestPermissions(activity, permissions, REQUEST_CODE);
+		}
+		return permissionStatus;
+	}
+
+	@Override
+	public void dispose () {
+		if (recorder.getState() == AudioRecord.STATE_INITIALIZED) {
+			recorder.stop();
+			recorder.release();
+		}
+	}
+
+	@Override
+	public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
+		Gdx.app.log("pine", "a");
+		if (requestCode == REQUEST_CODE && Arrays.equals(permissions, AndroidAudioRecorder.permissions)) {
+			recorder = new AudioRecord(MediaRecorder.AudioSource.MIC, samplingRate, channelConfig, AudioFormat.ENCODING_PCM_16BIT,
+																 minBufferSize);
+			recorder.startRecording();
 		}
 	}
 

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/DefaultAndroidAudio.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/DefaultAndroidAudio.java
@@ -45,9 +45,11 @@ import java.util.List;
 public class DefaultAndroidAudio implements AndroidAudio {
 	private final SoundPool soundPool;
 	private final AudioManager manager;
-	private final List<AndroidMusic> musics = new ArrayList<AndroidMusic>();
+	private final List<AndroidMusic> musics = new ArrayList<>();
+	private final Context context;
 
 	public DefaultAndroidAudio (Context context, AndroidApplicationConfiguration config) {
+		this.context = context;
 		if (!config.disableAudio) {
 			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
 				AudioAttributes audioAttrib = new AudioAttributes.Builder().setUsage(AudioAttributes.USAGE_GAME)
@@ -210,7 +212,16 @@ public class DefaultAndroidAudio implements AndroidAudio {
 		if (soundPool == null) {
 			throw new GdxRuntimeException("Android audio is not enabled by the application config.");
 		}
-		return new AndroidAudioRecorder(samplingRate, isMono);
+		return new AndroidAudioRecorder(samplingRate, isMono, context);
+	}
+
+	/** {@inheritDoc} */
+	@Override
+	public AudioRecorder newAudioRecorder (int samplingRate, boolean isMono, boolean requestPermission) {
+		if (soundPool == null) {
+			throw new GdxRuntimeException("Android audio is not enabled by the application config.");
+		}
+		return new AndroidAudioRecorder(samplingRate, isMono, context, requestPermission);
 	}
 
 	/** Kills the soundpool and all other resources */

--- a/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/mock/audio/MockAudioRecorder.java
+++ b/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/mock/audio/MockAudioRecorder.java
@@ -28,6 +28,16 @@ public class MockAudioRecorder implements AudioRecorder {
 	}
 
 	@Override
+	public Permissions hasPermission() {
+		return Permissions.DENIED;
+	}
+
+	@Override
+	public Permissions requestPermission () {
+		return hasPermission();
+	}
+
+	@Override
 	public void dispose () {
 
 	}

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/audio/JavaSoundAudioRecorder.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/audio/JavaSoundAudioRecorder.java
@@ -30,9 +30,13 @@ public class JavaSoundAudioRecorder implements AudioRecorder {
 	private byte[] buffer = new byte[1024 * 4];
 
 	public JavaSoundAudioRecorder (int samplingRate, boolean isMono) {
+		this(samplingRate, isMono, true);
+	}
+
+	public JavaSoundAudioRecorder (int samplingRate, boolean isMono, boolean requestPermission) {
 		try {
 			AudioFormat format = new AudioFormat(Encoding.PCM_SIGNED, samplingRate, 16, isMono ? 1 : 2, isMono ? 2 : 4, samplingRate,
-				false);
+																					 false);
 			line = AudioSystem.getTargetDataLine(format);
 			line.open(format, buffer.length);
 			line.start();
@@ -51,6 +55,14 @@ public class JavaSoundAudioRecorder implements AudioRecorder {
 
 		for (int i = 0, j = 0; i < numSamples * 2; i += 2, j++)
 			samples[offset + j] = (short)((buffer[i + 1] << 8) | (buffer[i] & 0xff));
+	}
+
+	public Permissions hasPermission () {
+		return Permissions.GRANTED;
+	}
+
+	public Permissions requestPermission () {
+		return hasPermission();
 	}
 
 	public void dispose () {

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/audio/OpenALLwjglAudio.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/audio/OpenALLwjglAudio.java
@@ -336,16 +336,30 @@ public class OpenALLwjglAudio implements LwjglAudio {
 	}
 
 	public AudioRecorder newAudioRecorder (int samplingRate, boolean isMono) {
+		return newAudioRecorder(samplingRate, isMono, true);
+	}
+
+	public AudioRecorder newAudioRecorder(int samplingRate, boolean isMono, boolean requestPermission) {
 		if (noDevice) return new AudioRecorder() {
 			@Override
 			public void read (short[] samples, int offset, int numSamples) {
 			}
 
 			@Override
+			public Permissions hasPermission() {
+				return Permissions.DENIED;
+			}
+
+			@Override
+			public Permissions requestPermission() {
+				return hasPermission();
+			}
+
+			@Override
 			public void dispose () {
 			}
 		};
-		return new JavaSoundAudioRecorder(samplingRate, isMono);
+		return new JavaSoundAudioRecorder(samplingRate, isMono, requestPermission);
 	}
 
 	/** Retains a list of the most recently played sounds and stops the sound played least recently if necessary for a new sound to

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/JavaSoundAudioRecorder.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/JavaSoundAudioRecorder.java
@@ -30,9 +30,13 @@ public class JavaSoundAudioRecorder implements AudioRecorder {
 	private byte[] buffer = new byte[1024 * 4];
 
 	public JavaSoundAudioRecorder (int samplingRate, boolean isMono) {
+		this(samplingRate, isMono, true);
+	}
+
+	public JavaSoundAudioRecorder (int samplingRate, boolean isMono, boolean requestPermission) {
 		try {
 			AudioFormat format = new AudioFormat(Encoding.PCM_SIGNED, samplingRate, 16, isMono ? 1 : 2, isMono ? 2 : 4, samplingRate,
-				false);
+																					 false);
 			line = AudioSystem.getTargetDataLine(format);
 			line.open(format, buffer.length);
 			line.start();
@@ -51,6 +55,14 @@ public class JavaSoundAudioRecorder implements AudioRecorder {
 
 		for (int i = 0, j = 0; i < numSamples * 2; i += 2, j++)
 			samples[offset + j] = (short)((buffer[i + 1] << 8) | (buffer[i] & 0xff));
+	}
+
+	public Permissions hasPermission () {
+		return Permissions.GRANTED;
+	}
+
+	public Permissions requestPermission () {
+		return hasPermission();
 	}
 
 	public void dispose () {

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALLwjgl3Audio.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALLwjgl3Audio.java
@@ -360,16 +360,30 @@ public class OpenALLwjgl3Audio implements Lwjgl3Audio {
 	}
 
 	public AudioRecorder newAudioRecorder (int samplingRate, boolean isMono) {
+		return newAudioRecorder(samplingRate, isMono, true);
+	}
+
+	public AudioRecorder newAudioRecorder (int samplingRate, boolean isMono, boolean requestPermission) {
 		if (noDevice) return new AudioRecorder() {
 			@Override
 			public void read (short[] samples, int offset, int numSamples) {
 			}
 
 			@Override
+			public Permissions hasPermission() {
+				return Permissions.DENIED;
+			}
+
+			@Override
+			public Permissions requestPermission() {
+				return hasPermission();
+			}
+
+			@Override
 			public void dispose () {
 			}
 		};
-		return new JavaSoundAudioRecorder(samplingRate, isMono);
+		return new JavaSoundAudioRecorder(samplingRate, isMono, requestPermission);
 	}
 
 	/** Retains a list of the most recently played sounds and stops the sound played least recently if necessary for a new sound to

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/mock/MockAudioRecorder.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/mock/MockAudioRecorder.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,6 +25,16 @@ public class MockAudioRecorder implements AudioRecorder {
 	@Override
 	public void read (short[] samples, int offset, int numSamples) {
 
+	}
+
+	@Override
+	public Permissions hasPermission() {
+		return Permissions.DENIED;
+	}
+
+	@Override
+	public Permissions requestPermission () {
+		return hasPermission();
 	}
 
 	@Override

--- a/gdx/src/com/badlogic/gdx/Audio.java
+++ b/gdx/src/com/badlogic/gdx/Audio.java
@@ -57,6 +57,16 @@ public interface Audio {
 	 * @throws GdxRuntimeException in case the recorder could not be created */
 	public AudioRecorder newAudioRecorder (int samplingRate, boolean isMono);
 
+	/** Creates a new {@link AudioRecorder}. The AudioRecorder has to be disposed after it is no longer used.
+	 *
+	 * @param samplingRate the sampling rate in Hertz
+	 * @param isMono whether the recorder records in mono or stereo
+	 * @param requestPermission whether to request RECORD_AUDIO permission on Android
+	 * @return the AudioRecorder
+	 *
+	 * @throws GdxRuntimeException in case the recorder could not be created */
+	public AudioRecorder newAudioRecorder (int samplingRate, boolean isMono, boolean requestPermission);
+
 	/**
 	 * <p>
 	 * Creates a new {@link Sound} which is used to play back audio effects such as gun shots or explosions. The Sound's audio data

--- a/gdx/src/com/badlogic/gdx/audio/AudioRecorder.java
+++ b/gdx/src/com/badlogic/gdx/audio/AudioRecorder.java
@@ -24,6 +24,8 @@ import com.badlogic.gdx.utils.Disposable;
  * 
  * @author mzechner */
 public interface AudioRecorder extends Disposable {
+	enum Permissions {GRANTED, RATIONALE, DENIED};
+
 	/** Reads in numSamples samples into the array samples starting at offset. If the recorder is in stereo you have to multiply
 	 * numSamples by 2.
 	 * 
@@ -31,6 +33,20 @@ public interface AudioRecorder extends Disposable {
 	 * @param offset the offset into the array
 	 * @param numSamples the number of samples to be read */
 	public void read (short[] samples, int offset, int numSamples);
+
+	/** Checks if RECORD_AUDIO permission has been granted on Android 6+.
+	 * If it returns RATIONALE, it is recommended to tell the user why you need microphone access.
+	 * @return GRANTED if has permission or is on on desktop backend;
+	 *         RATIONALE if user has previously denied permission;
+	 *         DENIED if user has permanently denied permission or is on headless backend.
+	 */
+	public Permissions hasPermission ();
+
+	/** Requests RECORD_AUDIO permission on Android 6+.
+	 * On older versions, you must add <code><uses-permission android:name="android.permission.RECORD_AUDIO" /></code> to the manifest.
+	 * @return {@link #hasPermission()}
+	 */
+	public Permissions requestPermission ();
 
 	/** Disposes the AudioRecorder */
 	public void dispose ();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/AudioRecorderTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/AudioRecorderTest.java
@@ -19,18 +19,25 @@ package com.badlogic.gdx.tests;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.audio.AudioDevice;
 import com.badlogic.gdx.audio.AudioRecorder;
+import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.g2d.BitmapFont;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.tests.utils.GdxTest;
+import com.badlogic.gdx.utils.ScreenUtils;
 
 public class AudioRecorderTest extends GdxTest {
 	short[] samples = new short[1024 * 4];
 	AudioDevice device;
 	AudioRecorder recorder;
 
+	SpriteBatch batch;
+	BitmapFont font;
+
 	@Override
 	public void create () {
 		device = Gdx.audio.newAudioDevice(44100, true);
-		recorder = Gdx.audio.newAudioRecorder(44100, true);
+		recorder = Gdx.audio.newAudioRecorder(44100, true, false);
 
 		Thread t = new Thread(new Runnable() {
 
@@ -44,11 +51,23 @@ public class AudioRecorderTest extends GdxTest {
 		});
 		t.setDaemon(true);
 		t.start();
-	}
 
+		batch = new SpriteBatch();
+		font = new BitmapFont();
+		font.getData().setScale(Gdx.graphics.getDensity() * 2);
+	}
+boolean touched = false;
 	@Override
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		if (Gdx.input.isTouched() && !touched) {
+			recorder.requestPermission();
+			touched = true;
+		}
+
+		ScreenUtils.clear(Color.BLACK);
+		batch.begin();
+		font.draw(batch, recorder.hasPermission().toString(), 50, Gdx.graphics.getBackBufferHeight() - 50);
+		batch.end();
 	}
 
 	@Override


### PR DESCRIPTION
I've opened this pull request as a draft to ask for help. The current state of this is the `RECORD_AUDIO` permission gets asked, but GDX Tests returns to the menu screen to do so rather than remain "in-game" as it were. Also, `onRequestPermissionsResult()` never gets called, which is a big problem!

The Google way would be to use `registerForActivityResult()` but I wasn't able to get that working even after adding the `androidx.activity` dependency, and I expect there might be some objections to adding `androidx.appcompat`.

Anyway, if I move the `recorder.startRecording()` lines about, I'm able to coax it into echoing the microphone on a real device (no dice in the emulator - probably something wrong on my end) which at least is a step up from nothing but crashes before due to lack of permission.

I also noticed we're using `MediaRecorder.AudioSource.MIC`, and no way of changing this is exposed. Seeing as the wiki notes "latency on almost all Android phones is ridiculously high", albeit on the `AudioDevice` page and I think it's referring to Gingerbread devices or possibly even older, I thought it might be interesting to consider `AudioSource.VOICE_PERFORMANCE` for Android versions which support this. A use case it mentions is karaoke, which is a bit like what this test is. However, I don't know how this actually differs from `MIC` and why it would have lower latency - does it try to cancel feedback, for example?

Below is some context to what this pull request is all about. It's all you'd see (maybe refined a bit) if this pull request wasn't a draft!

***

Since Android 6.0 Marshmallow, Android has used [runtime permissions](https://developer.android.com/training/permissions/requesting). This made using `AudioRecorder` on Android a little more annoying, as access to the microphone is one of these runtime permissions.

I've added a `hasPermission()` method to `AudioRecorder` to help developers determine if their app has permission to record audio. There's also `requestPermission()` which requests permission, though this won't do anything if the user has said to never be asked again.

It's recommended that developers check `hasPermission()` before using an `AudioRecorder`. Display a prompt that explains why your app will use the microphone, especially if it's `RATIONALE` - this is your last chance before the user denies your app microphone access for good!

Note that `AudioRecorder` has never been supported on iOS and GWT, and this pull request does not resolve that. But if it were to be supported on those platforms, I expect they'd go through the same permissions rigamarole.

Windows and macOS also have microphone permissions stuff going on these days, but I don't know if we can access that. So `hasPermission()` always returns `GRANTED` on desktop.

If permission is denied, `AudioRecorder#read()` will return silence. Think of it like the microphone being unplugged.

I don't consider this to be a breaking change, though app developers may want to remove their own permission checks if this is merged.