### PR TITLE
Get color depth on GWT, refresh rate on Android

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -53,6 +53,7 @@
 - API ADDITION: Emulate Timer#isEmpty on GWT
 - API Addition: Bits add copy constructor public Bits (Bits bitsToCpy)
 - API Addition: Added List#drawSelection().
+- API Fix: Display mode on GWT now attempts to return the correct color depth.
 
 [1.10.0]
 - [BREAKING CHANGE] Android armeabi support has been removed. To migrate your projects: remove any dependency with natives-armeabi qualifier from your gradle build file, this apply to gdx-platform, gdx-bullet-platform, gdx-freetype-platform and gdx-box2d-platform.

--- a/CHANGES
+++ b/CHANGES
@@ -53,7 +53,7 @@
 - API ADDITION: Emulate Timer#isEmpty on GWT
 - API Addition: Bits add copy constructor public Bits (Bits bitsToCpy)
 - API Addition: Added List#drawSelection().
-- API Fix: Display mode on GWT now attempts to return the correct color depth.
+- API Fix: getDisplayMode() is now more accurate on Android and GWT.
 
 [1.10.0]
 - [BREAKING CHANGE] Android armeabi support has been removed. To migrate your projects: remove any dependency with natives-armeabi qualifier from your gradle build file, this apply to gdx-platform, gdx-bullet-platform, gdx-freetype-platform and gdx-box2d-platform.

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphics.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphics.java
@@ -16,6 +16,8 @@
 
 package com.badlogic.gdx.backends.android;
 
+import android.content.Context;
+import android.hardware.display.DisplayManager;
 import android.opengl.GLSurfaceView;
 import android.opengl.GLSurfaceView.EGLConfigChooser;
 import android.opengl.GLSurfaceView.Renderer;
@@ -36,6 +38,7 @@ import com.badlogic.gdx.graphics.Cursor.SystemCursor;
 import com.badlogic.gdx.graphics.glutils.FrameBuffer;
 import com.badlogic.gdx.graphics.glutils.GLVersion;
 import com.badlogic.gdx.graphics.glutils.ShaderProgram;
+import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.utils.GdxRuntimeException;
 import com.badlogic.gdx.utils.SnapshotArray;
 
@@ -685,9 +688,24 @@ public class AndroidGraphics extends AbstractGraphics implements Renderer {
 
 	@Override
 	public DisplayMode getDisplayMode () {
+		Display display;
 		DisplayMetrics metrics = new DisplayMetrics();
-		app.getWindowManager().getDefaultDisplay().getMetrics(metrics);
-		return new AndroidDisplayMode(metrics.widthPixels, metrics.heightPixels, 0, 0);
+
+		if (Build.VERSION.SDK_INT >= 17) {
+			DisplayManager displayManager = (DisplayManager)app.getContext().getSystemService(Context.DISPLAY_SERVICE);
+			display = displayManager.getDisplay(Display.DEFAULT_DISPLAY);
+			display.getRealMetrics(metrics); // Deprecated but no direct equivalent
+		} else {
+			display = app.getWindowManager().getDefaultDisplay();
+			display.getMetrics(metrics); // Excludes system UI!
+		}
+
+		int width = metrics.widthPixels;
+		int height = metrics.heightPixels;
+		int refreshRate = MathUtils.roundPositive(display.getRefreshRate());
+		int bitsPerPixel = config.r + config.g + config.b + config.a;
+
+		return new AndroidDisplayMode(width, height, refreshRate, bitsPerPixel);
 	}
 
 	@Override

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtGraphics.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtGraphics.java
@@ -229,6 +229,10 @@ public class GwtGraphics extends AbstractGraphics {
 		return $wnd.screen.height;
 	}-*/;
 
+	private native int getColorDepthJSNI () /*-{
+		return $wnd.screen.colorDepth;
+	}-*/;
+
 	private native boolean isFullscreenJSNI () /*-{
 		// Standards compliant check for fullscreen
 		if ("fullscreenElement" in $doc) {
@@ -339,7 +343,7 @@ public class GwtGraphics extends AbstractGraphics {
 	@Override
 	public DisplayMode getDisplayMode () {
 		double density = config.usePhysicalPixels ? getNativeScreenDensity() : 1;
-		return new DisplayMode((int)(getScreenWidthJSNI() * density), (int)(getScreenHeightJSNI() * density), 60, 8) {};
+		return new DisplayMode((int)(getScreenWidthJSNI() * density), (int)(getScreenHeightJSNI() * density), 60, getColorDepthJSNI()) {};
 	}
 
 	@Override

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/graphics/Pixmap.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/graphics/Pixmap.java
@@ -382,7 +382,7 @@ public class Pixmap implements Disposable {
 		rectangle(x, y, width, height, DrawType.STROKE);
 	}
 
-	/** Draws an area form another Pixmap to this Pixmap.
+	/** Draws an area from another Pixmap to this Pixmap.
 	 * 
 	 * @param pixmap The other Pixmap
 	 * @param x The target x-coordinate (top left corner)
@@ -392,21 +392,21 @@ public class Pixmap implements Disposable {
 		image(image, 0, 0, image.getWidth(), image.getHeight(), x, y, image.getWidth(), image.getHeight());
 	}
 
-	/** Draws an area form another Pixmap to this Pixmap.
+	/** Draws an area from another Pixmap to this Pixmap.
 	 * 
 	 * @param pixmap The other Pixmap
 	 * @param x The target x-coordinate (top left corner)
 	 * @param y The target y-coordinate (top left corner)
 	 * @param srcx The source x-coordinate (top left corner)
-	 * @param srcy The source y-coordinate (top left corner);
+	 * @param srcy The source y-coordinate (top left corner)
 	 * @param srcWidth The width of the area form the other Pixmap in pixels
-	 * @param srcHeight The height of the area form the other Pixmap in pixles */
+	 * @param srcHeight The height of the area form the other Pixmap in pixels */
 	public void drawPixmap (Pixmap pixmap, int x, int y, int srcx, int srcy, int srcWidth, int srcHeight) {
 		CanvasElement image = pixmap.getCanvasElement();
 		image(image, srcx, srcy, srcWidth, srcHeight, x, y, srcWidth, srcHeight);
 	}
 
-	/** Draws an area form another Pixmap to this Pixmap. This will automatically scale and stretch the source image to the
+	/** Draws an area from another Pixmap to this Pixmap. This will automatically scale and stretch the source image to the
 	 * specified target rectangle. Use {@link Pixmap#setFilter(Filter)} to specify the type of filtering to be used (nearest
 	 * neighbour or bilinear).
 	 * 
@@ -474,7 +474,7 @@ public class Pixmap implements Disposable {
 		ensureCanvasExists();
 		if (pixels == null) pixels = context.getImageData(0, 0, width, height).getData();
 		int i = x * 4 + y * width * 4;
-		int r = pixels.get(i + 0) & 0xff;
+		int r = pixels.get(i) & 0xff;
 		int g = pixels.get(i + 1) & 0xff;
 		int b = pixels.get(i + 2) & 0xff;
 		int a = pixels.get(i + 3) & 0xff;

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/graphics/Pixmap.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/graphics/Pixmap.java
@@ -474,7 +474,7 @@ public class Pixmap implements Disposable {
 		ensureCanvasExists();
 		if (pixels == null) pixels = context.getImageData(0, 0, width, height).getData();
 		int i = x * 4 + y * width * 4;
-		int r = pixels.get(i) & 0xff;
+		int r = pixels.get(i + 0) & 0xff;
 		int g = pixels.get(i + 1) & 0xff;
 		int b = pixels.get(i + 2) & 0xff;
 		int a = pixels.get(i + 3) & 0xff;

--- a/gdx/src/com/badlogic/gdx/Graphics.java
+++ b/gdx/src/com/badlogic/gdx/Graphics.java
@@ -59,7 +59,7 @@ public interface Graphics {
 	class DisplayMode {
 		/** the width in physical pixels **/
 		public final int width;
-		/** the height in physical pixles **/
+		/** the height in physical pixels **/
 		public final int height;
 		/** the refresh rate in Hertz **/
 		public final int refreshRate;


### PR DESCRIPTION
Is there any particular reason why we're always returning 8 bits per pixel (256 colours) on the GWT backend?

I've set it to use `screen.colorDepth` instead, which has [supreme compatibility](https://caniuse.com/?search=colordepth). It's identical to `pixelDepth` but is supported by Internet Explorer 4 (and doesn't seem deprecated in any capacity - I don't know why there's two identical properties) so I couldn't resist.

In non-Chromium-based browsers I think it always returns 24bpp. This isn't particularly useful, I must admit, but at least it's one strange number out the way.

There's still no clean way of getting the monitor's refresh rate that I know of. Could measure the frame rate, but it's just not the same.

***

This pull request has now expanded to include Android in the mix, which was just returning 0 for refresh rate and colour depth. The refresh rate gets rounded to the nearest integer - I checked the desktop backend on Linux and the same behaviour seems to occur there, except any rounding must occur at the LWJGL/GLFW level. I don't know what behaviour we'd see on variable refresh rate devices - probably just the maximum refresh rate?

Devices on Android 4.2 and newer will additionally benefit from more accurate screen resolution detection. I don't advise people use this in their game, but there may be some circumstances where it's useful to know the device's actual resolution, including status bar and whatever that the game might be unable to access.