### PR TITLE
Fix #6816 RE: the 2D particle editor

### DIFF
--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/EffectPanel.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/EffectPanel.java
@@ -128,7 +128,7 @@ class EffectPanel extends JPanel {
 
 	void emitterSelected () {
 		int row = emitterTable.getSelectedRow() - 1;
-		if (row == -1) {
+		if (row <= -1 || row >=  emitterTableModel.getRowCount()) {
 			row = editIndex;
 			emitterTable.getSelectionModel().setSelectionInterval(row, row);
 		}
@@ -238,9 +238,9 @@ class EffectPanel extends JPanel {
 	}
 
 	void move (int direction) {
-		if (direction < 0 && editIndex == 0) return;
+		if (direction < 0 && editIndex <= 0) return;
 		Array<ParticleEmitter> emitters = editor.effect.getEmitters();
-		if (direction > 0 && editIndex == emitters.size - 1) return;
+		if (direction > 0 && editIndex >= emitters.size - 1) return;
 		int insertIndex = editIndex + direction;
 		Object name = emitterTableModel.getValueAt(editIndex, 0);
 		emitterTableModel.removeRow(editIndex);

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/EffectPanel.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/EffectPanel.java
@@ -128,7 +128,7 @@ class EffectPanel extends JPanel {
 
 	void emitterSelected () {
 		int row = emitterTable.getSelectedRow() - 1;
-		if (row <= -1 || row >=  emitterTableModel.getRowCount()) {
+		if (row <= -1 || row >= emitterTableModel.getRowCount()) {
 			row = editIndex;
 			emitterTable.getSelectionModel().setSelectionInterval(row, row);
 		}

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/EffectPanel.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/EffectPanel.java
@@ -127,7 +127,7 @@ class EffectPanel extends JPanel {
 	}
 
 	void emitterSelected () {
-		int row = emitterTable.getSelectedRow();
+		int row = emitterTable.getSelectedRow() - 1;
 		if (row == -1) {
 			row = editIndex;
 			emitterTable.getSelectionModel().setSelectionInterval(row, row);

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/ParticleEditor.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/ParticleEditor.java
@@ -205,7 +205,7 @@ public class ParticleEditor extends JFrame {
 	}
 
 	public ParticleEmitter getEmitter () {
-		return effect.getEmitters().get(effectPanel.editIndex);
+		return effect.getEmitters().get(Math.max(0, effectPanel.editIndex));
 	}
 
 	public void setEnabled (ParticleEmitter emitter, boolean enabled) {


### PR DESCRIPTION
It seems like some off-by-one issues were introduced into the 2D particle editor in the last commit, though I still don't know why they're happening. One place, emitterSelected(), now always tries to correct that off-by-one in the index. This PR also adds extra checks to ensure that moving an emitter up or down in the list won't take it into a negative index or otherwise out-of-bounds.

You should probably try to reproduce the errors in #6816 before merging, probably by opening `tests/gdx-tests-android/assets/data/test.p` in the particle editor, so you get an idea of what was broken before this PR (essentially, opening any .p files). As far as I can tell, with this PR, that `test.p` file opens just fine now, and whatever UI I tried also worked. I didn't try all of the widgets, though.