### PR TITLE
Update dead links with new ones.

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -17,7 +17,7 @@ requests](#pull-requests), but please respect the following restrictions:
 
 * Please **do not** use the issue tracker for personal support requests (use
   the official [libGDX Discord](https://libgdx.com/community/discord/) or [subreddit](https://www.reddit.com/r/libgdx/)).
-  See also [Getting Help](https://github.com/libgdx/libgdx/wiki/Getting-Help).
+  See also [Getting Help](https://libgdx.com/wiki/articles/getting-help).
 
 * Please **do not** derail or troll issues. Keep the discussion on topic and
   respect the opinions of others.
@@ -38,7 +38,7 @@ Guidelines for bug reports:
    latest `master` or development branch in the repository.
 
 3. **Isolate the problem** &mdash; create a [reduced test
-   case](https://github.com/libgdx/libgdx/wiki/Getting-Help#executable-example-code).
+   case](https://libgdx.com/wiki/articles/getting-help#executable-example-code).
 
 A good bug report shouldn't leave others needing to chase you up for more
 information. Please try to be as detailed as possible in your report. What is
@@ -51,7 +51,7 @@ Create a [pull request](#pull-requests) with your proposed correction and
 a description of the problem you are fixing. Please do **not** create a separate
 issue for the bug report, the pull request is enough.
 
-See [Getting Help](https://github.com/libgdx/libgdx/wiki/Getting-Help) for more information and an example.
+See [Getting Help](https://libgdx.com/wiki/articles/getting-help) for more information and an example.
 
 
 <a name="features"></a>

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -5,7 +5,7 @@ _Please provide the details of your issue_
 
 #### Reproduction steps/code
 _Even if you think your issue is trivial to reproduce, please supply a [SSCCE](http://sscce.org/) that demonstrates your issue. This saves time on our end, and makes it much more likely that your issue will be fixed.
-You can find barebones templates [here](https://github.com/libgdx/libgdx/wiki/Getting-help)_
+You can find barebones templates [here](https://libgdx.com/wiki/articles/getting-help)_
 
 #### Version of libGDX and/or relevant dependencies
 _Please provide the version(s) affected._

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetupUI.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetupUI.java
@@ -233,7 +233,7 @@ public class GdxSetupUI extends JFrame {
 			infoLabel.setAlignmentX(Component.CENTER_ALIGNMENT);
 			panel.add(infoLabel);
 			JEditorPane pane = new JEditorPane("text/html",
-				"<a href=\"https://github.com/libgdx/libgdx/wiki/Dependency-management-with-Gradle\">Dependency Management</a>");
+				"<a href=\"https://libgdx.com/wiki/articles/dependency-management-with-gradle\">Dependency Management</a>");
 			pane.addHyperlinkListener(new HyperlinkListener() {
 				@Override
 				public void hyperlinkUpdate (HyperlinkEvent e) {

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/SettingsDialog.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/SettingsDialog.java
@@ -113,7 +113,7 @@ public class SettingsDialog extends JDialog {
 						Desktop desktop = Desktop.getDesktop();
 						try {
 							URI uri = new URI(
-								"https://github.com/libgdx/libgdx/wiki/Improving-workflow-with-Gradle#how-to-remove-gradle-ide-integration-from-your-project");
+								"https://libgdx.com/wiki/articles/improving-workflow-with-gradle#how-to-remove-gradle-ide-integration-from-your-project");
 							desktop.browse(uri);
 						} catch (IOException ex) {
 							ex.printStackTrace();

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/DistanceFieldFont.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/DistanceFieldFont.java
@@ -28,7 +28,7 @@ import com.badlogic.gdx.graphics.glutils.ShaderProgram;
 import com.badlogic.gdx.utils.Array;
 
 /** Renders bitmap fonts using distance field textures, see the
- * <a href="https://github.com/libgdx/libgdx/wiki/Distance-field-fonts">Distance Field Fonts wiki article</a> for usage.
+ * <a href="https://libgdx.com/wiki/graphics/2d/fonts/distance-field-fonts">Distance Field Fonts wiki article</a> for usage.
  * Initialize the SpriteBatch with the {@link #createDistanceFieldShader()} shader.
  * <p>
  * Attention: The batch is flushed before and after each string is rendered.
@@ -93,7 +93,7 @@ public class DistanceFieldFont extends BitmapFont {
 		this.distanceFieldSmoothing = distanceFieldSmoothing;
 	}
 
-	/** Returns a new instance of the distance field shader, see https://github.com/libgdx/libgdx/wiki/Distance-field-fonts if the
+	/** Returns a new instance of the distance field shader, see https://libgdx.com/wiki/graphics/2d/fonts/distance-field-fonts if the
 	 * u_smoothing uniform > 0.0. Otherwise the same code as the default SpriteBatch shader is used. */
 	static public ShaderProgram createDistanceFieldShader () {
 		String vertexShader = "attribute vec4 " + ShaderProgram.POSITION_ATTRIBUTE + ";\n" //

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Skin.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Skin.java
@@ -53,7 +53,7 @@ import com.badlogic.gdx.utils.reflect.ReflectionException;
  * regions in the atlas as ninepatches, sprites, drawables, etc. The get* methods return an instance of the object in the skin.
  * The new* methods return a copy of an instance in the skin.
  * <p>
- * See the <a href="https://github.com/libgdx/libgdx/wiki/Skin">documentation</a> for more.
+ * See the <a href="https://libgdx.com/wiki/graphics/2d/scene2d/skin">documentation</a> for more.
  * @author Nathan Sweet */
 public class Skin implements Disposable {
 	ObjectMap<Class, ObjectMap<String, Object>> resources = new ObjectMap();

--- a/gdx/src/com/badlogic/gdx/utils/Json.java
+++ b/gdx/src/com/badlogic/gdx/utils/Json.java
@@ -41,7 +41,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /** Reads/writes Java objects to/from JSON, automatically. See the wiki for usage:
- * https://github.com/libgdx/libgdx/wiki/Reading-and-writing-JSON
+ * https://libgdx.com/wiki/utils/reading-and-writing-json
  * @author Nathan Sweet */
 public class Json {
 	static private final boolean debug = false;

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/ShaderTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/ShaderTest.java
@@ -43,8 +43,8 @@ import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.GdxRuntimeException;
 
 public class ShaderTest extends GdxTest {
-	// Create a custom attribute, see https://github.com/libgdx/libgdx/wiki/Material-and-environment
-	// See also: http://blog.xoppa.com/using-materials-with-libgdx/
+	// Create a custom attribute, see https://libgdx.com/wiki/graphics/3d/material-and-environment
+	// See also: https://xoppa.github.io/blog/using-materials-with-libgdx/
 	public static class TestAttribute extends Attribute {
 		public final static String Alias = "Test";
 		public final static long ID = register(Alias);
@@ -74,7 +74,7 @@ public class ShaderTest extends GdxTest {
 		}
 	}
 
-	// Create a custom shader, see also http://blog.xoppa.com/creating-a-shader-with-libgdx
+	// Create a custom shader, see also https://xoppa.github.io/blog/creating-a-shader-with-libgdx/
 	// BaseShader adds some basic functionality used to manage uniforms etc.
 	public static class TestShader extends BaseShader {
 		// @off


### PR DESCRIPTION
I have made changes in these files and updated old https://github.com/libgdx/libgdx/wiki/ and http://blog.xoppa.com links to their counterparts on libgdx.com and xoppa.github.io. 
 

- .github/CONTRIBUTING.md
- .github/ISSUE_TEMPLATE.md
- extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetupUI.java
- extensions/gdx-setup/src/com/badlogic/gdx/setup/SettingsDialog.java
- gdx/src/com/badlogic/gdx/graphics/g2d/DistanceFieldFont.java
- gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Skin.java
- gdx/src/com/badlogic/gdx/utils/Json.java
- tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/ShaderTest.java

I haven't tested it in any other way than making sure the links I've copied work. 