### PR TITLE
FileHandle#map() should use the File from FileHandle#file()

### DIFF
--- a/gdx/src/com/badlogic/gdx/files/FileHandle.java
+++ b/gdx/src/com/badlogic/gdx/files/FileHandle.java
@@ -276,9 +276,10 @@ public class FileHandle {
 		if (type == FileType.Classpath) throw new GdxRuntimeException("Cannot map a classpath file: " + this);
 		RandomAccessFile raf = null;
 		try {
-			raf = new RandomAccessFile(file, mode == MapMode.READ_ONLY ? "r" : "rw");
+			File f = file();
+			raf = new RandomAccessFile(f, mode == MapMode.READ_ONLY ? "r" : "rw");
 			FileChannel fileChannel = raf.getChannel();
-			ByteBuffer map = fileChannel.map(mode, 0, file.length());
+			ByteBuffer map = fileChannel.map(mode, 0, f.length());
 			map.order(ByteOrder.nativeOrder());
 			return map;
 		} catch (Exception ex) {


### PR DESCRIPTION
Fixes a minor mistake from #5181 which would prevent mapping files of certain `FileType`s on certain platforms.