### PR TITLE
Set duplicatesStrategy = DuplicatesStrategy.EXCLUDE in gdx/build.gradle

### DIFF
--- a/gdx/build.gradle
+++ b/gdx/build.gradle
@@ -35,7 +35,7 @@ compileJava {
 }
 
 jar {
-	duplicatesStrategy = "warn"
+	duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }
 
 dependencies {


### PR DESCRIPTION
copyIdeaResources gets run while compiling the jar, leading to duplicate resource entries.

https://github.com/libgdx/libgdx/blob/master/gdx/build.gradle#L53-L57