### PR TITLE
Don't fail on javadocs error for gwt

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,6 +95,12 @@ allprojects {
             options.addStringOption('Xdoclint:none,-missing', '-quiet')
         }
     }
+
+    if (JavaVersion.current().isJava9Compatible()) {
+        tasks.withType(Javadoc) {
+            options.addStringOption("-release", "8");
+        }
+    }
 }
 
 configure(subprojects - project(":tests:gdx-tests-android")) {


### PR DESCRIPTION
Java 11's javadoc seems to ignore any classpath entries in special packages. This leads to the gwt emu classes being unavailable for javadoc processing. Resulting in the following error.

```
$ ./gradlew :backends:gdx-backend-gwt:javadoc 

> Task :backends:gdx-backend-gwt:javadoc

libgdx/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtGL20.java:22: error: cannot find symbol
import java.nio.HasArrayBufferView;
               ^
  symbol:   class HasArrayBufferView
  location: package java.nio
1 error
```
This fix isn't ideal, but I don't really have a better idea how to make this work. Existing [Xdoclint](https://github.com/libgdx/libgdx/blob/7b7d78c175c2f3ed288215cbed9587edb35f70ab/build.gradle#L95) is applied, but doesn't prevent this being a fatal error.