### PR TITLE
Fix xcframework publish

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -45,8 +45,8 @@ jobs:
 
       - name: Pack artifacts
         run: |
-          find .  -name "*.a" -o -name "*.dll" -o -name "*.dylib" -o -name "*.so" | grep "libs" > native-files-list
-          zip natives-ios -@ < native-files-list
+          find .  -name "*.a" -o -name "*.dll" -o -name "*.dylib" -o -name "*.so" -o -name "*.xcframework"  | grep "libs" > native-files-list
+          zip -r natives-ios -@ < native-files-list
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
@@ -317,8 +317,8 @@ jobs:
 
       - name: Pack natives
         run: |
-          find .  -name "*.a" -o -name "*.dll" -o -name "*.dylib" -o -name "*.so" -o -name "*-natives.jar"| grep "libs" > native-files-list
-          zip natives -@ < native-files-list
+          find .  -name "*.a" -o -name "*.dll" -o -name "*.dylib" -o -name "*.so" -o -name "*-natives.jar" -o -name "*.xcframework" | grep "libs" > native-files-list
+          zip -r natives -@ < native-files-list
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
Follow up pr for: https://github.com/libgdx/libgdx/pull/6796
I have accidentally broken the publishing for iOS.
As it seems for publishing libraries are first collected into the natives-ios.zip folder, they get unpacked again, get packed again and than unpacked for publishing with the jnigen task. 
Do I understand the procedure correct? If yes, these changes should fix the publish issue.