### PR TITLE
Increase iOS min supported version to 9.0.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,5 @@
 [1.10.1]
+- [BREAKING CHANGE] iOS: Increased min supported iOS version to 9.0. Update your Info.plist file if necessary.
 - [BREAKING CHANGE] Removed Maven and Ant build systems. libGDX is now solely built with Gradle. See https://libgdx.com/dev/from-source/ for updated build instructions.
 - [BREAKING CHANGE] Android Moved natives loading out of static init block, see #5795
 - [BREAKING CHANGE] Linux: Shared libraries are now built on Ubuntu 18.04 (up from Ubuntu 16.04)

--- a/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/ios/Info.plist.xml
+++ b/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/ios/Info.plist.xml
@@ -29,7 +29,7 @@
     <key>UIStatusBarHidden</key>
     <true/>
     <key>MinimumOSVersion</key>
-    <string>8.0</string>
+    <string>9.0</string>
     <key>UIDeviceFamily</key>
     <array>
         <integer>1</integer>

--- a/tests/gdx-tests-iosrobovm/Info.plist.xml
+++ b/tests/gdx-tests-iosrobovm/Info.plist.xml
@@ -29,7 +29,7 @@
         <key>UIStatusBarHidden</key>
         <true/>
         <key>MinimumOSVersion</key>
-        <string>8.0</string>
+        <string>9.0</string>
         <key>UIDeviceFamily</key>
         <array>
             <integer>1</integer>


### PR DESCRIPTION
Trying to run libGDX Gdx Tests on Simulator on an Intel Mac throws the following error:
```
targeted OS version does not support use of thread local variables in _stbi__load_and_postprocess_8bit for architecture x86_64
```
This may be related to recent update of stb image (https://github.com/libgdx/libgdx/pull/6818).

Setting min iOS to 9.0 fixes it on Simulator. I'm not able to test on a device with iOS 8.

Before the stb upgrade we were already setting deployment target to 9.0 when building ObjectAL https://github.com/libgdx/libgdx/blob/a1b9b4dfe34fe7a5075844ecbbe6b60f14d65644/backends/gdx-backend-robovm/build-objectal.sh#L17 so I think it makes sense to move up our min iOS version to 9 in any case.