### PR TITLE
Add `getAlignment()` to `List`

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/List.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/List.java
@@ -420,6 +420,10 @@ public class List<T> extends Widget implements Cullable {
 		this.alignment = alignment;
 	}
 
+	public int getAlignment () {
+		return alignment;
+	}
+
 	public void setTypeToSelect (boolean typeToSelect) {
 		this.typeToSelect = typeToSelect;
 	}


### PR DESCRIPTION
Resolves #6832. I was unable to find any other Scene2D classes where you can set the alignment but not get the alignment.