### PR TITLE
Never stall with AssetManager on GWT

### DIFF
--- a/gdx/src/com/badlogic/gdx/assets/AssetManager.java
+++ b/gdx/src/com/badlogic/gdx/assets/AssetManager.java
@@ -433,8 +433,7 @@ public class AssetManager implements Disposable {
 	 * of a single task that happens in the GL thread takes a long time.
 	 * @return true if all loading is finished. */
 	public boolean update (int millis) {
-		if (Gdx.app.getType() == Application.ApplicationType.WebGL)
-			return update();
+		if (Gdx.app.getType() == Application.ApplicationType.WebGL) return update();
 		long endTime = TimeUtils.millis() + millis;
 		while (true) {
 			boolean done = update();

--- a/gdx/src/com/badlogic/gdx/assets/AssetManager.java
+++ b/gdx/src/com/badlogic/gdx/assets/AssetManager.java
@@ -430,8 +430,8 @@ public class AssetManager implements Disposable {
 
 	/** Updates the AssetManager continuously for the specified number of milliseconds, yielding the CPU to the loading thread
 	 * between updates. This may block for less time if all loading tasks are complete. This may block for more time if the portion
-	 * of a single task that happens in the GL thread takes a long time.
-	 * On GWT, updates for a single task instead (see {@link #update()}).
+	 * of a single task that happens in the GL thread takes a long time. On GWT, updates for a single task instead (see
+	 * {@link #update()}).
 	 * @return true if all loading is finished. */
 	public boolean update (int millis) {
 		if (Gdx.app.getType() == Application.ApplicationType.WebGL) return update();

--- a/gdx/src/com/badlogic/gdx/assets/AssetManager.java
+++ b/gdx/src/com/badlogic/gdx/assets/AssetManager.java
@@ -17,6 +17,7 @@
 package com.badlogic.gdx.assets;
 
 import com.badlogic.gdx.Application;
+import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.assets.loaders.AssetLoader;
 import com.badlogic.gdx.assets.loaders.BitmapFontLoader;
 import com.badlogic.gdx.assets.loaders.CubemapLoader;
@@ -432,6 +433,8 @@ public class AssetManager implements Disposable {
 	 * of a single task that happens in the GL thread takes a long time.
 	 * @return true if all loading is finished. */
 	public boolean update (int millis) {
+		if (Gdx.app.getType() == Application.ApplicationType.WebGL)
+			return update();
 		long endTime = TimeUtils.millis() + millis;
 		while (true) {
 			boolean done = update();

--- a/gdx/src/com/badlogic/gdx/assets/AssetManager.java
+++ b/gdx/src/com/badlogic/gdx/assets/AssetManager.java
@@ -431,6 +431,7 @@ public class AssetManager implements Disposable {
 	/** Updates the AssetManager continuously for the specified number of milliseconds, yielding the CPU to the loading thread
 	 * between updates. This may block for less time if all loading tasks are complete. This may block for more time if the portion
 	 * of a single task that happens in the GL thread takes a long time.
+	 * On GWT, updates for a single task instead (see {@link #update()}).
 	 * @return true if all loading is finished. */
 	public boolean update (int millis) {
 		if (Gdx.app.getType() == Application.ApplicationType.WebGL) return update();


### PR DESCRIPTION
I haven't given this solution a great deal of thought, but I've just spent a long time getting to the bottom of the problem and I think you can guess what moods I'm in. I'd like it fixed so others don't have to lose sleep over the same problem. Or if this is a stupid solution but no-one comes up with a better way of doing it, at least document to never call it (in javadocs and/or wiki) with the `millis` overload on GWT.

Passing a number of milliseconds into `AssetManager#update` on GWT is a terrible idea. Not only do you get a reduced frame rate with no reduction in load time (even on localhost), you're also at great risk (only when using a custom asset filter, I think) of running into the `File not prefetched, but finishLoading was probably called` error due to the likelihood of exceeding [100,000 ticks](https://github.com/libgdx/libgdx/blob/79cf00af53b7f38667291fbacf544d3074a811bd/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/assets/AssetLoadingTask.java#L98-L99) (one tick == one `AssetLoadingTask#update`). 

This is especially likely if the files are not cached and for some reason more likely when running in an iframe on Google Chrome (Chrome tends to be faster than Firefox for me; not sure where iframes fit into it though). If anyone does their own testing, note that incognito mode isn't a perfect testing zone - it still seems to be affected by some level of caching even if not the full-on disk cache.

My theory is the ticks accumulate extremely quickly while waiting for a file to download, since it's stuck in this loop unable to do anything else. `update(1)` would practically guarantee a crash on the first itch.io-hosted run of my game on GWT, but `update()` is perfectly fine.