### PR TITLE
Add ability to load OBJ models with vertex color

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -12,6 +12,7 @@
 - iOS: Update to MobiVM 2.3.15
 - Update to LWJGL 3.3.1
 - API Addition: ObjLoader now supports ambientColor, ambientTexture, transparencyTexture, specularTexture and shininessTexture
+- API Addition: ObjLoader now supports color by vertex
 - API Addition: PointSpriteParticleBatch blending is now configurable.
 - TOOLS Features: Blending mode and sort mode can be changed in Flame particle 3D editor.
 - API Addition: Polygon methods setVertex, getVertex, getVertexCount, getCentroid.


### PR DESCRIPTION
Use cases for this feature:
- Models generated by 3D scans
- Models generated by AI like pifuhd: https://github.com/facebookresearch/pifuhd

Note: This is not an official standard but is widely used.