### PR TITLE
Fix Particle Editor Issues after recent commits, close #6816

### DIFF
--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/EffectPanel.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/EffectPanel.java
@@ -243,7 +243,7 @@ class EffectPanel extends JPanel {
 		if (direction > 0 && editIndex >= emitters.size - 1) return;
 		int insertIndex = editIndex + direction;
 		Object name = emitterTableModel.getValueAt(editIndex, 0);
-		Boolean active = (Boolean) emitterTableModel.getValueAt(editIndex, 1);
+		Boolean active = (Boolean)emitterTableModel.getValueAt(editIndex, 1);
 		emitterTableModel.removeRow(editIndex);
 		ParticleEmitter emitter = emitters.removeIndex(editIndex);
 		emitterTableModel.insertRow(insertIndex, new Object[] {name, active});

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/EffectPanel.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/EffectPanel.java
@@ -129,8 +129,8 @@ class EffectPanel extends JPanel {
 	void emitterSelected () {
 		int row = emitterTable.getSelectedRow();
 		if (row <= -1 || row >= emitterTableModel.getRowCount()) {
-			//During move up/down row can be -1 because called from modifyValue callback in table
-			//No selection update should be made while swapping rows
+			// During move up/down row can be -1 because called from modifyValue callback in table
+			// No selection update should be made while swapping rows
 			return;
 		}
 		if (row == editIndex) return;

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/EffectPanel.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/EffectPanel.java
@@ -129,8 +129,9 @@ class EffectPanel extends JPanel {
 	void emitterSelected () {
 		int row = emitterTable.getSelectedRow();
 		if (row <= -1 || row >= emitterTableModel.getRowCount()) {
-			row = editIndex;
-			emitterTable.getSelectionModel().setSelectionInterval(row, row);
+			//During move up/down row can be -1 because called from modifyValue callback in table
+			//No selection update should be made while swapping rows
+			return;
 		}
 		if (row == editIndex) return;
 		editIndex = row;

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/EffectPanel.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/EffectPanel.java
@@ -128,7 +128,7 @@ class EffectPanel extends JPanel {
 
 	void emitterSelected () {
 		int row = emitterTable.getSelectedRow();
-		if (row == -1) {
+		if (row <= -1 || row >= emitterTableModel.getRowCount()) {
 			row = editIndex;
 			emitterTable.getSelectionModel().setSelectionInterval(row, row);
 		}
@@ -165,7 +165,7 @@ class EffectPanel extends JPanel {
 			JOptionPane.showMessageDialog(editor, "Error opening effect.");
 			return;
 		}
-		for (ParticleEmitter emitter : editor.effect.getEmitters()) {
+		for (ParticleEmitter emitter : new Array.ArrayIterator<>(editor.effect.getEmitters())) {
 			emitter.setPosition(editor.worldCamera.viewportWidth / 2, editor.worldCamera.viewportHeight / 2);
 			emitterTableModel.addRow(new Object[] {emitter.getName(), true});
 		}
@@ -238,14 +238,15 @@ class EffectPanel extends JPanel {
 	}
 
 	void move (int direction) {
-		if (direction < 0 && editIndex == 0) return;
+		if (direction < 0 && editIndex <= 0) return;
 		Array<ParticleEmitter> emitters = editor.effect.getEmitters();
-		if (direction > 0 && editIndex == emitters.size - 1) return;
+		if (direction > 0 && editIndex >= emitters.size - 1) return;
 		int insertIndex = editIndex + direction;
 		Object name = emitterTableModel.getValueAt(editIndex, 0);
+		Boolean active = (Boolean) emitterTableModel.getValueAt(editIndex, 1);
 		emitterTableModel.removeRow(editIndex);
 		ParticleEmitter emitter = emitters.removeIndex(editIndex);
-		emitterTableModel.insertRow(insertIndex, new Object[] {name});
+		emitterTableModel.insertRow(insertIndex, new Object[] {name, active});
 		emitters.insert(insertIndex, emitter);
 		editIndex = insertIndex;
 		emitterTable.getSelectionModel().setSelectionInterval(editIndex, editIndex);
@@ -360,7 +361,7 @@ class EffectPanel extends JPanel {
 				emitterTable.getTableHeader().setReorderingAllowed(false);
 				emitterTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
 				scroll.setViewportView(emitterTable);
-				emitterTableModel = new DefaultTableModel(new String[0][0], new String[] {"Emitter", ""});
+				emitterTableModel = new DefaultTableModel(new String[0][0], new String[] {"Emitter", "Active"});
 				emitterTable.setModel(emitterTableModel);
 				emitterTable.getSelectionModel().addListSelectionListener(new ListSelectionListener() {
 					public void valueChanged (ListSelectionEvent event) {

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/ParticleEditor.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/ParticleEditor.java
@@ -205,7 +205,11 @@ public class ParticleEditor extends JFrame {
 	}
 
 	public ParticleEmitter getEmitter () {
-		return effect.getEmitters().get(effectPanel.editIndex);
+		Array<ParticleEmitter> emitters = effect.getEmitters();
+		if (effectPanel.editIndex < emitters.size) {
+			return emitters.get(effectPanel.editIndex);
+		}
+		return emitters.get(0);
 	}
 
 	public void setEnabled (ParticleEmitter emitter, boolean enabled) {


### PR DESCRIPTION
As point out in #6816 this commit #6678 has introduced some issues in Emitter reading and manipulating operations. The reason is that since in Swing libGDX rendering runs on a different thread of the UI in some cases `ParticleEffect` emitters list is not synced with what UI shows producing a bunch of out of bounds exception.
This should also fix move emitter up/down operations.

Thanks :)