### PR TITLE
Added ChainShape#clear method, close #6647

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -50,6 +50,7 @@
 - API Addition: Add NWSEResize, NESWResize, AllResize, and NotAllowed SystemCursors
 - API Addition: GWTApplication#getJavaHeap and getNativeHeap are now supported
 - API Addition: Box2D Shape now implements Disposable
+- API Addition: Added ChainShape#clear method
 - API Addition: Addes Tooltip#setTouchIndependent; see #6758
 - API ADDITION: Emulate Timer#isEmpty on GWT
 - API Addition: Bits add copy constructor public Bits (Bits bitsToCpy)

--- a/extensions/gdx-box2d/gdx-box2d-gwt/src/com/badlogic/gdx/physics/box2d/gwt/emu/com/badlogic/gdx/physics/box2d/ChainShape.java
+++ b/extensions/gdx-box2d/gdx-box2d-gwt/src/com/badlogic/gdx/physics/box2d/gwt/emu/com/badlogic/gdx/physics/box2d/ChainShape.java
@@ -144,6 +144,11 @@ public class ChainShape extends Shape {
 		vertex.set(v.x, v.y);
 	}
 
+	/** Clear all vertices in the chain and free the memory. */
+	public void clear () {
+		shape.clear();
+	}
+
 	@Override
 	public float getRadius () {
 		return shape.getRadius();

--- a/extensions/gdx-box2d/gdx-box2d-gwt/src/com/badlogic/gdx/physics/box2d/gwt/emu/org/jbox2d/collision/shapes/ChainShape.java
+++ b/extensions/gdx-box2d/gdx-box2d-gwt/src/com/badlogic/gdx/physics/box2d/gwt/emu/org/jbox2d/collision/shapes/ChainShape.java
@@ -54,6 +54,11 @@ public class ChainShape extends Shape {
 		m_count = 0;
 	}
 
+	public void clear () {
+		m_vertices = null;
+		m_count = 0;
+	}
+
 	@Override
 	public int getChildCount () {
 		return m_count - 1;

--- a/extensions/gdx-box2d/gdx-box2d/src/com/badlogic/gdx/physics/box2d/ChainShape.java
+++ b/extensions/gdx-box2d/gdx-box2d/src/com/badlogic/gdx/physics/box2d/ChainShape.java
@@ -178,6 +178,16 @@ public class ChainShape extends Shape {
 		return isLooped;
 	}
 
+	/** Clear all vertices in the chain and free the memory. */
+	public void clear() {
+		jniClear(addr);
+	}
+
+	private native void jniClear(long addr); /*
+		b2ChainShape* chain = (b2ChainShape*)addr;
+		chain->Clear();
+	*/
+
 // /// Implement b2Shape. Vertices are cloned using b2Alloc.
 // b2Shape* Clone(b2BlockAllocator* allocator) const;
 //


### PR DESCRIPTION
As explained in #6647 `b2ChainShape::Clear()` method must be called if vertices of a chain needs to be updated. I noticed that jbox2d included in libGDX didn't implement the `clear` method, while the official repository yes https://github.com/jbox2d/jbox2d/blob/fa4c74cbcdb607454150db131012c9469a70c55f/jbox2d-library/src/main/java/org/jbox2d/collision/shapes/ChainShape.java#L60 .

I tested changes on LWGL3 and GWT without issues.