### PR TITLE
Extract iOS audio session management into methods on IOSAudio interface

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -57,7 +57,7 @@
 - API Fix: getDisplayMode() is now more accurate on Android and GWT.
 - API Addition: JsonValue#iterator(String) to more easily iterate a child that may not exist.
 - API Addition: Added ExtendViewport#setScaling, eg for use with Scaling.contain.
-- API Addition: Added activate and deactivate methods to IOSAudio to manage custom audio sessions.
+- API Addition: Added application lifecycle methods to IOSAudio for custom audio implementations.
 
 [1.10.0]
 - [BREAKING CHANGE] Android armeabi support has been removed. To migrate your projects: remove any dependency with natives-armeabi qualifier from your gradle build file, this apply to gdx-platform, gdx-bullet-platform, gdx-freetype-platform and gdx-box2d-platform.

--- a/CHANGES
+++ b/CHANGES
@@ -57,6 +57,7 @@
 - API Fix: getDisplayMode() is now more accurate on Android and GWT.
 - API Addition: JsonValue#iterator(String) to more easily iterate a child that may not exist.
 - API Addition: Added ExtendViewport#setScaling, eg for use with Scaling.contain.
+- API Addition: Added activate and deactivate methods to IOSAudio to manage custom audio sessions.
 
 [1.10.0]
 - [BREAKING CHANGE] Android armeabi support has been removed. To migrate your projects: remove any dependency with natives-armeabi qualifier from your gradle build file, this apply to gdx-platform, gdx-bullet-platform, gdx-freetype-platform and gdx-box2d-platform.

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSApplication.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSApplication.java
@@ -237,17 +237,18 @@ public class IOSApplication implements Application {
 
 	final void didBecomeActive (UIApplication uiApp) {
 		Gdx.app.debug("IOSApplication", "resumed");
-		audio.activate();
+		audio.didBecomeActive();
 		graphics.makeCurrent();
 		graphics.resume();
 	}
 
 	final void willEnterForeground (UIApplication uiApp) {
-		audio.deactivate();
+		audio.willEnterForeground();
 	}
 
 	final void willResignActive (UIApplication uiApp) {
 		Gdx.app.debug("IOSApplication", "paused");
+		audio.willResignActive();
 		graphics.makeCurrent();
 		graphics.pause();
 		Gdx.gl.glFinish();
@@ -255,6 +256,7 @@ public class IOSApplication implements Application {
 
 	final void willTerminate (UIApplication uiApp) {
 		Gdx.app.debug("IOSApplication", "disposed");
+		audio.willTerminate();
 		graphics.makeCurrent();
 		Array<LifecycleListener> listeners = lifecycleListeners;
 		synchronized (listeners) {

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSApplication.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSApplication.java
@@ -47,8 +47,6 @@ import com.badlogic.gdx.Input;
 import com.badlogic.gdx.LifecycleListener;
 import com.badlogic.gdx.Net;
 import com.badlogic.gdx.Preferences;
-import com.badlogic.gdx.backends.iosrobovm.objectal.OALAudioSession;
-import com.badlogic.gdx.backends.iosrobovm.objectal.OALSimpleAudio;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.Clipboard;
 
@@ -239,29 +237,13 @@ public class IOSApplication implements Application {
 
 	final void didBecomeActive (UIApplication uiApp) {
 		Gdx.app.debug("IOSApplication", "resumed");
-		// workaround for ObjectAL crash problem
-		// see: https://groups.google.com/g/objectal-for-iphone/c/ubRWltp_i1Q
-		OALAudioSession audioSession = OALAudioSession.sharedInstance();
-		if (audioSession != null) {
-			audioSession.forceEndInterruption();
-		}
-		if (config.allowIpod) {
-			OALSimpleAudio audio = OALSimpleAudio.sharedInstance();
-			if (audio != null) {
-				audio.setUseHardwareIfAvailable(false);
-			}
-		}
+		audio.activate();
 		graphics.makeCurrent();
 		graphics.resume();
 	}
 
 	final void willEnterForeground (UIApplication uiApp) {
-		// workaround for ObjectAL crash problem
-		// see: https://groups.google.com/forum/?fromgroups=#!topic/objectal-for-iphone/ubRWltp_i1Q
-		OALAudioSession audioSession = OALAudioSession.sharedInstance();
-		if (audioSession != null) {
-			audioSession.forceEndInterruption();
-		}
+		audio.deactivate();
 	}
 
 	final void willResignActive (UIApplication uiApp) {

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSAudio.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSAudio.java
@@ -19,4 +19,13 @@ package com.badlogic.gdx.backends.iosrobovm;
 import com.badlogic.gdx.Audio;
 
 public interface IOSAudio extends Audio {
+	/** Handles the app being activated / going to foreground.
+	 *
+	 * For example, this could (re-)activate and configure the audio session. */
+	public void activate ();
+
+	/** Handles the app being deactivated / going to background.
+	 *
+	 * For example, this could deactivate the audio session. */
+	public void deactivate ();
 }

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSAudio.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSAudio.java
@@ -19,13 +19,11 @@ package com.badlogic.gdx.backends.iosrobovm;
 import com.badlogic.gdx.Audio;
 
 public interface IOSAudio extends Audio {
-	/** Handles the app being activated / going to foreground.
-	 *
-	 * For example, this could (re-)activate and configure the audio session. */
-	public void activate ();
+	public void didBecomeActive ();
 
-	/** Handles the app being deactivated / going to background.
-	 *
-	 * For example, this could deactivate the audio session. */
-	public void deactivate ();
+	public void willEnterForeground ();
+
+	public void willResignActive ();
+
+	public void willTerminate ();
 }

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/objectal/OALIOSAudio.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/objectal/OALIOSAudio.java
@@ -32,43 +32,6 @@ public class OALIOSAudio implements IOSAudio {
 
 	private final IOSApplicationConfiguration config;
 
-	private void forceEndInterruption () {
-		OALAudioSession audioSession = OALAudioSession.sharedInstance();
-		if (audioSession != null) {
-			audioSession.forceEndInterruption();
-		}
-	}
-
-	@Override
-	public void didBecomeActive () {
-		// workaround for ObjectAL crash problem
-		// see: https://groups.google.com/g/objectal-for-iphone/c/ubRWltp_i1Q
-		forceEndInterruption();
-		if (config.allowIpod) {
-			OALSimpleAudio audio = OALSimpleAudio.sharedInstance();
-			if (audio != null) {
-				audio.setUseHardwareIfAvailable(false);
-			}
-		}
-	}
-
-	@Override
-	public void willEnterForeground () {
-		// workaround for ObjectAL crash problem
-		// see: https://groups.google.com/forum/?fromgroups=#!topic/objectal-for-iphone/ubRWltp_i1Q
-		forceEndInterruption();
-	}
-
-	@Override
-	public void willResignActive () {
-
-	}
-
-	@Override
-	public void willTerminate () {
-
-	}
-
 	public OALIOSAudio (IOSApplicationConfiguration config) {
 		this.config = config;
 		if (!config.useAudio) return;
@@ -107,4 +70,40 @@ public class OALIOSAudio implements IOSAudio {
 		throw new GdxRuntimeException("Error creating music audio track");
 	}
 
+	@Override
+	public void didBecomeActive () {
+		// workaround for ObjectAL crash problem
+		// see: https://groups.google.com/g/objectal-for-iphone/c/ubRWltp_i1Q
+		forceEndInterruption();
+		if (config.allowIpod) {
+			OALSimpleAudio audio = OALSimpleAudio.sharedInstance();
+			if (audio != null) {
+				audio.setUseHardwareIfAvailable(false);
+			}
+		}
+	}
+
+	@Override
+	public void willEnterForeground () {
+		// workaround for ObjectAL crash problem
+		// see: https://groups.google.com/forum/?fromgroups=#!topic/objectal-for-iphone/ubRWltp_i1Q
+		forceEndInterruption();
+	}
+
+	@Override
+	public void willResignActive () {
+
+	}
+
+	@Override
+	public void willTerminate () {
+
+	}
+
+	private void forceEndInterruption () {
+		OALAudioSession audioSession = OALAudioSession.sharedInstance();
+		if (audioSession != null) {
+			audioSession.forceEndInterruption();
+		}
+	}
 }

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/objectal/OALIOSAudio.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/objectal/OALIOSAudio.java
@@ -32,14 +32,18 @@ public class OALIOSAudio implements IOSAudio {
 
 	private final IOSApplicationConfiguration config;
 
-	@Override
-	public void activate () {
-		// workaround for ObjectAL crash problem
-		// see: https://groups.google.com/g/objectal-for-iphone/c/ubRWltp_i1Q
+	private void forceEndInterruption () {
 		OALAudioSession audioSession = OALAudioSession.sharedInstance();
 		if (audioSession != null) {
 			audioSession.forceEndInterruption();
 		}
+	}
+
+	@Override
+	public void didBecomeActive () {
+		// workaround for ObjectAL crash problem
+		// see: https://groups.google.com/g/objectal-for-iphone/c/ubRWltp_i1Q
+		forceEndInterruption();
 		if (config.allowIpod) {
 			OALSimpleAudio audio = OALSimpleAudio.sharedInstance();
 			if (audio != null) {
@@ -49,13 +53,20 @@ public class OALIOSAudio implements IOSAudio {
 	}
 
 	@Override
-	public void deactivate () {
+	public void willEnterForeground () {
 		// workaround for ObjectAL crash problem
 		// see: https://groups.google.com/forum/?fromgroups=#!topic/objectal-for-iphone/ubRWltp_i1Q
-		OALAudioSession audioSession = OALAudioSession.sharedInstance();
-		if (audioSession != null) {
-			audioSession.forceEndInterruption();
-		}
+		forceEndInterruption();
+	}
+
+	@Override
+	public void willResignActive () {
+
+	}
+
+	@Override
+	public void willTerminate () {
+
 	}
 
 	public OALIOSAudio (IOSApplicationConfiguration config) {

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/objectal/OALIOSAudio.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/objectal/OALIOSAudio.java
@@ -30,7 +30,36 @@ import com.badlogic.gdx.utils.GdxRuntimeException;
 
 public class OALIOSAudio implements IOSAudio {
 
+	private final IOSApplicationConfiguration config;
+
+	@Override
+	public void activate () {
+		// workaround for ObjectAL crash problem
+		// see: https://groups.google.com/g/objectal-for-iphone/c/ubRWltp_i1Q
+		OALAudioSession audioSession = OALAudioSession.sharedInstance();
+		if (audioSession != null) {
+			audioSession.forceEndInterruption();
+		}
+		if (config.allowIpod) {
+			OALSimpleAudio audio = OALSimpleAudio.sharedInstance();
+			if (audio != null) {
+				audio.setUseHardwareIfAvailable(false);
+			}
+		}
+	}
+
+	@Override
+	public void deactivate () {
+		// workaround for ObjectAL crash problem
+		// see: https://groups.google.com/forum/?fromgroups=#!topic/objectal-for-iphone/ubRWltp_i1Q
+		OALAudioSession audioSession = OALAudioSession.sharedInstance();
+		if (audioSession != null) {
+			audioSession.forceEndInterruption();
+		}
+	}
+
 	public OALIOSAudio (IOSApplicationConfiguration config) {
+		this.config = config;
 		if (!config.useAudio) return;
 		OALSimpleAudio audio = OALSimpleAudio.sharedInstance();
 		if (audio != null) {


### PR DESCRIPTION
This removes direct calls to ObjectAL functions from IOSApplication and replaces it with calls to new 'activate' and 'deactivate' functions on the IOSAudio interface.

My motivation is to better support alternative IOSAudio implementations, which manage the audio session themselves. (I personally use one based on AVFoundation). 