### PR TITLE
Set window title to project name

### DIFF
--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3WindowConfiguration.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3WindowConfiguration.java
@@ -150,7 +150,7 @@ public class Lwjgl3WindowConfiguration {
 		this.fullscreenMode = (Lwjgl3DisplayMode)mode;
 	}
 
-	/** Sets the window title. Defaults to empty string. */
+	/** Sets the window title. If null, the application listener's class name is used. */
 	public void setTitle (String title) {
 		this.title = title;
 	}

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3WindowConfiguration.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3WindowConfiguration.java
@@ -39,7 +39,7 @@ public class Lwjgl3WindowConfiguration {
 	String[] windowIconPaths;
 	Lwjgl3WindowListener windowListener;
 	Lwjgl3DisplayMode fullscreenMode;
-	String title = "";
+	String title;
 	Color initialBackgroundColor = Color.BLACK;
 	boolean initialVisible = true;
 	boolean vSyncEnabled = true;

--- a/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/lwjgl2/src/DesktopLauncher
+++ b/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/lwjgl2/src/DesktopLauncher
@@ -7,6 +7,7 @@ import %PACKAGE%.%MAIN_CLASS%;
 public class DesktopLauncher {
 	public static void main (String[] arg) {
 		LwjglApplicationConfiguration config = new LwjglApplicationConfiguration();
+		config.title = "%APP_NAME%";
 		new LwjglApplication(new %MAIN_CLASS%(), config);
 	}
 }

--- a/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/lwjgl3/src/DesktopLauncher
+++ b/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/lwjgl3/src/DesktopLauncher
@@ -9,6 +9,7 @@ public class DesktopLauncher {
 	public static void main (String[] arg) {
 		Lwjgl3ApplicationConfiguration config = new Lwjgl3ApplicationConfiguration();
 		config.setForegroundFPS(60);
+		config.setTitle("%APP_NAME%");
 		new Lwjgl3Application(new %MAIN_CLASS%(), config);
 	}
 }

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetupUI.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetupUI.java
@@ -454,7 +454,7 @@ public class GdxSetupUI extends JFrame {
 	class Form extends JPanel {
 		ExternalExtensionsDialog externalExtensionsDialog = new ExternalExtensionsDialog(dependencies);
 		JLabel nameLabel = new JLabel("Project name:");
-		JTextField nameText = new JTextField("my-gdx-game");
+		JTextField nameText = new JTextField("My GDX Game");
 		JLabel packageLabel = new JLabel("Package name:");
 		JTextField packageText = new JTextField("com.mygdx.game");
 		JLabel gameClassLabel = new JLabel("Game class:");


### PR DESCRIPTION
I don't mean to tread on any toes here, but after a few days of silence I'm proposing this solution for undoing the recent change that causes LWJGL3 projects to default to having no window title. This pull request restores the window title for old projects, corrects the javadoc, makes new projects use the project name for the window title (same as other backends) and changes the default project name in gdx-setup to clarify that the project name can and should have spaces and proper capitalisation.