### PR TITLE
Add ability to host GWT module on a different domain than the site

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplication.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplication.java
@@ -92,7 +92,10 @@ public abstract class GwtApplication implements EntryPoint, Application {
 	public abstract GwtApplicationConfiguration getConfig ();
 
 	public String getPreloaderBaseURL () {
-		return GWT.getHostPageBaseURL() + "assets/";
+		String moduleUrl = GWT.getModuleBaseURL();
+		// Total Length - len("html") - len("/")
+		int correctLength = moduleUrl.length() - GWT.getModuleName().length() - 1;
+		return moduleUrl.substring(0, correctLength) + "assets/";
 	}
 
 	@Override

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/preloader/AssetDownloader.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/preloader/AssetDownloader.java
@@ -18,6 +18,7 @@ package com.badlogic.gdx.backends.gwt.preloader;
 
 import com.badlogic.gdx.backends.gwt.preloader.AssetFilter.AssetType;
 import com.badlogic.gdx.utils.GdxRuntimeException;
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.ImageElement;
 import com.google.gwt.dom.client.NativeEvent;
 import com.google.gwt.typedarrays.shared.Int8Array;
@@ -143,7 +144,14 @@ public class AssetDownloader {
 	}
 
 	public void loadImage (final String url, final String mimeType, final AssetLoaderListener<ImageElement> listener) {
-		loadImage(url, mimeType, null, listener);
+		String crossOrigin = null;
+
+		// Enable CORS if we're running from a different URL to the host page
+		if (!url.startsWith(GWT.getHostPageBaseURL())) {
+			crossOrigin = "anonymous";
+		}
+
+		loadImage(url, mimeType, crossOrigin, listener);
 	}
 
 	public void loadImage (final String url, final String mimeType, final String crossOrigin,


### PR DESCRIPTION
This is a port of https://github.com/tommyettinger/gdx-backends/pull/1 to the main LibGDX GWT backend project. The main use case of this PR, is it allows the module and host URLs to differ, allowing for externally hosting the actual application on a CDN, S3 bucket, or similar.

For thin webapps, such as React sites, bundling the LibGDX app within the site can be a problem. 

I wrote about hosting apps with this setup a while ago here, https://madelinemiller.dev/blog/embed-gwt-in-react/ - and have been using the linked PR (which this change is a clone of) for multiple years with multiple LibGDX games without issue.