### PR TITLE
Case for Removal of Deprecated status on Lwjgl3ApplicationConfiguration.setTransparentFramebuffer()

### DIFF
--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3ApplicationConfiguration.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3ApplicationConfiguration.java
@@ -167,8 +167,7 @@ public class Lwjgl3ApplicationConfiguration extends Lwjgl3WindowConfiguration {
 		this.samples = samples;
 	}
 
-	/** Set transparent window hint
-	 * Results may vary on different OS and GPUs.
+	/** Set transparent window hint Results may vary on different OS and GPUs.
 	 * @param transparentFramebuffer */
 	public void setTransparentFramebuffer (boolean transparentFramebuffer) {
 		this.transparentFramebuffer = transparentFramebuffer;

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3ApplicationConfiguration.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3ApplicationConfiguration.java
@@ -168,9 +168,8 @@ public class Lwjgl3ApplicationConfiguration extends Lwjgl3WindowConfiguration {
 	}
 
 	/** Set transparent window hint
-	 * @deprecated Results may vary on different OS and GPUs. See https://github.com/glfw/glfw/issues/1237
+	 * Results may vary on different OS and GPUs.
 	 * @param transparentFramebuffer */
-	@Deprecated
 	public void setTransparentFramebuffer (boolean transparentFramebuffer) {
 		this.transparentFramebuffer = transparentFramebuffer;
 	}

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3ApplicationConfiguration.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3ApplicationConfiguration.java
@@ -167,7 +167,7 @@ public class Lwjgl3ApplicationConfiguration extends Lwjgl3WindowConfiguration {
 		this.samples = samples;
 	}
 
-	/** Set transparent window hint Results may vary on different OS and GPUs.
+	/** Set transparent window hint. Results may vary on different OS and GPUs. Usage with the ANGLE backend is less consistent.
 	 * @param transparentFramebuffer */
 	public void setTransparentFramebuffer (boolean transparentFramebuffer) {
 		this.transparentFramebuffer = transparentFramebuffer;


### PR DESCRIPTION
With the recent push to make lwjgl3 the default backend for desktop. I believe it's time to take a look at the removal of the Deprecated status that was originally placed on setTransparentFramebuffer() back in 2018 during the closure of this issue. #5313

This might seem insignificant, but having this method Deprecated is a big red flag to anyone who may like to use this pretty cool, though niche, feature. But does it even need to be anymore? I've done some digging and that's what we are here to decide.

First, The original comment in the code references an issue in the GLFW repo from 4 years ago which is still open to this day. [issue 1237](https://github.com/glfw/glfw/issues/1237) Which states that a user with an NVIDIA gpu running windows 10 was having issue with a test program using window transparency. The issue will most likely never be closed as the original user has not commented in about 4 years. Even as recently as this past week there have been other user's questioning whether it is still relevant.

Second, This same problem was brought up in a separate issue later that year in the same GLFW repo by another user with an NVIDIA card [issue 1288](https://github.com/glfw/glfw/issues/1288). Though the difference here is this user followed up on the issue a few months later stating that an NVIDIA driver update resolved this problem. Issue closed. This was about 4 years ago.

Obviously we need more proof than this, so I went about verifying for myself as best I could.
Just to cover all our bases. I created 4 different builds of the default projects and added a transparent window using setTransparentFramebuffer(true)
One for libGDX 1.10.0, one for libGDX-1.10.1-SNAPSHOT, one for libGDX with the gdx-lwjgl3-glfw-awt-macos extension and finally an ANGLE build using gdx-lwjgl3-angle. 

Since the issue originally cited nvidia cards able to test on a win10 laptop with a GTX 860M.
All 4 tests worked perfectly and showed a transparent window. I've supplied a SS below.
![nvidiaTest1](https://user-images.githubusercontent.com/55356015/163761470-1e81e170-67b6-4abe-bab3-c06ded368bde.png)

I also performed tests on a Win10 AMD pc, and a Win 11 with integrated intel graphics. All Worked.
I tested on an Ubuntu instance in VMWare. All worked, EXCEPT the ANGEL build, it did not show transparency.

I was also able to run these tests on a friends 2011 Macbook Pro, you can see the results below.
![macbook](https://user-images.githubusercontent.com/55356015/163765034-b6e71896-9271-4bc1-8e1e-8485456e1066.png)

3 of my tests worked but I was unable to test the ANGEL build as during testing I was unable to get it to run, regardless of transparency settings it was throwing a GLFW_API_UNAVAILABLE error. Though I think this was related to the outdated macbook itself.

Lastly I was able to test on a 2014 Mac-Mini
![macmini](https://user-images.githubusercontent.com/55356015/163762473-980d01bd-96bc-4c25-aa75-1cfd29bc20e1.png)
3 of the test's passed but the ANGLE build did not show any transparency. Just like my testing on the Ubuntu VM.

I reached out to fellow dev's on discord to see if anyone would help me do some testing.
@Frosty-J came through and helped a lot by providing some of  the following.
Seems like windows XP and Vista don't seem to make the cut.
![image](https://user-images.githubusercontent.com/55356015/163763172-225cc96d-5e1d-4d94-9478-13ff640154fb.png)
![image](https://user-images.githubusercontent.com/55356015/163763324-1498df6f-9c18-4994-bb9d-4f0edece960c.png)

But anything Windows 7 and above did.
![image](https://user-images.githubusercontent.com/55356015/163763388-c31dacff-de3e-472a-8062-860206928cb8.png)
![image](https://user-images.githubusercontent.com/55356015/163763427-855e17e1-1b92-4534-ae06-226c438308a8.png)

And just like with my tests on Linux and the mac VM, the ANGLE build doesn't seem to show transparency.
![image](https://user-images.githubusercontent.com/55356015/163762941-cb4212b8-8e99-4ee8-b549-e3b1473c140e.png)

That was all we were able to put together for now. But considering the original reason for deprecation stemmed from that initial issue linked in the comment about nvidia cards. I'm not sure how relevant that is 4 years later.

This PR simply removes the Deprecated annotation along with that github link as I don't believe it's been relevant for years. I did choose to leave the "Results may vary on different OS and GPUs." Only because I can't thoroughly test everything.

If we could get more participants to do their own test, it would be appreciated.

