### PR TITLE
Proguard rule to keep com.badlogic.gdx.scenes.scene2d.InputEvent

### DIFF
--- a/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/android/proguard-rules.pro
+++ b/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/android/proguard-rules.pro
@@ -28,6 +28,7 @@
 -dontwarn com.badlogic.gdx.graphics.g2d.freetype.FreetypeBuild
 
 -keep class com.badlogic.gdx.scenes.scene2d.InputEvent
+-keep class com.badlogic.gdx.scenes.scene2d.Stage$TouchFocus
 
 # Required if using Gdx-Controllers extension
 -keep class com.badlogic.gdx.controllers.android.AndroidControllers

--- a/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/android/proguard-rules.pro
+++ b/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/android/proguard-rules.pro
@@ -27,6 +27,8 @@
 -dontwarn com.badlogic.gdx.jnigen.BuildTarget*
 -dontwarn com.badlogic.gdx.graphics.g2d.freetype.FreetypeBuild
 
+-keep class com.badlogic.gdx.scenes.scene2d.InputEvent
+
 # Required if using Gdx-Controllers extension
 -keep class com.badlogic.gdx.controllers.android.AndroidControllers
 


### PR DESCRIPTION
I upgraded from libgdx 1.9.12 to 1.10.0  and encountered a crash on my minified android release builds when calling `stage.clear()`. Seems the Scene2d InputEvent is being used through reflection. Adding a rule to keep that class with proguard fixed the crashes for me.

InputEvent crash
```text
Fatal Exception: com.badlogic.gdx.utils.GdxRuntimeException: Unable to create new instance: b2.f
       at com.badlogic.gdx.utils.ReflectionPool.newObject(ReflectionPool.java:62)
       at com.badlogic.gdx.utils.Pool.obtain(Pool.java:53)
       at com.badlogic.gdx.utils.Pools.obtain(Pools.java:48)
       at com.badlogic.gdx.scenes.scene2d.Stage.I(Stage.java:2)
       at com.badlogic.gdx.scenes.scene2d.Stage.cancelTouchFocus(Stage.java:517)
       at com.badlogic.gdx.scenes.scene2d.Stage.unfocusAll(Stage.java:601)
       at com.badlogic.gdx.scenes.scene2d.Stage.clear(Stage.java:593)
       ...

Caused by com.badlogic.gdx.utils.reflect.ReflectionException: Exception occurred in constructor for class: b2.f
       at com.badlogic.gdx.utils.reflect.Constructor.newInstance(Constructor.java:62)
       at com.badlogic.gdx.utils.ReflectionPool.c(ReflectionPool.java:2)
       at com.badlogic.gdx.utils.Pool.obtain(Pool.java:53)
       at com.badlogic.gdx.utils.Pools.obtain(Pools.java:48)
       at com.badlogic.gdx.scenes.scene2d.Stage.I(Stage.java:2)
       at com.badlogic.gdx.scenes.scene2d.Stage.cancelTouchFocus(Stage.java:517)
       at com.badlogic.gdx.scenes.scene2d.Stage.unfocusAll(Stage.java:601)
       at com.badlogic.gdx.scenes.scene2d.Stage.clear(Stage.java:593)
       ...
```

TouchFocus crash
```text
Fatal Exception: java.lang.RuntimeException: Actor: MY_ACTOR_NAME
       at com.badlogic.gdx.scenes.scene2d.Actor.notify(Actor.java:192)
       at com.badlogic.gdx.scenes.scene2d.Actor.fire(Actor.java:148)
       at com.badlogic.gdx.scenes.scene2d.Stage.touchDown(Stage.java:285)
       at com.badlogic.gdx.backends.android.DefaultAndroidInput.processEvents(DefaultAndroidInput.java:420)
       at com.badlogic.gdx.backends.android.AndroidGraphics.onDrawFrame(AndroidGraphics.java:469)
       at android.opengl.GLSurfaceView$GLThread.guardedRun(GLSurfaceView.java:1591)
       at android.opengl.GLSurfaceView$GLThread.run(GLSurfaceView.java:1286)

Caused by com.badlogic.gdx.utils.GdxRuntimeException: Unable to create new instance: com.badlogic.gdx.scenes.scene2d.Stage$a
       at com.badlogic.gdx.utils.ReflectionPool.newObject(ReflectionPool.java:62)
       at com.badlogic.gdx.utils.Pool.obtain(Pool.java:53)
       at com.badlogic.gdx.utils.Pools.obtain(Pools.java:48)
       at com.badlogic.gdx.scenes.scene2d.Stage.addTouchFocus(Stage.java:457)
       at com.badlogic.gdx.scenes.scene2d.InputListener.handle(InputListener.java:66)
       at com.badlogic.gdx.scenes.scene2d.Actor.notify(Actor.java:188)
       at com.badlogic.gdx.scenes.scene2d.Actor.fire(Actor.java:148)
       at com.badlogic.gdx.scenes.scene2d.Stage.touchDown(Stage.java:285)
       at com.badlogic.gdx.backends.android.DefaultAndroidInput.processEvents(DefaultAndroidInput.java:420)
       at com.badlogic.gdx.backends.android.AndroidGraphics.onDrawFrame(AndroidGraphics.java:469)
       at android.opengl.GLSurfaceView$GLThread.guardedRun(GLSurfaceView.java:1591)
       at android.opengl.GLSurfaceView$GLThread.run(GLSurfaceView.java:1286)

Caused by com.badlogic.gdx.utils.reflect.ReflectionException: Exception occurred in constructor for class: com.badlogic.gdx.scenes.scene2d.Stage$a
       at com.badlogic.gdx.utils.reflect.Constructor.newInstance(Constructor.java:62)
       at com.badlogic.gdx.utils.ReflectionPool.c(ReflectionPool.java:2)
       at com.badlogic.gdx.utils.Pool.obtain(Pool.java:53)
       at com.badlogic.gdx.utils.Pools.obtain(Pools.java:48)
       at com.badlogic.gdx.scenes.scene2d.Stage.addTouchFocus(Stage.java:457)
       at com.badlogic.gdx.scenes.scene2d.InputListener.handle(InputListener.java:66)
       at com.badlogic.gdx.scenes.scene2d.Actor.notify(Actor.java:188)
       at com.badlogic.gdx.scenes.scene2d.Actor.fire(Actor.java:148)
       at com.badlogic.gdx.scenes.scene2d.Stage.touchDown(Stage.java:285)
       at com.badlogic.gdx.backends.android.DefaultAndroidInput.processEvents(DefaultAndroidInput.java:420)
       at com.badlogic.gdx.backends.android.AndroidGraphics.onDrawFrame(AndroidGraphics.java:469)
       at android.opengl.GLSurfaceView$GLThread.guardedRun(GLSurfaceView.java:1591)
       at android.opengl.GLSurfaceView$GLThread.run(GLSurfaceView.java:1286)
```