### PR TITLE
Fix Sprite's getColor() behavior

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g2d/Sprite.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/Sprite.java
@@ -630,12 +630,6 @@ public class Sprite extends TextureRegion {
 	/** Returns the color of this sprite. If the returned instance is manipulated, {@link #setColor(Color)} must be called
 	 * afterward. */
 	public Color getColor () {
-		int intBits = NumberUtils.floatToIntColor(vertices[C1]);
-		Color color = this.color;
-		color.r = (intBits & 0xff) / 255f;
-		color.g = ((intBits >>> 8) & 0xff) / 255f;
-		color.b = ((intBits >>> 16) & 0xff) / 255f;
-		color.a = ((intBits >>> 24) & 0xff) / 255f;
 		return color;
 	}
 

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/Sprite.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/Sprite.java
@@ -22,7 +22,6 @@ import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.math.Rectangle;
-import com.badlogic.gdx.utils.NumberUtils;
 
 /** Holds the geometry, color, and texture information for drawing 2D sprites using {@link Batch}. A Sprite has a position and a
  * size given as width and height. The position is relative to the origin of the coordinate system specified via


### PR DESCRIPTION
As described in [issue 6862](https://github.com/libgdx/libgdx/issues/6862) `getColor()` returns a vertex's modified color instead of the `color` variable stored in the `Sprite`.

Even if the reason for the current implementation is to keep sync when the user modifies the vertices' colors directly, current `getColor()` implementation only takes `C1` into account.

Thanks to @tommyettinger, @mgsx-dev, @Frosty-J & @MobiDevelop for helping me understand key concepts