### PR TITLE
Change javadocs link to javadoc.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ As we use Gradle, there's no need to download libGDX itself  &ndash; this can al
 - [A Simple Game](https://libgdx.com/wiki/start/a-simple-game)
 - [Tutorials & Demos](https://libgdx.com/wiki/start/demos-and-tutorials)
 
-We also provide [javadocs](https://libgdx.badlogicgames.com/nightlies/docs/api/) online. The javadocs are bundled with every libGDX distribution for consumption in your favorite IDE.
+We also provide [javadocs](https://javadoc.io/doc/com.badlogicgames.gdx) online. The javadocs are bundled with every libGDX distribution for consumption in your favorite IDE.
 
 ## Community & Contributing
 You can follow the **latest news** about libGDX on our [blog](https://libgdx.com/news/). Another good way to get in touch with our community is to join the official [libGDX Discord](https://libgdx.com/community/discord/).

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/net/HttpRequestExample.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/net/HttpRequestExample.java
@@ -29,7 +29,7 @@ public class HttpRequestExample extends GdxTest {
 	@Override
 	public void create () {
 		HttpRequest request = new HttpRequest(HttpMethods.GET);
-		request.setUrl("http://libgdx.badlogicgames.com/nightlies/dist/AUTHORS");
+		request.setUrl("https://raw.githubusercontent.com/libgdx/libgdx/master/AUTHORS");
 		Gdx.net.sendHttpRequest(request, new HttpResponseListener() {
 			@Override
 			public void handleHttpResponse (HttpResponse httpResponse) {

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/net/NetAPITest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/net/NetAPITest.java
@@ -109,9 +109,9 @@ public class NetAPITest extends GdxTest implements HttpResponseListener {
 					else if (clickedButton == btnDownloadText)
 						url = "https://www.apache.org/licenses/LICENSE-2.0.txt";
 					else if (clickedButton == btnDownloadLarge)
-						url = "https://libgdx.badlogicgames.com/releases/libgdx-1.2.0.zip";
+						url = "https://github.com/libgdx/libgdx/archive/refs/tags/1.11.0.zip";
 					else if (clickedButton == btnDownloadError)
-						url = "https://www.badlogicgames.com/doesnotexist";
+						url = "https://libgdx.com/doesnotexist";
 					else if (clickedButton == btnOpenUri) {
 						Gdx.net.openURI("https://libgdx.com");
 						return;


### PR DESCRIPTION
As discussed on Discord, the javadocs hosted at libgdx.badlogicgames.com are outdated. While generating our own javadocs and hosting them at libgdx.com would be nice, this is an adequate stopgap in the meantime.

Related: https://github.com/libgdx/libgdx.github.io/issues/105