### PR TITLE
Added -use option to javadoc generation

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,6 @@
 [1.11.1]
 - iOS: Add new MobiVM MetalANGLE backend
+- Javadoc: Add "-use" flag to javadoc generation
 
 [1.11.0]
 - [BREAKING CHANGE] iOS: Increased min supported iOS version to 9.0. Update your Info.plist file if necessary.

--- a/build.gradle
+++ b/build.gradle
@@ -85,6 +85,7 @@ allprojects {
     }
     tasks.withType(Javadoc) {
         options.encoding = 'UTF-8'
+        options.addBooleanOption('use', true);
     }
     tasks.withType(Test) {
         systemProperty 'file.encoding', 'UTF-8'


### PR DESCRIPTION
In the discord server James discovered that the generated javadoc doesn't have the "use" navigation tab anymore compared to the old javadoc still hosted on the badlogic servers

This PR is very simple and adds the ["-use"](https://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html#CHDGCJEG) flag to the javadoc generation and therefore adds that feature back.


Example: 

Old ones:
https://libgdx.badlogicgames.com/ci/nightlies/docs/api/com/badlogic/gdx/maps/package-use.html
![image](https://user-images.githubusercontent.com/11274700/169670515-24271761-798c-47e4-8d1b-1b6052c0fd3f.png)

Current ones:
https://javadoc.io/static/com.badlogicgames.gdx/gdx/1.11.0/com/badlogic/gdx/maps/package-summary.html
![image](https://user-images.githubusercontent.com/11274700/169670507-0941119c-5040-44aa-9f8e-d5a5988db0da.png)
