### PR TITLE
fix SortedIntList when used with allocateIterators

### DIFF
--- a/gdx/src/com/badlogic/gdx/utils/SortedIntList.java
+++ b/gdx/src/com/badlogic/gdx/utils/SortedIntList.java
@@ -115,7 +115,7 @@ public class SortedIntList<E> implements Iterable<SortedIntList.Node<E>> {
 	 * Use the {@link Iterator} constructor for nested or multithreaded iteration. */
 	public java.util.Iterator<Node<E>> iterator () {
 		if (Collections.allocateIterators) return new Iterator();
-		if (iterator == null) iterator = new Iterator();
+		if (iterator == null) return iterator = new Iterator();
 		return iterator.reset();
 	}
 

--- a/gdx/src/com/badlogic/gdx/utils/SortedIntList.java
+++ b/gdx/src/com/badlogic/gdx/utils/SortedIntList.java
@@ -114,7 +114,7 @@ public class SortedIntList<E> implements Iterable<SortedIntList.Node<E>> {
 	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called.
 	 * Use the {@link Iterator} constructor for nested or multithreaded iteration. */
 	public java.util.Iterator<Node<E>> iterator () {
-		if (Collections.allocateIterators) return new Iterator().reset();
+		if (Collections.allocateIterators) return new Iterator();
 		if (iterator == null) iterator = new Iterator();
 		return iterator.reset();
 	}
@@ -122,6 +122,10 @@ public class SortedIntList<E> implements Iterable<SortedIntList.Node<E>> {
 	public class Iterator implements java.util.Iterator<Node<E>> {
 		private Node<E> position;
 		private Node<E> previousPosition;
+
+		public Iterator () {
+			reset();
+		}
 
 		@Override
 		public boolean hasNext () {

--- a/gdx/src/com/badlogic/gdx/utils/SortedIntList.java
+++ b/gdx/src/com/badlogic/gdx/utils/SortedIntList.java
@@ -114,7 +114,7 @@ public class SortedIntList<E> implements Iterable<SortedIntList.Node<E>> {
 	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called.
 	 * Use the {@link Iterator} constructor for nested or multithreaded iteration. */
 	public java.util.Iterator<Node<E>> iterator () {
-		if (Collections.allocateIterators) return new Iterator();
+		if (Collections.allocateIterators) return new Iterator().reset();
 		if (iterator == null) iterator = new Iterator();
 		return iterator.reset();
 	}

--- a/gdx/test/com/badlogic/gdx/utils/SortedIntListTest.java
+++ b/gdx/test/com/badlogic/gdx/utils/SortedIntListTest.java
@@ -1,0 +1,21 @@
+package com.badlogic.gdx.utils;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SortedIntListTest {
+
+	@Test
+	public void testIteratorWithAllocation(){
+		Collections.allocateIterators = true;
+		try{
+			SortedIntList<String> list = new SortedIntList<String>();
+			list.insert(0, "hello");
+			Assert.assertEquals(1, list.size);
+			Assert.assertEquals("hello", list.get(0));
+			Assert.assertEquals("hello", list.iterator().next().value);
+		}finally{
+			Collections.allocateIterators = false;
+		}
+	}
+}

--- a/gdx/test/com/badlogic/gdx/utils/SortedIntListTest.java
+++ b/gdx/test/com/badlogic/gdx/utils/SortedIntListTest.java
@@ -1,3 +1,4 @@
+
 package com.badlogic.gdx.utils;
 
 import org.junit.Assert;
@@ -6,15 +7,15 @@ import org.junit.Test;
 public class SortedIntListTest {
 
 	@Test
-	public void testIteratorWithAllocation(){
+	public void testIteratorWithAllocation () {
 		Collections.allocateIterators = true;
-		try{
+		try {
 			SortedIntList<String> list = new SortedIntList<String>();
 			list.insert(0, "hello");
 			Assert.assertEquals(1, list.size);
 			Assert.assertEquals("hello", list.get(0));
 			Assert.assertEquals("hello", list.iterator().next().value);
-		}finally{
+		} finally {
 			Collections.allocateIterators = false;
 		}
 	}


### PR DESCRIPTION
SortedIntList is used with DecalBatch and doesn't work when using `Collections.allocateIterators = true`.

I didn't investigate for all other collections but i suspect there are similar issues.

Feel free to commit to this PR if you find some other.