### PR TITLE
Bitcode is deprecated on XCode 14

### DIFF
--- a/backends/gdx-backend-robovm/build-objectal.sh
+++ b/backends/gdx-backend-robovm/build-objectal.sh
@@ -12,8 +12,8 @@ tar xvfz $BUILD_DIR/objectal.tar.gz -C $BUILD_DIR --strip-components 1
 
 XCODEPROJ=$BUILD_DIR/ObjectAL/ObjectAL.xcodeproj
 
-xcodebuild -project $XCODEPROJ -arch armv7  -sdk iphoneos         CONFIGURATION_BUILD_DIR=$BUILD_DIR/armv7  OTHER_CFLAGS="-fembed-bitcode -target armv7-apple-ios9.0.0"
-xcodebuild -project $XCODEPROJ -arch arm64  -sdk iphoneos         CONFIGURATION_BUILD_DIR=$BUILD_DIR/arm64  OTHER_CFLAGS="-fembed-bitcode -target arm64-apple-ios9.0.0"
+xcodebuild -project $XCODEPROJ -arch armv7  -sdk iphoneos         CONFIGURATION_BUILD_DIR=$BUILD_DIR/armv7  OTHER_CFLAGS="-target armv7-apple-ios9.0.0"
+xcodebuild -project $XCODEPROJ -arch arm64  -sdk iphoneos         CONFIGURATION_BUILD_DIR=$BUILD_DIR/arm64  OTHER_CFLAGS="-target arm64-apple-ios9.0.0"
 xcodebuild -project $XCODEPROJ -arch x86_64 -sdk iphonesimulator  CONFIGURATION_BUILD_DIR=$BUILD_DIR/x86_64 OTHER_CFLAGS="-target x86_64-simulator-apple-ios9.0.0"
 xcodebuild -project $XCODEPROJ -arch arm64  -sdk iphonesimulator  CONFIGURATION_BUILD_DIR=$BUILD_DIR/arm64-simulator  OTHER_CFLAGS="-target arm64-simulator-apple-ios9.0.0"
 

--- a/backends/gdx-backend-robovm/build-objectal.sh
+++ b/backends/gdx-backend-robovm/build-objectal.sh
@@ -15,7 +15,7 @@ XCODEPROJ=$BUILD_DIR/ObjectAL/ObjectAL.xcodeproj
 xcodebuild -project $XCODEPROJ -arch armv7  -sdk iphoneos         CONFIGURATION_BUILD_DIR=$BUILD_DIR/armv7  OTHER_CFLAGS="-fembed-bitcode -target armv7-apple-ios9.0.0"
 xcodebuild -project $XCODEPROJ -arch arm64  -sdk iphoneos         CONFIGURATION_BUILD_DIR=$BUILD_DIR/arm64  OTHER_CFLAGS="-fembed-bitcode -target arm64-apple-ios9.0.0"
 xcodebuild -project $XCODEPROJ -arch x86_64 -sdk iphonesimulator  CONFIGURATION_BUILD_DIR=$BUILD_DIR/x86_64 OTHER_CFLAGS="-target x86_64-simulator-apple-ios9.0.0"
-xcodebuild -project $XCODEPROJ -arch arm64  -sdk iphonesimulator  CONFIGURATION_BUILD_DIR=$BUILD_DIR/arm64-simulator  OTHER_CFLAGS="-fembed-bitcode -target arm64-simulator-apple-ios9.0.0"
+xcodebuild -project $XCODEPROJ -arch arm64  -sdk iphonesimulator  CONFIGURATION_BUILD_DIR=$BUILD_DIR/arm64-simulator  OTHER_CFLAGS="-target arm64-simulator-apple-ios9.0.0"
 
 mkdir $BUILD_DIR/real/
 


### PR DESCRIPTION
~~This is nothing really relevant, I just noticed it by accident.
The embedded bitcode is only relevant when publishing in the App Store.~~
Bitcode appears to be deprecated on XCode 14 and won't be accepted even on AppStore submissions. 