### PR TITLE
Scene2D actor, add duplicate some method to use Vector2 instead of x, y

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 [1.11.1]
 - iOS: Add new MobiVM MetalANGLE backend
 - Javadoc: Add "-use" flag to javadoc generation
+- API Addition: Scene2D, Actor.java Duplicate some method to use Vector2 instead of (float x, float y) : setPosition(Vector2), setPosition(Vector2, int alignment), moveBy(Vector2 move)
 
 [1.11.0]
 - [BREAKING CHANGE] iOS: Increased min supported iOS version to 9.0. Update your Info.plist file if necessary.

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/Actor.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/Actor.java
@@ -520,6 +520,11 @@ public class Actor {
 		}
 	}
 
+	/** @see #setPosition(float x, float y) */
+	public void setPosition (Vector2 pos) {
+		this.setPosition(pos.x, pos.y);
+	}
+
 	/** Sets the position using the specified {@link Align alignment}. Note this may set the position to non-integer
 	 * coordinates. */
 	public void setPosition (float x, float y, int alignment) {
@@ -540,6 +545,11 @@ public class Actor {
 		}
 	}
 
+	/** @see #setPosition(float x, float y, int alignment) */
+	public void setPosition (Vector2 pos, int alignment) {
+		this.setPosition(pos.x, pos.y, alignment);
+	}
+
 	/** Add x and y to current position */
 	public void moveBy (float x, float y) {
 		if (x != 0 || y != 0) {
@@ -547,6 +557,11 @@ public class Actor {
 			this.y += y;
 			positionChanged();
 		}
+	}
+
+	/** @see #moveBy(float x, float y) */
+	public void moveBy (Vector2 move) {
+		this.moveBy(move.x, move.y);
 	}
 
 	public float getWidth () {


### PR DESCRIPTION
Hi i add some methods in Actor.java to use Vector2 instead of float x, float y.
I do it because is boring to do setPosition(pos.x, pos.y)
 (often my Vector2 var has a big name so its more like 
`        image.setPosition(GameHudConstants.POS_ATTACK.x, GameHudConstants.POS_ATTACK.y);`

Methods duplicate : setPosition (Vector2 pos), setPosition (Vector2 pos, int alignment), moveBy (Vector2 move)

This commit add nothing new, it just for code comfort.

thanks for reading.
