### PR TITLE
Add more docs on stereo sound panning

### DIFF
--- a/gdx/src/com/badlogic/gdx/audio/Sound.java
+++ b/gdx/src/com/badlogic/gdx/audio/Sound.java
@@ -51,6 +51,7 @@ public interface Sound extends Disposable {
 	public long play (float volume);
 
 	/** Plays the sound. If the sound is already playing, it will be played again, concurrently.
+	 * Note that panning only works for mono sounds, not for stereo sounds!
 	 * @param volume the volume in the range [0,1]
 	 * @param pitch the pitch multiplier, 1 == default, >1 == faster, <1 == slower, the value has to be between 0.5 and 2.0
 	 * @param pan panning in the range -1 (full left) to 1 (full right). 0 is center position.
@@ -69,6 +70,7 @@ public interface Sound extends Disposable {
 
 	/** Plays the sound, looping. If the sound is already playing, it will be played again, concurrently. You need to stop the
 	 * sound via a call to {@link #stop(long)} using the returned id.
+	 * Note that panning only works for mono sounds, not for stereo sounds!
 	 * @param volume the volume in the range [0,1]
 	 * @param pitch the pitch multiplier, 1 == default, >1 == faster, <1 == slower, the value has to be between 0.5 and 2.0
 	 * @param pan panning in the range -1 (full left) to 1 (full right). 0 is center position.

--- a/gdx/src/com/badlogic/gdx/audio/Sound.java
+++ b/gdx/src/com/badlogic/gdx/audio/Sound.java
@@ -51,7 +51,7 @@ public interface Sound extends Disposable {
 	public long play (float volume);
 
 	/** Plays the sound. If the sound is already playing, it will be played again, concurrently.
-	 * Note that panning only works for mono sounds, not for stereo sounds!
+	 * Note that (with the exception of the web backend) panning only works for mono sounds, not for stereo sounds!
 	 * @param volume the volume in the range [0,1]
 	 * @param pitch the pitch multiplier, 1 == default, >1 == faster, <1 == slower, the value has to be between 0.5 and 2.0
 	 * @param pan panning in the range -1 (full left) to 1 (full right). 0 is center position.
@@ -70,7 +70,7 @@ public interface Sound extends Disposable {
 
 	/** Plays the sound, looping. If the sound is already playing, it will be played again, concurrently. You need to stop the
 	 * sound via a call to {@link #stop(long)} using the returned id.
-	 * Note that panning only works for mono sounds, not for stereo sounds!
+	 * Note that (with the exception of the web backend) panning only works for mono sounds, not for stereo sounds!
 	 * @param volume the volume in the range [0,1]
 	 * @param pitch the pitch multiplier, 1 == default, >1 == faster, <1 == slower, the value has to be between 0.5 and 2.0
 	 * @param pan panning in the range -1 (full left) to 1 (full right). 0 is center position.


### PR DESCRIPTION
In #4256, docs on how panning only works for mono sounds was added to the `Sound#setPan()` method.

However for anyone trying to use `Sound#play()` with the panning argument, they won't see this note in the Javadocs.

I'd like to suggest adding the same note to these method docs!