### PR TITLE
Add back OpenGLES linking for gdx-setup

### DIFF
--- a/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/ios/robovm.xml
+++ b/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/ios/robovm.xml
@@ -37,6 +37,7 @@
   </libs>
   <frameworks>
     <framework>UIKit</framework>
+    <framework>OpenGLES</framework>
     <framework>QuartzCore</framework>
     <framework>CoreGraphics</framework>
     <framework>OpenAL</framework>


### PR DESCRIPTION
See https://github.com/libgdx/libgdx/issues/6884 for more information

After this is merged I will open a reverting pr that should than get merged when releasing the next version.

Fixes https://github.com/libgdx/libgdx/issues/6884