### PR TITLE
Revert "Add back OpenGLES linking for gdx-setup"

### DIFF
--- a/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/ios/robovm.xml
+++ b/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/ios/robovm.xml
@@ -37,7 +37,6 @@
   </libs>
   <frameworks>
     <framework>UIKit</framework>
-    <framework>OpenGLES</framework>
     <framework>QuartzCore</framework>
     <framework>CoreGraphics</framework>
     <framework>OpenAL</framework>


### PR DESCRIPTION
Reverts libgdx/libgdx#6887

As discussed in #6884, don't merge this before the next libGDX release
@obigu could you milestone this?