### PR TITLE
Set immersive mode to true by default on Android

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,5 @@
 [1.11.1]
+- [BREAKING CHANGE] Android: Immersive mode is now true by default. Set `useImmersiveMode` config to `false` to disable it. 
 - iOS: Add new MobiVM MetalANGLE backend
 - API Addition: Added Haptics API with 4 different Input#vibrate() methods with complete Android and iOS implementations.
 - Javadoc: Add "-use" flag to javadoc generation

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplicationConfiguration.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplicationConfiguration.java
@@ -88,7 +88,7 @@ public class AndroidApplicationConfiguration {
 	public boolean getTouchEventsForLiveWallpaper = false;
 
 	/** set this to true to enable Android 4.4 KitKat's 'Immersive mode' **/
-	public boolean useImmersiveMode = false;
+	public boolean useImmersiveMode = true;
 
 	/** Experimental, whether to enable OpenGL ES 3 if supported. If not supported it will fall-back to OpenGL ES 2.0. When GL ES
 	 * 3* is enabled, {@link com.badlogic.gdx.Gdx#gl30} can be used to access its functionality. Requires at least Android 4.3 (API


### PR DESCRIPTION
Immersive mode is nowadays enabled on most games and should be default. Backwards compatibility wise should not be a big deal (for those who don't read CHANGES) as the difference is obvious.