### PR TITLE
Set new defaults for auto-hide home indicator and screen edges deferring system gestures 

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,6 @@
 [1.11.1]
+- [BREAKING CHANGE] iOS: `hideHomeIndicator` set to `false` by default (was `true`).
+- [BREAKING CHANGE] iOS: `screenEdgesDeferringSystemGestures` set to `UIRectEdge.All` by default (was `UIRectEdge.None`).
 - iOS: Add new MobiVM MetalANGLE backend
 - API Addition: Added Haptics API with 4 different Input#vibrate() methods with complete Android and iOS implementations.
 - Javadoc: Add "-use" flag to javadoc generation

--- a/backends/gdx-backend-robovm-metalangle/src/com/badlogic/gdx/backends/iosrobovm/IOSApplicationConfiguration.java
+++ b/backends/gdx-backend-robovm-metalangle/src/com/badlogic/gdx/backends/iosrobovm/IOSApplicationConfiguration.java
@@ -68,15 +68,16 @@ public class IOSApplicationConfiguration {
 	/** whether the status bar should be visible or not * */
 	public boolean statusBarVisible = false;
 
-	/** whether the home indicator should be hidden or not * */
-	public boolean hideHomeIndicator = true;
+	/** whether the home indicator should auto-hide or not. Be careful that if enabled, leaving the app only takes one swipe
+	 * gesture instead of two and the indicator is never semitransparent. * */
+	public boolean hideHomeIndicator = false;
 
 	/** Whether to override the ringer/mute switch, see https://github.com/libgdx/libgdx/issues/4430 */
 	public boolean overrideRingerSwitch = false;
 
 	/** Edges where app gestures must be fired over system gestures. Prior to iOS 11, UIRectEdge.All was default behaviour if
 	 * status bar hidden, see https://github.com/libgdx/libgdx/issues/5110 * */
-	public UIRectEdge screenEdgesDeferringSystemGestures = UIRectEdge.None;
+	public UIRectEdge screenEdgesDeferringSystemGestures = UIRectEdge.All;
 
 	/** The maximum number of threads to use for network requests. Default is {@link Integer#MAX_VALUE}. */
 	public int maxNetThreads = Integer.MAX_VALUE;

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSApplicationConfiguration.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSApplicationConfiguration.java
@@ -77,15 +77,16 @@ public class IOSApplicationConfiguration {
 	/** whether the status bar should be visible or not **/
 	public boolean statusBarVisible = false;
 
-	/** whether the home indicator should be hidden or not **/
-	public boolean hideHomeIndicator = true;
+	/** whether the home indicator should auto-hide or not. Be careful that if enabled, leaving the app only takes one swipe
+	 * gesture instead of two and the indicator is never semitransparent. **/
+	public boolean hideHomeIndicator = false;
 
 	/** Whether to override the ringer/mute switch, see https://github.com/libgdx/libgdx/issues/4430 */
 	public boolean overrideRingerSwitch = false;
 
 	/** Edges where app gestures must be fired over system gestures. Prior to iOS 11, UIRectEdge.All was default behaviour if
 	 * status bar hidden, see https://github.com/libgdx/libgdx/issues/5110 **/
-	public UIRectEdge screenEdgesDeferringSystemGestures = UIRectEdge.None;
+	public UIRectEdge screenEdgesDeferringSystemGestures = UIRectEdge.All;
 
 	/** The maximum number of threads to use for network requests. Default is {@link Integer#MAX_VALUE}. */
 	public int maxNetThreads = Integer.MAX_VALUE;


### PR DESCRIPTION
This is like the Android immersive mode on iOS that should be default for games. 

Current screen edges deferring system gestures defaults were set to `None` initially for backwards compatibility but they are not good for games as the system takes precedence over the game on gestures which means it's easy to "exit" the app or open settings while playing and, depending on the game and UI, some edges areas may even be inaccessible. It is a quite recurrent issue/question on Discord.

Auto-hide home indicator setting is somehow related to system deferring edges settings. If set to `true`, the home indicator keeps appearing and disappearing on swipe movements and one single swipe from the bottom (instead of 2) "exits" the app. It may be appropriate for apps such as video players in which you want a totally clean display area (not even the translucent home indicator) but most games should set it to `false`.