### PR TITLE
Fix iOS Keyboard type not changing immediately

### DIFF
--- a/backends/gdx-backend-robovm-metalangle/src/com/badlogic/gdx/backends/iosrobovm/DefaultIOSInput.java
+++ b/backends/gdx-backend-robovm-metalangle/src/com/badlogic/gdx/backends/iosrobovm/DefaultIOSInput.java
@@ -460,9 +460,9 @@ public class DefaultIOSInput extends AbstractInput implements IOSInput {
 		if (textfield == null) createDefaultTextField();
 		softkeyboardActive = visible;
 		if (visible) {
-			UIKeyboardType preferredInputType;
 			if (type == null) type = OnscreenKeyboardType.Default;
 			textfield.setKeyboardType(getIosInputType(type));
+			textfield.reloadInputViews();
 			textfield.becomeFirstResponder();
 			textfield.setDelegate(textDelegate);
 		} else {

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/DefaultIOSInput.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/DefaultIOSInput.java
@@ -451,9 +451,9 @@ public class DefaultIOSInput extends AbstractInput implements IOSInput {
 		if (textfield == null) createDefaultTextField();
 		softkeyboardActive = visible;
 		if (visible) {
-			UIKeyboardType preferredInputType;
 			if (type == null) type = OnscreenKeyboardType.Default;
 			textfield.setKeyboardType(getIosInputType(type));
+			textfield.reloadInputViews();
 			textfield.becomeFirstResponder();
 			textfield.setDelegate(textDelegate);
 		} else {


### PR DESCRIPTION
Currently the keyboard type does not change immediately when running "setOnscreenKeyboardVisible". This can be seen by running the "OnscreenKeyboardTest" test.
This pr fixes the issue.