### PR TITLE
AndroidDaydream input null check

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidDaydream.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidDaydream.java
@@ -287,7 +287,7 @@ public class AndroidDaydream extends DreamService implements AndroidApplicationB
 		boolean keyboardAvailable = false;
 		if (config.hardKeyboardHidden == Configuration.HARDKEYBOARDHIDDEN_NO) keyboardAvailable = true;
 		if (input != null) {
-		    input.setKeyboardAvailable(keyboardAvailable);
+			input.setKeyboardAvailable(keyboardAvailable);
 		}
 	}
 

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidDaydream.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidDaydream.java
@@ -286,7 +286,9 @@ public class AndroidDaydream extends DreamService implements AndroidApplicationB
 		super.onConfigurationChanged(config);
 		boolean keyboardAvailable = false;
 		if (config.hardKeyboardHidden == Configuration.HARDKEYBOARDHIDDEN_NO) keyboardAvailable = true;
-		input.setKeyboardAvailable(keyboardAvailable);
+		if (input != null) {
+		    input.setKeyboardAvailable(keyboardAvailable);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
I've had numerous crash reports on Galaxy S21 and S22 family devices with an NPE in `AndroidDaydream.onConfigurationChanged()`. My best guess of what's happening is that these devices are calling `onConfigurationChanged()` before `onAttachedToWindow()`, so `input` is still null.

This change should be safe because
1. If `onConfigurationChanged()` is called before `onAttachedToWindow()`, the keyboard state will be updated in the user's `initialize()` call.
2. It's a screen-saver. We probably don't care if the keyboard is attached anyway.

I don't have one of the offending devices to test on, but I also don't know how many of you actually use AndroidDaydream. If I don't get any feedback in a couple of weeks, I plan to go ahead and pull this.