### PR TITLE
disable depth mask when rendering transparent decals

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g3d/decals/CameraGroupStrategy.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/decals/CameraGroupStrategy.java
@@ -133,6 +133,7 @@ public class CameraGroupStrategy implements GroupStrategy, Disposable {
 	public void beforeGroup (int group, Array<Decal> contents) {
 		if (group == GROUP_BLEND) {
 			Gdx.gl.glEnable(GL20.GL_BLEND);
+			Gdx.gl.glDepthMask(false);
 			contents.sort(cameraSorter);
 		} else {
 			for (int i = 0, n = contents.size; i < n; i++) {
@@ -162,6 +163,7 @@ public class CameraGroupStrategy implements GroupStrategy, Disposable {
 	public void afterGroup (int group) {
 		if (group == GROUP_BLEND) {
 			Gdx.gl.glDisable(GL20.GL_BLEND);
+			Gdx.gl.glDepthMask(true);
 		}
 	}
 


### PR DESCRIPTION
When transparent decals collides, some transparent pixels of one could cull others because they all read from and write to depth buffer.

Since they are already sorted (back to front), there is no reason to write into the depth buffer.

While fixing th issue, i noticed that the same thing was already done in SimpleOrthoGroupStrategy, so i think it's a simple missing or an edge case in CameraGroupStrategy.

I can't see a use case where this change would be a problem. I think it'll fix a lot more cases than breaking anything.