### PR TITLE
[LWJGL3] Negative monitor coords

### DIFF
--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Graphics.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Graphics.java
@@ -446,10 +446,8 @@ public class Lwjgl3Graphics extends AbstractGraphics implements Disposable {
 				GLFW.glfwGetMonitorWorkarea(monitor.monitorHandle, tmpBuffer, tmpBuffer2, tmpBuffer3, tmpBuffer4);
 				minX = tmpBuffer.get(0);
 				minY = tmpBuffer2.get(0);
-				GLFW.glfwSetWindowMonitor(window.getWindowHandle(), 0,
-					Math.max(minX, minX + (tmpBuffer3.get(0) - width) / 2),
-					Math.max(minY, minY + (tmpBuffer4.get(0) - height) / 2), width, height,
-					displayModeBeforeFullscreen.refreshRate);
+				GLFW.glfwSetWindowMonitor(window.getWindowHandle(), 0, Math.max(minX, minX + (tmpBuffer3.get(0) - width) / 2),
+					Math.max(minY, minY + (tmpBuffer4.get(0) - height) / 2), width, height, displayModeBeforeFullscreen.refreshRate);
 			} else {
 				GLFW.glfwSetWindowMonitor(window.getWindowHandle(), 0, windowPosXBeforeFullscreen, windowPosYBeforeFullscreen, width,
 					height, displayModeBeforeFullscreen.refreshRate);

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Graphics.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Graphics.java
@@ -419,9 +419,10 @@ public class Lwjgl3Graphics extends AbstractGraphics implements Disposable {
 
 	@Override
 	public boolean setWindowedMode (int width, int height) {
+		int minX, minY;
 		window.getInput().resetPollingStates();
 		if (!isFullscreen()) {
-			int newX = 0, newY = 0, minX, minY;
+			int newX = 0, newY = 0;
 			boolean centerWindow = false;
 			if (width != logicalWidth || height != logicalHeight) {
 				centerWindow = true;
@@ -443,9 +444,11 @@ public class Lwjgl3Graphics extends AbstractGraphics implements Disposable {
 			if (width != windowWidthBeforeFullscreen || height != windowHeightBeforeFullscreen) { // Center window
 				Lwjgl3Monitor monitor = (Lwjgl3Monitor)getMonitor();
 				GLFW.glfwGetMonitorWorkarea(monitor.monitorHandle, tmpBuffer, tmpBuffer2, tmpBuffer3, tmpBuffer4);
+				minX = tmpBuffer.get(0);
+				minY = tmpBuffer2.get(0);
 				GLFW.glfwSetWindowMonitor(window.getWindowHandle(), 0,
-					Math.max(0, tmpBuffer.get(0) + (tmpBuffer3.get(0) - width) / 2),
-					Math.max(0, tmpBuffer2.get(0) + (tmpBuffer4.get(0) - height) / 2), width, height,
+					Math.max(minX, minX + (tmpBuffer3.get(0) - width) / 2),
+					Math.max(minY, minY + (tmpBuffer4.get(0) - height) / 2), width, height,
 					displayModeBeforeFullscreen.refreshRate);
 			} else {
 				GLFW.glfwSetWindowMonitor(window.getWindowHandle(), 0, windowPosXBeforeFullscreen, windowPosYBeforeFullscreen, width,

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Graphics.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Graphics.java
@@ -421,14 +421,16 @@ public class Lwjgl3Graphics extends AbstractGraphics implements Disposable {
 	public boolean setWindowedMode (int width, int height) {
 		window.getInput().resetPollingStates();
 		if (!isFullscreen()) {
-			int newX = 0, newY = 0;
+			int newX = 0, newY = 0, minX, minY;
 			boolean centerWindow = false;
 			if (width != logicalWidth || height != logicalHeight) {
 				centerWindow = true;
 				Lwjgl3Monitor monitor = (Lwjgl3Monitor)getMonitor();
 				GLFW.glfwGetMonitorWorkarea(monitor.monitorHandle, tmpBuffer, tmpBuffer2, tmpBuffer3, tmpBuffer4);
-				newX = Math.max(0, tmpBuffer.get(0) + (tmpBuffer3.get(0) - width) / 2);
-				newY = Math.max(0, tmpBuffer2.get(0) + (tmpBuffer4.get(0) - height) / 2);
+				minX = tmpBuffer.get(0);
+				minY = tmpBuffer2.get(0);
+				newX = Math.max(minX, minX + (tmpBuffer3.get(0) - width) / 2);
+				newY = Math.max(minY, minY + (tmpBuffer4.get(0) - height) / 2);
 			}
 			GLFW.glfwSetWindowSize(window.getWindowHandle(), width, height);
 			if (centerWindow) {


### PR DESCRIPTION
Support positioning on monitors with negative relative coordinates.

Tested it on my Windows machine with a monitor who's coords are negative (top left corner is to left of/above primary monitor).