### PR TITLE
Seamless/gapless looping of music on Android

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidMusic.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidMusic.java
@@ -215,10 +215,10 @@ public class AndroidMusic implements Music, MediaPlayer.OnCompletionListener {
 	};
 
 	@TargetApi(16)
-	private MediaPlayer.OnCompletionListener createOnCompletionListener(final MediaPlayer next) {
+	private MediaPlayer.OnCompletionListener createOnCompletionListener (final MediaPlayer next) {
 		return new MediaPlayer.OnCompletionListener() {
 			@Override
-			public void onCompletion(MediaPlayer mediaPlayer) {
+			public void onCompletion (MediaPlayer mediaPlayer) {
 				mediaPlayer.reset();
 				try {
 					mediaPlayer.setDataSource(descriptor.getFileDescriptor(), descriptor.getStartOffset(), descriptor.getLength());
@@ -242,7 +242,7 @@ public class AndroidMusic implements Music, MediaPlayer.OnCompletionListener {
 				.setUsage(AudioAttributes.USAGE_GAME).build());
 		}
 
-		AndroidFileHandle aHandle = (AndroidFileHandle) file;
+		AndroidFileHandle aHandle = (AndroidFileHandle)file;
 		if (aHandle.type() == Files.FileType.Internal) {
 			try {
 				this.descriptor = aHandle.getAssetFileDescriptor();

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidMusic.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidMusic.java
@@ -18,24 +18,39 @@ package com.badlogic.gdx.backends.android;
 
 import java.io.IOException;
 
+import android.annotation.TargetApi;
+import android.content.res.AssetFileDescriptor;
+import android.media.AudioAttributes;
+import android.media.AudioManager;
 import android.media.MediaPlayer;
+import android.os.Build;
 
+import com.badlogic.gdx.Files;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.audio.Music;
+import com.badlogic.gdx.files.FileHandle;
+import com.badlogic.gdx.utils.GdxRuntimeException;
 
 public class AndroidMusic implements Music, MediaPlayer.OnCompletionListener {
 	private final AndroidAudio audio;
-	private MediaPlayer player;
+	private MediaPlayer player, player2;
+	private MediaPlayer currentPlayer, nextPlayer;
 	private boolean isPrepared = true;
 	protected boolean wasPlaying = false;
-	private float volume = 1f;
+	private float volume = 1f, pan = 0;
 	protected OnCompletionListener onCompletionListener;
+	private AssetFileDescriptor descriptor;
+	private final FileHandle file;
+	private boolean isLooping;
 
-	AndroidMusic (AndroidAudio audio, MediaPlayer player) {
+	AndroidMusic (AndroidAudio audio, FileHandle file) {
 		this.audio = audio;
-		this.player = player;
+		this.file = file;
+
+		this.player = createMediaPlayer();
+		this.currentPlayer = player;
+
 		this.onCompletionListener = null;
-		this.player.setOnCompletionListener(this);
 	}
 
 	@Override
@@ -43,10 +58,12 @@ public class AndroidMusic implements Music, MediaPlayer.OnCompletionListener {
 		if (player == null) return;
 		try {
 			player.release();
+			if (player2 != null) player2.release();
 		} catch (Throwable t) {
 			Gdx.app.log("AndroidMusic", "error while disposing AndroidMusic instance, non-fatal");
 		} finally {
 			player = null;
+			player2 = null;
 			onCompletionListener = null;
 			audio.notifyMusicDisposed(this);
 		}
@@ -54,20 +71,14 @@ public class AndroidMusic implements Music, MediaPlayer.OnCompletionListener {
 
 	@Override
 	public boolean isLooping () {
-		if (player == null) return false;
-		try {
-			return player.isLooping();
-		} catch (IllegalStateException e) {
-			e.printStackTrace();
-			return false;
-		}
+		return isLooping;
 	}
 
 	@Override
 	public boolean isPlaying () {
 		if (player == null) return false;
 		try {
-			return player.isPlaying();
+			return player.isPlaying() || player2.isPlaying();
 		} catch (IllegalStateException e) {
 			e.printStackTrace();
 			return false;
@@ -78,9 +89,7 @@ public class AndroidMusic implements Music, MediaPlayer.OnCompletionListener {
 	public void pause () {
 		if (player == null) return;
 		try {
-			if (player.isPlaying()) {
-				player.pause();
-			}
+			currentPlayer.pause();
 		} catch (IllegalStateException e) {
 			e.printStackTrace();
 		}
@@ -92,27 +101,43 @@ public class AndroidMusic implements Music, MediaPlayer.OnCompletionListener {
 		if (player == null) return;
 		try {
 			if (!isPrepared) {
-				player.prepare();
+				currentPlayer.prepare();
 				isPrepared = true;
 			}
-			player.start();
-		} catch (IllegalStateException e) {
-			e.printStackTrace();
-		} catch (IOException e) {
+			currentPlayer.start();
+		} catch (IllegalStateException | IOException e) {
 			e.printStackTrace();
 		}
 	}
 
 	@Override
 	public void setLooping (boolean isLooping) {
+		this.isLooping = isLooping;
 		if (player == null) return;
-		player.setLooping(isLooping);
+		if (Build.VERSION.SDK_INT >= 16) {
+			if (isLooping) {
+				if (player2 == null) {
+					player2 = createMediaPlayer();
+					nextPlayer = player2;
+					setPan(pan, volume);
+				}
+				currentPlayer.setOnCompletionListener(createOnCompletionListener(nextPlayer));
+				nextPlayer.setOnCompletionListener(createOnCompletionListener(currentPlayer));
+				currentPlayer.setNextMediaPlayer(nextPlayer);
+			} else if (player2 != null) {
+				currentPlayer.setNextMediaPlayer(null);
+				currentPlayer.setOnCompletionListener(null);
+			}
+		} else {
+			player.setLooping(isLooping);
+		}
 	}
 
 	@Override
 	public void setVolume (float volume) {
 		if (player == null) return;
 		player.setVolume(volume, volume);
+		if (player2 != null) player2.setVolume(volume, volume);
 		this.volume = volume;
 	}
 
@@ -124,6 +149,7 @@ public class AndroidMusic implements Music, MediaPlayer.OnCompletionListener {
 	@Override
 	public void setPan (float pan, float volume) {
 		if (player == null) return;
+		this.pan = pan;
 		float leftVolume = volume;
 		float rightVolume = volume;
 
@@ -134,13 +160,14 @@ public class AndroidMusic implements Music, MediaPlayer.OnCompletionListener {
 		}
 
 		player.setVolume(leftVolume, rightVolume);
+		if (player2 != null) player2.setVolume(volume, volume);
 		this.volume = volume;
 	}
 
 	@Override
 	public void stop () {
 		if (player == null) return;
-		player.stop();
+		currentPlayer.stop();
 		isPrepared = false;
 	}
 
@@ -148,13 +175,11 @@ public class AndroidMusic implements Music, MediaPlayer.OnCompletionListener {
 		if (player == null) return;
 		try {
 			if (!isPrepared) {
-				player.prepare();
+				currentPlayer.prepare();
 				isPrepared = true;
 			}
-			player.seekTo((int)(position * 1000));
-		} catch (IllegalStateException e) {
-			e.printStackTrace();
-		} catch (IOException e) {
+			currentPlayer.seekTo((int)(position * 1000));
+		} catch (IllegalStateException | IOException e) {
 			e.printStackTrace();
 		}
 	}
@@ -162,12 +187,12 @@ public class AndroidMusic implements Music, MediaPlayer.OnCompletionListener {
 	@Override
 	public float getPosition () {
 		if (player == null) return 0.0f;
-		return player.getCurrentPosition() / 1000f;
+		return currentPlayer.getCurrentPosition() / 1000f;
 	}
 
 	public float getDuration () {
 		if (player == null) return 0.0f;
-		return player.getDuration() / 1000f;
+		return currentPlayer.getDuration() / 1000f;
 	}
 
 	@Override
@@ -188,4 +213,55 @@ public class AndroidMusic implements Music, MediaPlayer.OnCompletionListener {
 			});
 		}
 	};
+
+	@TargetApi(16)
+	private MediaPlayer.OnCompletionListener createOnCompletionListener(final MediaPlayer next) {
+		return new MediaPlayer.OnCompletionListener() {
+			@Override
+			public void onCompletion(MediaPlayer mediaPlayer) {
+				mediaPlayer.reset();
+				try {
+					mediaPlayer.setDataSource(descriptor.getFileDescriptor(), descriptor.getStartOffset(), descriptor.getLength());
+					mediaPlayer.prepare();
+				} catch (IOException e) {
+					e.printStackTrace();
+				}
+				next.setNextMediaPlayer(mediaPlayer);
+				currentPlayer = next;
+				nextPlayer = mediaPlayer;
+			}
+		};
+	}
+
+	private MediaPlayer createMediaPlayer () {
+		MediaPlayer mediaPlayer = new MediaPlayer();
+		if (Build.VERSION.SDK_INT <= 21) {
+			mediaPlayer.setAudioStreamType(AudioManager.STREAM_MUSIC);
+		} else {
+			mediaPlayer.setAudioAttributes(new AudioAttributes.Builder().setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
+				.setUsage(AudioAttributes.USAGE_GAME).build());
+		}
+
+		AndroidFileHandle aHandle = (AndroidFileHandle) file;
+		if (aHandle.type() == Files.FileType.Internal) {
+			try {
+				this.descriptor = aHandle.getAssetFileDescriptor();
+				mediaPlayer.setDataSource(descriptor.getFileDescriptor(), descriptor.getStartOffset(), descriptor.getLength());
+				mediaPlayer.prepare();
+			} catch (Exception ex) {
+				throw new GdxRuntimeException(
+					"Error loading audio file: " + file + "\nNote: Internal audio files must be placed in the assets directory.", ex);
+			}
+		} else {
+			try {
+				mediaPlayer.setDataSource(aHandle.file().getPath());
+				mediaPlayer.prepare();
+			} catch (Exception ex) {
+				throw new GdxRuntimeException(
+					"Error loading audio file: " + file + "\nNote: Internal audio files must be placed in the assets directory.", ex);
+			}
+		}
+
+		return mediaPlayer;
+	}
 }

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/DefaultAndroidAudio.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/DefaultAndroidAudio.java
@@ -21,7 +21,6 @@ import android.content.Context;
 import android.content.res.AssetFileDescriptor;
 import android.media.AudioAttributes;
 import android.media.AudioManager;
-import android.media.MediaPlayer;
 import android.media.SoundPool;
 import android.os.Build;
 
@@ -34,7 +33,6 @@ import com.badlogic.gdx.audio.Sound;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.utils.GdxRuntimeException;
 
-import java.io.FileDescriptor;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -130,30 +128,18 @@ public class DefaultAndroidAudio implements AndroidAudio {
 	 * @param fd the FileDescriptor from which to create the Music
 	 *
 	 * @see Audio#newMusic(FileHandle) */
-	//todo
-	/*public Music newMusic (FileDescriptor fd) {
-		if (soundPool == null) {
-			throw new GdxRuntimeException("Android audio is not enabled by the application config.");
-		}
-
-		MediaPlayer mediaPlayer = createMediaPlayer();
-		MediaPlayer mediaPlayer2 = createMediaPlayer();
-
-		try {
-			mediaPlayer.setDataSource(fd);
-			mediaPlayer2.setDataSource(fd);
-			mediaPlayer.prepare();
-			mediaPlayer2.prepare();
-
-			AndroidMusic music = new AndroidMusic(this, mediaPlayer, mediaPlayer2);
-			synchronized (musics) {
-				musics.add(music);
-			}
-			return music;
-		} catch (Exception ex) {
-			throw new GdxRuntimeException("Error loading audio from FileDescriptor", ex);
-		}
-	}*/
+	// todo
+	/*
+	 * public Music newMusic (FileDescriptor fd) { if (soundPool == null) { throw new
+	 * GdxRuntimeException("Android audio is not enabled by the application config."); }
+	 * 
+	 * MediaPlayer mediaPlayer = createMediaPlayer(); MediaPlayer mediaPlayer2 = createMediaPlayer();
+	 * 
+	 * try { mediaPlayer.setDataSource(fd); mediaPlayer2.setDataSource(fd); mediaPlayer.prepare(); mediaPlayer2.prepare();
+	 * 
+	 * AndroidMusic music = new AndroidMusic(this, mediaPlayer, mediaPlayer2); synchronized (musics) { musics.add(music); } return
+	 * music; } catch (Exception ex) { throw new GdxRuntimeException("Error loading audio from FileDescriptor", ex); } }
+	 */
 
 	/** {@inheritDoc} */
 	@Override
@@ -213,6 +199,5 @@ public class DefaultAndroidAudio implements AndroidAudio {
 			musics.remove(this);
 		}
 	}
-
 
 }

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/DefaultAndroidAudio.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/DefaultAndroidAudio.java
@@ -115,59 +115,37 @@ public class DefaultAndroidAudio implements AndroidAudio {
 		if (soundPool == null) {
 			throw new GdxRuntimeException("Android audio is not enabled by the application config.");
 		}
-		AndroidFileHandle aHandle = (AndroidFileHandle)file;
 
-		MediaPlayer mediaPlayer = createMediaPlayer();
-
-		if (aHandle.type() == FileType.Internal) {
-			try {
-				AssetFileDescriptor descriptor = aHandle.getAssetFileDescriptor();
-				mediaPlayer.setDataSource(descriptor.getFileDescriptor(), descriptor.getStartOffset(), descriptor.getLength());
-				descriptor.close();
-				mediaPlayer.prepare();
-				AndroidMusic music = new AndroidMusic(this, mediaPlayer);
-				synchronized (musics) {
-					musics.add(music);
-				}
-				return music;
-			} catch (Exception ex) {
-				throw new GdxRuntimeException(
-					"Error loading audio file: " + file + "\nNote: Internal audio files must be placed in the assets directory.", ex);
-			}
-		} else {
-			try {
-				mediaPlayer.setDataSource(aHandle.file().getPath());
-				mediaPlayer.prepare();
-				AndroidMusic music = new AndroidMusic(this, mediaPlayer);
-				synchronized (musics) {
-					musics.add(music);
-				}
-				return music;
-			} catch (Exception ex) {
-				throw new GdxRuntimeException("Error loading audio file: " + file, ex);
-			}
+		AndroidMusic music = new AndroidMusic(this, file);
+		synchronized (musics) {
+			musics.add(music);
 		}
+		return music;
 
 	}
 
 	/** Creates a new Music instance from the provided FileDescriptor. It is the caller's responsibility to close the file
 	 * descriptor. It is safe to do so as soon as this call returns.
-	 * 
+	 *
 	 * @param fd the FileDescriptor from which to create the Music
-	 * 
+	 *
 	 * @see Audio#newMusic(FileHandle) */
-	public Music newMusic (FileDescriptor fd) {
+	//todo
+	/*public Music newMusic (FileDescriptor fd) {
 		if (soundPool == null) {
 			throw new GdxRuntimeException("Android audio is not enabled by the application config.");
 		}
 
 		MediaPlayer mediaPlayer = createMediaPlayer();
+		MediaPlayer mediaPlayer2 = createMediaPlayer();
 
 		try {
 			mediaPlayer.setDataSource(fd);
+			mediaPlayer2.setDataSource(fd);
 			mediaPlayer.prepare();
+			mediaPlayer2.prepare();
 
-			AndroidMusic music = new AndroidMusic(this, mediaPlayer);
+			AndroidMusic music = new AndroidMusic(this, mediaPlayer, mediaPlayer2);
 			synchronized (musics) {
 				musics.add(music);
 			}
@@ -175,7 +153,7 @@ public class DefaultAndroidAudio implements AndroidAudio {
 		} catch (Exception ex) {
 			throw new GdxRuntimeException("Error loading audio from FileDescriptor", ex);
 		}
-	}
+	}*/
 
 	/** {@inheritDoc} */
 	@Override
@@ -236,14 +214,5 @@ public class DefaultAndroidAudio implements AndroidAudio {
 		}
 	}
 
-	protected MediaPlayer createMediaPlayer () {
-		MediaPlayer mediaPlayer = new MediaPlayer();
-		if (Build.VERSION.SDK_INT <= 21) {
-			mediaPlayer.setAudioStreamType(AudioManager.STREAM_MUSIC);
-		} else {
-			mediaPlayer.setAudioAttributes(new AudioAttributes.Builder().setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
-				.setUsage(AudioAttributes.USAGE_GAME).build());
-		}
-		return mediaPlayer;
-	}
+
 }


### PR DESCRIPTION
I've been moaning in #6622 lately, so I decided to just get on with it. This is a work-in-progress thing for seamless audio looping. No ETA, and to make matters worse I intend to go on holiday soon without access to my desktop computer's RAM.

Currently `MusicTest` seems to be working fine. API 16+ gets the seamless approach and <= 15 gets the normal one. Here's what each sounds like in the emulator at the loop point of a 90-second Ogg Vorbis (GitHub doesn't allow audio uploads, hence why they're videos without video tracks - be sure to unmute):

<table><tr><td>

https://user-images.githubusercontent.com/60154347/177068907-08a8c215-289c-43a4-a758-b7340f4d550c.mp4

</td><td>

https://user-images.githubusercontent.com/60154347/177068925-25703f7a-e722-4175-aedd-36848fcccb71.mp4

</td></tr></table>

When `music.setLooping(true)` is called, a second `MediaPlayer` is created, and it loops back and forth between them. So this pull request doesn't add any overhead for non-looping music. I considered if we should expose a boolean for whether the looping should attempt to be seamless or not, but it seemed silly to have that when it only applied to Android. Though the whole situation is a complete farce - I don't see why seamless looping still isn't part of the Android API, when [seamless queuing is](https://developer.android.com/reference/android/media/MediaPlayer#setNextMediaPlayer(android.media.MediaPlayer)).

It's currently a draft because I haven't tested too thoroughly, I don't know if I should be concerned about `E/MediaPlayerNative: error (-38, 0)` and `E/MediaPlayer: Error (-38,0)`, and things may break if merged in its current state (`newMusic (FileDescriptor fd)` is commented out for a start). Maybe someone can steer it in the right direction without hurting my drafty feelings too badly.

I also want to consider if we can expose this to the core module, somehow. Take for example the following code:

```java
musicIntro.setOnCompletionListener(new Music.OnCompletionListener() {
  @Override
  public void onCompletion(Music music) {
    musicChorus.play();
  }
});
```

This introduces a gap. In a perfect world, we'd be able to do something like `musicIntro.setNextMusic(musicChorus)` without a gap. But the cross-platform nature of libGDX complicates matters.