### PR TITLE
Remove fallback on Android Haptics vibrate(VibrationType)

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidHaptics.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidHaptics.java
@@ -29,17 +29,17 @@ public class AndroidHaptics {
 	private final Vibrator vibrator;
 	private AudioAttributes audioAttributes;
 	private boolean vibratorSupport;
-	private boolean amplitudeSupport;
+	private boolean hapticsSupport;
 
 	public AndroidHaptics (Context context) {
 		vibratorSupport = false;
-		amplitudeSupport = false;
+		hapticsSupport = false;
 		this.vibrator = (Vibrator)context.getSystemService(Context.VIBRATOR_SERVICE);
 		if (vibrator != null && vibrator.hasVibrator()) {
 			vibratorSupport = true;
-			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
 				if (vibrator.hasAmplitudeControl()) {
-					amplitudeSupport = true;
+					hapticsSupport = true;
 				}
 				this.audioAttributes = new AudioAttributes.Builder().setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
 					.setUsage(AudioAttributes.USAGE_GAME).build();
@@ -57,7 +57,7 @@ public class AndroidHaptics {
 	}
 
 	public void vibrate (Input.VibrationType vibrationType) {
-		if (amplitudeSupport) {
+		if (hapticsSupport) {
 			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
 				int vibrationEffect;
 				switch (vibrationType) {
@@ -79,7 +79,7 @@ public class AndroidHaptics {
 	}
 
 	public void vibrate (int milliseconds, int intensity, boolean fallback) {
-		if (amplitudeSupport) {
+		if (hapticsSupport) {
 			intensity = MathUtils.clamp(intensity, 0, 255);
 			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
 				vibrator.vibrate(VibrationEffect.createOneShot(milliseconds, intensity));
@@ -90,7 +90,7 @@ public class AndroidHaptics {
 		return vibratorSupport;
 	}
 
-	public boolean hasAmplitudeSupport () {
-		return amplitudeSupport;
+	public boolean hasHapticsSupport () {
+		return hapticsSupport;
 	}
 }

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidHaptics.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidHaptics.java
@@ -74,22 +74,6 @@ public class AndroidHaptics {
 					throw new IllegalArgumentException("Unknown VibrationType " + vibrationType);
 				}
 				vibrator.vibrate(VibrationEffect.createPredefined(vibrationEffect), audioAttributes);
-			} else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-				int amplitude;
-				switch (vibrationType) {
-				case LIGHT:
-					amplitude = 50;
-					break;
-				case MEDIUM:
-					amplitude = VibrationEffect.DEFAULT_AMPLITUDE;
-					break;
-				case HEAVY:
-					amplitude = 250;
-					break;
-				default:
-					throw new IllegalArgumentException("Unknown VibrationType " + vibrationType);
-				}
-				vibrator.vibrate(VibrationEffect.createOneShot(25, amplitude));
 			}
 		}
 	}

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/DefaultAndroidInput.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/DefaultAndroidInput.java
@@ -832,7 +832,7 @@ public class DefaultAndroidInput extends AbstractInput implements AndroidInput {
 		if (peripheral == Peripheral.HardwareKeyboard) return keyboardAvailable;
 		if (peripheral == Peripheral.OnscreenKeyboard) return true;
 		if (peripheral == Peripheral.Vibrator) return haptics.hasVibratorAvailable();
-		if (peripheral == Peripheral.HapticFeedback) return haptics.hasAmplitudeSupport();
+		if (peripheral == Peripheral.HapticFeedback) return haptics.hasHapticsSupport();
 		if (peripheral == Peripheral.MultitouchScreen) return hasMultitouch;
 		if (peripheral == Peripheral.RotationVector) return rotationVectorAvailable;
 		if (peripheral == Peripheral.Pressure) return true;


### PR DESCRIPTION
I've been able to run some tests on some Android devices to see how consistent the new haptics/vibration API is and I've found the fallback for Android O devices for the `vibrate(VibrationType)` call is not good enough, there's no feeling of impact whatsoever.

The main problem on Android ecosystem is that AFAIK there's no way to know for sure if the device has proper haptics support or a simple vibrator with amplitude control capabilities which makes all the difference. 

I think the best approach to assume haptics support is to require both amplitude control capaibilities and Android version to be at least Q because in that case the device must implement the Haptics API (https://source.android.com/devices/input/haptics/haptics-implement) and we ensure `vibrate(VibrationType)` will work (even if there's a certain risk it doesn't feel as good as it should on some specific device).