### PR TITLE
[Gradle] Replace usage of 'tasks.whenTaskAdded()' to 'tasks.matching()' in Android project

### DIFF
--- a/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/android/build.gradle
+++ b/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/android/build.gradle
@@ -59,10 +59,8 @@ task copyAndroidNatives {
     }
 }
 
-tasks.whenTaskAdded { packageTask ->
-    if (packageTask.name.contains("merge") && packageTask.name.contains("JniLibFolders")) {
-        packageTask.dependsOn 'copyAndroidNatives'
-    }
+tasks.matching { it.name.contains("merge") && it.name.contains("JniLibFolders") }.configureEach { packageTask ->
+    packageTask.dependsOn 'copyAndroidNatives'
 }
 
 task run(type: Exec) {


### PR DESCRIPTION
Replace usage of `tasks.whenTaskAdded()` to `tasks.matching()` in Android project for comply with Gradle guidelines of ["Task Configurations Avoidance"](https://docs.gradle.org/current/userguide/task_configuration_avoidance.html#sec:old_vs_new_configuration_api_overview)

This is implemented in order to avoid initializing ("lazy" configuration phase) all other independent tasks when starting any Gradle task. 


---
#### Performance of `gradle help` task

Before: [gradle performance link](https://scans.gradle.com/s/tlql5gfkwvgkq/performance/configuration#summary-tasks-created-during-configuration)
After: [gradle performance link](https://scans.gradle.com/s/lmnzq2xswo2jg/performance/configuration#summary-tasks-created-during-configuration)

![image](https://user-images.githubusercontent.com/2379473/177667831-c5d6d899-959e-4f91-9956-5a2f750a4abb.png)


