### PR TITLE
Remove copyIdeaResources tasks

### DIFF
--- a/extensions/gdx-lwjgl3-angle/build.gradle
+++ b/extensions/gdx-lwjgl3-angle/build.gradle
@@ -25,10 +25,3 @@ sourceSets.main.java.srcDirs = ["src"]
 sourceSets.main.resources.srcDirs = ["res"]
 
 tasks.withType(Jar) { duplicatesStrategy = DuplicatesStrategy.INCLUDE }
-
-// Workaround needed for IDEA to have resources on classpath when running tests (like gdx-tests-lwjgl3)
-task copyIdeaResources(type: Copy) {
-	from "${projectDir}/res"
-	into "${buildDir}/classes/java/main/"
-}
-processResources.dependsOn copyIdeaResources

--- a/extensions/gdx-lwjgl3-glfw-awt-macos/build.gradle
+++ b/extensions/gdx-lwjgl3-glfw-awt-macos/build.gradle
@@ -22,10 +22,3 @@ sourceSets.main.java.srcDirs = ["src"]
 sourceSets.main.resources.srcDirs = ["res"]
 
 tasks.withType(Jar) { duplicatesStrategy = DuplicatesStrategy.INCLUDE }
-
-// Workaround needed for IDEA to have resources on classpath when running tests (like gdx-tests-lwjgl3)
-task copyIdeaResources(type: Copy) {
-	from "${projectDir}/res"
-	into "${buildDir}/classes/java/main/"
-}
-processResources.dependsOn copyIdeaResources

--- a/gdx/build.gradle
+++ b/gdx/build.gradle
@@ -49,13 +49,7 @@ test {
 	}
 }
 
-// Workaround needed for IDEA to have resources on classpath when running tests (like gdx-tests-lwjgl3)
-task copyIdeaResources(type: Copy) {
-	from "${projectDir}/res"
-	into "${buildDir}/classes/java/main/"
-}
 processResources.duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-processResources.dependsOn copyIdeaResources
 
 apply plugin: "com.badlogicgames.gdx.gdx-jnigen"
 jnigen {


### PR DESCRIPTION
When we upgraded to Gradle 7 (https://github.com/libgdx/libgdx/pull/6811) an issue was introduced that caused Gradle not to apply optimizations to the execution making builds much slower than they were.

There's this warnings spammed all over the place
```
Execution optimizations have been disabled for task ':tests:gdx-tests-gwt:javadoc' to ensure correctness due to the following reasons:
  - Gradle detected a problem with the following location: 'XXX\XXX\libgdx\gdx\build\classes\java\main'. Reason: Task ':tests:gdx-tests-gwt:javadoc' uses this output of task ':gdx:copyIdeaResources' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.5/userguide/validation_problems.html#implicit_dependency for more details about this problem.
 ```

The `copyIdeaResources` tasks was necessary to run tests from IDEA as it wasn't copying resources found in `gdx/res` to any classpath output folder which caused some tests to crash when unable to find the resource. If I remember correctly, this was an issue only on some backends such as Lwjgl3.

I've run tests  without the task on IDEA 2022.1.3 and the resources are copied to `/build/resources` and available on classpath. I've made sure I `Clean Project` (and run `clean`Gradle task as well) before testing and it seems to work. **I have no idea why it works now so, before approving or merging this please test it yourself to make sure I haven't made a mistake.**

