### PR TITLE
Fix building ye runnables

### DIFF
--- a/extensions/gdx-tools/build.gradle
+++ b/extensions/gdx-tools/build.gradle
@@ -32,10 +32,10 @@ ext {
 	toolsAssetsDir = ["assets"]
 }
 
-task dist2DParticles (type: Jar) {
+task dist2DParticles (type: Jar, dependsOn: configurations.runtimeClasspath) {
 	duplicatesStrategy(DuplicatesStrategy.EXCLUDE)
 
-	from files(sourceSets.main.java.outputDir)
+	from files(sourceSets.main.java.classesDirectory)
 	from files(sourceSets.main.output.resourcesDir)
 	from {configurations.runtimeClasspath.collect {zipTree(it)}}
 	from files(toolsAssetsDir)
@@ -47,10 +47,10 @@ task dist2DParticles (type: Jar) {
 	}
 }
 
-task dist3DParticles (type: Jar) {
+task dist3DParticles (type: Jar, dependsOn: configurations.runtimeClasspath) {
 	duplicatesStrategy(DuplicatesStrategy.EXCLUDE)
 
-	from files(sourceSets.main.java.outputDir)
+	from files(sourceSets.main.java.classesDirectory)
 	from files(sourceSets.main.output.resourcesDir)
 	from {configurations.runtimeClasspath.collect {zipTree(it)}}
 	from files(toolsAssetsDir)
@@ -62,10 +62,10 @@ task dist3DParticles (type: Jar) {
 	}
 }
 
-task distHiero (type: Jar) {
+task distHiero (type: Jar, dependsOn: configurations.runtimeClasspath) {
 	duplicatesStrategy(DuplicatesStrategy.EXCLUDE)
 
-	from files(sourceSets.main.java.outputDir)
+	from files(sourceSets.main.java.classesDirectory)
 	from files(sourceSets.main.output.resourcesDir)
 	from {configurations.runtimeClasspath.collect {zipTree(it)}}
 	from files(toolsAssetsDir)
@@ -77,10 +77,10 @@ task distHiero (type: Jar) {
 	}
 }
 
-task distTexturePacker (type: Jar) {
+task distTexturePacker (type: Jar, dependsOn: configurations.runtimeClasspath) {
 	duplicatesStrategy(DuplicatesStrategy.EXCLUDE)
 
-	from files(sourceSets.main.java.outputDir)
+	from files(sourceSets.main.java.classesDirectory)
 	from files(sourceSets.main.output.resourcesDir)
 	from {configurations.runtimeClasspath.collect {zipTree(it)}}
 	from files(toolsAssetsDir)
@@ -93,7 +93,6 @@ task distTexturePacker (type: Jar) {
 }
 
 task buildRunnables (dependsOn: [
-	build,
 	dist2DParticles,
 	dist3DParticles,
 	distHiero,


### PR DESCRIPTION
I've got the solution from here https://discuss.gradle.org/t/gradle-fat-jar-with-module-dependency-fails-to-build-module-jar/43380

`sourceSets.main.java.outputDir` is deprecated so change it to `sourceSets.main.java.classesDirectory`