### PR TITLE
Allow overriding native library loading in android

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplication.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplication.java
@@ -112,7 +112,7 @@ public class AndroidApplication extends Activity implements AndroidApplicationBa
 		if (this.getVersion() < MINIMUM_SDK) {
 			throw new GdxRuntimeException("libGDX requires Android API Level " + MINIMUM_SDK + " or later.");
 		}
-		GdxNativesLoader.load();
+		config.nativeLoader.load();
 		setApplicationLogger(new AndroidApplicationLogger());
 		graphics = new AndroidGraphics(this, config,
 			config.resolutionStrategy == null ? new FillResolutionStrategy() : config.resolutionStrategy);

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplicationConfiguration.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplicationConfiguration.java
@@ -23,6 +23,7 @@ import com.badlogic.gdx.Input;
 import com.badlogic.gdx.audio.Sound;
 import com.badlogic.gdx.backends.android.surfaceview.FillResolutionStrategy;
 import com.badlogic.gdx.backends.android.surfaceview.ResolutionStrategy;
+import com.badlogic.gdx.utils.GdxNativesLoader;
 
 /** Class defining the configuration of an {@link AndroidApplication}. Allows you to disable the use of the accelerometer to save
  * battery among other things.
@@ -98,4 +99,12 @@ public class AndroidApplicationConfiguration {
 
 	/** The maximum number of threads to use for network requests. Default is {@link Integer#MAX_VALUE}. */
 	public int maxNetThreads = Integer.MAX_VALUE;
+
+	/** The loader used to load native libraries. Override this to use a different loading strategy. */
+	public GdxNativeLoader nativeLoader = new GdxNativeLoader() {
+		@Override
+		public void load() {
+			GdxNativesLoader.load();
+		}
+	};
 }

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/GdxNativeLoader.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/GdxNativeLoader.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogic.gdx.backends.android;
+
+/** Interface defining how to load native libraries. */
+public interface GdxNativeLoader {
+
+	/** Load GDX native libraries. */
+	void load();
+}


### PR DESCRIPTION
Hello! This PR adds an extra option to `AndroidApplicationConfiguration`: `nativeLoader`, which lets the developer specify a different strategy to load the gdx native libraries, for example [ReLinker](https://github.com/KeepSafe/ReLinker).

The motivation behind this PR is to allow devs to workaround issues that might rise by loading native libraries via `System.loadLibrary()`, which is something suggested on the [android docs](https://developer.android.com/ndk/guides/cpp-support#shared_runtimes).

This is my first PR! I think I might be missing something, please let me know in case :)

Should I add these changes under `1.11.1` in the `CHANGES` file?