### PR TITLE
Small fixes for gdx.gwt.xml .

### DIFF
--- a/gdx/res/com/badlogic/gdx.gwt.xml
+++ b/gdx/res/com/badlogic/gdx.gwt.xml
@@ -437,11 +437,12 @@
 		<include name="utils/NumberUtils.java"/> <!-- Emulated -->
 		<include name="utils/ObjectFloatMap.java"/>
 		<include name="utils/ObjectIntMap.java"/>
+		<include name="utils/ObjectLongMap.java"/>
 		<include name="utils/ObjectMap.java"/>
 		<include name="utils/ObjectSet.java"/>
 		<include name="utils/OrderedMap.java"/>
 		<include name="utils/OrderedSet.java"/>
-		<include name="utils/PausableThread.java"/>
+		<include name="utils/PauseableThread.java"/>
 		<include name="utils/PerformanceCounter.java"/>
 		<include name="utils/PerformanceCounters.java"/>
 		<include name="utils/Pool.java"/>
@@ -449,8 +450,8 @@
 		<include name="utils/Pools.java"/>
 		<include name="utils/Predicate.java"/>
 		<include name="utils/PropertiesUtils.java"/>
-		<include name="utils/Queue.java"/>
 		<include name="utils/QuadTreeFloat.java"/>
+		<include name="utils/Queue.java"/>
 		<include name="utils/QuickSelect.java"/>
 		<include name="utils/ReflectionPool.java"/>
 		<include name="utils/Scaling.java"/>


### PR DESCRIPTION
In the .gwt.xml file that defines which files are usable sources for GWT, ObjectLongMap was missing as a source, and PauseableThread was spelled incorrectly. Before, if you tried to use ObjectLongMap in conjunction with reflection on GWT, it would fail because the compiler didn't know ObjectLongMap existed. I don't know anything about PauseableThread, other than the name of the class has an 'e' in the middle and the source entry previously didn't. It might not make sense as being usable on GWT, but it was originally an "include" and not an "exclude," so I fixed the spelling only.