### PR TITLE
Gradle 7.5.1

### DIFF
--- a/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/gradle/wrapper/gradle-wrapper.properties
+++ b/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
I've let https://github.com/tommyettinger/gdx-liftoff/commit/6582f6f0badf7ae1ecc660e51a2ec90c22678251 sit for a bit without catastrophe, so we can probably apply the same to gdx-setup. I don't think 7.5.1 vs 7.5 really makes a lick of difference to libGDX users, but might as well. Next Gradle release looks likely to be 7.6.

* [Release notes](https://docs.gradle.org/7.5.1/release-notes.html)

Budget Lyze:

![Budget Lyze](https://user-images.githubusercontent.com/60154347/183442159-f4f3219f-7a55-4b04-93aa-0e4a18a3b5a0.jpeg)