### PR TITLE
Fix lwjgl3 tests

### DIFF
--- a/tests/gdx-tests-lwjgl3/build.gradle
+++ b/tests/gdx-tests-lwjgl3/build.gradle
@@ -42,11 +42,6 @@ task launchTestsLwjgl3 (dependsOn: classes, type: JavaExec) {
 	standardInput = System.in
 	workingDir = new File("../gdx-tests-android/assets")
 	ignoreExitValue = true
-
-	if (System.getProperty("os.name").toLowerCase().contains("mac")) {
-		// Required to run lwjgl java apps on Mac OSX
-		jvmArgs = ["-XstartOnFirstThread"]
-	}
 }
 configure (launchTestsLwjgl3) {
 	group "LibGDX"


### PR DESCRIPTION
Because of gdx-lwjgl3-glfw-awt-macos, startOnFirstThread isn't needed anymore.