### PR TITLE
Add war gradle plugin to gdx-tests-gwt

### DIFF
--- a/tests/gdx-tests-gwt/build.gradle
+++ b/tests/gdx-tests-gwt/build.gradle
@@ -27,6 +27,7 @@ configurations.all {
 }
 
 apply plugin: 'gwt'
+apply plugin: 'war'
 apply plugin: 'org.gretty'
 
 import org.wisepersist.gradle.plugins.gwt.GwtSuperDev


### PR DESCRIPTION
I'm readding this plugin because without it some gwt checks aren't run with `gradlew build`. This introduced the problem mentioned in #6946. It seems that some tasks are not called without this plugin. The dist task for gdx-tests-gwt doesn't work currently because of the mentioned PR. SuperDev seem to work on the other hand. I'm not sure why this plugin got removed in 630431293ce3193994055a79b0473baf71a5f6a5