### PR TITLE
Mark PauseableThread as excluded on GWT.

### DIFF
--- a/gdx/res/com/badlogic/gdx.gwt.xml
+++ b/gdx/res/com/badlogic/gdx.gwt.xml
@@ -442,7 +442,7 @@
 		<include name="utils/ObjectSet.java"/>
 		<include name="utils/OrderedMap.java"/>
 		<include name="utils/OrderedSet.java"/>
-		<include name="utils/PauseableThread.java"/>
+		<exclude name="utils/PauseableThread.java"/> <!-- Reason: Threading -->
 		<include name="utils/PerformanceCounter.java"/>
 		<include name="utils/PerformanceCounters.java"/>
 		<include name="utils/Pool.java"/>


### PR DESCRIPTION
This fixes the compilation issues that #6946 introduced (by fixing a typo in the name of this class) and that were then encountered by #6963 . 