### PR TITLE
`charter encoding` → `character encoding`

### DIFF
--- a/gdx/src/com/badlogic/gdx/utils/I18NBundle.java
+++ b/gdx/src/com/badlogic/gdx/utils/I18NBundle.java
@@ -135,7 +135,7 @@ public class I18NBundle {
 	/** Creates a new bundle using the specified <code>baseFileHandle</code> and <code>encoding</code>; the default locale is used.
 	 * 
 	 * @param baseFileHandle the file handle to the base of the bundle
-	 * @param encoding the charter encoding
+	 * @param encoding the character encoding
 	 * @return a bundle for the given base file handle and locale
 	 * @exception NullPointerException if <code>baseFileHandle</code> or <code>encoding</code> is <code>null</code>
 	 * @exception MissingResourceException if no bundle for the specified base file handle can be found */
@@ -147,7 +147,7 @@ public class I18NBundle {
 	 * 
 	 * @param baseFileHandle the file handle to the base of the bundle
 	 * @param locale the locale for which a bundle is desired
-	 * @param encoding the charter encoding
+	 * @param encoding the character encoding
 	 * @return a bundle for the given base file handle and locale
 	 * @exception NullPointerException if <code>baseFileHandle</code>, <code>locale</code> or <code>encoding</code> is
 	 *               <code>null</code>


### PR DESCRIPTION
It's very difficult to debug why some characters don't work right in properties files when the documentation goes on about charters.

Anyway, the issue in my case is properties are ISO-8859-1 (at least for Java 8 and older) but libGDX defaults to UTF-8. As far as I understand, GWT will always want UTF-8, so to fix this [IDEA/AS' default can be changed](https://www.jetbrains.com/help/idea/properties-files.html#encoding). Setting the encoding at the bottom-right of the IDE is disabled for properties.