### PR TITLE
Optimize first render time of the RoboVM backend. Fixes #6971

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,7 @@
 - [BREAKING CHANGE] Android: Immersive mode is now true by default. Set `useImmersiveMode` config to `false` to disable it. 
 - [BREAKING CHANGE] iOS: `hideHomeIndicator` set to `false` by default (was `true`).
 - [BREAKING CHANGE] iOS: `screenEdgesDeferringSystemGestures` set to `UIRectEdge.All` by default (was `UIRectEdge.None`).
+- [BREAKING CHANGE] iOS: `ApplicationListener.create` and first `resize` are now called within `UIApplicationDelegate.didFinishLaunching`. Allows for earlier rendering and prevents black screen frames after launch screen. NOTE: App will get terminated if this method is blocked for more than 10-20 sec. 
 - [BREAKING CHANGE] Actor#localToAscendantCoordinates throws an exception if the specified actor is not an ascendant.
 - [BREAKING CHANGE] WidgetGroup#hit first validates the layout.
 - iOS: Add new MobiVM MetalANGLE backend

--- a/backends/gdx-backend-robovm-metalangle/src/com/badlogic/gdx/backends/iosrobovm/IOSApplication.java
+++ b/backends/gdx-backend-robovm-metalangle/src/com/badlogic/gdx/backends/iosrobovm/IOSApplication.java
@@ -142,7 +142,11 @@ public class IOSApplication implements Application {
 		Gdx.net = this.net;
 		this.input.setupPeripherals();
 		this.uiWindow.setRootViewController(this.graphics.viewController);
+		this.graphics.updateSafeInsets();
 		Gdx.app.debug("IOSApplication", "created");
+		listener.create();
+		listener.resize(this.graphics.getWidth(), this.graphics.getHeight());
+		this.graphics.view.display();
 		return true;
 	}
 

--- a/backends/gdx-backend-robovm-metalangle/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
+++ b/backends/gdx-backend-robovm-metalangle/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
@@ -186,6 +186,14 @@ public class IOSGraphics extends AbstractGraphics {
 		// time + FPS
 		lastFrameTime = System.nanoTime();
 		framesStart = lastFrameTime;
+		// enable OpenGL
+		makeCurrent();
+		// OpenGL glViewport() function expects backbuffer coordinates instead of logical coordinates
+		gl20.glViewport(0, 0, screenBounds.backBufferWidth, screenBounds.backBufferHeight);
+		String versionString = gl20.glGetString(GL20.GL_VERSION);
+		String vendorString = gl20.glGetString(GL20.GL_VENDOR);
+		String rendererString = gl20.glGetString(GL20.GL_RENDERER);
+		glVersion = new GLVersion(Application.ApplicationType.iOS, versionString, vendorString, rendererString);
 		appPaused = false;
 	}
 
@@ -214,25 +222,11 @@ public class IOSGraphics extends AbstractGraphics {
 		app.listener.pause();
 	}
 
-	boolean created = false;
-
 	public void draw (MGLKView view, CGRect rect) {
 		makeCurrent();
 		// massive hack, GLKView resets the viewport on each draw call, so IOSGLES20
 		// stores the last known viewport and we reset it here...
 		gl20.glViewport(IOSGLES20.x, IOSGLES20.y, IOSGLES20.width, IOSGLES20.height);
-		if (!created) {
-			// OpenGL glViewport() function expects backbuffer coordinates instead of logical coordinates
-			gl20.glViewport(0, 0, screenBounds.backBufferWidth, screenBounds.backBufferHeight);
-			String versionString = gl20.glGetString(GL20.GL_VERSION);
-			String vendorString = gl20.glGetString(GL20.GL_VENDOR);
-			String rendererString = gl20.glGetString(GL20.GL_RENDERER);
-			glVersion = new GLVersion(Application.ApplicationType.iOS, versionString, vendorString, rendererString);
-			updateSafeInsets();
-			app.listener.create();
-			app.listener.resize(getWidth(), getHeight());
-			created = true;
-		}
 		if (appPaused) {
 			return;
 		}

--- a/backends/gdx-backend-robovm-metalangle/src/com/badlogic/gdx/backends/iosrobovm/IOSUIViewController.java
+++ b/backends/gdx-backend-robovm-metalangle/src/com/badlogic/gdx/backends/iosrobovm/IOSUIViewController.java
@@ -27,8 +27,8 @@ public class IOSUIViewController extends MGLKViewController {
 	}
 
 	@Override
-	public void viewWillAppear (boolean arg0) {
-		super.viewWillAppear(arg0);
+	public void viewWillAppear (boolean animated) {
+		super.viewWillAppear(animated);
 		// start GLKViewController even though we may only draw a single frame
 		// (we may be in non-continuous mode)
 		setPaused(false);
@@ -74,7 +74,7 @@ public class IOSUIViewController extends MGLKViewController {
 		final IOSScreenBounds newBounds = app.computeBounds();
 		graphics.screenBounds = newBounds;
 		// Layout may happen without bounds changing, don't trigger resize in that case
-		if (graphics.created && (newBounds.width != oldBounds.width || newBounds.height != oldBounds.height)) {
+		if (newBounds.width != oldBounds.width || newBounds.height != oldBounds.height) {
 			graphics.makeCurrent();
 			graphics.updateSafeInsets();
 			graphics.gl20.glViewport(0, 0, newBounds.backBufferWidth, newBounds.backBufferHeight);

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSApplication.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSApplication.java
@@ -149,7 +149,16 @@ public class IOSApplication implements Application {
 		this.input.setupPeripherals();
 
 		this.uiWindow.setRootViewController(this.graphics.viewController);
+		this.graphics.updateSafeInsets();
+		
 		Gdx.app.debug("IOSApplication", "created");
+
+		listener.create();
+		listener.resize(this.graphics.getWidth(), this.graphics.getHeight());
+
+		// make sure the OpenGL view has contents before displaying it
+		this.graphics.view.display();
+
 		return true;
 	}
 

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
@@ -185,6 +185,16 @@ public class IOSGraphics extends AbstractGraphics {
 		lastFrameTime = System.nanoTime();
 		framesStart = lastFrameTime;
 
+		// enable OpenGL
+		makeCurrent();
+		// OpenGL glViewport() function expects backbuffer coordinates instead of logical coordinates
+		gl20.glViewport(0, 0, screenBounds.backBufferWidth, screenBounds.backBufferHeight);
+
+		String versionString = gl20.glGetString(GL20.GL_VERSION);
+		String vendorString = gl20.glGetString(GL20.GL_VENDOR);
+		String rendererString = gl20.glGetString(GL20.GL_RENDERER);
+		glVersion = new GLVersion(Application.ApplicationType.iOS, versionString, vendorString, rendererString);
+
 		appPaused = false;
 	}
 
@@ -215,28 +225,12 @@ public class IOSGraphics extends AbstractGraphics {
 		app.listener.pause();
 	}
 
-	boolean created = false;
-
 	public void draw (GLKView view, CGRect rect) {
 		makeCurrent();
 		// massive hack, GLKView resets the viewport on each draw call, so IOSGLES20
 		// stores the last known viewport and we reset it here...
 		gl20.glViewport(IOSGLES20.x, IOSGLES20.y, IOSGLES20.width, IOSGLES20.height);
 
-		if (!created) {
-			// OpenGL glViewport() function expects backbuffer coordinates instead of logical coordinates
-			gl20.glViewport(0, 0, screenBounds.backBufferWidth, screenBounds.backBufferHeight);
-
-			String versionString = gl20.glGetString(GL20.GL_VERSION);
-			String vendorString = gl20.glGetString(GL20.GL_VENDOR);
-			String rendererString = gl20.glGetString(GL20.GL_RENDERER);
-			glVersion = new GLVersion(Application.ApplicationType.iOS, versionString, vendorString, rendererString);
-
-			updateSafeInsets();
-			app.listener.create();
-			app.listener.resize(getWidth(), getHeight());
-			created = true;
-		}
 		if (appPaused) {
 			return;
 		}

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSUIViewController.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSUIViewController.java
@@ -23,8 +23,8 @@ public class IOSUIViewController extends GLKViewController {
 	}
 
 	@Override
-	public void viewWillAppear (boolean arg0) {
-		super.viewWillAppear(arg0);
+	public void viewWillAppear (boolean animated) {
+		super.viewWillAppear(animated);
 		// start GLKViewController even though we may only draw a single frame
 		// (we may be in non-continuous mode)
 		setPaused(false);
@@ -70,7 +70,7 @@ public class IOSUIViewController extends GLKViewController {
 		final IOSScreenBounds newBounds = app.computeBounds();
 		graphics.screenBounds = newBounds;
 		// Layout may happen without bounds changing, don't trigger resize in that case
-		if (graphics.created && (newBounds.width != oldBounds.width || newBounds.height != oldBounds.height)) {
+		if (newBounds.width != oldBounds.width || newBounds.height != oldBounds.height) {
 			graphics.makeCurrent();
 			graphics.updateSafeInsets();
 			graphics.gl20.glViewport(0, 0, newBounds.backBufferWidth, newBounds.backBufferHeight);


### PR DESCRIPTION
This PR changes the iOS backend to have completely setup OpenGL and call `ApplicationListener.create()` within the `UIApplicationDelegate.didFinishLaunching()` method. Before this PR it was lazily done on the first draw call from `GLKView`.

Once `didFinishLaunching()` returns iOS starts a fading transition from the launch screen to the root view controller. Without this change the root view controller has no contents yet and will therefore display black frames. Please see the following gifs for comparison on the default libGDX app. It is more noticeable if you have more resources to load for your first screen.

[Before](https://media.giphy.com/media/ySB9B0QY9r9MUL12db/giphy.gif)
[After](https://media.giphy.com/media/2h5zI1BY87NQL4fxYF/giphy.gif)

One important note: With this change all code inside `ApplicationListener.create()` and `resize()` will block the return of `didFinishLaunching()`. Apple has a time limit of a few seconds before the code must have executed otherwise it will terminate the application. So developers should only load necessary resources for the first app screen and offload any heavy stuff for later (like `AssetManager.update()` inside the render method). This recommendation is not new but blocking the render thread for 10 seconds after `didFinishLaunching()` will at least not crash the app.

Fixes #6971 