### PR TITLE
Add API to (auto) switch output device on lwjgl3

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -15,6 +15,8 @@
 - iOS: Add new MobiVM MetalANGLE backend
 - iOS: Update to MobiVM 2.3.19
 - Update to LWJGL 3.3.2
+- API Addition: Added Audio#switchOutputDevice and Audio#getAvailableOutputDevices to specify output devices. Only works for LWJGL3
+- Fix LWJGL3: Audio doesn't die anymore, if a device gets disconnected
 - API Addition: Added Haptics API with 4 different Input#vibrate() methods with complete Android and iOS implementations.
 - Fix: Fixed Android and iOS touch cancelled related issues, see #6871.
 - Javadoc: Add "-use" flag to javadoc generation

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/DefaultAndroidAudio.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/DefaultAndroidAudio.java
@@ -150,6 +150,16 @@ public class DefaultAndroidAudio implements AndroidAudio {
 
 	}
 
+	@Override
+	public boolean switchOutputDevice (String deviceIdentifier) {
+		return true;
+	}
+
+	@Override
+	public String[] getAvailableOutputDevices () {
+		return new String[0];
+	}
+
 	/** Creates a new Music instance from the provided FileDescriptor. It is the caller's responsibility to close the file
 	 * descriptor. It is safe to do so as soon as this call returns.
 	 * 

--- a/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/mock/audio/MockAudio.java
+++ b/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/mock/audio/MockAudio.java
@@ -46,4 +46,14 @@ public class MockAudio implements Audio {
 	public Music newMusic (FileHandle file) {
 		return new MockMusic();
 	}
+
+	@Override
+	public boolean switchOutputDevice (String deviceIdentifier) {
+		return true;
+	}
+
+	@Override
+	public String[] getAvailableOutputDevices () {
+		return new String[0];
+	}
 }

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/audio/OpenALLwjglAudio.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/audio/OpenALLwjglAudio.java
@@ -135,6 +135,16 @@ public class OpenALLwjglAudio implements LwjglAudio {
 		}
 	}
 
+	@Override
+	public boolean switchOutputDevice (String deviceIdentifier) {
+		return true;
+	}
+
+	@Override
+	public String[] getAvailableOutputDevices () {
+		return new String[0];
+	}
+
 	int obtainSource (boolean isMusic) {
 		if (noDevice) return 0;
 		for (int i = 0, n = idleSources.size; i < n; i++) {

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALLwjgl3Audio.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALLwjgl3Audio.java
@@ -48,7 +48,7 @@ import org.lwjgl.openal.ALCCapabilities;
 import org.lwjgl.openal.ALUtil;
 import org.lwjgl.openal.SOFTDirectChannels;
 import org.lwjgl.openal.SOFTReopenDevice;
-import org.lwjgl.system.MemoryUtil;
+import org.lwjgl.openal.SOFTXHoldOnDisconnect;
 import org.lwjgl.openal.SOFTDirectChannelsRemix;
 
 /** @author Nathan Sweet */
@@ -126,8 +126,7 @@ public class OpenALLwjgl3Audio implements Lwjgl3Audio {
 		((Buffer)position).flip();
 		alListenerfv(AL_POSITION, position);
 
-		// AL_STOP_SOURCES_ON_DISCONNECT_SOFT
-		alDisable(0x19AB);
+		alDisable(SOFTXHoldOnDisconnect.AL_STOP_SOURCES_ON_DISCONNECT_SOFT);
 		observerThread = new Thread(new Runnable() {
 
 			private String[] lastAvailableDevices = new String[0];
@@ -222,13 +221,7 @@ public class OpenALLwjgl3Audio implements Lwjgl3Audio {
 		if (setPreferred) {
 			preferredOutputDevice = deviceIdentifier;
 		}
-
-		if (deviceIdentifier == null) {
-			return SOFTReopenDevice.nalcReopenDeviceSOFT(device, MemoryUtil.memAddressSafe((ByteBuffer)null),
-				MemoryUtil.memAddressSafe((IntBuffer)null));
-		} else {
-			return SOFTReopenDevice.alcReopenDeviceSOFT(device, deviceIdentifier, (IntBuffer)null);
-		}
+		return SOFTReopenDevice.alcReopenDeviceSOFT(device, deviceIdentifier, (IntBuffer)null);
 	}
 
 	@Override

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALLwjgl3Audio.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALLwjgl3Audio.java
@@ -131,6 +131,7 @@ public class OpenALLwjgl3Audio implements Lwjgl3Audio {
 		observerThread = new Thread(new Runnable() {
 
 			private String[] lastAvailableDevices = new String[0];
+
 			@Override
 			public void run () {
 				while (true) {

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALLwjgl3Audio.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALLwjgl3Audio.java
@@ -16,30 +16,18 @@
 
 package com.badlogic.gdx.backends.lwjgl3.audio;
 
-import static org.lwjgl.openal.AL10.AL_BUFFER;
-import static org.lwjgl.openal.AL10.AL_NO_ERROR;
-import static org.lwjgl.openal.AL10.AL_ORIENTATION;
-import static org.lwjgl.openal.AL10.AL_PAUSED;
-import static org.lwjgl.openal.AL10.AL_PLAYING;
-import static org.lwjgl.openal.AL10.AL_POSITION;
-import static org.lwjgl.openal.AL10.AL_SOURCE_STATE;
-import static org.lwjgl.openal.AL10.AL_STOPPED;
-import static org.lwjgl.openal.AL10.AL_VELOCITY;
-import static org.lwjgl.openal.AL10.alDeleteSources;
-import static org.lwjgl.openal.AL10.alGenSources;
-import static org.lwjgl.openal.AL10.alGetError;
-import static org.lwjgl.openal.AL10.alGetSourcei;
-import static org.lwjgl.openal.AL10.alListenerfv;
-import static org.lwjgl.openal.AL10.alSourcePause;
-import static org.lwjgl.openal.AL10.alSourcePlay;
-import static org.lwjgl.openal.AL10.alSourceStop;
-import static org.lwjgl.openal.AL10.alSourcei;
+import static org.lwjgl.openal.AL10.*;
 import static org.lwjgl.openal.ALC10.*;
+import static org.lwjgl.openal.EXTDisconnect.ALC_CONNECTED;
+import static org.lwjgl.openal.EnumerateAllExt.ALC_ALL_DEVICES_SPECIFIER;
 
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.FloatBuffer;
 import java.nio.IntBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import org.lwjgl.BufferUtils;
 import org.lwjgl.openal.AL;
@@ -57,7 +45,10 @@ import com.badlogic.gdx.utils.LongMap;
 import com.badlogic.gdx.utils.ObjectMap;
 import org.lwjgl.openal.ALC;
 import org.lwjgl.openal.ALCCapabilities;
+import org.lwjgl.openal.ALUtil;
 import org.lwjgl.openal.SOFTDirectChannels;
+import org.lwjgl.openal.SOFTReopenDevice;
+import org.lwjgl.system.MemoryUtil;
 import org.lwjgl.openal.SOFTDirectChannelsRemix;
 
 /** @author Nathan Sweet */
@@ -72,6 +63,8 @@ public class OpenALLwjgl3Audio implements Lwjgl3Audio {
 	private ObjectMap<String, Class<? extends OpenALMusic>> extensionToMusicClass = new ObjectMap();
 	private OpenALSound[] recentSounds;
 	private int mostRecetSound = -1;
+	private String preferredOutputDevice = null;
+	private Thread observerThread;
 
 	Array<OpenALMusic> music = new Array(false, 1, OpenALMusic.class);
 	long device;
@@ -133,6 +126,55 @@ public class OpenALLwjgl3Audio implements Lwjgl3Audio {
 		((Buffer)position).flip();
 		alListenerfv(AL_POSITION, position);
 
+		// AL_STOP_SOURCES_ON_DISCONNECT_SOFT
+		alDisable(0x19AB);
+		observerThread = new Thread(new Runnable() {
+
+			private String[] lastAvailableDevices = new String[0];
+			@Override
+			public void run () {
+				while (true) {
+					boolean isConnected = alcGetInteger(device, ALC_CONNECTED) != 0;
+					if (!isConnected) {
+						// The device is at a state where it can't recover
+						// This is usually the windows path on removing a device
+						switchOutputDevice(null, false);
+						continue;
+					}
+					if (preferredOutputDevice != null) {
+						if (Arrays.asList(getAvailableOutputDevices()).contains(preferredOutputDevice)) {
+							if (!preferredOutputDevice.equals(alcGetString(device, ALC_ALL_DEVICES_SPECIFIER))) {
+								// The preferred output device is reconnected, let's switch back to it
+								switchOutputDevice(preferredOutputDevice);
+							}
+						} else {
+							// This is usually the mac/linux path
+							if (preferredOutputDevice.equals(alcGetString(device, ALC_ALL_DEVICES_SPECIFIER))) {
+								// The preferred output device is reconnected, let's switch back to it
+								switchOutputDevice(null, false);
+							}
+						}
+					} else {
+						String[] currentDevices = getAvailableOutputDevices();
+						List<String> currentDevicesList = new ArrayList<>(Arrays.asList(currentDevices));
+						currentDevicesList.removeAll(Arrays.asList(lastAvailableDevices));
+						// If a new device got added, re evaluate "auto" mode
+						if (currentDevicesList.size() != 0) {
+							switchOutputDevice(null);
+						}
+						lastAvailableDevices = currentDevices;
+					}
+					try {
+						Thread.sleep(1000);
+					} catch (InterruptedException ignored) {
+						return;
+					}
+				}
+			}
+		});
+		observerThread.setDaemon(true);
+		observerThread.start();
+
 		recentSounds = new OpenALSound[simultaneousSources];
 	}
 
@@ -168,6 +210,31 @@ public class OpenALLwjgl3Audio implements Lwjgl3Audio {
 		} catch (Exception ex) {
 			throw new GdxRuntimeException("Error creating music " + musicClass.getName() + " for file: " + file, ex);
 		}
+	}
+
+	@Override
+	public boolean switchOutputDevice (String deviceIdentifier) {
+		return switchOutputDevice(deviceIdentifier, true);
+	}
+
+	private boolean switchOutputDevice (String deviceIdentifier, boolean setPreferred) {
+		if (setPreferred) {
+			preferredOutputDevice = deviceIdentifier;
+		}
+
+		if (deviceIdentifier == null) {
+			return SOFTReopenDevice.nalcReopenDeviceSOFT(device, MemoryUtil.memAddressSafe((ByteBuffer)null),
+				MemoryUtil.memAddressSafe((IntBuffer)null));
+		} else {
+			return SOFTReopenDevice.alcReopenDeviceSOFT(device, deviceIdentifier, (IntBuffer)null);
+		}
+	}
+
+	@Override
+	public String[] getAvailableOutputDevices () {
+		List<String> devices = ALUtil.getStringList(0, ALC_ALL_DEVICES_SPECIFIER);
+		if (devices == null) return new String[0];
+		return devices.toArray(new String[0]);
 	}
 
 	int obtainSource (boolean isMusic) {
@@ -307,6 +374,7 @@ public class OpenALLwjgl3Audio implements Lwjgl3Audio {
 
 	public void dispose () {
 		if (noDevice) return;
+		observerThread.interrupt();
 		for (int i = 0, n = allSources.size; i < n; i++) {
 			int sourceID = allSources.get(i);
 			int state = alGetSourcei(sourceID, AL_SOURCE_STATE);

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/mock/MockAudio.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/mock/MockAudio.java
@@ -48,6 +48,16 @@ public class MockAudio implements Lwjgl3Audio {
 	}
 
 	@Override
+	public boolean switchOutputDevice (String deviceIdentifier) {
+		return true;
+	}
+
+	@Override
+	public String[] getAvailableOutputDevices () {
+		return new String[0];
+	}
+
+	@Override
 	public void update () {
 	}
 

--- a/backends/gdx-backend-robovm-metalangle/src/com/badlogic/gdx/backends/iosrobovm/objectal/OALIOSAudio.java
+++ b/backends/gdx-backend-robovm-metalangle/src/com/badlogic/gdx/backends/iosrobovm/objectal/OALIOSAudio.java
@@ -58,6 +58,16 @@ public class OALIOSAudio implements IOSAudio {
 	}
 
 	@Override
+	public boolean switchOutputDevice (String deviceIdentifier) {
+		return true;
+	}
+
+	@Override
+	public String[] getAvailableOutputDevices () {
+		return new String[0];
+	}
+
+	@Override
 	public void didBecomeActive () {
 		// workaround for ObjectAL crash problem
 		// see: https://groups.google.com/g/objectal-for-iphone/c/ubRWltp_i1Q

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/objectal/OALIOSAudio.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/objectal/OALIOSAudio.java
@@ -71,6 +71,16 @@ public class OALIOSAudio implements IOSAudio {
 	}
 
 	@Override
+	public boolean switchOutputDevice (String deviceIdentifier) {
+		return true;
+	}
+
+	@Override
+	public String[] getAvailableOutputDevices () {
+		return new String[0];
+	}
+
+	@Override
 	public void didBecomeActive () {
 		// workaround for ObjectAL crash problem
 		// see: https://groups.google.com/g/objectal-for-iphone/c/ubRWltp_i1Q

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/DefaultGwtAudio.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/DefaultGwtAudio.java
@@ -50,4 +50,14 @@ public class DefaultGwtAudio implements GwtAudio {
 	public Music newMusic (FileHandle file) {
 		return webAudioAPIManager.createMusic(file);
 	}
+
+	@Override
+	public boolean switchOutputDevice (String deviceIdentifier) {
+		return true;
+	}
+
+	@Override
+	public String[] getAvailableOutputDevices () {
+		return new String[0];
+	}
 }

--- a/gdx/src/com/badlogic/gdx/Audio.java
+++ b/gdx/src/com/badlogic/gdx/Audio.java
@@ -22,6 +22,7 @@ import com.badlogic.gdx.audio.Music;
 import com.badlogic.gdx.audio.Sound;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.utils.GdxRuntimeException;
+import com.badlogic.gdx.utils.Null;
 
 /** This interface encapsulates the creation and management of audio resources. It allows you to get direct access to the audio
  * hardware via the {@link AudioDevice} and {@link AudioRecorder} interfaces, create sound effects via the {@link Sound} interface
@@ -85,4 +86,17 @@ public interface Audio {
 	 * @return the new Music or null if the Music could not be loaded
 	 * @throws GdxRuntimeException in case the music could not be loaded */
 	public Music newMusic (FileHandle file);
+
+	/** Sets a new OutputDevice. The identifier can be retrieved from {@link Audio#getAvailableOutputDevices()}. If null is passed,
+	 * it will switch to auto.
+	 *
+	 * @param deviceIdentifier device identifier to switch to, or null for auto */
+	public boolean switchOutputDevice (@Null String deviceIdentifier);
+
+	/** This function returns a list of fully qualified Output device names. This function is only implemented on desktop. On all
+	 * other platforms it will return a empty array. It will also return a empty array on error. The names returned need os
+	 * dependent preprocessing before exposing to a user.
+	 *
+	 * @return A array of available output devices */
+	public String[] getAvailableOutputDevices ();
 }

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/AudioChangeDeviceTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/AudioChangeDeviceTest.java
@@ -1,0 +1,66 @@
+
+package com.badlogic.gdx.tests;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.scenes.scene2d.Actor;
+import com.badlogic.gdx.scenes.scene2d.Stage;
+import com.badlogic.gdx.scenes.scene2d.ui.SelectBox;
+import com.badlogic.gdx.scenes.scene2d.ui.Skin;
+import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
+import com.badlogic.gdx.tests.utils.GdxTest;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class AudioChangeDeviceTest extends GdxTest {
+
+	private Stage stage;
+	private Skin skin;
+
+	@Override
+	public void create () {
+		stage = new Stage();
+		Gdx.input.setInputProcessor(stage);
+		skin = new Skin(Gdx.files.internal("data/uiskin.json"));
+		final SelectBox<String> selectBox = new SelectBox<>(skin);
+		List<String> tmp = new ArrayList<>(Arrays.asList(Gdx.audio.getAvailableOutputDevices()));
+		tmp.add(0, "Auto");
+		selectBox.setItems(tmp.toArray(new String[0]));
+		Gdx.audio.newSound(Gdx.files.internal("data").child("bubblepop-stereo-left-only.wav")).loop();
+		selectBox.addListener(new ChangeListener() {
+
+			@Override
+			public void changed (ChangeEvent event, Actor actor) {
+				if (selectBox.getSelected().equals("Auto")) {
+					Gdx.app.getAudio().switchOutputDevice(null);
+					return;
+				}
+				Gdx.app.getAudio().switchOutputDevice(selectBox.getSelected());
+			}
+		});
+		selectBox.setWidth(200);
+		selectBox.setPosition(200, 200);
+
+		stage.addActor(selectBox);
+	}
+
+	@Override
+	public void render () {
+		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		stage.act(Gdx.graphics.getDeltaTime());
+		stage.draw();
+	}
+
+	@Override
+	public void resize (int width, int height) {
+		stage.getViewport().update(width, height, true);
+	}
+
+	@Override
+	public void dispose () {
+		stage.dispose();
+		skin.dispose();
+	}
+}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
@@ -108,6 +108,7 @@ public class GdxTests {
 		AnnotationTest.class,
 		AssetManagerTest.class,
 		AtlasIssueTest.class,
+		AudioChangeDeviceTest.class,
 		AudioDeviceTest.class,
 		AudioRecorderTest.class,
 		AudioSoundAndMusicIsolationTest.class,


### PR DESCRIPTION
This pr adds support for three main things (only for lwjgl3):
1. Auto switching the Output device if e.g. a headphone gets disconnected. This is mainly relevant on windows, because before that the audio just died.
2. It reevaluates the default device, if a new device gets connected, and therefor maybe switches to it (the os decides)
3. It adds a API to specifically select a output device. This API supports swapping too, so if the device gets disconnected and reconected, it will be choosen again.

I also added a Test for this.