### PR TITLE
Modify to allow FreeBSD to build with minimal changes

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/scenes/scene2d/utils/UIUtils.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/scenes/scene2d/utils/UIUtils.java
@@ -10,7 +10,7 @@ public class UIUtils {
 	static public boolean isAndroid = Navigator.getPlatform().contains("Android");
 	static public boolean isMac = Navigator.getPlatform().contains("Mac");
 	static public boolean isWindows = Navigator.getPlatform().contains("Win");
-	static public boolean isLinux = Navigator.getPlatform().contains("Linux");
+	static public boolean isLinux = Navigator.getPlatform().contains("Linux") || Navigator.getPlatform().contains("FreeBSD");
 	static public boolean isIos = Navigator.getPlatform().contains("iPhone") || Navigator.getPlatform().contains("iPod")
 		|| Navigator.getPlatform().contains("iPad");
 

--- a/extensions/gdx-freetype/build.gradle
+++ b/extensions/gdx-freetype/build.gradle
@@ -79,9 +79,9 @@ jnigen {
 		cppExcludes = ["freetype/subprojects/"]
 
 		cFlags += " -DFT2_BUILD_LIBRARY "
-                cFlags += System.getenv("CC_FLAGS")
+		cFlags += System.getenv("CC_FLAGS")
 		cppFlags += " -DFT2_BUILD_LIBRARY "
-                cppFlags += System.getenv("CPP_FLAGS")
+		cppFlags += System.getenv("CPP_FLAGS")
 	}
 	add(Windows, x32)
 	add(Windows, x64)

--- a/extensions/gdx-freetype/build.gradle
+++ b/extensions/gdx-freetype/build.gradle
@@ -78,8 +78,10 @@ jnigen {
 
 		cppExcludes = ["freetype/subprojects/"]
 
-		cFlags += " -DFT2_BUILD_LIBRARY"
-		cppFlags += " -DFT2_BUILD_LIBRARY"
+		cFlags += " -DFT2_BUILD_LIBRARY "
+                cFlags += System.getenv("CC_FLAGS")
+		cppFlags += " -DFT2_BUILD_LIBRARY "
+                cppFlags += System.getenv("CPP_FLAGS")
 	}
 	add(Windows, x32)
 	add(Windows, x64)

--- a/extensions/gdx-lwjgl3-angle/src/com/badlogic/gdx/backends/lwjgl3/angle/ANGLELoader.java
+++ b/extensions/gdx-lwjgl3-angle/src/com/badlogic/gdx/backends/lwjgl3/angle/ANGLELoader.java
@@ -26,7 +26,7 @@ import java.util.zip.CRC32;
 
 public class ANGLELoader {
 	static public boolean isWindows = System.getProperty("os.name").contains("Windows");
-	static public boolean isLinux = System.getProperty("os.name").contains("Linux");
+	static public boolean isLinux = System.getProperty("os.name").contains("Linux") || System.getProperty("os.name").contains("FreeBSD");
 	static public boolean isMac = System.getProperty("os.name").contains("Mac");
 	static public boolean isARM = System.getProperty("os.arch").startsWith("arm")
 		|| System.getProperty("os.arch").startsWith("aarch64");

--- a/extensions/gdx-lwjgl3-angle/src/com/badlogic/gdx/backends/lwjgl3/angle/ANGLELoader.java
+++ b/extensions/gdx-lwjgl3-angle/src/com/badlogic/gdx/backends/lwjgl3/angle/ANGLELoader.java
@@ -26,7 +26,8 @@ import java.util.zip.CRC32;
 
 public class ANGLELoader {
 	static public boolean isWindows = System.getProperty("os.name").contains("Windows");
-	static public boolean isLinux = System.getProperty("os.name").contains("Linux") || System.getProperty("os.name").contains("FreeBSD");
+	static public boolean isLinux = System.getProperty("os.name").contains("Linux")
+		|| System.getProperty("os.name").contains("FreeBSD");
 	static public boolean isMac = System.getProperty("os.name").contains("Mac");
 	static public boolean isARM = System.getProperty("os.arch").startsWith("arm")
 		|| System.getProperty("os.arch").startsWith("aarch64");

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/UIUtils.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/UIUtils.java
@@ -12,7 +12,8 @@ public final class UIUtils {
 	static public boolean isAndroid = System.getProperty("java.runtime.name").contains("Android");
 	static public boolean isMac = !isAndroid && System.getProperty("os.name").contains("Mac");
 	static public boolean isWindows = !isAndroid && System.getProperty("os.name").contains("Windows");
-	static public boolean isLinux = !isAndroid && System.getProperty("os.name").contains("Linux") || System.getProperty("os.name").contains("FreeBSD");
+	static public boolean isLinux = !isAndroid && System.getProperty("os.name").contains("Linux")
+		|| System.getProperty("os.name").contains("FreeBSD");
 	static public boolean isIos = !isAndroid && (!(isWindows || isLinux || isMac));
 
 	static public boolean left () {

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/UIUtils.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/UIUtils.java
@@ -12,7 +12,7 @@ public final class UIUtils {
 	static public boolean isAndroid = System.getProperty("java.runtime.name").contains("Android");
 	static public boolean isMac = !isAndroid && System.getProperty("os.name").contains("Mac");
 	static public boolean isWindows = !isAndroid && System.getProperty("os.name").contains("Windows");
-	static public boolean isLinux = !isAndroid && System.getProperty("os.name").contains("Linux");
+	static public boolean isLinux = !isAndroid && System.getProperty("os.name").contains("Linux") || System.getProperty("os.name").contains("FreeBSD");
 	static public boolean isIos = !isAndroid && (!(isWindows || isLinux || isMac));
 
 	static public boolean left () {


### PR DESCRIPTION
These changes add support for FreeBSD by having `isLinux` be true for it as well. However projects likely need to be manually compiled by the user using self compiled natives, unless a FreeBSD CI system is built which iirc github doesn't offer. 

The changes to [extensions/gdx-freetype/build.gradle](https://github.com/libgdx/libgdx/compare/master...Mia-Rain:libgdx:master#diff-2c01f9a8a05474bdfd5b3225e4178d570d44b86c12212bcfdeacd98e350cd367) are needed so that `$CPP_FLAGS` and `$CC_FLAGS` can be set to `-I/usr/local/include/freetype2` otherwise compilation fails.


fixes: #4606 