### PR TITLE
Recreate window

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+- Lwjgl3: #recreateWindow now stops itself from creating more than one window
+- API "Addition": removed #setMSAASamples, #setColorBits, #setDepthBits & #setStencilBits
+
 - Lwjgl3: Added #recreateWindow to Lwjgl3Application; used to apply changes that require a new window to be created.
 - API Addition: Lwjgl3Graphics now has #setMSAASamples, #setColorBits, #setDepthBits, #setStencilBits, #setBackBufferConfig (these use the aforementioned recreateWindow() method) & #setIdleFPS
 - POSSIBLE [BREAKING CHANGE] Lwjgl3: #recreateWindow instantiates new Gdx.input & Gdx.graphics, which can be a problem for already existing pointers

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,6 @@
 - Lwjgl3: Added #recreateWindow to Lwjgl3Application; used to apply changes that require a new window to be created.
 - API Addition: Lwjgl3Graphics now has #setMSAASamples, #setColorBits, #setDepthBits, #setStencilBits, #setBackBufferConfig (these use the aforementioned recreateWindow() method) & #setIdleFPS
+- POSSIBLE [BREAKING CHANGE] Lwjgl3: #recreateWindow instantiates new Gdx.input & Gdx.graphics, which can be a problem for already existing pointers
 
 [1.11.1]
 - [BREAKING CHANGE] Added #touchCancelled to InputProcessor interface, see #6871.

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+- Lwjgl3: Added #recreateWindow to Lwjgl3Application; used to apply changes that require a new window to be created.
+- API Addition: Lwjgl3Graphics now has #setMSAASamples, #setColorBits, #setDepthBits, #setStencilBits, #setBackBufferConfig (these use the aforementioned recreateWindow() method) & #setIdleFPS
+
 [1.11.1]
 - [BREAKING CHANGE] Added #touchCancelled to InputProcessor interface, see #6871.
 - [BREAKING CHANGE] Android: Immersive mode is now true by default. Set `useImmersiveMode` config to `false` to disable it. 

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Graphics.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Graphics.java
@@ -101,7 +101,7 @@ public class Lwjgl3Graphics extends AbstractGraphics implements Disposable {
 		} else {
 			try {
 				this.gl20 = window.getConfig().glEmulation == Lwjgl3ApplicationConfiguration.GLEmulation.GL20 ? new Lwjgl3GL20()
-						: (GL20)Class.forName("com.badlogic.gdx.backends.lwjgl3.angle.Lwjgl3GLES20").newInstance();
+					: (GL20)Class.forName("com.badlogic.gdx.backends.lwjgl3.angle.Lwjgl3GLES20").newInstance();
 			} catch (Throwable t) {
 				throw new GdxRuntimeException("Couldn't instantiate GLES20.", t);
 			}
@@ -151,7 +151,7 @@ public class Lwjgl3Graphics extends AbstractGraphics implements Disposable {
 		Lwjgl3Graphics.this.logicalHeight = tmpBuffer2.get(0);
 		Lwjgl3ApplicationConfiguration config = window.getConfig();
 		bufferFormat = new BufferFormat(config.r, config.g, config.b, config.a, config.depth, config.stencil, config.samples,
-				false);
+			false);
 	}
 
 	void update () {
@@ -319,8 +319,8 @@ public class Lwjgl3Graphics extends AbstractGraphics implements Disposable {
 			DisplayMode mode = getDisplayMode(monitor);
 
 			overlap = Math.max(0,
-					Math.min(windowX + windowWidth, monitor.virtualX + mode.width) - Math.max(windowX, monitor.virtualX))
-					* Math.max(0, Math.min(windowY + windowHeight, monitor.virtualY + mode.height) - Math.max(windowY, monitor.virtualY));
+				Math.min(windowX + windowWidth, monitor.virtualX + mode.width) - Math.max(windowX, monitor.virtualX))
+				* Math.max(0, Math.min(windowY + windowHeight, monitor.virtualY + mode.height) - Math.max(windowY, monitor.virtualY));
 
 			if (bestOverlap < overlap) {
 				bestOverlap = overlap;
@@ -392,7 +392,7 @@ public class Lwjgl3Graphics extends AbstractGraphics implements Disposable {
 			} else {
 				// different monitor and/or refresh rate
 				GLFW.glfwSetWindowMonitor(window.getWindowHandle(), newMode.getMonitor(), 0, 0, newMode.width, newMode.height,
-						newMode.refreshRate);
+					newMode.refreshRate);
 			}
 		} else {
 			// store window position so we can restore it when switching from fullscreen to windowed later
@@ -400,7 +400,7 @@ public class Lwjgl3Graphics extends AbstractGraphics implements Disposable {
 
 			// switch from windowed to fullscreen
 			GLFW.glfwSetWindowMonitor(window.getWindowHandle(), newMode.getMonitor(), 0, 0, newMode.width, newMode.height,
-					newMode.refreshRate);
+				newMode.refreshRate);
 		}
 		updateFramebufferInfo();
 
@@ -442,12 +442,12 @@ public class Lwjgl3Graphics extends AbstractGraphics implements Disposable {
 				Lwjgl3Monitor monitor = (Lwjgl3Monitor)getMonitor();
 				GLFW.glfwGetMonitorWorkarea(monitor.monitorHandle, tmpBuffer, tmpBuffer2, tmpBuffer3, tmpBuffer4);
 				GLFW.glfwSetWindowMonitor(window.getWindowHandle(), 0,
-						Math.max(0, tmpBuffer.get(0) + (tmpBuffer3.get(0) - width) / 2),
-						Math.max(0, tmpBuffer2.get(0) + (tmpBuffer4.get(0) - height) / 2), width, height,
-						displayModeBeforeFullscreen.refreshRate);
+					Math.max(0, tmpBuffer.get(0) + (tmpBuffer3.get(0) - width) / 2),
+					Math.max(0, tmpBuffer2.get(0) + (tmpBuffer4.get(0) - height) / 2), width, height,
+					displayModeBeforeFullscreen.refreshRate);
 			} else {
 				GLFW.glfwSetWindowMonitor(window.getWindowHandle(), 0, windowPosXBeforeFullscreen, windowPosYBeforeFullscreen, width,
-						height, displayModeBeforeFullscreen.refreshRate);
+					height, displayModeBeforeFullscreen.refreshRate);
 			}
 		}
 		updateFramebufferInfo();
@@ -534,31 +534,11 @@ public class Lwjgl3Graphics extends AbstractGraphics implements Disposable {
 		Lwjgl3Cursor.setSystemCursor(getWindow().getWindowHandle(), systemCursor);
 	}
 
-	public void setIdleFPS(int idleFPS) {
+	public void setIdleFPS (int idleFPS) {
 		getWindow().getConfig().idleFPS = idleFPS;
 	}
 
-	public void setMSAASamples(int samples) {
-		Lwjgl3ApplicationConfiguration config = getWindow().getConfig();
-		setBackBufferConfig(config.r, config.g, config.b, config.a, config.depth, config.stencil, samples);
-	}
-
-	public void setColorBits(int r, int g, int b, int a) {
-		Lwjgl3ApplicationConfiguration config = getWindow().getConfig();
-		setBackBufferConfig(r, g, b, a, config.depth, config.stencil, config.samples);
-	}
-
-	public void setDepthBits(int depth) {
-		Lwjgl3ApplicationConfiguration config = getWindow().getConfig();
-		setBackBufferConfig(config.r, config.g, config.b, config.a, depth, config.stencil, config.samples);
-	}
-
-	public void setStencilBits(int stencil) {
-		Lwjgl3ApplicationConfiguration config = getWindow().getConfig();
-		setBackBufferConfig(config.r, config.g, config.b, config.a, config.depth, stencil, config.samples);
-	}
-
-	public void setBackBufferConfig(int r, int g, int b, int a, int depth, int stencil, int samples) {
+	public void setBackBufferConfig (int r, int g, int b, int a, int depth, int stencil, int samples) {
 		Lwjgl3ApplicationConfiguration config = getWindow().getConfig();
 		config.setBackBufferConfig(r, g, b, a, depth, stencil, samples);
 		((Lwjgl3Application)Gdx.app).recreateWindow();

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Graphics.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Graphics.java
@@ -101,7 +101,7 @@ public class Lwjgl3Graphics extends AbstractGraphics implements Disposable {
 		} else {
 			try {
 				this.gl20 = window.getConfig().glEmulation == Lwjgl3ApplicationConfiguration.GLEmulation.GL20 ? new Lwjgl3GL20()
-					: (GL20)Class.forName("com.badlogic.gdx.backends.lwjgl3.angle.Lwjgl3GLES20").newInstance();
+						: (GL20)Class.forName("com.badlogic.gdx.backends.lwjgl3.angle.Lwjgl3GLES20").newInstance();
 			} catch (Throwable t) {
 				throw new GdxRuntimeException("Couldn't instantiate GLES20.", t);
 			}
@@ -151,7 +151,7 @@ public class Lwjgl3Graphics extends AbstractGraphics implements Disposable {
 		Lwjgl3Graphics.this.logicalHeight = tmpBuffer2.get(0);
 		Lwjgl3ApplicationConfiguration config = window.getConfig();
 		bufferFormat = new BufferFormat(config.r, config.g, config.b, config.a, config.depth, config.stencil, config.samples,
-			false);
+				false);
 	}
 
 	void update () {
@@ -319,8 +319,8 @@ public class Lwjgl3Graphics extends AbstractGraphics implements Disposable {
 			DisplayMode mode = getDisplayMode(monitor);
 
 			overlap = Math.max(0,
-				Math.min(windowX + windowWidth, monitor.virtualX + mode.width) - Math.max(windowX, monitor.virtualX))
-				* Math.max(0, Math.min(windowY + windowHeight, monitor.virtualY + mode.height) - Math.max(windowY, monitor.virtualY));
+					Math.min(windowX + windowWidth, monitor.virtualX + mode.width) - Math.max(windowX, monitor.virtualX))
+					* Math.max(0, Math.min(windowY + windowHeight, monitor.virtualY + mode.height) - Math.max(windowY, monitor.virtualY));
 
 			if (bestOverlap < overlap) {
 				bestOverlap = overlap;
@@ -392,7 +392,7 @@ public class Lwjgl3Graphics extends AbstractGraphics implements Disposable {
 			} else {
 				// different monitor and/or refresh rate
 				GLFW.glfwSetWindowMonitor(window.getWindowHandle(), newMode.getMonitor(), 0, 0, newMode.width, newMode.height,
-					newMode.refreshRate);
+						newMode.refreshRate);
 			}
 		} else {
 			// store window position so we can restore it when switching from fullscreen to windowed later
@@ -400,7 +400,7 @@ public class Lwjgl3Graphics extends AbstractGraphics implements Disposable {
 
 			// switch from windowed to fullscreen
 			GLFW.glfwSetWindowMonitor(window.getWindowHandle(), newMode.getMonitor(), 0, 0, newMode.width, newMode.height,
-				newMode.refreshRate);
+					newMode.refreshRate);
 		}
 		updateFramebufferInfo();
 
@@ -442,12 +442,12 @@ public class Lwjgl3Graphics extends AbstractGraphics implements Disposable {
 				Lwjgl3Monitor monitor = (Lwjgl3Monitor)getMonitor();
 				GLFW.glfwGetMonitorWorkarea(monitor.monitorHandle, tmpBuffer, tmpBuffer2, tmpBuffer3, tmpBuffer4);
 				GLFW.glfwSetWindowMonitor(window.getWindowHandle(), 0,
-					Math.max(0, tmpBuffer.get(0) + (tmpBuffer3.get(0) - width) / 2),
-					Math.max(0, tmpBuffer2.get(0) + (tmpBuffer4.get(0) - height) / 2), width, height,
-					displayModeBeforeFullscreen.refreshRate);
+						Math.max(0, tmpBuffer.get(0) + (tmpBuffer3.get(0) - width) / 2),
+						Math.max(0, tmpBuffer2.get(0) + (tmpBuffer4.get(0) - height) / 2), width, height,
+						displayModeBeforeFullscreen.refreshRate);
 			} else {
 				GLFW.glfwSetWindowMonitor(window.getWindowHandle(), 0, windowPosXBeforeFullscreen, windowPosYBeforeFullscreen, width,
-					height, displayModeBeforeFullscreen.refreshRate);
+						height, displayModeBeforeFullscreen.refreshRate);
 			}
 		}
 		updateFramebufferInfo();
@@ -532,6 +532,36 @@ public class Lwjgl3Graphics extends AbstractGraphics implements Disposable {
 	@Override
 	public void setSystemCursor (SystemCursor systemCursor) {
 		Lwjgl3Cursor.setSystemCursor(getWindow().getWindowHandle(), systemCursor);
+	}
+
+	public void setIdleFPS(int idleFPS) {
+		getWindow().getConfig().idleFPS = idleFPS;
+	}
+
+	public void setMSAASamples(int samples) {
+		Lwjgl3ApplicationConfiguration config = getWindow().getConfig();
+		setBackBufferConfig(config.r, config.g, config.b, config.a, config.depth, config.stencil, samples);
+	}
+
+	public void setColorBits(int r, int g, int b, int a) {
+		Lwjgl3ApplicationConfiguration config = getWindow().getConfig();
+		setBackBufferConfig(r, g, b, a, config.depth, config.stencil, config.samples);
+	}
+
+	public void setDepthBits(int depth) {
+		Lwjgl3ApplicationConfiguration config = getWindow().getConfig();
+		setBackBufferConfig(config.r, config.g, config.b, config.a, depth, config.stencil, config.samples);
+	}
+
+	public void setStencilBits(int stencil) {
+		Lwjgl3ApplicationConfiguration config = getWindow().getConfig();
+		setBackBufferConfig(config.r, config.g, config.b, config.a, config.depth, stencil, config.samples);
+	}
+
+	public void setBackBufferConfig(int r, int g, int b, int a, int depth, int stencil, int samples) {
+		Lwjgl3ApplicationConfiguration config = getWindow().getConfig();
+		config.setBackBufferConfig(r, g, b, a, depth, stencil, samples);
+		((Lwjgl3Application)Gdx.app).recreateWindow();
 	}
 
 	@Override

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Window.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Window.java
@@ -242,8 +242,8 @@ public class Lwjgl3Window implements Disposable {
 		closeWindow(true);
 	}
 
-	/** Closes this window and pauses and disposes the associated {@link ApplicationListener},
-	 * depending on {@code callDisposeOnListener}.
+	/** Closes this window and pauses and disposes the associated {@link ApplicationListener}, depending on
+	 * {@code callDisposeOnListener}.
 	 * @param callDisposeOnListener should the {@link ApplicationListener} be disposed of? */
 	public void closeWindow (boolean callDisposeOnListener) {
 		this.callDisposeOnListener = callDisposeOnListener;
@@ -352,8 +352,8 @@ public class Lwjgl3Window implements Disposable {
 
 	static void setSizeLimits (long windowHandle, int minWidth, int minHeight, int maxWidth, int maxHeight) {
 		GLFW.glfwSetWindowSizeLimits(windowHandle, minWidth > -1 ? minWidth : GLFW.GLFW_DONT_CARE,
-				minHeight > -1 ? minHeight : GLFW.GLFW_DONT_CARE, maxWidth > -1 ? maxWidth : GLFW.GLFW_DONT_CARE,
-				maxHeight > -1 ? maxHeight : GLFW.GLFW_DONT_CARE);
+			minHeight > -1 ? minHeight : GLFW.GLFW_DONT_CARE, maxWidth > -1 ? maxWidth : GLFW.GLFW_DONT_CARE,
+			maxHeight > -1 ? maxHeight : GLFW.GLFW_DONT_CARE);
 	}
 
 	Lwjgl3Graphics getGraphics () {
@@ -425,9 +425,9 @@ public class Lwjgl3Window implements Disposable {
 
 	void initializeListener () {
 		if (!listenerInitialized) {
-			//If the window has been created just to change its configuration,
-			//there's no need to call create() on the ApplicationListener,
-			//since it was already called before.
+			// If the window has been created just to change its configuration,
+			// there's no need to call create() on the ApplicationListener,
+			// since it was already called before.
 			if (callCreateOnListener) {
 				listener.create();
 			}
@@ -451,8 +451,8 @@ public class Lwjgl3Window implements Disposable {
 		dispose();
 	}
 
-	/** Disposes of this window and pauses and disposes the associated {@link ApplicationListener},
-	 * depending on {@code callDisposeOnListener}. */
+	/** Disposes of this window and pauses and disposes the associated {@link ApplicationListener}, depending on
+	 * {@code callDisposeOnListener}. */
 	@Override
 	public void dispose () {
 		if (callDisposeOnListener) {

--- a/tests/gdx-tests-lwjgl3/src/com/badlogic/gdx/tests/lwjgl3/Lwjgl3RecreateWindowTest.java
+++ b/tests/gdx-tests-lwjgl3/src/com/badlogic/gdx/tests/lwjgl3/Lwjgl3RecreateWindowTest.java
@@ -1,6 +1,8 @@
 package com.badlogic.gdx.tests.lwjgl3;
 
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Graphics;
+import com.badlogic.gdx.Input;
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application;
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3ApplicationConfiguration;
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Graphics;
@@ -25,8 +27,18 @@ public class Lwjgl3RecreateWindowTest extends GdxTest {
     private Skin skin;
     private Stage stage;
 
+    private Input input;
+    private Graphics graphics;
+
     @Override
     public void create () {
+        //!!! Recreating a window causes Gdx.input & Gdx.graphics to be constructed
+        //from the window itself. What this means is that if I have a reference to
+        //these objects, then recreate the window, said objects will not point to
+        //the newly created instances, leading to strange results.
+        input = Gdx.input;
+        graphics = Gdx.graphics;
+
         stage = new Stage();
         skin = new Skin(Gdx.files.internal("data/uiskin.json"));
         Gdx.input.setInputProcessor(stage);
@@ -74,6 +86,9 @@ public class Lwjgl3RecreateWindowTest extends GdxTest {
         ScreenUtils.clear(1, 0, 0, 1);
         stage.act();
         stage.draw();
+
+        // Uncomment to see the input.getX()/input.getY() values, then recreate the window
+        //System.out.println(input.getX() + "\t" + input.getY() + "\t" + graphics);
     }
 
     @Override

--- a/tests/gdx-tests-lwjgl3/src/com/badlogic/gdx/tests/lwjgl3/Lwjgl3RecreateWindowTest.java
+++ b/tests/gdx-tests-lwjgl3/src/com/badlogic/gdx/tests/lwjgl3/Lwjgl3RecreateWindowTest.java
@@ -64,7 +64,7 @@ public class Lwjgl3RecreateWindowTest extends GdxTest {
         button.addListener(new ClickListener() {
             @Override
             public void clicked (InputEvent event, float x, float y) {
-                ((Lwjgl3Graphics)Gdx.graphics).setMSAASamples(16);
+                ((Lwjgl3Graphics)Gdx.graphics).setBackBufferConfig(8, 8, 8, 8, 16, 0, 16);
             }
         });
         table.add(button);
@@ -73,10 +73,22 @@ public class Lwjgl3RecreateWindowTest extends GdxTest {
         button.addListener(new ClickListener() {
             @Override
             public void clicked (InputEvent event, float x, float y) {
-                ((Lwjgl3Graphics)Gdx.graphics).setMSAASamples(0);
+                ((Lwjgl3Graphics)Gdx.graphics).setBackBufferConfig(8, 8, 8, 8, 16, 0, 0);
             }
         });
         table.add(button);
+        table.row();
+
+        button = new TextButton("(Attempt to) recreate window 10 times", skin);
+        button.addListener(new ClickListener() {
+            @Override
+            public void clicked (InputEvent event, float x, float y) {
+                for (int i = 0; i < 10; i++) {
+                    ((Lwjgl3Graphics)Gdx.graphics).setBackBufferConfig(8, 8, 8, 8, 16, 0, 0);
+                }
+            }
+        });
+        table.add(button).colspan(2);
 
         stage.addActor(table);
     }

--- a/tests/gdx-tests-lwjgl3/src/com/badlogic/gdx/tests/lwjgl3/Lwjgl3RecreateWindowTest.java
+++ b/tests/gdx-tests-lwjgl3/src/com/badlogic/gdx/tests/lwjgl3/Lwjgl3RecreateWindowTest.java
@@ -1,0 +1,108 @@
+package com.badlogic.gdx.tests.lwjgl3;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application;
+import com.badlogic.gdx.backends.lwjgl3.Lwjgl3ApplicationConfiguration;
+import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Graphics;
+import com.badlogic.gdx.scenes.scene2d.InputEvent;
+import com.badlogic.gdx.scenes.scene2d.Stage;
+import com.badlogic.gdx.scenes.scene2d.ui.Label;
+import com.badlogic.gdx.scenes.scene2d.ui.Skin;
+import com.badlogic.gdx.scenes.scene2d.ui.Table;
+import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
+import com.badlogic.gdx.scenes.scene2d.utils.ClickListener;
+import com.badlogic.gdx.tests.utils.GdxTest;
+import com.badlogic.gdx.utils.Align;
+import com.badlogic.gdx.utils.ScreenUtils;
+
+/** Tests for window recreation when changing settings such as MSAA sampling.
+ *
+ * {@link com.badlogic.gdx.InputProcessor} carries over into the newly created window.
+ *
+ * @author aretecorp */
+public class Lwjgl3RecreateWindowTest extends GdxTest {
+
+    private Skin skin;
+    private Stage stage;
+
+    @Override
+    public void create () {
+        stage = new Stage();
+        skin = new Skin(Gdx.files.internal("data/uiskin.json"));
+        Gdx.input.setInputProcessor(stage);
+        Table root = new Table();
+        root.setFillParent(true);
+        root.align(Align.left | Align.top);
+        stage.addActor(root);
+
+        createActors();
+
+        System.out.println(Lwjgl3RecreateWindowTest.class.getSimpleName() + " has been created.");
+    }
+
+    private void createActors() {
+        Table table = new Table();
+        table.setFillParent(true);
+
+        Label label = new Label("You gotta squint for this one.", skin);
+        table.add(label).colspan(2).center();
+        table.row();
+
+        TextButton button = new TextButton("x16 MSAA", skin);
+        button.addListener(new ClickListener() {
+            @Override
+            public void clicked (InputEvent event, float x, float y) {
+                ((Lwjgl3Graphics)Gdx.graphics).setMSAASamples(16);
+            }
+        });
+        table.add(button);
+
+        button = new TextButton("x0 MSAA", skin);
+        button.addListener(new ClickListener() {
+            @Override
+            public void clicked (InputEvent event, float x, float y) {
+                ((Lwjgl3Graphics)Gdx.graphics).setMSAASamples(0);
+            }
+        });
+        table.add(button);
+
+        stage.addActor(table);
+    }
+
+    @Override
+    public void render () {
+        ScreenUtils.clear(1, 0, 0, 1);
+        stage.act();
+        stage.draw();
+    }
+
+    @Override
+    public void resize (int width, int height) {
+        System.out.println(Lwjgl3RecreateWindowTest.class.getSimpleName() + " has resized with " + width + "x" + height);
+        stage.getViewport().update(width, height, true);
+    }
+
+    @Override
+    public void resume () {
+    }
+
+    @Override
+    public void pause () {
+    }
+
+    @Override
+    public void dispose () {
+        System.out.println(Lwjgl3RecreateWindowTest.class.getSimpleName() + " has been disposed of.");
+    }
+
+    public static void main (String[] argv) throws SecurityException {
+        final Lwjgl3RecreateWindowTest test = new Lwjgl3RecreateWindowTest();
+
+        Lwjgl3ApplicationConfiguration config = new Lwjgl3ApplicationConfiguration();
+        config.setWindowedMode(800, 600);
+        config.setTitle("Recreate window test");
+
+        new Lwjgl3Application(test, config);
+    }
+
+}


### PR DESCRIPTION
### What has been changed
Lwjgl3: Added `Lwjgl3RecreateWindowTest` to gdx-tests-lwjgl3
Lwjgl3: Added `recreateWindow()` to `Lwjgl3Application`; used to apply changes to settings that require a new window to be created
API Addition: `Lwjgl3Graphics` now has `setMSAASamples()`, `setColorBits()`, `setDepthBits()`, `setStencilBits()`, `setBackBufferConfig()` (these use the aforementioned `recreateWindow()` method) & `setIdleFPS()`
POSSIBLE [BREAKING CHANGE] Lwjgl3: `recreateWindow()` instantiates new `Gdx.input` & `Gdx.graphics`, which can be a problem for already existing pointers

### What does the test do?
Lets the user change the MSAA samples value at runtime, while you'd normally be able to set this option before starting the `ApplicationListener`.

### Why was this done?
It was done because most commercial games let the user change the amount of anti aliasing without asking the user to restart the game.

### What platforms has this change been tested on?
LWJGL3 on Windows - I tried to make this work with LWJGL2 but I didn't make it.
I haven't even touched HTML5 and Android / iOS, mostly because this I don't think this feature is really necessary on these platforms. That's why I didn't add the new methods in `Lwjgl3Graphics` to the `Graphics` interface; they'd do nothing for 4 platforms out of 5 (counting the LWJGL2 backend).

### Notes
If you were to make the `recreateWindow(Lwjgl3ApplicationConfiguration)` method public you could change absolutely anything about the new window, and while that was the intent originally, I figured out pretty quickly it would cause more issues than what it's worth. 
For example, if one were to recreate the window with `config.disableAudio=false` while it previously would have been `true`, all `Sound` & `Music` objects created before the new window instance would be `MockSound` & `MockMusic`, respectively - therefore they wouldn't play despite `Gdx.audio` not being `MockAudio` and the setting being `false`; I would have to have an event in the `ApplicationListener` to inform the programmer of the window change, and that seemed a little too much. 
This exact same problem manifests itself in a different way with `Gdx.input` & `Gdx.graphics` - if I were polling for input with a pointer to `Gdx.input` I obtained before the window change, then after said change the data I'd get would be stuck to however it was before the new window.