### PR TITLE
Added soundId support for AsynchronousSound

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidSound.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidSound.java
@@ -23,10 +23,11 @@ import com.badlogic.gdx.audio.Sound;
 import com.badlogic.gdx.utils.IntArray;
 
 final class AndroidSound implements Sound {
+	final static int MAX_STREAMS_COUNT = 8;
 	final SoundPool soundPool;
 	final AudioManager manager;
 	final int soundId;
-	final IntArray streamIds = new IntArray(8);
+	final IntArray streamIds = new IntArray(MAX_STREAMS_COUNT);
 
 	AndroidSound (SoundPool pool, AudioManager manager, int soundId) {
 		this.soundPool = pool;
@@ -46,7 +47,7 @@ final class AndroidSound implements Sound {
 
 	@Override
 	public long play (float volume) {
-		if (streamIds.size == 8) streamIds.pop();
+		if (streamIds.size == MAX_STREAMS_COUNT) streamIds.pop();
 		int streamId = soundPool.play(soundId, volume, volume, 1, 0, 1);
 		// standardise error code with other backends
 		if (streamId == 0) return -1;
@@ -101,7 +102,7 @@ final class AndroidSound implements Sound {
 
 	@Override
 	public long loop (float volume) {
-		if (streamIds.size == 8) streamIds.pop();
+		if (streamIds.size == MAX_STREAMS_COUNT) streamIds.pop();
 		int streamId = soundPool.play(soundId, volume, volume, 2, -1, 1);
 		// standardise error code with other backends
 		if (streamId == 0) return -1;
@@ -137,7 +138,7 @@ final class AndroidSound implements Sound {
 
 	@Override
 	public long play (float volume, float pitch, float pan) {
-		if (streamIds.size == 8) streamIds.pop();
+		if (streamIds.size == MAX_STREAMS_COUNT) streamIds.pop();
 		float leftVolume = volume;
 		float rightVolume = volume;
 		if (pan < 0) {
@@ -154,7 +155,7 @@ final class AndroidSound implements Sound {
 
 	@Override
 	public long loop (float volume, float pitch, float pan) {
-		if (streamIds.size == 8) streamIds.pop();
+		if (streamIds.size == MAX_STREAMS_COUNT) streamIds.pop();
 		float leftVolume = volume;
 		float rightVolume = volume;
 		if (pan < 0) {

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AsynchronousAndroidAudio.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AsynchronousAndroidAudio.java
@@ -40,6 +40,6 @@ public class AsynchronousAndroidAudio extends DefaultAndroidAudio {
 	@Override
 	public Sound newSound (FileHandle file) {
 		Sound sound = super.newSound(file);
-		return new AsynchronousSound(sound, handler);
+		return new AsynchronousSound(sound, handler, AndroidSound.MAX_STREAMS_COUNT);
 	}
 }

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AsynchronousSound.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AsynchronousSound.java
@@ -3,81 +3,99 @@ package com.badlogic.gdx.backends.android;
 
 import android.os.Handler;
 import com.badlogic.gdx.audio.Sound;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class AsynchronousSound implements Sound {
 
 	private final Sound sound;
 	private final Handler handler;
+	private final AtomicInteger playedSoundsCounter = new AtomicInteger();
+	private final int soundIdsCountToSave;
+	private final long[] soundIds;
 
-	public AsynchronousSound (Sound sound, Handler handler) {
+	public AsynchronousSound (Sound sound, Handler handler, int soundIdsCountToSave) {
 		this.sound = sound;
 		this.handler = handler;
+		this.soundIdsCountToSave = soundIdsCountToSave;
+		this.soundIds = new long[soundIdsCountToSave];
 	}
 
 	@Override
 	public long play () {
+		final int soundNumber = playedSoundsCounter.getAndIncrement();
 		handler.post(new Runnable() {
 			@Override
 			public void run () {
-				sound.play();
+				long soundId = sound.play();
+				saveSoundId(soundNumber, soundId);
 			}
 		});
-		return 0;
+		return soundNumber;
 	}
 
 	@Override
 	public long play (final float volume) {
+		final int soundNumber = playedSoundsCounter.getAndIncrement();
 		handler.post(new Runnable() {
 			@Override
 			public void run () {
-				sound.play(volume);
+				long soundId = sound.play(volume);
+				saveSoundId(soundNumber, soundId);
 			}
 		});
-		return 0;
+		return soundNumber;
 	}
 
 	@Override
 	public long play (final float volume, final float pitch, final float pan) {
+		final int soundNumber = playedSoundsCounter.getAndIncrement();
 		handler.post(new Runnable() {
 			@Override
 			public void run () {
-				sound.play(volume, pitch, pan);
+				long soundId = sound.play(volume, pitch, pan);
+				saveSoundId(soundNumber, soundId);
 			}
 		});
-		return 0;
+		return soundNumber;
 	}
 
 	@Override
 	public long loop () {
+		final int soundNumber = playedSoundsCounter.getAndIncrement();
 		handler.post(new Runnable() {
 			@Override
 			public void run () {
-				sound.loop();
+				long soundId = sound.loop();
+				saveSoundId(soundNumber, soundId);
 			}
 		});
-		return 0;
+		return soundNumber;
 	}
 
 	@Override
 	public long loop (final float volume) {
+		final int soundNumber = playedSoundsCounter.getAndIncrement();
 		handler.post(new Runnable() {
 			@Override
 			public void run () {
-				sound.loop(volume);
+				long soundId = sound.loop(volume);
+				saveSoundId(soundNumber, soundId);
 			}
 		});
-		return 0;
+		return soundNumber;
 	}
 
 	@Override
 	public long loop (final float volume, final float pitch, final float pan) {
+		final int soundNumber = playedSoundsCounter.getAndIncrement();
 		handler.post(new Runnable() {
 			@Override
 			public void run () {
-				sound.loop(volume, pitch, pan);
+				long soundId = sound.loop(volume, pitch, pan);
+				saveSoundId(soundNumber, soundId);
 			}
 		});
-		return 0;
+		return soundNumber;
 	}
 
 	@Override
@@ -102,36 +120,51 @@ public class AsynchronousSound implements Sound {
 
 	@Override
 	public void stop (long soundId) {
-		throw new UnsupportedOperationException("Asynchronous audio doesn't support sound id based operations.");
+		long realSoundId = getSoundId(soundId);
+		sound.stop(realSoundId);
 	}
 
 	@Override
 	public void pause (long soundId) {
-		throw new UnsupportedOperationException("Asynchronous audio doesn't support sound id based operations.");
+		long realSoundId = getSoundId(soundId);
+		sound.pause(realSoundId);
 	}
 
 	@Override
 	public void resume (long soundId) {
-		throw new UnsupportedOperationException("Asynchronous audio doesn't support sound id based operations.");
+		long realSoundId = getSoundId(soundId);
+		sound.resume(realSoundId);
 	}
 
 	@Override
 	public void setLooping (long soundId, boolean looping) {
-		throw new UnsupportedOperationException("Asynchronous audio doesn't support sound id based operations.");
+		long realSoundId = getSoundId(soundId);
+		sound.setLooping(realSoundId, looping);
 	}
 
 	@Override
 	public void setPitch (long soundId, float pitch) {
-		throw new UnsupportedOperationException("Asynchronous audio doesn't support sound id based operations.");
+		long realSoundId = getSoundId(soundId);
+		sound.setPitch(realSoundId, pitch);
 	}
 
 	@Override
 	public void setVolume (long soundId, float volume) {
-		throw new UnsupportedOperationException("Asynchronous audio doesn't support sound id based operations.");
+		long realSoundId = getSoundId(soundId);
+		sound.setVolume(realSoundId, volume);
 	}
 
 	@Override
 	public void setPan (long soundId, float pan, float volume) {
-		throw new UnsupportedOperationException("Asynchronous audio doesn't support sound id based operations.");
+		long realSoundId = getSoundId(soundId);
+		sound.setPan(realSoundId, pan, volume);
+	}
+
+	private void saveSoundId(int soundNumber, long soundId) {
+		soundIds[soundNumber % soundIdsCountToSave] = soundId;
+	}
+
+	private long getSoundId(long soundId) {
+		return soundIds[(int)soundId % soundIdsCountToSave];
 	}
 }


### PR DESCRIPTION
Some time ago @obigu added asynchronous sound implementation for Android ( https://github.com/libgdx/libgdx/pull/6243 ) but it lacks support for soundId methods. This PR is my suggestion how to add support for soundId in AsynchronousSound.

I've added `MAX_STREAMS_COUNT` static field to pass it to `AsynchronousSound` constructor. I could use `MAX_STREAMS_COUNT` directly in `AsynchronousSound` but `AsynchronousSound` operates with `Sound`, not `AndroidSound`. So I do not want to tie `AsynchronousSound` with `AndroidSound`.

My next doubt is about executing methods with soundId (`stop(long soundId)`, `pause(long soundId)`, `resume(long soundId)`, etc..): I running them directly, not through `Handler`. I do not know if it's ok but @obigu did the same with `stop()`, `resume()` and `pause()` methods earlier in his PR.

I've tested this solution and it works in my game but probably should be tested by others.