### PR TITLE
Make libGDX buildable from source again with XCode 14

### DIFF
--- a/backends/gdx-backend-robovm/build-objectal.sh
+++ b/backends/gdx-backend-robovm/build-objectal.sh
@@ -3,6 +3,9 @@ set -e
 BASE=$(cd $(dirname $0); pwd -P)
 
 BUILD_DIR=$BASE/target/objectal
+XCODE_VERSION=$(xcodebuild -version | sed -En 's/Xcode[[:space:]]+([0-9\.]*)/\1/p')
+IS_XCODE14=$(bc -l <<< "$XCODE_VERSION >= 14.0")
+
 rm -rf $BUILD_DIR
 mkdir -p $BUILD_DIR
 
@@ -12,17 +15,23 @@ tar xvfz $BUILD_DIR/objectal.tar.gz -C $BUILD_DIR --strip-components 1
 
 XCODEPROJ=$BUILD_DIR/ObjectAL/ObjectAL.xcodeproj
 
-xcodebuild -project $XCODEPROJ -arch armv7  -sdk iphoneos         CONFIGURATION_BUILD_DIR=$BUILD_DIR/armv7  OTHER_CFLAGS="-target armv7-apple-ios9.0.0"
+if [[ IS_XCODE14 -eq 0 ]]; then
+  xcodebuild -project $XCODEPROJ -arch armv7  -sdk iphoneos         CONFIGURATION_BUILD_DIR=$BUILD_DIR/armv7  OTHER_CFLAGS="-target armv7-apple-ios9.0.0"
+fi
 xcodebuild -project $XCODEPROJ -arch arm64  -sdk iphoneos         CONFIGURATION_BUILD_DIR=$BUILD_DIR/arm64  OTHER_CFLAGS="-target arm64-apple-ios9.0.0"
 xcodebuild -project $XCODEPROJ -arch x86_64 -sdk iphonesimulator  CONFIGURATION_BUILD_DIR=$BUILD_DIR/x86_64 OTHER_CFLAGS="-target x86_64-simulator-apple-ios9.0.0"
 xcodebuild -project $XCODEPROJ -arch arm64  -sdk iphonesimulator  CONFIGURATION_BUILD_DIR=$BUILD_DIR/arm64-simulator  OTHER_CFLAGS="-target arm64-simulator-apple-ios9.0.0"
 
 mkdir $BUILD_DIR/real/
 
-lipo $BUILD_DIR/armv7/libObjectAL.a \
-     $BUILD_DIR/arm64/libObjectAL.a \
-     -create \
-     -output $BUILD_DIR/real/libObjectAL.a
+if [[ IS_XCODE14 -eq 0 ]]; then
+  lipo $BUILD_DIR/armv7/libObjectAL.a \
+       $BUILD_DIR/arm64/libObjectAL.a \
+       -create \
+       -output $BUILD_DIR/real/libObjectAL.a
+else
+  cp $BUILD_DIR/arm64/libObjectAL.a $BUILD_DIR/real/libObjectAL.a
+fi
 
 mkdir $BUILD_DIR/sim/
 

--- a/backends/gdx-backend-robovm/build-objectal.sh
+++ b/backends/gdx-backend-robovm/build-objectal.sh
@@ -3,8 +3,8 @@ set -e
 BASE=$(cd $(dirname $0); pwd -P)
 
 BUILD_DIR=$BASE/target/objectal
-XCODE_VERSION=$(xcodebuild -version | sed -En 's/Xcode[[:space:]]+([0-9\.]*)/\1/p')
-IS_XCODE14=$(bc -l <<< "$XCODE_VERSION >= 14.0")
+XCODE_VERSION=$(xcodebuild -version | sed -En 's/Xcode[[:space:]]+([0-9]*)[\.0-9]*/\1/p')
+IS_XCODE14=$(bc -l <<< "$XCODE_VERSION >= 14")
 
 rm -rf $BUILD_DIR
 mkdir -p $BUILD_DIR

--- a/gdx/build.gradle
+++ b/gdx/build.gradle
@@ -73,7 +73,13 @@ jnigen {
 		cppExcludes = []
 	}
 	robovm {
-		extraLib("libs/ObjectAL.xcframework/ios-arm64_armv7/libObjectAL.a", "device")
+		if (file("libs/ios32/ObjectAL.xcframework/ios-arm64_armv7/").exists()) {
+			extraLib("libs/ObjectAL.xcframework/ios-arm64_armv7/libObjectAL.a", "device")
+		} else if (file("libs/ios32/ObjectAL.xcframework/ios-arm64/").exists()) {
+			extraLib("libs/ObjectAL.xcframework/ios-arm64/libObjectAL.a", "device")
+		} else {
+			getLogger().warn("ObjectAL is not build yet. Please run `fetchNatives` or build it to silence this warning.")
+		}
 		extraLib("libs/ObjectAL.xcframework/ios-arm64_x86_64-simulator/libObjectAL.a", "simulator")
 	}
 }


### PR DESCRIPTION
https://developer.apple.com/documentation/xcode-release-notes/xcode-14-release-notes
"Building iOS projects with deployment targets for the armv7, armv7s, and i386 architectures is no longer supported. (92831716)"

This leads to build failures when trying to build libGDX from source. This pr fixes these in a first attempt.
The if - else blocks in the roboVM config block are not optimal. It would be best if we would have xcframework support in roboVM, or atleast in jnigen, to handle these cases better.