### PR TITLE
Angle backend: Fixing vertex buffer array indexing for glDrawElements

### DIFF
--- a/extensions/gdx-lwjgl3-angle/src/com/badlogic/gdx/backends/lwjgl3/angle/Lwjgl3GLES20.java
+++ b/extensions/gdx-lwjgl3-angle/src/com/badlogic/gdx/backends/lwjgl3/angle/Lwjgl3GLES20.java
@@ -264,18 +264,6 @@ public class Lwjgl3GLES20 implements GL20 {
 		GLES20.glDrawArrays(mode, first, count);
 	}
 
-	/*public void glDrawElements (int mode, int count, int type, Buffer indices) {
-		if (indices instanceof ShortBuffer && type == com.badlogic.gdx.graphics.GL20.GL_UNSIGNED_SHORT)
-			GLES20.glDrawElements(mode, (ShortBuffer)indices);
-		else if (indices instanceof ByteBuffer && type == com.badlogic.gdx.graphics.GL20.GL_UNSIGNED_SHORT)
-			GLES20.glDrawElements(mode, ((ByteBuffer)indices).asShortBuffer());
-		else if (indices instanceof ByteBuffer && type == com.badlogic.gdx.graphics.GL20.GL_UNSIGNED_BYTE)
-			GLES20.glDrawElements(mode, (ByteBuffer)indices);
-		else
-			throw new GdxRuntimeException(
-				"Can't use " + indices.getClass().getName() + " with this method. Use ShortBuffer or ByteBuffer instead.");
-	}*/
-
 	public void glDrawElements (int mode, int count, int type, Buffer indices) {
 		if (indices instanceof ShortBuffer && type == com.badlogic.gdx.graphics.GL20.GL_UNSIGNED_SHORT) {
 			ShortBuffer sb = (ShortBuffer)indices;

--- a/extensions/gdx-lwjgl3-angle/src/com/badlogic/gdx/backends/lwjgl3/angle/Lwjgl3GLES20.java
+++ b/extensions/gdx-lwjgl3-angle/src/com/badlogic/gdx/backends/lwjgl3/angle/Lwjgl3GLES20.java
@@ -264,7 +264,7 @@ public class Lwjgl3GLES20 implements GL20 {
 		GLES20.glDrawArrays(mode, first, count);
 	}
 
-	public void glDrawElements (int mode, int count, int type, Buffer indices) {
+	/*public void glDrawElements (int mode, int count, int type, Buffer indices) {
 		if (indices instanceof ShortBuffer && type == com.badlogic.gdx.graphics.GL20.GL_UNSIGNED_SHORT)
 			GLES20.glDrawElements(mode, (ShortBuffer)indices);
 		else if (indices instanceof ByteBuffer && type == com.badlogic.gdx.graphics.GL20.GL_UNSIGNED_SHORT)
@@ -274,6 +274,33 @@ public class Lwjgl3GLES20 implements GL20 {
 		else
 			throw new GdxRuntimeException(
 				"Can't use " + indices.getClass().getName() + " with this method. Use ShortBuffer or ByteBuffer instead.");
+	}*/
+
+	public void glDrawElements (int mode, int count, int type, Buffer indices) {
+		if (indices instanceof ShortBuffer && type == com.badlogic.gdx.graphics.GL20.GL_UNSIGNED_SHORT) {
+			ShortBuffer sb = (ShortBuffer)indices;
+			int position = sb.position();
+			int oldLimit = sb.limit();
+			sb.limit(position + count);
+			GLES20.glDrawElements(mode, sb);
+			sb.limit(oldLimit);
+		} else if (indices instanceof ByteBuffer && type == com.badlogic.gdx.graphics.GL20.GL_UNSIGNED_SHORT) {
+			ShortBuffer sb = ((ByteBuffer)indices).asShortBuffer();
+			int position = sb.position();
+			int oldLimit = sb.limit();
+			sb.limit(position + count);
+			GLES20.glDrawElements(mode, sb);
+			sb.limit(oldLimit);
+		} else if (indices instanceof ByteBuffer && type == com.badlogic.gdx.graphics.GL20.GL_UNSIGNED_BYTE) {
+			ByteBuffer bb = (ByteBuffer)indices;
+			int position = bb.position();
+			int oldLimit = bb.limit();
+			bb.limit(position + count);
+			GLES20.glDrawElements(mode, bb);
+			bb.limit(oldLimit);
+		} else
+			throw new GdxRuntimeException("Can't use " + indices.getClass().getName()
+					+ " with this method. Use ShortBuffer or ByteBuffer instead. Blame LWJGL");
 	}
 
 	public void glEnable (int cap) {


### PR DESCRIPTION
Rendering sprite batches was causing rendering artifacts when using the Angle backend, it looks like commit https://github.com/libgdx/libgdx/commit/a94b96834f541870174cf90f7c9247da6e97c0eb  broke this rendering path due to changing the other GL20 backends but not the Angle path.

Before:
<img width="1464" alt="Screen Shot 2022-09-27 at 9 31 46 PM" src="https://user-images.githubusercontent.com/1374/192891975-0920a9e4-6de6-409a-a3e4-ced816e34d21.png">

After:
<img width="1624" alt="Screen Shot 2022-09-28 at 2 13 52 PM" src="https://user-images.githubusercontent.com/1374/192892012-a40a9e47-7a4e-458f-85ac-516f64cd196c.png">
