### PR TITLE
Fixed predefined Light iOS vibration

### DIFF
--- a/backends/gdx-backend-robovm-metalangle/src/com/badlogic/gdx/backends/iosrobovm/IOSHaptics.java
+++ b/backends/gdx-backend-robovm-metalangle/src/com/badlogic/gdx/backends/iosrobovm/IOSHaptics.java
@@ -118,7 +118,7 @@ public class IOSHaptics {
 			UIImpactFeedbackStyle uiImpactFeedbackStyle;
 			switch (vibrationType) {
 			case LIGHT:
-				uiImpactFeedbackStyle = UIImpactFeedbackStyle.Soft;
+				uiImpactFeedbackStyle = UIImpactFeedbackStyle.Light;
 				break;
 			case MEDIUM:
 				uiImpactFeedbackStyle = UIImpactFeedbackStyle.Medium;

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSHaptics.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSHaptics.java
@@ -127,7 +127,7 @@ public class IOSHaptics {
 			UIImpactFeedbackStyle uiImpactFeedbackStyle;
 			switch (vibrationType) {
 			case LIGHT:
-				uiImpactFeedbackStyle = UIImpactFeedbackStyle.Soft;
+				uiImpactFeedbackStyle = UIImpactFeedbackStyle.Light;
 				break;
 			case MEDIUM:
 				uiImpactFeedbackStyle = UIImpactFeedbackStyle.Medium;

--- a/extensions/gdx-lwjgl3-angle/src/com/badlogic/gdx/backends/lwjgl3/angle/Lwjgl3GLES20.java
+++ b/extensions/gdx-lwjgl3-angle/src/com/badlogic/gdx/backends/lwjgl3/angle/Lwjgl3GLES20.java
@@ -288,7 +288,7 @@ public class Lwjgl3GLES20 implements GL20 {
 			bb.limit(oldLimit);
 		} else
 			throw new GdxRuntimeException("Can't use " + indices.getClass().getName()
-					+ " with this method. Use ShortBuffer or ByteBuffer instead. Blame LWJGL");
+				+ " with this method. Use ShortBuffer or ByteBuffer instead. Blame LWJGL");
 	}
 
 	public void glEnable (int cap) {


### PR DESCRIPTION
Should be `light`. `soft` will crash on <iOS13 and on >iOS13 doesn't do anything apparently. https://developer.apple.com/documentation/uikit/uiimpactfeedbackgenerator/feedbackstyle