### PR TITLE
Remove unnecessary null check in GestureDetector

### DIFF
--- a/gdx/src/com/badlogic/gdx/input/GestureDetector.java
+++ b/gdx/src/com/badlogic/gdx/input/GestureDetector.java
@@ -153,11 +153,8 @@ public class GestureDetector extends InputAdapter {
 
 		// handle pinch zoom
 		if (pinching) {
-			if (listener != null) {
-				boolean result = listener.pinch(initialPointer1, initialPointer2, pointer1, pointer2);
-				return listener.zoom(initialPointer1.dst(initialPointer2), pointer1.dst(pointer2)) || result;
-			}
-			return false;
+			boolean result = listener.pinch(initialPointer1, initialPointer2, pointer1, pointer2);
+			return listener.zoom(initialPointer1.dst(initialPointer2), pointer1.dst(pointer2)) || result;
 		}
 
 		// update tracker


### PR DESCRIPTION
In [GestureDetector.java](https://github.com/libgdx/libgdx/blob/master/gdx/src/com/badlogic/gdx/input/GestureDetector.java), #5466 is closed by making the `listener` final field non-null and performing a null check in the constructor. Since `listener` is no longer nullable, following `listener` field null checks are no longer necessary.

This PR removes an unnecessary null check in GestureDetector.java
