### PR TITLE
Update gha to ubuntu-20.04

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -112,7 +112,7 @@ jobs:
           rm -f ~/.gradle/caches/modules-2/gc.properties
 
   natives-linux:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:
@@ -162,7 +162,7 @@ jobs:
           rm -f ~/.gradle/caches/modules-2/gc.properties
 
   natives-windows:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:
@@ -210,7 +210,7 @@ jobs:
           rm -f ~/.gradle/caches/modules-2/gc.properties
 
   natives-android:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:
@@ -255,7 +255,7 @@ jobs:
           rm -f ~/.gradle/caches/modules-2/gc.properties
 
   pack-natives:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs: [natives-macos, natives-linux, natives-windows, natives-ios, natives-android]
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -346,7 +346,7 @@ jobs:
           rm -f ~/.gradle/caches/modules-2/gc.properties
 
   publish:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs: pack-natives
     env:
       ORG_GRADLE_PROJECT_MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
@@ -394,7 +394,7 @@ jobs:
         run: ./gradlew build publish -PRELEASE -Psigning.gnupg.keyId=${{ secrets.GPG_KEYID }} -Psigning.gnupg.passphrase=${{ secrets.GPG_PASSPHRASE }} -Psigning.gnupg.keyName=${{ secrets.GPG_KEYID }}
 
   build-and-upload-runnables:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs: pack-natives
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
Soo, GitHub will remove the ubuntu 18.04 image by 4/1/2023.
https://github.com/actions/runner-images/issues/6002
They are already starting to let runner fail at specific times.
This is what happened e.g. here https://github.com/libgdx/libgdx/actions/runs/3250859896/jobs/5335094874 even though date wasn't mentioned as brownout date.

So the only way is probably upgrading. However because of the dynamic linking against libc, afaik this change would make the binarys incompatible with older OS.
The only way I could think of to work around this would be, to run a nested docker container for builds, but not sure whether this would be feasible.