### PR TITLE
Fix ExtendViewport.

### DIFF
--- a/gdx/src/com/badlogic/gdx/utils/viewport/ExtendViewport.java
+++ b/gdx/src/com/badlogic/gdx/utils/viewport/ExtendViewport.java
@@ -68,15 +68,14 @@ public class ExtendViewport extends Viewport {
 		// Extend, possibly in both directions depending on the scaling.
 		int viewportWidth = Math.round(scaled.x);
 		int viewportHeight = Math.round(scaled.y);
-		if (viewportWidth < screenWidth) {
+		if (viewportWidth < viewportHeight) {
 			float toViewportSpace = viewportHeight / worldHeight;
 			float toWorldSpace = worldHeight / viewportHeight;
 			float lengthen = (screenWidth - viewportWidth) * toWorldSpace;
 			if (maxWorldWidth > 0) lengthen = Math.min(lengthen, maxWorldWidth - minWorldWidth);
 			worldWidth += lengthen;
 			viewportWidth += Math.round(lengthen * toViewportSpace);
-		}
-		if (viewportHeight < screenHeight) {
+		} else if (viewportWidth > viewportHeight) {
 			float toViewportSpace = viewportWidth / worldWidth;
 			float toWorldSpace = worldWidth / viewportWidth;
 			float lengthen = (screenHeight - viewportHeight) * toWorldSpace;


### PR DESCRIPTION
Hi there!

Recently I started to use ExtendViewport in my game and noticed strange behavior: in some cases it doesn't scale content on screen in correct way.

I use perspective camera for my 3D game and when I try to narrow down the game window, content doesn't fit on the screen horizontally (viewport works like I use "fill" scaling mode).
I looked in the library code and found a check that compares scaled viewport and screen sizes instead of viewport aspect ratio.

This PR fixes this issue.