### PR TITLE
Fix lwjgl3 SetCursorPosition

### DIFF
--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/DefaultLwjgl3Input.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/DefaultLwjgl3Input.java
@@ -342,6 +342,7 @@ public class DefaultLwjgl3Input extends AbstractInput implements Lwjgl3Input {
 			y = (int)(y * yScale);
 		}
 		GLFW.glfwSetCursorPos(window.getWindowHandle(), x, y);
+		cursorPosCallback.invoke(window.getWindowHandle(), x, y);
 	}
 
 	protected char characterForKeyCode (int key) {


### PR DESCRIPTION
Fix https://github.com/libgdx/libgdx/issues/7010

The internal variables `int mouseX, mouseY;` in `DefaultLwjgl3Input` are not updated when calling the `setCursorPosition` method. So, if you call `SetCursorPosition()` and next `getX()` or` getY()` the returned values are not updated.

This only happens in lwjgl3 backend.

