### PR TITLE
fix #7016 ModelBuilder invalid overflow

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,7 @@
 - [BREAKING CHANGE] Actor#localToAscendantCoordinates throws an exception if the specified actor is not an ascendant.
 - [BREAKING CHANGE] WidgetGroup#hit first validates the layout.
 - [BREAKING CHANGE] Cell getters return object wrapper instead of primitives.
+- [BREAKING CHANGE] MeshPartBuilder#lastIndex now returns int instead of short.
 - iOS: Add new MobiVM MetalANGLE backend
 - API Addition: Added Haptics API with 4 different Input#vibrate() methods with complete Android and iOS implementations.
 - Fix: Fixed Android and iOS touch cancelled related issues, see #6871.

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/utils/MeshBuilder.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/utils/MeshBuilder.java
@@ -469,8 +469,8 @@ public class MeshBuilder implements MeshPartBuilder {
 	private int lastIndex = -1;
 
 	@Override
-	public short lastIndex () {
-		return (short)lastIndex;
+	public int lastIndex () {
+		return lastIndex;
 	}
 
 	private final static Vector3 vTmp = new Vector3();

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/utils/MeshPartBuilder.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/utils/MeshPartBuilder.java
@@ -103,7 +103,7 @@ public interface MeshPartBuilder {
 	public short vertex (final VertexInfo info);
 
 	/** @return The index of the last added vertex. */
-	public short lastIndex ();
+	public int lastIndex ();
 
 	/** Add an index, MeshPartBuilder expects all meshes to be indexed. */
 	public void index (final short value);

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/utils/ModelBuilder.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/utils/ModelBuilder.java
@@ -50,7 +50,7 @@ public class ModelBuilder {
 
 	private MeshBuilder getBuilder (final VertexAttributes attributes) {
 		for (final MeshBuilder mb : builders)
-			if (mb.getAttributes().equals(attributes) && mb.lastIndex() < Short.MAX_VALUE / 2) return mb;
+			if (mb.getAttributes().equals(attributes) && mb.lastIndex() < MeshBuilder.MAX_VERTICES / 2) return mb;
 		final MeshBuilder result = new MeshBuilder();
 		result.begin(attributes);
 		builders.add(result);


### PR DESCRIPTION
Since MeshBuilder now supports up to 64k vertices, lastIndex method could returns negative values (because of int to short conversion). The issue happens when MeshBuilder contains more than 32k vertices.

This is a breaking change because of method signature change but it only impacts the 3 classes in the repo and it shouldn't be too hard to fix for user code implementing their own MeshBuilder.
I don't think there is a better fix because lastIndex method could returns -1 when it is empty and when lastIndex is 65535. So there was no way to determine what was the value after short conversion.

Note that i also changed the limit of MeshBuilder resuse, it was half of the old limit (32k / 2), it is now half of the new limit (64k / 2). So it could have positive impacts on user code for some cases : bigger meshes means less draw calls.