### PR TITLE
Show saved aspect texture region settings on region picker panel

### DIFF
--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/RegionInfluencerPanel.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/RegionInfluencerPanel.java
@@ -52,7 +52,7 @@ public class RegionInfluencerPanel extends InfluencerPanel<RegionInfluencer> imp
 				if (atlas != null)
 					regionPickerPanel.setAtlas(atlas, atlasFilename);
 				else
-					regionPickerPanel.setTexture(editor.getTexture());
+					regionPickerPanel.setTexture(editor.getTexture(), value);
 
 				regionPickerPanel.revalidate();
 				regionPickerPanel.repaint();

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/RegionPickerPanel.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/RegionPickerPanel.java
@@ -17,6 +17,7 @@ import javax.swing.JSeparator;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.TextureAtlas;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
+import com.badlogic.gdx.graphics.g3d.particles.influencers.RegionInfluencer;
 import com.badlogic.gdx.utils.Array;
 
 /** @author Inferno */
@@ -192,12 +193,13 @@ public class RegionPickerPanel extends JPanel {
 		repaint();
 	}
 
-	public void setTexture (Texture texture) {
+	public void setTexture (Texture texture, RegionInfluencer influencer) {
 		texturePanel.clearSelection();
 		texturePanel.setTexture(texture);
 		CustomCardLayout cardLayout = (CustomCardLayout)content.getLayout();
 		cardLayout.show(content, "texture");
 		showGenerationPanel(true);
+		initializeComponentsByTexture(texture, influencer);
 		content.revalidate();
 		content.repaint();
 		revalidate();
@@ -206,6 +208,24 @@ public class RegionPickerPanel extends JPanel {
 
 	private void showGenerationPanel (boolean isShown) {
 		generationPanel.setVisible(isShown);
+	}
+
+	private void initializeComponentsByTexture (Texture texture, RegionInfluencer influencer) {
+		rowSlider.setValue(getRowNumber(texture, influencer.regions.first()));
+		columnSlider.setValue(getColumnNumber(texture, influencer.regions.first()));
+		generateRegions((GenerationMode)generateBox.getSelectedItem());
+
+		texturePanel.select(influencer.regions);
+		texturePanel.revalidate();
+		texturePanel.repaint();
+	}
+
+	private int getRowNumber (Texture texture, RegionInfluencer.AspectTextureRegion atr) {
+		return texture.getHeight() / new TextureRegion(texture, atr.u, atr.v, atr.u2, atr.v2).getRegionHeight();
+	}
+
+	private int getColumnNumber (Texture texture, RegionInfluencer.AspectTextureRegion atr) {
+		return texture.getWidth() / new TextureRegion(texture, atr.u, atr.v, atr.u2, atr.v2).getRegionWidth();
 	}
 
 }

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/TexturePanel.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/TexturePanel.java
@@ -9,6 +9,7 @@ import java.awt.event.MouseEvent;
 
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
+import com.badlogic.gdx.graphics.g3d.particles.influencers.RegionInfluencer;
 import com.badlogic.gdx.graphics.glutils.FileTextureData;
 import com.badlogic.gdx.utils.Array;
 
@@ -104,6 +105,23 @@ public class TexturePanel extends ImagePanel {
 		selectedRegions.addAll(unselectedRegions);
 		unselectedRegions.clear();
 		repaint();
+	}
+
+	public void select (Array<RegionInfluencer.AspectTextureRegion> regions) {
+		clearSelection();
+
+		for (int i = 0; i < regions.size; ++i) {
+			RegionInfluencer.AspectTextureRegion atr = regions.get(i);
+
+			for (int j = 0; j < unselectedRegions.size; ++j) {
+				TextureRegion tr = unselectedRegions.get(j);
+
+				if (tr.getU() == atr.u && tr.getV() == atr.v && tr.getU2() == atr.u2 && tr.getV2() == atr.v2) {
+					select(tr);
+					--j;
+				}
+			}
+		}
 	}
 
 	@Override


### PR DESCRIPTION
Currently if I open a particle what has texture with region influencer then this doesn't visible on the view of this influencer.

Example:
![current](https://user-images.githubusercontent.com/1684274/199675047-970a1032-ca81-45a5-abc4-331933816348.gif)

With this fix:
![with_fix](https://user-images.githubusercontent.com/1684274/199675078-2bda0403-cf83-4d02-877f-aa72ba264a64.gif)

Example particle:
[smoke.zip](https://github.com/libgdx/libgdx/files/9926653/smoke.zip)

