### PR TITLE
Avoids unnecessary flushing in case we are drawing

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g2d/SpriteBatch.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/SpriteBatch.java
@@ -1071,6 +1071,8 @@ public class SpriteBatch implements Batch {
 
 	@Override
 	public void setShader (ShaderProgram shader) {
+		if (shader == customShader) // avoid unnecessary flushing in case we are drawing
+			return;
 		if (drawing) {
 			flush();
 		}


### PR DESCRIPTION
Improved on SpriteBatch.setShader(): it won't flush anymore in case we are drawing and given shader is same as current one.