### PR TITLE
Apply formatter

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplicationConfiguration.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplicationConfiguration.java
@@ -103,7 +103,7 @@ public class AndroidApplicationConfiguration {
 	/** The loader used to load native libraries. Override this to use a different loading strategy. */
 	public GdxNativeLoader nativeLoader = new GdxNativeLoader() {
 		@Override
-		public void load() {
+		public void load () {
 			GdxNativesLoader.load();
 		}
 	};

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/GdxNativeLoader.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/GdxNativeLoader.java
@@ -20,5 +20,5 @@ package com.badlogic.gdx.backends.android;
 public interface GdxNativeLoader {
 
 	/** Load GDX native libraries. */
-	void load();
+	void load ();
 }

--- a/tests/gdx-tests-gwt/src/com/badlogic/gdx/tests/gwt/client/GwtTestWrapper.java
+++ b/tests/gdx-tests-gwt/src/com/badlogic/gdx/tests/gwt/client/GwtTestWrapper.java
@@ -97,7 +97,6 @@ import com.badlogic.gdx.tests.gwt.GwtInputTest;
 import com.badlogic.gdx.tests.gwt.GwtWindowModeTest;
 import com.badlogic.gdx.tests.math.CollisionPlaygroundTest;
 import com.badlogic.gdx.tests.math.OctreeTest;
-import com.badlogic.gdx.tests.math.collision.CollisionPlaygroundTest;
 import com.badlogic.gdx.tests.math.collision.OrientedBoundingBoxTest;
 import com.badlogic.gdx.tests.net.OpenBrowserExample;
 import com.badlogic.gdx.tests.superkoalio.SuperKoalio;


### PR DESCRIPTION
Builds are currently busted because #6940 got merged without the formatter being run, I think. Interestingly, the formatter can run on my own fork - just not in libGDX's master branch because it's protected.