### PR TITLE
fix bone weights default values

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/DefaultShader.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/DefaultShader.java
@@ -504,6 +504,7 @@ public class DefaultShader extends BaseShader {
 	protected final long attributesMask;
 	private final long vertexMask;
 	private final int textureCoordinates;
+	private int[] boneWeightsLocations;
 	protected final Config config;
 	/** Attributes which are not required but always supported. */
 	private final static long optionalAttributes = IntAttribute.CullFace | DepthTestAttribute.Type;
@@ -560,6 +561,9 @@ public class DefaultShader extends BaseShader {
 		int boneWeights = renderable.meshPart.mesh.getVertexAttributes().getBoneWeights();
 		if (boneWeights > config.numBoneWeights) {
 			throw new GdxRuntimeException("too many bone weights: " + boneWeights + ", max configured: " + config.numBoneWeights);
+		}
+		if (renderable.bones != null) {
+			boneWeightsLocations = new int[config.numBoneWeights];
 		}
 
 		// Global uniforms
@@ -634,6 +638,12 @@ public class DefaultShader extends BaseShader {
 		spotLightsExponentOffset = loc(u_spotLights0exponent) - spotLightsLoc;
 		spotLightsSize = loc(u_spotLights1color) - spotLightsLoc;
 		if (spotLightsSize < 0) spotLightsSize = 0;
+
+		if (boneWeightsLocations != null) {
+			for (int i = 0; i < boneWeightsLocations.length; i++) {
+				boneWeightsLocations[i] = program.getAttributeLocation(ShaderProgram.BONEWEIGHT_ATTRIBUTE + i);
+			}
+		}
 	}
 
 	private static final boolean and (final long mask, final long flag) {
@@ -783,6 +793,15 @@ public class DefaultShader extends BaseShader {
 		lightsSet = false;
 
 		if (has(u_time)) set(u_time, time += Gdx.graphics.getDeltaTime());
+
+		// set generic vertex attribute value for all bone weights in case a mesh has missing attributes.
+		if (boneWeightsLocations != null) {
+			for (int location : boneWeightsLocations) {
+				if (location >= 0) {
+					Gdx.gl.glVertexAttrib2f(location, 0, 0);
+				}
+			}
+		}
 	}
 
 	@Override


### PR DESCRIPTION
This is a bug fix for the recently merged PR #6522.

When a vertex attribute is not enabled it uses its generic value. I didn't notice it during my tests probably because it was set to zeros. But in real life, it could be anything and these garbage data break some model skinning.

With this change, all bone weights generic value are set to zeros (bone index 0 with zero weight). Then when a mesh with less bone weights that what has been configured is rendered these default values are used for all disabled bone weights.

Example:
- DefaultShader.numBoneWeights = 4
- a model A with 4 bone weights
- a model B with 1 bone weight
- a single shader will be created for both
- when rendering model A, all bone weights will be enabled and data will be fetched from mesh data in vertex shader.
- when rendering model B, only first bone weight will be enabled, all other bone weights will be zeros in vertex shader.

Note that generic values are maintained in th OpenGL state (and not in the shader program state), that's why we have to set them before rendering with a shader.