### PR TITLE
Fix #6790; align GWT with other platforms

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/graphics/glutils/VertexBufferObjectWithVAO.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/graphics/glutils/VertexBufferObjectWithVAO.java
@@ -190,7 +190,7 @@ public class VertexBufferObjectWithVAO implements VertexData {
 	}
 
 	private void unbindAttributes (ShaderProgram shaderProgram) {
-		if (cachedLocations == null) {
+		if (cachedLocations.size == 0) {
 			return;
 		}
 		int numAttributes = attributes.size();


### PR DESCRIPTION
The object `cachedLocations` can never be `null` as it's initialized and never reassigned. This makes the if statement useless and triggers therefore a bug (`IndexOutOfBoundsException`).