### PR TITLE
Remove unnecessary glEnable calls for TEXTURE_2D

### DIFF
--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/IndexBufferObjectShaderTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/IndexBufferObjectShaderTest.java
@@ -48,7 +48,6 @@ public class IndexBufferObjectShaderTest extends GdxTest {
 		Gdx.gl.glViewport(0, 0, Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight());
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 
-		Gdx.gl.glEnable(GL20.GL_TEXTURE_2D);
 		shader.bind();
 		shader.setUniformi("u_texture", 0);
 		texture.bind();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/MipMapTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/MipMapTest.java
@@ -114,7 +114,6 @@ public class MipMapTest extends GdxTest {
 	@Override
 	public void render () {
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-		Gdx.gl.glEnable(GL20.GL_TEXTURE_2D);
 
 		camera.update();
 


### PR DESCRIPTION
I noticed two tests while working on WebGL2 branch that were complaining of a GL_INVALID_ENUM. Both tests appear to have an old line of code from OpenGL 1.0 Fixed Function Pipeline days in them. 

`Gdx.gl.glEnable(GL20.GL_TEXTURE_2D);`

In OpenGL 2.0 this line serves no purpose if using Fragment Shaders (which the tests do) as documented here: https://registry.khronos.org/OpenGL-Refpages/gl2.1/xhtml/glEnable.xml

In GLES 2.0 I do not even see it as an available parameter. https://docs.gl/es2/glEnable

In OpenGL 3.x it's deprecated and results in GL_INVALID_ENUM. 

This PR removes the lines as they appear to serve no purpose on OpenGL 2.0 in this context and result in errors on OpenGL 3.x