### PR TITLE
`Window`: Remove duplicate `background` assignment

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Window.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Window.java
@@ -358,7 +358,6 @@ public class Window extends Table {
 		}
 
 		public WindowStyle (WindowStyle style) {
-			background = style.background;
 			titleFont = style.titleFont;
 			if (style.titleFontColor != null) titleFontColor = new Color(style.titleFontColor);
 			background = style.background;


### PR DESCRIPTION
Following silence in #7031, this pull request removes a pointless line.  
inb4 it turns out to be holding together the fabric of time and space.