### PR TITLE
[Gradle] Replace task creating with a 'tasks.register' to comply with 'Task Configuration Avoidance'

### DIFF
--- a/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/android/build.gradle
+++ b/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/android/build.gradle
@@ -35,7 +35,7 @@ android {
 // called every time gradle gets executed, takes the native dependencies of
 // the natives configuration, and extracts them to the proper libs/ folders
 // so they get packed with the APK.
-task copyAndroidNatives {
+tasks.register('copyAndroidNatives') {
     doFirst {
         file("libs/armeabi-v7a/").mkdirs()
         file("libs/arm64-v8a/").mkdirs()
@@ -63,7 +63,7 @@ tasks.matching { it.name.contains("merge") && it.name.contains("JniLibFolders") 
     packageTask.dependsOn 'copyAndroidNatives'
 }
 
-task run(type: Exec) {
+tasks.register('run', Exec) {
     def path
     def localProperties = project.file("../local.properties")
     if (localProperties.exists()) {

--- a/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/lwjgl2/build.gradle
+++ b/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/lwjgl2/build.gradle
@@ -5,7 +5,8 @@ sourceSets.main.resources.srcDirs = ["../%ASSET_PATH%"]
 project.ext.mainClassName = "%PACKAGE%.DesktopLauncher"
 project.ext.assetsDir = new File("../%ASSET_PATH%")
 
-task run(dependsOn: classes, type: JavaExec) {
+tasks.register('run', JavaExec) {
+    dependsOn classes
     main = project.mainClassName
     classpath = sourceSets.main.runtimeClasspath
     standardInput = System.in
@@ -13,7 +14,8 @@ task run(dependsOn: classes, type: JavaExec) {
     ignoreExitValue = true
 }
 
-task debug(dependsOn: classes, type: JavaExec) {
+tasks.register('debug', JavaExec) {
+    dependsOn classes
     main = project.mainClassName
     classpath = sourceSets.main.runtimeClasspath
     standardInput = System.in
@@ -22,18 +24,16 @@ task debug(dependsOn: classes, type: JavaExec) {
     debug = true
 }
 
-task dist(type: Jar) {
+tasks.register('dist', Jar) {
+    dependsOn classes
+    dependsOn configurations.runtimeClasspath
     manifest {
         attributes 'Main-Class': project.mainClassName
     }
-    dependsOn configurations.runtimeClasspath
     from {
         configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
     }
     with jar
 }
-
-
-dist.dependsOn classes
 
 eclipse.project.name = appName + "-legacy_desktop"

--- a/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/lwjgl3/build.gradle
+++ b/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/lwjgl3/build.gradle
@@ -7,7 +7,8 @@ project.ext.assetsDir = new File("../%ASSET_PATH%")
 
 import org.gradle.internal.os.OperatingSystem
 
-task run(dependsOn: classes, type: JavaExec) {
+tasks.register('run', JavaExec) {
+    dependsOn classes
     main = project.mainClassName
     classpath = sourceSets.main.runtimeClasspath
     standardInput = System.in
@@ -20,7 +21,8 @@ task run(dependsOn: classes, type: JavaExec) {
     }
 }
 
-task debug(dependsOn: classes, type: JavaExec) {
+tasks.register('debug', JavaExec) {
+    dependsOn classes
     main = project.mainClassName
     classpath = sourceSets.main.runtimeClasspath
     standardInput = System.in
@@ -29,19 +31,17 @@ task debug(dependsOn: classes, type: JavaExec) {
     debug = true
 }
 
-task dist(type: Jar) {
+tasks.register('dist', Jar) {
+    dependsOn classes
+    dependsOn configurations.runtimeClasspath
     duplicatesStrategy(DuplicatesStrategy.EXCLUDE)
     manifest {
         attributes 'Main-Class': project.mainClassName
     }
-    dependsOn configurations.runtimeClasspath
     from {
         configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
     }
     with jar
 }
-
-
-dist.dependsOn classes
 
 eclipse.project.name = appName + "-desktop"


### PR DESCRIPTION
Replace immediate **task creating** with a lazy `tasks.register` to comply with [**Task Configuration Avoidance**](https://docs.gradle.org/current/userguide/task_configuration_avoidance.html)

Related to #6920 

![image](https://user-images.githubusercontent.com/39597999/206042764-487c9cf1-f288-4460-bf3c-46d45376aa60.png)
