### PR TITLE
Removed unused references to old jnigen Build classes

### DIFF
--- a/backends/gdx-backends-gwt/issues.txt
+++ b/backends/gdx-backends-gwt/issues.txt
@@ -47,7 +47,6 @@ feasible due to the use of Canvas.
 - Excluded from ant build (build-template.xml)!
 
 [Unsupported Classes]
-GdxBuild.java
 GdxNativesLoader.java
 SharedLibraryLoader.java
 Gdx2DPixmap.java

--- a/extensions/gdx-box2d/gdx-box2d/res/com/badlogic/gdx/physics/box2d.gwt.xml
+++ b/extensions/gdx-box2d/gdx-box2d/res/com/badlogic/gdx/physics/box2d.gwt.xml
@@ -2,6 +2,5 @@
 <!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit trunk//EN" "http://www.gwtproject.org/doctype/2.8.0/gwt-module.dtd">
 <module>
 	<source path="box2d">
-	    <exclude name="utils/Box2DBuild.java"/>
 	</source>
 </module>

--- a/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/android/proguard-rules.pro
+++ b/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/android/proguard-rules.pro
@@ -22,10 +22,6 @@
 -verbose
 
 -dontwarn com.badlogic.gdx.backends.android.AndroidFragmentApplication
--dontwarn com.badlogic.gdx.utils.GdxBuild
--dontwarn com.badlogic.gdx.physics.box2d.utils.Box2DBuild
--dontwarn com.badlogic.gdx.jnigen.BuildTarget*
--dontwarn com.badlogic.gdx.graphics.g2d.freetype.FreetypeBuild
 
 # Required if using Gdx-Controllers extension
 -keep class com.badlogic.gdx.controllers.android.AndroidControllers

--- a/gdx/res/com/badlogic/gdx.gwt.xml
+++ b/gdx/res/com/badlogic/gdx.gwt.xml
@@ -419,7 +419,6 @@
 		<include name="utils/Disposable.java"/>
 		<include name="utils/FloatArray.java"/>
 		<include name="utils/FlushablePool.java"/>
-		<exclude name="utils/GdxBuild.java"/> <!-- Reason: Natives -->
 		<exclude name="utils/GdxNativesLoader.java"/> <!-- Reason: Natives -->
 		<include name="utils/GdxRuntimeException.java"/>
 		<include name="utils/I18NBundle.java"/>


### PR DESCRIPTION
The jnigen `*Build` classes were removed on https://github.com/libgdx/libgdx/pull/5701 but some references were still around.

I think the `box2d.gwt.xml` file can be fully deleted, please let me know if that's the case, for the moment I've just removed the exclusion.