### PR TITLE
fix: make angle loader compatible with osx app bundles

### DIFF
--- a/extensions/gdx-lwjgl3-angle/README.md
+++ b/extensions/gdx-lwjgl3-angle/README.md
@@ -1,0 +1,31 @@
+# lwjgl3-angle
+
+This extension adds angle support to the lwjgl3 backend.
+
+## Usage
+
+To use it, add the `gdx-lwjgl3-angle` extension to your gdx-lwjgl3 desktop project.
+Then call `config.setOpenGLEmulation(GLEmulation.ANGLE_GLES20, 0, 0)` on your `Lwjgl3ApplicationConfiguration` instance
+before creating your `Lwjgl3Application`. 
+
+Check out [#6672](https://github.com/libgdx/libgdx/pull/6672) for more
+information.
+
+### OSX App Bundles using jpackage
+
+Due to the way the libraries are loaded, special care is required when
+distributing your app as OSX App Bundle.
+Note that this requires a recent JDK (see https://github.com/openjdk/jdk/pull/11922)
+
+1. Grab the `libEGL.dylib` and `libGLESv2.dylib` files from the `macosxarm64` and `macosx64` folder (inside the jar, or
+   download from [here](https://github.com/libgdx/gdx-angle-natives))
+2. Merge them into a single universal library:
+   ```
+   lipo macosxarm64/libEGL.dylib macosx64/libEGL.dylib -output libEGL.dylib -create
+   lipo macosxarm64/libGLESv2.dylib macosx64/libGLESv2.dylib -output libGLESv2.dylib -create
+    ```
+3. Place the two libraries into your app bundle: `your-app.app/Contents/Frameworks/`
+4. Sign, notarize and stamp your app as usual
+
+
+See [#7058](https://github.com/libgdx/libgdx/issues/7058) for more details.

--- a/extensions/gdx-lwjgl3-angle/src/com/badlogic/gdx/backends/lwjgl3/angle/ANGLELoader.java
+++ b/extensions/gdx-lwjgl3-angle/src/com/badlogic/gdx/backends/lwjgl3/angle/ANGLELoader.java
@@ -17,12 +17,11 @@
 package com.badlogic.gdx.backends.lwjgl3.angle;
 
 import com.badlogic.gdx.utils.GdxRuntimeException;
+import com.badlogic.gdx.utils.SharedLibraryLoader;
 
-import java.io.*;
-import java.lang.reflect.Method;
-import java.util.Random;
-import java.util.UUID;
-import java.util.zip.CRC32;
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
 
 public class ANGLELoader {
 	static public boolean isWindows = System.getProperty("os.name").contains("Windows");
@@ -34,144 +33,21 @@ public class ANGLELoader {
 	static public boolean is64Bit = System.getProperty("os.arch").contains("64")
 		|| System.getProperty("os.arch").startsWith("armv8");
 
-	static private final Random random = new Random();
-	static private File egl;
-	static private File gles;
-	static private File lastWorkingDir;
+	/** Holds the extracted library files to be deleted after the glfw initialization. This is currently only used on osx */
+	static private File[] loadedLibraries = new File[0];
 
-	public static void closeQuietly (Closeable c) {
-		if (c != null) {
-			try {
-				c.close();
-			} catch (Throwable ignored) {
-			}
-		}
-	}
-
-	static String randomUUID () {
-		return new UUID(random.nextLong(), random.nextLong()).toString();
-	}
-
-	public static String crc (InputStream input) {
-		if (input == null) throw new IllegalArgumentException("input cannot be null.");
-		CRC32 crc = new CRC32();
-		byte[] buffer = new byte[4096];
-		try {
-			while (true) {
-				int length = input.read(buffer);
-				if (length == -1) break;
-				crc.update(buffer, 0, length);
-			}
-		} catch (Exception ex) {
-		} finally {
-			closeQuietly(input);
-		}
-		return Long.toString(crc.getValue(), 16);
-	}
-
-	private static File extractFile (String sourcePath, File outFile) {
-		try {
-			if (!outFile.getParentFile().exists() && !outFile.getParentFile().mkdirs()) throw new GdxRuntimeException(
-				"Couldn't create ANGLE native library output directory " + outFile.getParentFile().getAbsolutePath());
-			OutputStream out = null;
-			InputStream in = null;
-
-			if (outFile.exists()) {
-				return outFile;
-			}
-
-			try {
-				out = new FileOutputStream(outFile);
-				in = ANGLELoader.class.getResourceAsStream("/" + sourcePath);
-				byte[] buffer = new byte[4096];
-				while (true) {
-					int length = in.read(buffer);
-					if (length == -1) break;
-					out.write(buffer, 0, length);
-				}
-				return outFile;
-			} finally {
-				closeQuietly(out);
-				closeQuietly(in);
-			}
-		} catch (Throwable t) {
-			throw new GdxRuntimeException("Couldn't load ANGLE shared library " + sourcePath, t);
-		}
-	}
-
-	/** Returns a path to a file that can be written. Tries multiple locations and verifies writing succeeds.
-	 * @return null if a writable path could not be found. */
-	private static File getExtractedFile (String dirName, String fileName) {
-		// Temp directory with username in path.
-		File idealFile = new File(
-			System.getProperty("java.io.tmpdir") + "/libgdx" + System.getProperty("user.name") + "/" + dirName, fileName);
-		if (canWrite(idealFile)) return idealFile;
-
-		// System provided temp directory.
-		try {
-			File file = File.createTempFile(dirName, null);
-			if (file.delete()) {
-				file = new File(file, fileName);
-				if (canWrite(file)) return file;
-			}
-		} catch (IOException ignored) {
-		}
-
-		// User home.
-		File file = new File(System.getProperty("user.home") + "/.libgdx/" + dirName, fileName);
-		if (canWrite(file)) return file;
-
-		// Relative directory.
-		file = new File(".temp/" + dirName, fileName);
-		if (canWrite(file)) return file;
-
-		// We are running in the OS X sandbox.
-		if (System.getenv("APP_SANDBOX_CONTAINER_ID") != null) return idealFile;
-
-		return null;
-	}
-
-	/** Returns true if the parent directories of the file can be created and the file can be written. */
-	private static boolean canWrite (File file) {
-		File parent = file.getParentFile();
-		File testFile;
-		if (file.exists()) {
-			if (!file.canWrite() || !canExecute(file)) return false;
-			// Don't overwrite existing file just to check if we can write to directory.
-			testFile = new File(parent, randomUUID().toString());
-		} else {
-			parent.mkdirs();
-			if (!parent.isDirectory()) return false;
-			testFile = file;
-		}
-		try {
-			new FileOutputStream(testFile).close();
-			if (!canExecute(testFile)) return false;
-			return true;
-		} catch (Throwable ex) {
-			return false;
-		} finally {
-			testFile.delete();
-		}
-	}
-
-	private static boolean canExecute (File file) {
-		try {
-			Method canExecute = File.class.getMethod("canExecute");
-			if ((Boolean)canExecute.invoke(file)) return true;
-
-			Method setExecutable = File.class.getMethod("setExecutable", boolean.class, boolean.class);
-			setExecutable.invoke(file, true, false);
-
-			return (Boolean)canExecute.invoke(file);
-		} catch (Exception ignored) {
-		}
-		return false;
+	/** Checks if the current jar/code location is inside an macOS app bundle
+	 *
+	 * @return True if app bundle */
+	static boolean isAppBundlePath () {
+		URL jarSource = ANGLELoader.class.getProtectionDomain().getCodeSource().getLocation();
+		return jarSource.getPath().matches(".*/[^/]+\\.app/.*");
 	}
 
 	public static void load () {
-		if ((isARM && !isMac) || (!isWindows && !isLinux && !isMac))
+		if ((isARM && !isMac) || (!isWindows && !isLinux && !isMac)) {
 			throw new GdxRuntimeException("ANGLE is only supported on x86/x86_64 Windows, x64 Linux, and x64/arm64 macOS.");
+		}
 		String osDir = null;
 		String ext = null;
 		if (isWindows) {
@@ -187,34 +63,53 @@ public class ANGLELoader {
 			ext = ".dylib";
 		}
 
-		String eglSource = osDir + "/libEGL" + ext;
-		String glesSource = osDir + "/libGLESv2" + ext;
-		String crc = crc(ANGLELoader.class.getResourceAsStream("/" + eglSource))
-			+ crc(ANGLELoader.class.getResourceAsStream("/" + glesSource));
-		egl = getExtractedFile(crc, new File(eglSource).getName());
-		gles = getExtractedFile(crc, new File(glesSource).getName());
+		String eglFileName = "libEGL" + ext;
+		String glesFileName = "libGLESv2" + ext;
+		String eglSource = osDir + "/" + eglFileName;
+		String glesSource = osDir + "/" + glesFileName;
 
-		if (!isMac) {
-			extractFile(eglSource, egl);
-			System.load(egl.getAbsolutePath());
-			extractFile(glesSource, gles);
-			System.load(gles.getAbsolutePath());
-		} else {
-			// On macOS, we can't preload the shared libraries. calling dlopen("path1/lib.dylib")
-			// then calling dlopen("lib.dylib") will not return the dylib loaded in the first dlopen()
-			// call, but instead perform the dlopen library search algorithm anew. Since the dylibs
-			// we extract are not in any paths dlopen knows about, GLFW fails to load them.
-			// Instead, we need to copy the shared libraries to the current working directory (which
-			// we can't temporarily change in pure Java either...). The dylibs will get deleted
-			// in postGlfwInit() once the first window has been created, and GLFW has loaded the dylibs.
-			lastWorkingDir = new File(".");
-			extractFile(eglSource, new File(lastWorkingDir, egl.getName()));
-			extractFile(glesSource, new File(lastWorkingDir, gles.getName()));
+		SharedLibraryLoader loader = new SharedLibraryLoader();
+		try {
+			if (!isMac) {
+				String dirName = loader.crc(ANGLELoader.class.getResourceAsStream("/" + eglSource))
+					+ loader.crc(ANGLELoader.class.getResourceAsStream("/" + glesSource));
+
+				File egl = loader.extractFile(eglSource, dirName);
+				System.load(egl.getAbsolutePath());
+
+				File gles = loader.extractFile(glesSource, dirName);
+				System.load(gles.getAbsolutePath());
+			} else {
+				// On macOS, we can't preload the shared libraries via the JVM. calling dlopen("path1/lib.dylib")
+				// then calling dlopen("lib.dylib") will not return the dylib loaded in the first dlopen()
+				// call, but instead perform the dlopen library search algorithm anew. Since the dylibs
+				// we extract are not in any paths dlopen knows about, GLFW fails to load them.
+				// Instead, we need to copy the shared libraries to the current working directory (which
+				// we can't temporarily change in pure Java either...). The dylibs will get deleted
+				// in postGlfwInit() once the first window has been created, and GLFW has loaded the dylibs.
+
+				// Note: This only works if the app is NOT executed via an app bundle, since extracting the files
+				// into the app bundle breaks the signature and osx won't run the app anymore at all.
+				// Therefore, if you want to use angle with an app bundle, be sure to include the dylibs
+				// manually since we won't extract them here.
+				if (isAppBundlePath()) {
+					// Running inside an app bundle - do nothing
+					return;
+				}
+
+				File lastWorkingDir = new File(".");
+				loader.extractFileTo(eglSource, lastWorkingDir);
+				loader.extractFileTo(glesSource, lastWorkingDir);
+				loadedLibraries = new File[] {new File(lastWorkingDir, eglFileName), new File(lastWorkingDir, glesFileName),};
+			}
+		} catch (IOException e) {
+			throw new GdxRuntimeException("Could not extract angle libraries: " + e.getMessage());
 		}
 	}
 
 	public static void postGlfwInit () {
-		new File(lastWorkingDir, egl.getName()).delete();
-		new File(lastWorkingDir, gles.getName()).delete();
+		for (File file : loadedLibraries) {
+			file.delete();
+		}
 	}
 }


### PR DESCRIPTION
This changeset fixes the `ANGLELoader` not working correctly when being executed via an osx app bundle.

The following changes have been made:
1. Do not extract libraries if executed via app bundle (working directory is `/` or a `*.app/` folder)
2. Remove duplicate code by using the `SharedLibraryLoader`
3. Add documentation how to include angle in an app bundle

The changeset has been tested on:
- Windows 11 (x64)
- OSX 12.6 (arm64)
- Linux Mint 21.1 (x64)

closes #7058 