### PR TITLE
Add API I18NBundle#keys()

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -27,6 +27,7 @@
 - LWJGL3 Fix: Stereo audio can now be played on mono output devices. This may also improve downmixing to stereo and upmixing to surround.
 - API Addition: Added CheckBox#getImageDrawable.
 - FIX: HexagonalTiledMapRenderer now displays maps with the correct stagger index.
+- API Addition: Added I18NBundle#keys() method.
 
 [1.11.0]
 - [BREAKING CHANGE] iOS: Increased min supported iOS version to 9.0. Update your Info.plist file if necessary.

--- a/gdx/src/com/badlogic/gdx/utils/I18NBundle.java
+++ b/gdx/src/com/badlogic/gdx/utils/I18NBundle.java
@@ -19,9 +19,11 @@ package com.badlogic.gdx.utils;
 import java.io.IOException;
 import java.io.Reader;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.MissingResourceException;
+import java.util.Set;
 
 import com.badlogic.gdx.files.FileHandle;
 
@@ -435,6 +437,20 @@ public class I18NBundle {
 					throw new MissingResourceException("Can't find bundle key " + key, this.getClass().getName(), key);
 				else
 					return "???" + key + "???";
+			}
+		}
+		return result;
+	}
+
+	/** Gets a key set of loaded properties. Keys will be copied into a new set and returned.
+	 *
+	 * @return a key set of loaded properties. Never null, might be an empty set */
+	public Set<String> keys () {
+		Set<String> result = new LinkedHashSet<>();
+		ObjectMap.Keys<String> keys = properties.keys();
+		if (keys != null) {
+			for (String key : keys) {
+				result.add(key);
 			}
 		}
 		return result;


### PR DESCRIPTION
Add `keys()` method to`I18NBundle`, this API returns a key set of loaded properties.

There is currently no public API to get loaded properties from `I18NBundle`. For example, if I want to preload FreetypeFont asset using the characters loaded from `I18NBundle` properties, this API can be useful.

This method will copy keys to a new set, which makes no side effect.
