### PR TITLE
Remove unused float array

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtGL20.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtGL20.java
@@ -99,7 +99,6 @@ public class GwtGL20 implements GL20 {
 	Int32Array intBuffer = TypedArrays.createInt32Array(2000 * 6);
 	Int16Array shortBuffer = TypedArrays.createInt16Array(2000 * 6);
 	Int8Array byteBuffer = TypedArrays.createInt8Array(2000 * 6);
-	float[] floatArray = new float[16000];
 
 	public final WebGLRenderingContext gl;
 


### PR DESCRIPTION
While working on WebGL2 PR I spotted an unused float array in GwtGL20. IDE reports no usages and manually searching I cannot find any usages either.