### PR TITLE
Bugfix for TmxMapLoader crash, Not loading ImageLayers inside Group Layers.

### DIFF
--- a/gdx/src/com/badlogic/gdx/maps/tiled/TmxMapLoader.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/TmxMapLoader.java
@@ -154,6 +154,19 @@ public class TmxMapLoader extends BaseTmxMapLoader<TmxMapLoader.Parameters> {
 			}
 		}
 
+		// GroupLayer descriptors
+		for (Element groupLayer : root.getChildrenByName("group")) {
+			 for (Element imageLayer : groupLayer.getChildrenByName("imagelayer")) {
+				 Element image = imageLayer.getChildByName("image");
+				 String source = image.getAttribute("source", null);
+
+				 if (source != null) {
+					 FileHandle handle = getRelativeFileHandle(tmxFile, source);
+					 fileHandles.add(handle);
+				 }
+			 }
+		}
+
 		return fileHandles;
 	}
 

--- a/gdx/src/com/badlogic/gdx/maps/tiled/TmxMapLoader.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/TmxMapLoader.java
@@ -154,21 +154,31 @@ public class TmxMapLoader extends BaseTmxMapLoader<TmxMapLoader.Parameters> {
 			}
 		}
 
-		// GroupLayer descriptors
-		for (Element groupLayer : root.getChildrenByName("group")) {
-			 for (Element imageLayer : groupLayer.getChildrenByName("imagelayer")) {
-				 Element image = imageLayer.getChildByName("image");
-				 String source = image.getAttribute("source", null);
-
-				 if (source != null) {
-					 FileHandle handle = getRelativeFileHandle(tmxFile, source);
-					 fileHandles.add(handle);
-				 }
-			 }
-		}
+		//Check Groups for ImageLayers
+		checkGroups(root, tmxFile, fileHandles);
 
 		return fileHandles;
 	}
+
+	/** Recursive function to look through all the possible groups within groups ImageLayers could be found in.
+	  * @param root element we are parsing
+	  * @param tmxFile the FileHandle of the current tmx we are looking at
+	  * @param fileHandles array of FileHandles being passed to be added on to */
+	 private void checkGroups(Element root, FileHandle tmxFile, Array<FileHandle> fileHandles) {
+		  // GroupLayer descriptors
+		  for (Element groupLayer : root.getChildrenByName("group")) {
+				for (Element imageLayer : groupLayer.getChildrenByName("imagelayer")) {
+					 Element image = imageLayer.getChildByName("image");
+					 String source = image.getAttribute("source", null);
+
+					 if (source != null) {
+						  FileHandle handle = getRelativeFileHandle(tmxFile, source);
+						  fileHandles.add(handle);
+					 }
+				}
+				checkGroups(groupLayer, tmxFile, fileHandles);
+		  }
+	 }
 
 	@Override
 	protected void addStaticTiles (FileHandle tmxFile, ImageResolver imageResolver, TiledMapTileSet tileSet, Element element,

--- a/gdx/src/com/badlogic/gdx/maps/tiled/TmxMapLoader.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/TmxMapLoader.java
@@ -154,31 +154,31 @@ public class TmxMapLoader extends BaseTmxMapLoader<TmxMapLoader.Parameters> {
 			}
 		}
 
-		//Check Groups for ImageLayers
+		// Check Groups for ImageLayers
 		checkGroups(root, tmxFile, fileHandles);
 
 		return fileHandles;
 	}
 
 	/** Recursive function to look through all the possible groups within groups that ImageLayers could be found in.
-	  * @param root element of the xml file we are parsing
-	  * @param tmxFile the FileHandle of the current tmx we are looking at
-	  * @param fileHandles array of FileHandles we pass in, to be added onto */
-	 private void checkGroups(Element root, FileHandle tmxFile, Array<FileHandle> fileHandles) {
-		  // GroupLayer descriptors
-		  for (Element groupLayer : root.getChildrenByName("group")) {
-				for (Element imageLayer : groupLayer.getChildrenByName("imagelayer")) {
-					 Element image = imageLayer.getChildByName("image");
-					 String source = image.getAttribute("source", null);
+	 * @param root element of the xml file we are parsing
+	 * @param tmxFile the FileHandle of the current tmx we are looking at
+	 * @param fileHandles array of FileHandles we pass in, to be added onto */
+	private void checkGroups (Element root, FileHandle tmxFile, Array<FileHandle> fileHandles) {
+		// GroupLayer descriptors
+		for (Element groupLayer : root.getChildrenByName("group")) {
+			for (Element imageLayer : groupLayer.getChildrenByName("imagelayer")) {
+				Element image = imageLayer.getChildByName("image");
+				String source = image.getAttribute("source", null);
 
-					 if (source != null) {
-						  FileHandle handle = getRelativeFileHandle(tmxFile, source);
-						  fileHandles.add(handle);
-					 }
+				if (source != null) {
+					FileHandle handle = getRelativeFileHandle(tmxFile, source);
+					fileHandles.add(handle);
 				}
-				checkGroups(groupLayer, tmxFile, fileHandles);
-		  }
-	 }
+			}
+			checkGroups(groupLayer, tmxFile, fileHandles);
+		}
+	}
 
 	@Override
 	protected void addStaticTiles (FileHandle tmxFile, ImageResolver imageResolver, TiledMapTileSet tileSet, Element element,

--- a/gdx/src/com/badlogic/gdx/maps/tiled/TmxMapLoader.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/TmxMapLoader.java
@@ -160,10 +160,10 @@ public class TmxMapLoader extends BaseTmxMapLoader<TmxMapLoader.Parameters> {
 		return fileHandles;
 	}
 
-	/** Recursive function to look through all the possible groups within groups ImageLayers could be found in.
-	  * @param root element we are parsing
+	/** Recursive function to look through all the possible groups within groups that ImageLayers could be found in.
+	  * @param root element of the xml file we are parsing
 	  * @param tmxFile the FileHandle of the current tmx we are looking at
-	  * @param fileHandles array of FileHandles being passed to be added on to */
+	  * @param fileHandles array of FileHandles we pass in, to be added onto */
 	 private void checkGroups(Element root, FileHandle tmxFile, Array<FileHandle> fileHandles) {
 		  // GroupLayer descriptors
 		  for (Element groupLayer : root.getChildrenByName("group")) {


### PR DESCRIPTION
I came across a bug in the TmxMapLoader. Apparently if you build a tiledmap. And you have an ImageLayer inside of a Group and try and load it using AssetManager. It ends up crashing when your program runs because it wont be able to load the image asset. Basically, The code in the TmxMapLoader, only looks for imagelayer tags in the root of the .tmx file. This section here:
https://github.com/libgdx/libgdx/blob/9fb9353c99ae5b30b455262832c13a84c2736bd4/gdx/src/com/badlogic/gdx/maps/tiled/TmxMapLoader.java#L147
But it doesn't look for them as children inside of the group tags so they never get loaded.
Example from a .tmx file: `<group id="4" name="Group 2">
  <imagelayer id="5" name="Image Layer 2" offsetx="111.654" offsety="-0.8052">
   <image source="test_image2.png" width="112" height="112"/>
  </imagelayer>
 </group>`
 Then when imageResolver.getImage(handle.path()); gets called, it ends up crashing with the old "GdxRuntimeException: Asset not loaded:" exception.
I put together what looks to be a fix, as discussed in the discord, since Groups may contain, groups and groups and groups. I made it a recursive function to handle these scenarios. I've added the xml of the .tmx file I used for testing.
![image](https://user-images.githubusercontent.com/55356015/214849067-488fb253-3776-4197-bbd4-b255f8e596c8.png)
`<?xml version="1.0" encoding="UTF-8"?>
<map version="1.9" tiledversion="1.9.2" orientation="orthogonal" renderorder="right-down" width="10" height="10" tilewidth="32" tileheight="32" infinite="0" nextlayerid="22" nextobjectid="1">
 <tileset firstgid="1" source="Lonesome_Forest_Summer_Tileset.tsx"/>
 <layer id="1" name="Tile Layer 1" width="10" height="10">
  <data encoding="csv">
0,0,0,0,0,0,0,0,0,0,
0,0,0,0,0,0,0,0,0,0,
0,0,0,0,0,0,0,0,0,0,
0,0,0,0,0,0,0,0,0,0,
0,0,0,0,0,0,0,0,0,0,
0,0,0,0,0,0,0,0,0,0,
0,0,0,0,0,0,0,0,0,0,
551,0,0,0,0,0,0,0,0,551,
0,0,0,0,0,0,0,0,0,0,
551,0,0,0,0,0,0,0,0,551
</data>
 </layer>
 <group id="4" name="Group 2">
  <imagelayer id="5" name="Image Layer 2" offsetx="111.654" offsety="-0.8052">
   <image source="test_image2.png" width="112" height="112"/>
  </imagelayer>
 </group>
 <group id="7" name="Group 4">
  <group id="8" name="Group 5">
   <group id="9" name="Group 6">
    <group id="6" name="Group 3"/>
    <group id="11" name="Group 7">
     <group id="17" name="Group 10">
      <group id="19" name="Group 12">
       <group id="18" name="Group 11">
        <group id="14" name="Group 9">
         <imagelayer id="16" name="Image Layer 6" offsetx="230.019" offsety="117.559">
          <image source="test_image6.png" width="112" height="112"/>
         </imagelayer>
        </group>
       </group>
      </group>
      <group id="20" name="Group 13"/>
      <imagelayer id="21" name="Image Layer 7" offsetx="103.871" offsety="230.556">
       <image source="test_image7.png" width="112" height="112"/>
      </imagelayer>
     </group>
     <group id="13" name="Group 8">
      <imagelayer id="15" name="Image Layer 5" offsetx="114.607" offsety="118.633">
       <image source="test_image5.png" width="112" height="112"/>
      </imagelayer>
     </group>
    </group>
    <imagelayer id="12" name="Image Layer 4" offsetx="0" offsety="118.096">
     <image source="test_image4.png" width="112" height="112"/>
    </imagelayer>
   </group>
   <imagelayer id="10" name="Image Layer 3" offsetx="223.846" offsety="-0.5368">
    <image source="test_image3.png" width="112" height="112"/>
   </imagelayer>
  </group>
 </group>
 <group id="2" name="Group 1">
  <imagelayer id="3" name="Image Layer 1">
   <image source="test_image.png" width="112" height="112"/>
  </imagelayer>
 </group>
</map>
`
