### PR TITLE
Fix Gradle deprecations and remove unnecessary enableJetifier config

### DIFF
--- a/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/lwjgl2/build.gradle
+++ b/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/lwjgl2/build.gradle
@@ -6,7 +6,7 @@ project.ext.mainClassName = "%PACKAGE%.DesktopLauncher"
 project.ext.assetsDir = new File("../%ASSET_PATH%")
 
 task run(dependsOn: classes, type: JavaExec) {
-    main = project.mainClassName
+    mainClass = project.mainClassName
     classpath = sourceSets.main.runtimeClasspath
     standardInput = System.in
     workingDir = project.assetsDir
@@ -14,7 +14,7 @@ task run(dependsOn: classes, type: JavaExec) {
 }
 
 task debug(dependsOn: classes, type: JavaExec) {
-    main = project.mainClassName
+    mainClass = project.mainClassName
     classpath = sourceSets.main.runtimeClasspath
     standardInput = System.in
     workingDir = project.assetsDir

--- a/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/lwjgl3/build.gradle
+++ b/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/lwjgl3/build.gradle
@@ -8,7 +8,7 @@ project.ext.assetsDir = new File("../%ASSET_PATH%")
 import org.gradle.internal.os.OperatingSystem
 
 task run(dependsOn: classes, type: JavaExec) {
-    main = project.mainClassName
+    mainClass = project.mainClassName
     classpath = sourceSets.main.runtimeClasspath
     standardInput = System.in
     workingDir = project.assetsDir
@@ -21,7 +21,7 @@ task run(dependsOn: classes, type: JavaExec) {
 }
 
 task debug(dependsOn: classes, type: JavaExec) {
-    main = project.mainClassName
+    mainClass = project.mainClassName
     classpath = sourceSets.main.runtimeClasspath
     standardInput = System.in
     workingDir = project.assetsDir

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,6 @@ org.gradle.daemon=true
 org.gradle.jvmargs=-Xms128m -Xmx2000m
 org.gradle.configureondemand=false
 android.useAndroidX=true
-android.enableJetifier=true
 
 group=com.badlogicgames.gdx
 version=1.11.1


### PR DESCRIPTION
`enableJetifier` is no longer needed, setting it to default (`false`) should in theory speed up the build. It can be checked using the `:backends:gdx-backend-android:checkJetifier` Gradle task.