### PR TITLE
Add glBlendEquationSeparate/glBlendFuncSeparate support in BlendingAttribute

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g3d/attributes/BlendingAttribute.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/attributes/BlendingAttribute.java
@@ -37,6 +37,15 @@ public class BlendingAttribute extends Attribute {
 	/** Specifies how the (existing) red, green, blue, and alpha destination blending factors are computed (default:
 	 * GL_ONE_MINUS_SRC_ALPHA) */
 	public int destFunction;
+	/** Specifies how the (incoming) red, green, blue, and alpha source blending factors are computed (default: GL_SRC_ALPHA) */
+	public int sourceFunctionAlpha;
+	/** Specifies how the (existing) red, green, blue, and alpha destination blending factors are computed (default:
+	 * GL_ONE_MINUS_SRC_ALPHA) */
+	public int destFunctionAlpha;
+	/** the blend equation for rgb (default: GL_FUNC_ADD) */
+	public int equationRGB;
+	/** the blend equation for alpha (default: GL_FUNC_ADD) */
+	public int equationAlpha;
 	/** The opacity used as source alpha value, ranging from 0 (fully transparent) to 1 (fully opaque), (default: 1). */
 	public float opacity = 1.f;
 
@@ -44,12 +53,21 @@ public class BlendingAttribute extends Attribute {
 		this(null);
 	}
 
-	public BlendingAttribute (final boolean blended, final int sourceFunc, final int destFunc, final float opacity) {
+	public BlendingAttribute (final boolean blended, final int sourceFuncRGB, final int destFuncRGB, final int sourceFuncAlpha,
+		final int destFuncAlpha, final int equationRGB, final int equationAlpha, final float opacity) {
 		super(Type);
 		this.blended = blended;
-		this.sourceFunction = sourceFunc;
-		this.destFunction = destFunc;
+		this.sourceFunction = sourceFuncRGB;
+		this.destFunction = destFuncRGB;
+		this.sourceFunctionAlpha = sourceFuncAlpha;
+		this.destFunctionAlpha = destFuncAlpha;
+		this.equationRGB = equationRGB;
+		this.equationAlpha = equationAlpha;
 		this.opacity = opacity;
+	}
+
+	public BlendingAttribute (final boolean blended, final int sourceFunc, final int destFunc, final float opacity) {
+		this(blended, sourceFunc, destFunc, sourceFunc, destFunc, GL20.GL_FUNC_ADD, GL20.GL_FUNC_ADD, opacity);
 	}
 
 	public BlendingAttribute (final int sourceFunc, final int destFunc, final float opacity) {
@@ -70,7 +88,11 @@ public class BlendingAttribute extends Attribute {
 
 	public BlendingAttribute (final BlendingAttribute copyFrom) {
 		this(copyFrom == null || copyFrom.blended, copyFrom == null ? GL20.GL_SRC_ALPHA : copyFrom.sourceFunction,
-			copyFrom == null ? GL20.GL_ONE_MINUS_SRC_ALPHA : copyFrom.destFunction, copyFrom == null ? 1.f : copyFrom.opacity);
+			copyFrom == null ? GL20.GL_ONE_MINUS_SRC_ALPHA : copyFrom.destFunction,
+			copyFrom == null ? GL20.GL_SRC_ALPHA : copyFrom.sourceFunctionAlpha,
+			copyFrom == null ? GL20.GL_ONE_MINUS_SRC_ALPHA : copyFrom.destFunctionAlpha,
+			copyFrom == null ? GL20.GL_FUNC_ADD : copyFrom.equationRGB, copyFrom == null ? GL20.GL_FUNC_ADD : copyFrom.equationAlpha,
+			copyFrom == null ? 1.f : copyFrom.opacity);
 	}
 
 	@Override
@@ -84,6 +106,10 @@ public class BlendingAttribute extends Attribute {
 		result = 947 * result + (blended ? 1 : 0);
 		result = 947 * result + sourceFunction;
 		result = 947 * result + destFunction;
+		result = 947 * result + sourceFunctionAlpha;
+		result = 947 * result + destFunctionAlpha;
+		result = 947 * result + equationRGB;
+		result = 947 * result + equationAlpha;
 		result = 947 * result + NumberUtils.floatToRawIntBits(opacity);
 		return result;
 	}
@@ -95,6 +121,10 @@ public class BlendingAttribute extends Attribute {
 		if (blended != other.blended) return blended ? 1 : -1;
 		if (sourceFunction != other.sourceFunction) return sourceFunction - other.sourceFunction;
 		if (destFunction != other.destFunction) return destFunction - other.destFunction;
+		if (sourceFunctionAlpha != other.sourceFunctionAlpha) return sourceFunctionAlpha - other.sourceFunctionAlpha;
+		if (destFunctionAlpha != other.destFunctionAlpha) return destFunctionAlpha - other.destFunctionAlpha;
+		if (equationRGB != other.equationRGB) return equationRGB - other.equationRGB;
+		if (equationAlpha != other.equationAlpha) return equationAlpha - other.equationAlpha;
 		return (MathUtils.isEqual(opacity, other.opacity)) ? 0 : (opacity < other.opacity ? 1 : -1);
 	}
 }

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/attributes/BlendingAttribute.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/attributes/BlendingAttribute.java
@@ -32,14 +32,14 @@ public class BlendingAttribute extends Attribute {
 	/** Whether this material should be considered blended (default: true). This is used for sorting (back to front instead of
 	 * front to back). */
 	public boolean blended;
-	/** Specifies how the (incoming) red, green, blue, and alpha source blending factors are computed (default: GL_SRC_ALPHA) */
+	/** Specifies how the (incoming) red, green, blue source blending factors are computed (default: GL_SRC_ALPHA) */
 	public int sourceFunction;
-	/** Specifies how the (existing) red, green, blue, and alpha destination blending factors are computed (default:
+	/** Specifies how the (existing) red, green, blue destination blending factors are computed (default:
 	 * GL_ONE_MINUS_SRC_ALPHA) */
 	public int destFunction;
-	/** Specifies how the (incoming) red, green, blue, and alpha source blending factors are computed (default: GL_SRC_ALPHA) */
+	/** Specifies how the (incoming) alpha source blending factor is computed (default: GL_SRC_ALPHA) */
 	public int sourceFunctionAlpha;
-	/** Specifies how the (existing) red, green, blue, and alpha destination blending factors are computed (default:
+	/** Specifies how the (existing) alpha destination blending factor is computed (default:
 	 * GL_ONE_MINUS_SRC_ALPHA) */
 	public int destFunctionAlpha;
 	/** the blend equation for rgb (default: GL_FUNC_ADD) */

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/DefaultShader.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/DefaultShader.java
@@ -828,7 +828,10 @@ public class DefaultShader extends BaseShader {
 		for (final Attribute attr : attributes) {
 			final long t = attr.type;
 			if (BlendingAttribute.is(t)) {
-				context.setBlending(true, ((BlendingAttribute)attr).sourceFunction, ((BlendingAttribute)attr).destFunction);
+				context.setBlending(((BlendingAttribute)attr).blended, ((BlendingAttribute)attr).sourceFunction,
+					((BlendingAttribute)attr).destFunction, ((BlendingAttribute)attr).sourceFunctionAlpha,
+					((BlendingAttribute)attr).destFunctionAlpha, ((BlendingAttribute)attr).equationRGB,
+					((BlendingAttribute)attr).equationAlpha);
 				set(u_opacity, ((BlendingAttribute)attr).opacity);
 			} else if ((t & IntAttribute.CullFace) == IntAttribute.CullFace)
 				cullFace = ((IntAttribute)attr).value;

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/utils/RenderContext.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/utils/RenderContext.java
@@ -17,7 +17,7 @@
 package com.badlogic.gdx.graphics.g3d.utils;
 
 import com.badlogic.gdx.Gdx;
-import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.*;
 
 /** Manages OpenGL state and tries to reduce state changes. Uses a {@link TextureBinder} to reduce texture binds as well. Call
  * {@link #begin()} to setup the context, call {@link #end()} to undo all state changes. Use the setters to change state, use
@@ -29,6 +29,10 @@ public class RenderContext {
 	private boolean blending;
 	private int blendSFactor;
 	private int blendDFactor;
+	private int blendSFactorAlpha;
+	private int blendDFactorAlpha;
+	private int blendEquationRGB;
+	private int blendEquationAlpha;
 	private int depthFunc;
 	private float depthRangeNear;
 	private float depthRangeFar;
@@ -48,7 +52,7 @@ public class RenderContext {
 		Gdx.gl.glDisable(GL20.GL_BLEND);
 		blending = false;
 		Gdx.gl.glDisable(GL20.GL_CULL_FACE);
-		cullFace = blendSFactor = blendDFactor = 0;
+		cullFace = blendSFactor = blendDFactor = blendSFactorAlpha = blendDFactorAlpha = blendEquationRGB = blendEquationAlpha = -1;
 		textureBinder.begin();
 	}
 
@@ -88,6 +92,11 @@ public class RenderContext {
 	}
 
 	public void setBlending (final boolean enabled, final int sFactor, final int dFactor) {
+		setBlending(enabled, sFactor, dFactor, sFactor, dFactor, GL20.GL_FUNC_ADD, GL20.GL_FUNC_ADD);
+	}
+
+	public void setBlending (final boolean enabled, final int sFactorRGB, final int dFactorRGB, final int sFactorAlpha,
+		final int dFactorAlpha, final int equationRGB, final int equationAlpha) {
 		if (enabled != blending) {
 			blending = enabled;
 			if (enabled)
@@ -95,10 +104,22 @@ public class RenderContext {
 			else
 				Gdx.gl.glDisable(GL20.GL_BLEND);
 		}
-		if (enabled && (blendSFactor != sFactor || blendDFactor != dFactor)) {
-			Gdx.gl.glBlendFunc(sFactor, dFactor);
-			blendSFactor = sFactor;
-			blendDFactor = dFactor;
+
+		if (enabled) {
+			if (blendEquationRGB != equationRGB || blendEquationAlpha != equationAlpha) {
+				Gdx.gl.glBlendEquationSeparate(equationRGB, equationAlpha);
+				blendEquationRGB = equationRGB;
+				blendEquationAlpha = equationAlpha;
+			}
+
+			if (blendSFactor != sFactorRGB || blendDFactor != dFactorRGB || blendSFactorAlpha != sFactorAlpha
+				|| blendDFactorAlpha != dFactorAlpha) {
+				Gdx.gl.glBlendFuncSeparate(sFactorRGB, dFactorRGB, sFactorAlpha, dFactorAlpha);
+				blendSFactor = sFactorRGB;
+				blendDFactor = dFactorRGB;
+				blendSFactorAlpha = sFactorAlpha;
+				blendDFactorAlpha = dFactorAlpha;
+			}
 		}
 	}
 


### PR DESCRIPTION
We really miss the possiblity to enable advanced blending modes in BlendingAttribute.
Blending towards fully transparent buffers (ie. FBO) needs more control for alpha and rgb equations, expecially when dealing with premultiplied alpha. 

This PR is API compliant and does not introduce additional openGL state changes if not used advanced blending features.

We also fix the following issues : #7085 , #7086

--