### PR TITLE
Fix for font scaling problem (https://github.com/libgdx/libgdx/issues/7100)

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFont.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFont.java
@@ -983,12 +983,10 @@ public class BitmapFont implements Disposable {
 			setScale(scaleX + amount, scaleY + amount);
 		}
 
-		/**
-		 * Undo last {@link #setScale(float, float)} operation. We need this to solve problem with limited float precision
+		/** Undo last {@link #setScale(float, float)} operation. We need this to solve problem with limited float precision
 		 * calculations which can cause some undesirable behaviour in certain widgets, as described here:
-		 * <a href="https://github.com/libgdx/libgdx/issues/7100">https://github.com/libgdx/libgdx/issues/7100</a>
-		 */
-		public void undoScale() {
+		 * <a href="https://github.com/libgdx/libgdx/issues/7100">https://github.com/libgdx/libgdx/issues/7100</a> */
+		public void undoScale () {
 			scaleX = backupScaleX;
 			scaleY = backupScaleY;
 
@@ -1005,7 +1003,7 @@ public class BitmapFont implements Disposable {
 			padBottom = backupPadBottom;
 		}
 
-		public String toString() {
+		public String toString () {
 			return name != null ? name : super.toString();
 		}
 	}

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFont.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFont.java
@@ -459,6 +459,24 @@ public class BitmapFont implements Disposable {
 		 * file, it needs to be set manually depending on how the glyphs are rendered on the backing textures. */
 		public float cursorX;
 
+		/*
+		 * Here we keep backup values for those attributes that get modified in setScale() method. We need it due to a bug described
+		 * here: https://github.com/libgdx/libgdx/issues/7100. We use them with undoScale() method.
+		 */
+		public float backupScaleX;
+		public float backupScaleY;
+		public float backupLineHeight;
+		public float backupSpaceXadvance;
+		public float backupXHeight;
+		public float backupCapHeight;
+		public float backupAscent;
+		public float backupDescent;
+		public float backupDown;
+		public float backupPadLeft;
+		public float backupPadRight;
+		public float backupPadTop;
+		public float backupPadBottom;
+
 		public final Glyph[][] glyphs = new Glyph[PAGES][];
 		/** The glyph to display for characters not in the font. May be null. */
 		public Glyph missingGlyph;
@@ -918,6 +936,22 @@ public class BitmapFont implements Disposable {
 		public void setScale (float scaleX, float scaleY) {
 			if (scaleX == 0) throw new IllegalArgumentException("scaleX cannot be 0.");
 			if (scaleY == 0) throw new IllegalArgumentException("scaleY cannot be 0.");
+
+			// backup current values before scaling (we'll need them with the undoScale() method):
+			backupScaleX = this.scaleX;
+			backupScaleY = this.scaleY;
+			backupLineHeight = lineHeight;
+			backupSpaceXadvance = spaceXadvance;
+			backupXHeight = xHeight;
+			backupCapHeight = capHeight;
+			backupAscent = ascent;
+			backupDescent = descent;
+			backupDown = down;
+			backupPadLeft = padLeft;
+			backupPadRight = padRight;
+			backupPadTop = padTop;
+			backupPadBottom = padBottom;
+
 			float x = scaleX / this.scaleX;
 			float y = scaleY / this.scaleY;
 			lineHeight *= y;
@@ -949,7 +983,29 @@ public class BitmapFont implements Disposable {
 			setScale(scaleX + amount, scaleY + amount);
 		}
 
-		public String toString () {
+		/**
+		 * Undo last {@link #setScale(float, float)} operation. We need this to solve problem with limited float precision
+		 * calculations which can cause some undesirable behaviour in certain widgets, as described here:
+		 * <a href="https://github.com/libgdx/libgdx/issues/7100">https://github.com/libgdx/libgdx/issues/7100</a>
+		 */
+		public void undoScale() {
+			scaleX = backupScaleX;
+			scaleY = backupScaleY;
+
+			lineHeight = backupLineHeight;
+			spaceXadvance = backupSpaceXadvance;
+			xHeight = backupXHeight;
+			capHeight = backupCapHeight;
+			ascent = backupAscent;
+			descent = backupDescent;
+			down = backupDown;
+			padLeft = backupPadLeft;
+			padRight = backupPadRight;
+			padTop = backupPadTop;
+			padBottom = backupPadBottom;
+		}
+
+		public String toString() {
 			return name != null ? name : super.toString();
 		}
 	}

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Label.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Label.java
@@ -140,13 +140,11 @@ public class Label extends Widget {
 
 	private void scaleAndComputePrefSize () {
 		BitmapFont font = cache.getFont();
-		float oldScaleX = font.getScaleX();
-		float oldScaleY = font.getScaleY();
 		if (fontScaleChanged) font.getData().setScale(fontScaleX, fontScaleY);
 
 		computePrefSize(Label.prefSizeLayout);
 
-		if (fontScaleChanged) font.getData().setScale(oldScaleX, oldScaleY);
+		if (fontScaleChanged) font.getData().undoScale();
 	}
 
 	protected void computePrefSize (GlyphLayout layout) {
@@ -166,8 +164,6 @@ public class Label extends Widget {
 
 	public void layout () {
 		BitmapFont font = cache.getFont();
-		float oldScaleX = font.getScaleX();
-		float oldScaleY = font.getScaleY();
 		if (fontScaleChanged) font.getData().setScale(fontScaleX, fontScaleY);
 
 		boolean wrap = this.wrap && ellipsis == null;
@@ -222,7 +218,7 @@ public class Label extends Widget {
 		layout.setText(font, text, 0, text.length, Color.WHITE, textWidth, lineAlign, wrap, ellipsis);
 		cache.setText(layout, x, y);
 
-		if (fontScaleChanged) font.getData().setScale(oldScaleX, oldScaleY);
+		if (fontScaleChanged) font.getData().undoScale();
 	}
 
 	public void draw (Batch batch, float parentAlpha) {


### PR DESCRIPTION
Fix for font scaling problem (as suggested by 'evilentity' on Discord). Fixes a problem with limited float precision calculations which can cause some undesirable behaviour in certain widgets, as described here: https://github.com/libgdx/libgdx/issues/7100