### PR TITLE
Use default property values to work on Graal.

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/UIUtils.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/UIUtils.java
@@ -14,8 +14,7 @@ public final class UIUtils {
 	static public boolean isAndroid = jrName.contains("Android");
 	static public boolean isMac = !isAndroid && osName.contains("Mac");
 	static public boolean isWindows = !isAndroid && osName.contains("Windows");
-	static public boolean isLinux = !isAndroid && osName.contains("Linux")
-		|| osName.contains("FreeBSD");
+	static public boolean isLinux = !isAndroid && osName.contains("Linux") || osName.contains("FreeBSD");
 	static public boolean isIos = !isAndroid && (!(isWindows || isLinux || isMac));
 
 	static public boolean left () {

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/UIUtils.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/UIUtils.java
@@ -4,18 +4,17 @@ package com.badlogic.gdx.scenes.scene2d.utils;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input.Buttons;
 import com.badlogic.gdx.Input.Keys;
+import com.badlogic.gdx.utils.SharedLibraryLoader;
 
 public final class UIUtils {
 	private UIUtils () {
 	}
 
-	static private final String osName = System.getProperty("os.name", "");
-	static private final String jrName = System.getProperty("java.runtime.name", "");
-	static public boolean isAndroid = jrName.contains("Android");
-	static public boolean isMac = !isAndroid && osName.contains("Mac");
-	static public boolean isWindows = !isAndroid && osName.contains("Windows");
-	static public boolean isLinux = !isAndroid && osName.contains("Linux") || osName.contains("FreeBSD");
-	static public boolean isIos = !isAndroid && (!(isWindows || isLinux || isMac));
+	static public boolean isAndroid = SharedLibraryLoader.isAndroid;
+	static public boolean isMac = SharedLibraryLoader.isMac;
+	static public boolean isWindows = SharedLibraryLoader.isWindows;
+	static public boolean isLinux = SharedLibraryLoader.isLinux;
+	static public boolean isIos = SharedLibraryLoader.isIos;
 
 	static public boolean left () {
 		return Gdx.input.isButtonPressed(Buttons.LEFT);

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/UIUtils.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/UIUtils.java
@@ -9,11 +9,13 @@ public final class UIUtils {
 	private UIUtils () {
 	}
 
-	static public boolean isAndroid = System.getProperty("java.runtime.name").contains("Android");
-	static public boolean isMac = !isAndroid && System.getProperty("os.name").contains("Mac");
-	static public boolean isWindows = !isAndroid && System.getProperty("os.name").contains("Windows");
-	static public boolean isLinux = !isAndroid && System.getProperty("os.name").contains("Linux")
-		|| System.getProperty("os.name").contains("FreeBSD");
+	static private final String osName = System.getProperty("os.name", "");
+	static private final String jrName = System.getProperty("java.runtime.name", "");
+	static public boolean isAndroid = jrName.contains("Android");
+	static public boolean isMac = !isAndroid && osName.contains("Mac");
+	static public boolean isWindows = !isAndroid && osName.contains("Windows");
+	static public boolean isLinux = !isAndroid && osName.contains("Linux")
+		|| osName.contains("FreeBSD");
 	static public boolean isIos = !isAndroid && (!(isWindows || isLinux || isMac));
 
 	static public boolean left () {


### PR DESCRIPTION
Graal Native Image seems to not define java.runtime.name, which means without a default, `isAndroid` would call `.contains("Android")` on null, and crash. Adding defaults for `System.getProperty()` seems like a vital step for anywhere that gets String properties. This fixes https://github.com/libgdx/libgdx/issues/7111 . Thanks to authorZhao for finding the bug and suggesting a fix.