### PR TITLE
Fix Mp3 Music setPosition works wrong #6628

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -12,6 +12,7 @@
 - [BREAKING CHANGE] 3D API - max bone weights is now configurable and limited to 4 by default. Change this value if you need less or more. See #6522.
 - [BREAKING CHANGE] Mesh#getVerticesBuffer, Mesh#getIndicesBuffer, VertexData#getBuffer, and IndexData#getBuffer are deprecated in favor to new methods with boolean parameter. If you subclassed some of these classes, you need to implement the new methods.
 - [BREAKING CHANGE] Desktop: The return value of AudioDevice#getLatency() is now in samples, and not milliseconds
+- LWJGL3 Fix: setPosision() for MP3 files.
 - iOS: Add new MobiVM MetalANGLE backend
 - iOS: Update to MobiVM 2.3.19
 - API Addition: Added Haptics API with 4 different Input#vibrate() methods with complete Android and iOS implementations.

--- a/CHANGES
+++ b/CHANGES
@@ -12,7 +12,7 @@
 - [BREAKING CHANGE] 3D API - max bone weights is now configurable and limited to 4 by default. Change this value if you need less or more. See #6522.
 - [BREAKING CHANGE] Mesh#getVerticesBuffer, Mesh#getIndicesBuffer, VertexData#getBuffer, and IndexData#getBuffer are deprecated in favor to new methods with boolean parameter. If you subclassed some of these classes, you need to implement the new methods.
 - [BREAKING CHANGE] Desktop: The return value of AudioDevice#getLatency() is now in samples, and not milliseconds
-- LWJGL3 Fix: setPosision() for MP3 files.
+- LWJGL Fix: setPosision() for MP3 files.
 - iOS: Add new MobiVM MetalANGLE backend
 - iOS: Update to MobiVM 2.3.19
 - API Addition: Added Haptics API with 4 different Input#vibrate() methods with complete Android and iOS implementations.

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/audio/OpenALMusic.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/audio/OpenALMusic.java
@@ -176,8 +176,10 @@ public abstract class OpenALMusic implements Music {
 			renderedSeconds = 0;
 		}
 		while (renderedSeconds < (position - maxSecondsPerBuffer)) {
-			if (read(tempBytes) <= 0) break;
-			renderedSeconds += maxSecondsPerBuffer;
+			int length = read(tempBytes);
+			if (length <= 0) break;
+			float currentBufferSeconds = maxSecondsPerBuffer * (float)length / (float)bufferSize;
+			renderedSeconds += currentBufferSeconds;
 		}
 		renderedSecondsQueue.add(renderedSeconds);
 		boolean filled = false;

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALMusic.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALMusic.java
@@ -177,8 +177,10 @@ public abstract class OpenALMusic implements Music {
 			renderedSeconds = 0;
 		}
 		while (renderedSeconds < (position - maxSecondsPerBuffer)) {
-			if (read(tempBytes) <= 0) break;
-			renderedSeconds += maxSecondsPerBuffer;
+			int length = read(tempBytes);
+			if (length <= 0) break;
+			float currentBufferSeconds = maxSecondsPerBuffer * (float) length / (float) bufferSize;
+			renderedSeconds += currentBufferSeconds;
 		}
 		renderedSecondsQueue.add(renderedSeconds);
 		boolean filled = false;

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALMusic.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALMusic.java
@@ -179,7 +179,7 @@ public abstract class OpenALMusic implements Music {
 		while (renderedSeconds < (position - maxSecondsPerBuffer)) {
 			int length = read(tempBytes);
 			if (length <= 0) break;
-			float currentBufferSeconds = maxSecondsPerBuffer * (float) length / (float) bufferSize;
+			float currentBufferSeconds = maxSecondsPerBuffer * (float)length / (float)bufferSize;
 			renderedSeconds += currentBufferSeconds;
 		}
 		renderedSecondsQueue.add(renderedSeconds);


### PR DESCRIPTION
setPosition for MP3 musics wasn't setting time position at the rigth place.

**How to test this fix ?**
You can see that this fix work by running `.\gradlew launchTestsLwjgl3` then choose MusicTest, play the mp3 file go to aproximatly 3:00. File is 3:03 min long, so it should stop at 3:03, but currently it continue over 3:10. (This fix make it stop at 3:03)
You can play file with a music player at libgdx/tests/gdx-tests-lwjgl3/build/resources/main/data/8.12.mp3 at 3:00 music fall down then stop at 3:03

**How does it fix it ?**
My guess is that mp3 reader don't fill buffer as wav & ogg do.
So to calculate how much of the file have been read we need to use the return of read(int) instead of bufferSize. Otherwise we think that 40960 have been read when only 40200. So wrong offset increase over time.