### PR TITLE
Move AndroidManifest package to build.gradle namespace

### DIFF
--- a/backends/gdx-backend-android/AndroidManifest.xml
+++ b/backends/gdx-backend-android/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.badlogic.gdx.backends.android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-feature android:glEsVersion="0x00020000" android:required="true"/>
 </manifest>

--- a/backends/gdx-backend-android/build.gradle
+++ b/backends/gdx-backend-android/build.gradle
@@ -23,6 +23,7 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
+	namespace "com.badlogic.gdx.backends.android"
 	compileSdkVersion versions.androidCompileSdk
 	buildToolsVersion versions.androidBuildTools
 

--- a/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/android/AndroidManifest.xml
+++ b/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/android/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="%PACKAGE%">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-feature android:glEsVersion="0x00020000" android:required="true" />
 

--- a/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/android/build.gradle
+++ b/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/android/build.gradle
@@ -1,4 +1,5 @@
 android {
+    namespace "%PACKAGE%"
     buildToolsVersion "%BUILD_TOOLS_VERSION%"
     compileSdkVersion %API_LEVEL%
     sourceSets {

--- a/tests/gdx-tests-android/AndroidManifest.xml
+++ b/tests/gdx-tests-android/AndroidManifest.xml
@@ -2,7 +2,6 @@
 <manifest
 	xmlns:android="http://schemas.android.com/apk/res/android"
 	xmlns:tools="http://schemas.android.com/tools"
-	package="com.badlogic.gdx.tests.android"
 	android:installLocation="auto">
 	<uses-permission android:name="android.permission.RECORD_AUDIO"/>
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>

--- a/tests/gdx-tests-android/build.gradle
+++ b/tests/gdx-tests-android/build.gradle
@@ -59,6 +59,7 @@ dependencies {
 }
 
 android {
+	namespace "com.badlogic.gdx.tests.android"
 	buildToolsVersion versions.androidBuildTools
 	compileSdkVersion versions.androidCompileSdk
 	sourceSets {


### PR DESCRIPTION
Moved to get rid of some deprecation warnings