### PR TITLE
fix OpenGL version in tests

### DIFF
--- a/tests/gdx-tests-lwjgl/src/com/badlogic/gdx/tests/lwjgl/LwjglTestStarter.java
+++ b/tests/gdx-tests-lwjgl/src/com/badlogic/gdx/tests/lwjgl/LwjglTestStarter.java
@@ -45,6 +45,7 @@ import com.badlogic.gdx.tests.utils.CommandLineOptions;
 import com.badlogic.gdx.tests.utils.GdxTest;
 import com.badlogic.gdx.tests.utils.GdxTestWrapper;
 import com.badlogic.gdx.tests.utils.GdxTests;
+import com.badlogic.gdx.utils.SharedLibraryLoader;
 
 public class LwjglTestStarter extends JFrame {
 	static CommandLineOptions options;
@@ -76,6 +77,10 @@ public class LwjglTestStarter extends JFrame {
 		config.forceExit = false;
 		if (useGL30) {
 			config.useGL30 = true;
+			if(!SharedLibraryLoader.isMac){
+				config.gles30ContextMajorVersion = 4;
+				config.gles30ContextMinorVersion = 3;
+			}
 			ShaderProgram.prependVertexCode = "#version 140\n#define varying out\n#define attribute in\n";
 			ShaderProgram.prependFragmentCode = "#version 140\n#define varying in\n#define texture2D texture\n#define gl_FragColor fragColor\nout vec4 fragColor;\n";
 		} else {

--- a/tests/gdx-tests-lwjgl/src/com/badlogic/gdx/tests/lwjgl/LwjglTestStarter.java
+++ b/tests/gdx-tests-lwjgl/src/com/badlogic/gdx/tests/lwjgl/LwjglTestStarter.java
@@ -77,7 +77,7 @@ public class LwjglTestStarter extends JFrame {
 		config.forceExit = false;
 		if (useGL30) {
 			config.useGL30 = true;
-			if(!SharedLibraryLoader.isMac){
+			if (!SharedLibraryLoader.isMac) {
 				config.gles30ContextMajorVersion = 4;
 				config.gles30ContextMinorVersion = 3;
 			}

--- a/tests/gdx-tests-lwjgl3/src/com/badlogic/gdx/tests/lwjgl3/Lwjgl3TestStarter.java
+++ b/tests/gdx-tests-lwjgl3/src/com/badlogic/gdx/tests/lwjgl3/Lwjgl3TestStarter.java
@@ -59,7 +59,11 @@ public class Lwjgl3TestStarter {
 			ShaderProgram.prependVertexCode = "#version 140\n#define varying out\n#define attribute in\n";
 			ShaderProgram.prependFragmentCode = "#version 140\n#define varying in\n#define texture2D texture\n#define gl_FragColor fragColor\nout vec4 fragColor;\n";
 
-			config.setOpenGLEmulation(Lwjgl3ApplicationConfiguration.GLEmulation.GL30, 3, 2);
+			if(SharedLibraryLoader.isMac){
+				config.setOpenGLEmulation(Lwjgl3ApplicationConfiguration.GLEmulation.GL30, 3, 2);
+			}else{
+				config.setOpenGLEmulation(Lwjgl3ApplicationConfiguration.GLEmulation.GL30, 4, 3);
+			}
 		}
 
 		if (options.angle) {

--- a/tests/gdx-tests-lwjgl3/src/com/badlogic/gdx/tests/lwjgl3/Lwjgl3TestStarter.java
+++ b/tests/gdx-tests-lwjgl3/src/com/badlogic/gdx/tests/lwjgl3/Lwjgl3TestStarter.java
@@ -59,9 +59,9 @@ public class Lwjgl3TestStarter {
 			ShaderProgram.prependVertexCode = "#version 140\n#define varying out\n#define attribute in\n";
 			ShaderProgram.prependFragmentCode = "#version 140\n#define varying in\n#define texture2D texture\n#define gl_FragColor fragColor\nout vec4 fragColor;\n";
 
-			if(SharedLibraryLoader.isMac){
+			if (SharedLibraryLoader.isMac) {
 				config.setOpenGLEmulation(Lwjgl3ApplicationConfiguration.GLEmulation.GL30, 3, 2);
-			}else{
+			} else {
 				config.setOpenGLEmulation(Lwjgl3ApplicationConfiguration.GLEmulation.GL30, 4, 3);
 			}
 		}


### PR DESCRIPTION
i noticed a crash running InstancedRenderingTest because glVertexAttribDivisor requires OpenGL 3.3+.

Note that OpenGL 4.3 is needed in order to fully emulate GLES 3.0. (see LwjglGL30 and Lwjgl3GL30 java imports)