### PR TITLE
fix instanced rendering when used with Renderable or Model

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/Mesh.java
+++ b/gdx/src/com/badlogic/gdx/graphics/Mesh.java
@@ -512,7 +512,7 @@ public class Mesh implements Disposable {
 	 * @param locations array containing the attribute locations. */
 	public void bind (final ShaderProgram shader, final int[] locations) {
 		vertices.bind(shader, locations);
-		if (instances != null && instances.getNumInstances() > 0) instances.bind(shader, locations);
+		if (instances != null && instances.getNumInstances() > 0) instances.bind(shader);
 		if (indices.getNumIndices() > 0) indices.bind();
 	}
 
@@ -531,7 +531,7 @@ public class Mesh implements Disposable {
 	 * @param locations array containing the attribute locations. */
 	public void unbind (final ShaderProgram shader, final int[] locations) {
 		vertices.unbind(shader, locations);
-		if (instances != null && instances.getNumInstances() > 0) instances.unbind(shader, locations);
+		if (instances != null && instances.getNumInstances() > 0) instances.unbind(shader);
 		if (indices.getNumIndices() > 0) indices.unbind();
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gles3/ModelInstancedRenderingTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gles3/ModelInstancedRenderingTest.java
@@ -17,30 +17,21 @@
 package com.badlogic.gdx.tests.gles3;
 
 import com.badlogic.gdx.Gdx;
-import com.badlogic.gdx.assets.loaders.ModelLoader;
 import com.badlogic.gdx.graphics.GL20;
-import com.badlogic.gdx.graphics.GL30;
 import com.badlogic.gdx.graphics.Mesh;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.graphics.VertexAttribute;
 import com.badlogic.gdx.graphics.VertexAttributes.Usage;
 import com.badlogic.gdx.graphics.g3d.Material;
-import com.badlogic.gdx.graphics.g3d.Model;
 import com.badlogic.gdx.graphics.g3d.ModelBatch;
-import com.badlogic.gdx.graphics.g3d.ModelInstance;
 import com.badlogic.gdx.graphics.g3d.Renderable;
 import com.badlogic.gdx.graphics.g3d.Shader;
-import com.badlogic.gdx.graphics.g3d.loader.G3dModelLoader;
-import com.badlogic.gdx.graphics.g3d.model.MeshPart;
-import com.badlogic.gdx.graphics.g3d.model.Node;
-import com.badlogic.gdx.graphics.g3d.model.NodePart;
 import com.badlogic.gdx.graphics.g3d.shaders.BaseShader;
 import com.badlogic.gdx.graphics.glutils.ShaderProgram;
 import com.badlogic.gdx.tests.utils.GdxTest;
 import com.badlogic.gdx.tests.utils.GdxTestConfig;
 import com.badlogic.gdx.utils.BufferUtils;
 import com.badlogic.gdx.utils.GdxRuntimeException;
-import com.badlogic.gdx.utils.JsonReader;
 import com.badlogic.gdx.utils.ScreenUtils;
 
 import java.nio.Buffer;
@@ -85,13 +76,13 @@ public class ModelInstancedRenderingTest extends GdxTest {
 		}
 		((Buffer)offsets).position(0);
 		mesh.setInstanceData(offsets);
-		
+
 		renderable = new Renderable();
 		renderable.material = new Material();
 		renderable.meshPart.set("quad instanced", mesh, 0, 6, GL20.GL_TRIANGLES);
 		renderable.worldTransform.idt();
 		renderable.shader = new BaseShader() {
-			
+
 			@Override
 			public void init () {
 				ShaderProgram.prependVertexCode = "#version 300 es\n";
@@ -103,20 +94,20 @@ public class ModelInstancedRenderingTest extends GdxTest {
 				}
 				init(program, renderable);
 			}
-			
+
 			@Override
 			public int compareTo (Shader other) {
 				return 0;
 			}
-			
+
 			@Override
 			public boolean canRender (Renderable instance) {
 				return true;
 			}
 		};
-		
+
 		renderable.shader.init();
-		
+
 		camera = new OrthographicCamera();
 		batch = new ModelBatch();
 	}
@@ -129,6 +120,7 @@ public class ModelInstancedRenderingTest extends GdxTest {
 		batch.render(renderable);
 		batch.end();
 	}
+
 	@Override
 	public void dispose () {
 		mesh.dispose();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gles3/ModelInstancedRenderingTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gles3/ModelInstancedRenderingTest.java
@@ -1,0 +1,138 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogic.gdx.tests.gles3;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.assets.loaders.ModelLoader;
+import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.GL30;
+import com.badlogic.gdx.graphics.Mesh;
+import com.badlogic.gdx.graphics.OrthographicCamera;
+import com.badlogic.gdx.graphics.VertexAttribute;
+import com.badlogic.gdx.graphics.VertexAttributes.Usage;
+import com.badlogic.gdx.graphics.g3d.Material;
+import com.badlogic.gdx.graphics.g3d.Model;
+import com.badlogic.gdx.graphics.g3d.ModelBatch;
+import com.badlogic.gdx.graphics.g3d.ModelInstance;
+import com.badlogic.gdx.graphics.g3d.Renderable;
+import com.badlogic.gdx.graphics.g3d.Shader;
+import com.badlogic.gdx.graphics.g3d.loader.G3dModelLoader;
+import com.badlogic.gdx.graphics.g3d.model.MeshPart;
+import com.badlogic.gdx.graphics.g3d.model.Node;
+import com.badlogic.gdx.graphics.g3d.model.NodePart;
+import com.badlogic.gdx.graphics.g3d.shaders.BaseShader;
+import com.badlogic.gdx.graphics.glutils.ShaderProgram;
+import com.badlogic.gdx.tests.utils.GdxTest;
+import com.badlogic.gdx.tests.utils.GdxTestConfig;
+import com.badlogic.gdx.utils.BufferUtils;
+import com.badlogic.gdx.utils.GdxRuntimeException;
+import com.badlogic.gdx.utils.JsonReader;
+import com.badlogic.gdx.utils.ScreenUtils;
+
+import java.nio.Buffer;
+import java.nio.FloatBuffer;
+
+@GdxTestConfig(requireGL30 = true)
+public class ModelInstancedRenderingTest extends GdxTest {
+
+	Mesh mesh;
+	private ModelBatch batch;
+	private OrthographicCamera camera;
+	private Renderable renderable;
+
+	private final static int INSTANCE_COUNT_SQRT = 100;
+	private final static int INSTANCE_COUNT = INSTANCE_COUNT_SQRT * INSTANCE_COUNT_SQRT;
+
+	@Override
+	public void create () {
+		if (Gdx.gl30 == null) {
+			throw new GdxRuntimeException("GLES 3.0 profile required for this test");
+		}
+
+		mesh = new Mesh(true, 6, 0, new VertexAttribute(Usage.Position, 2, "a_position"));
+
+		float size = 2f / (float)Math.sqrt(INSTANCE_COUNT) * 0.5f;
+
+		float[] vertices = new float[] {0.0f, 0.0f, size, 0.0f, 0.0f, size,
+
+			size, 0.0f, size, size, 0.0f, size};
+
+		mesh.setVertices(vertices);
+
+		mesh.enableInstancedRendering(true, INSTANCE_COUNT, new VertexAttribute(Usage.Position, 2, "i_offset"),
+			new VertexAttribute(Usage.ColorUnpacked, 4, "i_color"));
+
+		FloatBuffer offsets = BufferUtils.newFloatBuffer(INSTANCE_COUNT * 6);
+		for (int x = 1; x <= INSTANCE_COUNT_SQRT; x++) {
+			for (int y = 1; y <= INSTANCE_COUNT_SQRT; y++) {
+				offsets.put(new float[] {x / (INSTANCE_COUNT_SQRT * 0.5f) - 1f, y / (INSTANCE_COUNT_SQRT * 0.5f) - 1f,
+					x / (float)INSTANCE_COUNT_SQRT, y / (float)INSTANCE_COUNT_SQRT, 1f, 1f});
+			}
+		}
+		((Buffer)offsets).position(0);
+		mesh.setInstanceData(offsets);
+		
+		renderable = new Renderable();
+		renderable.material = new Material();
+		renderable.meshPart.set("quad instanced", mesh, 0, 6, GL20.GL_TRIANGLES);
+		renderable.worldTransform.idt();
+		renderable.shader = new BaseShader() {
+			
+			@Override
+			public void init () {
+				ShaderProgram.prependVertexCode = "#version 300 es\n";
+				ShaderProgram.prependFragmentCode = "#version 300 es\n";
+				program = new ShaderProgram(Gdx.files.internal("data/shaders/instanced-rendering.vert"),
+					Gdx.files.internal("data/shaders/instanced-rendering.frag"));
+				if (!program.isCompiled()) {
+					throw new GdxRuntimeException("Shader compile error: " + program.getLog());
+				}
+				init(program, renderable);
+			}
+			
+			@Override
+			public int compareTo (Shader other) {
+				return 0;
+			}
+			
+			@Override
+			public boolean canRender (Renderable instance) {
+				return true;
+			}
+		};
+		
+		renderable.shader.init();
+		
+		camera = new OrthographicCamera();
+		batch = new ModelBatch();
+	}
+
+	@Override
+	public void render () {
+		ScreenUtils.clear(0.2f, 0.2f, 0.2f, 1f);
+
+		batch.begin(camera);
+		batch.render(renderable);
+		batch.end();
+	}
+	@Override
+	public void dispose () {
+		mesh.dispose();
+		batch.dispose();
+		renderable.shader.dispose();
+	}
+}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
@@ -82,6 +82,7 @@ import com.badlogic.gdx.tests.gles2.SimpleVertexShader;
 import com.badlogic.gdx.tests.gles2.VertexArrayTest;
 import com.badlogic.gdx.tests.gles3.GL30Texture3DTest;
 import com.badlogic.gdx.tests.gles3.InstancedRenderingTest;
+import com.badlogic.gdx.tests.gles3.ModelInstancedRenderingTest;
 import com.badlogic.gdx.tests.gles3.PixelBufferObjectTest;
 import com.badlogic.gdx.tests.math.collision.OrientedBoundingBoxTest;
 import com.badlogic.gdx.tests.net.NetAPITest;
@@ -195,6 +196,7 @@ public class GdxTests {
 		MipMapTest.class,
 		ModelTest.class,
 		ModelCacheTest.class,
+		ModelInstancedRenderingTest.class,
 		MoveSpriteExample.class,
 		MultipleRenderTargetTest.class,
 		MultitouchTest.class,


### PR DESCRIPTION
ModelInstancedRenderingTest is a copy of InstancedRenderingTest but using renderables instead.

In this case, Mesh used cached vertex attributes location for instanced buffer, which was wrong : instanced attributes are not part of vertex attributes.

Without the fix, the provided test crash because it has more instanced attributes than vertex attributes (index out of bounds exception) but for other cases, it fails silently and instanced data wasn't available in the shader.

This change is not optimal, we could cache instanced attributes locations as well but i'm not sure the best way to do that without breaking API a bit : we would need something like :
* change `Mesh.bind/unbind (final ShaderProgram shader, final int[] vertexLocations, final int [] instancedLocations)`
* add `Mesh.getInstancedAttributes()`

Since it's an optimisation, it should be done in another PR anyway. Any opinion on that ?