### PR TITLE
MathUtils.lerpAngle() fixes for extreme inputs.

### DIFF
--- a/gdx/src/com/badlogic/gdx/math/MathUtils.java
+++ b/gdx/src/com/badlogic/gdx/math/MathUtils.java
@@ -580,7 +580,7 @@ public final class MathUtils {
 	 * @return the interpolated angle in the range [0, PI2[ */
 	public static float lerpAngle (float fromRadians, float toRadians, float progress) {
 		float delta = (((toRadians - fromRadians) % PI2 + PI2 + PI) % PI2) - PI;
-		return (fromRadians + delta * progress + PI2) % PI2;
+		return ((fromRadians + delta * progress) % PI2 + PI2) % PI2;
 	}
 
 	/** Linearly interpolates between two angles in degrees. Takes into account that angles wrap at 360 degrees and always takes
@@ -591,8 +591,8 @@ public final class MathUtils {
 	 * @param progress interpolation value in the range [0, 1]
 	 * @return the interpolated angle in the range [0, 360[ */
 	public static float lerpAngleDeg (float fromDegrees, float toDegrees, float progress) {
-		float delta = (((toDegrees - fromDegrees) % 360 + 360 + 180) % 360) - 180;
-		return (fromDegrees + delta * progress + 360) % 360;
+		float delta = (((toDegrees - fromDegrees) % 360f + 360f + 180f) % 360f) - 180f;
+		return ((fromDegrees + delta * progress) % 360f + 360f) % 360f;
 	}
 
 	// ---

--- a/gdx/src/com/badlogic/gdx/math/MathUtils.java
+++ b/gdx/src/com/badlogic/gdx/math/MathUtils.java
@@ -579,7 +579,7 @@ public final class MathUtils {
 	 * @param progress interpolation value in the range [0, 1]
 	 * @return the interpolated angle in the range [0, PI2[ */
 	public static float lerpAngle (float fromRadians, float toRadians, float progress) {
-		float delta = ((toRadians - fromRadians + PI2 + PI) % PI2) - PI;
+		float delta = (((toRadians - fromRadians) % PI2 + PI2 + PI) % PI2) - PI;
 		return (fromRadians + delta * progress + PI2) % PI2;
 	}
 
@@ -591,7 +591,7 @@ public final class MathUtils {
 	 * @param progress interpolation value in the range [0, 1]
 	 * @return the interpolated angle in the range [0, 360[ */
 	public static float lerpAngleDeg (float fromDegrees, float toDegrees, float progress) {
-		float delta = ((toDegrees - fromDegrees + 360 + 180) % 360) - 180;
+		float delta = (((toDegrees - fromDegrees) % 360 + 360 + 180) % 360) - 180;
 		return (fromDegrees + delta * progress + 360) % 360;
 	}
 

--- a/gdx/test/com/badlogic/gdx/math/MathUtilsTest.java
+++ b/gdx/test/com/badlogic/gdx/math/MathUtilsTest.java
@@ -9,10 +9,33 @@ import org.junit.Test;
 public class MathUtilsTest {
 
 	@Test
+	public void lerpAngle () {
+		assertEquals(PI / 18f, MathUtils.lerpAngle(PI / 18f, PI / 6f, 0.0f), 0.01f);
+		assertEquals(PI / 9f, MathUtils.lerpAngle(PI / 18f, PI / 6f, 0.5f), 0.01f);
+		assertEquals(PI / 6f, MathUtils.lerpAngle(PI / 18f, PI / 6f, 1.0f), 0.01f);
+
+		// checks both negative c, which should produce a result close to HALF_PI, and
+		// positive c, which should be close to PI + HALF_PI.
+		// intentionally skips where c == 0, because there are two equally-valid results for that case.
+		for (float c = -1f; c <= 1f; c += 0.003f) {
+			assertEquals(PI + Math.copySign(HALF_PI, c) + c, MathUtils.lerpAngle(0, PI2 + PI + c + c, 0.5f), 0.01f);
+			assertEquals(PI + Math.copySign(HALF_PI, c) + c, MathUtils.lerpAngle(PI2 + PI + c + c, 0, 0.5f), 0.01f);
+		}
+	}
+
+	@Test
 	public void lerpAngleDeg () {
 		assertEquals(10, MathUtils.lerpAngleDeg(10, 30, 0.0f), 0.01f);
 		assertEquals(20, MathUtils.lerpAngleDeg(10, 30, 0.5f), 0.01f);
 		assertEquals(30, MathUtils.lerpAngleDeg(10, 30, 1.0f), 0.01f);
+
+		// checks both negative c, which should produce a result close to 90, and
+		// positive c, which should be close to 270.
+		// intentionally skips where c == 0, because there are two equally-valid results for that case.
+		for (float c = -80f; c <= 80f; c += 0.3f) {
+			assertEquals(180f + Math.copySign(90f, c) + c, MathUtils.lerpAngleDeg(0, 540 + c + c, 0.5f), 0.01f);
+			assertEquals(180f + Math.copySign(90f, c) + c, MathUtils.lerpAngleDeg(540 + c + c, 0, 0.5f), 0.01f);
+		}
 	}
 
 	@Test


### PR DESCRIPTION
When lerpAngle() or lerpAngleDeg() would be given a large negative angle, the result would be incorrect before, often by a large amount. This was found in #7104 by ZumiKua, and probably affects most libGDX versions so far. The discussion at that issue covers most of what went into this PR. I tested this both in libGDX's tests and in my library [digital's tests](https://github.com/tommyettinger/digital/blob/main/src/test/java/com/github/tommyettinger/digital/MathToolsTest.java), and it seems just about bulletproof for finite inputs. There could certainly be issues if any numbers get large enough to incur FP precision loss, but at some point you just have to say "your numbers are too big to be precise, so don't expect correct results." The downside here is that to support most of the reasonable number line, we need two more `%` operations, which are not incredibly cheap. However, because it's really common for angles to go above or below the 0-360 degree range when users can control an angle, I think having correct results for larger negative inputs is important.