### PR TITLE
Use latest Gradle API to register tasks

### DIFF
--- a/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/android/build.gradle
+++ b/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/android/build.gradle
@@ -2,18 +2,18 @@ android {
     namespace "%PACKAGE%"
     buildToolsVersion "%BUILD_TOOLS_VERSION%"
     compileSdkVersion %API_LEVEL%
-    sourceSets {
-        main {
-            manifest.srcFile 'AndroidManifest.xml'
-            java.srcDirs = ['src']
-            aidl.srcDirs = ['src']
-            renderscript.srcDirs = ['src']
-            res.srcDirs = ['res']
-            assets.srcDirs = ['../%ASSET_PATH%']
-            jniLibs.srcDirs = ['libs']
-        }
+        sourceSets {
+            main {
+                manifest.srcFile 'AndroidManifest.xml'
+                java.srcDirs = ['src']
+                aidl.srcDirs = ['src']
+                renderscript.srcDirs = ['src']
+                res.srcDirs = ['res']
+                assets.srcDirs = ['../%ASSET_PATH%']
+                jniLibs.srcDirs = ['libs']
+            }
 
-    }
+        }
     packagingOptions {
         exclude 'META-INF/robovm/ios/robovm.xml'
     }
@@ -36,7 +36,7 @@ android {
 // called every time gradle gets executed, takes the native dependencies of
 // the natives configuration, and extracts them to the proper libs/ folders
 // so they get packed with the APK.
-task copyAndroidNatives {
+tasks.register('copyAndroidNatives') {
     doFirst {
         file("libs/armeabi-v7a/").mkdirs()
         file("libs/arm64-v8a/").mkdirs()
@@ -47,9 +47,9 @@ task copyAndroidNatives {
             def outputDir = null
             if (jar.name.endsWith("natives-arm64-v8a.jar")) outputDir = file("libs/arm64-v8a")
             if (jar.name.endsWith("natives-armeabi-v7a.jar")) outputDir = file("libs/armeabi-v7a")
-            if(jar.name.endsWith("natives-x86_64.jar")) outputDir = file("libs/x86_64")
-            if(jar.name.endsWith("natives-x86.jar")) outputDir = file("libs/x86")
-            if(outputDir != null) {
+            if (jar.name.endsWith("natives-x86_64.jar")) outputDir = file("libs/x86_64")
+            if (jar.name.endsWith("natives-x86.jar")) outputDir = file("libs/x86")
+            if (outputDir != null) {
                 copy {
                     from zipTree(jar)
                     into outputDir
@@ -64,7 +64,7 @@ tasks.matching { it.name.contains("merge") && it.name.contains("JniLibFolders") 
     packageTask.dependsOn 'copyAndroidNatives'
 }
 
-task run(type: Exec) {
+tasks.register('run', Exec) {
     def path
     def localProperties = project.file("../local.properties")
     if (localProperties.exists()) {

--- a/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/android/build.gradle
+++ b/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/android/build.gradle
@@ -2,18 +2,18 @@ android {
     namespace "%PACKAGE%"
     buildToolsVersion "%BUILD_TOOLS_VERSION%"
     compileSdkVersion %API_LEVEL%
-        sourceSets {
-            main {
-                manifest.srcFile 'AndroidManifest.xml'
-                java.srcDirs = ['src']
-                aidl.srcDirs = ['src']
-                renderscript.srcDirs = ['src']
-                res.srcDirs = ['res']
-                assets.srcDirs = ['../%ASSET_PATH%']
-                jniLibs.srcDirs = ['libs']
-            }
-
+    sourceSets {
+        main {
+            manifest.srcFile 'AndroidManifest.xml'
+            java.srcDirs = ['src']
+            aidl.srcDirs = ['src']
+            renderscript.srcDirs = ['src']
+            res.srcDirs = ['res']
+            assets.srcDirs = ['../%ASSET_PATH%']
+            jniLibs.srcDirs = ['libs']
         }
+
+    }
     packagingOptions {
         exclude 'META-INF/robovm/ios/robovm.xml'
     }

--- a/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/html/build.gradle
+++ b/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/html/build.gradle
@@ -22,7 +22,7 @@ gretty.resourceBase = project.buildDir.path + "/gwt/draftOut"
 gretty.contextPath = "/"
 gretty.portPropertiesFileName = "TEMP_PORTS.properties"
 
-task startHttpServer () {
+tasks.register("startHttpServer") {
     dependsOn draftCompileGwt
 
     doFirst {
@@ -38,7 +38,8 @@ task startHttpServer () {
     }
 }
 
-task beforeRun(type: AppBeforeIntegrationTestTask, dependsOn: startHttpServer) {
+tasks.register("beforeRun", AppBeforeIntegrationTestTask) {
+    dependsOn startHttpServer
     // The next line allows ports to be reused instead of
     // needing a process to be manually terminated.
     file("build/TEMP_PORTS.properties").delete()
@@ -50,14 +51,15 @@ task beforeRun(type: AppBeforeIntegrationTestTask, dependsOn: startHttpServer) {
     interactive false
 }
 
-task superDev (type: GwtSuperDev) {
+tasks.register("superDev", GwtSuperDev) {
     dependsOn startHttpServer
     doFirst {
         gwt.modules = gwt.devModules
     }
 }
 
-task dist(dependsOn: [clean, compileGwt]) {
+tasks.register("dist") {
+    dependsOn clean, compileGwt
     doLast {
         file("build/dist").mkdirs()
         copy {
@@ -67,7 +69,7 @@ task dist(dependsOn: [clean, compileGwt]) {
         copy {
             from "webapp"
             into "build/dist"
-            }
+        }
         copy {
             from "war"
             into "build/dist"
@@ -75,7 +77,7 @@ task dist(dependsOn: [clean, compileGwt]) {
     }
 }
 
-task addSource {
+tasks.register("addSource") {
     doLast {
         sourceSets.main.compileClasspath += files(project(':core').sourceSets.main.allJava.srcDirs)
     }

--- a/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/html/build.gradle
+++ b/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/html/build.gradle
@@ -22,7 +22,7 @@ gretty.resourceBase = project.buildDir.path + "/gwt/draftOut"
 gretty.contextPath = "/"
 gretty.portPropertiesFileName = "TEMP_PORTS.properties"
 
-tasks.register("startHttpServer") {
+tasks.register('startHttpServer') {
     dependsOn draftCompileGwt
 
     doFirst {
@@ -38,7 +38,7 @@ tasks.register("startHttpServer") {
     }
 }
 
-tasks.register("beforeRun", AppBeforeIntegrationTestTask) {
+tasks.register('beforeRun', AppBeforeIntegrationTestTask) {
     dependsOn startHttpServer
     // The next line allows ports to be reused instead of
     // needing a process to be manually terminated.
@@ -51,14 +51,14 @@ tasks.register("beforeRun", AppBeforeIntegrationTestTask) {
     interactive false
 }
 
-tasks.register("superDev", GwtSuperDev) {
+tasks.register('superDev', GwtSuperDev) {
     dependsOn startHttpServer
     doFirst {
         gwt.modules = gwt.devModules
     }
 }
 
-tasks.register("dist") {
+tasks.register('dist') {
     dependsOn clean, compileGwt
     doLast {
         file("build/dist").mkdirs()
@@ -77,7 +77,7 @@ tasks.register("dist") {
     }
 }
 
-tasks.register("addSource") {
+tasks.register('addSource') {
     doLast {
         sourceSets.main.compileClasspath += files(project(':core').sourceSets.main.allJava.srcDirs)
     }

--- a/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/lwjgl2/build.gradle
+++ b/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/lwjgl2/build.gradle
@@ -5,7 +5,8 @@ sourceSets.main.resources.srcDirs = ["../%ASSET_PATH%"]
 project.ext.mainClassName = "%PACKAGE%.DesktopLauncher"
 project.ext.assetsDir = new File("../%ASSET_PATH%")
 
-task run(dependsOn: classes, type: JavaExec) {
+tasks.register('run', JavaExec) {
+    dependsOn classes
     mainClass = project.mainClassName
     classpath = sourceSets.main.runtimeClasspath
     standardInput = System.in
@@ -13,7 +14,8 @@ task run(dependsOn: classes, type: JavaExec) {
     ignoreExitValue = true
 }
 
-task debug(dependsOn: classes, type: JavaExec) {
+tasks.register('debug', JavaExec) {
+    dependsOn classes
     mainClass = project.mainClassName
     classpath = sourceSets.main.runtimeClasspath
     standardInput = System.in
@@ -22,7 +24,7 @@ task debug(dependsOn: classes, type: JavaExec) {
     debug = true
 }
 
-task dist(type: Jar) {
+tasks.register('dist', Jar) {
     manifest {
         attributes 'Main-Class': project.mainClassName
     }

--- a/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/lwjgl3/build.gradle
+++ b/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/lwjgl3/build.gradle
@@ -7,7 +7,8 @@ project.ext.assetsDir = new File("../%ASSET_PATH%")
 
 import org.gradle.internal.os.OperatingSystem
 
-task run(dependsOn: classes, type: JavaExec) {
+tasks.register('run', JavaExec) {
+    dependsOn classes
     mainClass = project.mainClassName
     classpath = sourceSets.main.runtimeClasspath
     standardInput = System.in
@@ -20,7 +21,8 @@ task run(dependsOn: classes, type: JavaExec) {
     }
 }
 
-task debug(dependsOn: classes, type: JavaExec) {
+tasks.register('debug', JavaExec) {
+    dependsOn classes
     mainClass = project.mainClassName
     classpath = sourceSets.main.runtimeClasspath
     standardInput = System.in
@@ -29,7 +31,7 @@ task debug(dependsOn: classes, type: JavaExec) {
     debug = true
 }
 
-task dist(type: Jar) {
+tasks.register('dist', Jar) {
     duplicatesStrategy(DuplicatesStrategy.EXCLUDE)
     manifest {
         attributes 'Main-Class': project.mainClassName


### PR DESCRIPTION
Gradle now recommends using `tasks.register`. See https://docs.gradle.org/current/userguide/task_configuration_avoidance.html#sec:task_configuration_avoidance_guidelines