### PR TITLE
feat: Update to jnigen 2.4.0

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -12,6 +12,9 @@
 - [BREAKING CHANGE] 3D API - max bone weights is now configurable and limited to 4 by default. Change this value if you need less or more. See #6522.
 - [BREAKING CHANGE] Mesh#getVerticesBuffer, Mesh#getIndicesBuffer, VertexData#getBuffer, and IndexData#getBuffer are deprecated in favor to new methods with boolean parameter. If you subclassed some of these classes, you need to implement the new methods.
 - [BREAKING CHANGE] Desktop: The return value of AudioDevice#getLatency() is now in samples, and not milliseconds
+- [BREAKING CHANGE] iOS: Removed armv7 builds
+- [BREAKING CHANGE] iOS: Use dynamic frameworks instead of static libs
+- Update to jnigen 2.4.0
 - LWJGL Fix: setPosision() for MP3 files.
 - iOS: Add new MobiVM MetalANGLE backend
 - iOS: Update to MobiVM 2.3.19

--- a/build.gradle
+++ b/build.gradle
@@ -19,10 +19,11 @@ buildscript {
 	repositories {
 		mavenCentral()
 		gradlePluginPortal()
+		maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
 	}
 	dependencies {
 		classpath "com.diffplug.spotless:spotless-plugin-gradle:${versions.spotless}"
-		classpath "com.badlogicgames.gdx:gdx-jnigen-gradle:2.3.1"
+		classpath "com.badlogicgames.gdx:gdx-jnigen-gradle:2.4.0-SNAPSHOT"
 	}
 }
 

--- a/extensions/gdx-box2d/gdx-box2d/jni/.gitignore
+++ b/extensions/gdx-box2d/gdx-box2d/jni/.gitignore
@@ -5,3 +5,4 @@ Android.mk
 Application.mk
 jni-headers
 memcpy_wrap.c
+Info.plist

--- a/extensions/gdx-bullet/jni/.gitignore
+++ b/extensions/gdx-bullet/jni/.gitignore
@@ -5,3 +5,4 @@ Android.mk
 Application.mk
 jni-headers
 memcpy_wrap.c
+Info.plist

--- a/extensions/gdx-freetype/jni/.gitignore
+++ b/extensions/gdx-freetype/jni/.gitignore
@@ -5,3 +5,4 @@ Android.mk
 Application.mk
 jni-headers
 memcpy_wrap.c
+Info.plist

--- a/gdx/build.gradle
+++ b/gdx/build.gradle
@@ -71,15 +71,9 @@ jnigen {
 	add(IOS) {
 		headerDirs = ["iosgl"]
 		cppExcludes = []
+		linkerFlags += " -undefined dynamic_lookup "
 	}
 	robovm {
-		if (file("libs/ios32/ObjectAL.xcframework/ios-arm64_armv7/").exists()) {
-			extraLib("libs/ObjectAL.xcframework/ios-arm64_armv7/libObjectAL.a", "device")
-		} else if (file("libs/ios32/ObjectAL.xcframework/ios-arm64/").exists()) {
-			extraLib("libs/ObjectAL.xcframework/ios-arm64/libObjectAL.a", "device")
-		} else {
-			getLogger().warn("ObjectAL is not build yet. Please run `fetchNatives` or build it to silence this warning.")
-		}
-		extraLib("libs/ObjectAL.xcframework/ios-arm64_x86_64-simulator/libObjectAL.a", "simulator")
+		extraXCFramework("libs/ObjectAL.xcframework")
 	}
 }

--- a/gdx/jni/.gitignore
+++ b/gdx/jni/.gitignore
@@ -5,3 +5,4 @@ Android.mk
 Application.mk
 jni-headers
 memcpy_wrap.c
+Info.plist


### PR DESCRIPTION
For the moment this pr relies on a snapshot. Once jnigen 2.4.0 is released, this pr will be updated and can be merged. 

Currently we need to rely on `-undefined dynamic_lookup` for the iosgl natives, since the symbol resolution is backend dependent for either MetalANGLE or OpenGLES. 

ObjectAL can be changed to a dynamic framework, if https://github.com/libgdx/ObjectAL-for-iPhone/pull/1 gets merged.