### PR TITLE
Use STBVorbis to decode ogg data for Sound

### DIFF
--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/Ogg.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/Ogg.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,19 +16,16 @@
 
 package com.badlogic.gdx.backends.lwjgl3.audio;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.ByteBuffer;
-import java.nio.IntBuffer;
-import java.nio.ShortBuffer;
-
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.utils.BufferUtils;
 import com.badlogic.gdx.utils.GdxRuntimeException;
 import com.badlogic.gdx.utils.StreamUtils;
 import org.lwjgl.stb.STBVorbis;
 import org.lwjgl.system.MemoryStack;
+
+import java.nio.ByteBuffer;
+import java.nio.IntBuffer;
+import java.nio.ShortBuffer;
 
 /** @author Nathan Sweet */
 public class Ogg {
@@ -71,43 +68,23 @@ public class Ogg {
 			super(audio);
 			if (audio.noDevice) return;
 
-			// read file into byte array
-			InputStream stream = file.read();
-			final ByteArrayOutputStream converterStream = new ByteArrayOutputStream();
-			final byte[] converterBuffer = new byte[20000];
-			try {
-				while (true) {
-					final int read = stream.read(converterBuffer);
-					if (read <= 0) {
-						break;
-					}
-					converterStream.write(converterBuffer, 0, read);
-				}
-			} catch (IOException e) {
-				throw new GdxRuntimeException("Error reading OGG file: " + file, e);
-			} finally {
-				StreamUtils.closeQuietly(stream);
-			}
-
 			// put the encoded audio data in a ByteBuffer
-			byte[] streamData = converterStream.toByteArray();
+			byte[] streamData = file.readBytes();
 			ByteBuffer encodedData = BufferUtils.newByteBuffer(streamData.length);
 			encodedData.put(streamData);
 			encodedData.flip();
 
 			try (MemoryStack stack = MemoryStack.stackPush()) {
-				final IntBuffer channelsBuffer = stack.mallocInt(1);
-				final IntBuffer sampleRateBuffer = stack.mallocInt(1);
+				final IntBuffer channels = stack.mallocInt(1);
+				final IntBuffer sampleRate = stack.mallocInt(1);
 
 				// decode
-				final ShortBuffer decodedData = STBVorbis.stb_vorbis_decode_memory(encodedData, channelsBuffer, sampleRateBuffer);
+				final ShortBuffer decodedData = STBVorbis.stb_vorbis_decode_memory(encodedData, channels, sampleRate);
 				if (decodedData == null) {
 					throw new GdxRuntimeException("Error decoding OGG file: " + file);
 				}
 
-				final int channels = channelsBuffer.get(0);
-				final int sampleRate = sampleRateBuffer.get(0);
-				setup(decodedData, channels, sampleRate);
+				setup(decodedData, channels.get(0), sampleRate.get(0));
 			}
 		}
 	}

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/Ogg.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/Ogg.java
@@ -75,16 +75,20 @@ public class Ogg {
 			encodedData.flip();
 
 			try (MemoryStack stack = MemoryStack.stackPush()) {
-				final IntBuffer channels = stack.mallocInt(1);
-				final IntBuffer sampleRate = stack.mallocInt(1);
+				final IntBuffer channelsBuffer = stack.mallocInt(1);
+				final IntBuffer sampleRateBuffer = stack.mallocInt(1);
 
 				// decode
-				final ShortBuffer decodedData = STBVorbis.stb_vorbis_decode_memory(encodedData, channels, sampleRate);
+				final ShortBuffer decodedData = STBVorbis.stb_vorbis_decode_memory(encodedData, channelsBuffer, sampleRateBuffer);
+				int channels = channelsBuffer.get(0);
+				int sampleRate = sampleRateBuffer.get(0);
 				if (decodedData == null) {
 					throw new GdxRuntimeException("Error decoding OGG file: " + file);
+				} else if (channels < 1 || channels > 2) {
+					throw new GdxRuntimeException("Error decoding OGG file, unsupported number of channels: " + file);
 				}
 
-				setup(decodedData, channels.get(0), sampleRate.get(0));
+				setup(decodedData, channels, sampleRate);
 			}
 		}
 	}

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALSound.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALSound.java
@@ -19,6 +19,7 @@ package com.badlogic.gdx.backends.lwjgl3.audio;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.ShortBuffer;
 
 import com.badlogic.gdx.audio.Sound;
 
@@ -36,20 +37,28 @@ public class OpenALSound implements Sound {
 	}
 
 	void setup (byte[] pcm, int channels, int sampleRate) {
-		this.channels = channels;
-		this.sampleRate = sampleRate;
 		int bytes = pcm.length - (pcm.length % (channels > 1 ? 4 : 2));
-		int samples = bytes / (2 * channels);
-		duration = samples / (float)sampleRate;
 
 		ByteBuffer buffer = ByteBuffer.allocateDirect(bytes);
 		buffer.order(ByteOrder.nativeOrder());
 		buffer.put(pcm, 0, bytes);
 		((Buffer)buffer).flip();
 
+		setup(buffer.asShortBuffer(), channels, sampleRate);
+	}
+
+	void setup (ShortBuffer pcm, int channels, int sampleRate) {
+		this.channels = channels;
+		this.sampleRate = sampleRate;
+		int pcmLength = pcm.limit();
+		int bytes = pcmLength - (pcmLength % (channels > 1 ? 4 : 2));
+		int samples = bytes / (2 * channels);
+		duration = samples / (float)sampleRate;
+		System.out.println("duration: " + duration);
+
 		if (bufferID == -1) {
 			bufferID = alGenBuffers();
-			alBufferData(bufferID, channels > 1 ? AL_FORMAT_STEREO16 : AL_FORMAT_MONO16, buffer.asShortBuffer(), sampleRate);
+			alBufferData(bufferID, channels > 1 ? AL_FORMAT_STEREO16 : AL_FORMAT_MONO16, pcm, sampleRate);
 		}
 	}
 

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALSound.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALSound.java
@@ -54,7 +54,6 @@ public class OpenALSound implements Sound {
 		int bytes = pcmLength - (pcmLength % (channels > 1 ? 4 : 2));
 		int samples = bytes / (2 * channels);
 		duration = samples / (float)sampleRate;
-		System.out.println("duration: " + duration);
 
 		if (bufferID == -1) {
 			bufferID = alGenBuffers();

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALSound.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALSound.java
@@ -16,12 +16,12 @@
 
 package com.badlogic.gdx.backends.lwjgl3.audio;
 
+import com.badlogic.gdx.audio.Sound;
+import com.badlogic.gdx.utils.BufferUtils;
+
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 import java.nio.ShortBuffer;
-
-import com.badlogic.gdx.audio.Sound;
 
 import static org.lwjgl.openal.AL10.*;
 
@@ -37,11 +37,8 @@ public class OpenALSound implements Sound {
 	}
 
 	void setup (byte[] pcm, int channels, int sampleRate) {
-		int bytes = pcm.length - (pcm.length % (channels > 1 ? 4 : 2));
-
-		ByteBuffer buffer = ByteBuffer.allocateDirect(bytes);
-		buffer.order(ByteOrder.nativeOrder());
-		buffer.put(pcm, 0, bytes);
+		ByteBuffer buffer = BufferUtils.newByteBuffer(pcm.length);
+		buffer.put(pcm);
 		((Buffer)buffer).flip();
 
 		setup(buffer.asShortBuffer(), channels, sampleRate);
@@ -50,10 +47,8 @@ public class OpenALSound implements Sound {
 	void setup (ShortBuffer pcm, int channels, int sampleRate) {
 		this.channels = channels;
 		this.sampleRate = sampleRate;
-		int pcmLength = pcm.limit();
-		int bytes = pcmLength - (pcmLength % (channels > 1 ? 4 : 2));
-		int samples = bytes / (2 * channels);
-		duration = samples / (float)sampleRate;
+		int sampleFrames = pcm.limit() / channels;
+		duration = sampleFrames / (float)sampleRate;
 
 		if (bufferID == -1) {
 			bufferID = alGenBuffers();

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALSound.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALSound.java
@@ -37,8 +37,9 @@ public class OpenALSound implements Sound {
 	}
 
 	void setup (byte[] pcm, int channels, int sampleRate) {
-		ByteBuffer buffer = BufferUtils.newByteBuffer(pcm.length);
-		buffer.put(pcm);
+		int validBytes = pcm.length - (pcm.length % (channels > 1 ? 4 : 2));
+		ByteBuffer buffer = BufferUtils.newByteBuffer(validBytes);
+		buffer.put(pcm, 0, validBytes);
 		((Buffer)buffer).flip();
 
 		setup(buffer.asShortBuffer(), channels, sampleRate);


### PR DESCRIPTION
I replaced the jorbis ogg decoder by STBVorbis for Sounds (literally the Sound class, not Music) in the lwjgl3 backend. This drastically reduces the loading time, usually something between 40% and 60%, depending on the file.

"Fixes" [https://github.com/libgdx/libgdx/issues/6635](https://github.com/libgdx/libgdx/issues/6635) I guess?

Since this change will affect almost all users and I don't want to take this lightly, I'd like to mention the limitations of the decoder, that ... I don't understand ... but maybe someone else:

- floor 0 not supported (used in old ogg vorbis files pre-2004)
- lossless sample-truncation at beginning ignored
- cannot concatenate multiple vorbis streams
- sample positions are 32-bit, limiting seekable 192Khz files to around 6 hours (Ogg supports 64-bit)

I only tested on Windows 11.