### PR TITLE
Allow packed depth stencil buffer creation

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/glutils/GLFrameBuffer.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/GLFrameBuffer.java
@@ -271,7 +271,10 @@ public abstract class GLFrameBuffer<T extends GLTexture> implements Disposable {
 		boolean runningGL30 = Gdx.graphics.isGL30Available();
 
 		if (!runningGL30) {
-			if (bufferBuilder.hasPackedStencilDepthRenderBuffer) {
+			final boolean supportsPackedDepthStencil = Gdx.graphics.supportsExtension("GL_OES_packed_depth_stencil")
+				|| Gdx.graphics.supportsExtension("GL_EXT_packed_depth_stencil");
+
+			if (bufferBuilder.hasPackedStencilDepthRenderBuffer && !supportsPackedDepthStencil) {
 				throw new GdxRuntimeException("Packed Stencil/Render render buffers are not available on GLES 2.0");
 			}
 			if (bufferBuilder.textureAttachmentSpecs.size > 1) {


### PR DESCRIPTION
Quick PR in order to allow the packed depth stencil render buffer creation even if it's not using GL30 (as it was done at https://github.com/dar-dev/libgdx-pr/blob/ae00db682e3182440099c9d41ab9e7ee3c4a40aa/gdx/src/com/badlogic/gdx/graphics/glutils/GLFrameBuffer.java#L230)