### PR TITLE
Remove Android Build Tools version check from gdx-setup

### DIFF
--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetup.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetup.java
@@ -74,12 +74,6 @@ public class GdxSetup {
 			} else {
 				DependencyBank.buildToolsVersion = newestLocalTool;
 			}
-		} else {
-			if (!versionsEqual(localToolVersion, targetToolVersion)) {
-				JOptionPane.showMessageDialog(null,
-					"Please update your Android SDK, you need build tools: " + DependencyBank.buildToolsVersion);
-				return false;
-			}
 		}
 
 		int newestLocalApi = getLatestApi(apis);
@@ -202,6 +196,7 @@ public class GdxSetup {
 		return true;
 	}
 
+	/** @return true if testVersion greater than version */
 	private static boolean compareVersions (int[] version, int[] testVersion) {
 		if (testVersion[0] > version[0]) {
 			return true;

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/SettingsDialog.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/SettingsDialog.java
@@ -88,7 +88,7 @@ public class SettingsDialog extends JDialog {
 			public void actionPerformed (ActionEvent e) {
 				if (offlineBox.isSelected()) {
 					int value = JOptionPane.showConfirmDialog(null,
-						"You have selected offline mode. This requires you to have your dependencies already in your maven/gradle cache.\n\nThe setup will fail if you do not have the correct dependenices already.\n\nDo you want to continue?",
+						"You have selected offline mode. This requires you to have your dependencies already in your maven/gradle cache.\n\nThe setup will fail if you do not have the correct dependencies already.\n\nDo you want to continue?",
 						"Warning!", JOptionPane.YES_NO_OPTION);
 					if (value == 0) {
 						onOK();


### PR DESCRIPTION
#7064 is causing problems for users on Discord, and even myself. If you don't have Build Tools 33.0.2 installed, gdx-setup tells you to update it. It doesn't say *how* to update it, just that it needs updating. For the record: Tools -> [if on IDEA, Android] -> SDK Manager -> SDK Tools -> check Show Package Details -> check or uncheck versions as desired (before this PR, 33.0.2 must be checked) -> OK.

As the Android plugin (for IntelliJ IDEA, or baked into Android Studio) will automatically install the correct Build Tools version (or prompt them to accept the licence if they haven't already done so) I see no need for this check. Frankly, it shouldn't even matter whether someone has 33.0.2 or 33.0.1 - any minor version will work 99% as well as any other.

Tested by:

1. Uninstalling my copy of Build Tools 33.0.2
2. Attempting to generate a project from the current gdx-setup (no cigar)
3. Generating a project using these new changes
4. Opening the project
5. Confirming that 33.0.2 has been installed