### PR TITLE
Another potential CI fix

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -178,6 +178,7 @@ jobs:
 
       - name: Install cross-compilation toolchains
         run: |
+          sudo apt update
           sudo apt install -y --force-yes mingw-w64 lib32z1
 
       - name: Cache Gradle packages

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -127,6 +127,7 @@ jobs:
 
       - name: Install cross-compilation toolchains
         run: |
+          sudo apt update
           sudo apt install -y --force-yes gcc g++
           sudo apt install -y --force-yes gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libc6-dev-arm64-cross
           sudo apt install -y --force-yes gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf libc6-dev-armhf-cross


### PR DESCRIPTION
I guess the issue is, that the runner image apt cache is out of date.
https://github.com/libgdx/libgdx/actions/runs/5115098538/jobs/9196023119
Even if it is not, change shouldn't hurt.