### PR TITLE
Upgrade to jnigen 2.4.1 to fix app store publishing

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -15,7 +15,7 @@
 - [BREAKING CHANGE] iOS: 32 bit (armv7) builds are no longer supported. Builds must be 64 bit (arm64) only.
 - [BREAKING CHANGE] iOS: Use dynamic frameworks instead of static libs
 - [BREAKING CHANGE] optimized Mesh#bind and Mesh#unbind have a new parameter for instanced attribute locations. If you use these methods without instancing, you can pass a null value.
-- Update to jnigen 2.4.0
+- Update to jnigen 2.4.1
 - LWJGL Fix: setPosision() for MP3 files.
 - iOS: Add new MobiVM MetalANGLE backend
 - iOS: Update to MobiVM 2.3.19

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
 	}
 	dependencies {
 		classpath "com.diffplug.spotless:spotless-plugin-gradle:${versions.spotless}"
-		classpath "com.badlogicgames.gdx:gdx-jnigen-gradle:2.4.0"
+		classpath "com.badlogicgames.gdx:gdx-jnigen-gradle:2.4.1"
 	}
 }
 


### PR DESCRIPTION
It was reported on discord, jnigen 2.4.0 has broken min iOS version configuration and app build with it, can't be deployed to the app store.