### PR TITLE
Fix borderless fullscreen when taskbar is on the left/top

### DIFF
--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
@@ -26,7 +26,6 @@ import com.badlogic.gdx.backends.lwjgl3.audio.Lwjgl3Audio;
 import com.badlogic.gdx.backends.lwjgl3.audio.OpenALLwjgl3Audio;
 import com.badlogic.gdx.graphics.glutils.GLVersion;
 
-import org.lwjgl.BufferUtils;
 import org.lwjgl.glfw.GLFW;
 import org.lwjgl.glfw.GLFWErrorCallback;
 import org.lwjgl.opengl.AMDDebugOutput;

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
@@ -50,6 +50,7 @@ import com.badlogic.gdx.LifecycleListener;
 import com.badlogic.gdx.Net;
 import com.badlogic.gdx.Preferences;
 import com.badlogic.gdx.backends.lwjgl3.audio.mock.MockAudio;
+import com.badlogic.gdx.math.GridPoint2;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.Clipboard;
 import com.badlogic.gdx.utils.GdxRuntimeException;
@@ -531,7 +532,7 @@ public class Lwjgl3Application implements Lwjgl3ApplicationBase {
 		Lwjgl3Window.setSizeLimits(windowHandle, config.windowMinWidth, config.windowMinHeight, config.windowMaxWidth,
 			config.windowMaxHeight);
 		if (config.fullscreenMode == null) {
-			if (config.windowX == -1 && config.windowY == -1) {
+			if (config.windowX == -1 && config.windowY == -1) { // i.e., center the window
 				int windowWidth = Math.max(config.windowWidth, config.windowMinWidth);
 				int windowHeight = Math.max(config.windowHeight, config.windowMinHeight);
 				if (config.windowMaxWidth > -1) windowWidth = Math.min(windowWidth, config.windowMaxWidth);
@@ -542,14 +543,9 @@ public class Lwjgl3Application implements Lwjgl3ApplicationBase {
 					monitorHandle = config.maximizedMonitor.monitorHandle;
 				}
 
-				IntBuffer areaXPos = BufferUtils.createIntBuffer(1);
-				IntBuffer areaYPos = BufferUtils.createIntBuffer(1);
-				IntBuffer areaWidth = BufferUtils.createIntBuffer(1);
-				IntBuffer areaHeight = BufferUtils.createIntBuffer(1);
-				GLFW.glfwGetMonitorWorkarea(monitorHandle, areaXPos, areaYPos, areaWidth, areaHeight);
-
-				GLFW.glfwSetWindowPos(windowHandle, Math.max(0, areaXPos.get(0) + areaWidth.get(0) / 2 - windowWidth / 2),
-					Math.max(0, areaYPos.get(0) + areaHeight.get(0) / 2 - windowHeight / 2));
+				GridPoint2 newPos = Lwjgl3ApplicationConfiguration.calculateCenteredWindowPosition(
+					Lwjgl3ApplicationConfiguration.toLwjgl3Monitor(monitorHandle), windowWidth, windowHeight);
+				GLFW.glfwSetWindowPos(windowHandle, newPos.x, newPos.y);
 			} else {
 				GLFW.glfwSetWindowPos(windowHandle, config.windowX, config.windowY);
 			}

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3ApplicationConfiguration.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3ApplicationConfiguration.java
@@ -36,6 +36,7 @@ import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Graphics.Lwjgl3Monitor;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.glutils.HdpiMode;
 import com.badlogic.gdx.graphics.glutils.HdpiUtils;
+import com.badlogic.gdx.math.GridPoint2;
 
 public class Lwjgl3ApplicationConfiguration extends Lwjgl3WindowConfiguration {
 	public static PrintStream errorStream = System.err;
@@ -281,5 +282,40 @@ public class Lwjgl3ApplicationConfiguration extends Lwjgl3WindowConfiguration {
 		int virtualY = tmp2.get(0);
 		String name = GLFW.glfwGetMonitorName(glfwMonitor);
 		return new Lwjgl3Monitor(glfwMonitor, virtualX, virtualY, name);
+	}
+
+	static GridPoint2 calculateCenteredWindowPosition (Lwjgl3Monitor monitor, int newWidth, int newHeight) {
+		IntBuffer tmp = BufferUtils.createIntBuffer(1);
+		IntBuffer tmp2 = BufferUtils.createIntBuffer(1);
+		IntBuffer tmp3 = BufferUtils.createIntBuffer(1);
+		IntBuffer tmp4 = BufferUtils.createIntBuffer(1);
+
+		DisplayMode displayMode = getDisplayMode(monitor);
+
+		GLFW.glfwGetMonitorWorkarea(monitor.monitorHandle, tmp, tmp2, tmp3, tmp4);
+		int workareaWidth = tmp3.get(0);
+		int workareaHeight = tmp4.get(0);
+
+		int minX, minY, maxX, maxY;
+
+		// If the new width is greater than the working area, we have to ignore stuff like the taskbar for centering and use the
+		// whole monitor's size
+		if (newWidth > workareaWidth) {
+			minX = monitor.virtualX;
+			maxX = displayMode.width;
+		} else {
+			minX = tmp.get(0);
+			maxX = workareaWidth;
+		}
+		// The same is true for height
+		if (newHeight > workareaHeight) {
+			minY = monitor.virtualY;
+			maxY = displayMode.height;
+		} else {
+			minY = tmp2.get(0);
+			maxY = workareaHeight;
+		}
+
+		return new GridPoint2(Math.max(minX, minX + (maxX - newWidth) / 2), Math.max(minY, minY + (maxY - newHeight) / 2));
 	}
 }

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Graphics.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Graphics.java
@@ -22,6 +22,7 @@ import com.badlogic.gdx.AbstractGraphics;
 import com.badlogic.gdx.Application;
 import com.badlogic.gdx.Gdx;
 
+import com.badlogic.gdx.math.GridPoint2;
 import com.badlogic.gdx.utils.GdxRuntimeException;
 import org.lwjgl.BufferUtils;
 import org.lwjgl.PointerBuffer;
@@ -68,8 +69,6 @@ public class Lwjgl3Graphics extends AbstractGraphics implements Disposable {
 
 	IntBuffer tmpBuffer = BufferUtils.createIntBuffer(1);
 	IntBuffer tmpBuffer2 = BufferUtils.createIntBuffer(1);
-	IntBuffer tmpBuffer3 = BufferUtils.createIntBuffer(1);
-	IntBuffer tmpBuffer4 = BufferUtils.createIntBuffer(1);
 
 	GLFWFramebufferSizeCallback resizeCallback = new GLFWFramebufferSizeCallback() {
 		volatile boolean posted;
@@ -455,36 +454,29 @@ public class Lwjgl3Graphics extends AbstractGraphics implements Disposable {
 
 	@Override
 	public boolean setWindowedMode (int width, int height) {
-		int minX, minY;
 		window.getInput().resetPollingStates();
 		if (!isFullscreen()) {
-			int newX = 0, newY = 0;
+			GridPoint2 newPos = null;
 			boolean centerWindow = false;
 			if (width != logicalWidth || height != logicalHeight) {
-				centerWindow = true;
-				Lwjgl3Monitor monitor = (Lwjgl3Monitor)getMonitor();
-				GLFW.glfwGetMonitorWorkarea(monitor.monitorHandle, tmpBuffer, tmpBuffer2, tmpBuffer3, tmpBuffer4);
-				minX = tmpBuffer.get(0);
-				minY = tmpBuffer2.get(0);
-				newX = Math.max(minX, minX + (tmpBuffer3.get(0) - width) / 2);
-				newY = Math.max(minY, minY + (tmpBuffer4.get(0) - height) / 2);
+				centerWindow = true; // recenter the window since its size changed
+				newPos = Lwjgl3ApplicationConfiguration.calculateCenteredWindowPosition((Lwjgl3Monitor)getMonitor(), width, height);
 			}
 			GLFW.glfwSetWindowSize(window.getWindowHandle(), width, height);
 			if (centerWindow) {
-				window.setPosition(newX, newY); // on macOS the centering has to happen _after_ the new window size was set
+				window.setPosition(newPos.x, newPos.y); // on macOS the centering has to happen _after_ the new window size was set
 			}
-		} else {
+		} else { // if we were in fullscreen mode, we should consider restoring a previous display mode
 			if (displayModeBeforeFullscreen == null) {
 				storeCurrentWindowPositionAndDisplayMode();
 			}
-			if (width != windowWidthBeforeFullscreen || height != windowHeightBeforeFullscreen) { // Center window
-				Lwjgl3Monitor monitor = (Lwjgl3Monitor)getMonitor();
-				GLFW.glfwGetMonitorWorkarea(monitor.monitorHandle, tmpBuffer, tmpBuffer2, tmpBuffer3, tmpBuffer4);
-				minX = tmpBuffer.get(0);
-				minY = tmpBuffer2.get(0);
-				GLFW.glfwSetWindowMonitor(window.getWindowHandle(), 0, Math.max(minX, minX + (tmpBuffer3.get(0) - width) / 2),
-					Math.max(minY, minY + (tmpBuffer4.get(0) - height) / 2), width, height, displayModeBeforeFullscreen.refreshRate);
-			} else {
+			if (width != windowWidthBeforeFullscreen || height != windowHeightBeforeFullscreen) { // center the window since its size
+				// changed
+				GridPoint2 newPos = Lwjgl3ApplicationConfiguration.calculateCenteredWindowPosition((Lwjgl3Monitor)getMonitor(), width,
+					height);
+				GLFW.glfwSetWindowMonitor(window.getWindowHandle(), 0, newPos.x, newPos.y, width, height,
+					displayModeBeforeFullscreen.refreshRate);
+			} else { // restore previous position
 				GLFW.glfwSetWindowMonitor(window.getWindowHandle(), 0, windowPosXBeforeFullscreen, windowPosYBeforeFullscreen, width,
 					height, displayModeBeforeFullscreen.refreshRate);
 			}


### PR DESCRIPTION
As reported by the redBadger on Discord, the borderless fullscreen code doesn't work, when the taskbar is displayd on the left or the top side. This PR fixes that.