### PR TITLE
Upgrade AndroidX fragment version

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -39,7 +39,7 @@ versions.androidCompileSdk = 32
 versions.androidTargetSdk = 32
 versions.androidMinSdk = 14
 versions.androidBuildTools = "33.0.0"
-versions.androidFragment = "1.2.3"
+versions.androidFragment = "1.5.7"
 versions.javaparser = "2.3.0"
 versions.spotless = "6.7.1"
 


### PR DESCRIPTION
Current androidx.fragment version is from 2020. Now that Android dependencies are properly managed, the Fragment dependeny will be transiently added to all projects so it's important to keep it up to date. I've chosen 1.5.7 instead of 1.6.0 to make sure it's stable.