### PR TITLE
One-line fix for Tiled failures on GWT.

### DIFF
--- a/backends/gdx-backends-gwt/res/com/badlogic/gwtref/GwtReflect.gwt.xml
+++ b/backends/gdx-backends-gwt/res/com/badlogic/gwtref/GwtReflect.gwt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit trunk//EN" "http://www.gwtproject.org/doctype/2.8.0/gwt-module.dtd">
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit trunk//EN" "https://www.gwtproject.org/doctype/2.8.2/gwt-module.dtd">
 <module>
 	<inherits name='com.google.gwt.user.User' />
 	<define-configuration-property name="gdx.reflect.include"
@@ -50,11 +50,7 @@
 
 	<extend-configuration-property name="gdx.reflect.include"
 		value="com.badlogic.gdx.maps" />
-	<extend-configuration-property name="gdx.reflect.include"
-		value="com.badlogic.gdx.maps.objects" />
-	<extend-configuration-property name="gdx.reflect.include"
-		value="com.badlogic.gdx.maps.tiled.objects" />
-	
+
 	<extend-configuration-property name="gdx.reflect.include"
 		value="com.badlogic.gdx.graphics.g3d.particles.ParticleEffect" />
 	<extend-configuration-property name="gdx.reflect.include"

--- a/backends/gdx-backends-gwt/res/com/badlogic/gwtref/GwtReflect.gwt.xml
+++ b/backends/gdx-backends-gwt/res/com/badlogic/gwtref/GwtReflect.gwt.xml
@@ -49,7 +49,33 @@
 		value="com.badlogic.gdx.Net" />
 
 	<extend-configuration-property name="gdx.reflect.include"
-		value="com.badlogic.gdx.maps" />
+		value="com.badlogic.gdx.maps.Map" />
+	<extend-configuration-property name="gdx.reflect.include"
+		value="com.badlogic.gdx.maps.MapGroupLayer" />
+	<extend-configuration-property name="gdx.reflect.include"
+		value="com.badlogic.gdx.maps.MapLayer" />
+	<extend-configuration-property name="gdx.reflect.include"
+		value="com.badlogic.gdx.maps.MapLayers" />
+	<extend-configuration-property name="gdx.reflect.include"
+		value="com.badlogic.gdx.maps.MapObject" />
+	<extend-configuration-property name="gdx.reflect.include"
+		value="com.badlogic.gdx.maps.MapObjects" />
+	<extend-configuration-property name="gdx.reflect.include"
+		value="com.badlogic.gdx.maps.MapProperties" />
+	<extend-configuration-property name="gdx.reflect.include"
+		value="com.badlogic.gdx.maps.objects" />
+	<extend-configuration-property name="gdx.reflect.include"
+		value="com.badlogic.gdx.maps.tiled.TiledMap" />
+	<extend-configuration-property name="gdx.reflect.include"
+		value="com.badlogic.gdx.maps.tiled.TiledMapImageLayer" />
+	<extend-configuration-property name="gdx.reflect.include"
+		value="com.badlogic.gdx.maps.tiled.TiledMapTileLayer" />
+	<extend-configuration-property name="gdx.reflect.include"
+		value="com.badlogic.gdx.maps.tiled.TiledMapTileSet" />
+	<extend-configuration-property name="gdx.reflect.include"
+		value="com.badlogic.gdx.maps.tiled.TiledMapTileSets" />
+	<extend-configuration-property name="gdx.reflect.include"
+		value="com.badlogic.gdx.maps.tiled.objects" />
 
 	<extend-configuration-property name="gdx.reflect.include"
 		value="com.badlogic.gdx.graphics.g3d.particles.ParticleEffect" />

--- a/backends/gdx-backends-gwt/res/com/badlogic/gwtref/GwtReflect.gwt.xml
+++ b/backends/gdx-backends-gwt/res/com/badlogic/gwtref/GwtReflect.gwt.xml
@@ -49,7 +49,7 @@
 		value="com.badlogic.gdx.Net" />
 
 	<extend-configuration-property name="gdx.reflect.include"
-		value="com.badlogic.gdx.maps.MapObject" />
+		value="com.badlogic.gdx.maps" />
 	<extend-configuration-property name="gdx.reflect.include"
 		value="com.badlogic.gdx.maps.objects" />
 	<extend-configuration-property name="gdx.reflect.include"


### PR DESCRIPTION
It seems like Tiled now uses reflection for more types than just MapObject in the `com.badlogic.gdx.maps` package, so this preemptively adds all of that package to the reflection cache, like how `com.badlogic.gdx.maps.objects` and `com.badlogic.gdx.maps.tiled.objects` already are added wholesale. It's possible that a more fine-grained set of classes could be added instead of the whole package, but it would just break again on GWT if any code used a class from outside that set.

Without this change, users can work around the bug by adding this to a .gwt.xml file:
```xml
	<extend-configuration-property name="gdx.reflect.include" value="com.badlogic.gdx.maps" />
```

The TiledMapObjectLoadingTest and SuperKoalio tests currently fail/crash if run on GWT without this PR (at least those). They pass with this PR in.