### PR TITLE
Lower GLIBC requirements by using chromium reversion script and patches

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -132,6 +132,70 @@ jobs:
           sudo apt install -y --force-yes gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libc6-dev-arm64-cross
           sudo apt install -y --force-yes gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf libc6-dev-armhf-cross
 
+      - name: Add patches to minimize needed GLIBC version
+        run: |
+          CURRENT_DIR="$(pwd)"
+          sudo apt-get -yq install python3
+          # download chromium reversion_glibc.py script from chromium source tree at pinned commit (incase they ever move or change it)
+          wget https://raw.githubusercontent.com/chromium/chromium/01bc42d648c45439e1beef8fd25fde3aef9079bc/build/linux/sysroot_scripts/reversion_glibc.py -O /tmp/reversion_glibc.py
+          # set targeted minimum GLIBC to 2.17
+          sed -i 's/26]/17]/g' /tmp/reversion_glibc.py
+          chmod +x /tmp/reversion_glibc.py
+          # download the host libc6 package from apt and patch the binaries in it
+          # replacing the host libc6 at runtime causes crashs and hangs but apt is able to do it without issue
+          sudo apt-get install --download-only --reinstall -y libc6
+          sudo rm -rf /tmp/libc6
+          sudo mkdir /tmp/libc6
+          sudo cp /var/cache/apt/archives/libc6_2.31-*_amd64.deb /tmp/libc6
+          cd /tmp/libc6
+          deb_name="$(ls)"
+          sudo ar x "$deb_name"
+          sudo tar xf data.tar.xz
+          sudo mkdir DEBIAN
+          sudo tar xf control.tar.xz -C DEBIAN
+          sudo rm -f control.tar.xz \
+            data.tar.xz \
+            debian-binary \
+            DEBIAN/md5sums \
+            DEBIAN/archives \
+            DEBIAN/conffiles \
+            "$deb_name"
+  
+          # patch libc6 in host download deb and cross compilers using the reversion_glibc.py script
+          files=(/tmp/libc6/lib/x86_64-linux-gnu/libc.so.6 /tmp/libc6/lib/x86_64-linux-gnu/libm.so.6 \
+          /usr/aarch64-linux-gnu/lib/libc.so.6 /usr/aarch64-linux-gnu/lib/libm.so.6 \
+          /usr/arm-linux-gnueabihf/lib/libc.so.6 /usr/arm-linux-gnueabihf/lib/libm.so.6 \
+          /libx32/libc.so.6 /libx32/libm.so.6 \
+          /lib32/libc.so.6 /lib32/libm.so.6 \
+          /usr/i686-linux-gnu/lib/libc.so.6 /usr/i686-linux-gnu/lib/libm.so.6)
+          for file in "${files[@]}"; do
+            [ -f $file ] && sudo python3 /tmp/reversion_glibc.py "$file"
+          done
+  
+          # install patched libc6 deb
+          sudo dpkg-deb -b . "$deb_name"
+          sudo apt install --reinstall --allow-downgrades -y ./"$deb_name"
+          cd "$CURRENT_DIR"
+          # __GLIBC_MINOR__ is used as a feature test macro.  Replace it with the
+          # earliest supported version of glibc 2.17
+          files=(/usr/include/features.h \
+          /usr/aarch64-linux-gnu/include/features.h \
+          /usr/arm-linux-gnueabihf/include/features.h \
+          /usr/i686-linux-gnu/include/features.h)
+          for file in "${files[@]}"; do
+            [ -f $file ] && sudo sed -i 's|\(#define\s\+__GLIBC_MINOR__\)|\1 17 //|' "$file"
+          done
+  
+          # fcntl64() was introduced in glibc 2.28.  Make sure to use fcntl() instead.
+          files=(/usr/include/fcntl.h \
+          /usr/aarch64-linux-gnu/include/fcntl.h \
+          /usr/arm-linux-gnueabihf/include/fcntl.h \
+          /usr/i686-linux-gnu/include/fcntl.h)
+          for file in "${files[@]}"; do
+            [ -f $file ] && sudo sed -i '{N; s/#ifndef __USE_FILE_OFFSET64\(\nextern int fcntl\)/#if 1\1/}' "$file"
+          done
+          true
+
       - name: Cache Gradle packages
         uses: actions/cache@v2
         with:

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -112,7 +112,7 @@ jobs:
           rm -f ~/.gradle/caches/modules-2/gc.properties
 
   natives-linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
         with:
@@ -146,15 +146,15 @@ jobs:
           sudo apt-get install --download-only --reinstall -y libc6
           sudo rm -rf /tmp/libc6
           sudo mkdir /tmp/libc6
-          sudo cp /var/cache/apt/archives/libc6_2.31-*_amd64.deb /tmp/libc6
+          sudo cp /var/cache/apt/archives/libc6_2.*-*_amd64.deb /tmp/libc6
           cd /tmp/libc6
           deb_name="$(ls)"
           sudo ar x "$deb_name"
-          sudo tar xf data.tar.xz
+          sudo tar xf data.tar.*
           sudo mkdir DEBIAN
-          sudo tar xf control.tar.xz -C DEBIAN
-          sudo rm -f control.tar.xz \
-            data.tar.xz \
+          sudo tar xf control.tar.* -C DEBIAN
+          sudo rm -f control.tar.* \
+            data.tar.* \
             debian-binary \
             DEBIAN/md5sums \
             DEBIAN/archives \
@@ -194,6 +194,22 @@ jobs:
           for file in "${files[@]}"; do
             [ -f $file ] && sudo sed -i '{N; s/#ifndef __USE_FILE_OFFSET64\(\nextern int fcntl\)/#if 1\1/}' "$file"
           done
+
+          # Do not use pthread_cond_clockwait as it was introduced in glibc 2.30.
+          files=(/usr/include/x86_64-linux-gnu/c++/*/bits/c++config.h \
+          /usr/include/aarch64-linux-gnu/c++/*/bits/c++config.h \
+          /usr/include/arm-linux-gnueabihf/c++/*/bits/c++config.h \
+          /usr/i686-linux-gnu/include/c++/*/i686-linux-gnu/x32/bits/c++config.h \
+          /usr/include/i386-linux-gnu/c++/*/bits/c++config.h \
+          /usr/include/x86_64-linux-gnu/c++/*/32/bits/c++config.h \
+          /usr/include/x86_64-linux-gnu/c++/*/x32/bits/c++config.h \
+          /usr/x86_64-linux-gnu/include/c++/*/x86_64-linux-gnu/32/bits/c++config.h \
+          /usr/x86_64-linux-gnu/include/c++/*/x86_64-linux-gnu/x32/bits/c++config.h \
+          /usr/x86_64-linux-gnux32/include/c++/*/x86_64-linux-gnux32/32/bits/c++config.h \
+          /usr/x86_64-linux-gnux32/include/c++/*/x86_64-linux-gnux32/bits/c++config.h)
+          for file in "${files[@]}"; do
+            [ -f $file ] && sudo sed -i 's|\(#define\s\+_GLIBCXX_USE_PTHREAD_COND_CLOCKWAIT\)|// \1|' "$file"
+          done
           true
 
       - name: Cache Gradle packages
@@ -227,7 +243,7 @@ jobs:
           rm -f ~/.gradle/caches/modules-2/gc.properties
 
   natives-windows:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
         with:
@@ -276,7 +292,7 @@ jobs:
           rm -f ~/.gradle/caches/modules-2/gc.properties
 
   natives-android:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
         with:
@@ -321,7 +337,7 @@ jobs:
           rm -f ~/.gradle/caches/modules-2/gc.properties
 
   pack-natives:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [natives-macos, natives-linux, natives-windows, natives-ios, natives-android]
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -412,7 +428,7 @@ jobs:
           rm -f ~/.gradle/caches/modules-2/gc.properties
 
   publish:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: pack-natives
     env:
       ORG_GRADLE_PROJECT_MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
@@ -460,7 +476,7 @@ jobs:
         run: ./gradlew build publish -PRELEASE -Psigning.gnupg.keyId=${{ secrets.GPG_KEYID }} -Psigning.gnupg.passphrase=${{ secrets.GPG_PASSPHRASE }} -Psigning.gnupg.keyName=${{ secrets.GPG_KEYID }}
 
   build-and-upload-runnables:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: pack-natives
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/build-pullrequest.yml
+++ b/.github/workflows/build-pullrequest.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   build-java:
     if: "!contains(github.event.head_commit.message, 'ci skip')"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
lowers GLIBC requirements that were bumped to up to GLIBC 2.31 as mentioned here https://github.com/libgdx/libgdx/pull/7005

previously up to 2.29 was found to be required on multiple of the libgdx binaries on multiple architectures on linux
```
./gdx/libs/linuxarm64/libgdxarm64.so: /lib/aarch64-linux-gnu/libm.so.6: version `GLIBC_2.29' not found (required by ./gdx/libs/linuxarm64/libgdxarm64.so)
```

see PR for more info about the same changes at the Jamepad repo https://github.com/libgdx/Jamepad/pull/22

successful actions run: https://github.com/theofficialgman/libgdx/actions/runs/5449736745/jobs/9914278499

@MrStahlfelge @Tom-Ski no more waiting, lets get this merged! no risk since you can always drop the changes (or @ me if you have issues).