### PR TITLE
Lower GLIBC requirements by using building linux natives on ubuntu 18.04 docker

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -133,7 +133,6 @@ jobs:
           zip \
           unzip \
           xz-utils \
-          openjdk-11-jdk-headless \
           maven \
           ant sudo locales
 

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -113,7 +113,36 @@ jobs:
 
   natives-linux:
     runs-on: ubuntu-20.04
+    container:
+      image: ubuntu:18.04
     steps:
+      - name: Install dependencies into minimal dockerfile
+        run: |
+          # ubuntu dockerfile is very minimal (only 122 packages are installed)
+          # need to install updated git (from official git ppa)
+          apt update
+          apt install -y software-properties-common
+          add-apt-repository ppa:git-core/ppa -y
+          # install dependencies expected by other steps
+          apt update
+          apt install -y git \
+          curl \
+          ca-certificates \
+          wget \
+          bzip2 \
+          zip \
+          unzip \
+          xz-utils \
+          openjdk-11-jdk-headless \
+          maven \
+          ant sudo locales
+
+          # set Locale to en_US.UTF-8 (avoids hang during compilation)
+          locale-gen en_US.UTF-8
+          echo "LANG=en_US.UTF-8" >> $GITHUB_ENV
+          echo "LANGUAGE=en_US.UTF-8" >> $GITHUB_ENV
+          echo "LC_ALL=en_US.UTF-8" >> $GITHUB_ENV
+
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0


### PR DESCRIPTION
alternative to https://github.com/libgdx/libgdx/pull/7177

https://github.com/theofficialgman/libgdx/actions/runs/5470509920

I personally prefer the GLIBC reversion script since it allows us to continue using github actions runners (and all the dependencies that are pre-installed). This PR has the same minimum GLIBC requirements (GLIBC 2.17)

I would attempt using musl to build the debs which would have an advantage of being able to statically link (no glibc) however its very difficult to compile projects using its (since everything including a projects dependencies need to be compiled with musl) (see https://github.com/desktop/dugite-native/pull/502#discussion_r1253754491 for my struggles with anothe project doing that)