### PR TITLE
Change androidx.fragment dependency to compileOnly

### DIFF
--- a/backends/gdx-backend-android/build.gradle
+++ b/backends/gdx-backend-android/build.gradle
@@ -52,5 +52,5 @@ android {
 
 dependencies {
 	implementation project(":gdx")
-	implementation libraries.android
+	compileOnly libraries.compileOnly.android
 }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -122,7 +122,7 @@ libraries.robovm = [
         "com.mobidevelop.robovm:robovm-cocoatouch:${versions.robovm}"
 ]
 
-libraries.android = [
+libraries.compileOnly.android = [
         "androidx.fragment:fragment:${versions.androidFragment}"
 ]
 

--- a/tests/gdx-tests-android/build.gradle
+++ b/tests/gdx-tests-android/build.gradle
@@ -54,7 +54,7 @@ apply from: "obb.gradle"
 dependencies {
 	implementation project(":tests:gdx-tests")
 	implementation project(":backends:gdx-backend-android")
-	implementation libraries.android
+	implementation libraries.compileOnly.android
 	implementation "androidx.multidex:multidex:${versions.multiDex}"
 }
 


### PR DESCRIPTION
The androidx.fragment dependency uses java8 features, and can therefor impose problems with r8/d8.
`androidx.fragment` is not needed by default and apps that do, will include the dependency on their own.

This change was tested and seems to fix the issues reported on discord.