### PR TITLE
Fixes potential IndexOutOfBoundsException on AsynchronousAndroidSound

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AsynchronousSound.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AsynchronousSound.java
@@ -82,7 +82,12 @@ public class AsynchronousSound implements Sound {
 
 	@Override
 	public void stop () {
-		sound.stop();
+		handler.post(new Runnable() {
+			@Override
+			public void run () {
+				sound.stop();
+			}
+		});
 	}
 
 	@Override


### PR DESCRIPTION
User "@muk" on Discord reported exception being thrown in rare cases when calling `stop()` on `AsynchronousAndroidSound`.

```
Exception java.lang.IndexOutOfBoundsException: index can't be >= size: 7 >= 7
  at com.badlogic.gdx.utils.IntArray.get (IntArray.java:131)
  at com.badlogic.gdx.backends.android.AndroidSound.stop (AndroidSound.java:59)
  at com.badlogic.gdx.backends.android.AsynchronousSound.stop (AsynchronousSound.java:85)
``` 

Running `stop` on the `Handler` thread should fix the issue.