### PR TITLE
Automatically switch audio device if it was changed on the OS

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,5 @@
 [1.12.1]
+- LWJGL3 Improvement: Audio device is automatically switched if it was changed in the operating system.
 
 [1.12.0]
 - [BREAKING CHANGE] Added #touchCancelled to InputProcessor interface, see #6871.

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALLwjgl3Audio.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALLwjgl3Audio.java
@@ -159,14 +159,8 @@ public class OpenALLwjgl3Audio implements Lwjgl3Audio {
 						List<String> currentDevicesList = new ArrayList<>(Arrays.asList(currentDevices));
 						currentDevicesList.removeAll(Arrays.asList(lastAvailableDevices));
 						// If a new device got added, re evaluate "auto" mode
-						if (currentDevicesList.size() != 0) {
+						if (!Arrays.equals(currentDevices, lastAvailableDevices)) {
 							switchOutputDevice(null);
-						}
-						// If the default device got changed on the OS, re evaluate "auto" mode
-						if (lastAvailableDevices.length != 0 && currentDevices.length != 0) {
-							if (!lastAvailableDevices[0].equals(currentDevices[0])) {
-								switchOutputDevice(null);
-							}
 						}
 						// Update last available devices
 						lastAvailableDevices = currentDevices;

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALLwjgl3Audio.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALLwjgl3Audio.java
@@ -162,6 +162,13 @@ public class OpenALLwjgl3Audio implements Lwjgl3Audio {
 						if (currentDevicesList.size() != 0) {
 							switchOutputDevice(null);
 						}
+						// If the default device got changed on the OS, re evaluate "auto" mode
+						if (lastAvailableDevices.length != 0 && currentDevices.length != 0) {
+							if (!lastAvailableDevices[0].equals(currentDevices[0])) {
+								switchOutputDevice(null);
+							}
+						}
+						// Update last available devices
 						lastAvailableDevices = currentDevices;
 					}
 					try {

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALLwjgl3Audio.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALLwjgl3Audio.java
@@ -25,7 +25,6 @@ import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.FloatBuffer;
 import java.nio.IntBuffer;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -156,8 +155,6 @@ public class OpenALLwjgl3Audio implements Lwjgl3Audio {
 						}
 					} else {
 						String[] currentDevices = getAvailableOutputDevices();
-						List<String> currentDevicesList = new ArrayList<>(Arrays.asList(currentDevices));
-						currentDevicesList.removeAll(Arrays.asList(lastAvailableDevices));
 						// If a new device got added, re evaluate "auto" mode
 						if (!Arrays.equals(currentDevices, lastAvailableDevices)) {
 							switchOutputDevice(null);


### PR DESCRIPTION
This simple PR checks if the default audio device set by the OS was changed, and if so, switches the output device internally using the "auto" mode.
Or in other words, if you launch your game, realize the sound is coming out from your speakers instead of your headphones, and change the default device on the OS (e.g. Windows), libGDX will understand that and redirect the output to the device you selected there.

This PR is very simple and works on the assumption that the active device is the first one in the list returned by `getAvailableOutputDevices()`. It was tested on Windows, but it should work everywhere as long as that assumption is held true elsewhere.


https://github.com/libgdx/libgdx/assets/2331058/4f01f0cf-585b-4b7f-9162-89d02edc70d9

