### PR TITLE
[Tiled] TiledLayer paralaxx default values fix

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,5 @@
 [1.12.1]
+- Tiled Fix: TiledLayer parallax default values fix
 
 [1.12.0]
 - [BREAKING CHANGE] Added #touchCancelled to InputProcessor interface, see #6871.

--- a/gdx/src/com/badlogic/gdx/maps/MapLayer.java
+++ b/gdx/src/com/badlogic/gdx/maps/MapLayer.java
@@ -27,8 +27,8 @@ public class MapLayer {
 	private float offsetY;
 	private float renderOffsetX;
 	private float renderOffsetY;
-	private float parallaxX;
-	private float parallaxY;
+	private float parallaxX = 1;
+	private float parallaxY = 1;
 	private boolean renderOffsetDirty = true;
 	private MapLayer parent;
 	private MapObjects objects = new MapObjects();


### PR DESCRIPTION
#6480 Added support for parallax, however there was a small oversight and created a unnecessary breaking (and confusing) change.

Now by default TileLayer.paralaxxX/Y is set to 0, and that makes the map not move when the camera moves around.

Therefore, when you create a new TiledMapTileLayer in code on your own the map doesn't move around unless you set paralaxxX/Y manually to 1.

You didn't need to do that before 1.12 and in my opinion, we should set that default to 1.

The TmxMapLoader works around that by setting a [layers default value to 1](https://github.com/Quillraven/libgdx/blob/098b4784d9dac1705416cde4020bce5b7eff6cc6/gdx/src/com/badlogic/gdx/maps/tiled/BaseTmxMapLoader.java#L323):
```java
float parallaxX = element.getFloatAttribute("parallaxx", 1f);
float parallaxY = element.getFloatAttribute("parallaxy", 1f);
```


With 0:

https://github.com/libgdx/libgdx/assets/11274700/ba1b17d9-8e10-4b0f-b665-5695a442fbd7

With 1:

https://github.com/libgdx/libgdx/assets/11274700/c27830a0-6be3-4d3a-9861-d5eef0bf42ce

Code:
```java
public class Main extends ApplicationAdapter {
    private final Viewport viewport = new FitViewport(4, 4);
    private OrthogonalTiledMapRenderer renderer;


    @Override
    public void create() {
        TiledMap map = new TiledMap();
        TiledMapTileLayer layer = new TiledMapTileLayer(4, 4, 16, 16);
        // If this is set to 1 it works, if its commented it doesn't work:
        layer.setParallaxX(1);
        layer.setParallaxY(1);

        TiledMapTileLayer.Cell cell = new TiledMapTileLayer.Cell();
        cell.setTile(new StaticTiledMapTile(new TextureRegion(createTexture())));
        layer.setCell(1, 1, cell);

        map.getLayers().add(layer);
        renderer = new OrthogonalTiledMapRenderer(map, 1 / 16f);
    }

    private Texture createTexture() {
        Pixmap pixmap = new Pixmap(16, 16, Pixmap.Format.RGB888);
        pixmap.setColor(Color.GREEN);
        pixmap.fill();

        return new Texture(pixmap);
    }

    @Override
    public void render() {
        ScreenUtils.clear(Color.BLACK);

        float speed = 3 * Gdx.graphics.getDeltaTime();

        if (Gdx.input.isKeyPressed(Input.Keys.W))
            viewport.getCamera().position.y -= speed;
        if (Gdx.input.isKeyPressed(Input.Keys.S))
            viewport.getCamera().position.y += speed;

        if (Gdx.input.isKeyPressed(Input.Keys.A))
            viewport.getCamera().position.x += speed;
        if (Gdx.input.isKeyPressed(Input.Keys.D))
            viewport.getCamera().position.x -= speed;

        viewport.apply();

        renderer.setView(((OrthographicCamera) viewport.getCamera()));
        renderer.render();
    }

    @Override
    public void resize(int width, int height) {
        viewport.update(width, height, true);
    }
}

```
