### PR TITLE
Update WebGL API - getFramebufferAttachmentParameter

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtGL20.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtGL20.java
@@ -637,9 +637,26 @@ public class GwtGL20 implements GL20 {
 	}
 
 	@Override
-	public void glGetFramebufferAttachmentParameteriv (int target, int attachment, int pname, IntBuffer params) {
-		// FIXME
-		throw new GdxRuntimeException("not implemented");
+	public void glGetFramebufferAttachmentParameteriv(int target, int attachment, int pname, IntBuffer params) {
+		switch (pname) {
+			case GL20.GL_FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE:
+			case GL20.GL_FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL:
+			case GL20.GL_FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE:
+				params.put(0, gl.getFramebufferAttachmentParameteri(target, attachment, pname));
+				params.flip();
+				break;
+			case GL20.GL_FRAMEBUFFER_ATTACHMENT_OBJECT_NAME:
+				WebGLTexture tex = gl.getParametero(pname);
+				if (tex == null) {
+					params.put(0);
+				} else {
+					params.put(textures.getKey(tex));
+				}
+				params.flip();
+				return;
+			default:
+				throw new GdxRuntimeException("glGetFramebufferAttachmentParameteriv Invalid enum for WebGL backend.");
+		}
 	}
 
 	@Override

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtGL30.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtGL30.java
@@ -580,6 +580,27 @@ public class GwtGL30 extends GwtGL20 implements GL30 {
 	}
 
 	@Override
+	public void glGetFramebufferAttachmentParameteriv(int target, int attachment, int pname, IntBuffer params) {
+		switch (pname) {
+			case GL30.GL_FRAMEBUFFER_ATTACHMENT_ALPHA_SIZE:
+			case GL30.GL_FRAMEBUFFER_ATTACHMENT_BLUE_SIZE:
+			case GL30.GL_FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING:
+			case GL30.GL_FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE:
+			case GL30.GL_FRAMEBUFFER_ATTACHMENT_DEPTH_SIZE:
+			case GL30.GL_FRAMEBUFFER_ATTACHMENT_GREEN_SIZE:
+			case GL30.GL_FRAMEBUFFER_ATTACHMENT_RED_SIZE:
+			case GL30.GL_FRAMEBUFFER_ATTACHMENT_STENCIL_SIZE:
+			case GL30.GL_FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER:
+				params.put(0, gl.getFramebufferAttachmentParameteri(target, attachment, pname));
+				params.flip();
+				break;
+			default:
+				// Assume it is a GL20 pname
+				super.glGetFramebufferAttachmentParameteriv(target, attachment, pname, params);
+		}
+	}
+
+	@Override
 	public void glGetQueryiv (int target, int pname, IntBuffer params) {
 		// Not 100% clear on this one. Returning the integer key for the query.
 		// Similar to how GwtGL20 handles FBO in glGetIntegerv

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/FrameBufferTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/FrameBufferTest.java
@@ -126,7 +126,7 @@ public class FrameBufferTest extends GdxTest {
 
 		spriteBatch = new SpriteBatch();
 		frameBuffer = new FrameBuffer(Format.RGB565, 128, 128, false);
-		stencilFrameBuffer = new FrameBuffer(Format.RGB565, 128, 128, true, true);
+		stencilFrameBuffer = new FrameBuffer(Format.RGB565, 128, 128, false, true);
 		createShader(Gdx.graphics);
 	}
 


### PR DESCRIPTION
Implements `glGetFramebufferAttachmentParameteriv` from both GL20 and GL30 for GwtGL20 and GwtGL30. I tested querying most of the values side by side with Desktop vs GWT on a FBO and received the same values on both platforms.

The WebGL equivalents are `getFramebufferAttachmentParameteri` and `getFramebufferAttachmentParametero`

Desktop Output:
```
[FrameBufferTest] GL_FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE: 5890
[FrameBufferTest] GL_FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL: 0
[FrameBufferTest] GL_FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE: 0
[FrameBufferTest] GL_FRAMEBUFFER_ATTACHMENT_GREEN_SIZE: 6
[FrameBufferTest] GL_FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE: 35863
[FrameBufferTest] GL_FRAMEBUFFER_ATTACHMENT_STENCIL_SIZE: 0
[FrameBufferTest] GL_FRAMEBUFFER_ATTACHMENT_ALPHA_SIZE: 0
[FrameBufferTest] GL_FRAMEBUFFER_ATTACHMENT_BLUE_SIZE: 5
[FrameBufferTest] GL_FRAMEBUFFER_ATTACHMENT_DEPTH_SIZE: 0
[FrameBufferTest] GL_FRAMEBUFFER_ATTACHMENT_RED_SIZE: 5
[FrameBufferTest] GL_FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER: 0
[FrameBufferTest] GL_FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING: 9729
```

WebGL Output:
```
FrameBufferTest: GL_FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE: 5890
FrameBufferTest: GL_FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL: 0
FrameBufferTest: GL_FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE: 0
FrameBufferTest: GL_FRAMEBUFFER_ATTACHMENT_GREEN_SIZE: 6
FrameBufferTest: GL_FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE: 35863
FrameBufferTest: GL_FRAMEBUFFER_ATTACHMENT_STENCIL_SIZE: 0
FrameBufferTest: GL_FRAMEBUFFER_ATTACHMENT_ALPHA_SIZE: 0
FrameBufferTest: GL_FRAMEBUFFER_ATTACHMENT_BLUE_SIZE: 5
FrameBufferTest: GL_FRAMEBUFFER_ATTACHMENT_DEPTH_SIZE: 0
FrameBufferTest: GL_FRAMEBUFFER_ATTACHMENT_RED_SIZE: 5
FrameBufferTest: GL_FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER: 0
FrameBufferTest: GL_FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING: 9729
```


Also, I updated `FrameBufferTest.java`. I noticed it fails on WebGL due to invalid combination for the FBO. The `stencilFrameBuffer` is set to true for both depth and stencil. Looking back at a 2017 commit, it looks like the depth was (likely) accidentally set to true during some FrameBuffer class changes. I can see no reason why the FBO needs depth for this test, and since it fails on GWT I am rolling it back to what it was before that commit, so that it runs on GWT again.

Commit that I believe broke it on WebGL:
![image](https://github.com/libgdx/libgdx/assets/28971753/452961e3-7286-40aa-a37c-3e3ff2be0490)


**Side Note:** I think the reason why the FBO fails on WebGL when depth and stencil is true is that WebGL seems to use a different value for Depth + Stencil for the Framebuffer, DEPTH_STENCIL, which only is present for WebGL Context. It seems Depth+Stencil FBO attachments on libGDX is non-functional on GWT at this time, but I guess it has never been needed so we haven't heard complaints about it. I believe fixing this is out of scope for this PR but worth a mention.

