### PR TITLE
Remove usage of deprecated tag on GL30

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplicationConfiguration.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplicationConfiguration.java
@@ -91,11 +91,11 @@ public class AndroidApplicationConfiguration {
 	/** set this to true to enable Android 4.4 KitKat's 'Immersive mode' **/
 	public boolean useImmersiveMode = true;
 
-	/** Experimental, whether to enable OpenGL ES 3 if supported. If not supported it will fall-back to OpenGL ES 2.0. When GL ES
+	/** Whether to enable OpenGL ES 3.0 if supported. If not supported it will fall-back to OpenGL ES 2.0. When GL ES
 	 * 3* is enabled, {@link com.badlogic.gdx.Gdx#gl30} can be used to access its functionality. Requires at least Android 4.3 (API
 	 * level 18).
-	 * @deprecated this option is currently experimental and not yet fully supported, expect issues. */
-	@Deprecated public boolean useGL30 = false;
+	 */
+	public boolean useGL30 = false;
 
 	/** The maximum number of threads to use for network requests. Default is {@link Integer#MAX_VALUE}. */
 	public int maxNetThreads = Integer.MAX_VALUE;

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplicationConfiguration.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplicationConfiguration.java
@@ -91,10 +91,9 @@ public class AndroidApplicationConfiguration {
 	/** set this to true to enable Android 4.4 KitKat's 'Immersive mode' **/
 	public boolean useImmersiveMode = true;
 
-	/** Whether to enable OpenGL ES 3.0 if supported. If not supported it will fall-back to OpenGL ES 2.0. When GL ES
-	 * 3* is enabled, {@link com.badlogic.gdx.Gdx#gl30} can be used to access its functionality. Requires at least Android 4.3 (API
-	 * level 18).
-	 */
+	/** Whether to enable OpenGL ES 3.0 if supported. If not supported it will fall-back to OpenGL ES 2.0. When GL ES 3* is
+	 * enabled, {@link com.badlogic.gdx.Gdx#gl30} can be used to access its functionality. Requires at least Android 4.3 (API level
+	 * 18). */
 	public boolean useGL30 = false;
 
 	/** The maximum number of threads to use for network requests. Default is {@link Integer#MAX_VALUE}. */

--- a/backends/gdx-backend-robovm-metalangle/src/com/badlogic/gdx/backends/iosrobovm/IOSApplicationConfiguration.java
+++ b/backends/gdx-backend-robovm-metalangle/src/com/badlogic/gdx/backends/iosrobovm/IOSApplicationConfiguration.java
@@ -61,9 +61,8 @@ public class IOSApplicationConfiguration {
 	/** whether or not the onScreenKeyboard should be closed on return key * */
 	public boolean keyboardCloseOnReturn = true;
 
-	/** Whether to enable OpenGL ES 3 if supported. If not supported it will fall-back to OpenGL ES 2.0. When GL ES 3
-	 * is enabled, {@link com.badlogic.gdx.Gdx#gl30} can be used to access it's functionality.
-	 */
+	/** Whether to enable OpenGL ES 3 if supported. If not supported it will fall-back to OpenGL ES 2.0. When GL ES 3 is enabled,
+	 * {@link com.badlogic.gdx.Gdx#gl30} can be used to access it's functionality. */
 	public boolean useGL30 = false;
 
 	/** whether the status bar should be visible or not * */

--- a/backends/gdx-backend-robovm-metalangle/src/com/badlogic/gdx/backends/iosrobovm/IOSApplicationConfiguration.java
+++ b/backends/gdx-backend-robovm-metalangle/src/com/badlogic/gdx/backends/iosrobovm/IOSApplicationConfiguration.java
@@ -61,10 +61,10 @@ public class IOSApplicationConfiguration {
 	/** whether or not the onScreenKeyboard should be closed on return key * */
 	public boolean keyboardCloseOnReturn = true;
 
-	/** Experimental, whether to enable OpenGL ES 3 if supported. If not supported it will fall-back to OpenGL ES 2.0. When GL ES 3
+	/** Whether to enable OpenGL ES 3 if supported. If not supported it will fall-back to OpenGL ES 2.0. When GL ES 3
 	 * is enabled, {@link com.badlogic.gdx.Gdx#gl30} can be used to access it's functionality.
-	 * @deprecated this option is currently experimental and not yet fully supported, expect issues. */
-	@Deprecated public boolean useGL30 = false;
+	 */
+	public boolean useGL30 = false;
 
 	/** whether the status bar should be visible or not * */
 	public boolean statusBarVisible = false;

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSApplicationConfiguration.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSApplicationConfiguration.java
@@ -70,9 +70,8 @@ public class IOSApplicationConfiguration {
 	/** whether or not the onScreenKeyboard should be closed on return key **/
 	public boolean keyboardCloseOnReturn = true;
 
-	/** Whether to enable OpenGL ES 3 if supported. If not supported it will fall-back to OpenGL ES 2.0. When GL ES 3
-	 * is enabled, {@link com.badlogic.gdx.Gdx#gl30} can be used to access it's functionality.
-	 */
+	/** Whether to enable OpenGL ES 3 if supported. If not supported it will fall-back to OpenGL ES 2.0. When GL ES 3 is enabled,
+	 * {@link com.badlogic.gdx.Gdx#gl30} can be used to access it's functionality. */
 	public boolean useGL30 = false;
 
 	/** whether the status bar should be visible or not **/

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSApplicationConfiguration.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSApplicationConfiguration.java
@@ -70,10 +70,10 @@ public class IOSApplicationConfiguration {
 	/** whether or not the onScreenKeyboard should be closed on return key **/
 	public boolean keyboardCloseOnReturn = true;
 
-	/** Experimental, whether to enable OpenGL ES 3 if supported. If not supported it will fall-back to OpenGL ES 2.0. When GL ES 3
+	/** Whether to enable OpenGL ES 3 if supported. If not supported it will fall-back to OpenGL ES 2.0. When GL ES 3
 	 * is enabled, {@link com.badlogic.gdx.Gdx#gl30} can be used to access it's functionality.
-	 * @deprecated this option is currently experimental and not yet fully supported, expect issues. */
-	@Deprecated public boolean useGL30 = false;
+	 */
+	public boolean useGL30 = false;
 
 	/** whether the status bar should be visible or not **/
 	public boolean statusBarVisible = false;

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplicationConfiguration.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplicationConfiguration.java
@@ -53,9 +53,8 @@ public class GwtApplicationConfiguration {
 	public TextArea log;
 	/** whether to use debugging mode for OpenGL calls. Errors will result in a RuntimeException being thrown. */
 	public boolean useDebugGL = false;
-	/** Whether to enable OpenGL ES 3.0 (aka WebGL2) if supported. If not supported it will fall-back to OpenGL ES
-	 * 2.0. When GL ES 3.0 is enabled, {@link com.badlogic.gdx.Gdx#gl30} can be used to access its functionality.
-	 */
+	/** Whether to enable OpenGL ES 3.0 (aka WebGL2) if supported. If not supported it will fall-back to OpenGL ES 2.0. When GL ES
+	 * 3.0 is enabled, {@link com.badlogic.gdx.Gdx#gl30} can be used to access its functionality. */
 	public boolean useGL30 = false;
 	/** preserve the back buffer, needed if you fetch a screenshot via canvas#toDataUrl, may have performance impact **/
 	public boolean preserveDrawingBuffer = false;

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplicationConfiguration.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplicationConfiguration.java
@@ -53,10 +53,10 @@ public class GwtApplicationConfiguration {
 	public TextArea log;
 	/** whether to use debugging mode for OpenGL calls. Errors will result in a RuntimeException being thrown. */
 	public boolean useDebugGL = false;
-	/** Experimental, whether to enable OpenGL ES 30 (aka WebGL2) if supported. If not supported it will fall-back to OpenGL ES
-	 * 2.0. When GL ES 30 is enabled, {@link com.badlogic.gdx.Gdx#gl30} can be used to access its functionality.
-	 * @deprecated this option is currently experimental and not yet fully supported, expect issues. */
-	@Deprecated public boolean useGL30 = false;
+	/** Whether to enable OpenGL ES 3.0 (aka WebGL2) if supported. If not supported it will fall-back to OpenGL ES
+	 * 2.0. When GL ES 3.0 is enabled, {@link com.badlogic.gdx.Gdx#gl30} can be used to access its functionality.
+	 */
+	public boolean useGL30 = false;
 	/** preserve the back buffer, needed if you fetch a screenshot via canvas#toDataUrl, may have performance impact **/
 	public boolean preserveDrawingBuffer = false;
 	/** whether to include an alpha channel in the color buffer to combine the color buffer with the rest of the webpage


### PR DESCRIPTION
Based on the linked issue, I have removed the use of deprecated tag on the useGL30 variables for Android, RoboVm, Metal-Angle, GWT. I also removed the experimental comment, but if any one feels some of these should still say experimental ( I don't know much about the IOS side) I can add that back in.

The original issue focused on Android, but I agree with MGSX that using deprecated is not appropriate even if we want to say it is experimental. 