### PR TITLE
[Android] Implement launcher zoom callback

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 [1.12.1]
 - LWJGL3 Improvement: Audio device is automatically switched if it was changed in the operating system.
 - Tiled Fix: TiledLayer parallax default values fix
+- Android: Added AndroidWallpaperListener#zoomChange() for listening to launcher zoom changes on Android 11+.
 
 [1.12.0]
 - [BREAKING CHANGE] Added #touchCancelled to InputProcessor interface, see #6871.

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidWallpaperListener.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidWallpaperListener.java
@@ -33,6 +33,10 @@ public interface AndroidWallpaperListener {
 	 * @param yPixelOffset */
 	void offsetChange (float xOffset, float yOffset, float xOffsetStep, float yOffsetStep, int xPixelOffset, int yPixelOffset);
 
+	/** Called on the rendering thread after the live wallpaper's zoom had changed.
+	 * @param zoom */
+	void zoomChange (float zoom);
+
 	/** Called after 'isPreview' state had changed. First time called just after application initialization.
 	 * @param isPreview current status, save this value and update always when this method is called if you want track live
 	 *           wallpaper isPreview status. */


### PR DESCRIPTION
Added launcher zoom callback for live wallpapers introduced in API 30, closes #7055.
It's basically the same structure as the existing onOffsetsChanged() so I copied the important methods and modified them accordingly. Hope I've done all right!