### PR TITLE
Fix some casts in ParticleEditor and Flame.

### DIFF
--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/NumericPanel.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/NumericPanel.java
@@ -59,7 +59,7 @@ class NumericPanel extends ParticleValuePanel<NumericValue> {
 		}
 		valueSpinner.addChangeListener(new ChangeListener() {
 			public void stateChanged (ChangeEvent event) {
-				NumericPanel.this.value.setValue((Float)valueSpinner.getValue());
+				NumericPanel.this.value.setValue(((Number)valueSpinner.getValue()).floatValue());
 			}
 		});
 	}

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/Slider.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/Slider.java
@@ -39,7 +39,7 @@ public class Slider extends JPanel {
 	}
 
 	public float getValue () {
-		return ((Double)spinner.getValue()).floatValue();
+		return ((Number)spinner.getValue()).floatValue();
 	}
 
 	public void addChangeListener (ChangeListener listener) {

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/NumericPanel.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/NumericPanel.java
@@ -42,7 +42,7 @@ class NumericPanel extends EditorPanel {
 
 		valueSpinner.addChangeListener(new ChangeListener() {
 			public void stateChanged (ChangeEvent event) {
-				value.setValue((Float)valueSpinner.getValue());
+				value.setValue(((Number)valueSpinner.getValue()).floatValue());
 			}
 		});
 	}

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/Slider.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/particleeditor/Slider.java
@@ -41,7 +41,7 @@ class Slider extends JPanel {
 	}
 
 	public float getValue () {
-		return ((Double)spinner.getValue()).floatValue();
+		return ((Number)spinner.getValue()).floatValue();
 	}
 
 	public void addChangeListener (ChangeListener listener) {


### PR DESCRIPTION
This is just a small fix for what seems to be a crash in ParticleEditor; it looks like it affects Flame as well. The issue stems from:
 - We have a `NumericValue` that stores a `float`.
 - We get that float and assign it to a `JSpinner` with a `SpinnerNumberModel`.
   - Inside the `JSpinner`, it is promoted and assigned to either a `double` or a `Double`, I'm not sure which.
 - We later get a value from the `JSpinner`, which gets returned as a boxed `Double`.
 - We try to cast this to `Float` so it can be auto-unboxed.
   - This causes a crash! `Double` cannot be cast to `Float`, even though their primitive forms can.

In this PR, we cast to `Number` instead of `Float`, and call `.floatValue()` on it. This is a pattern already used heavily in Hiero.

There are no other changes in this PR. Happy reviewing!