### PR TITLE
Fix for #7216 (bitwise precedence).

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g3d/utils/MeshBuilder.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/utils/MeshBuilder.java
@@ -795,7 +795,7 @@ public class MeshBuilder implements MeshPartBuilder {
 
 		ensureIndices(indices.length);
 		for (int i = 0; i < indices.length; ++i)
-			index((short)(indices[i] & 0xFFFF + offset));
+			index((short)((indices[i] & 0xFFFF) + offset));
 	}
 
 	// TODO: The following methods are deprecated and will be removed in a future release


### PR DESCRIPTION
This is just a one-line fix for one case where the operator precedence wasn't immediately clear, and was wrong in MeshBuilder. The line in question uses bitwise AND to mask `indices[i]` with `0xFFFF` and intends to then add `offset`. Because addition binds more tightly than bitwise AND, the mask `0xFFFF` changes to some invalid mask value and only then is it applied to `indices[i]`. This commit clarifies and fixes the precedence by grouping the bitwise AND so it happens first with a valid mask, and only then will `offset` be added.