### PR TITLE
Cache packed color on Sprite

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g2d/Sprite.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/Sprite.java
@@ -351,7 +351,7 @@ public class Sprite extends TextureRegion {
 	public void setAlpha (float a) {
 		if (color.a != a) {
 			color.a = a;
-			packedColor = this.color.toFloatBits();
+			packedColor = color.toFloatBits();
 			vertices[C1] = packedColor;
 			vertices[C2] = packedColor;
 			vertices[C3] = packedColor;
@@ -362,7 +362,7 @@ public class Sprite extends TextureRegion {
 	/** @see #setColor(Color) */
 	public void setColor (float r, float g, float b, float a) {
 		color.set(r, g, b, a);
-		packedColor = this.color.toFloatBits();
+		packedColor = color.toFloatBits();
 		float[] vertices = this.vertices;
 		vertices[C1] = packedColor;
 		vertices[C2] = packedColor;

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/Sprite.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/Sprite.java
@@ -370,7 +370,7 @@ public class Sprite extends TextureRegion {
 		vertices[C4] = packedColor;
 	}
 
-	/** Sets the color of this sprite, expanding the alpha from 0-254 to 0-255.
+	/** Sets the packed color used to tint this sprite.
 	 * @see #setColor(Color)
 	 * @see Color#toFloatBits() */
 	public void setPackedColor (float packedColor) {

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/Sprite.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/Sprite.java
@@ -639,7 +639,7 @@ public class Sprite extends TextureRegion {
 	}
 
 	/** Returns the packed color of this sprite. */
-	public float getPackedColor() {
+	public float getPackedColor () {
 		return packedColor;
 	}
 

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/Sprite.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/Sprite.java
@@ -37,6 +37,7 @@ public class Sprite extends TextureRegion {
 
 	final float[] vertices = new float[SPRITE_SIZE];
 	private final Color color = new Color(1, 1, 1, 1);
+	private float packedColor = Color.WHITE_FLOAT_BITS;
 	private float x, y;
 	float width, height;
 	private float originX, originY;
@@ -338,45 +339,50 @@ public class Sprite extends TextureRegion {
 	/** Sets the color used to tint this sprite. Default is {@link Color#WHITE}. */
 	public void setColor (Color tint) {
 		color.set(tint);
-		float color = tint.toFloatBits();
+		packedColor = tint.toFloatBits();
 		float[] vertices = this.vertices;
-		vertices[C1] = color;
-		vertices[C2] = color;
-		vertices[C3] = color;
-		vertices[C4] = color;
+		vertices[C1] = packedColor;
+		vertices[C2] = packedColor;
+		vertices[C3] = packedColor;
+		vertices[C4] = packedColor;
 	}
 
 	/** Sets the alpha portion of the color used to tint this sprite. */
 	public void setAlpha (float a) {
-		color.a = a;
-		float color = this.color.toFloatBits();
-		vertices[C1] = color;
-		vertices[C2] = color;
-		vertices[C3] = color;
-		vertices[C4] = color;
+		if (color.a != a) {
+			color.a = a;
+			packedColor = this.color.toFloatBits();
+			vertices[C1] = packedColor;
+			vertices[C2] = packedColor;
+			vertices[C3] = packedColor;
+			vertices[C4] = packedColor;
+		}
 	}
 
 	/** @see #setColor(Color) */
 	public void setColor (float r, float g, float b, float a) {
 		color.set(r, g, b, a);
-		float color = this.color.toFloatBits();
+		packedColor = this.color.toFloatBits();
 		float[] vertices = this.vertices;
-		vertices[C1] = color;
-		vertices[C2] = color;
-		vertices[C3] = color;
-		vertices[C4] = color;
+		vertices[C1] = packedColor;
+		vertices[C2] = packedColor;
+		vertices[C3] = packedColor;
+		vertices[C4] = packedColor;
 	}
 
 	/** Sets the color of this sprite, expanding the alpha from 0-254 to 0-255.
 	 * @see #setColor(Color)
 	 * @see Color#toFloatBits() */
 	public void setPackedColor (float packedColor) {
-		Color.abgr8888ToColor(color, packedColor);
-		float[] vertices = this.vertices;
-		vertices[C1] = packedColor;
-		vertices[C2] = packedColor;
-		vertices[C3] = packedColor;
-		vertices[C4] = packedColor;
+		if (this.packedColor != packedColor) {
+			this.packedColor = packedColor;
+			Color.abgr8888ToColor(color, packedColor);
+			float[] vertices = this.vertices;
+			vertices[C1] = packedColor;
+			vertices[C2] = packedColor;
+			vertices[C3] = packedColor;
+			vertices[C4] = packedColor;
+		}
 	}
 
 	/** Sets the origin in relation to the sprite's position for scaling and rotation. */
@@ -630,6 +636,11 @@ public class Sprite extends TextureRegion {
 	 * afterward. */
 	public Color getColor () {
 		return color;
+	}
+
+	/** Returns the packed color of this sprite. */
+	public float getPackedColor() {
+		return packedColor;
 	}
 
 	public void setRegion (float u, float v, float u2, float v2) {

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/Sprite.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/Sprite.java
@@ -374,7 +374,8 @@ public class Sprite extends TextureRegion {
 	 * @see #setColor(Color)
 	 * @see Color#toFloatBits() */
 	public void setPackedColor (float packedColor) {
-		if (this.packedColor != packedColor) {
+		// Handle 0f/-0f special case
+		if (packedColor != this.packedColor || (packedColor  == 0f && this.packedColor == 0f && Float.floatToIntBits(packedColor) != Float.floatToIntBits(this.packedColor))) {
 			this.packedColor = packedColor;
 			Color.abgr8888ToColor(color, packedColor);
 			float[] vertices = this.vertices;

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/Sprite.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/Sprite.java
@@ -375,7 +375,8 @@ public class Sprite extends TextureRegion {
 	 * @see Color#toFloatBits() */
 	public void setPackedColor (float packedColor) {
 		// Handle 0f/-0f special case
-		if (packedColor != this.packedColor || (packedColor  == 0f && this.packedColor == 0f && Float.floatToIntBits(packedColor) != Float.floatToIntBits(this.packedColor))) {
+		if (packedColor != this.packedColor || (packedColor == 0f && this.packedColor == 0f
+			&& Float.floatToIntBits(packedColor) != Float.floatToIntBits(this.packedColor))) {
 			this.packedColor = packedColor;
 			Color.abgr8888ToColor(color, packedColor);
 			float[] vertices = this.vertices;

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/SpriteDrawable.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/SpriteDrawable.java
@@ -41,7 +41,7 @@ public class SpriteDrawable extends BaseDrawable implements TransformDrawable {
 
 	public void draw (Batch batch, float x, float y, float width, float height) {
 		Color spriteColor = sprite.getColor();
-		float oldColor = spriteColor.toFloatBits();
+		float oldColor = sprite.getPackedColor();
 		sprite.setColor(spriteColor.mul(batch.getColor()));
 
 		sprite.setRotation(0);
@@ -56,7 +56,7 @@ public class SpriteDrawable extends BaseDrawable implements TransformDrawable {
 		float scaleY, float rotation) {
 
 		Color spriteColor = sprite.getColor();
-		float oldColor = spriteColor.toFloatBits();
+		float oldColor = sprite.getPackedColor();
 		sprite.setColor(spriteColor.mul(batch.getColor()));
 
 		sprite.setOrigin(originX, originY);


### PR DESCRIPTION
When profiling my apps I've realized the transformations between Color and packed color float have a pretty high CPU usage (in my case about 5%) as it may occur hundreds of times per frame.

Caching packed color in `Sprite` allows the optmization not to do the conversion when the color is the same and avoid lots of unnecessary conversions in some cases. You can see it only makes this check on `setAlpha()` and `setPackedColor()`, the reason being that adding a `this.color.equals(color)` check would cause 2 calls to `toIntBits()` making the optimization worthless.

With this change we open the possibility for further optimizations on the consumer side. For example `ParticleEmitter` currently calls `setColor()` every frame on each single particle. It could now call `setAlpha()` or `setPackedColor()` instead saving resources when the `Color` of the `Particle` hasn't changed.

@NathanSweet  It'd be great if you could have a look