### PR TITLE
Migrate to androidX

### DIFF
--- a/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/gradle.properties
+++ b/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/gradle.properties
@@ -1,3 +1,5 @@
 org.gradle.daemon=true
 org.gradle.jvmargs=-Xms128m -Xmx1500m
 org.gradle.configureondemand=false
+android.useAndroidX=true
+android.enableJetifier=true


### PR DESCRIPTION
In the `com.badlogicgames.gdx:gdx-backend-android:1.12.0` there are `androidx` dependencies.

![image](https://github.com/libgdx/libgdx/assets/594987/65f2873f-359e-43aa-9f60-3d42da21215f)

Now we have to setup `android.useAndroidX=true` in order to build and run android project.
From official android documentation: https://developer.android.com/jetpack/androidx/migrate
