### PR TITLE
Add comment to Input.Keys documentation for ⌘ Command key

### DIFF
--- a/gdx/src/com/badlogic/gdx/Input.java
+++ b/gdx/src/com/badlogic/gdx/Input.java
@@ -158,7 +158,7 @@ public interface Input {
 		public static final int SOFT_RIGHT = 2;
 		public static final int SPACE = 62;
 		public static final int STAR = 17;
-		public static final int SYM = 63;
+		public static final int SYM = 63; // on MacOS, this is Command (⌘)
 		public static final int T = 48;
 		public static final int TAB = 61;
 		public static final int U = 49;


### PR DESCRIPTION
I couldn't find an online reference for Mac-specific keycodes, so adding this comment to hopefully aid anyone who develops on MacOS for LibGDX in the future.

I'm aware this is probably a very niche group, but I think having some documentation would be helpful here anyway.