### PR TITLE
Allow to disable SelectBoxScrollPane reset selection on exit behavior

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/SelectBox.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/SelectBox.java
@@ -426,6 +426,7 @@ public class SelectBox<T> extends Widget implements Disableable {
 		final List<T> list;
 		private InputListener hideListener;
 		private Actor previousScrollFocus;
+		boolean resetSelectionOnExit = true;
 
 		public SelectBoxScrollPane (final SelectBox<T> selectBox) {
 			super(null, selectBox.style.scrollStyle);
@@ -458,7 +459,7 @@ public class SelectBox<T> extends Widget implements Disableable {
 
 			addListener(new InputListener() {
 				public void exit (InputEvent event, float x, float y, int pointer, @Null Actor toActor) {
-					if (toActor == null || !isAscendantOf(toActor)) {
+					if ((toActor == null || !isAscendantOf(toActor)) && resetSelectionOnExit) {
 						T selected = selectBox.getSelected();
 						if (selected != null) list.selection.set(selected);
 					}
@@ -488,6 +489,10 @@ public class SelectBox<T> extends Widget implements Disableable {
 					return false;
 				}
 			};
+		}
+
+		public void setResetSelectionOnExit(boolean resetSelectionOnExit) {
+			this.resetSelectionOnExit = resetSelectionOnExit;
 		}
 
 		/** Allows a subclass to customize the select box list. The default implementation returns a list that delegates


### PR DESCRIPTION
There's a default behavior for `SelectBoxScrollPane` which is quite confusing on UX point of view. When de cursor exit from the scroll pane the selection is reset to the current value which create a bad UX, it's common to exit the scroll pane by mistake and this create confusions:

https://github.com/libgdx/libgdx/assets/5543339/eb58353d-d943-44f3-b936-fcb5d2cffc28

With this PR there's now an option to disable the default behavior:

https://github.com/libgdx/libgdx/assets/5543339/670741ec-9da7-4282-a114-e88bef936c1d

Similar to the behavior of any other software:

https://github.com/libgdx/libgdx/assets/5543339/2a0309c9-c472-4321-a78a-aa04845f0052

(Dunno why I can't record the cursor, btw it enter end exit from the scroll pane)