### PR TITLE
Fix setCursor releasing the caught cursor on the LWJGL 3 backend.

### DIFF
--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Cursor.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Cursor.java
@@ -111,8 +111,7 @@ public class Lwjgl3Cursor implements Cursor {
 			GLFW.glfwSetInputMode(windowHandle, GLFW.GLFW_CURSOR, GLFW.GLFW_CURSOR_HIDDEN);
 			return;
 		} else if (inputModeBeforeNoneCursor != -1) {
-			GLFW.glfwSetInputMode(windowHandle, GLFW.GLFW_CURSOR,
-				inputModeBeforeNoneCursor == -1 ? GLFW.GLFW_CURSOR_NORMAL : inputModeBeforeNoneCursor);
+			GLFW.glfwSetInputMode(windowHandle, GLFW.GLFW_CURSOR, inputModeBeforeNoneCursor);
 			inputModeBeforeNoneCursor = -1;
 		}
 		Long glfwCursor = systemCursors.get(systemCursor);

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Cursor.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Cursor.java
@@ -107,12 +107,12 @@ public class Lwjgl3Cursor implements Cursor {
 
 	static void setSystemCursor (long windowHandle, SystemCursor systemCursor) {
 		if (systemCursor == SystemCursor.None) {
-			if (inputModeBeforeNoneCursor == -1)
-				inputModeBeforeNoneCursor = GLFW.glfwGetInputMode(windowHandle, GLFW.GLFW_CURSOR);
+			if (inputModeBeforeNoneCursor == -1) inputModeBeforeNoneCursor = GLFW.glfwGetInputMode(windowHandle, GLFW.GLFW_CURSOR);
 			GLFW.glfwSetInputMode(windowHandle, GLFW.GLFW_CURSOR, GLFW.GLFW_CURSOR_HIDDEN);
 			return;
 		} else if (inputModeBeforeNoneCursor != -1) {
-			GLFW.glfwSetInputMode(windowHandle, GLFW.GLFW_CURSOR, inputModeBeforeNoneCursor == -1 ? GLFW.GLFW_CURSOR_NORMAL : inputModeBeforeNoneCursor);
+			GLFW.glfwSetInputMode(windowHandle, GLFW.GLFW_CURSOR,
+				inputModeBeforeNoneCursor == -1 ? GLFW.GLFW_CURSOR_NORMAL : inputModeBeforeNoneCursor);
 			inputModeBeforeNoneCursor = -1;
 		}
 		Long glfwCursor = systemCursors.get(systemCursor);

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Cursor.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Cursor.java
@@ -111,7 +111,7 @@ public class Lwjgl3Cursor implements Cursor {
 				inputModeBeforeNoneCursor = GLFW.glfwGetInputMode(windowHandle, GLFW.GLFW_CURSOR);
 			GLFW.glfwSetInputMode(windowHandle, GLFW.GLFW_CURSOR, GLFW.GLFW_CURSOR_HIDDEN);
 			return;
-		} else {
+		} else if (inputModeBeforeNoneCursor != -1) {
 			GLFW.glfwSetInputMode(windowHandle, GLFW.GLFW_CURSOR, inputModeBeforeNoneCursor == -1 ? GLFW.GLFW_CURSOR_NORMAL : inputModeBeforeNoneCursor);
 			inputModeBeforeNoneCursor = -1;
 		}

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Cursor.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Cursor.java
@@ -32,6 +32,8 @@ public class Lwjgl3Cursor implements Cursor {
 	static final Array<Lwjgl3Cursor> cursors = new Array<Lwjgl3Cursor>();
 	static final Map<SystemCursor, Long> systemCursors = new HashMap<SystemCursor, Long>();
 
+	private static int inputModeBeforeNoneCursor = -1;
+
 	final Lwjgl3Window window;
 	Pixmap pixmapCopy;
 	GLFWImage glfwImage;
@@ -105,10 +107,13 @@ public class Lwjgl3Cursor implements Cursor {
 
 	static void setSystemCursor (long windowHandle, SystemCursor systemCursor) {
 		if (systemCursor == SystemCursor.None) {
+			if (inputModeBeforeNoneCursor == -1)
+				inputModeBeforeNoneCursor = GLFW.glfwGetInputMode(windowHandle, GLFW.GLFW_CURSOR);
 			GLFW.glfwSetInputMode(windowHandle, GLFW.GLFW_CURSOR, GLFW.GLFW_CURSOR_HIDDEN);
 			return;
 		} else {
-			GLFW.glfwSetInputMode(windowHandle, GLFW.GLFW_CURSOR, GLFW.GLFW_CURSOR_NORMAL);
+			GLFW.glfwSetInputMode(windowHandle, GLFW.GLFW_CURSOR, inputModeBeforeNoneCursor == -1 ? GLFW.GLFW_CURSOR_NORMAL : inputModeBeforeNoneCursor);
+			inputModeBeforeNoneCursor = -1;
 		}
 		Long glfwCursor = systemCursors.get(systemCursor);
 		if (glfwCursor == null) {


### PR DESCRIPTION
Fix #7175. 

The bug was caused by the fact that the `NONE` system cursor isn't handled as a cursor by GLFW but rather as an input mode. When we set the input mode to `GLFW_CURSOR_NORMAL`, we also overwrote whether the cursor was caught. 