### PR TITLE
chore: Update to gwt 2.10.0

### DIFF
--- a/backends/gdx-backends-gwt/res/com/badlogic/gdx/backends/gdx_backends_gwt.gwt.xml
+++ b/backends/gdx-backends-gwt/res/com/badlogic/gdx/backends/gdx_backends_gwt.gwt.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.9.0//EN" "https://www.gwtproject.org/doctype/2.9.0/gwt-module.dtd">
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.10.0//EN" "https://www.gwtproject.org/doctype/2.10.0/gwt-module.dtd">
 <module rename-to='com.badlogic.gdx.backends.gwt'>
 	<inherits name='com.google.gwt.user.User' />
 	<!-- Inherit edited chrome theme ("gwt"-prefixed classes only) for a little bit of default styling in the text input dialogs -->
 	<inherits name='com.badlogic.gdx.backends.gwt.theme.chrome.Chrome'/>
 	<inherits name="com.google.gwt.http.HTTP"/>
-	
+
 	<inherits name="com.badlogic.gdx" />
 	<inherits name="com.google.gwt.webgl.WebGL" />
 	<inherits name="com.badlogic.gwtref.GwtReflect"/>
@@ -19,13 +19,13 @@
 		<exclude name="**/PreloaderBundleGenerator.java"/>
 		<exclude name="**/FileWrapper.java"/>
 	</source>
-	
+
 	<define-configuration-property name="gdx.assetpath" is-multi-valued="false"/>
 	<define-configuration-property name="gdx.assetfilterclass" is-multi-valued="false"/>
 	<define-configuration-property name="gdx.assetoutputpath" is-multi-valued="false"/>
-	
+
 	<generate-with class="com.badlogic.gdx.backends.gwt.preloader.PreloaderBundleGenerator">
 		<when-type-assignable class="com.badlogic.gdx.backends.gwt.preloader.PreloaderBundle"/>
 	</generate-with>
-	
+
 </module>

--- a/backends/gdx-backends-gwt/res/com/badlogic/gdx/backends/gdx_backends_gwt.gwt.xml
+++ b/backends/gdx-backends-gwt/res/com/badlogic/gdx/backends/gdx_backends_gwt.gwt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.5.1//EN" "http://www.gwtproject.org/doctype/2.5.1/gwt-module.dtd">
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.9.0//EN" "https://www.gwtproject.org/doctype/2.9.0/gwt-module.dtd">
 <module rename-to='com.badlogic.gdx.backends.gwt'>
 	<inherits name='com.google.gwt.user.User' />
 	<!-- Inherit edited chrome theme ("gwt"-prefixed classes only) for a little bit of default styling in the text input dialogs -->
@@ -9,6 +9,7 @@
 	<inherits name="com.badlogic.gdx" />
 	<inherits name="com.google.gwt.webgl.WebGL" />
 	<inherits name="com.badlogic.gwtref.GwtReflect"/>
+	<inherits name="jsinterop.annotations.Annotations" />
 
 	<public path="gwt/resources"/>
 	<super-source path="gwt/emu" />

--- a/backends/gdx-backends-gwt/res/com/badlogic/gwtref/GwtReflect.gwt.xml
+++ b/backends/gdx-backends-gwt/res/com/badlogic/gwtref/GwtReflect.gwt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit trunk//EN" "https://www.gwtproject.org/doctype/2.8.2/gwt-module.dtd">
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit trunk//EN" "https://www.gwtproject.org/doctype/2.9.0/gwt-module.dtd">
 <module>
 	<inherits name='com.google.gwt.user.User' />
 	<define-configuration-property name="gdx.reflect.include"

--- a/backends/gdx-backends-gwt/res/com/badlogic/gwtref/GwtReflect.gwt.xml
+++ b/backends/gdx-backends-gwt/res/com/badlogic/gwtref/GwtReflect.gwt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit trunk//EN" "https://www.gwtproject.org/doctype/2.9.0/gwt-module.dtd">
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit trunk//EN" "https://www.gwtproject.org/doctype/2.10.0/gwt-module.dtd">
 <module>
 	<inherits name='com.google.gwt.user.User' />
 	<define-configuration-property name="gdx.reflect.include"
@@ -97,7 +97,7 @@
 		value="com.badlogic.gdx.graphics.g3d.particles.influencers" />
 	<extend-configuration-property name="gdx.reflect.include"
 		value="com.badlogic.gdx.graphics.g3d.particles.renderers" />
-	
+
     <extend-configuration-property name="gdx.reflect.include"
         value="java.util.Collection" />
 	<extend-configuration-property name="gdx.reflect.include"

--- a/backends/gdx-backends-gwt/res/com/google/gwt/webgl/WebGL.gwt.xml
+++ b/backends/gdx-backends-gwt/res/com/google/gwt/webgl/WebGL.gwt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit trunk//EN" "https://www.gwtproject.org/doctype/2.9.0/gwt-module.dtd">
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit trunk//EN" "https://www.gwtproject.org/doctype/2.10.0/gwt-module.dtd">
 <module>
   <inherits name="com.google.gwt.user.User"/>
   <inherits name="com.google.gwt.canvas.Canvas"/>

--- a/backends/gdx-backends-gwt/res/com/google/gwt/webgl/WebGL.gwt.xml
+++ b/backends/gdx-backends-gwt/res/com/google/gwt/webgl/WebGL.gwt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit trunk//EN" "http://www.gwtproject.org/doctype/2.8.0/gwt-module.dtd">
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit trunk//EN" "https://www.gwtproject.org/doctype/2.9.0/gwt-module.dtd">
 <module>
   <inherits name="com.google.gwt.user.User"/>
   <inherits name="com.google.gwt.canvas.Canvas"/>

--- a/backends/gdx-backends-gwt/res/jsinterop/annotations/Annotations.gwt.xml
+++ b/backends/gdx-backends-gwt/res/jsinterop/annotations/Annotations.gwt.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.9.0//EN" "https://www.gwtproject.org/doctype/2.9.0/gwt-module.dtd">
+<module>
+	<source path="" />
+</module>

--- a/backends/gdx-backends-gwt/res/jsinterop/annotations/Annotations.gwt.xml
+++ b/backends/gdx-backends-gwt/res/jsinterop/annotations/Annotations.gwt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.9.0//EN" "https://www.gwtproject.org/doctype/2.9.0/gwt-module.dtd">
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.10.0//EN" "https://www.gwtproject.org/doctype/2.10.0/gwt-module.dtd">
 <module>
 	<source path="" />
 </module>

--- a/extensions/gdx-box2d/gdx-box2d-gwt/res/com/badlogic/gdx/physics/box2d/box2d-gwt.gwt.xml
+++ b/extensions/gdx-box2d/gdx-box2d-gwt/res/com/badlogic/gdx/physics/box2d/box2d-gwt.gwt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit trunk//EN" "https://www.gwtproject.org/doctype/2.9.0/gwt-module.dtd">
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit trunk//EN" "https://www.gwtproject.org/doctype/2.10.0/gwt-module.dtd">
 <module>
 	<inherits name='com.badlogic.gdx.physics.box2d'/>
 	<source path="gwt"/>

--- a/extensions/gdx-box2d/gdx-box2d-gwt/res/com/badlogic/gdx/physics/box2d/box2d-gwt.gwt.xml
+++ b/extensions/gdx-box2d/gdx-box2d-gwt/res/com/badlogic/gdx/physics/box2d/box2d-gwt.gwt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit trunk//EN" "http://www.gwtproject.org/doctype/2.8.0/gwt-module.dtd">
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit trunk//EN" "https://www.gwtproject.org/doctype/2.9.0/gwt-module.dtd">
 <module>
 	<inherits name='com.badlogic.gdx.physics.box2d'/>
 	<source path="gwt"/>

--- a/extensions/gdx-box2d/gdx-box2d/res/com/badlogic/gdx/physics/box2d.gwt.xml
+++ b/extensions/gdx-box2d/gdx-box2d/res/com/badlogic/gdx/physics/box2d.gwt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit trunk//EN" "http://www.gwtproject.org/doctype/2.8.0/gwt-module.dtd">
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit trunk//EN" "https://www.gwtproject.org/doctype/2.9.0/gwt-module.dtd">
 <module>
 	<source path="box2d">
 	</source>

--- a/extensions/gdx-box2d/gdx-box2d/res/com/badlogic/gdx/physics/box2d.gwt.xml
+++ b/extensions/gdx-box2d/gdx-box2d/res/com/badlogic/gdx/physics/box2d.gwt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit trunk//EN" "https://www.gwtproject.org/doctype/2.9.0/gwt-module.dtd">
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit trunk//EN" "https://www.gwtproject.org/doctype/2.10.0/gwt-module.dtd">
 <module>
 	<source path="box2d">
 	</source>

--- a/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/core/CoreGdxDefinition
+++ b/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/core/CoreGdxDefinition
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit trunk//EN" "http://www.gwtproject.org/doctype/2.8.0/gwt-module.dtd">
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit trunk//EN" "https://www.gwtproject.org/doctype/2.9.0/gwt-module.dtd">
 <module>
 	<source path="%PACKAGE_DIR%" />
 </module>

--- a/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/core/CoreGdxDefinition
+++ b/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/core/CoreGdxDefinition
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit trunk//EN" "https://www.gwtproject.org/doctype/2.9.0/gwt-module.dtd">
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit trunk//EN" "https://www.gwtproject.org/doctype/2.10.0/gwt-module.dtd">
 <module>
 	<source path="%PACKAGE_DIR%" />
 </module>

--- a/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/html/GdxDefinition
+++ b/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/html/GdxDefinition
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit trunk//EN" "http://www.gwtproject.org/doctype/2.8.0/gwt-module.dtd">
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit trunk//EN" "https://www.gwtproject.org/doctype/2.9.0/gwt-module.dtd">
 <module rename-to="html">
 %GWT_INHERITS%
 	<inherits name='%MAIN_CLASS%' />

--- a/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/html/GdxDefinition
+++ b/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/html/GdxDefinition
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit trunk//EN" "https://www.gwtproject.org/doctype/2.9.0/gwt-module.dtd">
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit trunk//EN" "https://www.gwtproject.org/doctype/2.10.0/gwt-module.dtd">
 <module rename-to="html">
 %GWT_INHERITS%
 	<inherits name='%MAIN_CLASS%' />

--- a/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/html/GdxDefinitionSuperdev
+++ b/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/html/GdxDefinitionSuperdev
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit trunk//EN" "https://www.gwtproject.org/doctype/2.9.0/gwt-module.dtd">
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit trunk//EN" "https://www.gwtproject.org/doctype/2.10.0/gwt-module.dtd">
 <module rename-to="html">
 %GWT_INHERITS%
     <inherits name='%PACKAGE%.GdxDefinition' />
-    
+
     <collapse-all-properties />
-    
-	<add-linker name="xsiframe"/>	
+
+	<add-linker name="xsiframe"/>
 	<set-configuration-property name="devModeRedirectEnabled" value="true"/>
-	<set-configuration-property name='xsiframe.failIfScriptTag' value='FALSE'/>	
+	<set-configuration-property name='xsiframe.failIfScriptTag' value='FALSE'/>
 </module>

--- a/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/html/GdxDefinitionSuperdev
+++ b/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/html/GdxDefinitionSuperdev
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit trunk//EN" "http://www.gwtproject.org/doctype/2.8.0/gwt-module.dtd">
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit trunk//EN" "https://www.gwtproject.org/doctype/2.9.0/gwt-module.dtd">
 <module rename-to="html">
 %GWT_INHERITS%
     <inherits name='%PACKAGE%.GdxDefinition' />

--- a/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/html/build.gradle
+++ b/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/html/build.gradle
@@ -14,7 +14,7 @@ gwt {
     }
 }
 
-import org.wisepersist.gradle.plugins.gwt.GwtSuperDev
+import org.docstr.gradle.plugins.gwt.GwtSuperDev
 import org.akhikhl.gretty.AppBeforeIntegrationTestTask
 
 gretty.httpPort = 8080

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/DependencyBank.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/DependencyBank.java
@@ -28,7 +28,7 @@ public class DependencyBank {
 	static String buildToolsVersion = "33.0.2";
 	static String androidAPILevel = "32";
 	static String androidMinAPILevel = "14";
-	static String gwtVersion = "2.8.2";
+	static String gwtVersion = "2.10.0";
 
 	// Repositories
 	static String mavenLocal = "mavenLocal()";
@@ -40,7 +40,7 @@ public class DependencyBank {
 	static String jitpackUrl = "https://jitpack.io";
 
 	// Project plugins
-	static String gwtPluginImport = "org.wisepersist:gwt-gradle-plugin:1.1.16";
+	static String gwtPluginImport = "org.docstr:gwt-gradle-plugin:1.1.29";
 	static String grettyPluginImport = "org.gretty:gretty:3.0.7";
 	static String androidPluginImport = "com.android.tools.build:gradle:7.2.2";
 	static String roboVMPluginImport = "com.mobidevelop.robovm:robovm-gradle-plugin:" + roboVMVersion;

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -24,8 +24,9 @@ ext {
 versions.java = project.hasProperty("javaVersion") ? Integer.parseInt(project.getProperty("javaVersion")) : 7
 versions.javaLwjgl3 = project.hasProperty("javaVersion") ? Integer.parseInt(project.getProperty("javaVersion")) : 8
 versions.robovm = "2.3.19"
-versions.gwt = "2.8.2"
-versions.gwtPlugin = "1.1.16"
+versions.gwt = "2.10.0"
+versions.gwtPlugin = "1.1.29"
+versions.jsinteropAnnotations = "2.0.2"
 versions.gretty = "3.0.7"
 versions.jglwf = "1.1"
 versions.lwjgl = "2.9.3"
@@ -127,7 +128,8 @@ libraries.compileOnly.android = [
 ]
 
 libraries.gwt = [
-        "com.google.gwt:gwt-user:${versions.gwt}"
+        "com.google.gwt:gwt-user:${versions.gwt}",
+        "com.google.jsinterop:jsinterop-annotations:${versions.jsinteropAnnotations}:sources"
 ]
 
 libraries.compileOnly.gwt = [

--- a/tests/gdx-tests-gwt/build.gradle
+++ b/tests/gdx-tests-gwt/build.gradle
@@ -16,7 +16,7 @@
 
 buildscript {
 	dependencies {
-		classpath "org.wisepersist:gwt-gradle-plugin:${versions.gwtPlugin}"
+		classpath "org.docstr:gwt-gradle-plugin:${versions.gwtPlugin}"
 		classpath "org.gretty:gretty:${versions.gretty}"
 	}
 }
@@ -30,7 +30,7 @@ apply plugin: 'gwt'
 apply plugin: 'war'
 apply plugin: 'org.gretty'
 
-import org.wisepersist.gradle.plugins.gwt.GwtSuperDev
+import org.docstr.gradle.plugins.gwt.GwtSuperDev
 import org.akhikhl.gretty.AppBeforeIntegrationTestTask
 
 gretty.httpPort = 8080
@@ -46,7 +46,7 @@ dependencies {
 }
 
 gwt {
-	gwtVersion='2.8.2' // Should match the gwt version used for building the gwt backend
+	gwtVersion='2.10.0' // Should match the gwt version used for building the gwt backend
 	maxHeapSize="1G" // Default 256m is not enough for gwt compiler. GWT is HUNGRY
 	minHeapSize="1G"
 

--- a/tests/gdx-tests-gwt/res/com/badlogic/gdx/tests/gwt/GdxTestsGwt.gwt.xml
+++ b/tests/gdx-tests-gwt/res/com/badlogic/gdx/tests/gwt/GdxTestsGwt.gwt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit trunk//EN" "http://www.gwtproject.org/doctype/2.8.0/gwt-module.dtd">
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit trunk//EN" "https://www.gwtproject.org/doctype/2.9.0/gwt-module.dtd">
 <module>
 	<inherits name='com.badlogic.gdx.backends.gdx_backends_gwt' />
 	<inherits name='com.badlogic.gdx.GdxTests' />

--- a/tests/gdx-tests-gwt/res/com/badlogic/gdx/tests/gwt/GdxTestsGwt.gwt.xml
+++ b/tests/gdx-tests-gwt/res/com/badlogic/gdx/tests/gwt/GdxTestsGwt.gwt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit trunk//EN" "https://www.gwtproject.org/doctype/2.9.0/gwt-module.dtd">
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit trunk//EN" "https://www.gwtproject.org/doctype/2.10.0/gwt-module.dtd">
 <module>
 	<inherits name='com.badlogic.gdx.backends.gdx_backends_gwt' />
 	<inherits name='com.badlogic.gdx.GdxTests' />

--- a/tests/gdx-tests/res/com/badlogic/gdx/GdxTests.gwt.xml
+++ b/tests/gdx-tests/res/com/badlogic/gdx/GdxTests.gwt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit trunk//EN" "http://www.gwtproject.org/doctype/2.8.0/gwt-module.dtd">
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit trunk//EN" "https://www.gwtproject.org/doctype/2.9.0/gwt-module.dtd">
 <module>
 	<source path="tests">
 		<exclude name="**/AssetsFileGenerator.java"/> <!-- utility -->

--- a/tests/gdx-tests/res/com/badlogic/gdx/GdxTests.gwt.xml
+++ b/tests/gdx-tests/res/com/badlogic/gdx/GdxTests.gwt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit trunk//EN" "https://www.gwtproject.org/doctype/2.9.0/gwt-module.dtd">
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit trunk//EN" "https://www.gwtproject.org/doctype/2.10.0/gwt-module.dtd">
 <module>
 	<source path="tests">
 		<exclude name="**/AssetsFileGenerator.java"/> <!-- utility -->


### PR DESCRIPTION
I don't know why there's no dtd for 2.10.0, so I chose the dtd from 2.9.0