### PR TITLE
Fix ANGLE GLES renderer on dekstop

### DIFF
--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
@@ -56,6 +56,7 @@ import com.badlogic.gdx.utils.GdxRuntimeException;
 import com.badlogic.gdx.utils.ObjectMap;
 import com.badlogic.gdx.utils.SharedLibraryLoader;
 import org.lwjgl.system.Configuration;
+import org.lwjgl.system.ThreadLocalUtil;
 
 public class Lwjgl3Application implements Lwjgl3ApplicationBase {
 	private final Lwjgl3ApplicationConfiguration config;
@@ -562,6 +563,8 @@ public class Lwjgl3Application implements Lwjgl3ApplicationBase {
 			try {
 				Class gles = Class.forName("org.lwjgl.opengles.GLES");
 				gles.getMethod("createCapabilities").invoke(gles);
+				// TODO: 06.10.23 Remove once https://github.com/LWJGL/lwjgl3/issues/931 is fixed
+				ThreadLocalUtil.setFunctionMissingAddresses(0);
 			} catch (Throwable e) {
 				throw new GdxRuntimeException("Couldn't initialize GLES", e);
 			}

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
@@ -563,7 +563,7 @@ public class Lwjgl3Application implements Lwjgl3ApplicationBase {
 			try {
 				Class gles = Class.forName("org.lwjgl.opengles.GLES");
 				gles.getMethod("createCapabilities").invoke(gles);
-				// TODO: 06.10.23 Remove once https://github.com/LWJGL/lwjgl3/issues/931 is fixed
+				// TODO: Remove once https://github.com/LWJGL/lwjgl3/issues/931 is fixed
 				ThreadLocalUtil.setFunctionMissingAddresses(0);
 			} catch (Throwable e) {
 				throw new GdxRuntimeException("Couldn't initialize GLES", e);


### PR DESCRIPTION
LWJGL 3.3.3 now disallows to call `ThreadLocalUtil#setFunctionMissingAddresses` multiple times.
This PR, not very elegant, fixes this issue by resetting the `FunctionMissingAddresses` after the `GLES` class set them in their static initializer. This way, when the `GL` class is initialized, it doesn't crash. 
This crash only happens with `Lwjgl3ApplicationConfiguration.GLEmulation.ANGLE_GLES20`
Related LWJGL3 issue: https://github.com/LWJGL/lwjgl3/issues/931

Fixes https://github.com/libgdx/libgdx/issues/7245