### PR TITLE
Fix delta time not being reset when resizing.

### DIFF
--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Graphics.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Graphics.java
@@ -100,6 +100,7 @@ public class Lwjgl3Graphics extends AbstractGraphics implements Disposable {
 		window.makeCurrent();
 		gl20.glViewport(0, 0, backBufferWidth, backBufferHeight);
 		window.getListener().resize(getWidth(), getHeight());
+		update();
 		window.getListener().render();
 		GLFW.glfwSwapBuffers(windowHandle);
 	}


### PR DESCRIPTION
On the LWJGL 3 backend, resizing causes [additional render calls](https://github.com/libgdx/libgdx/blob/35ac7a1e3f640934e9cac403438a0c4dca49cc35/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Graphics.java#L104C3-L104C33). However, for those, the delta time is never updated, it just stays the same as for the last 'real' frame. This leads to the game speeding up when the window is resized.

Fixes #7253.