### PR TITLE
Prevent loss of precision in OrthographicCamera.update

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/OrthographicCamera.java
+++ b/gdx/src/com/badlogic/gdx/graphics/OrthographicCamera.java
@@ -45,7 +45,6 @@ public class OrthographicCamera extends Camera {
 	}
 
 	private final Vector3 tmp = new Vector3();
-	private final Matrix4 tmpMat = new Matrix4();
 
 	@Override
 	public void update () {
@@ -57,7 +56,7 @@ public class OrthographicCamera extends Camera {
 		projection.setToOrtho(zoom * -viewportWidth / 2, zoom * (viewportWidth / 2), zoom * -(viewportHeight / 2),
 			zoom * viewportHeight / 2, near, far);
 		view.setToLookAt(direction, up);
-		view.mul(tmpMat.setToTranslation(-position.x, -position.y, -position.z));
+		view.translate(-position.x, -position.y, -position.z);
 		combined.set(projection);
 		Matrix4.mul(combined.val, view.val);
 

--- a/gdx/src/com/badlogic/gdx/graphics/OrthographicCamera.java
+++ b/gdx/src/com/badlogic/gdx/graphics/OrthographicCamera.java
@@ -45,6 +45,7 @@ public class OrthographicCamera extends Camera {
 	}
 
 	private final Vector3 tmp = new Vector3();
+	private final Matrix4 tmpMat = new Matrix4();
 
 	@Override
 	public void update () {
@@ -55,7 +56,8 @@ public class OrthographicCamera extends Camera {
 	public void update (boolean updateFrustum) {
 		projection.setToOrtho(zoom * -viewportWidth / 2, zoom * (viewportWidth / 2), zoom * -(viewportHeight / 2),
 			zoom * viewportHeight / 2, near, far);
-		view.setToLookAt(position, tmp.set(position).add(direction), up);
+		view.setToLookAt(direction, up);
+		view.mul(tmpMat.setToTranslation(-position.x, -position.y, -position.z));
 		combined.set(projection);
 		Matrix4.mul(combined.val, view.val);
 


### PR DESCRIPTION
Currently `position` and `direction` are first added and then in  `Matrix4.setToLookAt` subtracted again. This can lead to loss of floating-point precision if the the components of `position` is much larger than those of `direction`.