### PR TITLE
Fix overlaps in the Rectangle Fixed #7257

### DIFF
--- a/gdx/src/com/badlogic/gdx/math/Rectangle.java
+++ b/gdx/src/com/badlogic/gdx/math/Rectangle.java
@@ -217,16 +217,17 @@ public class Rectangle implements Serializable, Shape2D {
 
 	/** @param r the other {@link Rectangle}
 	 * @return whether this rectangle overlaps the other rectangle. */
-	public boolean overlaps (Rectangle r) {
+	public boolean overlaps(Rectangle r) {
 		float thisLeft = width >= 0 ? x : x + width;
-		float thisRight = width >= 0 ? x+width : x;
+		float thisRight = width >= 0 ? x + width : x;
 		float thisButton = height >= 0 ? y : y + height;
 		float thisTop = height >= 0 ? y + height : y;
 
 		float thatLeft = r.width >= 0 ? r.x : r.x + r.width;
-		float thatRight = r.width >= 0 ? r.x+r.width : r.x;
+		float thatRight = r.width >= 0 ? r.x + r.width : r.x;
 		float thatButton = r.height >= 0 ? r.y : r.y + r.height;
-		float thatTop = r.height >= 0 ?r. y + r.height : r.y;
+		float thatTop = r.height >= 0 ? r.y + r.height : r.y;
+
 		return thisLeft < thatRight && thisRight > thatLeft && thisButton < thatTop && thisTop > thatButton;
 	}
 

--- a/gdx/src/com/badlogic/gdx/math/Rectangle.java
+++ b/gdx/src/com/badlogic/gdx/math/Rectangle.java
@@ -218,7 +218,16 @@ public class Rectangle implements Serializable, Shape2D {
 	/** @param r the other {@link Rectangle}
 	 * @return whether this rectangle overlaps the other rectangle. */
 	public boolean overlaps (Rectangle r) {
-		return x < r.x + r.width && x + width > r.x && y < r.y + r.height && y + height > r.y;
+		float thisLeft = width >= 0 ? x : x + width;
+		float thisRight = width >= 0 ? x+width : x;
+		float thisButton = height >= 0 ? y : y + height;
+		float thisTop = height >= 0 ? y + height : y;
+
+		float thatLeft = r.width >= 0 ? r.x : r.x + r.width;
+		float thatRight = r.width >= 0 ? r.x+r.width : r.x;
+		float thatButton = r.height >= 0 ? r.y : r.y + r.height;
+		float thatTop = r.height >= 0 ?r. y + r.height : r.y;
+		return thisLeft < thatRight && thisRight > thatLeft && thisButton < thatTop && thisTop > thatButton;
 	}
 
 	/** Sets the values of the given rectangle to this rectangle.


### PR DESCRIPTION
Fix overlaps in the Rectangle
check both Rectangle's side to determine which on is the left and witch one is the right, then this method could be used to negative width and height!
Fixed #7257