### PR TITLE
Fixes #7256

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@
 - API Addition: TiledDrawable: Align can be set to manipulate the alignment of the rendering (TiledDrawable#setAlign, TiledDrawable#getAlign)
 - API Addition: TiledDrawable#draw: Also available as a static function (with align) if you don't want to create an extra instance per texture region
 - Android: Removed mouse catching added on 1.12.0 due to unintended effects (see #7187).
+- Android: Fixed touch state inconsistency when touching screen with 3 fingers on some devices (see #7256)
 - iOS: Update to MobiVM 2.3.20
 - API Addition: Using "object" property in Tiled object now fetches MapObject being pointed to, and BaseTmxMapLoader includes method for fetching map where key is id and value is MapObject instance.
 - Update to LWJGL 3.3.3

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidTouchHandler.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidTouchHandler.java
@@ -23,6 +23,8 @@ import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input.Buttons;
 import com.badlogic.gdx.backends.android.DefaultAndroidInput.TouchEvent;
 
+import java.util.Arrays;
+
 /** Multitouch handler for devices running Android >= 2.0. If device is capable of (fake) multitouch this will report additional
  * pointers.
  * 
@@ -82,6 +84,10 @@ public class AndroidTouchHandler {
 				input.touched[realPointerIndex] = false;
 				input.button[realPointerIndex] = 0;
 				input.pressure[realPointerIndex] = 0;
+				if (action == MotionEvent.ACTION_CANCEL) {
+					Arrays.fill(input.realId, -1);
+					Arrays.fill(input.touched, false);
+				}
 				break;
 
 			case MotionEvent.ACTION_MOVE:


### PR DESCRIPTION
Some custom system Android gestures such as touching the screen with 3 fingers to capure a screenshot can trigger an ACTION_CANCEL event. All pointers need to be reset in those cases to avoid an inconsistent state.

I haven't been able to test the PR because I don't have a device that has these kind of gestures so, even if the change is low risk, testing is needed to confirm the fix works.