### PR TITLE
Fix longPress being triggered on back Android System gesture

### DIFF
--- a/gdx/src/com/badlogic/gdx/input/GestureDetector.java
+++ b/gdx/src/com/badlogic/gdx/input/GestureDetector.java
@@ -236,6 +236,12 @@ public class GestureDetector extends InputAdapter {
 		return handled;
 	}
 
+	@Override
+	public boolean touchCancelled(int screenX, int screenY, int pointer, int button) {
+		cancel();
+		return super.touchCancelled(screenX, screenY, pointer, button);
+	}
+
 	/** No further gesture events will be triggered for the current touch, if any. */
 	public void cancel () {
 		longPressTask.cancel();

--- a/gdx/src/com/badlogic/gdx/input/GestureDetector.java
+++ b/gdx/src/com/badlogic/gdx/input/GestureDetector.java
@@ -237,7 +237,7 @@ public class GestureDetector extends InputAdapter {
 	}
 
 	@Override
-	public boolean touchCancelled(int screenX, int screenY, int pointer, int button) {
+	public boolean touchCancelled (int screenX, int screenY, int pointer, int button) {
 		cancel();
 		return super.touchCancelled(screenX, screenY, pointer, button);
 	}


### PR DESCRIPTION
Fixes #7263. `GestureDetector` needs to reset the long press state when a touch cancel occurs to prevent inconsistent states.

To reproduce the issue adapt `GestureDetectorTest` to catch back key an follow the issue reproduction steps (enable System Gestures).

Fix tested on Pixel 3 with Android 12.