### PR TITLE
fix: npe in depth shader diffuseTexture 

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/DepthShader.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/DepthShader.java
@@ -122,12 +122,10 @@ public class DepthShader extends DefaultShader {
 			if (renderable.meshPart.mesh.getVertexAttributes().getBoneWeights() > config.numBoneWeights) return false;
 		}
 		final Attributes attributes = combineAttributes(renderable);
-		if (attributes.has(BlendingAttribute.Type)) {
-			if ((attributesMask & BlendingAttribute.Type) != BlendingAttribute.Type) return false;
-			if (attributes
-				.has(TextureAttribute.Diffuse) != ((attributesMask & TextureAttribute.Diffuse) == TextureAttribute.Diffuse))
-				return false;
-		}
+		if (attributes.has(BlendingAttribute.Type) && ((attributesMask & BlendingAttribute.Type) != BlendingAttribute.Type))
+			return false;
+		if (attributes.has(TextureAttribute.Diffuse) != ((attributesMask & TextureAttribute.Diffuse) == TextureAttribute.Diffuse))
+			return false;
 		return (renderable.bones != null) == (numBones > 0);
 	}
 


### PR DESCRIPTION
Line: https://github.com/libgdx/libgdx/blob/7fb396541a8c2777c92a5062aaa49afcab0bec1f/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/DefaultShader.java#L237C32-L237C50

This is throwing an npe because the DepthShader canRender() is recycling the shader without the diffuse texture attribute.

Step to replicate: 
 - open: "gdx-gltf-demo-desktop-2.1.0.jar" from gdx-gltf repo (https://github.com/mgsx-dev/gdx-gltf)
 - load this glTF model: https://sketchfab.com/3d-models/2021-lamborghini-countach-lpi-800-4-d76b94884432422b966d1a7f8815afb5
 - enable shadow pass from gltf scene manager
 - npe