### PR TITLE
Update missing build.gradle files with new syntax for registering tasks

### DIFF
--- a/backends/gdx-backend-robovm-metalangle/build.gradle
+++ b/backends/gdx-backend-robovm-metalangle/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 	generatorImplementation 'com.github.javaparser:javaparser-core:3.24.2'
 }
 
-task generate(type: JavaExec) {
+tasks.register('generate', JavaExec) {
 	dependsOn configurations.generator
 
 	mainClass = 'JavaCodeGenerator'
@@ -55,7 +55,7 @@ task generate(type: JavaExec) {
 	outputs.dir 'src/'
 }
 
-task fetchMetalANGLE(type: Download) {
+tasks.register('fetchMetalANGLE', Download) {
 	doFirst {
 		file("build/tmp").mkdirs();
 	}
@@ -65,7 +65,7 @@ task fetchMetalANGLE(type: Download) {
 	useETag "all"
 }
 
-task fetchMetalANGLESimulator(type: Download) {
+tasks.register('fetchMetalANGLESimulator', Download) {
 	doFirst {
 		file("build/tmp").mkdirs();
 	}
@@ -75,19 +75,22 @@ task fetchMetalANGLESimulator(type: Download) {
 	useETag "all"
 }
 
-task verifyMetalANGLE(dependsOn: fetchMetalANGLE, type: Verify) {
+tasks.register('verifyMetalANGLE', Verify) {
+	dependsOn fetchMetalANGLE
 	src 'build/tmp/MetalANGLE.framework.ios.zip'
 	algorithm 'SHA-256'
 	checksum '9b6e7c82d41749266200ed19bb184c4f47df63c4dcde0972186ea557de623018'
 }
 
-task verifyMetalANGLESimulator(dependsOn: fetchMetalANGLESimulator, type: Verify) {
+tasks.register('verifyMetalANGLESimulator', Verify) {
+	dependsOn fetchMetalANGLESimulator
 	src 'build/tmp/MetalANGLE.framework.ios.simulator.zip'
 	algorithm 'SHA-256'
 	checksum '63ff063bf7825e2da9a01eda981067eb4eacd42e202c86f448541d2c5bd564a9'
 }
 
-task extractMetalANGLE(dependsOn: verifyMetalANGLE, type: Copy) {
+tasks.register('extractMetalANGLE', Copy) {
+	dependsOn verifyMetalANGLE
 	doFirst {
 		file("build/tmp/real").mkdirs();
 	}
@@ -95,7 +98,8 @@ task extractMetalANGLE(dependsOn: verifyMetalANGLE, type: Copy) {
 	into 'build/tmp/real'
 }
 
-task extractMetalANGLESimulator(dependsOn: verifyMetalANGLESimulator, type: Copy) {
+tasks.register('extractMetalANGLESimulator', Copy) {
+	dependsOn verifyMetalANGLESimulator
 	doFirst {
 		file("build/tmp/sim").mkdirs();
 	}
@@ -103,10 +107,8 @@ task extractMetalANGLESimulator(dependsOn: verifyMetalANGLESimulator, type: Copy
 	into 'build/tmp/sim'
 }
 
-task buildMetalANGLE(dependsOn: [
-	extractMetalANGLE,
-	extractMetalANGLESimulator
-], type: Exec) {
+tasks.register('buildMetalANGLE', Exec) {
+	dependsOn extractMetalANGLE, extractMetalANGLESimulator
 	doFirst {
 		delete("res/META-INF/robovm/ios/libs/MetalANGLE.xcframework")
 		file("res/META-INF/robovm/ios/libs").mkdirs();
@@ -122,14 +124,15 @@ task buildMetalANGLE(dependsOn: [
 	outputs.dir 'res/META-INF/robovm/ios/libs/MetalANGLE.xcframework'
 }
 
-task jnigenBuildIOS(dependsOn: buildMetalANGLE) {
+tasks.register('jnigenBuildIOS') {
+	dependsOn buildMetalANGLE
 }
 
-task jnigenBuild() {
+tasks.register('jnigenBuild') {
 }
 
 //Dummy task to make compatible with publish
-task jnigen() {
+tasks.register('jnigen') {
 }
 
 if(OperatingSystem.current() == OperatingSystem.MAC_OS) {

--- a/build.gradle
+++ b/build.gradle
@@ -176,58 +176,60 @@ configure(subprojects - project(":backends") - project(":extensions") - project(
 	}
 }
 
-task setupExternalNativesDirs() {
+tasks.register('setupExternalNativesDirs') {
 	doLast {
 		file("build").mkdir();
 		file("extensions/gdx-lwjgl3-angle/res").mkdirs();
 		file("extensions/gdx-lwjgl3-glfw-awt-macos/res/macosx64").mkdirs();
 		file("extensions/gdx-lwjgl3-glfw-awt-macos/res/macosarm64").mkdirs();
 	}
-	outputs.upToDateWhen { false }
+	doNotTrackState("Don't track state")
 }
 
-task fetchAngleNativesZIP(dependsOn: setupExternalNativesDirs, type: Download) {
+tasks.register('fetchAngleNativesZIP', Download) {
+	dependsOn setupExternalNativesDirs
 	src 'https://raw.githubusercontent.com/libgdx/gdx-angle-natives/master/gdx-angle-natives.zip'
 	dest 'build/gdx-angle-natives.zip'
 	onlyIfModified true
 	useETag "all"
 }
 
-task fetchGlfwAWT(dependsOn: setupExternalNativesDirs, type: Download) {
+tasks.register('fetchGlfwAWT', Download) {
+	dependsOn setupExternalNativesDirs
 	src 'https://raw.githubusercontent.com/badlogic/glfw/master/libglfw.dylib'
 	dest 'extensions/gdx-lwjgl3-glfw-awt-macos/res/macosx64/libglfw.dylib'
 	onlyIfModified true
 	useETag "all"
 }
 
-task fetchGlfwAWTARM64(dependsOn: setupExternalNativesDirs, type: Download) {
+tasks.register('fetchGlfwAWTARM64', Download) {
+	dependsOn setupExternalNativesDirs
 	src 'https://raw.githubusercontent.com/badlogic/glfw/master/libglfwarm64.dylib'
 	dest 'extensions/gdx-lwjgl3-glfw-awt-macos/res/macosarm64/libglfwarm64.dylib'
 	onlyIfModified true
 	useETag "all"
 }
 
-task fetchExternalNatives(dependsOn: [
-	fetchAngleNativesZIP,
-	fetchGlfwAWT,
-	fetchGlfwAWTARM64
-] , type: Copy) {
+tasks.register('fetchExternalNatives', Copy) {
+	dependsOn fetchAngleNativesZIP, fetchGlfwAWT, fetchGlfwAWTARM64
 	from zipTree("build/gdx-angle-natives.zip")
 	into "./extensions/gdx-lwjgl3-angle/res"
-	outputs.upToDateWhen { false }
+	doNotTrackState("Don't track state")
 }
 
-task fetchGdxNativesZIP(dependsOn: fetchExternalNatives, type: Download) {
+tasks.register('fetchGdxNativesZIP', Download) {
+	dependsOn fetchExternalNatives
 	src "https://libgdx-nightlies.s3.eu-central-1.amazonaws.com/libgdx-nightlies/natives.zip"
 	dest "build/natives.zip"
 	onlyIfModified true
 	useETag "all"
 }
 
-task fetchNatives(dependsOn: fetchGdxNativesZIP, type: Copy) {
+tasks.register('fetchNatives', Copy) {
+	dependsOn fetchGdxNativesZIP
 	from zipTree("build/natives.zip")
 	into "."
-	outputs.upToDateWhen { false }
+	doNotTrackState("Don't track state")
 }
 
 apply from: rootProject.file('publish.gradle')

--- a/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/html/build.gradle
+++ b/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/html/build.gradle
@@ -38,7 +38,8 @@ tasks.register('startHttpServer') {
     }
 }
 
-task beforeRun(type: AppBeforeIntegrationTestTask, dependsOn: startHttpServer) {
+tasks.register('beforeRun', AppBeforeIntegrationTestTask) {
+    dependsOn startHttpServer
     // The next line allows ports to be reused instead of
     // needing a process to be manually terminated.
     file("build/TEMP_PORTS.properties").delete()

--- a/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/html/build.gradle
+++ b/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/html/build.gradle
@@ -38,8 +38,7 @@ tasks.register('startHttpServer') {
     }
 }
 
-tasks.register('beforeRun', AppBeforeIntegrationTestTask) {
-    dependsOn startHttpServer
+task beforeRun(type: AppBeforeIntegrationTestTask, dependsOn: startHttpServer) {
     // The next line allows ports to be reused instead of
     // needing a process to be manually terminated.
     file("build/TEMP_PORTS.properties").delete()

--- a/extensions/gdx-tools/build.gradle
+++ b/extensions/gdx-tools/build.gradle
@@ -32,7 +32,8 @@ ext {
 	toolsAssetsDir = ["assets"]
 }
 
-task dist2DParticles (type: Jar, dependsOn: configurations.runtimeClasspath) {
+tasks.register('dist2DParticles', Jar) {
+	dependsOn configurations.runtimeClasspath
 	duplicatesStrategy(DuplicatesStrategy.EXCLUDE)
 
 	from files(sourceSets.main.java.classesDirectory)
@@ -47,7 +48,8 @@ task dist2DParticles (type: Jar, dependsOn: configurations.runtimeClasspath) {
 	}
 }
 
-task dist3DParticles (type: Jar, dependsOn: configurations.runtimeClasspath) {
+tasks.register('dist3DParticles', Jar) {
+	dependsOn configurations.runtimeClasspath
 	duplicatesStrategy(DuplicatesStrategy.EXCLUDE)
 
 	from files(sourceSets.main.java.classesDirectory)
@@ -62,7 +64,8 @@ task dist3DParticles (type: Jar, dependsOn: configurations.runtimeClasspath) {
 	}
 }
 
-task distHiero (type: Jar, dependsOn: configurations.runtimeClasspath) {
+tasks.register('distHiero', Jar) {
+	dependsOn configurations.runtimeClasspath
 	duplicatesStrategy(DuplicatesStrategy.EXCLUDE)
 
 	from files(sourceSets.main.java.classesDirectory)
@@ -77,7 +80,8 @@ task distHiero (type: Jar, dependsOn: configurations.runtimeClasspath) {
 	}
 }
 
-task distTexturePacker (type: Jar, dependsOn: configurations.runtimeClasspath) {
+tasks.register('distTexturePacker', Jar) {
+	dependsOn configurations.runtimeClasspath
 	duplicatesStrategy(DuplicatesStrategy.EXCLUDE)
 
 	from files(sourceSets.main.java.classesDirectory)
@@ -92,12 +96,8 @@ task distTexturePacker (type: Jar, dependsOn: configurations.runtimeClasspath) {
 	}
 }
 
-task buildRunnables (dependsOn: [
-	dist2DParticles,
-	dist3DParticles,
-	distHiero,
-	distTexturePacker
-]) {
+tasks.register('buildRunnables') {
+	dependsOn dist2DParticles, dist3DParticles, distHiero, distTexturePacker
 	doLast {
 		println "Building ye runnables"
 	}

--- a/tests/gdx-tests-android/build.gradle
+++ b/tests/gdx-tests-android/build.gradle
@@ -87,7 +87,7 @@ android {
 // called every time gradle gets executed, takes the native dependencies of
 // the natives configuration, and extracts them to the proper libs/ folders
 // so they get packed with the APK.
-task copyAndroidNatives() {
+tasks.register('copyAndroidNatives') {
 	doFirst {
 		file("libs/armeabi-v7a/").mkdirs();
 		file("libs/arm64-v8a/").mkdirs();
@@ -116,8 +116,6 @@ task copyAndroidNatives() {
 	}
 }
 
-tasks.whenTaskAdded { packageTask ->
-	if (packageTask.name.contains("merge") && packageTask.name.contains("JniLibFolders")) {
-		packageTask.dependsOn 'copyAndroidNatives'
-	}
+tasks.matching { it.name.contains("merge") && it.name.contains("JniLibFolders") }.configureEach { packageTask ->
+	packageTask.dependsOn 'copyAndroidNatives'
 }

--- a/tests/gdx-tests-android/obb.gradle
+++ b/tests/gdx-tests-android/obb.gradle
@@ -1,4 +1,4 @@
-task copyAssets {
+tasks.register('copyAssets') {
 	doLast {
 		def assets = fileTree('assets')
 		copy {
@@ -11,7 +11,7 @@ task copyAssets {
 	}
 }
 
-task zipAssets(type: Zip) {
+tasks.register('zipAssets', Zip) {
 	destinationDirectory = file("build/obb")
 	entryCompression = ZipEntryCompression.STORED
 	from "build/obbassets"
@@ -40,11 +40,11 @@ def getADBPath() {
 	adb
 }
 
-task createOBBDir(type: Exec) {
+tasks.register('createOBBDir', Exec) {
 	def adb = getADBPath()
 	commandLine "$adb", 'shell', 'mkdir', '-p', '/mnt/sdcard/Android/obb/com.badlogic.gdx.tests.android'
 }
-task uploadOBB(type: Exec) {
+tasks.register('uploadOBB', Exec) {
 	def adb = getADBPath()
 	commandLine "$adb", 'push', 'build/obb/main.1.com.badlogic.gdx.tests.android.obb', '/mnt/sdcard/Android/obb/com.badlogic.gdx.tests.android'
 }

--- a/tests/gdx-tests-gwt/build.gradle
+++ b/tests/gdx-tests-gwt/build.gradle
@@ -74,8 +74,7 @@ tasks.register('startHttpServer') {
 	}
 }
 
-tasks.register('beforeRun', AppBeforeIntegrationTestTask) {
-	dependsOn startHttpServer
+task beforeRun(type: AppBeforeIntegrationTestTask, dependsOn: startHttpServer) {
 	// The next line allows ports to be reused instead of
 	// needing a process to be manually terminated.
 	file("build/TEMP_PORTS.properties").delete()

--- a/tests/gdx-tests-gwt/build.gradle
+++ b/tests/gdx-tests-gwt/build.gradle
@@ -58,7 +58,7 @@ gwt {
 	compiler.disableCastChecking = true
 }
 
-task startHttpServer () {
+tasks.register('startHttpServer') {
 	dependsOn draftCompileGwt
 
 	doFirst {
@@ -74,7 +74,8 @@ task startHttpServer () {
 	}
 }
 
-task beforeRun(type: AppBeforeIntegrationTestTask, dependsOn: startHttpServer) {
+tasks.register('beforeRun', AppBeforeIntegrationTestTask) {
+	dependsOn startHttpServer
 	// The next line allows ports to be reused instead of
 	// needing a process to be manually terminated.
 	file("build/TEMP_PORTS.properties").delete()
@@ -86,14 +87,15 @@ task beforeRun(type: AppBeforeIntegrationTestTask, dependsOn: startHttpServer) {
 	interactive false
 }
 
-task superDev (type: GwtSuperDev) {
+tasks.register('superDev', GwtSuperDev) {
 	dependsOn startHttpServer
 	doFirst {
 		gwt.modules = gwt.devModules
 	}
 }
 
-task dist(dependsOn: [clean, compileGwt]) {
+tasks.register('dist') {
+	dependsOn clean, compileGwt
 	doLast {
 		file("build/dist").mkdirs()
 		copy {
@@ -112,7 +114,7 @@ task dist(dependsOn: [clean, compileGwt]) {
 }
 
 
-task addSource {
+tasks.register('addSource') {
 	doLast {
 		sourceSets.main.compileClasspath += files(project(':tests:gdx-tests').sourceSets.main.allJava.srcDirs)
 		sourceSets.main.compileClasspath += files(project(':tests:gdx-tests').sourceSets.main.resources.srcDirs)

--- a/tests/gdx-tests-lwjgl/build.gradle
+++ b/tests/gdx-tests-lwjgl/build.gradle
@@ -25,7 +25,8 @@ dependencies {
 	implementation testnatives.desktop
 }
 
-task launchTestsLwjgl (dependsOn: classes, type: JavaExec) {
+tasks.register('launchTestsLwjgl', JavaExec) {
+	dependsOn classes
 	mainClass = mainTestClass
 	classpath = sourceSets.main.runtimeClasspath
 	standardInput = System.in
@@ -36,7 +37,8 @@ configure (launchTestsLwjgl) {
 	group "LibGDX"
 	description = "Run the Lwjgl tests"
 }
-task dist(type: Jar, dependsOn: classes) {
+tasks.register('dist', Jar) {
+	dependsOn classes
 	manifest {
 		attributes 'Main-Class': project.mainTestClass
 	}

--- a/tests/gdx-tests-lwjgl3/build.gradle
+++ b/tests/gdx-tests-lwjgl3/build.gradle
@@ -35,7 +35,8 @@ dependencies {
 	implementation testnatives.desktop
 }
 
-task launchTestsLwjgl3 (dependsOn: classes, type: JavaExec) {
+tasks.register('launchTestsLwjgl3', JavaExec) {
+	dependsOn classes
 	mainClass = mainTestClass
 	classpath = sourceSets.main.runtimeClasspath
 	standardInput = System.in
@@ -46,7 +47,8 @@ configure (launchTestsLwjgl3) {
 	group "LibGDX"
 	description = "Run the Lwjgl3 tests"
 }
-task dist(type: Jar, dependsOn: classes) {
+tasks.register('dist', Jar) {
+	dependsOn classes
 	manifest {
 		attributes 'Main-Class': project.mainTestClass
 	}


### PR DESCRIPTION
Some Gradle build files were still using old syntax after https://github.com/libgdx/libgdx/pull/7134.
