### PR TITLE
Tighten Spotless rules to only include java src folders

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -109,7 +109,7 @@ allprojects {
 		lineEndings 'UNIX'
 
 		java {
-			target '**/*.java'
+			target 'src/**/*.java', 'test/**/*.java', 'generator/**/*.java'
 			removeUnusedImports()
 			eclipse().configFile new File(rootProject.projectDir.absolutePath, 'eclipse-formatter.xml')
 		}


### PR DESCRIPTION
Prevents Spotless from scanning output folders which causes issues with Gradle 8 (see https://github.com/libgdx/libgdx/pull/7246).

The only folders I've found that contain java files not present in a `src` folder are test classes in `gdx/test` and `gdx-backend-robovm-metalangle/generator` class.