### PR TITLE
Ensure that all ANGLE calls go through GLES classes

### DIFF
--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
@@ -35,7 +35,6 @@ import org.lwjgl.opengl.GL;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL43;
 import org.lwjgl.opengl.GLCapabilities;
-import org.lwjgl.opengl.GLDebugMessageCallback;
 import org.lwjgl.opengl.GLUtil;
 import org.lwjgl.opengl.KHRDebug;
 import org.lwjgl.system.Callback;
@@ -58,7 +57,6 @@ import com.badlogic.gdx.utils.GdxRuntimeException;
 import com.badlogic.gdx.utils.ObjectMap;
 import com.badlogic.gdx.utils.SharedLibraryLoader;
 import org.lwjgl.system.Configuration;
-import org.lwjgl.system.ThreadLocalUtil;
 
 public class Lwjgl3Application implements Lwjgl3ApplicationBase {
 	private final Lwjgl3ApplicationConfiguration config;
@@ -467,8 +465,8 @@ public class Lwjgl3Application implements Lwjgl3ApplicationBase {
 		window.setVisible(config.initialVisible);
 
 		for (int i = 0; i < 2; i++) {
-			window.getGraphics().gl20.glClearColor(config.initialBackgroundColor.r, config.initialBackgroundColor.g, config.initialBackgroundColor.b,
-				config.initialBackgroundColor.a);
+			window.getGraphics().gl20.glClearColor(config.initialBackgroundColor.r, config.initialBackgroundColor.g,
+				config.initialBackgroundColor.b, config.initialBackgroundColor.a);
 			window.getGraphics().gl20.glClear(GL11.GL_COLOR_BUFFER_BIT);
 			GLFW.glfwSwapBuffers(windowHandle);
 		}
@@ -584,7 +582,8 @@ public class Lwjgl3Application implements Lwjgl3ApplicationBase {
 
 		if (config.debug) {
 			if (config.glEmulation == GLEmulation.ANGLE_GLES20) {
-				throw new IllegalStateException("ANGLE currently can't be used with with Lwjgl3ApplicationConfiguration#enableGLDebugOutput");
+				throw new IllegalStateException(
+					"ANGLE currently can't be used with with Lwjgl3ApplicationConfiguration#enableGLDebugOutput");
 			}
 			glDebugCallback = GLUtil.setupDebugMessageCallback(config.debugStream);
 			setGLDebugMessageControl(GLDebugMessageSeverity.NOTIFICATION, false);

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/GLVersion.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/GLVersion.java
@@ -120,12 +120,11 @@ public class GLVersion {
 		return releaseVersion;
 	}
 
-	/**
-	 * @return The version string as reported by `glGetString(GL_VERSION)`
-	 */
-	public String getVersionString() {
+	/** @return The version string as reported by `glGetString(GL_VERSION)` */
+	public String getVersionString () {
 		return versionString;
 	}
+
 	/** @return the vendor string associated with the current GL connection */
 	public String getVendorString () {
 		return vendorString;

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/GLVersion.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/GLVersion.java
@@ -28,6 +28,7 @@ public class GLVersion {
 	private int minorVersion;
 	private int releaseVersion;
 
+	private final String versionString;
 	private final String vendorString;
 	private final String rendererString;
 
@@ -65,7 +66,7 @@ public class GLVersion {
 			vendorString = "";
 			rendererString = "";
 		}
-
+		this.versionString = versionString;
 		this.vendorString = vendorString;
 		this.rendererString = rendererString;
 	}
@@ -119,6 +120,12 @@ public class GLVersion {
 		return releaseVersion;
 	}
 
+	/**
+	 * @return The version string as reported by `glGetString(GL_VERSION)`
+	 */
+	public String getVersionString() {
+		return versionString;
+	}
 	/** @return the vendor string associated with the current GL connection */
 	public String getVendorString () {
 		return vendorString;


### PR DESCRIPTION
https://github.com/libgdx/libgdx/pull/7251 introduced a hack to temporary solve https://github.com/LWJGL/lwjgl3/issues/931 .

This PR proposes a proper solution, since the current approach is not stable as noted in: https://github.com/LWJGL/lwjgl3/issues/931#issuecomment-1793555387

ANGLE and `Lwjgl3TestStarter#enableGLDebugOutput` are now explicitly stated to not work together, before it would simply crash. A proper fix is out of scope of this PR.