### PR TITLE
Fixed scene2d.ui layout for fractional positions and sizes.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,6 @@
 [1.12.2-SNAPSHOT]
 - Fixed GlyphLayout for fixed width glyph offsets at the start and end of lines.
+- Fixed scene2d.ui layout for fractional positions and sizes.
 
 [1.12.1]
 - LWJGL3 Improvement: Audio device is automatically switched if it was changed in the operating system.

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Container.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Container.java
@@ -143,10 +143,10 @@ public class Container<T extends Actor> extends WidgetGroup {
 			y += (containerHeight - height) / 2;
 
 		if (round) {
-			x = Math.round(x);
-			y = Math.round(y);
-			width = Math.round(width);
-			height = Math.round(height);
+			x = (float)Math.floor(x);
+			y = (float)Math.floor(y);
+			width = (float)Math.ceil(width);
+			height = (float)Math.ceil(height);
 		}
 
 		actor.setBounds(x, y, width, height);

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Container.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Container.java
@@ -4,6 +4,7 @@ package com.badlogic.gdx.scenes.scene2d.ui;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.g2d.Batch;
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
+import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.math.Rectangle;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.Touchable;
@@ -143,10 +144,10 @@ public class Container<T extends Actor> extends WidgetGroup {
 			y += (containerHeight - height) / 2;
 
 		if (round) {
-			x = (float)Math.floor(x);
-			y = (float)Math.floor(y);
-			width = (float)Math.ceil(width);
-			height = (float)Math.ceil(height);
+			x = MathUtils.floor(x);
+			y = MathUtils.floor(y);
+			width = MathUtils.ceil(width);
+			height = MathUtils.ceil(height);
 		}
 
 		actor.setBounds(x, y, width, height);

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Container.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Container.java
@@ -144,10 +144,10 @@ public class Container<T extends Actor> extends WidgetGroup {
 			y += (containerHeight - height) / 2;
 
 		if (round) {
-			x = MathUtils.floor(x);
-			y = MathUtils.floor(y);
-			width = MathUtils.ceil(width);
-			height = MathUtils.ceil(height);
+			x = (float)Math.floor(x);
+			y = (float)Math.floor(y);
+			width = (float)Math.ceil(width);
+			height = (float)Math.ceil(height);
 		}
 
 		actor.setBounds(x, y, width, height);

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/HorizontalGroup.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/HorizontalGroup.java
@@ -124,8 +124,8 @@ public class HorizontalGroup extends WidgetGroup {
 		}
 		prefHeight += padTop + padBottom;
 		if (round) {
-			prefWidth = Math.round(prefWidth);
-			prefHeight = Math.round(prefHeight);
+			prefWidth = (float)Math.ceil(prefWidth);
+			prefHeight = (float)Math.ceil(prefHeight);
 		}
 	}
 
@@ -193,7 +193,7 @@ public class HorizontalGroup extends WidgetGroup {
 				y += (rowHeight - height) / 2;
 
 			if (round)
-				child.setBounds(Math.round(x), Math.round(y), Math.round(width), Math.round(height));
+				child.setBounds((float)Math.floor(x), (float)Math.floor(y), (float)Math.ceil(width), (float)Math.ceil(height));
 			else
 				child.setBounds(x, y, width, height);
 			x += width + space;
@@ -283,7 +283,7 @@ public class HorizontalGroup extends WidgetGroup {
 				y += (rowHeight - height) / 2;
 
 			if (round)
-				child.setBounds(Math.round(x), Math.round(y), Math.round(width), Math.round(height));
+				child.setBounds((float)Math.floor(x), (float)Math.floor(y), (float)Math.ceil(width), (float)Math.ceil(height));
 			else
 				child.setBounds(x, y, width, height);
 			x += width + space;

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/HorizontalGroup.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/HorizontalGroup.java
@@ -125,8 +125,8 @@ public class HorizontalGroup extends WidgetGroup {
 		}
 		prefHeight += padTop + padBottom;
 		if (round) {
-			prefWidth = MathUtils.ceil(prefWidth);
-			prefHeight = MathUtils.ceil(prefHeight);
+			prefWidth = (float)Math.ceil(prefWidth);
+			prefHeight = (float)Math.ceil(prefHeight);
 		}
 	}
 
@@ -194,7 +194,7 @@ public class HorizontalGroup extends WidgetGroup {
 				y += (rowHeight - height) / 2;
 
 			if (round)
-				child.setBounds(MathUtils.floor(x), MathUtils.floor(y), MathUtils.ceil(width), MathUtils.ceil(height));
+				child.setBounds((float)Math.floor(x), (float)Math.floor(y), (float)Math.ceil(width), (float)Math.ceil(height));
 			else
 				child.setBounds(x, y, width, height);
 			x += width + space;
@@ -284,7 +284,7 @@ public class HorizontalGroup extends WidgetGroup {
 				y += (rowHeight - height) / 2;
 
 			if (round)
-				child.setBounds(MathUtils.floor(x), MathUtils.floor(y), MathUtils.ceil(width), MathUtils.ceil(height));
+				child.setBounds((float)Math.floor(x), (float)Math.floor(y), (float)Math.ceil(width), (float)Math.ceil(height));
 			else
 				child.setBounds(x, y, width, height);
 			x += width + space;

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/HorizontalGroup.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/HorizontalGroup.java
@@ -18,6 +18,7 @@ package com.badlogic.gdx.scenes.scene2d.ui;
 
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer.ShapeType;
+import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.Touchable;
 import com.badlogic.gdx.scenes.scene2d.utils.Layout;
@@ -124,8 +125,8 @@ public class HorizontalGroup extends WidgetGroup {
 		}
 		prefHeight += padTop + padBottom;
 		if (round) {
-			prefWidth = (float)Math.ceil(prefWidth);
-			prefHeight = (float)Math.ceil(prefHeight);
+			prefWidth = MathUtils.ceil(prefWidth);
+			prefHeight = MathUtils.ceil(prefHeight);
 		}
 	}
 
@@ -193,7 +194,7 @@ public class HorizontalGroup extends WidgetGroup {
 				y += (rowHeight - height) / 2;
 
 			if (round)
-				child.setBounds((float)Math.floor(x), (float)Math.floor(y), (float)Math.ceil(width), (float)Math.ceil(height));
+				child.setBounds(MathUtils.floor(x), MathUtils.floor(y), MathUtils.ceil(width), MathUtils.ceil(height));
 			else
 				child.setBounds(x, y, width, height);
 			x += width + space;
@@ -283,7 +284,7 @@ public class HorizontalGroup extends WidgetGroup {
 				y += (rowHeight - height) / 2;
 
 			if (round)
-				child.setBounds((float)Math.floor(x), (float)Math.floor(y), (float)Math.ceil(width), (float)Math.ceil(height));
+				child.setBounds(MathUtils.floor(x), MathUtils.floor(y), MathUtils.ceil(width), MathUtils.ceil(height));
 			else
 				child.setBounds(x, y, width, height);
 			x += width + space;

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ProgressBar.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ProgressBar.java
@@ -145,7 +145,7 @@ public class ProgressBar extends Widget implements Disableable {
 					x + (width - knobAfter.getMinWidth()) * 0.5f, //
 					y + position + knobHeightHalf, //
 					knobAfter.getMinWidth(),
-					total - (round ? Math.round(beforeHeight - knobHeightHalf) : beforeHeight - knobHeightHalf));
+					total - (round ? (float)Math.ceil(beforeHeight - knobHeightHalf) : beforeHeight - knobHeightHalf));
 			}
 			if (currentKnob != null) {
 				float w = currentKnob.getMinWidth(), h = currentKnob.getMinHeight();
@@ -178,7 +178,8 @@ public class ProgressBar extends Widget implements Disableable {
 				drawRound(batch, knobAfter, //
 					x + position + knobWidthHalf, //
 					y + (height - knobAfter.getMinHeight()) * 0.5f, //
-					total - (round ? Math.round(beforeWidth - knobWidthHalf) : beforeWidth - knobWidthHalf), knobAfter.getMinHeight());
+					total - (round ? (float)Math.ceil(beforeWidth - knobWidthHalf) : beforeWidth - knobWidthHalf),
+					knobAfter.getMinHeight());
 			}
 			if (currentKnob != null) {
 				float w = currentKnob.getMinWidth(), h = currentKnob.getMinHeight();
@@ -192,10 +193,10 @@ public class ProgressBar extends Widget implements Disableable {
 
 	private void drawRound (Batch batch, Drawable drawable, float x, float y, float w, float h) {
 		if (round) {
-			x = Math.round(x);
-			y = Math.round(y);
-			w = Math.round(w);
-			h = Math.round(h);
+			x = (float)Math.floor(x);
+			y = (float)Math.floor(y);
+			w = (float)Math.ceil(w);
+			h = (float)Math.ceil(h);
 		}
 		drawable.draw(batch, x, y, w, h);
 	}

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ProgressBar.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ProgressBar.java
@@ -145,7 +145,7 @@ public class ProgressBar extends Widget implements Disableable {
 					x + (width - knobAfter.getMinWidth()) * 0.5f, //
 					y + position + knobHeightHalf, //
 					knobAfter.getMinWidth(),
-					total - (round ? (float)Math.ceil(beforeHeight - knobHeightHalf) : beforeHeight - knobHeightHalf));
+					total - (round ? MathUtils.ceil(beforeHeight - knobHeightHalf) : beforeHeight - knobHeightHalf));
 			}
 			if (currentKnob != null) {
 				float w = currentKnob.getMinWidth(), h = currentKnob.getMinHeight();
@@ -178,7 +178,7 @@ public class ProgressBar extends Widget implements Disableable {
 				drawRound(batch, knobAfter, //
 					x + position + knobWidthHalf, //
 					y + (height - knobAfter.getMinHeight()) * 0.5f, //
-					total - (round ? (float)Math.ceil(beforeWidth - knobWidthHalf) : beforeWidth - knobWidthHalf),
+					total - (round ? MathUtils.ceil(beforeWidth - knobWidthHalf) : beforeWidth - knobWidthHalf),
 					knobAfter.getMinHeight());
 			}
 			if (currentKnob != null) {
@@ -193,10 +193,10 @@ public class ProgressBar extends Widget implements Disableable {
 
 	private void drawRound (Batch batch, Drawable drawable, float x, float y, float w, float h) {
 		if (round) {
-			x = (float)Math.floor(x);
-			y = (float)Math.floor(y);
-			w = (float)Math.ceil(w);
-			h = (float)Math.ceil(h);
+			x = MathUtils.floor(x);
+			y = MathUtils.floor(y);
+			w = MathUtils.ceil(w);
+			h = MathUtils.ceil(h);
 		}
 		drawable.draw(batch, x, y, w, h);
 	}

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ProgressBar.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ProgressBar.java
@@ -145,7 +145,7 @@ public class ProgressBar extends Widget implements Disableable {
 					x + (width - knobAfter.getMinWidth()) * 0.5f, //
 					y + position + knobHeightHalf, //
 					knobAfter.getMinWidth(),
-					total - (round ? MathUtils.ceil(beforeHeight - knobHeightHalf) : beforeHeight - knobHeightHalf));
+					total - (round ? (float)Math.ceil(beforeHeight - knobHeightHalf) : beforeHeight - knobHeightHalf));
 			}
 			if (currentKnob != null) {
 				float w = currentKnob.getMinWidth(), h = currentKnob.getMinHeight();
@@ -178,7 +178,7 @@ public class ProgressBar extends Widget implements Disableable {
 				drawRound(batch, knobAfter, //
 					x + position + knobWidthHalf, //
 					y + (height - knobAfter.getMinHeight()) * 0.5f, //
-					total - (round ? MathUtils.ceil(beforeWidth - knobWidthHalf) : beforeWidth - knobWidthHalf),
+					total - (round ? (float)Math.ceil(beforeWidth - knobWidthHalf) : beforeWidth - knobWidthHalf),
 					knobAfter.getMinHeight());
 			}
 			if (currentKnob != null) {
@@ -193,10 +193,10 @@ public class ProgressBar extends Widget implements Disableable {
 
 	private void drawRound (Batch batch, Drawable drawable, float x, float y, float w, float h) {
 		if (round) {
-			x = MathUtils.floor(x);
-			y = MathUtils.floor(y);
-			w = MathUtils.ceil(w);
-			h = MathUtils.ceil(h);
+			x = (float)Math.floor(x);
+			y = (float)Math.floor(y);
+			w = (float)Math.ceil(w);
+			h = (float)Math.ceil(h);
 		}
 		drawable.draw(batch, x, y, w, h);
 	}

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Table.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Table.java
@@ -833,10 +833,10 @@ public class Table extends WidgetGroup {
 			if (maxWidth > 0 && prefWidth > maxWidth) prefWidth = maxWidth;
 			if (maxHeight > 0 && prefHeight > maxHeight) prefHeight = maxHeight;
 			if (round) {
-				minWidth = MathUtils.ceil(minWidth);
-				minHeight = MathUtils.ceil(minHeight);
-				prefWidth = MathUtils.ceil(prefWidth);
-				prefHeight = MathUtils.ceil(prefHeight);
+				minWidth = (float)Math.ceil(minWidth);
+				minHeight = (float)Math.ceil(minHeight);
+				prefWidth = (float)Math.ceil(prefWidth);
+				prefHeight = (float)Math.ceil(prefHeight);
 			}
 
 			if (colspan == 1) { // Spanned column min and pref width is added later.
@@ -908,8 +908,8 @@ public class Table extends WidgetGroup {
 			if (prefWidth < minWidth) prefWidth = minWidth;
 			if (maxWidth > 0 && prefWidth > maxWidth) prefWidth = maxWidth;
 			if (round) {
-				minWidth = MathUtils.ceil(minWidth);
-				prefWidth = MathUtils.ceil(prefWidth);
+				minWidth = (float)Math.ceil(minWidth);
+				prefWidth = (float)Math.ceil(prefWidth);
 			}
 
 			float spannedMinWidth = -(c.computedPadLeft + c.computedPadRight), spannedPrefWidth = spannedMinWidth;
@@ -1143,10 +1143,10 @@ public class Table extends WidgetGroup {
 			c.actorY = layoutHeight - currentY - c.actorY - c.actorHeight;
 
 			if (round) {
-				c.actorWidth = MathUtils.ceil(c.actorWidth);
-				c.actorHeight = MathUtils.ceil(c.actorHeight);
-				c.actorX = MathUtils.floor(c.actorX);
-				c.actorY = MathUtils.floor(c.actorY);
+				c.actorWidth = (float)Math.ceil(c.actorWidth);
+				c.actorHeight = (float)Math.ceil(c.actorHeight);
+				c.actorX = (float)Math.floor(c.actorX);
+				c.actorY = (float)Math.floor(c.actorY);
 			}
 
 			if (c.actor != null) c.actor.setBounds(c.actorX, c.actorY, c.actorWidth, c.actorHeight);

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Table.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Table.java
@@ -22,6 +22,7 @@ import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.g2d.Batch;
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer.ShapeType;
+import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.math.Rectangle;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.Touchable;
@@ -832,10 +833,10 @@ public class Table extends WidgetGroup {
 			if (maxWidth > 0 && prefWidth > maxWidth) prefWidth = maxWidth;
 			if (maxHeight > 0 && prefHeight > maxHeight) prefHeight = maxHeight;
 			if (round) {
-				minWidth = (float)Math.ceil(minWidth);
-				minHeight = (float)Math.ceil(minHeight);
-				prefWidth = (float)Math.ceil(prefWidth);
-				prefHeight = (float)Math.ceil(prefHeight);
+				minWidth = MathUtils.ceil(minWidth);
+				minHeight = MathUtils.ceil(minHeight);
+				prefWidth = MathUtils.ceil(prefWidth);
+				prefHeight = MathUtils.ceil(prefHeight);
 			}
 
 			if (colspan == 1) { // Spanned column min and pref width is added later.
@@ -907,8 +908,8 @@ public class Table extends WidgetGroup {
 			if (prefWidth < minWidth) prefWidth = minWidth;
 			if (maxWidth > 0 && prefWidth > maxWidth) prefWidth = maxWidth;
 			if (round) {
-				minWidth = (float)Math.ceil(minWidth);
-				prefWidth = (float)Math.ceil(prefWidth);
+				minWidth = MathUtils.ceil(minWidth);
+				prefWidth = MathUtils.ceil(prefWidth);
 			}
 
 			float spannedMinWidth = -(c.computedPadLeft + c.computedPadRight), spannedPrefWidth = spannedMinWidth;
@@ -1142,10 +1143,10 @@ public class Table extends WidgetGroup {
 			c.actorY = layoutHeight - currentY - c.actorY - c.actorHeight;
 
 			if (round) {
-				c.actorWidth = (float)Math.ceil(c.actorWidth);
-				c.actorHeight = (float)Math.ceil(c.actorHeight);
-				c.actorX = (float)Math.floor(c.actorX);
-				c.actorY = (float)Math.floor(c.actorY);
+				c.actorWidth = MathUtils.ceil(c.actorWidth);
+				c.actorHeight = MathUtils.ceil(c.actorHeight);
+				c.actorX = MathUtils.floor(c.actorX);
+				c.actorY = MathUtils.floor(c.actorY);
 			}
 
 			if (c.actor != null) c.actor.setBounds(c.actorX, c.actorY, c.actorWidth, c.actorHeight);

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextArea.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextArea.java
@@ -117,7 +117,7 @@ public class TextArea extends TextField {
 		} else {
 			// without ceil we might end up with one less row then expected
 			// due to how linesShowing is calculated in #sizeChanged and #getHeight() returning rounded value
-			float prefHeight = MathUtils.ceil(style.font.getLineHeight() * prefRows);
+			float prefHeight = (float)Math.ceil(style.font.getLineHeight() * prefRows);
 			if (style.background != null) {
 				prefHeight = Math.max(prefHeight + style.background.getBottomHeight() + style.background.getTopHeight(),
 					style.background.getMinHeight());

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/VerticalGroup.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/VerticalGroup.java
@@ -124,8 +124,8 @@ public class VerticalGroup extends WidgetGroup {
 		}
 		prefWidth += padLeft + padRight;
 		if (round) {
-			prefWidth = Math.round(prefWidth);
-			prefHeight = Math.round(prefHeight);
+			prefWidth = (float)Math.ceil(prefWidth);
+			prefHeight = (float)Math.ceil(prefHeight);
 		}
 	}
 
@@ -194,7 +194,7 @@ public class VerticalGroup extends WidgetGroup {
 
 			y -= height + space;
 			if (round)
-				child.setBounds(Math.round(x), Math.round(y), Math.round(width), Math.round(height));
+				child.setBounds((float)Math.floor(x), (float)Math.floor(y), (float)Math.ceil(width), (float)Math.ceil(height));
 			else
 				child.setBounds(x, y, width, height);
 
@@ -283,7 +283,7 @@ public class VerticalGroup extends WidgetGroup {
 
 			y -= height + space;
 			if (round)
-				child.setBounds(Math.round(x), Math.round(y), Math.round(width), Math.round(height));
+				child.setBounds((float)Math.floor(x), (float)Math.floor(y), (float)Math.ceil(width), (float)Math.ceil(height));
 			else
 				child.setBounds(x, y, width, height);
 

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/VerticalGroup.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/VerticalGroup.java
@@ -18,6 +18,7 @@ package com.badlogic.gdx.scenes.scene2d.ui;
 
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer.ShapeType;
+import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.Touchable;
 import com.badlogic.gdx.scenes.scene2d.utils.Layout;
@@ -124,8 +125,8 @@ public class VerticalGroup extends WidgetGroup {
 		}
 		prefWidth += padLeft + padRight;
 		if (round) {
-			prefWidth = (float)Math.ceil(prefWidth);
-			prefHeight = (float)Math.ceil(prefHeight);
+			prefWidth = MathUtils.ceil(prefWidth);
+			prefHeight = MathUtils.ceil(prefHeight);
 		}
 	}
 
@@ -194,7 +195,7 @@ public class VerticalGroup extends WidgetGroup {
 
 			y -= height + space;
 			if (round)
-				child.setBounds((float)Math.floor(x), (float)Math.floor(y), (float)Math.ceil(width), (float)Math.ceil(height));
+				child.setBounds(MathUtils.floor(x), MathUtils.floor(y), MathUtils.ceil(width), MathUtils.ceil(height));
 			else
 				child.setBounds(x, y, width, height);
 
@@ -283,7 +284,7 @@ public class VerticalGroup extends WidgetGroup {
 
 			y -= height + space;
 			if (round)
-				child.setBounds((float)Math.floor(x), (float)Math.floor(y), (float)Math.ceil(width), (float)Math.ceil(height));
+				child.setBounds(MathUtils.floor(x), MathUtils.floor(y), MathUtils.ceil(width), MathUtils.ceil(height));
 			else
 				child.setBounds(x, y, width, height);
 

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/VerticalGroup.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/VerticalGroup.java
@@ -125,8 +125,8 @@ public class VerticalGroup extends WidgetGroup {
 		}
 		prefWidth += padLeft + padRight;
 		if (round) {
-			prefWidth = MathUtils.ceil(prefWidth);
-			prefHeight = MathUtils.ceil(prefHeight);
+			prefWidth = (float)Math.ceil(prefWidth);
+			prefHeight = (float)Math.ceil(prefHeight);
 		}
 	}
 
@@ -195,7 +195,7 @@ public class VerticalGroup extends WidgetGroup {
 
 			y -= height + space;
 			if (round)
-				child.setBounds(MathUtils.floor(x), MathUtils.floor(y), MathUtils.ceil(width), MathUtils.ceil(height));
+				child.setBounds((float)Math.floor(x), (float)Math.floor(y), (float)Math.ceil(width), (float)Math.ceil(height));
 			else
 				child.setBounds(x, y, width, height);
 
@@ -284,7 +284,7 @@ public class VerticalGroup extends WidgetGroup {
 
 			y -= height + space;
 			if (round)
-				child.setBounds(MathUtils.floor(x), MathUtils.floor(y), MathUtils.ceil(width), MathUtils.ceil(height));
+				child.setBounds((float)Math.floor(x), (float)Math.floor(y), (float)Math.ceil(width), (float)Math.ceil(height));
 			else
 				child.setBounds(x, y, width, height);
 


### PR DESCRIPTION
When "rounding" for UI layout, floor x/y and ceil width/height.

For example if a label has a fractional width like 123.4, rounding a Container's width gives 123 and the label won't fit.

Table already does this, so I'm pretty sure it's the right thing to do in all other layouts. If others can please check this doesn't negatively affect their apps, that would be great!