### PR TITLE
Add instanced attributes flags to GLSL prefix

### DIFF
--- a/gdx/res/com/badlogic/gdx/graphics/g3d/shaders/default.vertex.glsl
+++ b/gdx/res/com/badlogic/gdx/graphics/g3d/shaders/default.vertex.glsl
@@ -103,7 +103,11 @@ attribute vec2 a_boneWeight7;
 #endif
 #endif
 
+#ifdef u_worldTrans_instancedFlag
+attribute mat4 u_worldTrans;
+#else
 uniform mat4 u_worldTrans;
+#endif //u_worldTrans_instancedFlag
 
 #if defined(numBones)
 #if numBones > 0

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/DefaultShader.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/DefaultShader.java
@@ -20,6 +20,7 @@ import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Camera;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.VertexAttribute;
+import com.badlogic.gdx.graphics.VertexAttributes;
 import com.badlogic.gdx.graphics.VertexAttributes.Usage;
 import com.badlogic.gdx.graphics.g3d.Attribute;
 import com.badlogic.gdx.graphics.g3d.Attributes;
@@ -744,6 +745,16 @@ public class DefaultShader extends BaseShader {
 		if ((attributesMask & FloatAttribute.AlphaTest) == FloatAttribute.AlphaTest)
 			prefix += "#define " + FloatAttribute.AlphaTestAlias + "Flag\n";
 		if (renderable.bones != null && config.numBones > 0) prefix += "#define numBones " + config.numBones + "\n";
+
+		if (renderable.meshPart.mesh.isInstanced()) {
+			final VertexAttributes instancedAttrs = renderable.meshPart.mesh.getInstancedAttributes();
+			final int attrsCount = instancedAttrs.size();
+			for (int i = 0; i < attrsCount; i++) {
+				final VertexAttribute attr = instancedAttrs.get(i);
+				prefix += "#define " + attr.alias + "_instancedFlag\n";
+			}
+		}
+
 		return prefix;
 	}
 

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/DefaultShader.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/DefaultShader.java
@@ -746,8 +746,8 @@ public class DefaultShader extends BaseShader {
 			prefix += "#define " + FloatAttribute.AlphaTestAlias + "Flag\n";
 		if (renderable.bones != null && config.numBones > 0) prefix += "#define numBones " + config.numBones + "\n";
 
-		if (renderable.meshPart.mesh.isInstanced()) {
-			final VertexAttributes instancedAttrs = renderable.meshPart.mesh.getInstancedAttributes();
+		final VertexAttributes instancedAttrs = renderable.meshPart.mesh.getInstancedAttributes();
+		if (instancedAttrs != null) {
 			final int attrsCount = instancedAttrs.size();
 			for (int i = 0; i < attrsCount; i++) {
 				final VertexAttribute attr = instancedAttrs.get(i);


### PR DESCRIPTION
Adds `#define attrib_instancedFlag` for each instanced attribute, mostly to allow declaring an attribute instead of a uniform when the specific attribute is instanced (like I did with u_worlTransform for example).

I tested it with this demo that implements instancing `u_worldTransform`: https://github.com/yahel-ck/libgdx_instancing_demo
The demo is using gdx-gltf to render, but it uses the same underlying LibGDX classes. 
I tested it on VMs of iOS and Android, and on a physical Android device (Samsung S21).

It wouldn't take much work to implement the demo solely with LibGDX so let me know if you think it's necessary, or if there are any other tests I should make.
Thanks :)