### PR TITLE
Added antialiasing flag to the ScreenUtils.

### DIFF
--- a/gdx/src/com/badlogic/gdx/utils/ScreenUtils.java
+++ b/gdx/src/com/badlogic/gdx/utils/ScreenUtils.java
@@ -59,19 +59,16 @@ public final class ScreenUtils {
 		clear(r, g, b, a, clearDepth, false);
 	}
 
-	/**
-	 * Clears the color buffers, optionally the depth buffer
-	 * and whether to apply antialiasing (requires to set number of samples in the launcher class).
+	/** Clears the color buffers, optionally the depth buffer and whether to apply antialiasing (requires to set number of samples
+	 * in the launcher class).
 	 *
-	 * @param clearDepth        Clears the depth buffer if true.
-	 * @param applyAntialiasing applies multi-sampling for antialiasing if true.
-	 */
-	public static void clear(float r, float g, float b, float a, boolean clearDepth, boolean applyAntialiasing) {
+	 * @param clearDepth Clears the depth buffer if true.
+	 * @param applyAntialiasing applies multi-sampling for antialiasing if true. */
+	public static void clear (float r, float g, float b, float a, boolean clearDepth, boolean applyAntialiasing) {
 		Gdx.gl.glClearColor(r, g, b, a);
 		int mask = GL20.GL_COLOR_BUFFER_BIT;
 		if (clearDepth) mask = mask | GL20.GL_DEPTH_BUFFER_BIT;
-		if (applyAntialiasing && Gdx.graphics.getBufferFormat().coverageSampling)
-			mask = mask | GL20.GL_COVERAGE_BUFFER_BIT_NV;
+		if (applyAntialiasing && Gdx.graphics.getBufferFormat().coverageSampling) mask = mask | GL20.GL_COVERAGE_BUFFER_BIT_NV;
 		Gdx.gl.glClear(mask);
 	}
 

--- a/gdx/src/com/badlogic/gdx/utils/ScreenUtils.java
+++ b/gdx/src/com/badlogic/gdx/utils/ScreenUtils.java
@@ -56,9 +56,22 @@ public final class ScreenUtils {
 	/** Clears the color buffers and optionally the depth buffer.
 	 * @param clearDepth Clears the depth buffer if true. */
 	public static void clear (float r, float g, float b, float a, boolean clearDepth) {
+		clear(r, g, b, a, clearDepth, false);
+	}
+
+	/**
+	 * Clears the color buffers, optionally the depth buffer
+	 * and whether to apply antialiasing (requires to set number of samples in the launcher class).
+	 *
+	 * @param clearDepth        Clears the depth buffer if true.
+	 * @param applyAntialiasing applies multi-sampling for antialiasing if true.
+	 */
+	public static void clear(float r, float g, float b, float a, boolean clearDepth, boolean applyAntialiasing) {
 		Gdx.gl.glClearColor(r, g, b, a);
 		int mask = GL20.GL_COLOR_BUFFER_BIT;
 		if (clearDepth) mask = mask | GL20.GL_DEPTH_BUFFER_BIT;
+		if (applyAntialiasing && Gdx.graphics.getBufferFormat().coverageSampling)
+			mask = mask | GL20.GL_COVERAGE_BUFFER_BIT_NV;
 		Gdx.gl.glClear(mask);
 	}
 


### PR DESCRIPTION
I wanted to use the ScreenUtils clear() with applying antialiasing and found out it didn't support that. Thought it could be useful. I added in the javadocs that it is required in the class launcher to specify the number of samples (`config.numSamples = 2` - recommended for Android is 2, and 3 for desktop )
Thanks