### PR TITLE
Adds status detection for an httpRequest

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidNet.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidNet.java
@@ -55,6 +55,11 @@ public class AndroidNet implements Net {
 	}
 
 	@Override
+	public boolean isHttpRequestPending (HttpRequest httpRequest) {
+		return netJavaImpl.isHttpRequestPending(httpRequest);
+	}
+
+	@Override
 	public ServerSocket newServerSocket (Protocol protocol, String hostname, int port, ServerSocketHints hints) {
 		return new NetJavaServerSocketImpl(protocol, hostname, port, hints);
 	}

--- a/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/HeadlessNet.java
+++ b/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/HeadlessNet.java
@@ -52,6 +52,11 @@ public class HeadlessNet implements Net {
 	}
 
 	@Override
+	public boolean isHttpRequestPending (HttpRequest httpRequest) {
+		return netJavaImpl.isHttpRequestPending(httpRequest);
+	}
+
+	@Override
 	public ServerSocket newServerSocket (Protocol protocol, String hostname, int port, ServerSocketHints hints) {
 		return new NetJavaServerSocketImpl(protocol, hostname, port, hints);
 	}

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglNet.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglNet.java
@@ -48,6 +48,11 @@ public class LwjglNet implements Net {
 	}
 
 	@Override
+	public boolean isHttpRequestPending (HttpRequest httpRequest) {
+		return netJavaImpl.isHttpRequestPending(httpRequest);
+	}
+
+	@Override
 	public ServerSocket newServerSocket (Protocol protocol, String ipAddress, int port, ServerSocketHints hints) {
 		return new NetJavaServerSocketImpl(protocol, ipAddress, port, hints);
 	}

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Net.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Net.java
@@ -50,6 +50,11 @@ public class Lwjgl3Net implements Net {
 	}
 
 	@Override
+	public boolean isHttpRequestPending (HttpRequest httpRequest) {
+		return netJavaImpl.isHttpRequestPending(httpRequest);
+	}
+
+	@Override
 	public ServerSocket newServerSocket (Protocol protocol, String ipAddress, int port, ServerSocketHints hints) {
 		return new NetJavaServerSocketImpl(protocol, ipAddress, port, hints);
 	}

--- a/backends/gdx-backend-robovm-metalangle/src/com/badlogic/gdx/backends/iosrobovm/IOSNet.java
+++ b/backends/gdx-backend-robovm-metalangle/src/com/badlogic/gdx/backends/iosrobovm/IOSNet.java
@@ -36,6 +36,11 @@ public class IOSNet implements Net {
 	}
 
 	@Override
+	public boolean isHttpRequestPending (HttpRequest httpRequest) {
+		return netJavaImpl.isHttpRequestPending(httpRequest);
+	}
+
+	@Override
 	public ServerSocket newServerSocket (Protocol protocol, String hostname, int port, ServerSocketHints hints) {
 		return new NetJavaServerSocketImpl(protocol, hostname, port, hints);
 	}

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSNet.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSNet.java
@@ -49,6 +49,11 @@ public class IOSNet implements Net {
 	}
 
 	@Override
+	public boolean isHttpRequestPending (HttpRequest httpRequest) {
+		return netJavaImpl.isHttpRequestPending(httpRequest);
+	}
+
+	@Override
 	public ServerSocket newServerSocket (Protocol protocol, String hostname, int port, ServerSocketHints hints) {
 		return new NetJavaServerSocketImpl(protocol, hostname, port, hints);
 	}

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtNet.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtNet.java
@@ -199,6 +199,11 @@ public class GwtNet implements Net {
 	}
 
 	@Override
+	public boolean isHttpRequestPending (HttpRequest httpRequest) {
+		return listeners.get(httpRequest) != null && requests.get(httpRequest) != null;
+	}
+
+	@Override
 	public ServerSocket newServerSocket (Protocol protocol, String hostname, int port, ServerSocketHints hints) {
 		throw new UnsupportedOperationException("Not implemented");
 	}

--- a/gdx/src/com/badlogic/gdx/Net.java
+++ b/gdx/src/com/badlogic/gdx/Net.java
@@ -348,6 +348,8 @@ public interface Net {
 
 	public void cancelHttpRequest (HttpRequest httpRequest);
 
+	public boolean isHttpRequestPending (HttpRequest httpRequest);
+
 	/** Protocol used by {@link Net#newServerSocket(Protocol, int, ServerSocketHints)} and
 	 * {@link Net#newClientSocket(Protocol, String, int, SocketHints)}.
 	 * @author mzechner */

--- a/gdx/src/com/badlogic/gdx/net/NetJavaImpl.java
+++ b/gdx/src/com/badlogic/gdx/net/NetJavaImpl.java
@@ -263,6 +263,10 @@ public class NetJavaImpl {
 		}
 	}
 
+	public boolean isHttpRequestPending (HttpRequest httpRequest) {
+		return getFromListeners(httpRequest) != null;
+	}
+
 	private void cancelTask (HttpRequest httpRequest) {
 		Future<?> task = tasks.get(httpRequest);
 


### PR DESCRIPTION
This commit adds the public boolean isHttpRequestPending (HttpRequest httpRequest) method to Gdx.net user interface. It allows end users to detect if an httpRequest is pending or already finished. It helpfull for creating advanced business logic.