### PR TITLE
Added possibility to reset a particle effect without starting it

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g2d/ParticleEffect.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/ParticleEffect.java
@@ -68,12 +68,7 @@ public class ParticleEffect implements Disposable {
 	 * @param resetScaling Whether to restore the original size and motion parameters if they were scaled. Repeated scaling and
 	 *           resetting may introduce error. */
 	public void reset (boolean resetScaling) {
-		for (int i = 0, n = emitters.size; i < n; i++)
-			emitters.get(i).reset();
-		if (resetScaling && (xSizeScale != 1f || ySizeScale != 1f || motionScale != 1f)) {
-			scaleEffect(1f / xSizeScale, 1f / ySizeScale, 1f / motionScale);
-			xSizeScale = ySizeScale = motionScale = 1f;
-		}
+		reset(resetScaling, true);
 	}
 
 	/** Resets the effect so it can be started again like a new effect.

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/ParticleEffect.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/ParticleEffect.java
@@ -76,6 +76,19 @@ public class ParticleEffect implements Disposable {
 		}
 	}
 
+	/** Resets the effect so it can be started again like a new effect.
+	 * @param resetScaling Whether to restore the original size and motion parameters if they were scaled. Repeated scaling and
+	 *           resetting may introduce error.
+	 * @param start Whether to start the effect after resetting. */
+	public void reset (boolean resetScaling, boolean start) {
+		for (int i = 0, n = emitters.size; i < n; i++)
+			emitters.get(i).reset(start);
+		if (resetScaling && (xSizeScale != 1f || ySizeScale != 1f || motionScale != 1f)) {
+			scaleEffect(1f / xSizeScale, 1f / ySizeScale, 1f / motionScale);
+			xSizeScale = ySizeScale = motionScale = 1f;
+		}
+	}
+
 	public void update (float delta) {
 		for (int i = 0, n = emitters.size; i < n; i++)
 			emitters.get(i).update(delta);

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/ParticleEffect.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/ParticleEffect.java
@@ -61,7 +61,7 @@ public class ParticleEffect implements Disposable {
 	/** Resets the effect so it can be started again like a new effect. Any changes to scale are reverted. See
 	 * {@link #reset(boolean)}. */
 	public void reset () {
-		reset(true);
+		reset(true, true);
 	}
 
 	/** Resets the effect so it can be started again like a new effect.

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/ParticleEmitter.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/ParticleEmitter.java
@@ -342,13 +342,7 @@ public class ParticleEmitter {
 	}
 
 	public void reset () {
-		emissionDelta = 0;
-		durationTimer = duration;
-		boolean[] active = this.active;
-		for (int i = 0, n = active.length; i < n; i++)
-			active[i] = false;
-		activeCount = 0;
-		start();
+		reset(true);
 	}
 
 	public void reset (boolean start) {

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/ParticleEmitter.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/ParticleEmitter.java
@@ -351,6 +351,16 @@ public class ParticleEmitter {
 		start();
 	}
 
+	public void reset (boolean start) {
+		emissionDelta = 0;
+		durationTimer = duration;
+		boolean[] active = this.active;
+		for (int i = 0, n = active.length; i < n; i++)
+			active[i] = false;
+		activeCount = 0;
+		if (start) start();
+	}
+
 	private void restart () {
 		delay = delayValue.active ? delayValue.newLowValue() : 0;
 		delayTimer = 0;


### PR DESCRIPTION
This commit adds the method `public void reset (boolean resetScaling, boolean start)` to particle effect which allows to reset it without starting. In my opinion it's very usefull method for constructing advanced business logic. Previously to reset a particle effect without starting it users had to dispose it, then to reload it again from disk. 