### PR TITLE
Set GdxSetup source level to java 8

### DIFF
--- a/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/core/build.gradle
+++ b/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/core/build.gradle
@@ -1,4 +1,4 @@
-sourceCompatibility = 1.7
+sourceCompatibility = 1.8
 [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
 
 sourceSets.main.java.srcDirs = [ "src/" ]

--- a/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/html/build.gradle
+++ b/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/html/build.gradle
@@ -86,7 +86,7 @@ tasks.compileGwt.dependsOn(addSource)
 tasks.draftCompileGwt.dependsOn(addSource)
 tasks.checkGwt.dependsOn(addSource)
 
-sourceCompatibility = 1.7
+sourceCompatibility = 1.8
 sourceSets.main.java.srcDirs = [ "src/" ]
 
 eclipse.project.name = appName + "-html"

--- a/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/ios/build.gradle
+++ b/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/ios/build.gradle
@@ -1,6 +1,6 @@
 sourceSets.main.java.srcDirs = [ "src/" ]
 
-sourceCompatibility = '1.7'
+sourceCompatibility = '1.8'
 [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
 
 ext {

--- a/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/lwjgl2/build.gradle
+++ b/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/lwjgl2/build.gradle
@@ -1,4 +1,4 @@
-sourceCompatibility = 1.7
+sourceCompatibility = 1.8
 sourceSets.main.java.srcDirs = [ "src/" ]
 sourceSets.main.resources.srcDirs = ["../%ASSET_PATH%"]
 

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetupUI.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/GdxSetupUI.java
@@ -186,6 +186,10 @@ public class GdxSetupUI extends JFrame {
 			modules.remove(ProjectType.HTML);
 		}
 
+		if (modules.contains(ProjectType.IOS)) {
+			JOptionPane.showMessageDialog(this, "WARNING. iOS has limited support to Java 8 languages features and APIs.");
+		}
+
 		if (modules.contains(ProjectType.ANDROID)) {
 			if (!GdxSetup.isSdkUpToDate(sdkLocation)) {
 				File sdkLocationFile = new File(sdkLocation);


### PR DESCRIPTION
Since Java 21 (LTS) is the default version when downloading java, many users (specially new libGDX users) are complaining new projects don't work. Even if libGDX iOS backend doesn't fully support Java 8 language features (see https://github.com/libgdx/libgdx/issues/5487) at this point I think, until we decide on the approach to move forward, we should change Gdx Setup source level to 8 on all modules.