### PR TITLE
Move #removeFromConnectionsAndListeners into the finally block.

### DIFF
--- a/gdx/src/com/badlogic/gdx/net/NetJavaImpl.java
+++ b/gdx/src/com/badlogic/gdx/net/NetJavaImpl.java
@@ -229,8 +229,8 @@ public class NetJavaImpl {
 							if (listener != null) {
 								listener.handleHttpResponse(clientResponse);
 							}
-							removeFromConnectionsAndListeners(httpRequest);
 						} finally {
+							removeFromConnectionsAndListeners(httpRequest);
 							connection.disconnect();
 						}
 					} catch (final Exception e) {


### PR DESCRIPTION
As mentioned [here](https://github.com/libgdx/libgdx/pull/7305#issuecomment-1870364802), a http request should be removed from the connections and listeners lists even if `HttpResponseListener#handleHttpResponse(clientResponse)` throws an exception. This mirrors the behavior for `HttpResponseListener#failed(e)` in lines 239 and 248 and is important because those list are checked  to see whether the request is still pending. 