### PR TITLE
Android: Quality of life improvement for android cutout handling.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@
 - libGDX is now built using Java 17 due to Gradle 8 requirements.
 - New GDX Setup projects now use Gradle 8.4 and AGP Plugin 8.1.2 which require at least Java 17.
 - Fixed Timer#stop, remember time spent stopped and delay tasks when started again. #7281
+- Android: Add configuration option to render under the cutout if available on the device.
 
 [1.12.1]
 - LWJGL3 Improvement: Audio device is automatically switched if it was changed in the operating system.

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplication.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplication.java
@@ -175,7 +175,7 @@ public class AndroidApplication extends Activity implements AndroidApplicationBa
 		// detect an already connected bluetooth keyboardAvailable
 		if (getResources().getConfiguration().keyboard != Configuration.KEYBOARD_NOKEYS) input.setKeyboardAvailable(true);
 
-		tryRenderUnderCutout(this.renderUnderCutout);
+		setLayoutInDisplayCutoutMode(this.renderUnderCutout);
 	}
 
 	protected FrameLayout.LayoutParams createLayoutParams () {
@@ -191,12 +191,11 @@ public class AndroidApplication extends Activity implements AndroidApplicationBa
 		}
 	}
 
-	@TargetApi(28)
-	private void tryRenderUnderCutout(boolean render) {
+	@TargetApi(Build.VERSION_CODES.P)
+	private void setLayoutInDisplayCutoutMode(boolean render) {
 		if(render && getVersion() >= Build.VERSION_CODES.P) {
 			WindowManager.LayoutParams lp = getWindow().getAttributes();
 			lp.layoutInDisplayCutoutMode = WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES;
-			getWindow().setAttributes(lp);
 		}
 	}
 

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplication.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplication.java
@@ -192,8 +192,8 @@ public class AndroidApplication extends Activity implements AndroidApplicationBa
 	}
 
 	@TargetApi(Build.VERSION_CODES.P)
-	private void setLayoutInDisplayCutoutMode(boolean render) {
-		if(render && getVersion() >= Build.VERSION_CODES.P) {
+	private void setLayoutInDisplayCutoutMode (boolean render) {
+		if (render && getVersion() >= Build.VERSION_CODES.P) {
 			WindowManager.LayoutParams lp = getWindow().getAttributes();
 			lp.layoutInDisplayCutoutMode = WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES;
 		}

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplication.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplication.java
@@ -61,6 +61,8 @@ public class AndroidApplication extends Activity implements AndroidApplicationBa
 	private int wasFocusChanged = -1;
 	private boolean isWaitingForAudio = false;
 
+	protected boolean renderUnderCutout = false;
+
 	/** This method has to be called in the {@link Activity#onCreate(Bundle)} method. It sets up all the things necessary to get
 	 * input, render via OpenGL and so on. Uses a default {@link AndroidApplicationConfiguration}.
 	 * 
@@ -124,6 +126,7 @@ public class AndroidApplication extends Activity implements AndroidApplicationBa
 		this.handler = new Handler();
 		this.useImmersiveMode = config.useImmersiveMode;
 		this.clipboard = new AndroidClipboard(this);
+		this.renderUnderCutout = config.renderUnderCutout;
 
 		// Add a specialized audio lifecycle listener
 		addLifecycleListener(new LifecycleListener() {
@@ -171,6 +174,8 @@ public class AndroidApplication extends Activity implements AndroidApplicationBa
 
 		// detect an already connected bluetooth keyboardAvailable
 		if (getResources().getConfiguration().keyboard != Configuration.KEYBOARD_NOKEYS) input.setKeyboardAvailable(true);
+
+		tryRenderUnderCutout(this.renderUnderCutout);
 	}
 
 	protected FrameLayout.LayoutParams createLayoutParams () {
@@ -183,6 +188,15 @@ public class AndroidApplication extends Activity implements AndroidApplicationBa
 	protected void createWakeLock (boolean use) {
 		if (use) {
 			getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+		}
+	}
+
+	@TargetApi(28)
+	private void tryRenderUnderCutout(boolean render) {
+		if(render && getVersion() >= Build.VERSION_CODES.P) {
+			WindowManager.LayoutParams lp = getWindow().getAttributes();
+			lp.layoutInDisplayCutoutMode = WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES;
+			getWindow().setAttributes(lp);
 		}
 	}
 

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplicationConfiguration.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplicationConfiguration.java
@@ -99,6 +99,9 @@ public class AndroidApplicationConfiguration {
 	/** The maximum number of threads to use for network requests. Default is {@link Integer#MAX_VALUE}. */
 	public int maxNetThreads = Integer.MAX_VALUE;
 
+	/** set this to true to render under the display cutout. Use the Graphics::getSafeInsetXX to get the safe render space */
+	public boolean renderUnderCutout;
+
 	/** The loader used to load native libraries. Override this to use a different loading strategy. */
 	public GdxNativeLoader nativeLoader = new GdxNativeLoader() {
 		@Override

--- a/tests/gdx-tests-android/src/com/badlogic/gdx/tests/android/GdxTestActivity.java
+++ b/tests/gdx-tests-android/src/com/badlogic/gdx/tests/android/GdxTestActivity.java
@@ -16,10 +16,7 @@
 
 package com.badlogic.gdx.tests.android;
 
-import android.os.Build;
 import android.os.Bundle;
-import android.view.Window;
-import android.view.WindowManager;
 
 import com.badlogic.gdx.backends.android.AndroidApplication;
 import com.badlogic.gdx.backends.android.AndroidApplicationConfiguration;

--- a/tests/gdx-tests-android/src/com/badlogic/gdx/tests/android/GdxTestActivity.java
+++ b/tests/gdx-tests-android/src/com/badlogic/gdx/tests/android/GdxTestActivity.java
@@ -31,13 +31,6 @@ public class GdxTestActivity extends AndroidApplication {
 	public void onCreate (Bundle bundle) {
 		super.onCreate(bundle);
 
-		// use the full display, even if we have a device with a notch
-		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-			Window applicationWindow = getApplicationWindow();
-			WindowManager.LayoutParams attrib = applicationWindow.getAttributes();
-			attrib.layoutInDisplayCutoutMode = WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES;
-		}
-
 		// obtain the test info
 		Bundle extras = getIntent().getExtras();
 		String testName = (String)extras.get("test");
@@ -48,6 +41,7 @@ public class GdxTestActivity extends AndroidApplication {
 		config.useImmersiveMode = true;
 		config.useRotationVectorSensor = true;
 		config.useGyroscope = true;
+		config.renderUnderCutout = true;
 		initialize(test, config);
 	}
 }


### PR DESCRIPTION
## "Problem":

Currently, the developer is required to know the Android API to get real fullscreen in Android devices with cutouts. This was already worked on before by @MrStahlfelge in #5714 when `Graphics::getSafeInsetsXX` was introduced. He also provided an example of how to get fullscreen on screens with cutouts.

https://github.com/libgdx/libgdx/blob/fd535ab38900cd266631a7bbeab83d10c1bc5403/tests/gdx-tests-android/src/com/badlogic/gdx/tests/android/GdxTestActivity.java#L35C1-L39C4

## Improvement:

- Add a config option called `AndroidApplicationConfiguration::renderUnderCutout` that allows the end user to use the space under the cutout.
- Check if the API is available on the device and use it if `AndroidApplicationConfiguration::renderUnderCutout` is set to true.

## Notes:

Not tested on IOS, licensing to expensive for a simple project. 

## Example:
```java
import android.os.Bundle;

import com.badlogic.gdx.backends.android.AndroidApplication;
import com.badlogic.gdx.backends.android.AndroidApplicationConfiguration;

public class GdxTestActivity extends AndroidApplication {

	public void onCreate (Bundle bundle) {
		super.onCreate(bundle);

		AndroidApplicationConfiguration config = new AndroidApplicationConfiguration();
		config.renderUnderCutout = true;
		initialize(new Game(), config);
	}
}

```