### PR TITLE
Download NDK versions instead of using shipped ones by the runner

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -211,7 +211,7 @@ jobs:
       - name: Download NDK
         run: |
           wget https://dl.google.com/android/repository/android-ndk-r25c-linux.zip -O android-ndk.zip
-          echo "53af80a1cce9144025b81c78c8cd556bff42bd0e  android-ndk.zip" | sha256sum --check
+          echo "769ee342ea75f80619d985c2da990c48b3d8eaf45f48783a2d48870d04b46108  android-ndk.zip" | sha256sum --check
           unzip android-ndk.zip
           echo "NDK_HOME=$(pwd)/android-ndk-r25c" >> $GITHUB_ENV
 

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -210,10 +210,10 @@ jobs:
 
       - name: Download NDK
         run: |
-          wget https://dl.google.com/android/repository/android-ndk-r23c-linux.zip -O android-ndk.zip
-          echo "e5053c126a47e84726d9f7173a04686a71f9a67a  android-ndk.zip" | sha256sum --check
+          wget https://dl.google.com/android/repository/android-ndk-r25c-linux.zip -O android-ndk.zip
+          echo "53af80a1cce9144025b81c78c8cd556bff42bd0e  android-ndk.zip" | sha256sum --check
           unzip android-ndk.zip
-          echo "NDK_HOME=$(pwd)/android-ndk-r23c" >> $GITHUB_ENV
+          echo "NDK_HOME=$(pwd)/android-ndk-r25c" >> $GITHUB_ENV
 
       - name: Build Android natives
         run: |

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -208,9 +208,15 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
 
+      - name: Download NDK
+        run: |
+          wget https://dl.google.com/android/repository/android-ndk-r23c-linux.zip -O android-ndk.zip
+          echo "e5053c126a47e84726d9f7173a04686a71f9a67a  android-ndk.zip" | sha256sum --check
+          unzip android-ndk.zip
+          echo "NDK_HOME=$(pwd)/android-ndk-r23c" >> $GITHUB_ENV
+
       - name: Build Android natives
         run: |
-          export NDK_HOME=$ANDROID_NDK_HOME
           ./gradlew jniGen jnigenBuildAndroid
 
       - name: Pack artifacts


### PR DESCRIPTION
Since the NDK version pointed by `ANDROID_NDK_HOME` can change at any time and newer NDK version discontinue support for older android version, I think it is preferable to pin our NDK version to a specific one.

See https://github.com/libgdx/libgdx/issues/7307#issuecomment-1908980174

I verified that the commands work locally, but I haven't verified them integrated into a GHA.