### PR TITLE
Add Stage Viewport Anchoring

### DIFF
--- a/gdx/src/com/badlogic/gdx/utils/viewport/Viewport.java
+++ b/gdx/src/com/badlogic/gdx/utils/viewport/Viewport.java
@@ -19,6 +19,7 @@ package com.badlogic.gdx.utils.viewport;
 import com.badlogic.gdx.ApplicationListener;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Screen;
+import com.badlogic.gdx.ScreenAdapter;
 import com.badlogic.gdx.graphics.Camera;
 import com.badlogic.gdx.graphics.glutils.HdpiUtils;
 import com.badlogic.gdx.math.Matrix4;
@@ -211,6 +212,30 @@ public abstract class Viewport {
 		this.screenY = screenY;
 		this.screenWidth = screenWidth;
 		this.screenHeight = screenHeight;
+	}
+
+	/** Anchors the viewport to a desired point on the screen regardless of
+	 * aspect ratio. This is typically called after {@link #update(int, int, boolean)}
+	 * @param width the new width in pixels from ApplicationListener#resize(int, int)
+	 * @param height the new height in pixels from ApplicationListener#resize(int, int)
+	 * @see ApplicationListener#resize(int, int)
+	 * @author Colten Reissmann */
+	public void updateAnchor (int width, int height, Align anchorPoint) {
+		if (Align.isLeft(anchorPoint)) {
+            setScreenX(0);
+        } else if ((Align.isRight(anchorPoint))) {
+            setScreenX(width - getScreenWidth());
+        } else if (Align.isCenterHorizontal(anchorPoint)) {
+            setScreenX((width - getScreenWidth()) / 2);
+        }
+
+        if ((Align.isTop(anchorPoint))) {
+            setScreenY(height - getScreenHeight());
+        } else if (Align.isBottom(anchorPoint)) {
+			setScreenY(0);
+        } else if (Align.isCenterVertical(anchorPoint)) {
+            setScreenY((height - getScreenHeight()) / 2);
+        }
 	}
 
 	/** Returns the left gutter (black bar) width in screen coordinates. */


### PR DESCRIPTION
A common issue I see online with LibGDX (and one I've experienced myself) is the problem of aligning stages to the edges of the screen. For example, some games may want a hot bar always "anchored" to the bottom of the screen or a sidebar anchored to the left or right. There are solutions for this problem in game engines like [Unity](https://docs.unity3d.com/Packages/com.unity.ugui@1.0/manual/UIBasicLayout.html), [Unreal Engine](https://docs.unrealengine.com/4.26/en-US/InteractiveExperiences/UMG/UserGuide/Anchors/), and [Godot](https://docs.godotengine.org/en/stable/tutorials/ui/size_and_anchors.html).

The code is relatively simple, but adding this would allow for much more freedom when creating stages. These changes may not work properly with changing the zoom of the camera.