### PR TITLE
Do not force-overwrite the LWJGL configuration option GLFW_LIBRARY_NAME

### DIFF
--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
@@ -121,7 +121,9 @@ public class Lwjgl3Application implements Lwjgl3ApplicationBase {
 			Class loader = Class.forName("com.badlogic.gdx.backends.lwjgl3.awt.GlfwAWTLoader");
 			Method load = loader.getMethod("load");
 			File sharedLib = (File)load.invoke(loader);
-			Configuration.GLFW_LIBRARY_NAME.set(sharedLib.getAbsolutePath());
+			if (Configuration.GLFW_LIBRARY_NAME.get() == null) {
+				Configuration.GLFW_LIBRARY_NAME.set(sharedLib.getAbsolutePath());
+			}
 			Configuration.GLFW_CHECK_THREAD0.set(false);
 		} catch (ClassNotFoundException t) {
 			return;


### PR DESCRIPTION
Right now, GLFW_LIBRARY_NAME *always* gets overwritten. That's an issue for people using this property, as there is no way to get around this. The proposal is to only rewrite the configuration if no custom location was used, i.e. the property still has the default value of `null`.