### PR TITLE
Make Pixmap safe to dispose if already disposed

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/Pixmap.java
+++ b/gdx/src/com/badlogic/gdx/graphics/Pixmap.java
@@ -391,7 +391,7 @@ public class Pixmap implements Disposable {
 
 	/** Releases all resources associated with this Pixmap. */
 	public void dispose () {
-		if (disposed) throw new GdxRuntimeException("Pixmap already disposed!");
+		if (disposed) Gdx.app.error("Pixmap", "Pixmap already disposed!");
 		pixmap.dispose();
 		disposed = true;
 	}

--- a/gdx/src/com/badlogic/gdx/graphics/Pixmap.java
+++ b/gdx/src/com/badlogic/gdx/graphics/Pixmap.java
@@ -391,7 +391,10 @@ public class Pixmap implements Disposable {
 
 	/** Releases all resources associated with this Pixmap. */
 	public void dispose () {
-		if (disposed) Gdx.app.error("Pixmap", "Pixmap already disposed!");
+		if (disposed) {
+			Gdx.app.error("Pixmap", "Pixmap already disposed!");
+			return;
+		}
 		pixmap.dispose();
 		disposed = true;
 	}


### PR DESCRIPTION
`Pixmap` seems to be the only `Disposable` class that is not safe to `dispose()` if already disposed. Unless there's a good reason for this we should treat this scenario more leniently. Issue originally raised in https://github.com/libgdx/libgdx/pull/7334.