### PR TITLE
Make Screen and ApplicationListener actually Disposable

### DIFF
--- a/gdx/src/com/badlogic/gdx/ApplicationListener.java
+++ b/gdx/src/com/badlogic/gdx/ApplicationListener.java
@@ -16,6 +16,8 @@
 
 package com.badlogic.gdx;
 
+import com.badlogic.gdx.utils.Disposable;
+
 /**
  * <p>
  * An <code>ApplicationListener</code> is called when the {@link Application} is created, resumed, rendering, paused or destroyed.
@@ -29,7 +31,7 @@ package com.badlogic.gdx;
  * </p>
  * 
  * @author mzechner */
-public interface ApplicationListener {
+public interface ApplicationListener implements Disposable {
 	/** Called when the {@link Application} is first created. */
 	public void create ();
 

--- a/gdx/src/com/badlogic/gdx/Screen.java
+++ b/gdx/src/com/badlogic/gdx/Screen.java
@@ -16,6 +16,8 @@
 
 package com.badlogic.gdx;
 
+import com.badlogic.gdx.utils.Disposable;
+
 /**
  * <p>
  * Represents one of many application screens, such as a main menu, a settings menu, the game screen and so on.
@@ -24,7 +26,7 @@ package com.badlogic.gdx;
  * Note that {@link #dispose()} is not called automatically.
  * </p>
  * @see Game */
-public interface Screen {
+public interface Screen implements Disposable {
 
 	/** Called when this screen becomes the current screen for a {@link Game}. */
 	public void show ();


### PR DESCRIPTION
Both Screen and ApplicationListener interfaces contain dispose() method, but still don't implement Disposable interface. Why not?