### PR TITLE
Fix incorrect glyph page index in FreeTypeFontGenerator

### DIFF
--- a/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGenerator.java
+++ b/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGenerator.java
@@ -598,9 +598,9 @@ public class FreeTypeFontGenerator implements Disposable {
 			}
 		}
 
-		String pixmapName = Integer.toString(glyph.hashCode());
+		String pixmapName = glyph.hashCode() + "_" + glyph.id;
 		Rectangle rect = packer.pack(pixmapName, mainPixmap);
-		glyph.page = packer.getPages().indexOf(packer.getPage(pixmapName), true);
+		glyph.page = packer.getPageIndex(pixmapName);
 		glyph.srcX = (int)rect.x;
 		glyph.srcY = (int)rect.y;
 

--- a/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGenerator.java
+++ b/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGenerator.java
@@ -598,8 +598,9 @@ public class FreeTypeFontGenerator implements Disposable {
 			}
 		}
 
-		Rectangle rect = packer.pack(mainPixmap);
-		glyph.page = packer.getPages().size - 1; // Glyph is always packed into the last page for now.
+		String pixmapName = Integer.toString(glyph.hashCode());
+		Rectangle rect = packer.pack(pixmapName, mainPixmap);
+		glyph.page = packer.getPages().indexOf(packer.getPage(pixmapName), true);
 		glyph.srcX = (int)rect.x;
 		glyph.srcY = (int)rect.y;
 


### PR DESCRIPTION
When using the BitmapFontWriter, fonts that require more than one texture page to fit all their glyphs fail. The resulting FNT file points to glyphs on the wrong page, resulting in a font that renders with odd looking characters. This occurs frequently with large fonts and with glyphs that could potentially land on the last row of the first page.

After some investigation, I discovered that it was a minor issue in FreeTypeFontGenerator causing this. It assigns the page index of each glyph to the last index of `packer.getPages()`. This is wrong because glyphs may still fit on the previous page depending on its dimensions.

The fix just applies the glyph hash code as the pixmap name to find the correct page. It's an inelegant solution, but does not require any API changes to adopt.