### PR TITLE
Only allow scrolling of a scroll pane if it has scroll focus

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ScrollPane.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ScrollPane.java
@@ -218,7 +218,7 @@ public class ScrollPane extends WidgetGroup {
 	protected void addScrollListener () {
 		addListener(new InputListener() {
 			public boolean scrolled (InputEvent event, float x, float y, float scrollAmountX, float scrollAmountY) {
-				if (getStage().getScrollFocus() != ScrollPane.this) return false;
+				event.cancel();
 				setScrollbarsVisible(true);
 				if (scrollY || scrollX) {
 					if (scrollY) {

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ScrollPane.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ScrollPane.java
@@ -218,6 +218,7 @@ public class ScrollPane extends WidgetGroup {
 	protected void addScrollListener () {
 		addListener(new InputListener() {
 			public boolean scrolled (InputEvent event, float x, float y, float scrollAmountX, float scrollAmountY) {
+				if (getStage().getScrollFocus() != ScrollPane.this) return false;
 				setScrollbarsVisible(true);
 				if (scrollY || scrollX) {
 					if (scrollY) {


### PR DESCRIPTION
This PR addresses the issue of a user using the scrollwheel inside a ScrollPane nested inside of another ScrollPane causing both to scroll at the same time. If you look at web browsers and other user interfaces, scrolling a nested scroll pane never scrolls the parent at the same time. Advanced layouts with lots of scrollable content will benefit from this.