### PR TITLE
Fix playback volume of mono sounds in the lwjgl3 backend

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,7 @@
 - Android: Add configuration option to render under the cutout if available on the device.
 - Fix: Keep SelectBox popup from extending past right edge of stage.
 - Added Framebuffer multisample support (see GL31FrameBufferMultisampleTest.java for basic usage)
+- Fixed playback volume of mono sounds
 
 [1.12.1]
 - LWJGL3 Improvement: Audio device is automatically switched if it was changed in the operating system.

--- a/CHANGES
+++ b/CHANGES
@@ -9,7 +9,7 @@
 - Android: Add configuration option to render under the cutout if available on the device.
 - Fix: Keep SelectBox popup from extending past right edge of stage.
 - Added Framebuffer multisample support (see GL31FrameBufferMultisampleTest.java for basic usage)
-- Fixed playback volume of mono sounds
+- Fixed playback volume of mono sounds and improved panning quality
 
 [1.12.1]
 - LWJGL3 Improvement: Audio device is automatically switched if it was changed in the operating system.

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALLwjgl3Audio.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALLwjgl3Audio.java
@@ -108,6 +108,8 @@ public class OpenALLwjgl3Audio implements Lwjgl3Audio {
 		for (int i = 0; i < simultaneousSources; i++) {
 			int sourceID = alGenSources();
 			if (alGetError() != AL_NO_ERROR) break;
+			alSourcef(sourceID, AL_ROLLOFF_FACTOR, 0f);
+			alSourcei(sourceID, AL_SOURCE_RELATIVE, AL_TRUE);
 			allSources.add(sourceID);
 		}
 		idleSources = new IntArray(allSources);
@@ -248,7 +250,7 @@ public class OpenALLwjgl3Audio implements Lwjgl3Audio {
 				alSourcei(sourceId, AL_BUFFER, 0);
 				AL10.alSourcef(sourceId, AL10.AL_GAIN, 1);
 				AL10.alSourcef(sourceId, AL10.AL_PITCH, 1);
-				AL10.alSource3f(sourceId, AL10.AL_POSITION, 0, 0, 1f);
+				AL10.alSource3f(sourceId, AL10.AL_POSITION, 0, 0, 0f);
 				AL10.alSourcei(sourceId, SOFTDirectChannels.AL_DIRECT_CHANNELS_SOFT, SOFTDirectChannelsRemix.AL_REMIX_UNMATCHED_SOFT);
 				return sourceId;
 			}
@@ -358,8 +360,8 @@ public class OpenALLwjgl3Audio implements Lwjgl3Audio {
 	public void setSoundPan (long soundId, float pan, float volume) {
 		int sourceId = soundIdToSource.get(soundId, -1);
 		if (sourceId != -1) {
-			AL10.alSource3f(sourceId, AL10.AL_POSITION, MathUtils.cos((pan - 1) * MathUtils.HALF_PI), 0,
-				MathUtils.sin((pan + 1) * MathUtils.HALF_PI));
+			AL10.alSource3f(sourceId, AL10.AL_POSITION, pan, 0,
+							(float) -Math.sqrt(1f - pan * pan));
 			AL10.alSourcef(sourceId, AL10.AL_GAIN, volume);
 		}
 	}

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALLwjgl3Audio.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALLwjgl3Audio.java
@@ -249,7 +249,7 @@ public class OpenALLwjgl3Audio implements Lwjgl3Audio {
 				alSourcei(sourceId, AL_BUFFER, 0);
 				AL10.alSourcef(sourceId, AL10.AL_GAIN, 1);
 				AL10.alSourcef(sourceId, AL10.AL_PITCH, 1);
-				AL10.alSource3f(sourceId, AL10.AL_POSITION, 0, 0, 0f);
+				AL10.alSource3f(sourceId, AL10.AL_POSITION, 0, 0, 0);
 				AL10.alSourcei(sourceId, SOFTDirectChannels.AL_DIRECT_CHANNELS_SOFT, SOFTDirectChannelsRemix.AL_REMIX_UNMATCHED_SOFT);
 				return sourceId;
 			}
@@ -359,7 +359,7 @@ public class OpenALLwjgl3Audio implements Lwjgl3Audio {
 	public void setSoundPan (long soundId, float pan, float volume) {
 		int sourceId = soundIdToSource.get(soundId, -1);
 		if (sourceId != -1) {
-			AL10.alSource3f(sourceId, AL10.AL_POSITION, pan, 0, (float)-Math.sqrt(1f - pan * pan));
+			AL10.alSource3f(sourceId, AL10.AL_POSITION, pan, 0, (float)-Math.sqrt(1d - pan * pan));
 			AL10.alSourcef(sourceId, AL10.AL_GAIN, volume);
 		}
 	}

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALLwjgl3Audio.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALLwjgl3Audio.java
@@ -35,7 +35,6 @@ import org.lwjgl.openal.AL10;
 import com.badlogic.gdx.audio.AudioDevice;
 import com.badlogic.gdx.audio.AudioRecorder;
 import com.badlogic.gdx.files.FileHandle;
-import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.GdxRuntimeException;
 import com.badlogic.gdx.utils.IntArray;
@@ -360,8 +359,7 @@ public class OpenALLwjgl3Audio implements Lwjgl3Audio {
 	public void setSoundPan (long soundId, float pan, float volume) {
 		int sourceId = soundIdToSource.get(soundId, -1);
 		if (sourceId != -1) {
-			AL10.alSource3f(sourceId, AL10.AL_POSITION, pan, 0,
-							(float) -Math.sqrt(1f - pan * pan));
+			AL10.alSource3f(sourceId, AL10.AL_POSITION, pan, 0, (float)-Math.sqrt(1f - pan * pan));
 			AL10.alSourcef(sourceId, AL10.AL_GAIN, volume);
 		}
 	}

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALLwjgl3Audio.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALLwjgl3Audio.java
@@ -109,6 +109,7 @@ public class OpenALLwjgl3Audio implements Lwjgl3Audio {
 			if (alGetError() != AL_NO_ERROR) break;
 			alSourcef(sourceID, AL_ROLLOFF_FACTOR, 0f);
 			alSourcei(sourceID, AL_SOURCE_RELATIVE, AL_TRUE);
+			alSourcei(sourceID, SOFTDirectChannels.AL_DIRECT_CHANNELS_SOFT, SOFTDirectChannelsRemix.AL_REMIX_UNMATCHED_SOFT);
 			allSources.add(sourceID);
 		}
 		idleSources = new IntArray(allSources);
@@ -250,7 +251,6 @@ public class OpenALLwjgl3Audio implements Lwjgl3Audio {
 				AL10.alSourcef(sourceId, AL10.AL_GAIN, 1);
 				AL10.alSourcef(sourceId, AL10.AL_PITCH, 1);
 				AL10.alSource3f(sourceId, AL10.AL_POSITION, 0, 0, 0);
-				AL10.alSourcei(sourceId, SOFTDirectChannels.AL_DIRECT_CHANNELS_SOFT, SOFTDirectChannelsRemix.AL_REMIX_UNMATCHED_SOFT);
 				return sourceId;
 			}
 		}

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALMusic.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALMusic.java
@@ -21,12 +21,10 @@ import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
 
 import org.lwjgl.BufferUtils;
-import org.lwjgl.openal.AL10;
 import org.lwjgl.openal.AL11;
 
 import com.badlogic.gdx.audio.Music;
 import com.badlogic.gdx.files.FileHandle;
-import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.utils.FloatArray;
 import com.badlogic.gdx.utils.GdxRuntimeException;
 

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALMusic.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALMusic.java
@@ -21,6 +21,7 @@ import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
 
 import org.lwjgl.BufferUtils;
+import org.lwjgl.openal.AL10;
 import org.lwjgl.openal.AL11;
 
 import com.badlogic.gdx.audio.Music;
@@ -157,8 +158,7 @@ public abstract class OpenALMusic implements Music {
 		this.pan = pan;
 		if (audio.noDevice) return;
 		if (sourceID == -1) return;
-		alSource3f(sourceID, AL_POSITION, MathUtils.cos((pan - 1) * MathUtils.HALF_PI), 0,
-			MathUtils.sin((pan + 1) * MathUtils.HALF_PI));
+		alSource3f(sourceID, AL_POSITION, pan, 0, (float)-Math.sqrt(1d - pan * pan));
 		alSourcef(sourceID, AL_GAIN, volume);
 	}
 


### PR DESCRIPTION
The position of sound sources was set to (0,0,1) in 3D space, resulting in sounds not playing at full volume. This led to varying levels of audio output volume compared to other backends (stereo sounds weren't affected).

This PR sets the position to (0,0,0). In order to not break panning, I had to change the way how 2D panning works.
If pan is set to 0 (center), sound output shouldn't differ from playing an unpanned sound. This was the case with the original panning calculation and a default source position of (0,0,1).

The new panning calculation is based on this [comment](https://github.com/kcat/openal-soft/issues/194#issuecomment-392520073) by kcat, the author of OpenAL Soft. If you read the comment, you'll notice a mention of a second variant in the last block. I've chosen this method because the sound output closely matches the output prior to this PR.

Visual comparison:
`play(volume, pitch, pan)`
The red line indicates the maximum level of output.
![pr](https://github.com/libgdx/libgdx/assets/108926/b566afcd-bd4c-4c6b-ab43-f6717f459ff6)
