### PR TITLE
Document units of Batch rotation

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g2d/Batch.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/Batch.java
@@ -155,8 +155,7 @@ public interface Batch extends Disposable {
 	 * rectangle is offset by originX, originY relative to the origin. Scale specifies the scaling factor by which the rectangle
 	 * should be scaled around originX, originY. Rotation specifies the angle of counter clockwise rotation of the rectangle around
 	 * originX, originY. 
-	 * @param rotation rotation in degrees
-	 */
+	 * @param rotation rotation in degrees */
 	public void draw (TextureRegion region, float x, float y, float originX, float originY, float width, float height,
 		float scaleX, float scaleY, float rotation);
 

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/Batch.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/Batch.java
@@ -155,7 +155,7 @@ public interface Batch extends Disposable {
 	 * rectangle is offset by originX, originY relative to the origin. Scale specifies the scaling factor by which the rectangle
 	 * should be scaled around originX, originY. Rotation specifies the angle of counter clockwise rotation of the rectangle around
 	 * originX, originY. 
-  	 * @param rotation rotation in degrees
+	 * @param rotation rotation in degrees
 	 */
 	public void draw (TextureRegion region, float x, float y, float originX, float originY, float width, float height,
 		float scaleX, float scaleY, float rotation);
@@ -164,7 +164,7 @@ public interface Batch extends Disposable {
 	 * to cover the given width and height. The rectangle is offset by originX, originY relative to the origin. Scale specifies the
 	 * scaling factor by which the rectangle should be scaled around originX, originY. Rotation specifies the angle of counter
 	 * clockwise rotation of the rectangle around originX, originY.
-  	 * @param rotation rotation in degrees
+	 * @param rotation rotation in degrees
 	 * @param clockwise If true, the texture coordinates are rotated 90 degrees clockwise. If false, they are rotated 90 degrees
 	 *           counter clockwise. */
 	public void draw (TextureRegion region, float x, float y, float originX, float originY, float width, float height,

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/Batch.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/Batch.java
@@ -88,7 +88,7 @@ public interface Batch extends Disposable {
 	 * @param height the height in pixels
 	 * @param scaleX the scale of the rectangle around originX/originY in x
 	 * @param scaleY the scale of the rectangle around originX/originY in y
-	 * @param rotation the angle of counter clockwise rotation of the rectangle around originX/originY
+	 * @param rotation the angle of counter clockwise rotation of the rectangle around originX/originY, in degrees
 	 * @param srcX the x-coordinate in texel space
 	 * @param srcY the y-coordinate in texel space
 	 * @param srcWidth the source with in texels
@@ -154,7 +154,9 @@ public interface Batch extends Disposable {
 	/** Draws a rectangle with the bottom left corner at x,y and stretching the region to cover the given width and height. The
 	 * rectangle is offset by originX, originY relative to the origin. Scale specifies the scaling factor by which the rectangle
 	 * should be scaled around originX, originY. Rotation specifies the angle of counter clockwise rotation of the rectangle around
-	 * originX, originY. */
+	 * originX, originY. 
+  	 * @param rotation rotation in degrees
+	 */
 	public void draw (TextureRegion region, float x, float y, float originX, float originY, float width, float height,
 		float scaleX, float scaleY, float rotation);
 
@@ -162,6 +164,7 @@ public interface Batch extends Disposable {
 	 * to cover the given width and height. The rectangle is offset by originX, originY relative to the origin. Scale specifies the
 	 * scaling factor by which the rectangle should be scaled around originX, originY. Rotation specifies the angle of counter
 	 * clockwise rotation of the rectangle around originX, originY.
+  	 * @param rotation rotation in degrees
 	 * @param clockwise If true, the texture coordinates are rotated 90 degrees clockwise. If false, they are rotated 90 degrees
 	 *           counter clockwise. */
 	public void draw (TextureRegion region, float x, float y, float originX, float originY, float width, float height,

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/Batch.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/Batch.java
@@ -154,7 +154,7 @@ public interface Batch extends Disposable {
 	/** Draws a rectangle with the bottom left corner at x,y and stretching the region to cover the given width and height. The
 	 * rectangle is offset by originX, originY relative to the origin. Scale specifies the scaling factor by which the rectangle
 	 * should be scaled around originX, originY. Rotation specifies the angle of counter clockwise rotation of the rectangle around
-	 * originX, originY. 
+	 * originX, originY.
 	 * @param rotation rotation in degrees */
 	public void draw (TextureRegion region, float x, float y, float originX, float originY, float width, float height,
 		float scaleX, float scaleY, float rotation);


### PR DESCRIPTION
In the Javadocs, it's not clear what the units of rotation are for Batch - are they degrees? radians?

After trial and error I found out they're degrees (e.g. 0...360), I think it'd be helpful to have this clearly documented in the API