### PR TITLE
Added a convenient method to clamp the vector's components.

### DIFF
--- a/gdx/src/com/badlogic/gdx/math/Vector3.java
+++ b/gdx/src/com/badlogic/gdx/math/Vector3.java
@@ -715,6 +715,20 @@ public class Vector3 implements Serializable, Vector<Vector3> {
 		return epsilonEquals(x, y, z, MathUtils.FLOAT_ROUNDING_ERROR);
 	}
 
+	/**
+	 * Clamps the vector's X, Y and Z with the given boundaries.
+	 *
+	 * @param min The minimum value to clamp the vector's components
+	 * @param max The maximum value to clamp the vector's components
+	 * @return this vector for chaining
+	 */
+	public Vector3 clampComponents(float min, float max) {
+		x = MathUtils.clamp(x, min, max);
+		y = MathUtils.clamp(y, min, max);
+		z = MathUtils.clamp(z, min, max);
+		return this;
+	}
+
 	@Override
 	public Vector3 setZero () {
 		this.x = 0;

--- a/gdx/src/com/badlogic/gdx/math/Vector3.java
+++ b/gdx/src/com/badlogic/gdx/math/Vector3.java
@@ -715,14 +715,12 @@ public class Vector3 implements Serializable, Vector<Vector3> {
 		return epsilonEquals(x, y, z, MathUtils.FLOAT_ROUNDING_ERROR);
 	}
 
-	/**
-	 * Clamps the vector's X, Y and Z with the given boundaries.
+	/** Clamps the vector's X, Y and Z with the given boundaries.
 	 *
 	 * @param min The minimum value to clamp the vector's components
 	 * @param max The maximum value to clamp the vector's components
-	 * @return this vector for chaining
-	 */
-	public Vector3 clampComponents(float min, float max) {
+	 * @return this vector for chaining */
+	public Vector3 clampComponents (float min, float max) {
 		x = MathUtils.clamp(x, min, max);
 		y = MathUtils.clamp(y, min, max);
 		z = MathUtils.clamp(z, min, max);


### PR DESCRIPTION
Hello,
I came across several times where I used the Vector3 to specify locations in my game's world and many times wanted to clamp the position to the map's size. So I thought instead of repeating it, it might be useful for other devs.
Thanks