### PR TITLE
Added new Color CLEAR_WHITE

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/Color.java
+++ b/gdx/src/com/badlogic/gdx/graphics/Color.java
@@ -33,6 +33,7 @@ public class Color {
 	public static final float WHITE_FLOAT_BITS = WHITE.toFloatBits();
 
 	public static final Color CLEAR = new Color(0, 0, 0, 0);
+	public static final Color CLEAR_WHITE = new Color(1, 1, 1, 0);
 
 	public static final Color BLUE = new Color(0, 0, 1, 1);
 	public static final Color NAVY = new Color(0, 0, 0.5f, 1);

--- a/gdx/src/com/badlogic/gdx/graphics/Colors.java
+++ b/gdx/src/com/badlogic/gdx/graphics/Colors.java
@@ -60,6 +60,7 @@ public final class Colors {
 	public static void reset () {
 		map.clear();
 		map.put("CLEAR", Color.CLEAR);
+		map.put("CLEAR_WHITE", Color.CLEAR_WHITE);
 		map.put("BLACK", Color.BLACK);
 
 		map.put("WHITE", Color.WHITE);


### PR DESCRIPTION
When you are tinting a texture, you may want to lerp from white to completely transparent. Unfortunately, if you use Color.CLEAR, it will also darken the image as it turns transparent. That's because Color.CLEAR is defined as (0, 0, 0, 0). That has its uses, but in this case Color.CLEAR_WHITE is a better option. It's defined as (1, 1, 1, 0). The texture will not be darkened if users implement this new Color. This change will not impact any existing code.