### PR TITLE
glTexImage2D support on GWT

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtGL20.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtGL20.java
@@ -949,28 +949,36 @@ public class GwtGL20 implements GL20 {
 		if (pixels == null) {
 			gl.texImage2D(target, level, internalformat, width, height, border, format, type, null);
 		} else {
-			if (pixels.limit() > 1) {
+			if (pixels instanceof FloatBuffer) {
 				HasArrayBufferView arrayHolder = (HasArrayBufferView)pixels;
-				ArrayBufferView webGLArray = arrayHolder.getTypedArray();
-				ArrayBufferView buffer;
-				if (pixels instanceof FloatBuffer) {
-					buffer = webGLArray;
-				} else {
+				ArrayBufferView buffer = arrayHolder.getTypedArray();
+				gl.texImage2D(target, level, internalformat, width, height, border, format, type, buffer);
+			} else if (pixels instanceof IntBuffer) {
+				if (pixels.limit() > 1) {
+					HasArrayBufferView arrayHolder = (HasArrayBufferView)pixels;
+					ArrayBufferView webGLArray = arrayHolder.getTypedArray();
 					int remainingBytes = pixels.remaining() * 4;
 					int byteOffset = webGLArray.byteOffset() + pixels.position() * 4;
-					buffer = Uint8ArrayNative.create(webGLArray.buffer(), byteOffset, remainingBytes);
-				}
-				gl.texImage2D(target, level, internalformat, width, height, border, format, type, buffer);
-			} else {
-				Pixmap pixmap = Pixmap.pixmaps.get(((IntBuffer)pixels).get(0));
-				// Prefer to use the HTMLImageElement when possible, since reading from the CanvasElement can be lossy.
-				if (pixmap.canUseImageElement()) {
-					gl.texImage2D(target, level, internalformat, format, type, pixmap.getImageElement());
-				} else if (pixmap.canUseVideoElement()) {
-					gl.texImage2D(target, level, internalformat, format, type, pixmap.getVideoElement());
+					ArrayBufferView buffer = Uint8ArrayNative.create(webGLArray.buffer(), byteOffset, remainingBytes);
+					gl.texImage2D(target, level, internalformat, width, height, border, format, type, buffer);
 				} else {
-					gl.texImage2D(target, level, internalformat, format, type, pixmap.getCanvasElement());
+					Pixmap pixmap = Pixmap.pixmaps.get(((IntBuffer)pixels).get(0));
+					// Prefer to use the HTMLImageElement when possible, since reading from the CanvasElement can be lossy.
+					if (pixmap.canUseImageElement()) {
+						gl.texImage2D(target, level, internalformat, format, type, pixmap.getImageElement());
+					} else if (pixmap.canUseVideoElement()) {
+						gl.texImage2D(target, level, internalformat, format, type, pixmap.getVideoElement());
+					} else {
+						gl.texImage2D(target, level, internalformat, format, type, pixmap.getCanvasElement());
+					}
 				}
+			} else if (pixels instanceof ByteBuffer) {
+				HasArrayBufferView arrayHolder = (HasArrayBufferView)pixels;
+				ArrayBufferView webGLArray = arrayHolder.getTypedArray();
+				int remainingBytes = pixels.remaining();
+				int byteOffset = webGLArray.byteOffset() + pixels.position();
+				ArrayBufferView buffer = Uint8ArrayNative.create(webGLArray.buffer(), byteOffset, remainingBytes);
+				gl.texImage2D(target, level, internalformat, width, height, border, format, type, buffer);
 			}
 		}
 	}

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtGL20.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtGL20.java
@@ -979,6 +979,8 @@ public class GwtGL20 implements GL20 {
 				int byteOffset = webGLArray.byteOffset() + pixels.position();
 				ArrayBufferView buffer = Uint8ArrayNative.create(webGLArray.buffer(), byteOffset, remainingBytes);
 				gl.texImage2D(target, level, internalformat, width, height, border, format, type, buffer);
+			} else {
+				throw new GdxRuntimeException("Unsupported Buffer type");
 			}
 		}
 	}

--- a/tests/gdx-tests-gwt/src/com/badlogic/gdx/tests/gwt/client/GwtTestWrapper.java
+++ b/tests/gdx-tests-gwt/src/com/badlogic/gdx/tests/gwt/client/GwtTestWrapper.java
@@ -98,6 +98,7 @@ import com.badlogic.gdx.tests.g3d.ModelCacheTest;
 import com.badlogic.gdx.tests.g3d.MultipleRenderTargetTest;
 import com.badlogic.gdx.tests.g3d.ShadowMappingTest;
 import com.badlogic.gdx.tests.g3d.TextureArrayTest;
+import com.badlogic.gdx.tests.gles2.GlTexImage2D;
 import com.badlogic.gdx.tests.gles2.VertexArrayTest;
 import com.badlogic.gdx.tests.gles3.GL30Texture3DTest;
 import com.badlogic.gdx.tests.gles3.NonPowerOfTwoTest;
@@ -293,6 +294,11 @@ public class GwtTestWrapper extends AbstractTestWrapper {
 		tests.add(new GwtInstancer() {
 			public GdxTest instance () {
 				return new GLProfilerErrorTest();
+			}
+		});
+		tests.add(new GwtInstancer() {
+			public GdxTest instance () {
+				return new GlTexImage2D();
 			}
 		});
 		tests.add(new GwtInstancer() {

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gles2/GlTexImage2D.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gles2/GlTexImage2D.java
@@ -1,0 +1,208 @@
+/*******************************************************************************
+ * Copyright 2024 See AUTHORS file.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogic.gdx.tests.gles2;
+
+import java.nio.FloatBuffer;
+import java.nio.ByteBuffer;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.Pixmap;
+import com.badlogic.gdx.graphics.glutils.ShaderProgram;
+import com.badlogic.gdx.tests.utils.GdxTest;
+import com.badlogic.gdx.utils.BufferUtils;
+
+/** Added during glTexImage2D corrections. 
+ * @author Ret-Mode */
+public class GlTexImage2D extends GdxTest {
+	
+	ShaderProgram shader;
+	
+	int texture = 0;
+	int pixmapTexture = 0;
+
+	int vertsBuffer = 0;
+	int pixmapBuffer = 0;
+	int uvBuffer = 0;
+
+	Pixmap pixmapCheck;
+
+	String vertexShader = 
+		  "attribute vec2 vPosition;                    \n" 
+		+ "attribute vec2 vTexCoords;                   \n"
+		+ "varying   vec2 fTexCoords;                   \n"
+		+ "void main()                                  \n"
+		+ "{                                            \n" 
+		+ "   gl_Position = vec4(vPosition, 0.0, 1.0);  \n" 
+		+ "   fTexCoords  = vTexCoords;                 \n"
+		+ "}";
+	String fragmentShader = 
+	      "#ifdef GL_ES\n" + "precision mediump float;\n" + "#endif\n"
+		+ "varying vec2 fTexCoords;                       \n"
+		+ "uniform sampler2D uTex2d;                      \n" 
+		+ "void main()                                    \n" 
+		+ "{                                              \n"
+		+ "  gl_FragColor = texture2D(uTex2d, fTexCoords);\n" 
+		+ "}";
+		
+	FloatBuffer verticesData = BufferUtils.newFloatBuffer(8);
+	FloatBuffer pixmapVerticesData = BufferUtils.newFloatBuffer(8);
+	FloatBuffer uvData = BufferUtils.newFloatBuffer(8);
+	ByteBuffer textureColorData = BufferUtils.newByteBuffer(12);
+
+	@Override
+	public void create () {
+		
+		float[] vertices = {-1.0f, 0.0f, 1.0f, 0.0f, 1.0f, 1.0f, -1.0f, 1.0f};
+		float[] pixmapVertices = {1.0f, 0.0f, -1.0f, 0.0f, -1.0f, -1.0f, 1.0f, -1.0f};
+		float[] uv = {0.0f, 0.0f, 1.0f, 0.0f, 1.0f, 1.0f, 0.0f, 1.0f};
+		byte[] data = {0x7F,  0x00,  0x00,  /* r */
+			           0x00,  0x7F,  0x00,  /* g */
+			           0x00,  0x00,  0x7F,  /* b */
+			           0x00,  0x7F,  0x7F}; /* rg */
+
+		verticesData.put(vertices);
+		verticesData.rewind();
+		pixmapVerticesData.put(pixmapVertices);
+		pixmapVerticesData.rewind();
+		uvData.put(uv);
+		uvData.rewind();
+		textureColorData.put(data);
+		textureColorData.rewind();
+	}
+
+	@Override
+	public void render () {
+		/* check if OpenGL context needs to be reloaded;
+		 * 	checking only texture should be sufficient; but i guess this check is redundant
+		 */
+		if (!Gdx.gl20.glIsTexture(texture)) {
+			reload();
+		}
+
+		/* bump bytes and upload to gpu */
+		for(int colorComponent = 0; colorComponent < textureColorData.capacity(); ++colorComponent) {
+			textureColorData.put(colorComponent, (byte)(textureColorData.get(colorComponent) + 1));
+		}
+		textureColorData.rewind();
+		Gdx.gl20.glActiveTexture(GL20.GL_TEXTURE1);
+		Gdx.gl20.glTexImage2D(GL20.GL_TEXTURE_2D, 0, GL20.GL_RGB, 2, 2, 0, 
+			GL20.GL_RGB, GL20.GL_UNSIGNED_BYTE, textureColorData);
+		Gdx.gl20.glActiveTexture(GL20.GL_TEXTURE0);
+
+		/* init drawing */
+		Gdx.gl20.glViewport(0, 0, Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight());
+		Gdx.gl20.glClear(GL20.GL_COLOR_BUFFER_BIT);
+
+		/* draw texture built from bytes */
+		Gdx.gl20.glBindBuffer(GL20.GL_ARRAY_BUFFER, vertsBuffer);
+		Gdx.gl20.glVertexAttribPointer(shader.getAttributeLocation("vPosition"), 2, GL20.GL_FLOAT, false, 0, 0);
+		shader.setUniformi("uTex2d", 1);
+		Gdx.gl20.glDrawArrays(GL20.GL_TRIANGLE_FAN, 0, 4);
+			
+		/* draw pixmap */
+		Gdx.gl20.glBindBuffer(GL20.GL_ARRAY_BUFFER, pixmapBuffer);
+		Gdx.gl20.glVertexAttribPointer(shader.getAttributeLocation("vPosition"), 2, GL20.GL_FLOAT, false, 0, 0);
+		shader.setUniformi("uTex2d", 2);
+		Gdx.gl20.glDrawArrays(GL20.GL_TRIANGLE_FAN, 0, 4);
+
+	}
+
+	private void reload() {
+
+		/* common */
+		Gdx.gl20.glPixelStorei(GL20.GL_UNPACK_ALIGNMENT, 1);
+
+		/* generate texture */
+		texture = Gdx.gl20.glGenTexture();
+		Gdx.gl20.glActiveTexture(GL20.GL_TEXTURE1);
+		Gdx.gl20.glBindTexture(GL20.GL_TEXTURE_2D, texture);
+		Gdx.gl20.glTexParameteri(GL20.GL_TEXTURE_2D, GL20.GL_TEXTURE_WRAP_S , GL20.GL_CLAMP_TO_EDGE);
+		Gdx.gl20.glTexParameteri(GL20.GL_TEXTURE_2D, GL20.GL_TEXTURE_WRAP_T , GL20.GL_CLAMP_TO_EDGE);
+		Gdx.gl20.glTexParameteri(GL20.GL_TEXTURE_2D, GL20.GL_TEXTURE_MAG_FILTER, GL20.GL_LINEAR);
+		Gdx.gl20.glTexParameteri(GL20.GL_TEXTURE_2D, GL20.GL_TEXTURE_MIN_FILTER, GL20.GL_LINEAR);
+		Gdx.gl20.glTexImage2D(GL20.GL_TEXTURE_2D, 0, GL20.GL_RGB, 2, 2, 0, 
+			GL20.GL_RGB, GL20.GL_UNSIGNED_BYTE, textureColorData);
+
+		/* load pixmap to verify that pixmap was not broken */
+		pixmapCheck = new Pixmap(Gdx.files.internal("data/walkanim.png"));
+
+		/* generate texture for pixmap */
+		pixmapTexture = Gdx.gl20.glGenTexture();
+		Gdx.gl20.glActiveTexture(GL20.GL_TEXTURE2);
+		Gdx.gl20.glBindTexture(GL20.GL_TEXTURE_2D, pixmapTexture);
+		Gdx.gl20.glTexParameteri(GL20.GL_TEXTURE_2D, GL20.GL_TEXTURE_WRAP_S , GL20.GL_CLAMP_TO_EDGE);
+		Gdx.gl20.glTexParameteri(GL20.GL_TEXTURE_2D, GL20.GL_TEXTURE_WRAP_T , GL20.GL_CLAMP_TO_EDGE);
+		Gdx.gl20.glTexParameteri(GL20.GL_TEXTURE_2D, GL20.GL_TEXTURE_MAG_FILTER, GL20.GL_LINEAR);
+		Gdx.gl20.glTexParameteri(GL20.GL_TEXTURE_2D, GL20.GL_TEXTURE_MIN_FILTER, GL20.GL_LINEAR);
+		Gdx.gl20.glTexImage2D(GL20.GL_TEXTURE_2D, 0, GL20.GL_RGBA, pixmapCheck.getWidth(), pixmapCheck.getHeight(), 0, 
+			GL20.GL_RGBA, GL20.GL_UNSIGNED_BYTE, pixmapCheck.getPixels());
+
+		/* set shader */
+		shader = new ShaderProgram(vertexShader, fragmentShader);
+		shader.bind();
+
+		/* set vertices */
+		vertsBuffer = Gdx.gl20.glGenBuffer();
+		Gdx.gl20.glBindBuffer(GL20.GL_ARRAY_BUFFER, vertsBuffer);
+		Gdx.gl20.glBufferData(GL20.GL_ARRAY_BUFFER, 8 * 4, verticesData, GL20.GL_STATIC_DRAW);
+
+		/* set pixmap verts */
+		pixmapBuffer = Gdx.gl20.glGenBuffer();
+		Gdx.gl20.glBindBuffer(GL20.GL_ARRAY_BUFFER, pixmapBuffer);
+		Gdx.gl20.glBufferData(GL20.GL_ARRAY_BUFFER, 8 * 4, pixmapVerticesData, GL20.GL_STATIC_DRAW);
+
+		/* set uvs */
+		uvBuffer = Gdx.gl20.glGenBuffer();
+		Gdx.gl20.glBindBuffer(GL20.GL_ARRAY_BUFFER, uvBuffer);
+		Gdx.gl20.glBufferData(GL20.GL_ARRAY_BUFFER, 8 * 4, uvData, GL20.GL_STATIC_DRAW);
+		Gdx.gl20.glVertexAttribPointer(shader.getAttributeLocation("vTexCoords"), 2, GL20.GL_FLOAT, false, 0, 0);
+		
+		/* finalize setup */
+		Gdx.gl20.glEnableVertexAttribArray(shader.getAttributeLocation("vPosition"));
+		Gdx.gl20.glEnableVertexAttribArray(shader.getAttributeLocation("vTexCoords"));
+		
+		Gdx.gl20.glActiveTexture(GL20.GL_TEXTURE0);
+		Gdx.gl20.glBindBuffer(GL20.GL_ARRAY_BUFFER, 0);
+	}
+
+	@Override
+	public void pause () {
+		dispose();
+	}
+
+	@Override
+	public void resume () {
+		reload();
+	}
+
+	@Override
+	public void dispose () {
+		Gdx.gl20.glDisableVertexAttribArray(shader.getAttributeLocation("vPosition"));
+		Gdx.gl20.glDisableVertexAttribArray(shader.getAttributeLocation("vTexCoords"));
+		
+		Gdx.gl20.glDeleteBuffer(vertsBuffer);
+		Gdx.gl20.glDeleteBuffer(pixmapBuffer);
+		Gdx.gl20.glDeleteBuffer(uvBuffer);
+		
+		Gdx.gl20.glDeleteTexture(texture);
+		Gdx.gl20.glDeleteTexture(pixmapTexture);
+
+		shader.dispose();
+		pixmapCheck.dispose();
+	}
+}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gles2/GlTexImage2D.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gles2/GlTexImage2D.java
@@ -26,12 +26,12 @@ import com.badlogic.gdx.graphics.glutils.ShaderProgram;
 import com.badlogic.gdx.tests.utils.GdxTest;
 import com.badlogic.gdx.utils.BufferUtils;
 
-/** Added during glTexImage2D corrections. 
+/** Added during glTexImage2D corrections.
  * @author Ret-Mode */
 public class GlTexImage2D extends GdxTest {
-	
+
 	ShaderProgram shader;
-	
+
 	int texture = 0;
 	int pixmapTexture = 0;
 
@@ -41,24 +41,15 @@ public class GlTexImage2D extends GdxTest {
 
 	Pixmap pixmapCheck;
 
-	String vertexShader = 
-		  "attribute vec2 vPosition;                    \n" 
-		+ "attribute vec2 vTexCoords;                   \n"
-		+ "varying   vec2 fTexCoords;                   \n"
-		+ "void main()                                  \n"
-		+ "{                                            \n" 
-		+ "   gl_Position = vec4(vPosition, 0.0, 1.0);  \n" 
-		+ "   fTexCoords  = vTexCoords;                 \n"
-		+ "}";
-	String fragmentShader = 
-	      "#ifdef GL_ES\n" + "precision mediump float;\n" + "#endif\n"
-		+ "varying vec2 fTexCoords;                       \n"
-		+ "uniform sampler2D uTex2d;                      \n" 
-		+ "void main()                                    \n" 
-		+ "{                                              \n"
-		+ "  gl_FragColor = texture2D(uTex2d, fTexCoords);\n" 
-		+ "}";
-		
+	String vertexShader = "attribute vec2 vPosition;                    \n" + "attribute vec2 vTexCoords;                   \n"
+		+ "varying   vec2 fTexCoords;                   \n" + "void main()                                  \n"
+		+ "{                                            \n" + "   gl_Position = vec4(vPosition, 0.0, 1.0);  \n"
+		+ "   fTexCoords  = vTexCoords;                 \n" + "}";
+	String fragmentShader = "#ifdef GL_ES\n" + "precision mediump float;\n" + "#endif\n"
+		+ "varying vec2 fTexCoords;                       \n" + "uniform sampler2D uTex2d;                      \n"
+		+ "void main()                                    \n" + "{                                              \n"
+		+ "  gl_FragColor = texture2D(uTex2d, fTexCoords);\n" + "}";
+
 	FloatBuffer verticesData = BufferUtils.newFloatBuffer(8);
 	FloatBuffer pixmapVerticesData = BufferUtils.newFloatBuffer(8);
 	FloatBuffer uvData = BufferUtils.newFloatBuffer(8);
@@ -66,14 +57,14 @@ public class GlTexImage2D extends GdxTest {
 
 	@Override
 	public void create () {
-		
+
 		float[] vertices = {-1.0f, 0.0f, 1.0f, 0.0f, 1.0f, 1.0f, -1.0f, 1.0f};
 		float[] pixmapVertices = {1.0f, 0.0f, -1.0f, 0.0f, -1.0f, -1.0f, 1.0f, -1.0f};
 		float[] uv = {0.0f, 0.0f, 1.0f, 0.0f, 1.0f, 1.0f, 0.0f, 1.0f};
-		byte[] data = {0x7F,  0x00,  0x00,  /* r */
-			           0x00,  0x7F,  0x00,  /* g */
-			           0x00,  0x00,  0x7F,  /* b */
-			           0x00,  0x7F,  0x7F}; /* rg */
+		byte[] data = {0x7F, 0x00, 0x00, /* r */
+			0x00, 0x7F, 0x00, /* g */
+			0x00, 0x00, 0x7F, /* b */
+			0x00, 0x7F, 0x7F}; /* rg */
 
 		verticesData.put(vertices);
 		verticesData.rewind();
@@ -87,21 +78,21 @@ public class GlTexImage2D extends GdxTest {
 
 	@Override
 	public void render () {
-		/* check if OpenGL context needs to be reloaded;
-		 * 	checking only texture should be sufficient; but i guess this check is redundant
+		/*
+		 * check if OpenGL context needs to be reloaded; checking only texture should be sufficient; but i guess this check is
+		 * redundant
 		 */
 		if (!Gdx.gl20.glIsTexture(texture)) {
 			reload();
 		}
 
 		/* bump bytes and upload to gpu */
-		for(int colorComponent = 0; colorComponent < textureColorData.capacity(); ++colorComponent) {
+		for (int colorComponent = 0; colorComponent < textureColorData.capacity(); ++colorComponent) {
 			textureColorData.put(colorComponent, (byte)(textureColorData.get(colorComponent) + 1));
 		}
 		textureColorData.rewind();
 		Gdx.gl20.glActiveTexture(GL20.GL_TEXTURE1);
-		Gdx.gl20.glTexImage2D(GL20.GL_TEXTURE_2D, 0, GL20.GL_RGB, 2, 2, 0, 
-			GL20.GL_RGB, GL20.GL_UNSIGNED_BYTE, textureColorData);
+		Gdx.gl20.glTexImage2D(GL20.GL_TEXTURE_2D, 0, GL20.GL_RGB, 2, 2, 0, GL20.GL_RGB, GL20.GL_UNSIGNED_BYTE, textureColorData);
 		Gdx.gl20.glActiveTexture(GL20.GL_TEXTURE0);
 
 		/* init drawing */
@@ -113,7 +104,7 @@ public class GlTexImage2D extends GdxTest {
 		Gdx.gl20.glVertexAttribPointer(shader.getAttributeLocation("vPosition"), 2, GL20.GL_FLOAT, false, 0, 0);
 		shader.setUniformi("uTex2d", 1);
 		Gdx.gl20.glDrawArrays(GL20.GL_TRIANGLE_FAN, 0, 4);
-			
+
 		/* draw pixmap */
 		Gdx.gl20.glBindBuffer(GL20.GL_ARRAY_BUFFER, pixmapBuffer);
 		Gdx.gl20.glVertexAttribPointer(shader.getAttributeLocation("vPosition"), 2, GL20.GL_FLOAT, false, 0, 0);
@@ -122,7 +113,7 @@ public class GlTexImage2D extends GdxTest {
 
 	}
 
-	private void reload() {
+	private void reload () {
 
 		/* common */
 		Gdx.gl20.glPixelStorei(GL20.GL_UNPACK_ALIGNMENT, 1);
@@ -131,12 +122,11 @@ public class GlTexImage2D extends GdxTest {
 		texture = Gdx.gl20.glGenTexture();
 		Gdx.gl20.glActiveTexture(GL20.GL_TEXTURE1);
 		Gdx.gl20.glBindTexture(GL20.GL_TEXTURE_2D, texture);
-		Gdx.gl20.glTexParameteri(GL20.GL_TEXTURE_2D, GL20.GL_TEXTURE_WRAP_S , GL20.GL_CLAMP_TO_EDGE);
-		Gdx.gl20.glTexParameteri(GL20.GL_TEXTURE_2D, GL20.GL_TEXTURE_WRAP_T , GL20.GL_CLAMP_TO_EDGE);
+		Gdx.gl20.glTexParameteri(GL20.GL_TEXTURE_2D, GL20.GL_TEXTURE_WRAP_S, GL20.GL_CLAMP_TO_EDGE);
+		Gdx.gl20.glTexParameteri(GL20.GL_TEXTURE_2D, GL20.GL_TEXTURE_WRAP_T, GL20.GL_CLAMP_TO_EDGE);
 		Gdx.gl20.glTexParameteri(GL20.GL_TEXTURE_2D, GL20.GL_TEXTURE_MAG_FILTER, GL20.GL_LINEAR);
 		Gdx.gl20.glTexParameteri(GL20.GL_TEXTURE_2D, GL20.GL_TEXTURE_MIN_FILTER, GL20.GL_LINEAR);
-		Gdx.gl20.glTexImage2D(GL20.GL_TEXTURE_2D, 0, GL20.GL_RGB, 2, 2, 0, 
-			GL20.GL_RGB, GL20.GL_UNSIGNED_BYTE, textureColorData);
+		Gdx.gl20.glTexImage2D(GL20.GL_TEXTURE_2D, 0, GL20.GL_RGB, 2, 2, 0, GL20.GL_RGB, GL20.GL_UNSIGNED_BYTE, textureColorData);
 
 		/* load pixmap to verify that pixmap was not broken */
 		pixmapCheck = new Pixmap(Gdx.files.internal("data/walkanim.png"));
@@ -145,12 +135,12 @@ public class GlTexImage2D extends GdxTest {
 		pixmapTexture = Gdx.gl20.glGenTexture();
 		Gdx.gl20.glActiveTexture(GL20.GL_TEXTURE2);
 		Gdx.gl20.glBindTexture(GL20.GL_TEXTURE_2D, pixmapTexture);
-		Gdx.gl20.glTexParameteri(GL20.GL_TEXTURE_2D, GL20.GL_TEXTURE_WRAP_S , GL20.GL_CLAMP_TO_EDGE);
-		Gdx.gl20.glTexParameteri(GL20.GL_TEXTURE_2D, GL20.GL_TEXTURE_WRAP_T , GL20.GL_CLAMP_TO_EDGE);
+		Gdx.gl20.glTexParameteri(GL20.GL_TEXTURE_2D, GL20.GL_TEXTURE_WRAP_S, GL20.GL_CLAMP_TO_EDGE);
+		Gdx.gl20.glTexParameteri(GL20.GL_TEXTURE_2D, GL20.GL_TEXTURE_WRAP_T, GL20.GL_CLAMP_TO_EDGE);
 		Gdx.gl20.glTexParameteri(GL20.GL_TEXTURE_2D, GL20.GL_TEXTURE_MAG_FILTER, GL20.GL_LINEAR);
 		Gdx.gl20.glTexParameteri(GL20.GL_TEXTURE_2D, GL20.GL_TEXTURE_MIN_FILTER, GL20.GL_LINEAR);
-		Gdx.gl20.glTexImage2D(GL20.GL_TEXTURE_2D, 0, GL20.GL_RGBA, pixmapCheck.getWidth(), pixmapCheck.getHeight(), 0, 
-			GL20.GL_RGBA, GL20.GL_UNSIGNED_BYTE, pixmapCheck.getPixels());
+		Gdx.gl20.glTexImage2D(GL20.GL_TEXTURE_2D, 0, GL20.GL_RGBA, pixmapCheck.getWidth(), pixmapCheck.getHeight(), 0, GL20.GL_RGBA,
+			GL20.GL_UNSIGNED_BYTE, pixmapCheck.getPixels());
 
 		/* set shader */
 		shader = new ShaderProgram(vertexShader, fragmentShader);
@@ -171,11 +161,11 @@ public class GlTexImage2D extends GdxTest {
 		Gdx.gl20.glBindBuffer(GL20.GL_ARRAY_BUFFER, uvBuffer);
 		Gdx.gl20.glBufferData(GL20.GL_ARRAY_BUFFER, 8 * 4, uvData, GL20.GL_STATIC_DRAW);
 		Gdx.gl20.glVertexAttribPointer(shader.getAttributeLocation("vTexCoords"), 2, GL20.GL_FLOAT, false, 0, 0);
-		
+
 		/* finalize setup */
 		Gdx.gl20.glEnableVertexAttribArray(shader.getAttributeLocation("vPosition"));
 		Gdx.gl20.glEnableVertexAttribArray(shader.getAttributeLocation("vTexCoords"));
-		
+
 		Gdx.gl20.glActiveTexture(GL20.GL_TEXTURE0);
 		Gdx.gl20.glBindBuffer(GL20.GL_ARRAY_BUFFER, 0);
 	}
@@ -194,11 +184,11 @@ public class GlTexImage2D extends GdxTest {
 	public void dispose () {
 		Gdx.gl20.glDisableVertexAttribArray(shader.getAttributeLocation("vPosition"));
 		Gdx.gl20.glDisableVertexAttribArray(shader.getAttributeLocation("vTexCoords"));
-		
+
 		Gdx.gl20.glDeleteBuffer(vertsBuffer);
 		Gdx.gl20.glDeleteBuffer(pixmapBuffer);
 		Gdx.gl20.glDeleteBuffer(uvBuffer);
-		
+
 		Gdx.gl20.glDeleteTexture(texture);
 		Gdx.gl20.glDeleteTexture(pixmapTexture);
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
@@ -79,6 +79,7 @@ import com.badlogic.gdx.tests.g3d.TangentialAccelerationTest;
 import com.badlogic.gdx.tests.g3d.TextureArrayTest;
 import com.badlogic.gdx.tests.g3d.TextureRegion3DTest;
 import com.badlogic.gdx.tests.g3d.utils.DefaultTextureBinderTest;
+import com.badlogic.gdx.tests.gles2.GlTexImage2D;
 import com.badlogic.gdx.tests.gles2.HelloTriangle;
 import com.badlogic.gdx.tests.gles2.SimpleVertexShader;
 import com.badlogic.gdx.tests.gles2.VertexArrayTest;
@@ -182,6 +183,7 @@ public class GdxTests {
 		GL32DebugControlTest.class,
 		GL32MultipleRenderTargetsBlendingTest.class,
 		GL32OffsetElementsTest.class,
+		GlTexImage2D.class,
 		GLProfilerErrorTest.class,
 		GroupCullingTest.class,
 		GroupFadeTest.class,


### PR DESCRIPTION
This PR adds ability to upload bytes as texture with a call to glTexImage2D on gwt target,

Currently on gwt this call expects always int buffers, and if the size is 1, then it is assumed that the int is actually index of a pixmap.

Test was also added targeting lwjgl3 and gwt, to verify that glTexImage2d actually works and that pixmap functionality was not broken (i can check currently only on those two platforms).


