### PR TITLE
Source-shade jnigen-loader into gdx

### DIFF
--- a/gdx/build.gradle
+++ b/gdx/build.gradle
@@ -24,13 +24,27 @@ if (JavaVersion.current().isJava9Compatible()) {
 sourceCompatibility = versions.java
 targetCompatibility = versions.java
 
-sourceSets.main.java.srcDirs = ["src"]
+sourceSets.main.java.srcDirs = ["src", layout.buildDirectory.dir("jnigen")]
 sourceSets.main.resources.srcDirs = ["res"]
 sourceSets.test.java.srcDirs = ["test"]
+
+configurations {
+	jnigenLoader
+}
+
+tasks.register('unpackJnigenLoader', Copy) {
+	from {
+		configurations["jnigenLoader"].collect {
+			it.isDirectory() ? it : zipTree(it)
+		}
+	}
+	into layout.buildDirectory.dir("jnigen")
+}
 
 compileJava {
 	options.fork = true
 	options.incremental = true
+	dependsOn unpackJnigenLoader
 }
 
 jar {
@@ -39,7 +53,11 @@ jar {
 
 dependencies {
 	testImplementation libraries.junit
-	api "com.badlogicgames.gdx:gdx-jnigen-loader:2.3.1"
+	jnigenLoader "com.badlogicgames.gdx:gdx-jnigen-loader:2.3.1:sources"
+}
+
+sourcesJar {
+	dependsOn unpackJnigenLoader
 }
 
 test {

--- a/gdx/build.gradle
+++ b/gdx/build.gradle
@@ -24,7 +24,10 @@ if (JavaVersion.current().isJava9Compatible()) {
 sourceCompatibility = versions.java
 targetCompatibility = versions.java
 
-sourceSets.main.java.srcDirs = ["src", layout.buildDirectory.dir("jnigen")]
+sourceSets.main.java.srcDirs = [
+	"src",
+	layout.buildDirectory.dir("jnigen")
+]
 sourceSets.main.resources.srcDirs = ["res"]
 sourceSets.test.java.srcDirs = ["test"]
 


### PR DESCRIPTION
This was done due to problems with JPMS as jnigen-loader shares the same package as some gdx classes.

Using traditional shading was not done as it would cause issues with the backends depending on jnigen-loader transitively (we cannot use the 'api' or 'compileOnlyApi' configurations as those wouldn't change the end result to other applications) and would also cause issues with the sources and javadoc jars not being the same as the actual sources

--

Somewhat blocking on https://github.com/libgdx/gdx-jnigen/pull/61, as jnigen-loader itself does not handle JPMS as intended at this point in time