### PR TITLE
[scene2d.ui] Fixed TextField breaking if the font has markup enabled.

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextField.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextField.java
@@ -352,8 +352,12 @@ public class TextField extends Widget implements Disableable {
 				drawMessageText(batch, messageFont, x + bgLeftWidth, y + textY + yOffset, width - bgLeftWidth - bgRightWidth);
 			}
 		} else {
+			BitmapFontData data = font.getData();
+			boolean markupEnabled = data.markupEnabled;
+			data.markupEnabled = false;
 			font.setColor(fontColor.r, fontColor.g, fontColor.b, fontColor.a * color.a * parentAlpha);
 			drawText(batch, font, x + bgLeftWidth, y + textY + yOffset);
+			data.markupEnabled = markupEnabled;
 		}
 		if (!disabled && cursorOn && cursorPatch != null) {
 			drawCursor(cursorPatch, batch, font, x + bgLeftWidth, y + textY);
@@ -418,7 +422,11 @@ public class TextField extends Widget implements Disableable {
 		} else
 			displayText = newDisplayText;
 
+		boolean markupEnabled = data.markupEnabled;
+		data.markupEnabled = false;
 		layout.setText(font, displayText.toString().replace('\r', ' ').replace('\n', ' '));
+		data.markupEnabled = markupEnabled;
+
 		glyphPositions.clear();
 		float x = 0;
 		if (layout.runs.size > 0) {


### PR DESCRIPTION
Fixes #4576 for TextField. Similar could be done for TextArea.