### PR TITLE
Alternative to #7357 for setting glyph page index.

### DIFF
--- a/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGenerator.java
+++ b/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGenerator.java
@@ -32,6 +32,7 @@ import com.badlogic.gdx.graphics.g2d.GlyphLayout.GlyphRun;
 import com.badlogic.gdx.graphics.g2d.PixmapPacker;
 import com.badlogic.gdx.graphics.g2d.PixmapPacker.GuillotineStrategy;
 import com.badlogic.gdx.graphics.g2d.PixmapPacker.PackStrategy;
+import com.badlogic.gdx.graphics.g2d.PixmapPacker.PixmapPackerRectangle;
 import com.badlogic.gdx.graphics.g2d.PixmapPacker.SkylineStrategy;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.graphics.g2d.freetype.FreeType.Bitmap;
@@ -598,9 +599,8 @@ public class FreeTypeFontGenerator implements Disposable {
 			}
 		}
 
-		String pixmapName = glyph.hashCode() + "_" + glyph.id;
-		Rectangle rect = packer.pack(pixmapName, mainPixmap);
-		glyph.page = packer.getPageIndex(pixmapName);
+		PixmapPackerRectangle rect = packer.pack(mainPixmap);
+		glyph.page = packer.getPages().indexOf(rect.page, true);
 		glyph.srcX = (int)rect.x;
 		glyph.srcY = (int)rect.y;
 

--- a/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGenerator.java
+++ b/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGenerator.java
@@ -43,7 +43,6 @@ import com.badlogic.gdx.graphics.g2d.freetype.FreeType.Library;
 import com.badlogic.gdx.graphics.g2d.freetype.FreeType.SizeMetrics;
 import com.badlogic.gdx.graphics.g2d.freetype.FreeType.Stroker;
 import com.badlogic.gdx.math.MathUtils;
-import com.badlogic.gdx.math.Rectangle;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.Disposable;
 import com.badlogic.gdx.utils.GdxRuntimeException;

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/PixmapPacker.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/PixmapPacker.java
@@ -152,7 +152,7 @@ public class PixmapPacker implements Disposable {
 
 	/** Inserts the pixmap without a name. It cannot be looked up by name.
 	 * @see #pack(String, Pixmap) */
-	public synchronized Rectangle pack (Pixmap image) {
+	public synchronized PixmapPackerRectangle pack (Pixmap image) {
 		return pack(null, image);
 	}
 
@@ -162,7 +162,7 @@ public class PixmapPacker implements Disposable {
 	 * @return Rectangle describing the area the pixmap was rendered to.
 	 * @throws GdxRuntimeException in case the image did not fit due to the page size being too small or providing a duplicate
 	 *            name. */
-	public synchronized Rectangle pack (String name, Pixmap image) {
+	public synchronized PixmapPackerRectangle pack (String name, Pixmap image) {
 		if (disposed) return null;
 		if (name != null && getRect(name) != null)
 			throw new GdxRuntimeException("Pixmap has already been packed with name: " + name);
@@ -282,6 +282,7 @@ public class PixmapPacker implements Disposable {
 			pixmapToDispose.dispose();
 		}
 
+		rect.page = page;
 		return rect;
 	}
 
@@ -849,10 +850,11 @@ public class PixmapPacker implements Disposable {
 	}
 
 	public static class PixmapPackerRectangle extends Rectangle {
-		int[] splits;
-		int[] pads;
-		int offsetX, offsetY;
-		int originalWidth, originalHeight;
+		public Page page;
+		public int[] splits;
+		public int[] pads;
+		public int offsetX, offsetY;
+		public int originalWidth, originalHeight;
 
 		PixmapPackerRectangle (int x, int y, int width, int height) {
 			super(x, y, width, height);


### PR DESCRIPTION
Sorry I'm late to #7357.

If `pack` returned a PixmapPackerRectangle, it could have a `Page page` field. Then we don't need a unique name, don't need to add to `rects` map, and page index lookup is `indexOf` pages rather than checking the name of all rects on all pages.

PixmapPackerRectangle is already public and exposed by PixmapPacker.Page#getRects, but all the fields are default access so it's not useful outside the package. All the fields could be public, as I'm guessing that was the intent of exposing the class.