### PR TITLE
Fix DragListener stopping when another button is pressed.

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/DragListener.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/DragListener.java
@@ -63,7 +63,7 @@ public class DragListener extends InputListener {
 	}
 
 	public void touchUp (InputEvent event, float x, float y, int pointer, int button) {
-		if (pointer == pressedPointer) {
+		if (pointer == pressedPointer && (this.button == -1 || button == this.button)) {
 			if (dragging) dragStop(event, x, y, pointer);
 			cancel();
 		}


### PR DESCRIPTION
DragListener should only stop dragging when touchUp matches the button it cares about.

Repro: left mouse drag, press and release right mouse.
Expected: left drag continues.
Actual: right mouse up stops left drag.