### PR TITLE
gdx-ttf fonts bleed black color onto glyphs when they have shadows of any color

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -12,6 +12,7 @@
 - Android: Add configuration option to render under the cutout if available on the device.
 - Fix: Keep SelectBox popup from extending past right edge of stage.
 - Added Framebuffer multisample support (see GL31FrameBufferMultisampleTest.java for basic usage)
+- Fix: Fonts generated with gdx-ttf no longer bleed when drawn with a shadow
 
 [1.12.1]
 - LWJGL3 Improvement: Audio device is automatically switched if it was changed in the operating system.

--- a/CHANGES
+++ b/CHANGES
@@ -12,7 +12,7 @@
 - Android: Add configuration option to render under the cutout if available on the device.
 - Fix: Keep SelectBox popup from extending past right edge of stage.
 - Added Framebuffer multisample support (see GL31FrameBufferMultisampleTest.java for basic usage)
-- Fix: Fonts generated with gdx-ttf no longer bleed when drawn with a shadow
+- Fix: Fonts generated with gdx-freetype no longer bleed when drawn with a shadow
 
 [1.12.1]
 - LWJGL3 Improvement: Audio device is automatically switched if it was changed in the operating system.

--- a/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGenerator.java
+++ b/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGenerator.java
@@ -528,7 +528,7 @@ public class FreeTypeFontGenerator implements Disposable {
 				int shadowOffsetX = Math.max(parameter.shadowOffsetX, 0), shadowOffsetY = Math.max(parameter.shadowOffsetY, 0);
 				int shadowW = mainW + Math.abs(parameter.shadowOffsetX), shadowH = mainH + Math.abs(parameter.shadowOffsetY);
 				// use the Gdx2DPixmap constructor to avoid filling the pixmap twice
-				Pixmap shadowPixmap = new Pixmap(new Gdx2DPixmap(shadowW, shadowH, mainPixmap.getFormat()));
+				Pixmap shadowPixmap = new Pixmap(new Gdx2DPixmap(shadowW, shadowH, Pixmap.Format.toGdx2DPixmapFormat(mainPixmap.getFormat())));
 				shadowPixmap.setColor(packer.getTransparentColor());
 				shadowPixmap.fill();
 

--- a/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGenerator.java
+++ b/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGenerator.java
@@ -527,7 +527,8 @@ public class FreeTypeFontGenerator implements Disposable {
 				int mainW = mainPixmap.getWidth(), mainH = mainPixmap.getHeight();
 				int shadowOffsetX = Math.max(parameter.shadowOffsetX, 0), shadowOffsetY = Math.max(parameter.shadowOffsetY, 0);
 				int shadowW = mainW + Math.abs(parameter.shadowOffsetX), shadowH = mainH + Math.abs(parameter.shadowOffsetY);
-				Pixmap shadowPixmap = new Pixmap(shadowW, shadowH, mainPixmap.getFormat());
+				// use the Gdx2DPixmap constructor to avoid filling the pixmap twice
+				Pixmap shadowPixmap = new Pixmap(new Gdx2DPixmap(shadowW, shadowH, mainPixmap.getFormat()));
 				shadowPixmap.setColor(packer.getTransparentColor());
 				shadowPixmap.fill();
 

--- a/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGenerator.java
+++ b/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGenerator.java
@@ -28,6 +28,7 @@ import com.badlogic.gdx.graphics.Texture.TextureFilter;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.graphics.g2d.BitmapFont.BitmapFontData;
 import com.badlogic.gdx.graphics.g2d.BitmapFont.Glyph;
+import com.badlogic.gdx.graphics.g2d.Gdx2DPixmap;
 import com.badlogic.gdx.graphics.g2d.GlyphLayout.GlyphRun;
 import com.badlogic.gdx.graphics.g2d.PixmapPacker;
 import com.badlogic.gdx.graphics.g2d.PixmapPacker.GuillotineStrategy;

--- a/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGenerator.java
+++ b/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGenerator.java
@@ -529,7 +529,8 @@ public class FreeTypeFontGenerator implements Disposable {
 				int shadowOffsetX = Math.max(parameter.shadowOffsetX, 0), shadowOffsetY = Math.max(parameter.shadowOffsetY, 0);
 				int shadowW = mainW + Math.abs(parameter.shadowOffsetX), shadowH = mainH + Math.abs(parameter.shadowOffsetY);
 				// use the Gdx2DPixmap constructor to avoid filling the pixmap twice
-				Pixmap shadowPixmap = new Pixmap(new Gdx2DPixmap(shadowW, shadowH, Pixmap.Format.toGdx2DPixmapFormat(mainPixmap.getFormat())));
+				Pixmap shadowPixmap = new Pixmap(
+					new Gdx2DPixmap(shadowW, shadowH, Pixmap.Format.toGdx2DPixmapFormat(mainPixmap.getFormat())));
 				shadowPixmap.setColor(packer.getTransparentColor());
 				shadowPixmap.fill();
 

--- a/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGenerator.java
+++ b/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGenerator.java
@@ -528,6 +528,8 @@ public class FreeTypeFontGenerator implements Disposable {
 				int shadowOffsetX = Math.max(parameter.shadowOffsetX, 0), shadowOffsetY = Math.max(parameter.shadowOffsetY, 0);
 				int shadowW = mainW + Math.abs(parameter.shadowOffsetX), shadowH = mainH + Math.abs(parameter.shadowOffsetY);
 				Pixmap shadowPixmap = new Pixmap(shadowW, shadowH, mainPixmap.getFormat());
+				shadowPixmap.setColor(packer.getTransparentColor());
+				shadowPixmap.fill();
 
 				Color shadowColor = parameter.shadowColor;
 				float a = shadowColor.a;


### PR DESCRIPTION
**Problem**:

An oversight in the design of shadows in the gdx-ttf extension: When drawing fonts with shadows, it initialized an additional pixmap "shadowPixmap" without changing it's default fill color, leading it to be transparent black (0, 0, 0, 0). Then it renders the font on top which leads to bleeding the black color on the font

**Example**:

![image](https://github.com/libgdx/libgdx/assets/8527540/6b07aa00-5a30-477c-947f-9581f182e001)
![image](https://github.com/libgdx/libgdx/assets/8527540/0e895d9b-8e31-4e19-85dc-23c5fee77095)


**Fix**:

Fill the shadow pixmap with the transparent color before using it, leaving transparent pixels to be the color choosen by the user.

![image](https://github.com/libgdx/libgdx/assets/8527540/15887deb-f81d-428c-80c1-065169bc4eab)

**Workaround**:

While we wait for this to get merged, here's the fix in the form of a 3 classes: https://gist.github.com/WinterAlexander/5ec4bc65de744fdd90354013e5c0c0d7
