### PR TITLE
Fixed Timer tasks being run after cancellation.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -13,6 +13,7 @@
 - Fix: Keep SelectBox popup from extending past right edge of stage.
 - Added Framebuffer multisample support (see GL31FrameBufferMultisampleTest.java for basic usage)
 - Fix: Fonts generated with gdx-freetype no longer bleed when drawn with a shadow
+- Fixed Timer tasks being run after cancellation.
 
 [1.12.1]
 - LWJGL3 Improvement: Audio device is automatically switched if it was changed in the operating system.

--- a/gdx/src/com/badlogic/gdx/utils/Timer.java
+++ b/gdx/src/com/badlogic/gdx/utils/Timer.java
@@ -266,6 +266,7 @@ public class Timer {
 		long pauseTimeMillis;
 
 		final Array<Task> postedTasks = new Array(2);
+		final Array<Task> runTasks = new Array(2);
 		private final Runnable runPostedTasks = new Runnable() {
 			public void run () {
 				runPostedTasks();
@@ -313,11 +314,13 @@ public class Timer {
 
 		void runPostedTasks () {
 			synchronized (postedTasks) {
-				Object[] items = postedTasks.items;
-				for (int i = 0, n = postedTasks.size; i < n; i++)
-					((Task)items[i]).run();
+				runTasks.addAll(postedTasks);
 				postedTasks.clear();
 			}
+			Object[] items = runTasks.items;
+			for (int i = 0, n = runTasks.size; i < n; i++)
+				((Task)items[i]).run();
+			runTasks.clear();
 		}
 
 		void addPostedTask (Task task) {

--- a/gdx/src/com/badlogic/gdx/utils/Timer.java
+++ b/gdx/src/com/badlogic/gdx/utils/Timer.java
@@ -27,6 +27,7 @@ public class Timer {
 	// TimerThread access is synchronized using threadLock.
 	// Timer access is synchronized using the Timer instance.
 	// Task access is synchronized using the Task instance.
+	// Posted tasks are synchronized using TimerThread#postedTasks.
 
 	static final Object threadLock = new Object();
 	static TimerThread thread;
@@ -118,15 +119,20 @@ public class Timer {
 	}
 
 	/** Cancels all tasks. */
-	public synchronized void clear () {
-		for (int i = 0, n = tasks.size; i < n; i++) {
-			Task task = tasks.get(i);
-			synchronized (task) {
-				task.executeTimeMillis = 0;
-				task.timer = null;
+	public void clear () {
+		synchronized (threadLock) {
+			TimerThread thread = thread();
+			synchronized (this) {
+				synchronized (thread.postedTasks) {
+					for (int i = 0, n = tasks.size; i < n; i++) {
+						Task task = tasks.get(i);
+						thread.removePostedTask(task);
+						task.reset();
+					}
+				}
+				tasks.clear();
 			}
 		}
-		tasks.clear();
 	}
 
 	/** Returns true if the timer has no tasks in the queue. Note that this can change at any time. Synchronize on the timer
@@ -135,7 +141,7 @@ public class Timer {
 		return tasks.size == 0;
 	}
 
-	synchronized long update (long timeMillis, long waitMillis) {
+	synchronized long update (TimerThread thread, long timeMillis, long waitMillis) {
 		for (int i = 0, n = tasks.size; i < n; i++) {
 			Task task = tasks.get(i);
 			synchronized (task) {
@@ -153,7 +159,7 @@ public class Timer {
 					waitMillis = Math.min(waitMillis, task.intervalMillis);
 					if (task.repeatCount > 0) task.repeatCount--;
 				}
-				task.app.postRunnable(task);
+				thread.addPostedTask(task);
 			}
 		}
 		return waitMillis;
@@ -212,21 +218,22 @@ public class Timer {
 
 		/** Cancels the task. It will not be executed until it is scheduled again. This method can be called at any time. */
 		public void cancel () {
-			Timer timer = this.timer;
-			if (timer != null) {
-				synchronized (timer) {
-					synchronized (this) {
-						executeTimeMillis = 0;
-						this.timer = null;
+			synchronized (threadLock) {
+				thread().removePostedTask(this);
+				Timer timer = this.timer;
+				if (timer != null) {
+					synchronized (timer) {
 						timer.tasks.removeValue(this, true);
+						reset();
 					}
-				}
-			} else {
-				synchronized (this) {
-					executeTimeMillis = 0;
-					this.timer = null;
-				}
+				} else
+					reset();
 			}
+		}
+
+		synchronized void reset () {
+			executeTimeMillis = 0;
+			this.timer = null;
 		}
 
 		/** Returns true if this task is scheduled to be executed in the future by a timer. The execution time may be reached at any
@@ -258,6 +265,13 @@ public class Timer {
 		Timer instance;
 		long pauseTimeMillis;
 
+		final Array<Task> postedTasks = new Array(2);
+		private final Runnable runPostedTasks = new Runnable() {
+			public void run () {
+				runPostedTasks();
+			}
+		};
+
 		public TimerThread () {
 			files = Gdx.files;
 			app = Gdx.app;
@@ -279,7 +293,7 @@ public class Timer {
 						long timeMillis = System.nanoTime() / 1000000;
 						for (int i = 0, n = instances.size; i < n; i++) {
 							try {
-								waitMillis = instances.get(i).update(timeMillis, waitMillis);
+								waitMillis = instances.get(i).update(this, timeMillis, waitMillis);
 							} catch (Throwable ex) {
 								throw new GdxRuntimeException("Task failed: " + instances.get(i).getClass().getName(), ex);
 							}
@@ -295,6 +309,30 @@ public class Timer {
 				}
 			}
 			dispose();
+		}
+
+		void runPostedTasks () {
+			synchronized (postedTasks) {
+				Object[] items = postedTasks.items;
+				for (int i = 0, n = postedTasks.size; i < n; i++)
+					((Task)items[i]).run();
+				postedTasks.clear();
+			}
+		}
+
+		void addPostedTask (Task task) {
+			synchronized (postedTasks) {
+				if (postedTasks.isEmpty()) task.app.postRunnable(runPostedTasks);
+				postedTasks.add(task);
+			}
+		}
+
+		void removePostedTask (Task task) {
+			synchronized (postedTasks) {
+				Object[] items = postedTasks.items;
+				for (int i = postedTasks.size - 1; i >= 0; i--)
+					if (items[i] == task) postedTasks.removeIndex(i);
+			}
 		}
 
 		public void resume () {
@@ -316,6 +354,9 @@ public class Timer {
 
 		public void dispose () { // OK to call multiple times.
 			synchronized (threadLock) {
+				synchronized (postedTasks) {
+					postedTasks.clear();
+				}
 				if (thread == this) thread = null;
 				instances.clear();
 				threadLock.notifyAll();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TimerTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TimerTest.java
@@ -22,16 +22,192 @@ import com.badlogic.gdx.utils.Timer;
 import com.badlogic.gdx.utils.Timer.Task;
 
 public class TimerTest extends GdxTest {
+	static final int expectedTests = 10;
+
 	@Override
 	public void create () {
+		Gdx.app.log("TimerTest", "Starting tests...");
+		testOnce();
+		testRepeat();
+		testCancelPosted();
+		testCancelPostedTwice();
+		testCancelPostedReschedule();
+		testStop();
+		testStopStart();
+		testDelay();
+		testClear();
+	}
+
+	float time;
+	int testCount;
+	Task repeatTask;
+
+	public void render () {
+		if (time < 2) {
+			time += Gdx.graphics.getDeltaTime();
+			if (time >= 2) {
+				if (testCount != expectedTests)
+					throw new RuntimeException("Some tests did not run: " + testCount + " != " + expectedTests);
+				Gdx.app.log("TimerTest", "SUCCESS! " + testCount + " tests passed.");
+				repeatTask.cancel();
+			}
+		}
+	}
+
+	void testOnce () {
+		Task task = Timer.schedule(new Task() {
+			@Override
+			public void run () {
+				Gdx.app.log("TimerTest", "testOnce");
+				testCount++;
+			}
+		}, 1);
+		assertScheduled(task);
+	}
+
+	void testRepeat () {
+		repeatTask = Timer.schedule(new Task() {
+			int count;
+
+			@Override
+			public void run () {
+				Gdx.app.log("TimerTest", "testRepeat");
+				if (++count <= 2) testCount++;
+			}
+		}, 1, 1);
+		assertScheduled(repeatTask);
+	}
+
+	void testCancelPosted () {
+		Task task = Timer.schedule(new Task() {
+			@Override
+			public void run () {
+				throw new RuntimeException("Cancelled task should not run.");
+			}
+		}, 0.01f);
+		assertScheduled(task);
+		sleep(200); // Sleep so the task is posted.
+		assertNotScheduled(task);
+		task.cancel(); // The posted task should not execute.
+		assertNotScheduled(task);
+		Gdx.app.log("TimerTest", "testCancelPosted");
+		testCount++;
+	}
+
+	void testCancelPostedTwice () {
+		Task task = new Task() {
+			@Override
+			public void run () {
+				throw new RuntimeException("Cancelled task should not run.");
+			}
+		};
+		Timer.schedule(task, 0.01f);
+		assertScheduled(task);
+		sleep(200); // Sleep so the task is posted.
+		assertNotScheduled(task);
+		Timer.schedule(task, 0.01f);
+		assertScheduled(task);
+		sleep(200); // Sleep so the task is posted.
+		assertNotScheduled(task);
+		task.cancel(); // The twice posted task should not execute.
+		assertNotScheduled(task);
+		Gdx.app.log("TimerTest", "testCancelPostedTwice");
+		testCount++;
+	}
+
+	void testCancelPostedReschedule () {
+		Task task = Timer.schedule(new Task() {
+			int count;
+
+			@Override
+			public void run () {
+				if (++count != 1) throw new RuntimeException("Rescheduled task should only run once.");
+				Gdx.app.log("TimerTest", "testCancelPostedReschedule");
+				testCount++;
+			}
+		}, 0.01f);
+		assertScheduled(task);
+		sleep(200); // Sleep so the task is posted.
+		assertNotScheduled(task);
+		task.cancel(); // The posted task should not execute.
+		assertNotScheduled(task);
+		Timer.schedule(task, 0.01f); // Schedule it again.
+		assertScheduled(task);
+	}
+
+	void testStop () {
 		Timer timer = new Timer();
 		Task task = timer.scheduleTask(new Task() {
 			@Override
 			public void run () {
-				Gdx.app.log("TimerTest", "ping");
+				throw new RuntimeException("Stopped timer should not run tasks.");
 			}
-		}, 1, 1);
+		}, 1);
+		assertScheduled(task);
+		timer.stop();
+		Gdx.app.log("TimerTest", "testStop");
+		testCount++;
+	}
 
-		Gdx.app.log("TimerTest", "is task scheduled: " + String.valueOf(task.isScheduled()));
+	void testStopStart () {
+		Timer timer = new Timer();
+		Task task = timer.scheduleTask(new Task() {
+			@Override
+			public void run () {
+				Gdx.app.log("TimerTest", "testStopStart");
+				testCount++;
+			}
+		}, 0.200f);
+		assertScheduled(task);
+		timer.stop();
+		sleep(300); // Sleep longer than task delay while stopped.
+		timer.start();
+		sleep(100);
+		assertScheduled(task); // Shouldn't have happened yet.
+	}
+
+	void testDelay () {
+		Timer timer = new Timer();
+		Task task = timer.scheduleTask(new Task() {
+			@Override
+			public void run () {
+				Gdx.app.log("TimerTest", "testDelay");
+				testCount++;
+			}
+		}, 0.200f);
+		assertScheduled(task);
+		timer.delay(200);
+		sleep(300); // Sleep longer than task delay.
+		assertScheduled(task); // Shouldn't have happened yet.
+	}
+
+	void testClear () {
+		Timer timer = new Timer();
+		Task task = timer.scheduleTask(new Task() {
+			@Override
+			public void run () {
+				throw new RuntimeException("Cleared timer should not run tasks.");
+			}
+		}, 0.200f);
+		assertScheduled(task);
+		timer.clear();
+		assertNotScheduled(task);
+		Gdx.app.log("TimerTest", "testClear");
+		testCount++;
+	}
+
+	void assertScheduled (Task task) {
+		if (!task.isScheduled()) throw new RuntimeException("Should be scheduled.");
+	}
+
+	void assertNotScheduled (Task task) {
+		if (task.isScheduled()) throw new RuntimeException("Should not be scheduled.");
+	}
+
+	void sleep (long millis) {
+		try {
+			Thread.sleep(millis);
+		} catch (InterruptedException ignored) {
+		}
 	}
 }


### PR DESCRIPTION
Timer considers a task "executed" when the timer thread posts it via `Gdx.app.postRunnable`. Code on the app thread may cancel a task that has been posted but not executed yet. It is then very confusing for the app to see a task `run` after it has been cancelled. To be safe, app code needs to check state for every task execution to make sure it is valid. This can be difficult, eg if a task is cancelled and rescheduled, the app could see both the cancelled and rescheduled execution.

We need a way for Timer to post runnables but still be able to remove them before they execute, if needed. This PR does that by having the timer post a single runnable `runPostedTasks` whenever there are one or more tasks that need to be executed. `runPostedTasks` then executes each task in `Array<Task> postedTasks`. When a task is cancelled, it is removed from `postedTasks`, solving the "executed after cancel" problem. From the app code perspective, everything should work as it did before.

`postedTasks` is stored in TimerThread (ie globally) rather than Timer because once a task is no longer scheduled to execute in the future, Task `reset` is called and `timer` set to null. It no longer knows about the timer, so wouldn't be able to remove itself from `postedTasks` on the timer.

New synchronization was added around `postedTasks`, which is synchronized when running tasks. That means a timer posting a new task must wait while all the `postedTasks` execute. This is probably OK, as tasks aren't generally long running and a newly added task won't be serviced until next frame anyway. If it were important, we could do like the LWJGL backends that use `Array<Runnable> runnables, executedRunnables`, synchronizing only long enough to copy the tasks that will run.

This PR also adds more lovely Timer tests.