### PR TITLE
gdx: Android: Build ELFs to support 16kB page size

### DIFF
--- a/extensions/gdx-box2d/gdx-box2d/build.gradle
+++ b/extensions/gdx-box2d/gdx-box2d/build.gradle
@@ -24,7 +24,9 @@ jnigen {
 	add(Linux, x64, ARM)
 	add(MacOsX, x64)
 	add(MacOsX, x64, ARM)
-	add(Android)
+	add(Android) {
+		linkerFlags += " -Wl,-z,max-page-size=0x4000"
+	}
 	add(IOS)
 
 	robovm {

--- a/extensions/gdx-bullet/build.gradle
+++ b/extensions/gdx-bullet/build.gradle
@@ -76,6 +76,7 @@ jnigen {
 	add(MacOsX, x64, ARM)
 	add(Android) {
 		cppFlags += " -fexceptions"
+		linkerFlags += " -Wl,-z,max-page-size=0x4000"
 		androidApplicationMk += "APP_STL := c++_static";
 	}
 	add(IOS) {

--- a/extensions/gdx-freetype/build.gradle
+++ b/extensions/gdx-freetype/build.gradle
@@ -94,6 +94,8 @@ jnigen {
 	add(MacOsX, x64, ARM) {
 		linkerFlags += " -framework CoreServices -framework Carbon"
 	}
-	add(Android)
+	add(Android) {
+		linkerFlags += " -Wl,-z,max-page-size=0x4000"
+	}
 	add(IOS)
 }

--- a/gdx/build.gradle
+++ b/gdx/build.gradle
@@ -64,6 +64,7 @@ jnigen {
 	add(Linux, x64, ARM)
 	add(Android) {
 		linkerFlags += " -llog"
+		linkerFlags += " -Wl,-z,max-page-size=0x4000"
 	}
 	add(MacOsX, x64)
 	add(MacOsX, x64, ARM)


### PR DESCRIPTION
Starting from V, android introduces support for 16kB page sizes. The NDK [1] and toolchain [2][3] have been updated to support the larger page size.

Update GDX build rules for android to use a 16kB max page size.

[1] https://github.com/android/ndk/wiki/Changelog-r27#announcements
[2] https://github.com/llvm/llvm-project/pull/70251
[3] https://github.com/llvm/llvm-project/pull/87413