### PR TITLE
Upgrade gha XCode to 14.3.1

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -32,7 +32,7 @@ jobs:
           # See https://github.com/actions/virtual-environments/issues/2557
           sudo mv /Library/Developer/CommandLineTools/SDKs/* /tmp
           sudo mv /Applications/Xcode.app /Applications/Xcode.app.bak
-          sudo mv /Applications/Xcode_13.2.app /Applications/Xcode.app
+          sudo mv /Applications/Xcode_14.3.1.app /Applications/Xcode.app
           sudo xcode-select -switch /Applications/Xcode.app
           /usr/bin/xcodebuild -version
           ./gradlew jniGen jnigenBuildIOS
@@ -71,7 +71,7 @@ jobs:
           # See https://github.com/actions/virtual-environments/issues/2557
           sudo mv /Library/Developer/CommandLineTools/SDKs/* /tmp
           sudo mv /Applications/Xcode.app /Applications/Xcode.app.bak
-          sudo mv /Applications/Xcode_13.2.app /Applications/Xcode.app
+          sudo mv /Applications/Xcode_14.3.1.app /Applications/Xcode.app
           sudo xcode-select -switch /Applications/Xcode.app
           /usr/bin/xcodebuild -version
           ./gradlew jniGen jnigenBuildMacOsX64 jnigenBuildMacOsXARM64


### PR DESCRIPTION
XCode 13.2 isn't available anymore

`macos-latest` is currently `macos-14` ([src](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories)) and the oldest XCode version there is 14.3.1 ([src](https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md#xcode))