### PR TITLE
Added a method to check if a sphere intersects a bounding box.

### DIFF
--- a/gdx/src/com/badlogic/gdx/math/Intersector.java
+++ b/gdx/src/com/badlogic/gdx/math/Intersector.java
@@ -345,35 +345,33 @@ public final class Intersector {
 		return v2a.len2() <= circle.radius * circle.radius;
 	}
 
-	/**
-	 * Checks if a sphere intersects with a bounding box.
+	/** Checks if a sphere intersects with a bounding box.
 	 *
 	 * @param sphere the sphere to check for intersection
 	 * @param bounds the bounding box to check for intersection
-	 * @return true if the sphere intersects the bounding box, false otherwise
-	 */
-	public static boolean intersectSphereBounds(Sphere sphere, BoundingBox bounds) {
+	 * @return true if the sphere intersects the bounding box, false otherwise */
+	public static boolean intersectSphereBounds (Sphere sphere, BoundingBox bounds) {
 		float dmin = 0;
 
 		Vector3 boundsMin = bounds.getMin(v0);
 		Vector3 boundsMax = bounds.getMax(v1);
 
 		if (sphere.center.x < boundsMin.x) {
-			dmin += (float) Math.pow(sphere.center.x - boundsMin.x, 2);
+			dmin += (float)Math.pow(sphere.center.x - boundsMin.x, 2);
 		} else if (sphere.center.x > boundsMax.x) {
-			dmin += (float) Math.pow(sphere.center.x - boundsMax.x, 2);
+			dmin += (float)Math.pow(sphere.center.x - boundsMax.x, 2);
 		}
 
 		if (sphere.center.y < boundsMin.y) {
-			dmin += (float) Math.pow(sphere.center.y - boundsMin.y, 2);
+			dmin += (float)Math.pow(sphere.center.y - boundsMin.y, 2);
 		} else if (sphere.center.y > boundsMax.y) {
-			dmin += (float) Math.pow(sphere.center.y - boundsMax.y, 2);
+			dmin += (float)Math.pow(sphere.center.y - boundsMax.y, 2);
 		}
 
 		if (sphere.center.z < boundsMin.z) {
-			dmin += (float) Math.pow(sphere.center.z - boundsMin.z, 2);
+			dmin += (float)Math.pow(sphere.center.z - boundsMin.z, 2);
 		} else if (sphere.center.z > boundsMax.z) {
-			dmin += (float) Math.pow(sphere.center.z - boundsMax.z, 2);
+			dmin += (float)Math.pow(sphere.center.z - boundsMax.z, 2);
 		}
 
 		return dmin <= Math.pow(sphere.radius, 2);

--- a/gdx/src/com/badlogic/gdx/math/Intersector.java
+++ b/gdx/src/com/badlogic/gdx/math/Intersector.java
@@ -20,6 +20,7 @@ import com.badlogic.gdx.math.Plane.PlaneSide;
 import com.badlogic.gdx.math.collision.BoundingBox;
 import com.badlogic.gdx.math.collision.OrientedBoundingBox;
 import com.badlogic.gdx.math.collision.Ray;
+import com.badlogic.gdx.math.collision.Sphere;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.FloatArray;
 
@@ -342,6 +343,40 @@ public final class Intersector {
 		}
 
 		return v2a.len2() <= circle.radius * circle.radius;
+	}
+
+	/**
+	 * Checks if a sphere intersects with a bounding box.
+	 *
+	 * @param sphere the sphere to check for intersection
+	 * @param bounds the bounding box to check for intersection
+	 * @return true if the sphere intersects the bounding box, false otherwise
+	 */
+	public static boolean intersectSphereBounds(Sphere sphere, BoundingBox bounds) {
+		float dmin = 0;
+
+		Vector3 boundsMin = bounds.getMin(v0);
+		Vector3 boundsMax = bounds.getMax(v1);
+
+		if (sphere.center.x < boundsMin.x) {
+			dmin += (float) Math.pow(sphere.center.x - boundsMin.x, 2);
+		} else if (sphere.center.x > boundsMax.x) {
+			dmin += (float) Math.pow(sphere.center.x - boundsMax.x, 2);
+		}
+
+		if (sphere.center.y < boundsMin.y) {
+			dmin += (float) Math.pow(sphere.center.y - boundsMin.y, 2);
+		} else if (sphere.center.y > boundsMax.y) {
+			dmin += (float) Math.pow(sphere.center.y - boundsMax.y, 2);
+		}
+
+		if (sphere.center.z < boundsMin.z) {
+			dmin += (float) Math.pow(sphere.center.z - boundsMin.z, 2);
+		} else if (sphere.center.z > boundsMax.z) {
+			dmin += (float) Math.pow(sphere.center.z - boundsMax.z, 2);
+		}
+
+		return dmin <= Math.pow(sphere.radius, 2);
 	}
 
 	/** Returns whether the given {@link Frustum} intersects a {@link BoundingBox}.

--- a/gdx/test/com/badlogic/gdx/math/IntersectorTest.java
+++ b/gdx/test/com/badlogic/gdx/math/IntersectorTest.java
@@ -235,7 +235,7 @@ public class IntersectorTest {
 	}
 
 	@Test
-	public void testIntersectSphereBounds( ) {
+	public void testIntersectSphereBounds () {
 		// Sphere inside box
 		Sphere sphere = new Sphere(new Vector3(5, 5, 5), 1);
 		BoundingBox bounds = new BoundingBox(new Vector3(0, 0, 0), new Vector3(10, 10, 10));

--- a/gdx/test/com/badlogic/gdx/math/IntersectorTest.java
+++ b/gdx/test/com/badlogic/gdx/math/IntersectorTest.java
@@ -3,6 +3,8 @@ package com.badlogic.gdx.math;
 
 import com.badlogic.gdx.math.Intersector.SplitTriangle;
 
+import com.badlogic.gdx.math.collision.BoundingBox;
+import com.badlogic.gdx.math.collision.Sphere;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -230,5 +232,29 @@ public class IntersectorTest {
 			Intersector.intersectPolygons(new Polygon(new float[] {3200.1453f, 88.00839f, 3233.9087f, 190.34174f, 3266.2905f, 0.0f}),
 				new Polygon(new float[] {3213.0f, 131.0f, 3214.0f, 131.0f, 3214.0f, 130.0f, 3213.0f, 130.0f}), intersectionPolygon));
 		assertEquals(0, intersectionPolygon.getVertexCount());
+	}
+
+	@Test
+	public void testIntersectSphereBounds( ) {
+		// Sphere inside box
+		Sphere sphere = new Sphere(new Vector3(5, 5, 5), 1);
+		BoundingBox bounds = new BoundingBox(new Vector3(0, 0, 0), new Vector3(10, 10, 10));
+
+		assertTrue(Intersector.intersectSphereBounds(sphere, bounds));
+
+		// Sphere outside box
+		sphere = new Sphere(new Vector3(20, 20, 20), 1);
+
+		assertFalse(Intersector.intersectSphereBounds(sphere, bounds));
+
+		// Sphere touches box's edge
+		sphere = new Sphere(new Vector3(10, 5, 5), 5);
+
+		assertTrue(Intersector.intersectSphereBounds(sphere, bounds));
+
+		// Sphere's center on box's edge
+		sphere = new Sphere(new Vector3(0, 5, 5), 1);
+
+		assertTrue(Intersector.intersectSphereBounds(sphere, bounds));
 	}
 }


### PR DESCRIPTION
Hello, I found myself several times using the method for checking intersection between a sphere and a bounding box introduced in the following answer by the user `nerdinand`:
https://stackoverflow.com/a/15247348/3450476

I thought it'd be useful to include it in the Intersector class instead of going back to that answer each time.