### PR TITLE
Deserialization of tiled maps which were changed from the code

### DIFF
--- a/gdx/src/com/badlogic/gdx/maps/tiled/TiledMapTileLayer.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/TiledMapTileLayer.java
@@ -49,6 +49,12 @@ public class TiledMapTileLayer extends MapLayer {
 		return tileHeight;
 	}
 
+	/** Creates TiledMap layer by deserialisation
+	 */
+	public TiledMapTileLayer () {
+		super();
+	}
+
 	/** Creates TiledMap layer
 	 * 
 	 * @param width layer width in tiles


### PR DESCRIPTION
The class com.badlogic.gdx.maps.tiled.TiledMapTileLayer should have a default constructor. The programmer can serialize the whole tiled map in a single JSON-file but can not deserialize it back.