### PR TITLE
Fix: Set alpha channel bits to 8 for Android backend

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplicationConfiguration.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplicationConfiguration.java
@@ -30,7 +30,7 @@ import com.badlogic.gdx.utils.GdxNativesLoader;
  * @author mzechner */
 public class AndroidApplicationConfiguration {
 	/** number of bits per color channel **/
-	public int r = 8, g = 8, b = 8, a = 0;
+	public int r = 8, g = 8, b = 8, a = 8;
 
 	/** number of bits for depth and stencil buffer **/
 	public int depth = 16, stencil = 0;


### PR DESCRIPTION
- Changed the default alpha channel bits from 0 to 8 in the Android backend.
- This resolves rendering issues with textures and masks that require alpha blending.
- Ensures consistent behavior between Android and desktop backends.