### PR TITLE
Lessen device requirements for `vibrate(VibrationType)`

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidHaptics.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidHaptics.java
@@ -60,7 +60,7 @@ public class AndroidHaptics {
 
 	@SuppressLint("MissingPermission")
 	public void vibrate (Input.VibrationType vibrationType) {
-		if (hapticsSupport) {
+		if (vibratorSupport) {
 			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
 				int vibrationEffect;
 				switch (vibrationType) {


### PR DESCRIPTION
Cheaper devices such as the Galaxy A04s can utilise these predefined effects. They don't have to be limited to devices with amplitude control. `TICK`, `CLICK` and `HEAVY_CLICK` seem to be 10, 20, and 30ms respectively, though this may be vendor-specific.