### PR TITLE
force a dummy render to make sure gl is initialized at the time of create

### DIFF
--- a/backends/gdx-backend-robovm-metalangle/src/com/badlogic/gdx/backends/iosrobovm/IOSApplication.java
+++ b/backends/gdx-backend-robovm-metalangle/src/com/badlogic/gdx/backends/iosrobovm/IOSApplication.java
@@ -145,6 +145,8 @@ public class IOSApplication implements Application {
 		this.uiWindow.setRootViewController(this.graphics.viewController);
 		this.graphics.updateSafeInsets();
 		Gdx.app.debug("IOSApplication", "created");
+		// Trigger first render, special case that is caught and returned
+		this.graphics.view.display();
 		listener.create();
 		listener.resize(this.graphics.getWidth(), this.graphics.getHeight());
 		// make sure the OpenGL view has contents before displaying it

--- a/backends/gdx-backend-robovm-metalangle/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
+++ b/backends/gdx-backend-robovm-metalangle/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
@@ -86,6 +86,8 @@ public class IOSGraphics extends AbstractGraphics {
 
 	private boolean isFrameRequested = true;
 
+	private boolean firstFrame = true;
+
 	IOSApplicationConfiguration config;
 
 	MGLContext context;
@@ -236,6 +238,12 @@ public class IOSGraphics extends AbstractGraphics {
 		// massive hack, GLKView resets the viewport on each draw call, so IOSGLES20
 		// stores the last known viewport and we reset it here...
 		gl20.glViewport(IOSGLES20.x, IOSGLES20.y, IOSGLES20.width, IOSGLES20.height);
+		// For default framebuffer, we render a dummy frame during initialization before create
+		// Return early so listener does not process
+		if (firstFrame) {
+			firstFrame = false;
+			return;
+		}
 		if (appPaused) {
 			return;
 		}

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSApplication.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSApplication.java
@@ -154,7 +154,7 @@ public class IOSApplication implements Application {
 
 		Gdx.app.debug("IOSApplication", "created");
 
-		//Trigger first render, special case that is caught and returned
+		// Trigger first render, special case that is caught and returned
 		this.graphics.view.display();
 
 		listener.create();

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSApplication.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSApplication.java
@@ -154,6 +154,9 @@ public class IOSApplication implements Application {
 
 		Gdx.app.debug("IOSApplication", "created");
 
+		//Trigger first render, special case that is caught and returned
+		this.graphics.view.display();
+
 		listener.create();
 		listener.resize(this.graphics.getWidth(), this.graphics.getHeight());
 

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
@@ -80,6 +80,8 @@ public class IOSGraphics extends AbstractGraphics {
 	private boolean isContinuous = true;
 	private boolean isFrameRequested = true;
 
+	private boolean firstFrame = true;
+
 	IOSApplicationConfiguration config;
 	EAGLContext context;
 	GLVersion glVersion;
@@ -240,6 +242,13 @@ public class IOSGraphics extends AbstractGraphics {
 		// massive hack, GLKView resets the viewport on each draw call, so IOSGLES20
 		// stores the last known viewport and we reset it here...
 		gl20.glViewport(IOSGLES20.x, IOSGLES20.y, IOSGLES20.width, IOSGLES20.height);
+
+		//For default framebuffer, we render a dummy frame during initialization before create
+		//Return early so listener does not process
+		if (firstFrame) {
+			firstFrame = false;
+			return;
+		}
 
 		if (appPaused) {
 			return;

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
@@ -243,8 +243,8 @@ public class IOSGraphics extends AbstractGraphics {
 		// stores the last known viewport and we reset it here...
 		gl20.glViewport(IOSGLES20.x, IOSGLES20.y, IOSGLES20.width, IOSGLES20.height);
 
-		//For default framebuffer, we render a dummy frame during initialization before create
-		//Return early so listener does not process
+		// For default framebuffer, we render a dummy frame during initialization before create
+		// Return early so listener does not process
 		if (firstFrame) {
 			firstFrame = false;
 			return;


### PR DESCRIPTION
addresses https://github.com/libgdx/libgdx/issues/7297

Simple dummy frame during init process. Tested this with the supplied test in the issue report