### PR TITLE
Prevent mouse cursor from being hidden when catched using GLFW_CURSOR_CAPTURED

### DIFF
--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/DefaultLwjgl3Input.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/DefaultLwjgl3Input.java
@@ -326,12 +326,12 @@ public class DefaultLwjgl3Input extends AbstractInput implements Lwjgl3Input {
 	@Override
 	public void setCursorCatched (boolean catched) {
 		GLFW.glfwSetInputMode(window.getWindowHandle(), GLFW.GLFW_CURSOR,
-			catched ? GLFW.GLFW_CURSOR_DISABLED : GLFW.GLFW_CURSOR_NORMAL);
+			catched ? GLFW.GLFW_CURSOR_CAPTURED : GLFW.GLFW_CURSOR_NORMAL);
 	}
 
 	@Override
 	public boolean isCursorCatched () {
-		return GLFW.glfwGetInputMode(window.getWindowHandle(), GLFW.GLFW_CURSOR) == GLFW.GLFW_CURSOR_DISABLED;
+		return GLFW.glfwGetInputMode(window.getWindowHandle(), GLFW.GLFW_CURSOR) == GLFW.GLFW_CURSOR_CAPTURED;
 	}
 
 	@Override

--- a/gdx/src/com/badlogic/gdx/Input.java
+++ b/gdx/src/com/badlogic/gdx/Input.java
@@ -957,7 +957,7 @@ public interface Input {
 		Landscape, Portrait
 	}
 
-	/** Only viable on the desktop. Will confine the mouse cursor location to the window and hide the mouse cursor. X and y
+	/** Only viable on the desktop. Will confine the mouse cursor location to the window and will not hide the mouse cursor. X and y
 	 * coordinates are still reported as if the mouse was not catched.
 	 * @param catched whether to catch or not to catch the mouse cursor */
 	public void setCursorCatched (boolean catched);


### PR DESCRIPTION
I'm not sure if this is intentional but when calling `setCursorCatched()`, the cursor is hidden, requiring the user to implement laggy software cursors: https://github.com/libgdx/libgdx/issues/6687

However GLFW supports `GLFW_CURSOR_CAPTURED` which keeps the cursor captured, but not hidden. Is there a reason libgdx uses `GLFW_CURSOR_DISABLED` and not `GLFW_CURSOR_CAPTURED`?

A workaround is to extend your Lwjgl3Application like so:

```java
	private static class BetterLwjgl3Input extends DefaultLwjgl3Input {
		
		private final Lwjgl3Window window;

		public BetterLwjgl3Input(Lwjgl3Window window) {
			super(window);
			this.window = window;
		}

		@Override
		public void setCursorCatched (boolean catched) {
			// change from Default input: use GLFW_CURSOR_CAPTURED not GLFW_CURSOR_DISABLED
			// so that the captured cursor is not invisible
			GLFW.glfwSetInputMode(window.getWindowHandle(), GLFW.GLFW_CURSOR,
				catched ? GLFW.GLFW_CURSOR_CAPTURED : GLFW.GLFW_CURSOR_NORMAL);
		}

		@Override
		public boolean isCursorCatched () {
			// change from Default input: use GLFW_CURSOR_CAPTURED not GLFW_CURSOR_DISABLED
			// so that the captured cursor is not invisible
			return GLFW.glfwGetInputMode(window.getWindowHandle(), GLFW.GLFW_CURSOR) == GLFW.GLFW_CURSOR_CAPTURED;
		}
		
	}
```

This _may_ not work on Cocoa Mac OS X (I'm not sure if that's relevant): https://github.com/glfw/glfw/blob/master/src/cocoa_window.m#L1647