### PR TITLE
Update to GWT 2.11.0

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,5 @@
 [1.12.2-SNAPSHOT]
-- [BREAKING CHANGE] GWT: Updated to 2.10.0. `com.google.jsinterop:jsinterop-annotations:2.0.2:sources` must be added as a dependency to your html project dependencies.
+- [BREAKING CHANGE] GWT: Updated to 2.11.0. `com.google.jsinterop:jsinterop-annotations:2.0.2:sources` must be added as a dependency to your html project dependencies.
 - [BREAKING CHANGE] Android: Minimum API level is now level 19 (Android 4.4)
 - [BREAKING CHANGE] iOS: Increased min supported iOS version to 12.0. Update your Info.plist file if necessary.
 - [BREAKING CHANGE] Android, iOS: Exceptions occurring in Runnable tasks scheduled through Gdx.app.postRunnable() are no longer swallowed and will crash the app (add a protection if required).

--- a/backends/gdx-backends-gwt/res/com/badlogic/gdx/backends/gdx_backends_gwt.gwt.xml
+++ b/backends/gdx-backends-gwt/res/com/badlogic/gdx/backends/gdx_backends_gwt.gwt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.10.0//EN" "https://www.gwtproject.org/doctype/2.10.0/gwt-module.dtd">
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.11.0//EN" "https://www.gwtproject.org/doctype/2.11.0/gwt-module.dtd">
 <module rename-to='com.badlogic.gdx.backends.gwt'>
 	<inherits name='com.google.gwt.user.User' />
 	<!-- Inherit edited chrome theme ("gwt"-prefixed classes only) for a little bit of default styling in the text input dialogs -->

--- a/backends/gdx-backends-gwt/res/com/badlogic/gwtref/GwtReflect.gwt.xml
+++ b/backends/gdx-backends-gwt/res/com/badlogic/gwtref/GwtReflect.gwt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit trunk//EN" "https://www.gwtproject.org/doctype/2.10.0/gwt-module.dtd">
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.11.0//EN" "https://www.gwtproject.org/doctype/2.11.0/gwt-module.dtd">
 <module>
 	<inherits name='com.google.gwt.user.User' />
 	<define-configuration-property name="gdx.reflect.include"

--- a/backends/gdx-backends-gwt/res/com/google/gwt/webgl/WebGL.gwt.xml
+++ b/backends/gdx-backends-gwt/res/com/google/gwt/webgl/WebGL.gwt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit trunk//EN" "https://www.gwtproject.org/doctype/2.10.0/gwt-module.dtd">
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.11.0//EN" "https://www.gwtproject.org/doctype/2.11.0/gwt-module.dtd">
 <module>
   <inherits name="com.google.gwt.user.User"/>
   <inherits name="com.google.gwt.canvas.Canvas"/>

--- a/backends/gdx-backends-gwt/res/jsinterop/annotations/Annotations.gwt.xml
+++ b/backends/gdx-backends-gwt/res/jsinterop/annotations/Annotations.gwt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.10.0//EN" "https://www.gwtproject.org/doctype/2.10.0/gwt-module.dtd">
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.11.0//EN" "https://www.gwtproject.org/doctype/2.11.0/gwt-module.dtd">
 <module>
 	<source path="" />
 </module>

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/files/FileHandle.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/com/badlogic/gdx/files/FileHandle.java
@@ -75,6 +75,10 @@ public class FileHandle {
 		throw new GdxRuntimeException("Stub");
 	}
 
+	public File file () {
+		throw new GdxRuntimeException("Stub");
+	}
+
 	/** Returns a stream for reading this file as bytes.
 	 * @throws GdxRuntimeException if the file handle represents a directory, doesn't exist, or could not be read. */
 	public InputStream read () {

--- a/extensions/gdx-box2d/gdx-box2d-gwt/res/com/badlogic/gdx/physics/box2d/box2d-gwt.gwt.xml
+++ b/extensions/gdx-box2d/gdx-box2d-gwt/res/com/badlogic/gdx/physics/box2d/box2d-gwt.gwt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit trunk//EN" "https://www.gwtproject.org/doctype/2.10.0/gwt-module.dtd">
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.11.0//EN" "https://www.gwtproject.org/doctype/2.11.0/gwt-module.dtd">
 <module>
 	<inherits name='com.badlogic.gdx.physics.box2d'/>
 	<source path="gwt"/>

--- a/extensions/gdx-box2d/gdx-box2d/res/com/badlogic/gdx/physics/box2d.gwt.xml
+++ b/extensions/gdx-box2d/gdx-box2d/res/com/badlogic/gdx/physics/box2d.gwt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit trunk//EN" "https://www.gwtproject.org/doctype/2.10.0/gwt-module.dtd">
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.11.0//EN" "https://www.gwtproject.org/doctype/2.11.0/gwt-module.dtd">
 <module>
 	<source path="box2d">
 	</source>

--- a/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/core/CoreGdxDefinition
+++ b/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/core/CoreGdxDefinition
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit trunk//EN" "https://www.gwtproject.org/doctype/2.10.0/gwt-module.dtd">
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.11.0//EN" "https://www.gwtproject.org/doctype/2.11.0/gwt-module.dtd">
 <module>
 	<source path="%PACKAGE_DIR%" />
 </module>

--- a/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/html/GdxDefinition
+++ b/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/html/GdxDefinition
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit trunk//EN" "https://www.gwtproject.org/doctype/2.10.0/gwt-module.dtd">
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.11.0//EN" "https://www.gwtproject.org/doctype/2.11.0/gwt-module.dtd">
 <module rename-to="html">
 %GWT_INHERITS%
 	<inherits name='%MAIN_CLASS%' />

--- a/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/html/GdxDefinitionSuperdev
+++ b/extensions/gdx-setup/res/com/badlogic/gdx/setup/resources/html/GdxDefinitionSuperdev
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit trunk//EN" "https://www.gwtproject.org/doctype/2.10.0/gwt-module.dtd">
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.11.0//EN" "https://www.gwtproject.org/doctype/2.11.0/gwt-module.dtd">
 <module rename-to="html">
 %GWT_INHERITS%
     <inherits name='%PACKAGE%.GdxDefinition' />

--- a/extensions/gdx-setup/src/com/badlogic/gdx/setup/DependencyBank.java
+++ b/extensions/gdx-setup/src/com/badlogic/gdx/setup/DependencyBank.java
@@ -28,7 +28,7 @@ public class DependencyBank {
 	static String buildToolsVersion = "33.0.2";
 	static String androidAPILevel = "33";
 	static String androidMinAPILevel = "19";
-	static String gwtVersion = "2.10.0";
+	static String gwtVersion = "2.11.0";
 
 	// Repositories
 	static String mavenLocal = "mavenLocal()";

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -24,7 +24,7 @@ ext {
 versions.java = project.hasProperty("javaVersion") ? Integer.parseInt(project.getProperty("javaVersion")) : 7
 versions.javaLwjgl3 = project.hasProperty("javaVersion") ? Integer.parseInt(project.getProperty("javaVersion")) : 8
 versions.robovm = "2.3.21"
-versions.gwt = "2.10.0"
+versions.gwt = "2.11.0"
 versions.gwtPlugin = "1.1.29"
 versions.jsinteropAnnotations = "2.0.2"
 versions.gretty = "3.1.0"
@@ -128,12 +128,12 @@ libraries.compileOnly.android = [
 ]
 
 libraries.gwt = [
-        "com.google.gwt:gwt-user:${versions.gwt}",
+        "org.gwtproject:gwt-user:${versions.gwt}",
         "com.google.jsinterop:jsinterop-annotations:${versions.jsinteropAnnotations}:sources"
 ]
 
 libraries.compileOnly.gwt = [
-        "com.google.gwt:gwt-dev:${versions.gwt}"
+        "org.gwtproject:gwt-dev:${versions.gwt}"
 ]
 
 libraries.junit = [

--- a/tests/gdx-tests-gwt/build.gradle
+++ b/tests/gdx-tests-gwt/build.gradle
@@ -42,11 +42,11 @@ dependencies {
 	implementation project(":tests:gdx-tests")
 	implementation project(":backends:gdx-backend-gwt")
 	implementation project(":extensions:gdx-box2d-parent:gdx-box2d-gwt")
-	compileOnly "com.google.gwt:gwt-dev:${versions.gwt}"
+	compileOnly "org.gwtproject:gwt-dev:${versions.gwt}"
 }
 
 gwt {
-	gwtVersion='2.10.0' // Should match the gwt version used for building the gwt backend
+	gwtVersion='2.11.0' // Should match the gwt version used for building the gwt backend
 	maxHeapSize="1G" // Default 256m is not enough for gwt compiler. GWT is HUNGRY
 	minHeapSize="1G"
 

--- a/tests/gdx-tests-gwt/res/com/badlogic/gdx/tests/gwt/GdxTestsGwt.gwt.xml
+++ b/tests/gdx-tests-gwt/res/com/badlogic/gdx/tests/gwt/GdxTestsGwt.gwt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit trunk//EN" "https://www.gwtproject.org/doctype/2.10.0/gwt-module.dtd">
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.11.0//EN" "https://www.gwtproject.org/doctype/2.11.0/gwt-module.dtd">
 <module>
 	<inherits name='com.badlogic.gdx.backends.gdx_backends_gwt' />
 	<inherits name='com.badlogic.gdx.GdxTests' />

--- a/tests/gdx-tests/res/com/badlogic/gdx/GdxTests.gwt.xml
+++ b/tests/gdx-tests/res/com/badlogic/gdx/GdxTests.gwt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit trunk//EN" "https://www.gwtproject.org/doctype/2.10.0/gwt-module.dtd">
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.11.0//EN" "https://www.gwtproject.org/doctype/2.11.0/gwt-module.dtd">
 <module>
 	<source path="tests">
 		<exclude name="**/AssetsFileGenerator.java"/> <!-- utility -->


### PR DESCRIPTION
This removes the need for any third-party backend to use GWT 2.11.0 . It updates the Maven coordinates to match the current ones for GWT itself (jsinterop didn't change). It updates the DTDs to match 2.11.0 and a working URL for that. It didn't need much else; some version strings needed changing.

The tests run, though they don't behave especially well (and I don't think this is related to 2.11.0). AudioChangeDeviceTest never stops beeping, even after closing the test, and opening it again makes it beep twice as much. The test list itself is over-sensitive to scrolling, and displays blank space at the bottom of the list instead of showing the last entries. Because the test list ScrollPane is essentially broken, I can't test anything after AudioChangeDeviceTest. Everything before that is fine, I guess.

Somewhat-related, this fixes a mysteriously missing stub method, `file()`, in GWT's emulated FileHandle class. It appears this was intended to be overridden in GwtFileHandle... but didn't actually exist to be overridden. With this change, the official libGDX has feature parity with the third-party backend Liftoff uses currently (and still will until there's a new stable release).