### PR TITLE
Fix iosgl function name mismatch

### DIFF
--- a/gdx/build.gradle
+++ b/gdx/build.gradle
@@ -37,12 +37,53 @@ jar {
 	duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }
 
+task regenerateIOSHeader {
+	def robovmProject = project(":backends:gdx-backend-robovm")
+	dependsOn robovmProject.sourceSets.main.runtimeClasspath
+	doLast {
+		[IOSGLES20: "iosgl20.h", IOSGLES30: "iosgl30.h"].each {input, output ->
+			exec {
+				workingDir robovmProject.file("build/classes/java/")
+				commandLine "javah"
+				args "-o", file("jni/iosgl/$output"), "-cp", robovmProject.sourceSets.main.runtimeClasspath.files.collect { it.getName() }.join(File.pathSeparator),
+						"com.badlogic.gdx.backends.iosrobovm.$input"
+			}
+		}
+	}
+}
+
+task validateIOSHeader {
+	dependsOn regenerateIOSHeader
+	doLast {
+		for (name in ["iosgl20", "iosgl30"]) {
+			def headerContent = file("jni/iosgl/${name}.h").readLines()
+			def cppContent = file("jni/iosgl/${name}.cpp").readLines()
+			for (headerLine in headerContent) {
+				if (headerLine.startsWith("JNIEXPORT")) {
+					if (!cppContent.contains(headerLine)) {
+						throw new RuntimeException("Header file for $name contains method $headerLine, which is not contained in the implementation")
+					}
+				}
+			}
+
+			for (contentLine in cppContent) {
+				if (contentLine.startsWith("JNIEXPORT")) {
+					if (!headerContent.contains(contentLine)) {
+						throw new RuntimeException("Implementation file for $name contains method $contentLine, which is not contained in the header")
+					}
+				}
+			}
+		}
+	}
+}
+
 dependencies {
 	testImplementation libraries.junit
 	api "com.badlogicgames.gdx:gdx-jnigen-loader:2.3.1"
 }
 
 test {
+	dependsOn("validateIOSHeader")
 	testLogging {
 		events "passed", "skipped", "failed", "standardOut", "standardError"
 	}

--- a/gdx/build.gradle
+++ b/gdx/build.gradle
@@ -42,11 +42,17 @@ task regenerateIOSHeader {
 	dependsOn robovmProject.sourceSets.main.runtimeClasspath
 	doLast {
 		[IOSGLES20: "iosgl20.h", IOSGLES30: "iosgl30.h"].each {input, output ->
+			def tempDir = File.createTempDir()
 			exec {
-				workingDir robovmProject.file("build/classes/java/")
-				commandLine "javah"
-				args "-o", file("jni/iosgl/$output"), "-cp", robovmProject.sourceSets.main.runtimeClasspath.files.collect { it.getName() }.join(File.pathSeparator),
-				"com.badlogic.gdx.backends.iosrobovm.$input"
+				workingDir robovmProject.file("src")
+				commandLine "javac"
+				args "-h", tempDir, "-cp", robovmProject.sourceSets.main.runtimeClasspath.files.collect { it.absolutePath }.join(File.pathSeparator),
+						"com/badlogic/gdx/backends/iosrobovm/${input}.java"
+			}
+			copy {
+				from tempDir
+				into "jni/iosgl"
+				rename ".*GLES([0-9]*)\\.h", "iosgl\$1.h"
 			}
 		}
 	}

--- a/gdx/build.gradle
+++ b/gdx/build.gradle
@@ -46,7 +46,7 @@ task regenerateIOSHeader {
 				workingDir robovmProject.file("build/classes/java/")
 				commandLine "javah"
 				args "-o", file("jni/iosgl/$output"), "-cp", robovmProject.sourceSets.main.runtimeClasspath.files.collect { it.getName() }.join(File.pathSeparator),
-						"com.badlogic.gdx.backends.iosrobovm.$input"
+				"com.badlogic.gdx.backends.iosrobovm.$input"
 			}
 		}
 	}

--- a/gdx/build.gradle
+++ b/gdx/build.gradle
@@ -47,7 +47,7 @@ task regenerateIOSHeader {
 				workingDir robovmProject.file("src")
 				commandLine "javac"
 				args "-h", tempDir, "-cp", robovmProject.sourceSets.main.runtimeClasspath.files.collect { it.absolutePath }.join(File.pathSeparator),
-						"com/badlogic/gdx/backends/iosrobovm/${input}.java"
+				"com/badlogic/gdx/backends/iosrobovm/${input}.java"
 			}
 			copy {
 				from tempDir

--- a/gdx/jni/iosgl/iosgl30.cpp
+++ b/gdx/jni/iosgl/iosgl30.cpp
@@ -156,7 +156,7 @@ JNIEXPORT void JNICALL Java_com_badlogic_gdx_backends_iosrobovm_IOSGLES30_glTexI
  * Method:    glTexImage3DJNI
  * Signature: (IIIIIIIIILjava/nio/Buffer;)V
  */
-JNIEXPORT void JNICALL Java_com_badlogic_gdx_backends_iosrobovm_IOSGLES30_glTexImage3DJNI__IIIIIIIIILjava_nio_Buffer_2
+JNIEXPORT void JNICALL Java_com_badlogic_gdx_backends_iosrobovm_IOSGLES30_glTexImage3DJNI
   (JNIEnv *env, jobject, jint target, jint level, jint internalformat, jint width, jint height, jint depth, jint border, jint format, jint type, jobject pixels) {
     void* dataPtr = getDirectBufferPointer( env, pixels );
     glTexImage3D(target, level, internalformat, width, height, depth, border, format, type, dataPtr);
@@ -167,7 +167,7 @@ JNIEXPORT void JNICALL Java_com_badlogic_gdx_backends_iosrobovm_IOSGLES30_glTexI
  * Method:    glTexImage3D
  * Signature: (IIIIIIIIII)V
  */
-JNIEXPORT void JNICALL Java_com_badlogic_gdx_backends_iosrobovm_IOSGLES30_glTexImage3D__IIIIIIIIII
+JNIEXPORT void JNICALL Java_com_badlogic_gdx_backends_iosrobovm_IOSGLES30_glTexImage3D
   (JNIEnv *env, jobject, jint target, jint level, jint internalformat, jint width, jint height, jint depth, jint border, jint format, jint type, jint offset) {
     glTexImage3D(target, level, internalformat, width, height, depth, border, format, type, (void*)offset);
 }
@@ -188,7 +188,7 @@ JNIEXPORT void JNICALL Java_com_badlogic_gdx_backends_iosrobovm_IOSGLES30_glTexS
  * Method:    glTexSubImage3DJNI
  * Signature: (IIIIIIIIIILjava/nio/Buffer;)V
  */
-JNIEXPORT void JNICALL Java_com_badlogic_gdx_backends_iosrobovm_IOSGLES30_glTexSubImage3DJNI__IIIIIIIIIILjava_nio_Buffer_2
+JNIEXPORT void JNICALL Java_com_badlogic_gdx_backends_iosrobovm_IOSGLES30_glTexSubImage3DJNI
   (JNIEnv *env, jobject, jint target, jint level, jint xoffset, jint yoffset, jint zoffset, jint width, jint height, jint depth, jint format, jint type, jobject pixels) {
     void* dataPtr = getDirectBufferPointer( env, pixels );
     glTexSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, dataPtr);
@@ -199,7 +199,7 @@ JNIEXPORT void JNICALL Java_com_badlogic_gdx_backends_iosrobovm_IOSGLES30_glTexS
  * Method:    glTexSubImage3D
  * Signature: (IIIIIIIIIII)V
  */
-JNIEXPORT void JNICALL Java_com_badlogic_gdx_backends_iosrobovm_IOSGLES30_glTexSubImage3D__IIIIIIIIIII
+JNIEXPORT void JNICALL Java_com_badlogic_gdx_backends_iosrobovm_IOSGLES30_glTexSubImage3D
   (JNIEnv *env, jobject, jint target, jint level, jint xoffset, jint yoffset, jint zoffset, jint width, jint height, jint depth, jint format, jint type, jint offset) {
     glTexSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, (void*)offset);
 }


### PR DESCRIPTION
The function name definition was changed in https://github.com/libgdx/libgdx/pull/6394, but not the corresponding cpp implementation names. This fixes it.

It also adds gradle tasks to generate and validate the content of these header files.

Fixes https://github.com/libgdx/libgdx/issues/7434