### PR TITLE
Apply `transient` to Array's Iterable, Iterator

### DIFF
--- a/gdx/src/com/badlogic/gdx/utils/Array.java
+++ b/gdx/src/com/badlogic/gdx/utils/Array.java
@@ -35,8 +35,8 @@ public class Array<T> implements Iterable<T> {
 	public int size;
 	public boolean ordered;
 
-	private ArrayIterable iterable;
-	private Predicate.PredicateIterable<T> predicateIterable;
+	private transient ArrayIterable<T> iterable;
+	private transient Predicate.PredicateIterable<T> predicateIterable;
 
 	/** Creates an ordered array with a capacity of 16. */
 	public Array () {
@@ -484,8 +484,8 @@ public class Array<T> implements Iterable<T> {
 	 * If {@link Collections#allocateIterators} is false, the same iterator instance is returned each time this method is called.
 	 * Use the {@link ArrayIterator} constructor for nested or multithreaded iteration. */
 	public ArrayIterator<T> iterator () {
-		if (Collections.allocateIterators) return new ArrayIterator(this, true);
-		if (iterable == null) iterable = new ArrayIterable(this);
+		if (Collections.allocateIterators) return new ArrayIterator<T>(this, true);
+		if (iterable == null) iterable = new ArrayIterable<T>(this);
 		return iterable.iterator();
 	}
 
@@ -667,7 +667,7 @@ public class Array<T> implements Iterable<T> {
 	static public class ArrayIterable<T> implements Iterable<T> {
 		private final Array<T> array;
 		private final boolean allowRemove;
-		private ArrayIterator iterator1, iterator2;
+		private transient ArrayIterator<T> iterator1, iterator2;
 
 // java.io.StringWriter lastAcquire = new java.io.StringWriter();
 
@@ -682,12 +682,12 @@ public class Array<T> implements Iterable<T> {
 
 		/** @see Collections#allocateIterators */
 		public ArrayIterator<T> iterator () {
-			if (Collections.allocateIterators) return new ArrayIterator(array, allowRemove);
+			if (Collections.allocateIterators) return new ArrayIterator<T>(array, allowRemove);
 // lastAcquire.getBuffer().setLength(0);
 // new Throwable().printStackTrace(new java.io.PrintWriter(lastAcquire));
 			if (iterator1 == null) {
-				iterator1 = new ArrayIterator(array, allowRemove);
-				iterator2 = new ArrayIterator(array, allowRemove);
+				iterator1 = new ArrayIterator<T>(array, allowRemove);
+				iterator2 = new ArrayIterator<T>(array, allowRemove);
 // iterator1.iterable = this;
 // iterator2.iterable = this;
 			}


### PR DESCRIPTION
Various other iterators were made `transient` a while ago, but Array wasn't touched. `SortedIntList`, `Queue`, all `Set` types, and all `Map` types all use `transient` for their cached iterators, but for some reason `Array` doesn't. This matters when using default (typically reflection-based) serialization in something like [Fury](https://fury.apache.org/), or maybe also Kryo if it allows not writing a serializer. If the `ArrayIterable` and `PredicateIterable` are not marked `transient`, then they get written and form a cycle of references back to the original `Array`. Fury can handle this by tracking refs and by registering `ArrayIterable` and `ArrayIterator`, but this causes a significant increase to file size. Anything can handle this by registering a custom serializer, as well, but I think the cached variables that don't actually affect serialized state should not go in serialized data.

This also adds generics in places where they had been used inconsistently within `Array`, but it only touches iteration-related code.