### PR TITLE
Localized key names for non-US keyboards

### DIFF
--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/DefaultLwjgl3Input.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/DefaultLwjgl3Input.java
@@ -18,6 +18,7 @@ package com.badlogic.gdx.backends.lwjgl3;
 
 import com.badlogic.gdx.input.NativeInputConfiguration;
 import org.lwjgl.glfw.GLFW;
+import static org.lwjgl.glfw.GLFW.*;
 import org.lwjgl.glfw.GLFWCharCallback;
 import org.lwjgl.glfw.GLFWCursorPosCallback;
 import org.lwjgl.glfw.GLFWKeyCallback;
@@ -29,6 +30,8 @@ import com.badlogic.gdx.graphics.glutils.HdpiMode;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.InputEventQueue;
 import com.badlogic.gdx.InputProcessor;
+
+
 
 public class DefaultLwjgl3Input extends AbstractInput implements Lwjgl3Input {
 	final Lwjgl3Window window;
@@ -130,6 +133,7 @@ public class DefaultLwjgl3Input extends AbstractInput implements Lwjgl3Input {
 	public DefaultLwjgl3Input (Lwjgl3Window window) {
 		this.window = window;
 		windowHandleChanged(window.getWindowHandle());
+		Keys.keyNameMapper = new Lwjgl3KeyNameMapper();
 	}
 
 	void keyCallback (long window, int key, int scancode, int action, int mods) {
@@ -607,7 +611,151 @@ public class DefaultLwjgl3Input extends AbstractInput implements Lwjgl3Input {
 			return Input.Keys.UNKNOWN;
 		}
 	}
+	public class Lwjgl3KeyNameMapper extends Keys.KeyNameMapper {
 
+		@Override
+		public String getKeyName (int keycode) {
+			if (keycode == 0) return null;
+			int glfwCode = getGLFWKeyCode(keycode);
+			if (glfwCode == GLFW_KEY_UNKNOWN) return null;
+			String name = GLFW.glfwGetKeyName(glfwCode, 0);
+			if (name == null) return null;
+			return name.toUpperCase();
+		}
+
+		private int getGLFWKeyCode (int gdxKeyCode) {
+			switch (gdxKeyCode) {
+				case Input.Keys.APOSTROPHE:
+					return GLFW_KEY_APOSTROPHE;
+				case Input.Keys.LEFT_BRACKET:
+				case Input.Keys.NUMPAD_LEFT_PAREN:
+					return GLFW_KEY_LEFT_BRACKET;
+				case Input.Keys.NUMPAD_RIGHT_PAREN:
+				case Input.Keys.RIGHT_BRACKET:
+					return GLFW_KEY_RIGHT_BRACKET;
+				case Input.Keys.EQUALS:
+					return GLFW_KEY_EQUAL;
+				case Input.Keys.NUM_0:
+					return GLFW_KEY_0;
+				case Input.Keys.NUM_1:
+					return GLFW_KEY_1;
+				case Input.Keys.NUM_2:
+					return GLFW_KEY_2;
+				case Input.Keys.NUM_3:
+					return GLFW_KEY_3;
+				case Input.Keys.NUM_4:
+					return GLFW_KEY_4;
+				case Input.Keys.NUM_5:
+					return GLFW_KEY_5;
+				case Input.Keys.NUM_6:
+					return GLFW_KEY_6;
+				case Input.Keys.NUM_7:
+					return GLFW_KEY_7;
+				case Input.Keys.NUM_8:
+					return GLFW_KEY_8;
+				case Input.Keys.NUM_9:
+					return GLFW_KEY_9;
+				case Input.Keys.A:
+					return GLFW_KEY_A;
+				case Input.Keys.B:
+					return GLFW_KEY_B;
+				case Input.Keys.C:
+					return GLFW_KEY_C;
+				case Input.Keys.D:
+					return GLFW_KEY_D;
+				case Input.Keys.E:
+					return GLFW_KEY_E;
+				case Input.Keys.F:
+					return GLFW_KEY_F;
+				case Input.Keys.G:
+					return GLFW_KEY_G;
+				case Input.Keys.H:
+					return GLFW_KEY_H;
+				case Input.Keys.I:
+					return GLFW_KEY_I;
+				case Input.Keys.J:
+					return GLFW_KEY_J;
+				case Input.Keys.K:
+					return GLFW_KEY_K;
+				case Input.Keys.L:
+					return GLFW_KEY_L;
+				case Input.Keys.M:
+					return GLFW_KEY_M;
+				case Input.Keys.N:
+					return GLFW_KEY_N;
+				case Input.Keys.O:
+					return GLFW_KEY_O;
+				case Input.Keys.P:
+					return GLFW_KEY_P;
+				case Input.Keys.Q:
+					return GLFW_KEY_Q;
+				case Input.Keys.R:
+					return GLFW_KEY_R;
+				case Input.Keys.S:
+					return GLFW_KEY_S;
+				case Input.Keys.T:
+					return GLFW_KEY_T;
+				case Input.Keys.U:
+					return GLFW_KEY_U;
+				case Input.Keys.V:
+					return GLFW_KEY_V;
+				case Input.Keys.W:
+					return GLFW_KEY_W;
+				case Input.Keys.X:
+					return GLFW_KEY_X;
+				case Input.Keys.Y:
+					return GLFW_KEY_Y;
+				case Input.Keys.Z:
+					return GLFW_KEY_Z;
+				case Input.Keys.BACKSLASH:
+					return GLFW_KEY_BACKSLASH;
+				case Input.Keys.COMMA:
+					return GLFW_KEY_COMMA;
+				case Input.Keys.MINUS:
+					return GLFW_KEY_MINUS;
+				case Input.Keys.PERIOD:
+					return GLFW_KEY_PERIOD;
+				case Input.Keys.SEMICOLON:
+					return GLFW_KEY_SEMICOLON;
+				case Input.Keys.SLASH:
+					return GLFW_KEY_SLASH;
+				case Input.Keys.NUMPAD_0:
+					return GLFW_KEY_KP_0;
+				case Input.Keys.NUMPAD_1:
+					return GLFW_KEY_KP_1;
+				case Input.Keys.NUMPAD_2:
+					return GLFW_KEY_KP_2;
+				case Input.Keys.NUMPAD_3:
+					return GLFW_KEY_KP_3;
+				case Input.Keys.NUMPAD_4:
+					return GLFW_KEY_KP_4;
+				case Input.Keys.NUMPAD_5:
+					return GLFW_KEY_KP_5;
+				case Input.Keys.NUMPAD_6:
+					return GLFW_KEY_KP_6;
+				case Input.Keys.NUMPAD_7:
+					return GLFW_KEY_KP_7;
+				case Input.Keys.NUMPAD_8:
+					return GLFW_KEY_KP_8;
+				case Input.Keys.NUMPAD_9:
+					return GLFW_KEY_KP_9;
+				case Input.Keys.NUMPAD_DOT:
+					return GLFW_KEY_KP_DECIMAL;
+				case Input.Keys.NUMPAD_ADD:
+					return GLFW_KEY_KP_ADD;
+				case Input.Keys.NUMPAD_SUBTRACT:
+					return GLFW_KEY_KP_SUBTRACT;
+				case Input.Keys.NUMPAD_DIVIDE:
+					return GLFW_KEY_KP_DIVIDE;
+				case Input.Keys.NUMPAD_MULTIPLY:
+					return GLFW_KEY_KP_MULTIPLY;
+				case Input.Keys.NUMPAD_EQUALS:
+					return GLFW_KEY_KP_EQUAL;
+				default:
+					return GLFW_KEY_UNKNOWN;
+			}
+		}
+	}
 	@Override
 	public void dispose () {
 		keyCallback.free();

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/DefaultLwjgl3Input.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/DefaultLwjgl3Input.java
@@ -611,7 +611,7 @@ public class DefaultLwjgl3Input extends AbstractInput implements Lwjgl3Input {
 			return Input.Keys.UNKNOWN;
 		}
 	}
-	public class Lwjgl3KeyNameMapper extends Keys.KeyNameMapper {
+	public static class Lwjgl3KeyNameMapper extends Keys.KeyNameMapper {
 
 		@Override
 		public String getKeyName (int keycode) {

--- a/gdx/src/com/badlogic/gdx/Input.java
+++ b/gdx/src/com/badlogic/gdx/Input.java
@@ -273,11 +273,21 @@ public interface Input {
 
 		public static final int MAX_KEYCODE = 255;
 
+		public static class KeyNameMapper {
+			public String getKeyName (int keycode) {
+				return null;
+			}
+		}
+
+		public static KeyNameMapper keyNameMapper = new KeyNameMapper();
+
 		/** @return a human readable representation of the keycode. The returned value can be used in
 		 *         {@link Input.Keys#valueOf(String)} */
 		public static String toString (int keycode) {
 			if (keycode < 0) throw new IllegalArgumentException("keycode cannot be negative, keycode: " + keycode);
 			if (keycode > MAX_KEYCODE) throw new IllegalArgumentException("keycode cannot be greater than 255, keycode: " + keycode);
+			String name = keyNameMapper.getKeyName(keycode);
+			if (name != null) return name;
 			switch (keycode) {
 			// META* variables should not be used with this method.
 			case UNKNOWN:


### PR DESCRIPTION
Linked to issue #6962 and #6957 and recent discussions in the Discord help forum.

Since LWJGL3 the key codes (Input.Keys.*) always follow the US keyboard layout.  This is not accidental, but a deliberate choice by the underlying GLFW library. However, for presentation to the user of key names (e.g. in a tutorial or a key binding screen), it would be good to follow the user's regional keyboard setting. E.g. if the user has an AZERTY keyboard, the "WASD" keys map to "ZQSD".

Following the discussion in issue #6957 the conclusion was that Input.Keys.toString should be region aware, i.e. present the key name as the user sees it on their keyboard.

This only applies to the LWJGL3 backend. The web backend (GWT and TeaVM) use key codes that are localized.

The solution is to use ```glfwGetKeyName(int key, int scancode)``` in GLFW to provide the name of a printable key.  This also required a mapping function ``getGLFWKeyCode`` to reverse the mapping from gdx key code back to GLFW code.  For non-printable keys, this original switch of Input.Keys.toString is maintained. The Input class was modified to allow alternative key names, the DefaultLwjgl3Input class was modified to introduce a key mapping for printable keys.

Tested on Windows with LWJGL3 with a UK and German keyboard.