### PR TITLE
Improve TexturePacker MaxRectsPacker pruning

### DIFF
--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/texturepacker/MaxRectsPacker.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/texturepacker/MaxRectsPacker.java
@@ -130,7 +130,7 @@ public class MaxRectsPacker implements Packer {
 					throw new RuntimeException("Image does not fit within max page width " + settings.maxWidth + paddingMessage + ": "
 						+ rect.name + " " + width + "x" + height);
 				}
-				if (height > maxHeight && width > maxHeight) {
+				if (height > maxHeight) {
 					String paddingMessage = edgePadY ? (" and Y edge padding " + paddingY + "*2") : "";
 					throw new RuntimeException("Image does not fit within max page height " + settings.maxHeight + paddingMessage
 						+ ": " + rect.name + " " + width + "x" + height);

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/texturepacker/MaxRectsPacker.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/texturepacker/MaxRectsPacker.java
@@ -67,8 +67,8 @@ public class MaxRectsPacker implements Packer {
 				// Sort by longest side if rotation is enabled.
 				sort.sort(inputRects, new Comparator<Rect>() {
 					public int compare (Rect o1, Rect o2) {
-						int n1 = o1.width > o1.height ? o1.width : o1.height;
-						int n2 = o2.width > o2.height ? o2.width : o2.height;
+						int n1 = Math.max(o1.width, o1.height);
+						int n2 = Math.max(o2.width, o2.height);
 						return n2 - n1;
 					}
 				});
@@ -82,7 +82,7 @@ public class MaxRectsPacker implements Packer {
 			}
 		}
 
-		Array<Page> pages = new Array();
+		Array<Page> pages = new Array<>();
 		while (inputRects.size > 0) {
 			progress.count = n - inputRects.size + 1;
 			if (progress.update(progress.count, n)) break;
@@ -130,7 +130,7 @@ public class MaxRectsPacker implements Packer {
 					throw new RuntimeException("Image does not fit within max page width " + settings.maxWidth + paddingMessage + ": "
 						+ rect.name + " " + width + "x" + height);
 				}
-				if (height > maxHeight && (!settings.rotation || width > maxHeight)) {
+				if (height > maxHeight && width > maxHeight) {
 					String paddingMessage = edgePadY ? (" and Y edge padding " + paddingY + "*2") : "";
 					throw new RuntimeException("Image does not fit within max page height " + settings.maxHeight + paddingMessage
 						+ ": " + rect.name + " " + width + "x" + height);
@@ -219,16 +219,16 @@ public class MaxRectsPacker implements Packer {
 	 *           all rects may be packed. */
 	private Page packAtSize (boolean fully, int width, int height, Array<Rect> inputRects) {
 		Page bestResult = null;
-		for (int i = 0, n = methods.length; i < n; i++) {
+		for (FreeRectChoiceHeuristic method : methods) {
 			maxRects.init(width, height);
 			Page result;
 			if (!settings.fast) {
-				result = maxRects.pack(inputRects, methods[i]);
+				result = maxRects.pack(inputRects, method);
 			} else {
-				Array<Rect> remaining = new Array();
+				Array<Rect> remaining = new Array<>();
 				for (int ii = 0, nn = inputRects.size; ii < nn; ii++) {
 					Rect rect = inputRects.get(ii);
-					if (maxRects.insert(rect, methods[i]) == null) {
+					if (maxRects.insert(rect, method) == null) {
 						while (ii < nn)
 							remaining.add(inputRects.get(ii++));
 					}
@@ -349,7 +349,7 @@ public class MaxRectsPacker implements Packer {
 
 		/** For each rectangle, packs each one then chooses the best and packs that. Slow! */
 		public Page pack (Array<Rect> rects, FreeRectChoiceHeuristic method) {
-			rects = new Array(rects);
+			rects = new Array<>(rects);
 			while (rects.size > 0) {
 				int bestRectIndex = -1;
 				Rect bestNode = new Rect();
@@ -391,7 +391,7 @@ public class MaxRectsPacker implements Packer {
 				h = Math.max(h, rect.y + rect.height);
 			}
 			Page result = new Page();
-			result.outputRects = new Array(usedRectangles);
+			result.outputRects = new Array<>(usedRectangles);
 			result.occupancy = getOccupancy();
 			result.width = w;
 			result.height = h;


### PR DESCRIPTION
The `TexturePacker` `MaxRectsPacker.MaxRects.pruneFreeList` method is O(n^3) in time, `n` being the number of `freeRectangles`.

`freeRectangles` size increases if you have many sprites with different sizes.

This PR changes the `pruneFreeList` method to use a O(n) approach.

Impirical tests, using 3000 random images generated by the code below showed the packer ran in around 60 seconds for the old method and in around 10 seconds for the new method.

```
  public static void generateRandomImages() throws Exception {
    Random random = new Random();
    for (int i = 0; i < 3000; i++) {
      BufferedImage image =
          new BufferedImage(
              32 + random.nextInt(32), 32 + random.nextInt(32), BufferedImage.TYPE_INT_ARGB);
      Graphics2D g2d = image.createGraphics();
      g2d.setColor(new Color(random.nextInt(256), random.nextInt(256), random.nextInt(256)));
      g2d.fillRect(0, 0, random.nextInt(32), random.nextInt(32));
      ImageIO.write(image, "png", new File("test/test" + i + ".png"));
    }
  }
```

For our game, it improved from 35~ minutes to 3~ minutes.