### PR TITLE
Fix when GLFW_LIBRARY_NAME.get() is null.

### DIFF
--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Graphics.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Graphics.java
@@ -73,7 +73,7 @@ public class Lwjgl3Graphics extends AbstractGraphics implements Disposable {
 	GLFWFramebufferSizeCallback resizeCallback = new GLFWFramebufferSizeCallback() {
 		@Override
 		public void invoke (long windowHandle, final int width, final int height) {
-			if (!Configuration.GLFW_LIBRARY_NAME.get().equals("glfw_async")) {
+			if (!"glfw_async".equals(Configuration.GLFW_LIBRARY_NAME.get())) {
 				updateFramebufferInfo();
 				if (!window.isListenerInitialized()) {
 					return;


### PR DESCRIPTION
This is a simple fix for the line:

```java
if (!Configuration.GLFW_LIBRARY_NAME.get().equals("glfw_async")) {
```

When `Configuration.GLFW_LIBRARY_NAME.get()` returns `null`, this throws an NPE. Flipping the `.equals()` means the LHS will never be null, making it valid when `GLFW_LIBRARY_NAME` is not set.

This also runs Spotless.