### PR TITLE
Feature/seperate instance data from mesh

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/Mesh.java
+++ b/gdx/src/com/badlogic/gdx/graphics/Mesh.java
@@ -623,18 +623,12 @@ public class Mesh implements Disposable {
 	 * @param count number of vertices or indices to use
 	 * @param autoBind overrides the autoBind member of this Mesh */
 	public void render (ShaderProgram shader, int primitiveType, int offset, int count, boolean autoBind) {
-		render(shader, primitiveType, offset, count, autoBind, null);
+		render(shader, primitiveType, offset, count, autoBind, instances);
 	}
 
 	public void render (ShaderProgram shader, int primitiveType, int offset, int count, boolean autoBind, InstanceData instances) {
 		if (count == 0) return;
-		boolean isInstanced;
-		if (instances != null) {
-			isInstanced = true;
-		} else {
-			isInstanced = this.isInstanced;
-			instances = this.instances;
-		}
+		boolean isInstanced = instances != null && (instances != this.instances || this.isInstanced);
 
 		if (autoBind) bind(shader, null, null, instances);
 

--- a/gdx/src/com/badlogic/gdx/graphics/Mesh.java
+++ b/gdx/src/com/badlogic/gdx/graphics/Mesh.java
@@ -81,7 +81,7 @@ public class Mesh implements Disposable {
 	boolean autoBind = true;
 	final boolean isVertexArray;
 
-	InstanceData instances;
+	public InstanceData instances;
 	boolean isInstanced = false;
 
 	protected Mesh (VertexData vertices, IndexData indices, boolean isVertexArray) {
@@ -512,6 +512,10 @@ public class Mesh implements Disposable {
 	 * @param locations array containing the vertex attribute locations.
 	 * @param instanceLocations array containing the instance attribute locations. */
 	public void bind (final ShaderProgram shader, final int[] locations, final int[] instanceLocations) {
+		bind(shader, locations, instanceLocations, instances);
+	}
+
+	public void bind (final ShaderProgram shader, final int[] locations, final int[] instanceLocations, InstanceData instances) {
 		vertices.bind(shader, locations);
 		if (instances != null && instances.getNumInstances() > 0) instances.bind(shader, instanceLocations);
 		if (indices.getNumIndices() > 0) indices.bind();
@@ -532,6 +536,10 @@ public class Mesh implements Disposable {
 	 * @param locations array containing the vertex attribute locations.
 	 * @param instanceLocations array containing the instance attribute locations. */
 	public void unbind (final ShaderProgram shader, final int[] locations, final int[] instanceLocations) {
+		unbind(shader, locations, instanceLocations, instances);
+	}
+
+	public void unbind (final ShaderProgram shader, final int[] locations, final int[] instanceLocations, InstanceData instances) {
 		vertices.unbind(shader, locations);
 		if (instances != null && instances.getNumInstances() > 0) instances.unbind(shader, instanceLocations);
 		if (indices.getNumIndices() > 0) indices.unbind();
@@ -615,9 +623,20 @@ public class Mesh implements Disposable {
 	 * @param count number of vertices or indices to use
 	 * @param autoBind overrides the autoBind member of this Mesh */
 	public void render (ShaderProgram shader, int primitiveType, int offset, int count, boolean autoBind) {
-		if (count == 0) return;
+		render(shader, primitiveType, offset, count, autoBind, null);
+	}
 
-		if (autoBind) bind(shader);
+	public void render (ShaderProgram shader, int primitiveType, int offset, int count, boolean autoBind, InstanceData instances) {
+		if (count == 0) return;
+		boolean isInstanced;
+		if (instances != null) {
+			isInstanced = true;
+		} else {
+			isInstanced = this.isInstanced;
+			instances = this.instances;
+		}
+
+		if (autoBind) bind(shader, null, null, instances);
 
 		if (isVertexArray) {
 			if (indices.getNumIndices() > 0) {

--- a/gdx/src/com/badlogic/gdx/graphics/Mesh.java
+++ b/gdx/src/com/badlogic/gdx/graphics/Mesh.java
@@ -81,7 +81,7 @@ public class Mesh implements Disposable {
 	boolean autoBind = true;
 	final boolean isVertexArray;
 
-	public InstanceData instances;
+	InstanceData instances;
 	boolean isInstanced = false;
 
 	protected Mesh (VertexData vertices, IndexData indices, boolean isVertexArray) {

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/ModelInstance.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/ModelInstance.java
@@ -56,8 +56,8 @@ public class ModelInstance implements RenderableProvider {
 	public Matrix4 transform;
 	/** user definable value, which is passed to the {@link Shader}. */
 	public Object userData;
-	/** Instanced rendering data, may be null.
-	 * Used to implement instanced rendering (rendering multiple instances with one draw call). */
+	/** Instanced rendering data, may be null. Used to implement instanced rendering (rendering multiple instances with one draw
+	 * call). */
 	private InstanceData instances;
 
 	/** Constructs a new ModelInstance with all nodes and materials of the given model.
@@ -222,11 +222,11 @@ public class ModelInstance implements RenderableProvider {
 		return new ModelInstance(this);
 	}
 
-	public InstanceData getInstances() {
+	public InstanceData getInstances () {
 		return instances;
 	}
 
-	public void setInstances(InstanceData instances) {
+	public void setInstances (InstanceData instances) {
 		this.instances = instances;
 	}
 

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/ModelInstance.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/ModelInstance.java
@@ -21,6 +21,7 @@ import com.badlogic.gdx.graphics.g3d.model.Node;
 import com.badlogic.gdx.graphics.g3d.model.NodeAnimation;
 import com.badlogic.gdx.graphics.g3d.model.NodeKeyframe;
 import com.badlogic.gdx.graphics.g3d.model.NodePart;
+import com.badlogic.gdx.graphics.glutils.InstanceData;
 import com.badlogic.gdx.math.Matrix4;
 import com.badlogic.gdx.math.Quaternion;
 import com.badlogic.gdx.math.Vector3;
@@ -55,6 +56,9 @@ public class ModelInstance implements RenderableProvider {
 	public Matrix4 transform;
 	/** user definable value, which is passed to the {@link Shader}. */
 	public Object userData;
+	/** Instanced rendering data, may be null.
+	 * Used to implement instanced rendering (rendering multiple instances with one draw call). */
+	private InstanceData instances;
 
 	/** Constructs a new ModelInstance with all nodes and materials of the given model.
 	 * @param model The {@link Model} to create an instance of. */
@@ -218,6 +222,14 @@ public class ModelInstance implements RenderableProvider {
 		return new ModelInstance(this);
 	}
 
+	public InstanceData getInstances() {
+		return instances;
+	}
+
+	public void setInstances(InstanceData instances) {
+		this.instances = instances;
+	}
+
 	private void copyNodes (Array<Node> nodes) {
 		for (int i = 0, n = nodes.size; i < n; ++i) {
 			final Node node = nodes.get(i);
@@ -376,6 +388,7 @@ public class ModelInstance implements RenderableProvider {
 		else
 			out.worldTransform.idt();
 		out.userData = userData;
+		out.instances = getInstances();
 		return out;
 	}
 

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/Renderable.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/Renderable.java
@@ -93,8 +93,8 @@ public class Renderable {
 	public Shader shader;
 	/** User definable value, may be null. */
 	public Object userData;
-	/** Instanced rendering data, may be null.
-	 * Used to implement instanced rendering (rendering multiple instances with one draw call). */
+	/** Instanced rendering data, may be null. Used to implement instanced rendering (rendering multiple instances with one draw
+	 * call). */
 	public InstanceData instances;
 
 	public Renderable set (Renderable renderable) {

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/Renderable.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/Renderable.java
@@ -19,6 +19,7 @@ package com.badlogic.gdx.graphics.g3d;
 import com.badlogic.gdx.graphics.Mesh;
 import com.badlogic.gdx.graphics.g3d.model.MeshPart;
 import com.badlogic.gdx.graphics.g3d.utils.ShaderProvider;
+import com.badlogic.gdx.graphics.glutils.InstanceData;
 import com.badlogic.gdx.math.Matrix4;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.Pool;
@@ -92,6 +93,9 @@ public class Renderable {
 	public Shader shader;
 	/** User definable value, may be null. */
 	public Object userData;
+	/** Instanced rendering data, may be null.
+	 * Used to implement instanced rendering (rendering multiple instances with one draw call). */
+	public InstanceData instances;
 
 	public Renderable set (Renderable renderable) {
 		worldTransform.set(renderable.worldTransform);
@@ -101,6 +105,7 @@ public class Renderable {
 		environment = renderable.environment;
 		shader = renderable.shader;
 		userData = renderable.userData;
+		instances = renderable.instances;
 		return this;
 	}
 }

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/model/MeshPart.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/model/MeshPart.java
@@ -19,6 +19,7 @@ package com.badlogic.gdx.graphics.g3d.model;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Mesh;
 import com.badlogic.gdx.graphics.g3d.Model;
+import com.badlogic.gdx.graphics.glutils.InstanceData;
 import com.badlogic.gdx.graphics.glutils.ShaderProgram;
 import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.math.collision.BoundingBox;
@@ -151,6 +152,13 @@ public class MeshPart {
 	 * @param autoBind overrides the autoBind member of the Mesh */
 	public void render (ShaderProgram shader, boolean autoBind) {
 		mesh.render(shader, primitiveType, offset, size, autoBind);
+	}
+
+	/** Renders the mesh part using the specified shader, must be called after {@link ShaderProgram#bind()}.
+	 * @param shader the shader to be used
+	 * @param autoBind overrides the autoBind member of the Mesh */
+	public void render (ShaderProgram shader, boolean autoBind, InstanceData instances) {
+		mesh.render(shader, primitiveType, offset, size, autoBind, instances);
 	}
 
 	/** Renders the mesh part using the specified shader, must be called after {@link ShaderProgram#bind()}.

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/BaseShader.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/BaseShader.java
@@ -221,6 +221,7 @@ public abstract class BaseShader implements Shader {
 		this.context = context;
 		program.bind();
 		currentMesh = null;
+		currentInstances = null;
 		for (int u, i = 0; i < globalUniforms.size; ++i)
 			if (setters.get(u = globalUniforms.get(i)) != null) setters.get(u).set(this, u, null, null);
 	}
@@ -289,8 +290,12 @@ public abstract class BaseShader implements Shader {
 	@Override
 	public void end () {
 		if (currentMesh != null) {
-			currentMesh.unbind(program, tempArray.items, tempArray2.items);
+			currentMesh.unbind(program, tempArray.items, null, null);
 			currentMesh = null;
+		}
+		if (currentInstances != null) {
+			currentInstances.unbind(program, tempArray2.items);
+			currentInstances = null;
 		}
 	}
 

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/BaseShader.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/BaseShader.java
@@ -293,13 +293,18 @@ public abstract class BaseShader implements Shader {
 	@Override
 	public void end () {
 		if (currentInstances == null) {
-			if (currentMesh != null) currentMesh.unbind(program, tempArray.items, tempArray2.items);
+			if (currentMesh != null) {
+				currentMesh.unbind(program, tempArray.items, tempArray2.items);
+				currentMesh = null;
+			}
 		} else {
-			if (currentMesh != null) currentMesh.unbind(program, tempArray.items, null, null);
+			if (currentMesh != null) {
+				currentMesh.unbind(program, tempArray.items, null, null);
+				currentMesh = null;
+			}
 			currentInstances.unbind(program, tempArray2.items);
+			currentInstances = null;
 		}
-		currentMesh = null;
-		currentInstances = null;
 	}
 
 	@Override

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/BaseShader.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/BaseShader.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,12 +16,7 @@
 
 package com.badlogic.gdx.graphics.g3d.shaders;
 
-import com.badlogic.gdx.graphics.Camera;
-import com.badlogic.gdx.graphics.Color;
-import com.badlogic.gdx.graphics.GLTexture;
-import com.badlogic.gdx.graphics.Mesh;
-import com.badlogic.gdx.graphics.VertexAttribute;
-import com.badlogic.gdx.graphics.VertexAttributes;
+import com.badlogic.gdx.graphics.*;
 import com.badlogic.gdx.graphics.g3d.Attributes;
 import com.badlogic.gdx.graphics.g3d.Renderable;
 import com.badlogic.gdx.graphics.g3d.Shader;
@@ -117,6 +112,7 @@ public abstract class BaseShader implements Shader {
 	private InstanceData currentInstances;
 
 	/** Register an uniform which might be used by this shader. Only possible prior to the call to init().
+	 *
 	 * @return The ID of the uniform to use in this shader. */
 	public int register (final String alias, final Validator validator, final Setter setter) {
 		if (locations != null) throw new GdxRuntimeException("Cannot register an uniform after initialization");
@@ -201,9 +197,8 @@ public abstract class BaseShader implements Shader {
 				final int location = program.getAttributeLocation(attr.alias);
 				if (location >= 0) attributes.put(attr.getKey(), location);
 			}
-			final VertexAttributes iattrs = renderable.instances != null ?
-					renderable.instances.getAttributes() :
-					renderable.meshPart.mesh.getInstancedAttributes();
+			final VertexAttributes iattrs = renderable.instances != null ? renderable.instances.getAttributes()
+				: renderable.meshPart.mesh.getInstancedAttributes();
 			if (iattrs != null) {
 				final int ic = iattrs.size();
 				for (int i = 0; i < ic; i++) {
@@ -266,37 +261,45 @@ public abstract class BaseShader implements Shader {
 		for (int u, i = 0; i < localUniforms.size; ++i)
 			if (setters.get(u = localUniforms.get(i)) != null) setters.get(u).set(this, u, renderable, combinedAttributes);
 
-		final InstanceData instances = renderable.instances != null ? renderable.instances : renderable.meshPart.mesh.instances;
-		if (currentMesh != renderable.meshPart.mesh) { // || renderable.instances != null) {
-			if (currentMesh != null) currentMesh.unbind(program, tempArray.items, null, null);
-			currentMesh = renderable.meshPart.mesh;
-			// currentInstances = instances;
-			// final VertexAttributes insAttrs = instances != null ? instances.getAttributes() : null;
-			currentMesh.bind(program, getAttributeLocations(renderable.meshPart.mesh.getVertexAttributes()),
-					null, null);
-		}
-
-		if (currentInstances != instances) {
-			if (currentInstances != null)
+		if (renderable.instances == null) {
+			if (currentMesh != renderable.meshPart.mesh) {
+				if (currentMesh != null) currentMesh.unbind(program, tempArray.items, tempArray2.items);
+				currentMesh = renderable.meshPart.mesh;
+				currentMesh.bind(program, getAttributeLocations(renderable.meshPart.mesh.getVertexAttributes()),
+					getInstancedAttributeLocations(renderable.meshPart.mesh.getInstancedAttributes()));
+			}
+			if (currentInstances != null) {
 				currentInstances.unbind(program, tempArray2.items);
-			currentInstances = instances;
-			if (instances != null)
-				instances.bind(program, getInstancedAttributeLocations(instances.getAttributes()));
-		}
+				currentInstances = null;
+			}
+			renderable.meshPart.render(program, false);
+		} else {
+			if (currentMesh != renderable.meshPart.mesh) {
+				if (currentMesh != null) currentMesh.unbind(program, tempArray.items, null, null);
+				currentMesh = renderable.meshPart.mesh;
+				currentMesh.bind(program, getAttributeLocations(renderable.meshPart.mesh.getVertexAttributes()), null, null);
+			}
 
-		renderable.meshPart.render(program, false, instances);
+			if (currentInstances != renderable.instances) {
+				if (currentInstances != null) currentInstances.unbind(program, tempArray2.items);
+				currentInstances = renderable.instances;
+				renderable.instances.bind(program, getInstancedAttributeLocations(renderable.instances.getAttributes()));
+			}
+
+			renderable.meshPart.render(program, false, renderable.instances);
+		}
 	}
 
 	@Override
 	public void end () {
-		if (currentMesh != null) {
-			currentMesh.unbind(program, tempArray.items, null, null);
-			currentMesh = null;
-		}
-		if (currentInstances != null) {
+		if (currentInstances == null) {
+			if (currentMesh != null) currentMesh.unbind(program, tempArray.items, tempArray2.items);
+		} else {
+			if (currentMesh != null) currentMesh.unbind(program, tempArray.items, null, null);
 			currentInstances.unbind(program, tempArray2.items);
-			currentInstances = null;
 		}
+		currentMesh = null;
+		currentInstances = null;
 	}
 
 	@Override

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/BaseShader.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/shaders/BaseShader.java
@@ -27,6 +27,7 @@ import com.badlogic.gdx.graphics.g3d.Renderable;
 import com.badlogic.gdx.graphics.g3d.Shader;
 import com.badlogic.gdx.graphics.g3d.utils.RenderContext;
 import com.badlogic.gdx.graphics.g3d.utils.TextureDescriptor;
+import com.badlogic.gdx.graphics.glutils.InstanceData;
 import com.badlogic.gdx.graphics.glutils.ShaderProgram;
 import com.badlogic.gdx.math.Matrix3;
 import com.badlogic.gdx.math.Matrix4;
@@ -113,6 +114,7 @@ public abstract class BaseShader implements Shader {
 	public RenderContext context;
 	public Camera camera;
 	private Mesh currentMesh;
+	private InstanceData currentInstances;
 
 	/** Register an uniform which might be used by this shader. Only possible prior to the call to init().
 	 * @return The ID of the uniform to use in this shader. */
@@ -199,7 +201,9 @@ public abstract class BaseShader implements Shader {
 				final int location = program.getAttributeLocation(attr.alias);
 				if (location >= 0) attributes.put(attr.getKey(), location);
 			}
-			final VertexAttributes iattrs = renderable.meshPart.mesh.getInstancedAttributes();
+			final VertexAttributes iattrs = renderable.instances != null ?
+					renderable.instances.getAttributes() :
+					renderable.meshPart.mesh.getInstancedAttributes();
 			if (iattrs != null) {
 				final int ic = iattrs.size();
 				for (int i = 0; i < ic; i++) {
@@ -260,13 +264,26 @@ public abstract class BaseShader implements Shader {
 	public void render (Renderable renderable, final Attributes combinedAttributes) {
 		for (int u, i = 0; i < localUniforms.size; ++i)
 			if (setters.get(u = localUniforms.get(i)) != null) setters.get(u).set(this, u, renderable, combinedAttributes);
-		if (currentMesh != renderable.meshPart.mesh) {
-			if (currentMesh != null) currentMesh.unbind(program, tempArray.items, tempArray2.items);
+
+		final InstanceData instances = renderable.instances != null ? renderable.instances : renderable.meshPart.mesh.instances;
+		if (currentMesh != renderable.meshPart.mesh) { // || renderable.instances != null) {
+			if (currentMesh != null) currentMesh.unbind(program, tempArray.items, null, null);
 			currentMesh = renderable.meshPart.mesh;
+			// currentInstances = instances;
+			// final VertexAttributes insAttrs = instances != null ? instances.getAttributes() : null;
 			currentMesh.bind(program, getAttributeLocations(renderable.meshPart.mesh.getVertexAttributes()),
-				getInstancedAttributeLocations(renderable.meshPart.mesh.getInstancedAttributes()));
+					null, null);
 		}
-		renderable.meshPart.render(program, false);
+
+		if (currentInstances != instances) {
+			if (currentInstances != null)
+				currentInstances.unbind(program, tempArray2.items);
+			currentInstances = instances;
+			if (instances != null)
+				instances.bind(program, getInstancedAttributeLocations(instances.getAttributes()));
+		}
+
+		renderable.meshPart.render(program, false, instances);
 	}
 
 	@Override


### PR DESCRIPTION
Hey :)
This change adds an `InstanceData` field to `Renderable` and `ModelInstance` to allow rendering the same mesh with different InstanceData buffers or without instances.
Currently LibGDX only supports enabling instanced rendering on a Mesh instance (with `enableInstancedRendering` method) so it can only be rendered with it's own InstanceData buffer and can't be rendered regularly unless you unset it's instances property.

An example use-case for this feature in my game is rendering instanced "chunks" to optimize rendering by culling out chunks that are out of view, and still using instanced rendering to optimize rendering each chunk.
Without this change I'm pretty sure the only way to implement this is by duplicating the Mesh object, which is extremly messy and memory inefficient.

Also I think it's more user-intuitive to have the instance data per `ModelInstance` rather than per `Mesh`.
Enabling instanced rendering on a `ModelInstance` would look something like this:
```java
ModelInstance modelInstance1 = ...;
ModelInstance modelInstance2 = ...; // Same Mesh as modelInstance1
modelInstance1.setInstances(InstanceBufferObject(...));
modelInstance2.setInstances(InstanceBufferObject(...)); // Different data than modelInstance1
```

I implemented this in a way that won't change or break the current flow of the rendering code unless the new `instances` property is set in the `Renderable` that's being drawn.
Using instance data on a `Mesh` still works.

These are the changes I made in each file:
* `Renderable` - Added optional instances field.
* `ModelInstace` - Added optional instances field, and changed `getRenderable` to use it.
* `Mesh` - Add `bind`,`unbind`,`render` methods that receive an external InstanceData object.
* `MeshPart` - Add `render` method that receives an external InstanceData object.
* `BaseShader` - Change `render`,`end`,`register` methods to use the renderable's instances if set. Also add `currentInstances` property to hold the last renderable's instances to use similarly to `currentMesh`.

I tested this on an Android device with my own game, which uses both instanced rendering and regular rendering so I know this doesn't break any standard functionality.
If you think it's necessary I could come up with some minimal demo project for you guys to test it out yourself.