### PR TITLE
Flame 3D particle editor UX improvement on bad user manipulations

### DIFF
--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/TextureLoaderPanel.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/TextureLoaderPanel.java
@@ -1,16 +1,23 @@
 
 package com.badlogic.gdx.tools.flame;
 
+import java.awt.GridBagConstraints;
+import java.awt.Insets;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.io.File;
+
+import javax.swing.DefaultComboBoxModel;
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JComboBox;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+
 import com.badlogic.gdx.assets.loaders.TextureLoader.TextureParameter;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.Texture.TextureFilter;
 import com.badlogic.gdx.graphics.g2d.TextureAtlas;
-
-import javax.swing.*;
-import java.awt.*;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.io.File;
 
 /** @author Inferno */
 public class TextureLoaderPanel extends EditorPanel {

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/TextureLoaderPanel.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/TextureLoaderPanel.java
@@ -59,7 +59,7 @@ public class TextureLoaderPanel extends EditorPanel {
 						editor.setAtlas(atlas);
 					} else {
 						JOptionPane.showMessageDialog(editor,
-								"Error loading atlas file. Make sure you must provide an atlas file, not an image file.");
+							"Error loading atlas file. Make sure you must provide an atlas file, not an image file.");
 					}
 				}
 			}

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/TextureLoaderPanel.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/TextureLoaderPanel.java
@@ -1,22 +1,16 @@
 
 package com.badlogic.gdx.tools.flame;
 
-import java.awt.GridBagConstraints;
-import java.awt.Insets;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.io.File;
-
-import javax.swing.DefaultComboBoxModel;
-import javax.swing.JButton;
-import javax.swing.JCheckBox;
-import javax.swing.JComboBox;
-import javax.swing.JLabel;
-
 import com.badlogic.gdx.assets.loaders.TextureLoader.TextureParameter;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.Texture.TextureFilter;
 import com.badlogic.gdx.graphics.g2d.TextureAtlas;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.io.File;
 
 /** @author Inferno */
 public class TextureLoaderPanel extends EditorPanel {
@@ -56,6 +50,8 @@ public class TextureLoaderPanel extends EditorPanel {
 					TextureAtlas atlas = editor.load(file.getAbsolutePath(), TextureAtlas.class, null, null);
 					if (atlas != null) {
 						editor.setAtlas(atlas);
+					} else {
+						JOptionPane.showMessageDialog(editor, "Error loading atlas file. Make sure you must provide an atlas file, not an image file.");
 					}
 				}
 			}
@@ -73,6 +69,8 @@ public class TextureLoaderPanel extends EditorPanel {
 					Texture texture = editor.load(file.getAbsolutePath(), Texture.class, null, params);
 					if (texture != null) {
 						editor.setTexture(texture);
+					} else {
+						JOptionPane.showMessageDialog(editor, "Error loading texture file.");
 					}
 				}
 			}

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/TextureLoaderPanel.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/TextureLoaderPanel.java
@@ -58,7 +58,8 @@ public class TextureLoaderPanel extends EditorPanel {
 					if (atlas != null) {
 						editor.setAtlas(atlas);
 					} else {
-						JOptionPane.showMessageDialog(editor, "Error loading atlas file. Make sure you must provide an atlas file, not an image file.");
+						JOptionPane.showMessageDialog(editor,
+								"Error loading atlas file. Make sure you must provide an atlas file, not an image file.");
 					}
 				}
 			}


### PR DESCRIPTION
# Issue

As a new user to LibGDX's 3D environment and particles, I found myself struggling with the flame editor. When trying to load an atlas, I saw it didn't work but the software provided no feedback. So my first reflex was to run the flame editor with java in command line to get output and this is what I saw:

![image](https://github.com/user-attachments/assets/75dc9437-2bce-4e0f-872a-1746f16a4ca7)

This was very confusing to me. 

# Solution

The goal of this PR is to enhance the UX of when trying to load an invalid file as atlas or texture. The most obvious mistake (which was mine) I think is to provide the PNG file instead of the ATLAS file for an atlas, so I made the atlas error message reflect that. There's also an error message when adding a bad texture file. This way we provide feedback to the user in case the operation they requested didn't work.