### PR TITLE
Change visibility of PolygonSpriteBatch.switchTexture() to protected

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -53,6 +53,7 @@
 - Adds status detection for an httpRequest
 - Fix ANGLE GLES renderer on dekstop (#7274)
 - Architecture support: Support for Linux RISC-V has been added. The gdx-xxx-natives-desktop.jar files now also contain native libraries for this architecture.
+- Change visibility of PolygonSpriteBatch.switchTexture() to protected
 
 [1.12.1]
 - LWJGL3 Improvement: Audio device is automatically switched if it was changed in the operating system.

--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,5 @@
 [1.13.1]
+- Change visibility of PolygonSpriteBatch.switchTexture() to protected
 
 [1.13.0]
 - [BREAKING CHANGE] GWT: Updated to 2.11.0. `com.google.jsinterop:jsinterop-annotations:2.0.2:sources` must be added as a dependency to your html project dependencies.
@@ -55,7 +56,6 @@
 - Adds status detection for an httpRequest
 - Fix ANGLE GLES renderer on dekstop (#7274)
 - Architecture support: Support for Linux RISC-V has been added. The gdx-xxx-natives-desktop.jar files now also contain native libraries for this architecture.
-- Change visibility of PolygonSpriteBatch.switchTexture() to protected
 
 [1.12.1]
 - LWJGL3 Improvement: Audio device is automatically switched if it was changed in the operating system.

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/PolygonSpriteBatch.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/PolygonSpriteBatch.java
@@ -1310,7 +1310,7 @@ public class PolygonSpriteBatch implements PolygonBatch {
 		}
 	}
 
-	private void switchTexture (Texture texture) {
+	protected void switchTexture (Texture texture) {
 		flush();
 		lastTexture = texture;
 		invTexWidth = 1.0f / texture.getWidth();


### PR DESCRIPTION
Change visibility of PolygonSpriteBatch.switchTexture() to protected

Use case: On texture switch pass the new texture size to a shader

(SpriteBatch.switchTexture is already protected)