### PR TITLE
Fix floating point inaccuracy with touch position on iOS

### DIFF
--- a/backends/gdx-backend-robovm-metalangle/src/com/badlogic/gdx/backends/iosrobovm/DefaultIOSInput.java
+++ b/backends/gdx-backend-robovm-metalangle/src/com/badlogic/gdx/backends/iosrobovm/DefaultIOSInput.java
@@ -1074,11 +1074,12 @@ public class DefaultIOSInput extends AbstractInput implements IOSInput {
 			// Get and map the location to our drawing space
 			{
 				CGPoint loc = touch.getLocationInView(app.graphics.view);
-				locX = (int)(loc.getX() - screenBounds.x);
-				locY = (int)(loc.getY() - screenBounds.y);
 				if (config.hdpiMode == HdpiMode.Pixels) {
-					locX *= app.pixelsPerPoint;
-					locY *= app.pixelsPerPoint;
+					locX = (int)((loc.getX() - screenBounds.x) * app.pixelsPerPoint);
+					locY = (int)((loc.getY() - screenBounds.y) * app.pixelsPerPoint);
+				} else {
+					locX = (int)(loc.getX() - screenBounds.x);
+					locY = (int)(loc.getY() - screenBounds.y);
 				}
 				// app.debug("IOSInput","pos= "+loc+" bounds= "+bounds+" x= "+locX+" locY= "+locY);
 			}

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/DefaultIOSInput.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/DefaultIOSInput.java
@@ -1075,11 +1075,12 @@ public class DefaultIOSInput extends AbstractInput implements IOSInput {
 			// Get and map the location to our drawing space
 			{
 				CGPoint loc = touch.getLocationInView(app.graphics.view);
-				locX = (int)(loc.getX() - screenBounds.x);
-				locY = (int)(loc.getY() - screenBounds.y);
 				if (config.hdpiMode == HdpiMode.Pixels) {
-					locX *= app.pixelsPerPoint;
-					locY *= app.pixelsPerPoint;
+					locX = (int)((loc.getX() - screenBounds.x) * app.pixelsPerPoint);
+					locY = (int)((loc.getY() - screenBounds.y) * app.pixelsPerPoint);
+				} else {
+					locX = (int)(loc.getX() - screenBounds.x);
+					locY = (int)(loc.getY() - screenBounds.y);
 				}
 				// app.debug("IOSInput","pos= "+loc+" bounds= "+bounds+" x= "+locX+" locY= "+locY);
 			}


### PR DESCRIPTION
`loc.getX/Y()` returns a double, which currently gets eagerly casted to an `int`. The leads to loss of accuracy if `HdpiMode.Pixels` is enabled and the `int` location is multiplied by the `pixelsPerPoint` float again.

This pr fixes this by first multiplying the floating point numbers and than casting to an Integer.
