### PR TITLE
Fix custom view usage on android

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/DefaultAndroidInput.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/DefaultAndroidInput.java
@@ -202,13 +202,6 @@ public class DefaultAndroidInput extends AbstractInput implements AndroidInput, 
 		// this is for backward compatibility: libGDX always caught the circle button, original comment:
 		// circle button on Xperia Play shouldn't need catchBack == true
 		setCatchKey(Keys.BUTTON_CIRCLE, true);
-		handle.post(new Runnable() {
-			@Override
-			public void run () {
-				// Early call to have a proper layouted EditText already on first call of openNativeInput
-				createDefaultEditText();
-			}
-		});
 	}
 
 	@Override
@@ -758,8 +751,9 @@ public class DefaultAndroidInput extends AbstractInput implements AndroidInput, 
 	}
 
 	private void createDefaultEditText () {
+		// TODO: 07.10.2024 This should probably just get the content/root view instead
 		View view = ((AndroidGraphics)app.getGraphics()).getView();
-		FrameLayout frameLayout = (FrameLayout)view.getParent();
+		ViewGroup frameLayout = (ViewGroup)view.getParent();
 		final RelativeLayout relativeLayout = new RelativeLayout(context);
 		relativeLayout.setGravity(Gravity.BOTTOM);
 		// Why? Why isn't it working without?


### PR DESCRIPTION
Eager initialization seems to be not needed, it works fine on my test. But I also fixed the cast for now, or made it more flexible.
At some point this probably needs rework too, but should be good enough for now.

Fixes https://github.com/libgdx/libgdx/issues/7465