### PR TITLE
Migrate androidx API to internal Android 30+ one

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplication.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplication.java
@@ -31,7 +31,7 @@ import android.view.Window;
 import android.view.WindowManager;
 import android.widget.FrameLayout;
 import com.badlogic.gdx.*;
-import com.badlogic.gdx.backends.android.keyboardheight.AndroidXKeyboardHeightProvider;
+import com.badlogic.gdx.backends.android.keyboardheight.AndroidRKeyboardHeightProvider;
 import com.badlogic.gdx.backends.android.keyboardheight.KeyboardHeightProvider;
 import com.badlogic.gdx.backends.android.keyboardheight.StandardKeyboardHeightProvider;
 import com.badlogic.gdx.backends.android.surfaceview.FillResolutionStrategy;
@@ -181,10 +181,8 @@ public class AndroidApplication extends Activity implements AndroidApplicationBa
 
 		setLayoutInDisplayCutoutMode(this.renderUnderCutout);
 
-		// As per the docs, it might work unreliable < 23 https://developer.android.com/jetpack/androidx/releases/core#1.5.0-alpha02
-		// So, I guess since 23 is pretty rare we can use the old API for the users
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-			keyboardHeightProvider = new AndroidXKeyboardHeightProvider(this);
+			keyboardHeightProvider = new AndroidRKeyboardHeightProvider(this);
 		} else {
 			keyboardHeightProvider = new StandardKeyboardHeightProvider(this);
 		}

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/keyboardheight/AndroidRKeyboardHeightProvider.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/keyboardheight/AndroidRKeyboardHeightProvider.java
@@ -4,14 +4,16 @@ package com.badlogic.gdx.backends.android.keyboardheight;
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.res.Configuration;
+import android.os.Build.VERSION_CODES;
 import android.view.View;
-import androidx.core.graphics.Insets;
-import androidx.core.view.OnApplyWindowInsetsListener;
-import androidx.core.view.ViewCompat;
-import androidx.core.view.WindowInsetsCompat;
+import android.view.View.OnApplyWindowInsetsListener;
+import android.view.WindowInsets;
+import android.graphics.Insets;
+import androidx.annotation.RequiresApi;
 import org.jetbrains.annotations.NotNull;
 
-public class AndroidXKeyboardHeightProvider implements KeyboardHeightProvider {
+@RequiresApi(api = VERSION_CODES.R)
+public class AndroidRKeyboardHeightProvider implements KeyboardHeightProvider {
 
 	private final View view;
 	private final Activity activity;
@@ -23,22 +25,22 @@ public class AndroidXKeyboardHeightProvider implements KeyboardHeightProvider {
 	/** The cached portrait height of the keyboard */
 	private static int keyboardPortraitHeight;
 
-	public AndroidXKeyboardHeightProvider (final Activity activity) {
+	public AndroidRKeyboardHeightProvider(final Activity activity) {
 		this.view = activity.findViewById(android.R.id.content);
 		this.activity = activity;
 	}
 
 	@Override
 	public void start () {
-		ViewCompat.setOnApplyWindowInsetsListener(view, new OnApplyWindowInsetsListener() {
+		view.setOnApplyWindowInsetsListener(new OnApplyWindowInsetsListener() {
 			@NotNull
 			@Override
-			public WindowInsetsCompat onApplyWindowInsets (@NotNull View v, @NotNull WindowInsetsCompat windowInsets) {
+			public WindowInsets onApplyWindowInsets (@NotNull View v, @NotNull WindowInsets windowInsets) {
 				if (observer == null) return windowInsets;
 				int orientation = activity.getResources().getConfiguration().orientation;
-				boolean isVisible = windowInsets.isVisible(WindowInsetsCompat.Type.ime());
+				boolean isVisible = windowInsets.isVisible(WindowInsets.Type.ime());
 				if (isVisible) {
-					Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.ime());
+					Insets insets = windowInsets.getInsets(WindowInsets.Type.ime());
 					if (orientation == Configuration.ORIENTATION_PORTRAIT) {
 						keyboardPortraitHeight = insets.bottom;
 					} else {
@@ -63,7 +65,7 @@ public class AndroidXKeyboardHeightProvider implements KeyboardHeightProvider {
 
 	@Override
 	public void close () {
-		ViewCompat.setOnApplyWindowInsetsListener(view, null);
+		view.setOnApplyWindowInsetsListener(null);
 	}
 
 	@Override

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/keyboardheight/AndroidRKeyboardHeightProvider.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/keyboardheight/AndroidRKeyboardHeightProvider.java
@@ -25,7 +25,7 @@ public class AndroidRKeyboardHeightProvider implements KeyboardHeightProvider {
 	/** The cached portrait height of the keyboard */
 	private static int keyboardPortraitHeight;
 
-	public AndroidRKeyboardHeightProvider(final Activity activity) {
+	public AndroidRKeyboardHeightProvider (final Activity activity) {
 		this.view = activity.findViewById(android.R.id.content);
 		this.activity = activity;
 	}

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/keyboardheight/AndroidRKeyboardHeightProvider.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/keyboardheight/AndroidRKeyboardHeightProvider.java
@@ -2,6 +2,7 @@
 package com.badlogic.gdx.backends.android.keyboardheight;
 
 import android.annotation.SuppressLint;
+import android.annotation.TargetApi;
 import android.app.Activity;
 import android.content.res.Configuration;
 import android.os.Build.VERSION_CODES;
@@ -9,10 +10,9 @@ import android.view.View;
 import android.view.View.OnApplyWindowInsetsListener;
 import android.view.WindowInsets;
 import android.graphics.Insets;
-import androidx.annotation.RequiresApi;
 import org.jetbrains.annotations.NotNull;
 
-@RequiresApi(api = VERSION_CODES.R)
+@TargetApi(VERSION_CODES.R)
 public class AndroidRKeyboardHeightProvider implements KeyboardHeightProvider {
 
 	private final View view;


### PR DESCRIPTION
This PR removes the need for androidx on libGDX usual use. 
From looking through the source, androidx on sdk 30+ just redirected the API to the system API anyway, so this shouldn't really change anything.