### PR TITLE
Change defaults of SpriteBatch to use VBO instead of VertexArray on gl2/gles2.0 

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/Mesh.java
+++ b/gdx/src/com/badlogic/gdx/graphics/Mesh.java
@@ -487,6 +487,10 @@ public class Mesh implements Disposable {
 		return vertices.getAttributes().vertexSize;
 	}
 
+	public IndexData getIndexData () {
+		return indices;
+	}
+
 	/** Sets whether to bind the underlying {@link VertexArray} or {@link VertexBufferObject} automatically on a call to one of the
 	 * render methods. Usually you want to use autobind. Manual binding is an expert functionality. There is a driver bug on the
 	 * MSM720xa chips that will fuck up memory if you manipulate the vertices and indices of a Mesh multiple times while it is

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/SpriteBatch.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/SpriteBatch.java
@@ -40,13 +40,10 @@ public class SpriteBatch implements Batch {
 	 *             used when gles 3 is not available, defaults to {@link VertexDataType#VertexArray}. */
 	@Deprecated public static VertexDataType defaultVertexDataType = VertexDataType.VertexBufferObject;
 
-	/**
-	 * Used to completely override the vertex type used by SpriteBatch. This is useful for picking a specific
-	 * vertex data type on construction of the sprite batch. Recommended to reset this back to defaultVertexDataType
-	 * Once the batch has been created with this flag
-	 */
-	@Deprecated
-	public static VertexDataType overrideVertexType = null;
+	/** Used to completely override the vertex type used by SpriteBatch. This is useful for picking a specific vertex data type on
+	 * construction of the sprite batch. Recommended to reset this back to defaultVertexDataType Once the batch has been created
+	 * with this flag */
+	@Deprecated public static VertexDataType overrideVertexType = null;
 
 	private VertexDataType currentDataType;
 
@@ -979,13 +976,12 @@ public class SpriteBatch implements Batch {
 		Mesh mesh = this.mesh;
 		mesh.setVertices(vertices, 0, idx);
 
-		//Only upload indices for the vertex array type
+		// Only upload indices for the vertex array type
 		if (currentDataType == VertexDataType.VertexArray) {
 			Buffer indicesBuffer = (Buffer)mesh.getIndicesBuffer(true);
 			indicesBuffer.position(0);
 			indicesBuffer.limit(count);
 		}
-
 
 		if (blendingDisabled) {
 			Gdx.gl.glDisable(GL20.GL_BLEND);

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/SpriteBatch.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/SpriteBatch.java
@@ -38,7 +38,17 @@ import java.nio.Buffer;
 public class SpriteBatch implements Batch {
 	/** @deprecated Do not use, this field is for testing only and is likely to be removed. Sets the {@link VertexDataType} to be
 	 *             used when gles 3 is not available, defaults to {@link VertexDataType#VertexArray}. */
-	@Deprecated public static VertexDataType defaultVertexDataType = VertexDataType.VertexArray;
+	@Deprecated public static VertexDataType defaultVertexDataType = VertexDataType.VertexBufferObject;
+
+	/**
+	 * Used to completely override the vertex type used by SpriteBatch. This is useful for picking a specific
+	 * vertex data type on construction of the sprite batch. Recommended to reset this back to defaultVertexDataType
+	 * Once the batch has been created with this flag
+	 */
+	@Deprecated
+	public static VertexDataType overrideVertexType = null;
+
+	private VertexDataType currentDataType;
 
 	private Mesh mesh;
 
@@ -101,7 +111,13 @@ public class SpriteBatch implements Batch {
 
 		VertexDataType vertexDataType = (Gdx.gl30 != null) ? VertexDataType.VertexBufferObjectWithVAO : defaultVertexDataType;
 
-		mesh = new Mesh(vertexDataType, false, size * 4, size * 6,
+		if (overrideVertexType != null) {
+			vertexDataType = overrideVertexType;
+		}
+
+		currentDataType = vertexDataType;
+
+		mesh = new Mesh(currentDataType, false, size * 4, size * 6,
 			new VertexAttribute(Usage.Position, 2, ShaderProgram.POSITION_ATTRIBUTE),
 			new VertexAttribute(Usage.ColorPacked, 4, ShaderProgram.COLOR_ATTRIBUTE),
 			new VertexAttribute(Usage.TextureCoordinates, 2, ShaderProgram.TEXCOORD_ATTRIBUTE + "0"));
@@ -131,8 +147,8 @@ public class SpriteBatch implements Batch {
 
 		// Pre bind the mesh to force the upload of indices data.
 		if (vertexDataType != VertexDataType.VertexArray) {
-			mesh.bind(shader);
-			mesh.unbind(shader);
+			mesh.getIndexData().bind();
+			mesh.getIndexData().unbind();
 		}
 	}
 
@@ -962,9 +978,14 @@ public class SpriteBatch implements Batch {
 		lastTexture.bind();
 		Mesh mesh = this.mesh;
 		mesh.setVertices(vertices, 0, idx);
-		Buffer indicesBuffer = (Buffer)mesh.getIndicesBuffer(false);
-		indicesBuffer.position(0);
-		indicesBuffer.limit(count);
+
+		//Only upload indices for the vertex array type
+		if (currentDataType == VertexDataType.VertexArray) {
+			Buffer indicesBuffer = (Buffer)mesh.getIndicesBuffer(true);
+			indicesBuffer.position(0);
+			indicesBuffer.limit(count);
+		}
+
 
 		if (blendingDisabled) {
 			Gdx.gl.glDisable(GL20.GL_BLEND);

--- a/tests/gdx-tests-gwt/src/com/badlogic/gdx/tests/gwt/client/GwtTestWrapper.java
+++ b/tests/gdx-tests-gwt/src/com/badlogic/gdx/tests/gwt/client/GwtTestWrapper.java
@@ -77,6 +77,7 @@ import com.badlogic.gdx.tests.SimpleStageCullingTest;
 import com.badlogic.gdx.tests.SortedSpriteTest;
 import com.badlogic.gdx.tests.SoundTest;
 import com.badlogic.gdx.tests.SpriteBatchShaderTest;
+import com.badlogic.gdx.tests.SpriteBatchPerformanceTest;
 import com.badlogic.gdx.tests.SpriteCacheOffsetTest;
 import com.badlogic.gdx.tests.SpriteCacheTest;
 import com.badlogic.gdx.tests.StageTest;
@@ -515,6 +516,11 @@ public class GwtTestWrapper extends AbstractTestWrapper {
 		tests.add(new GwtInstancer() {
 			public GdxTest instance () {
 				return new SpriteBatchShaderTest();
+			}
+		});
+		tests.add(new GwtInstancer() {
+			public GdxTest instance () {
+				return new SpriteBatchPerformanceTest();
 			}
 		});
 		tests.add(new GwtInstancer() {

--- a/tests/gdx-tests-lwjgl3/build.gradle
+++ b/tests/gdx-tests-lwjgl3/build.gradle
@@ -55,5 +55,6 @@ tasks.register('dist', Jar) {
 	from {
 		configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
 	}
+	duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 	with jar
 }

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/SpriteBatchPerformanceTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/SpriteBatchPerformanceTest.java
@@ -16,79 +16,133 @@
 
 package com.badlogic.gdx.tests;
 
+import com.badlogic.gdx.Application;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.Mesh;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.graphics.glutils.VertexData;
+import com.badlogic.gdx.graphics.profiling.GLErrorListener;
+import com.badlogic.gdx.graphics.profiling.GLProfiler;
 import com.badlogic.gdx.math.WindowedMean;
 import com.badlogic.gdx.tests.utils.GdxTest;
 import com.badlogic.gdx.tests.utils.GdxTestConfig;
+import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.StringBuilder;
 
 @GdxTestConfig
 public class SpriteBatchPerformanceTest extends GdxTest {
 
-	private Texture texture;
-	private SpriteBatch spriteBatch;
-	private WindowedMean counter = new WindowedMean(10000);
-	private StringBuilder stringBuilder = new StringBuilder();
+    private Texture texture;
+    private SpriteBatch spriteBatch;
+    private StringBuilder stringBuilder = new StringBuilder();
 
-	private BitmapFont bitmapFont;
+    private BitmapFont bitmapFont;
 
-	@Override
-	public void create () {
-		texture = new Texture(Gdx.files.internal("data/badlogic.jpg"));
-		spriteBatch = new SpriteBatch(8191);
-		bitmapFont = new BitmapFont();
-	}
 
-	@Override
-	public void render () {
-		Gdx.gl20.glViewport(0, 0, Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight());
-		Gdx.gl20.glClearColor(0.2f, 0.2f, 0.2f, 1);
-		Gdx.gl20.glClear(GL20.GL_COLOR_BUFFER_BIT);
+    private static class PerfTest {
+        Mesh.VertexDataType vertexDataType;
+        WindowedMean counter = new WindowedMean(10000);
 
-		spriteBatch.begin();
+        PerfTest (Mesh.VertexDataType type) {
+            this.vertexDataType = type;
+        }
+    }
 
-		// Accelerate the draws
-		for (int j = 0; j < 100; j++) {
+    private Array<PerfTest> perfTests = new Array<>();
 
-			// fill the batch
-			for (int i = 0; i < 8190; i++) {
-				spriteBatch.draw(texture, 0, 0, 1, 1);
-			}
+    @Override
+    public void create () {
+        texture = new Texture(Gdx.files.internal("data/badlogic.jpg"));
+        spriteBatch = new SpriteBatch(8191);
+        bitmapFont = new BitmapFont();
 
-			long beforeFlush = System.nanoTime();
 
-			spriteBatch.flush();
-			Gdx.gl.glFlush();
-			long afterFlush = System.nanoTime();
+        if (Gdx.graphics.isGL30Available()) {
+            perfTests.add(new PerfTest(Mesh.VertexDataType.VertexBufferObjectWithVAO));
 
-			counter.addValue(afterFlush - beforeFlush);
+            if (Gdx.app.getType() != Application.ApplicationType.Desktop) {
+                perfTests.add(new PerfTest(Mesh.VertexDataType.VertexBufferObject));
+            }
+        } else {
+            perfTests.add(new PerfTest(Mesh.VertexDataType.VertexArray));
+            perfTests.add(new PerfTest(Mesh.VertexDataType.VertexBufferObject));
+        }
 
-		}
+        GLProfiler glProfiler = new GLProfiler(Gdx.graphics);
+        glProfiler.setListener(new GLErrorListener() {
+            @Override
+            public void onError (int error) {
+                System.out.println("GLProfiler: error: " + error);
+            }
+        });
+        glProfiler.enable();
 
-		spriteBatch.end();
+    }
 
-		spriteBatch.begin();
-		stringBuilder.setLength(0);
+    @Override
+    public void render () {
+        Gdx.gl20.glViewport(0, 0, Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight());
+        Gdx.gl20.glClearColor(0.2f, 0.2f, 0.2f, 1);
+        Gdx.gl20.glClear(GL20.GL_COLOR_BUFFER_BIT);
 
-		if (counter.hasEnoughData()) {
-			stringBuilder.append("Mean Time ms: ");
-			stringBuilder.append(counter.getMean() / 1e6);
-		} else {
-			stringBuilder.append("Please wait, collecting data...");
-		}
+        int draws = 100;
+        int spritesToFill = 8190;
 
-		bitmapFont.draw(spriteBatch, stringBuilder, 0, 200);
-		spriteBatch.end();
-	}
+        for (PerfTest perfTest : perfTests) {
+            SpriteBatch.overrideVertexType = perfTest.vertexDataType;
 
-	@Override
-	public void dispose () {
-		texture.dispose();
-		spriteBatch.dispose();
-	}
+            SpriteBatch testingBatch = new SpriteBatch(8191);
+            Gdx.gl.glFlush();
+            testingBatch.begin();
+            for (int i = 0; i < draws; i++) {
+                for (int j = 0; j < spritesToFill; j++) {
+                    testingBatch.draw(texture, 0, 0, 1, 1);
+                }
+
+                long beforeFlush = System.nanoTime();
+                testingBatch.flush();
+                Gdx.gl.glFlush();
+                long afterFlush = System.nanoTime();
+
+                perfTest.counter.addValue(afterFlush - beforeFlush);
+            }
+
+            testingBatch.end();
+            testingBatch.dispose();
+            Gdx.gl.glFlush();
+        }
+
+
+        spriteBatch.begin();
+
+        stringBuilder.setLength(0);
+        for (PerfTest perfTest : perfTests) {
+            stringBuilder.append("Type: ");
+            stringBuilder.append(perfTest.vertexDataType);
+            stringBuilder.append("\n");
+
+            if (perfTest.counter.hasEnoughData()) {
+                stringBuilder.append("Mean Time ms: ");
+                float nanoTimeMean = perfTest.counter.getMean();
+                stringBuilder.append(nanoTimeMean / 1e6);
+            } else {
+                stringBuilder.append("Please wait, collecting data...");
+            }
+            stringBuilder.append("\n\n");
+        }
+        bitmapFont.draw(spriteBatch, stringBuilder, 0, 400);
+
+
+        spriteBatch.end();
+    }
+
+    @Override
+    public void dispose () {
+        texture.dispose();
+        spriteBatch.dispose();
+    }
 
 }

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/SpriteBatchPerformanceTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/SpriteBatchPerformanceTest.java
@@ -23,7 +23,6 @@ import com.badlogic.gdx.graphics.Mesh;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
-import com.badlogic.gdx.graphics.glutils.VertexData;
 import com.badlogic.gdx.graphics.profiling.GLErrorListener;
 import com.badlogic.gdx.graphics.profiling.GLProfiler;
 import com.badlogic.gdx.math.WindowedMean;
@@ -35,114 +34,110 @@ import com.badlogic.gdx.utils.StringBuilder;
 @GdxTestConfig
 public class SpriteBatchPerformanceTest extends GdxTest {
 
-    private Texture texture;
-    private SpriteBatch spriteBatch;
-    private StringBuilder stringBuilder = new StringBuilder();
+	private Texture texture;
+	private SpriteBatch spriteBatch;
+	private StringBuilder stringBuilder = new StringBuilder();
 
-    private BitmapFont bitmapFont;
+	private BitmapFont bitmapFont;
 
+	private static class PerfTest {
+		Mesh.VertexDataType vertexDataType;
+		WindowedMean counter = new WindowedMean(10000);
 
-    private static class PerfTest {
-        Mesh.VertexDataType vertexDataType;
-        WindowedMean counter = new WindowedMean(10000);
+		PerfTest (Mesh.VertexDataType type) {
+			this.vertexDataType = type;
+		}
+	}
 
-        PerfTest (Mesh.VertexDataType type) {
-            this.vertexDataType = type;
-        }
-    }
+	private Array<PerfTest> perfTests = new Array<>();
 
-    private Array<PerfTest> perfTests = new Array<>();
+	@Override
+	public void create () {
+		texture = new Texture(Gdx.files.internal("data/badlogic.jpg"));
+		spriteBatch = new SpriteBatch(8191);
+		bitmapFont = new BitmapFont();
 
-    @Override
-    public void create () {
-        texture = new Texture(Gdx.files.internal("data/badlogic.jpg"));
-        spriteBatch = new SpriteBatch(8191);
-        bitmapFont = new BitmapFont();
+		if (Gdx.graphics.isGL30Available()) {
+			perfTests.add(new PerfTest(Mesh.VertexDataType.VertexBufferObjectWithVAO));
 
+			if (Gdx.app.getType() != Application.ApplicationType.Desktop) {
+				perfTests.add(new PerfTest(Mesh.VertexDataType.VertexBufferObject));
+			}
+		} else {
+			perfTests.add(new PerfTest(Mesh.VertexDataType.VertexArray));
+			perfTests.add(new PerfTest(Mesh.VertexDataType.VertexBufferObject));
+		}
 
-        if (Gdx.graphics.isGL30Available()) {
-            perfTests.add(new PerfTest(Mesh.VertexDataType.VertexBufferObjectWithVAO));
+		GLProfiler glProfiler = new GLProfiler(Gdx.graphics);
+		glProfiler.setListener(new GLErrorListener() {
+			@Override
+			public void onError (int error) {
+				System.out.println("GLProfiler: error: " + error);
+			}
+		});
+		glProfiler.enable();
 
-            if (Gdx.app.getType() != Application.ApplicationType.Desktop) {
-                perfTests.add(new PerfTest(Mesh.VertexDataType.VertexBufferObject));
-            }
-        } else {
-            perfTests.add(new PerfTest(Mesh.VertexDataType.VertexArray));
-            perfTests.add(new PerfTest(Mesh.VertexDataType.VertexBufferObject));
-        }
+	}
 
-        GLProfiler glProfiler = new GLProfiler(Gdx.graphics);
-        glProfiler.setListener(new GLErrorListener() {
-            @Override
-            public void onError (int error) {
-                System.out.println("GLProfiler: error: " + error);
-            }
-        });
-        glProfiler.enable();
+	@Override
+	public void render () {
+		Gdx.gl20.glViewport(0, 0, Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight());
+		Gdx.gl20.glClearColor(0.2f, 0.2f, 0.2f, 1);
+		Gdx.gl20.glClear(GL20.GL_COLOR_BUFFER_BIT);
 
-    }
+		int draws = 100;
+		int spritesToFill = 8190;
 
-    @Override
-    public void render () {
-        Gdx.gl20.glViewport(0, 0, Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight());
-        Gdx.gl20.glClearColor(0.2f, 0.2f, 0.2f, 1);
-        Gdx.gl20.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		for (PerfTest perfTest : perfTests) {
+			SpriteBatch.overrideVertexType = perfTest.vertexDataType;
 
-        int draws = 100;
-        int spritesToFill = 8190;
+			SpriteBatch testingBatch = new SpriteBatch(8191);
+			Gdx.gl.glFlush();
+			testingBatch.begin();
+			for (int i = 0; i < draws; i++) {
+				for (int j = 0; j < spritesToFill; j++) {
+					testingBatch.draw(texture, 0, 0, 1, 1);
+				}
 
-        for (PerfTest perfTest : perfTests) {
-            SpriteBatch.overrideVertexType = perfTest.vertexDataType;
+				long beforeFlush = System.nanoTime();
+				testingBatch.flush();
+				Gdx.gl.glFlush();
+				long afterFlush = System.nanoTime();
 
-            SpriteBatch testingBatch = new SpriteBatch(8191);
-            Gdx.gl.glFlush();
-            testingBatch.begin();
-            for (int i = 0; i < draws; i++) {
-                for (int j = 0; j < spritesToFill; j++) {
-                    testingBatch.draw(texture, 0, 0, 1, 1);
-                }
+				perfTest.counter.addValue(afterFlush - beforeFlush);
+			}
 
-                long beforeFlush = System.nanoTime();
-                testingBatch.flush();
-                Gdx.gl.glFlush();
-                long afterFlush = System.nanoTime();
+			testingBatch.end();
+			testingBatch.dispose();
+			Gdx.gl.glFlush();
+		}
 
-                perfTest.counter.addValue(afterFlush - beforeFlush);
-            }
+		spriteBatch.begin();
 
-            testingBatch.end();
-            testingBatch.dispose();
-            Gdx.gl.glFlush();
-        }
+		stringBuilder.setLength(0);
+		for (PerfTest perfTest : perfTests) {
+			stringBuilder.append("Type: ");
+			stringBuilder.append(perfTest.vertexDataType);
+			stringBuilder.append("\n");
 
+			if (perfTest.counter.hasEnoughData()) {
+				stringBuilder.append("Mean Time ms: ");
+				float nanoTimeMean = perfTest.counter.getMean();
+				stringBuilder.append(nanoTimeMean / 1e6);
+			} else {
+				stringBuilder.append("Please wait, collecting data...");
+			}
+			stringBuilder.append("\n\n");
+		}
+		bitmapFont.draw(spriteBatch, stringBuilder, 0, 400);
 
-        spriteBatch.begin();
+		spriteBatch.end();
+	}
 
-        stringBuilder.setLength(0);
-        for (PerfTest perfTest : perfTests) {
-            stringBuilder.append("Type: ");
-            stringBuilder.append(perfTest.vertexDataType);
-            stringBuilder.append("\n");
-
-            if (perfTest.counter.hasEnoughData()) {
-                stringBuilder.append("Mean Time ms: ");
-                float nanoTimeMean = perfTest.counter.getMean();
-                stringBuilder.append(nanoTimeMean / 1e6);
-            } else {
-                stringBuilder.append("Please wait, collecting data...");
-            }
-            stringBuilder.append("\n\n");
-        }
-        bitmapFont.draw(spriteBatch, stringBuilder, 0, 400);
-
-
-        spriteBatch.end();
-    }
-
-    @Override
-    public void dispose () {
-        texture.dispose();
-        spriteBatch.dispose();
-    }
+	@Override
+	public void dispose () {
+		texture.dispose();
+		spriteBatch.dispose();
+	}
 
 }


### PR DESCRIPTION
Regression in gwt due to VertexArray/IndexArray not being implemented the same on all platforms.

After tests, I havent seen an issue in just moving from client side buffers (VA), to VBOs as the new default.

For all other buffer types we can still pre-upload indices, and save us some nice time during rendering.

Test results for lwjgl, lwjlg3, android and gwt below. IOS not tested yet.


Times here are all just relative to each other. Lower the better
```
android gl2
0.195 vertex array 
0.159 vbo

android gl3
0.171 vao
0.168 vbo

===============

lwjgl2 gl2
0.105 vertex array
0.88 vbo

lwjgl2 gl3
0.09 vao

===============

lwjgl3 gl2
0.105 vertex array
0.09 vbo

lwjgl3 gl3
0.08 vao

===============

gwt gl2
1.427 vertex array
1.309 vbo

gwt gl3
1.309 vbo
0.921 vao
```



https://github.com/libgdx/libgdx/issues/7480
https://github.com/libgdx/libgdx/commit/bfe255a2727377b910be20af48d40867c588a8a3