### PR TITLE
XmlReader.getChildren() + XmlReader.replaceChild()

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 [1.13.1]
 - iOS: Update to MobiVM 2.3.22
 - Change visibility of PolygonSpriteBatch.switchTexture() to protected
+- Added XmlReader.getChildren() and XmlReader.replaceChild()
 
 [1.13.0]
 - [BREAKING CHANGE] GWT: Updated to 2.11.0. `com.google.jsinterop:jsinterop-annotations:2.0.2:sources` must be added as a dependency to your html project dependencies.

--- a/gdx/res/com/badlogic/gdx/utils/XmlReader.rl
+++ b/gdx/res/com/badlogic/gdx/utils/XmlReader.rl
@@ -294,6 +294,10 @@ public class XmlReader {
 			if (children == null) return 0;
 			return children.size;
 		}
+		
+		public Array<Element> getChildren () {
+        	return children;
+       	}
 
 		/** @throws GdxRuntimeException if the element has no children. */
 		public Element getChild (int index) {
@@ -324,6 +328,13 @@ public class XmlReader {
 
 		public void remove () {
 			parent.removeChild(this);
+		}
+		
+		public void replaceChild (Element child, Element replacement) {
+			if (children == null) throw new GdxRuntimeException("Element has no children: " + name);
+			final int index = children.indexOf(child, true);
+			if (index == -1) throw new GdxRuntimeException("Element does not contain child: " + child);
+			children.set(index, replacement);
 		}
 
 		public Element getParent () {

--- a/gdx/res/com/badlogic/gdx/utils/XmlReader.rl
+++ b/gdx/res/com/badlogic/gdx/utils/XmlReader.rl
@@ -296,8 +296,8 @@ public class XmlReader {
 		}
 		
 		public Array<Element> getChildren () {
-        	return children;
-       	}
+        		return children;
+       		}
 
 		/** @throws GdxRuntimeException if the element has no children. */
 		public Element getChild (int index) {

--- a/gdx/src/com/badlogic/gdx/utils/XmlReader.java
+++ b/gdx/src/com/badlogic/gdx/utils/XmlReader.java
@@ -507,6 +507,10 @@ public class XmlReader {
 			return children.size;
 		}
 
+		public Array<Element> getChildren () {
+			return children;
+		}
+
 		/** @throws GdxRuntimeException if the element has no children. */
 		public Element getChild (int index) {
 			if (children == null) throw new GdxRuntimeException("Element has no children: " + name);
@@ -532,6 +536,14 @@ public class XmlReader {
 
 		public void removeChild (Element child) {
 			if (children != null) children.removeValue(child, true);
+		}
+
+		public void replaceChild (Element child, boolean identity, Element replacement) {
+			if (children == null) throw new GdxRuntimeException("Element has no children: " + name);
+			final int index = children.indexOf(child, identity);
+			if (index == -1) throw new GdxRuntimeException("Element does not contain child: " + child);
+			children.removeIndex(index);
+			children.insert(index, replacement);
 		}
 
 		public void remove () {

--- a/gdx/src/com/badlogic/gdx/utils/XmlReader.java
+++ b/gdx/src/com/badlogic/gdx/utils/XmlReader.java
@@ -538,18 +538,17 @@ public class XmlReader {
 			if (children != null) children.removeValue(child, true);
 		}
 
-		public void replaceChild (Element child, Element replacement) {
-			if (children == null) throw new GdxRuntimeException("Element has no children: " + name);
-			final int index = children.indexOf(child, true);
-			if (index == -1) throw new GdxRuntimeException("Element does not contain child: " + child);
-			children.removeIndex(index);
-			children.insert(index, replacement);
-		}
-
 		public void remove () {
 			parent.removeChild(this);
 		}
 
+		public void replaceChild (Element child, Element replacement) {
+			if (children == null) throw new GdxRuntimeException("Element has no children: " + name);
+			final int index = children.indexOf(child, true);
+			if (index == -1) throw new GdxRuntimeException("Element does not contain child: " + child);
+			children.set(index, replacement);
+		}
+		
 		public Element getParent () {
 			return parent;
 		}

--- a/gdx/src/com/badlogic/gdx/utils/XmlReader.java
+++ b/gdx/src/com/badlogic/gdx/utils/XmlReader.java
@@ -548,7 +548,7 @@ public class XmlReader {
 			if (index == -1) throw new GdxRuntimeException("Element does not contain child: " + child);
 			children.set(index, replacement);
 		}
-		
+
 		public Element getParent () {
 			return parent;
 		}

--- a/gdx/src/com/badlogic/gdx/utils/XmlReader.java
+++ b/gdx/src/com/badlogic/gdx/utils/XmlReader.java
@@ -538,9 +538,9 @@ public class XmlReader {
 			if (children != null) children.removeValue(child, true);
 		}
 
-		public void replaceChild (Element child, boolean identity, Element replacement) {
+		public void replaceChild (Element child, Element replacement) {
 			if (children == null) throw new GdxRuntimeException("Element has no children: " + name);
-			final int index = children.indexOf(child, identity);
+			final int index = children.indexOf(child, true);
 			if (index == -1) throw new GdxRuntimeException("Element does not contain child: " + child);
 			children.removeIndex(index);
 			children.insert(index, replacement);


### PR DESCRIPTION
Until now XmlReader did not offer any possibility to e.g. replace a child or to access the children of an Element directly to perform actions there.
This PR introduces these two methods to manipulate xml files. (In my case I want to adjust my Tiled .tmx and .tsx files in a custom map packer)

- XmlReader.getChildren()
- XmlReader.replaceChild()