### PR TITLE
Hiero font name validation ( #7502 )

### DIFF
--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/hiero/Hiero.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/hiero/Hiero.java
@@ -295,8 +295,8 @@ public class Hiero extends JFrame {
 
 		if (unicodeFont == null) {
 			// Load from java.awt.Font (kerning not available!).
-			unicodeFont = new UnicodeFont(Font.decode((String)fontList.getSelectedValue()), fontSize, boldCheckBox.isSelected(),
-				italicCheckBox.isSelected());
+			unicodeFont = new UnicodeFont(new Font((String)fontList.getSelectedValue(), Font.PLAIN, 12), fontSize,
+				boldCheckBox.isSelected(), italicCheckBox.isSelected());
 		}
 
 		unicodeFont.setMono(monoCheckBox.isSelected());

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/imagepacker/ImagePacker.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/imagepacker/ImagePacker.java
@@ -40,11 +40,11 @@ import javax.imageio.ImageIO;
  * </p>
  * 
  * <p>
- * <b>Usage:</b> instanciate an <code>ImagePacker</code> instance, load and optionally sort the images you want to add by size
+ * <b>Usage:</b> instantiate an <code>ImagePacker</code> instance, load and optionally sort the images you want to add by size
  * (e.g. area) then insert each image via a call to {@link #insertImage(String, BufferedImage)}. When you are done with inserting
  * images you can call {@link #getImage()} for the {@link BufferedImage} that holds the packed images. Additionally you can get a
- * <code>Map<String, Rectangle></code> where the keys the names you specified when inserting and the values are the rectangles
- * within the packed image where that specific image is located. All things are given in pixels.
+ * {@code Map<String, Rectangle>} where the keys the names you specified when inserting and the values are the rectangles within
+ * the packed image where that specific image is located. All things are given in pixels.
  * </p>
  * 
  * <p>


### PR DESCRIPTION
This makes the small change of replacing the arcane `Font.decode()` with the Font constructor, specifying style PLAIN and size 12 (the defaults). The constructor is said to be equivalent in the `decode()` docs, but this way won't create a size-93 font when reading in a Font called `Bauhaus 93`, for instance, because the number won't get interpreted if we avoid decode(). I also fixed a minor JavaDoc error and a spelling mistake in the same general gdx-tools project, since these popped up when building runnables. This will close #7502 . I'm not sure this requires a CHANGES entry because I don't know if we even track gdx-tools in CHANGES.