### PR TITLE
Fix for classpath files on GWT.

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/preloader/PreloaderBundleGenerator.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/preloader/PreloaderBundleGenerator.java
@@ -99,7 +99,7 @@ public class PreloaderBundleGenerator extends Generator {
 				FileWrapper dest = target.child(orig.name());
 				try {
 					InputStream resourceStream = context.getClass().getClassLoader().getResourceAsStream(classpathFile);
-					copy(resourceStream, dest.path(), dest, assetFilter, assets);
+					copy(resourceStream, orig.path(), dest, assetFilter, assets);
 				} catch (IOException e) {
 					e.printStackTrace();
 				}


### PR DESCRIPTION
This solves the problem in at least libGDX tests where the default font, lsans-15, is used by `new BitmapFont()` with no args. It also should fix some 3D code that uses default shaders from classpath files.

It's a one-line change! Four chars, really. I don't know precisely why this works, but it does. It makes sense that filePathOrig should come from orig, not dest, though, and now that is true.