### PR TITLE
Add AndroidX Core dependency to Android backend

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,5 @@
 [1.13.1]
+- [BREAKING CHANGE] Android: Since 1.13.0 libGDX requires setting `android.useAndroidX=true` in your gradle.properties file. In 1.13.1 it is NO longer needed to define the `androidx.core:core` dependency in your Android module.
 - iOS: Update to MobiVM 2.3.22
 - iOS: Fixes Gdx.openURI() not working on iOS 18.1 Simulator.
 - Change visibility of PolygonSpriteBatch.switchTexture() to protected

--- a/backends/gdx-backend-android/build.gradle
+++ b/backends/gdx-backend-android/build.gradle
@@ -25,7 +25,6 @@ apply plugin: 'com.android.library'
 android {
 	namespace "com.badlogic.gdx.backends.android"
 	compileSdkVersion versions.androidCompileSdk
-	buildToolsVersion versions.androidBuildTools
 
 	defaultConfig {
 		minSdkVersion versions.androidMinSdk
@@ -52,5 +51,6 @@ android {
 
 dependencies {
 	implementation project(":gdx")
+	implementation libraries.android
 	compileOnly libraries.compileOnly.android
 }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -36,11 +36,12 @@ versions.jorbis = "0.0.17"
 versions.junit = "4.13.2"
 versions.androidPlugin = "8.1.2"
 versions.multiDex = "2.0.1"
-versions.androidCompileSdk = 33
-versions.androidTargetSdk = 33
+versions.androidCompileSdk = 34
+versions.androidTargetSdk = 34
 versions.androidMinSdk = 19
-versions.androidBuildTools = "33.0.2"
-versions.androidFragment = "1.5.7"
+versions.androidxFragment = "1.5.7"
+versions.androidxCore = "1.13.1"
+versions.kotlinBomTests = "2.0.21"
 versions.javaparser = "2.3.0"
 versions.spotless = "6.7.1"
 
@@ -130,8 +131,12 @@ libraries.robovm = [
         "com.mobidevelop.robovm:robovm-cocoatouch:${versions.robovm}"
 ]
 
+libraries.android = [
+        "androidx.core:core:${versions.androidxCore}",
+]
+
 libraries.compileOnly.android = [
-        "androidx.fragment:fragment:${versions.androidFragment}"
+        "androidx.fragment:fragment:${versions.androidxFragment}"
 ]
 
 libraries.gwt = [

--- a/tests/gdx-tests-android/build.gradle
+++ b/tests/gdx-tests-android/build.gradle
@@ -56,11 +56,12 @@ dependencies {
 	implementation project(":backends:gdx-backend-android")
 	implementation libraries.compileOnly.android
 	implementation "androidx.multidex:multidex:${versions.multiDex}"
+	// Fix Duplicate class kotlin.collections.jdk8.CollectionsJDK8Kt found in modules kotlin-stdlib-X.X.X.jar
+	implementation(platform("org.jetbrains.kotlin:kotlin-bom:${versions.kotlinBomTests}"))
 }
 
 android {
 	namespace "com.badlogic.gdx.tests.android"
-	buildToolsVersion versions.androidBuildTools
 	compileSdkVersion versions.androidCompileSdk
 	sourceSets {
 		main {


### PR DESCRIPTION
https://github.com/libgdx/libgdx/pull/7004 introduced a dependency to `androidx.core` that was not added as a transitive dependency and required users to manually add it to their projects.

The version chosen of AndroidX Core is `1.13.1` which is the latest we can support with out `minSDK` of `19`. This version requires setting `targetSdk` to, at least, `34` which is something we had to do anyway because Google Play requires 34+ target sdk anyway.

The Android Tests module also requires Kotlin BOM dependency to handle a dependency collision that is well documented and should disappear when we upgrade to newer versions in the future.

Finally I've removed the explicit `BuildTools` version as it is automatically set by the AGP.