### PR TITLE
Use docker container action for building Linux natives in natives-linux job to fix issues with Node 20+

### DIFF
--- a/.github/actions/build-linux-natives/Dockerfile
+++ b/.github/actions/build-linux-natives/Dockerfile
@@ -1,0 +1,8 @@
+# Container image that runs your code
+FROM ubuntu:18.04
+
+# Copies your code file from your action repository to the filesystem path `/` of the container
+COPY entrypoint.sh /entrypoint.sh
+
+# Code file to execute when the docker container starts up (`entrypoint.sh`)
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/build-linux-natives/action.yml
+++ b/.github/actions/build-linux-natives/action.yml
@@ -1,0 +1,6 @@
+# action.yml
+name: 'Build Linux Natives in Docker Container'
+description: 'Build Linux Natives in Ubuntu 18.04 docker container'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'

--- a/.github/actions/build-linux-natives/entrypoint.sh
+++ b/.github/actions/build-linux-natives/entrypoint.sh
@@ -1,0 +1,44 @@
+#!/bin/sh -l
+
+# ubuntu dockerfile is very minimal (only 122 packages are installed)
+# need to install updated git (from official git ppa)
+apt-get -q update
+apt-get -yq install software-properties-common
+add-apt-repository ppa:git-core/ppa -y
+# install dependencies expected by other steps
+apt-get -q update
+apt-get -yq install git \
+curl \
+ca-certificates \
+wget \
+bzip2 \
+zip \
+unzip \
+xz-utils \
+sudo gnupg locales
+
+# set Locale to en_US.UTF-8 (avoids hang during compilation)
+locale-gen en_US.UTF-8
+export LANG=en_US.UTF-8
+export LANGUAGE=en_US.UTF-8
+export LC_ALL=en_US.UTF-8
+
+# add zulu apt repository - https://docs.azul.com/core/install/debian
+curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg
+echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" | tee /etc/apt/sources.list.d/zulu.list
+apt-get -q update
+# install zulu JDK and Java build tools
+apt-get -yq install zulu17-jdk-headless maven ant
+
+# Install cross-compilation toolchains
+apt-get -yq --force-yes install gcc g++
+apt-get -yq --force-yes install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libc6-dev-arm64-cross
+apt-get -yq --force-yes install gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf libc6-dev-armhf-cross
+apt-get -yq --force-yes install gcc-riscv64-linux-gnu g++-riscv64-linux-gnu libc6-dev-riscv64-cross
+
+# Build Linux natives
+./gradlew jniGen jnigenBuildLinux64 jnigenBuildLinuxARM jnigenBuildLinuxARM64 jnigenBuildLinuxRISCV64 --no-daemon
+
+# Pack artifacts
+find .  -name "*.a" -o -name "*.dll" -o -name "*.dylib" -o -name "*.so" | grep "libs" > native-files-list
+zip natives-linux -@ < native-files-list

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -8,9 +8,6 @@ on:
   release:
     types: [ published ]
 
-env:
-  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
-
 jobs:
 
   natives-ios:
@@ -92,65 +89,15 @@ jobs:
 
   natives-linux:
     runs-on: ubuntu-20.04
-    container:
-      image: ubuntu:18.04
     steps:
-      - name: Install dependencies into minimal dockerfile
-        run: |
-          # ubuntu dockerfile is very minimal (only 122 packages are installed)
-          # need to install updated git (from official git ppa)
-          apt update
-          apt install -y software-properties-common
-          add-apt-repository ppa:git-core/ppa -y
-          # install dependencies expected by other steps
-          apt update
-          apt install -y git \
-          curl \
-          ca-certificates \
-          wget \
-          bzip2 \
-          zip \
-          unzip \
-          xz-utils \
-          maven \
-          ant sudo locales
-
-          # set Locale to en_US.UTF-8 (avoids hang during compilation)
-          locale-gen en_US.UTF-8
-          echo "LANG=en_US.UTF-8" >> $GITHUB_ENV
-          echo "LANGUAGE=en_US.UTF-8" >> $GITHUB_ENV
-          echo "LC_ALL=en_US.UTF-8" >> $GITHUB_ENV
-
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
           submodules: 'recursive'
 
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'zulu'
-          java-version: '17'
-
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
-
-      - name: Install cross-compilation toolchains
-        run: |
-          sudo apt update
-          sudo apt install -y --force-yes gcc g++
-          sudo apt install -y --force-yes gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libc6-dev-arm64-cross
-          sudo apt install -y --force-yes gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf libc6-dev-armhf-cross
-          sudo apt install -y --force-yes gcc-riscv64-linux-gnu g++-riscv64-linux-gnu libc6-dev-riscv64-cross
-
-      - name: Build Linux natives
-        run: |
-          ./gradlew jniGen jnigenBuildLinux64 jnigenBuildLinuxARM jnigenBuildLinuxARM64 jnigenBuildLinuxRISCV64
-
-      - name: Pack artifacts
-        run: |
-          find .  -name "*.a" -o -name "*.dll" -o -name "*.dylib" -o -name "*.so" | grep "libs" > native-files-list
-          zip natives-linux -@ < native-files-list
+      - name: Build Linux Natives in Docker Container
+        uses: ./.github/actions/build-linux-natives
+        id: docker
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
Similar to https://github.com/libgdx/Jamepad/pull/34, this uses a dockerfile and script to build the linux natives in a Ubuntu 18.04 docker container instead of running the entire natives-linux job in the container. This prevents needing to run actions like checkout and upload-artifact in the container, meaning it can still use glibc 2.17 to build without any issues with Node. Hopefully this means it can continue to work with newer versions of checkout and upload-artifact for the forseeable future. I haven't updated those action versions in this PR, but they can be updated without any issues.

I've done this by moving the docker setup (that was introduced in #7178) into its own action (which is local to the repo) that runs a script in the container that builds the natives. How it works is that when the workflow uses this action and enters the docker container, the working directory is mounted and mapped from the runner onto the container. So the runner does all the GitHub actions to clone/setup the repo and then enters the container to build and pack the natives. After the container exits the changes persist on the runner and the runner uploads the artifacts.

See https://docs.github.com/en/actions/sharing-automations/creating-actions/creating-a-docker-container-action for more info on docker container actions.

Tested working here: https://github.com/SonicGDX/libgdx/actions/runs/12339676708

Other minor changes:

- Used `apt-get` instead of `apt` because using `apt` in a script gives the warning message "apt does not have a stable CLI interface".
- Removed usages of `sudo` just to be consistent (I can't always use sudo because initially sudo isn't installed)
- Added `--no-daemon` to gradle command because only one gradle command is being run so the daemon isn't necessary.
- Added `--quiet` to apt-get usages to cut down unuseful lines in logs
- Moved around arguments to `apt-get` so they're always at the front
- removed setup-java and gradle-build-action usages in the natives-linux step because zulu installation is done in the container and gradle is downloaded when the wrapper is run. This of course has the downside that the gradle action cache can't be used, but running the gradle-build-action in the runner doesn't seem to work due to lock file issues.
- `gnupg` gets installed anyway as a dependency but I added it explicitly because it is needed for dearmoring the azul key

Having the action be in a separate actions folder may not be desirable, in which case I can probably move the action into the workflow folder somewhere but I'm not sure where.

Closes #7477 