### PR TITLE
Downgrade LWJGL 3 to 3.3.3

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@
 - Change visibility of PolygonSpriteBatch.switchTexture() to protected
 - Added XmlReader.getChildren() and XmlReader.replaceChild()
 - LWJGL3: Fix pauseWhenLostFocus not working as expected
+- LWJGL 3: Downgrade to 3.3.3 due to AV false positives on 3.3.4 and OpenAL log spamming issue on 3.3.5.
 - API Addition: Added FPSLogger#setBound
 - Android: Fix crash on startup if `setContentView` was manually called after `initializeForView`
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -30,7 +30,7 @@ versions.jsinteropAnnotations = "2.0.2"
 versions.gretty = "3.1.0"
 versions.jglwf = "1.1"
 versions.lwjgl = "2.9.3"
-versions.lwjgl3 = "3.3.4"
+versions.lwjgl3 = "3.3.3"
 versions.jlayer = "1.0.1-gdx"
 versions.jorbis = "0.0.17"
 versions.junit = "4.13.2"
@@ -58,7 +58,7 @@ libraries.lwjgl3 = [
         "org.lwjgl:lwjgl:${versions.lwjgl3}:natives-linux",
         "org.lwjgl:lwjgl:${versions.lwjgl3}:natives-linux-arm32",
         "org.lwjgl:lwjgl:${versions.lwjgl3}:natives-linux-arm64",
-        "org.lwjgl:lwjgl:${versions.lwjgl3}:natives-linux-riscv64",
+//        "org.lwjgl:lwjgl:${versions.lwjgl3}:natives-linux-riscv64",
         "org.lwjgl:lwjgl:${versions.lwjgl3}:natives-macos",
         "org.lwjgl:lwjgl:${versions.lwjgl3}:natives-macos-arm64",
         "org.lwjgl:lwjgl:${versions.lwjgl3}:natives-windows",
@@ -67,7 +67,7 @@ libraries.lwjgl3 = [
         "org.lwjgl:lwjgl-glfw:${versions.lwjgl3}:natives-linux",
         "org.lwjgl:lwjgl-glfw:${versions.lwjgl3}:natives-linux-arm32",
         "org.lwjgl:lwjgl-glfw:${versions.lwjgl3}:natives-linux-arm64",
-        "org.lwjgl:lwjgl-glfw:${versions.lwjgl3}:natives-linux-riscv64",
+//        "org.lwjgl:lwjgl-glfw:${versions.lwjgl3}:natives-linux-riscv64",
         "org.lwjgl:lwjgl-glfw:${versions.lwjgl3}:natives-macos",
         "org.lwjgl:lwjgl-glfw:${versions.lwjgl3}:natives-macos-arm64",
         "org.lwjgl:lwjgl-glfw:${versions.lwjgl3}:natives-windows",
@@ -76,7 +76,7 @@ libraries.lwjgl3 = [
         "org.lwjgl:lwjgl-jemalloc:${versions.lwjgl3}:natives-linux",
         "org.lwjgl:lwjgl-jemalloc:${versions.lwjgl3}:natives-linux-arm32",
         "org.lwjgl:lwjgl-jemalloc:${versions.lwjgl3}:natives-linux-arm64",
-        "org.lwjgl:lwjgl-jemalloc:${versions.lwjgl3}:natives-linux-riscv64",
+//        "org.lwjgl:lwjgl-jemalloc:${versions.lwjgl3}:natives-linux-riscv64",
         "org.lwjgl:lwjgl-jemalloc:${versions.lwjgl3}:natives-macos",
         "org.lwjgl:lwjgl-jemalloc:${versions.lwjgl3}:natives-macos-arm64",
         "org.lwjgl:lwjgl-jemalloc:${versions.lwjgl3}:natives-windows",
@@ -85,7 +85,7 @@ libraries.lwjgl3 = [
         "org.lwjgl:lwjgl-openal:${versions.lwjgl3}:natives-linux",
         "org.lwjgl:lwjgl-openal:${versions.lwjgl3}:natives-linux-arm32",
         "org.lwjgl:lwjgl-openal:${versions.lwjgl3}:natives-linux-arm64",
-        "org.lwjgl:lwjgl-openal:${versions.lwjgl3}:natives-linux-riscv64",
+//        "org.lwjgl:lwjgl-openal:${versions.lwjgl3}:natives-linux-riscv64",
         "org.lwjgl:lwjgl-openal:${versions.lwjgl3}:natives-macos",
         "org.lwjgl:lwjgl-openal:${versions.lwjgl3}:natives-macos-arm64",
         "org.lwjgl:lwjgl-openal:${versions.lwjgl3}:natives-windows",
@@ -94,7 +94,7 @@ libraries.lwjgl3 = [
         "org.lwjgl:lwjgl-opengl:${versions.lwjgl3}:natives-linux",
         "org.lwjgl:lwjgl-opengl:${versions.lwjgl3}:natives-linux-arm32",
         "org.lwjgl:lwjgl-opengl:${versions.lwjgl3}:natives-linux-arm64",
-        "org.lwjgl:lwjgl-opengl:${versions.lwjgl3}:natives-linux-riscv64",
+//        "org.lwjgl:lwjgl-opengl:${versions.lwjgl3}:natives-linux-riscv64",
         "org.lwjgl:lwjgl-opengl:${versions.lwjgl3}:natives-macos",
         "org.lwjgl:lwjgl-opengl:${versions.lwjgl3}:natives-macos-arm64",
         "org.lwjgl:lwjgl-opengl:${versions.lwjgl3}:natives-windows",
@@ -103,7 +103,7 @@ libraries.lwjgl3 = [
         "org.lwjgl:lwjgl-stb:${versions.lwjgl3}:natives-linux",
         "org.lwjgl:lwjgl-stb:${versions.lwjgl3}:natives-linux-arm32",
         "org.lwjgl:lwjgl-stb:${versions.lwjgl3}:natives-linux-arm64",
-        "org.lwjgl:lwjgl-stb:${versions.lwjgl3}:natives-linux-riscv64",
+//        "org.lwjgl:lwjgl-stb:${versions.lwjgl3}:natives-linux-riscv64",
         "org.lwjgl:lwjgl-stb:${versions.lwjgl3}:natives-macos",
         "org.lwjgl:lwjgl-stb:${versions.lwjgl3}:natives-macos-arm64",
         "org.lwjgl:lwjgl-stb:${versions.lwjgl3}:natives-windows",
@@ -117,7 +117,7 @@ libraries.lwjgl3GLES = [
         "org.lwjgl:lwjgl-opengles:${versions.lwjgl3}:natives-linux",
         "org.lwjgl:lwjgl-opengles:${versions.lwjgl3}:natives-linux-arm32",
         "org.lwjgl:lwjgl-opengles:${versions.lwjgl3}:natives-linux-arm64",
-        "org.lwjgl:lwjgl-opengles:${versions.lwjgl3}:natives-linux-riscv64",
+//        "org.lwjgl:lwjgl-opengles:${versions.lwjgl3}:natives-linux-riscv64",
         "org.lwjgl:lwjgl-opengles:${versions.lwjgl3}:natives-macos",
         "org.lwjgl:lwjgl-opengles:${versions.lwjgl3}:natives-macos-arm64",
         "org.lwjgl:lwjgl-opengles:${versions.lwjgl3}:natives-windows",


### PR DESCRIPTION
Given the AV false positives of 3.3.4 (https://github.com/libgdx/libgdx/issues/7552) and some on 3.3.5 and the log spamming issue occurring on 3.3.5 (https://github.com/kcat/openal-soft/issues/1086) that won't be fixed until 3.3.6 best approach is to downgrade to stable 3.3.3 for libGDX 1.13.1 release until these problems are fixed.

RISC-V natives won't be shipped with libGDX, if there's any RISC-V user they can upgrade lwjgl and add the dependencies on their end.