### PR TITLE
Replace uses of expand&fill with grow

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Dialog.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Dialog.java
@@ -76,7 +76,7 @@ public class Dialog extends Window {
 		setModal(true);
 
 		defaults().space(6);
-		add(contentTable = new Table(skin)).expand().fill();
+		add(contentTable = new Table(skin)).grow();
 		row();
 		add(buttonTable = new Table(skin)).fillX();
 

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextButton.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextButton.java
@@ -45,7 +45,7 @@ public class TextButton extends Button {
 		setStyle(style);
 		label = newLabel(text, new LabelStyle(style.font, style.fontColor));
 		label.setAlignment(Align.center);
-		add(label).expand().fill();
+		add(label).grow();
 		setSize(getPrefWidth(), getPrefHeight());
 	}
 

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Window.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Window.java
@@ -76,7 +76,7 @@ public class Window extends Table {
 				if (drawTitleTable) super.draw(batch, parentAlpha);
 			}
 		};
-		titleTable.add(titleLabel)..growX().minWidth(0);
+		titleTable.add(titleLabel).growX().minWidth(0);
 		addActor(titleTable);
 
 		setStyle(style);

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Window.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Window.java
@@ -76,7 +76,7 @@ public class Window extends Table {
 				if (drawTitleTable) super.draw(batch, parentAlpha);
 			}
 		};
-		titleTable.add(titleLabel).expandX().fillX().minWidth(0);
+		titleTable.add(titleLabel)..growX().minWidth(0);
 		addActor(titleTable);
 
 		setStyle(style);

--- a/tests/gdx-tests-lwjgl3/src/com/badlogic/gdx/tests/lwjgl3/Lwjgl3TestStarter.java
+++ b/tests/gdx-tests-lwjgl3/src/com/badlogic/gdx/tests/lwjgl3/Lwjgl3TestStarter.java
@@ -151,7 +151,7 @@ public class Lwjgl3TestStarter {
 				});
 			}
 
-			container.add(scroll).expand().fill();
+			container.add(scroll).grow();
 			container.row();
 
 			lastClickedTestButton = (TextButton)table.findActor(prefs.getString("LastTest"));

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/AbstractTestWrapper.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/AbstractTestWrapper.java
@@ -85,7 +85,7 @@ public abstract class AbstractTestWrapper extends GdxTest {
 					test.resize(Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
 				}
 			});
-			table.add(button)..growX();
+			table.add(button).growX();
 		}
 		container.row();
 		container.add(new Label("Click on a test to start it, press ESC or tap the upper left corner to close it.",

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/AbstractTestWrapper.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/AbstractTestWrapper.java
@@ -63,7 +63,7 @@ public abstract class AbstractTestWrapper extends GdxTest {
 		container.debug();
 		Table table = new Table();
 		ScrollPane scroll = new ScrollPane(table);
-		container.add(scroll).expand().fill();
+		container.add(scroll).grow();
 		container.setFillParent(true);
 		table.pad(10).defaults().expandX().space(4);
 		Arrays.sort(tests, new Comparator<Instancer>() {
@@ -85,7 +85,7 @@ public abstract class AbstractTestWrapper extends GdxTest {
 					test.resize(Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
 				}
 			});
-			table.add(button).expandX().fillX();
+			table.add(button)..growX();
 		}
 		container.row();
 		container.add(new Label("Click on a test to start it, press ESC or tap the upper left corner to close it.",

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ContainerTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ContainerTest.java
@@ -71,7 +71,7 @@ public class ContainerTest extends GdxTest {
 
 	Table label (String text) {
 		Table table = new Table().debug();
-		table.add(new Label(text, skin)).fill().expand();
+		table.add(new Label(text, skin))..grow();
 		return table;
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ContainerTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ContainerTest.java
@@ -71,7 +71,7 @@ public class ContainerTest extends GdxTest {
 
 	Table label (String text) {
 		Table table = new Table().debug();
-		table.add(new Label(text, skin))..grow();
+		table.add(new Label(text, skin)).grow();
 		return table;
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/GroupCullingTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/GroupCullingTest.java
@@ -46,7 +46,7 @@ public class GroupCullingTest extends GdxTest {
 		skin = new Skin(Gdx.files.internal("data/uiskin.json"));
 
 		Table labels = new Table();
-		root.add(new ScrollPane(labels, skin)).expand().fill();
+		root.add(new ScrollPane(labels, skin)).grow();
 		root.row();
 		root.add(drawnLabel = new Label("", skin));
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ScrollPaneScrollBarsTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ScrollPaneScrollBarsTest.java
@@ -181,7 +181,7 @@ public class ScrollPaneScrollBarsTest extends GdxTest {
 		Table[] tables = new Table[] {bottomLeftTable, bottomRightTable, topLeftTable, topRightTable, horizOnlyTopTable,
 			horizOnlyBottomTable, vertOnlyLeftTable, vertOnlyRightTable};
 		for (Table t : tables)
-			t.defaults().expandX().fillX();
+			t.defaults()..growX();
 
 		horizOnlyTopTable
 			.add(new Label("HORIZONTAL-ONLY-TOP verify HORIZONTAL scroll bar is on the TOP and properly aligned", skin)).row();
@@ -219,14 +219,14 @@ public class ScrollPaneScrollBarsTest extends GdxTest {
 			vertOnlyRightTable.add(new Image(skin.getDrawable("default-rect"))).height(20).row();
 		}
 
-		bottomLeft.add(bottomLeftScroll).expand().fill().colspan(4);
-		bottomRight.add(bottomRightScroll).expand().fill().colspan(4);
-		topLeft.add(topLeftScroll).expand().fill().colspan(4);
-		topRight.add(topRightScroll).expand().fill().colspan(4);
-		horizOnlyTop.add(horizOnlyTopScroll).expand().fill().colspan(4);
-		horizOnlyBottom.add(horizOnlyBottomScroll).expand().fill().colspan(4);
-		vertOnlyLeft.add(vertOnlyLeftScroll).expand().fill().colspan(4);
-		vertOnlyRight.add(vertOnlyRightScroll).expand().fill().colspan(4);
+		bottomLeft.add(bottomLeftScroll).grow().colspan(4);
+		bottomRight.add(bottomRightScroll).grow().colspan(4);
+		topLeft.add(topLeftScroll).grow().colspan(4);
+		topRight.add(topRightScroll).grow().colspan(4);
+		horizOnlyTop.add(horizOnlyTopScroll).grow().colspan(4);
+		horizOnlyBottom.add(horizOnlyBottomScroll).grow().colspan(4);
+		vertOnlyLeft.add(vertOnlyLeftScroll).grow().colspan(4);
+		vertOnlyRight.add(vertOnlyRightScroll).grow().colspan(4);
 
 		for (ScrollPane pane : scrollPanes) {
 			pane.setFadeScrollBars(doFade);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ScrollPaneScrollBarsTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ScrollPaneScrollBarsTest.java
@@ -181,7 +181,7 @@ public class ScrollPaneScrollBarsTest extends GdxTest {
 		Table[] tables = new Table[] {bottomLeftTable, bottomRightTable, topLeftTable, topRightTable, horizOnlyTopTable,
 			horizOnlyBottomTable, vertOnlyLeftTable, vertOnlyRightTable};
 		for (Table t : tables)
-			t.defaults()..growX();
+			t.defaults().growX();
 
 		horizOnlyTopTable
 			.add(new Label("HORIZONTAL-ONLY-TOP verify HORIZONTAL scroll bar is on the TOP and properly aligned", skin)).row();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ScrollPaneTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ScrollPaneTest.java
@@ -63,7 +63,7 @@ public class ScrollPaneTest extends GdxTest {
 		table.pad(10).defaults().expandX().space(4);
 		for (int i = 0; i < 100; i++) {
 			table.row();
-			table.add(new Label(i + "uno", skin))..growX();
+			table.add(new Label(i + "uno", skin)).growX();
 
 			TextButton button = new TextButton(i + "dos", skin);
 			table.add(button);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ScrollPaneTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ScrollPaneTest.java
@@ -63,7 +63,7 @@ public class ScrollPaneTest extends GdxTest {
 		table.pad(10).defaults().expandX().space(4);
 		for (int i = 0; i < 100; i++) {
 			table.row();
-			table.add(new Label(i + "uno", skin)).expandX().fillX();
+			table.add(new Label(i + "uno", skin))..growX();
 
 			TextButton button = new TextButton(i + "dos", skin);
 			table.add(button);
@@ -111,7 +111,7 @@ public class ScrollPaneTest extends GdxTest {
 			}
 		});
 
-		container.add(scroll).expand().fill().colspan(4);
+		container.add(scroll).grow().colspan(4);
 		container.row().space(10).padBottom(10);
 		container.add(flickButton).right().expandX();
 		container.add(onTopButton);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ScrollPaneTextAreaTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ScrollPaneTextAreaTest.java
@@ -27,7 +27,7 @@ public class ScrollPaneTextAreaTest extends GdxTest {
 		stage.addActor(container);
 
 		container.setFillParent(true);
-		container.pad(10).defaults()..growX().space(4);
+		container.pad(10).defaults().growX().space(4);
 
 		textArea = new TextArea(">>> FIRST LINE <<<\n" + "Scrolling to the bottom of the area you should see the last line.\n"
 			+ "Lorem ipsum dolor sit amet, consectetur adipiscing elit.\n"

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ScrollPaneTextAreaTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ScrollPaneTextAreaTest.java
@@ -27,7 +27,7 @@ public class ScrollPaneTextAreaTest extends GdxTest {
 		stage.addActor(container);
 
 		container.setFillParent(true);
-		container.pad(10).defaults().expandX().fillX().space(4);
+		container.pad(10).defaults()..growX().space(4);
 
 		textArea = new TextArea(">>> FIRST LINE <<<\n" + "Scrolling to the bottom of the area you should see the last line.\n"
 			+ "Lorem ipsum dolor sit amet, consectetur adipiscing elit.\n"

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TreeTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TreeTest.java
@@ -95,7 +95,7 @@ public class TreeTest extends GdxTest {
 			}
 		});
 
-		table.add(tree)..grow();
+		table.add(tree).grow();
 	}
 
 	public void render () {

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TreeTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TreeTest.java
@@ -95,7 +95,7 @@ public class TreeTest extends GdxTest {
 			}
 		});
 
-		table.add(tree).fill().expand();
+		table.add(tree)..grow();
 	}
 
 	public void render () {

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/UITest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/UITest.java
@@ -163,12 +163,12 @@ public class UITest extends GdxTest {
 		window.add(slider).minWidth(100).fillX().colspan(3);
 		window.row();
 		window.add(selectBox).maxWidth(100);
-		window.add(textfield).minWidth(100).expandX().fillX().colspan(3);
+		window.add(textfield).minWidth(100)..growX().colspan(3);
 		window.row();
-		window.add(splitPane).fill().expand().colspan(4).maxHeight(200);
+		window.add(splitPane)..grow().colspan(4).maxHeight(200);
 		window.row();
 		window.add(passwordLabel).colspan(2);
-		window.add(passwordTextField).minWidth(100).expandX().fillX().colspan(2);
+		window.add(passwordTextField).minWidth(100)..growX().colspan(2);
 		window.row();
 		window.add(fpsLabel).colspan(4);
 		window.pack();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/UITest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/UITest.java
@@ -165,7 +165,7 @@ public class UITest extends GdxTest {
 		window.add(selectBox).maxWidth(100);
 		window.add(textfield).minWidth(100).growX().colspan(3);
 		window.row();
-		window.add(splitPane)..grow().colspan(4).maxHeight(200);
+		window.add(splitPane).grow().colspan(4).maxHeight(200);
 		window.row();
 		window.add(passwordLabel).colspan(2);
 		window.add(passwordTextField).minWidth(100).growX().colspan(2);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/UITest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/UITest.java
@@ -163,12 +163,12 @@ public class UITest extends GdxTest {
 		window.add(slider).minWidth(100).fillX().colspan(3);
 		window.row();
 		window.add(selectBox).maxWidth(100);
-		window.add(textfield).minWidth(100)..growX().colspan(3);
+		window.add(textfield).minWidth(100).growX().colspan(3);
 		window.row();
 		window.add(splitPane)..grow().colspan(4).maxHeight(200);
 		window.row();
 		window.add(passwordLabel).colspan(2);
-		window.add(passwordTextField).minWidth(100)..growX().colspan(2);
+		window.add(passwordTextField).minWidth(100).growX().colspan(2);
 		window.row();
 		window.add(fpsLabel).colspan(4);
 		window.pack();


### PR DESCRIPTION
Replaces all uses of `.expand().fill()` and variations by the appropriate `.grow()`, which is the preferred shorthand.