### PR TITLE
Added FT_Set_Transform/Get_Transform and FT_Glyph_Transform

### DIFF
--- a/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeType.java
+++ b/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeType.java
@@ -26,6 +26,7 @@ import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.Pixmap.Blending;
 import com.badlogic.gdx.graphics.Pixmap.Format;
+import com.badlogic.gdx.math.Affine2;
 import com.badlogic.gdx.utils.BufferUtils;
 import com.badlogic.gdx.utils.Disposable;
 import com.badlogic.gdx.utils.GdxRuntimeException;
@@ -341,6 +342,58 @@ public class FreeType {
 			return FT_Get_Char_Index((FT_Face)face, charCode);
 		*/
 
+		public void setTransform(Affine2 affine) {
+			setTransform(address, affine.m00, affine.m01, affine.m10, affine.m11, affine.m02, affine.m12);
+		}
+
+		private static native void setTransform(long face, float xx, float xy, float yx, float yy, float deltaX, float deltaY); /*
+			FT_Matrix ftMatrix = { 0 };
+
+			ftMatrix.xx = (FT_Fixed)(xx * 0x10000L);
+			ftMatrix.xy = (FT_Fixed)(xy * 0x10000L);
+			ftMatrix.yx = (FT_Fixed)(yx * 0x10000L);
+			ftMatrix.yy = (FT_Fixed)(yy * 0x10000L);
+
+			FT_Vector ftDelta = { 0 };
+			ftDelta.x = (FT_Pos)(deltaX * 64.0);
+			ftDelta.y = (FT_Pos)(deltaY * 64.0);
+			FT_Set_Transform((FT_Face)face, &ftMatrix, &ftDelta);
+		*/
+
+		public Affine2 getTransform(Affine2 transform) {
+			float[] v = getTransform(address);
+
+			transform.m00 = v[0];
+			transform.m01 = v[1];
+			transform.m10 = v[2];
+			transform.m11 = v[3];
+
+			transform.m02 = v[4];
+			transform.m12 = v[5];
+			return transform;
+		}
+
+		private static native float[] getTransform(long face); /*
+			FT_Face ftFace = (FT_Face)face;
+			FT_Matrix ftMatrix;
+			FT_Vector ftDelta;
+
+			FT_Get_Transform(ftFace, &ftMatrix, &ftDelta);
+
+			jfloatArray transformValues = env->NewFloatArray(6);
+			jfloat *values = env->GetFloatArrayElements(transformValues, NULL);
+
+			values[0] = (float)(ftMatrix.xx / 0x10000L);
+			values[1] = (float)(ftMatrix.xy / 0x10000L);
+			values[2] = (float)(ftMatrix.yx / 0x10000L);
+			values[3] = (float)(ftMatrix.yy / 0x10000L);
+			values[4] = (float)(ftDelta.x / 64.0);
+			values[5] = (float)(ftDelta.y / 64.0);
+
+			env->ReleaseFloatArrayElements(transformValues, values, 0);
+			return transformValues;
+		*/
+
 	}
 	
 	public static class Size extends Pointer {
@@ -607,6 +660,24 @@ public class FreeType {
 		private static native int getTop(long glyph); /*
 			FT_BitmapGlyph glyph_bitmap = ((FT_BitmapGlyph)glyph);
 			return glyph_bitmap->top;
+		*/
+
+		public void transform(Affine2 affine) {
+			transform(address, affine.m00, affine.m01, affine.m10, affine.m11, affine.m02, affine.m12);
+		}
+
+		private static native void transform(long glyph, float xx, float xy, float yx, float yy, float deltaX, float deltaY); /*
+			FT_Matrix ftMatrix = { 0 };
+
+			ftMatrix.xx = (FT_Fixed)(xx * 0x10000L);
+			ftMatrix.xy = (FT_Fixed)(xy * 0x10000L);
+			ftMatrix.yx = (FT_Fixed)(yx * 0x10000L);
+			ftMatrix.yy = (FT_Fixed)(yy * 0x10000L);
+
+			FT_Vector ftDelta = { 0 };
+			ftDelta.x = (FT_Pos)(deltaX * 64.0);
+			ftDelta.y = (FT_Pos)(deltaY * 64.0);
+			FT_Glyph_Transform((FT_Glyph)glyph, &ftMatrix, &ftDelta);
 		*/
 
 	}

--- a/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGenerator.java
+++ b/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGenerator.java
@@ -43,6 +43,7 @@ import com.badlogic.gdx.graphics.g2d.freetype.FreeType.GlyphSlot;
 import com.badlogic.gdx.graphics.g2d.freetype.FreeType.Library;
 import com.badlogic.gdx.graphics.g2d.freetype.FreeType.SizeMetrics;
 import com.badlogic.gdx.graphics.g2d.freetype.FreeType.Stroker;
+import com.badlogic.gdx.math.Affine2;
 import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.Disposable;
@@ -302,7 +303,7 @@ public class FreeTypeFontGenerator implements Disposable {
 		data.flipped = parameter.flip;
 		data.ascent = FreeType.toInt(fontMetrics.getAscender());
 		data.descent = FreeType.toInt(fontMetrics.getDescender());
-		data.lineHeight = FreeType.toInt(fontMetrics.getHeight());
+		data.lineHeight = (int)(FreeType.toInt(fontMetrics.getHeight()) * parameter.transform.m11);
 		float baseLine = data.ascent;
 
 		// if bitmapped
@@ -489,6 +490,9 @@ public class FreeTypeFontGenerator implements Disposable {
 
 		GlyphSlot slot = face.getGlyph();
 		FreeType.Glyph mainGlyph = slot.getGlyph();
+		if (parameter.transform != null) {
+			face.setTransform(parameter.transform);
+		}
 		try {
 			mainGlyph.toBitmap(parameter.mono ? FreeType.FT_RENDER_MODE_MONO : FreeType.FT_RENDER_MODE_NORMAL);
 		} catch (GdxRuntimeException e) {
@@ -586,7 +590,8 @@ public class FreeTypeFontGenerator implements Disposable {
 			glyph.yoffset = -mainGlyph.getTop() + (int)baseLine;
 		else
 			glyph.yoffset = -(glyph.height - mainGlyph.getTop()) - (int)baseLine;
-		glyph.xadvance = FreeType.toInt(metrics.getHoriAdvance()) + (int)parameter.borderWidth + parameter.spaceX;
+		glyph.xadvance = (int)(FreeType.toInt(metrics.getHoriAdvance()) * parameter.transform.m00) + (int)parameter.borderWidth
+			+ parameter.spaceX;
 
 		if (bitmapped) {
 			mainPixmap.setColor(Color.CLEAR);
@@ -801,5 +806,7 @@ public class FreeTypeFontGenerator implements Disposable {
 		 * modified after creating a font. If a PixmapPacker is not specified, the font glyph page textures will use
 		 * {@link FreeTypeFontGenerator#getMaxTextureSize()}. */
 		public boolean incremental;
+		/** Glyph transformation */
+		public Affine2 transform = new Affine2();
 	}
 }


### PR DESCRIPTION
This pull request adds `FT_Set_Transform`, `FT_Get_Transform`, and `FT_Glyph_Transform` to the FreeType class and adds an Affine transformation in `FreeTypeFontParameter` that can be used for transformations like font stretch and slant:

```java
FreeTypeFontGenerator.FreeTypeFontParameter fontParameter = new FreeTypeFontGenerator.FreeTypeFontParameter();
[...]
fontParameter.transform.shear(MathUtils.tan(slantAngle),0);
fontParameter.transform.scale(1.5,1); // 150% stretch 
```

![image](https://github.com/user-attachments/assets/99ac7d18-cedd-4d33-a1f2-7fa9518c0669)