### PR TITLE
Add x,y documentation to Shape2D Circle and Ellipse

### DIFF
--- a/gdx/src/com/badlogic/gdx/math/Circle.java
+++ b/gdx/src/com/badlogic/gdx/math/Circle.java
@@ -30,8 +30,8 @@ public class Circle implements Serializable, Shape2D {
 
 	/** Constructs a new circle with the given X and Y coordinates and the given radius.
 	 * 
-	 * @param x X coordinate
-	 * @param y Y coordinate
+	 * @param x X coordinate of the center of the circle
+	 * @param y Y coordinate of the center of the circle
 	 * @param radius The radius of the circle */
 	public Circle (float x, float y, float radius) {
 		this.x = x;
@@ -41,7 +41,7 @@ public class Circle implements Serializable, Shape2D {
 
 	/** Constructs a new circle using a given {@link Vector2} that contains the desired X and Y coordinates, and a given radius.
 	 * 
-	 * @param position The position {@link Vector2}.
+	 * @param position The position {@link Vector2} of the center of the circle
 	 * @param radius The radius */
 	public Circle (Vector2 position, float radius) {
 		this.x = position.x;
@@ -70,8 +70,8 @@ public class Circle implements Serializable, Shape2D {
 
 	/** Sets a new location and radius for this circle.
 	 * 
-	 * @param x X coordinate
-	 * @param y Y coordinate
+	 * @param x X coordinate of the center of the circle
+	 * @param y Y coordinate of the center of the circle
 	 * @param radius Circle radius */
 	public void set (float x, float y, float radius) {
 		this.x = x;

--- a/gdx/src/com/badlogic/gdx/math/Ellipse.java
+++ b/gdx/src/com/badlogic/gdx/math/Ellipse.java
@@ -46,8 +46,8 @@ public class Ellipse implements Serializable, Shape2D {
 
 	/** Constructs a new ellipse
 	 * 
-	 * @param x X coordinate
-	 * @param y Y coordinate
+	 * @param x X coordinate of the center of the ellipse
+	 * @param y Y coordinate of the center of the ellipse
 	 * @param width the width of the ellipse
 	 * @param height the height of the ellipse */
 	public Ellipse (float x, float y, float width, float height) {
@@ -59,7 +59,7 @@ public class Ellipse implements Serializable, Shape2D {
 
 	/** Constructs a new ellipse
 	 * 
-	 * @param position Position vector
+	 * @param position Position vector of the center of the ellipse
 	 * @param width the width of the ellipse
 	 * @param height the height of the ellipse */
 	public Ellipse (Vector2 position, float width, float height) {
@@ -71,7 +71,7 @@ public class Ellipse implements Serializable, Shape2D {
 
 	/** Constructs a new ellipse
 	 * 
-	 * @param position Position vector
+	 * @param position Position vector of the center of the ellipse
 	 * @param size Size vector */
 	public Ellipse (Vector2 position, Vector2 size) {
 		this.x = position.x;
@@ -114,8 +114,8 @@ public class Ellipse implements Serializable, Shape2D {
 
 	/** Sets a new position and size for this ellipse.
 	 * 
-	 * @param x X coordinate
-	 * @param y Y coordinate
+	 * @param x X coordinate of the center of the ellipse
+	 * @param y Y coordinate of the center of the ellipse
 	 * @param width the width of the ellipse
 	 * @param height the height of the ellipse */
 	public void set (float x, float y, float width, float height) {
@@ -150,7 +150,7 @@ public class Ellipse implements Serializable, Shape2D {
 	}
 
 	/** Sets the x and y-coordinates of ellipse center from a {@link Vector2}.
-	 * @param position The position vector
+	 * @param position The position vector of the center of the ellipse
 	 * @return this ellipse for chaining */
 	public Ellipse setPosition (Vector2 position) {
 		this.x = position.x;
@@ -160,8 +160,8 @@ public class Ellipse implements Serializable, Shape2D {
 	}
 
 	/** Sets the x and y-coordinates of ellipse center
-	 * @param x The x-coordinate
-	 * @param y The y-coordinate
+	 * @param x The x-coordinate of the center of the ellipse
+	 * @param y The y-coordinate of the center of the ellipse
 	 * @return this ellipse for chaining */
 	public Ellipse setPosition (float x, float y) {
 		this.x = x;


### PR DESCRIPTION
The Javadocs for Circle and Ellipse did not clearly state what the (x,y) for both referred to - is it the top-left point or the center of the object? - and this PR updates the documentation to state that yes, the (x,y) for both refers to the center of the object