### PR TITLE
Add option to use Box2D native ContactFilter for performance optimization

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,7 @@
 [1.14.0]
 - [BREAKING CHANGE] Android: Updated minSDK to 21. Multidex config is no longer required, please check https://developer.android.com/build/multidex.
+- [BREAKING CHANGE] Android: Proguard config line `boolean getUseDefaultContactFilter();` needs to be added. See https://github.com/libgdx/libgdx/pull/7578.
+- API Addition: Allow option to set Box2D native ContactFilter (World#setContactFilter(null)) for performance improvements.
 - API Addition: Added BooleanArray#replaceFirst and BooleanArray#replaceAll
 - API Addition: Added ByteArray#replaceFirst and ByteArray#replaceAll
 - API Addition: Added CharArray#replaceFirst and CharArray#replaceAll

--- a/extensions/gdx-box2d/gdx-box2d/src/com/badlogic/gdx/physics/box2d/World.java
+++ b/extensions/gdx-box2d/gdx-box2d/src/com/badlogic/gdx/physics/box2d/World.java
@@ -99,7 +99,8 @@ public:
 	{
 		this->env = env;
 		this->obj = obj;
-		useDefaultContactFilter = env->CallBooleanMethod( obj, useDefaultContactFilterID );
+		if( useDefaultContactFilterID != 0 )
+			useDefaultContactFilter = env->CallBooleanMethod( obj, useDefaultContactFilterID );
 	}
 
 	virtual bool ShouldCollide(b2Fixture* fixtureA, b2Fixture* fixtureB)

--- a/extensions/gdx-box2d/gdx-box2d/src/com/badlogic/gdx/physics/box2d/World.java
+++ b/extensions/gdx-box2d/gdx-box2d/src/com/badlogic/gdx/physics/box2d/World.java
@@ -59,6 +59,7 @@ public final class World implements Disposable {
 
 static jclass worldClass = 0;
 static jmethodID shouldCollideID = 0;
+static jmethodID useDefaultContactFilterID = 0;
 static jmethodID beginContactID = 0;
 static jmethodID endContactID = 0;
 static jmethodID preSolveID = 0;
@@ -91,17 +92,21 @@ class CustomContactFilter: public b2ContactFilter
 private:
 	JNIEnv* env;
 	jobject obj;
+	jboolean useDefaultContactFilter;
 
 public:
 	CustomContactFilter( JNIEnv* env, jobject obj )
 	{
 		this->env = env;
 		this->obj = obj;
+		useDefaultContactFilter = env->CallBooleanMethod( obj, useDefaultContactFilterID );
 	}
 
 	virtual bool ShouldCollide(b2Fixture* fixtureA, b2Fixture* fixtureB)
 	{
-		if( shouldCollideID != 0 )
+		if( useDefaultContactFilter == true )
+			return b2ContactFilter::ShouldCollide( fixtureA, fixtureB );
+		else if( shouldCollideID != 0 )
 			return env->CallBooleanMethod( obj, shouldCollideID, (jlong)fixtureA, (jlong)fixtureB );
 		else
 			return true;
@@ -246,6 +251,7 @@ b2ContactFilter defaultFilter;
 			reportFixtureID = env->GetMethodID(worldClass, "reportFixture", "(J)Z" );
 			reportRayFixtureID = env->GetMethodID(worldClass, "reportRayFixture", "(JFFFFF)F" );
 			shouldCollideID = env->GetMethodID( worldClass, "contactFilter", "(JJ)Z");
+			useDefaultContactFilterID = env->GetMethodID( worldClass, "getUseDefaultContactFilter", "()Z" );
 		}
 	
 		b2World* world = new b2World( b2Vec2( gravityX, gravityY ));
@@ -264,11 +270,19 @@ b2ContactFilter defaultFilter;
 		this.contactFilter = filter;
 		setUseDefaultContactFilter(filter == null);
 	}
+
+	private boolean useDefaultContactFilter;
+
+	/** Internal method called from JNI
+	 * @return whether the native default ContactFilter should be used */
+	private boolean getUseDefaultContactFilter() {
+		return useDefaultContactFilter;
+	}
 	
-	/** tells the native code not to call the Java world class if use is false **/
-	private native void setUseDefaultContactFilter(boolean use); /*
-		// FIXME
-	*/
+	/** Sets flag to tell the native code not to call the Java World class if use is true **/
+	private void setUseDefaultContactFilter(boolean use) {
+		useDefaultContactFilter = use;
+	}
 
 	/** Register a contact event listener. The listener is owned by you and must remain in scope. */
 	public void setContactListener (ContactListener listener) {

--- a/extensions/gdx-box2d/gdx-box2d/src/com/badlogic/gdx/physics/box2d/World.java
+++ b/extensions/gdx-box2d/gdx-box2d/src/com/badlogic/gdx/physics/box2d/World.java
@@ -105,7 +105,7 @@ public:
 
 	virtual bool ShouldCollide(b2Fixture* fixtureA, b2Fixture* fixtureB)
 	{
-		if( useDefaultContactFilter == true )
+		if( useDefaultContactFilter == JNI_TRUE )
 			return b2ContactFilter::ShouldCollide( fixtureA, fixtureB );
 		else if( shouldCollideID != 0 )
 			return env->CallBooleanMethod( obj, shouldCollideID, (jlong)fixtureA, (jlong)fixtureB );


### PR DESCRIPTION
On Box2D `World` class we have this [FIXME](https://github.com/libgdx/libgdx/blob/435da504c87b735778e89dca44ba1812fadffb55/extensions/gdx-box2d/gdx-box2d/src/com/badlogic/gdx/physics/box2d/World.java#L268-L271). It's been there for many years and I guess the idea was to make it an option to use the default native ContactFilter for performance reasons. 

Currently, every time the decision whether two fixtures are to collide or not, a java upcall to `contactFilter (long fixtureA, long fixtureB)` is made. If the user has defined a custom `ContactFilter` it will be executed, if not, the default Box2D logic based on category, mask and groups to determine if they should collide is run on Java side. 

Looking for the reason on why we are executing the default shouldCollide Box2D logic on the Java side I've found this https://github.com/libgdx/libgdx/issues/597 which seems to suggest a bug in Box2D at the time related to negative group ids (haven't tested or investgated this particular issue). I ignore the reason why this was not fixed on the Box2d library itself but at the time the solution was to always run the shouldCollide logic on Java and the FIXME was added. 

The problem with this approach is that Java calls from JNI are quite expensive and there are scenarios in which potentially thousands of calls are being made per jniStep causing a significant performance impact.

To give some numbers of a real world example, on a brick breaker game I've stressed test it to see the maximum number of concurrent balls while keeping 60fps.

**iOS iPhone 12 Pro**
Before: 2000 balls
After: 3500 balls

**Android Pixel 6**
Before: 1900 balls
After: 2900 balls

As you can see, on some scenarios the performance gains are Massive.

With this change it is possible to set the default native contact filter by calling `setContactFilter(null)`. This is the least breaking approach as it requires that the user explicitly makes the call. Ommiting it will default to previous Java default resolution (`contactFilter()`) but we can decide at some point if we want it to be default.

Acknowledgments to @Berstanio for suggesting this approach and support

---

**Important**: If this is merged it will require Android projects that use Box2D to add `boolean getUseDefaultContactFilter();` to Proguard to the folowing block:
```
-keepclassmembers class com.badlogic.gdx.physics.box2d.World {
   boolean contactFilter(long, long);
   boolean getUseDefaultContactFilter();
   void    beginContact(long);
   void    endContact(long);
   void    preSolve(long, long);
   void    postSolve(long, long);
   boolean reportFixture(long);
   float   reportRayFixture(long, float, float, float, float, float);
}
```
Liftoff affected as well @tommyettinger 
