### PR TITLE
Update LWJGL to 3.3.6 since AV problem has been fixed.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -10,6 +10,7 @@
 - API Addition: Added ShortArray#replaceFirst and ShortArray#replaceAll
 - API Addition: Added SnapshotArray#replaceFirst and SnapshotArray#replaceAll
 - Android: Fixed rare NPE when `onDestroy` was called
+- LWJGL 3: Re-upgrade to 3.3.6 since AV false positives have veen fixed
 
 [1.13.1]
 - [BREAKING CHANGE] Android: Since 1.13.0 libGDX requires setting `android.useAndroidX=true` in your gradle.properties file. In 1.13.1 it is NO longer needed to define the `androidx.core:core` dependency in your Android module.

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -30,7 +30,7 @@ versions.jsinteropAnnotations = "2.0.2"
 versions.gretty = "3.1.0"
 versions.jglwf = "1.1"
 versions.lwjgl = "2.9.3"
-versions.lwjgl3 = "3.3.3"
+versions.lwjgl3 = "3.3.6"
 versions.jlayer = "1.0.1-gdx"
 versions.jorbis = "0.0.17"
 versions.junit = "4.13.2"
@@ -57,7 +57,7 @@ libraries.lwjgl3 = [
         "org.lwjgl:lwjgl:${versions.lwjgl3}:natives-linux",
         "org.lwjgl:lwjgl:${versions.lwjgl3}:natives-linux-arm32",
         "org.lwjgl:lwjgl:${versions.lwjgl3}:natives-linux-arm64",
-//        "org.lwjgl:lwjgl:${versions.lwjgl3}:natives-linux-riscv64",
+        "org.lwjgl:lwjgl:${versions.lwjgl3}:natives-linux-riscv64",
         "org.lwjgl:lwjgl:${versions.lwjgl3}:natives-macos",
         "org.lwjgl:lwjgl:${versions.lwjgl3}:natives-macos-arm64",
         "org.lwjgl:lwjgl:${versions.lwjgl3}:natives-windows",
@@ -66,7 +66,7 @@ libraries.lwjgl3 = [
         "org.lwjgl:lwjgl-glfw:${versions.lwjgl3}:natives-linux",
         "org.lwjgl:lwjgl-glfw:${versions.lwjgl3}:natives-linux-arm32",
         "org.lwjgl:lwjgl-glfw:${versions.lwjgl3}:natives-linux-arm64",
-//        "org.lwjgl:lwjgl-glfw:${versions.lwjgl3}:natives-linux-riscv64",
+        "org.lwjgl:lwjgl-glfw:${versions.lwjgl3}:natives-linux-riscv64",
         "org.lwjgl:lwjgl-glfw:${versions.lwjgl3}:natives-macos",
         "org.lwjgl:lwjgl-glfw:${versions.lwjgl3}:natives-macos-arm64",
         "org.lwjgl:lwjgl-glfw:${versions.lwjgl3}:natives-windows",
@@ -75,7 +75,7 @@ libraries.lwjgl3 = [
         "org.lwjgl:lwjgl-jemalloc:${versions.lwjgl3}:natives-linux",
         "org.lwjgl:lwjgl-jemalloc:${versions.lwjgl3}:natives-linux-arm32",
         "org.lwjgl:lwjgl-jemalloc:${versions.lwjgl3}:natives-linux-arm64",
-//        "org.lwjgl:lwjgl-jemalloc:${versions.lwjgl3}:natives-linux-riscv64",
+        "org.lwjgl:lwjgl-jemalloc:${versions.lwjgl3}:natives-linux-riscv64",
         "org.lwjgl:lwjgl-jemalloc:${versions.lwjgl3}:natives-macos",
         "org.lwjgl:lwjgl-jemalloc:${versions.lwjgl3}:natives-macos-arm64",
         "org.lwjgl:lwjgl-jemalloc:${versions.lwjgl3}:natives-windows",
@@ -84,7 +84,7 @@ libraries.lwjgl3 = [
         "org.lwjgl:lwjgl-openal:${versions.lwjgl3}:natives-linux",
         "org.lwjgl:lwjgl-openal:${versions.lwjgl3}:natives-linux-arm32",
         "org.lwjgl:lwjgl-openal:${versions.lwjgl3}:natives-linux-arm64",
-//        "org.lwjgl:lwjgl-openal:${versions.lwjgl3}:natives-linux-riscv64",
+        "org.lwjgl:lwjgl-openal:${versions.lwjgl3}:natives-linux-riscv64",
         "org.lwjgl:lwjgl-openal:${versions.lwjgl3}:natives-macos",
         "org.lwjgl:lwjgl-openal:${versions.lwjgl3}:natives-macos-arm64",
         "org.lwjgl:lwjgl-openal:${versions.lwjgl3}:natives-windows",
@@ -93,7 +93,7 @@ libraries.lwjgl3 = [
         "org.lwjgl:lwjgl-opengl:${versions.lwjgl3}:natives-linux",
         "org.lwjgl:lwjgl-opengl:${versions.lwjgl3}:natives-linux-arm32",
         "org.lwjgl:lwjgl-opengl:${versions.lwjgl3}:natives-linux-arm64",
-//        "org.lwjgl:lwjgl-opengl:${versions.lwjgl3}:natives-linux-riscv64",
+        "org.lwjgl:lwjgl-opengl:${versions.lwjgl3}:natives-linux-riscv64",
         "org.lwjgl:lwjgl-opengl:${versions.lwjgl3}:natives-macos",
         "org.lwjgl:lwjgl-opengl:${versions.lwjgl3}:natives-macos-arm64",
         "org.lwjgl:lwjgl-opengl:${versions.lwjgl3}:natives-windows",
@@ -102,7 +102,7 @@ libraries.lwjgl3 = [
         "org.lwjgl:lwjgl-stb:${versions.lwjgl3}:natives-linux",
         "org.lwjgl:lwjgl-stb:${versions.lwjgl3}:natives-linux-arm32",
         "org.lwjgl:lwjgl-stb:${versions.lwjgl3}:natives-linux-arm64",
-//        "org.lwjgl:lwjgl-stb:${versions.lwjgl3}:natives-linux-riscv64",
+        "org.lwjgl:lwjgl-stb:${versions.lwjgl3}:natives-linux-riscv64",
         "org.lwjgl:lwjgl-stb:${versions.lwjgl3}:natives-macos",
         "org.lwjgl:lwjgl-stb:${versions.lwjgl3}:natives-macos-arm64",
         "org.lwjgl:lwjgl-stb:${versions.lwjgl3}:natives-windows",
@@ -116,7 +116,7 @@ libraries.lwjgl3GLES = [
         "org.lwjgl:lwjgl-opengles:${versions.lwjgl3}:natives-linux",
         "org.lwjgl:lwjgl-opengles:${versions.lwjgl3}:natives-linux-arm32",
         "org.lwjgl:lwjgl-opengles:${versions.lwjgl3}:natives-linux-arm64",
-//        "org.lwjgl:lwjgl-opengles:${versions.lwjgl3}:natives-linux-riscv64",
+        "org.lwjgl:lwjgl-opengles:${versions.lwjgl3}:natives-linux-riscv64",
         "org.lwjgl:lwjgl-opengles:${versions.lwjgl3}:natives-macos",
         "org.lwjgl:lwjgl-opengles:${versions.lwjgl3}:natives-macos-arm64",
         "org.lwjgl:lwjgl-opengles:${versions.lwjgl3}:natives-windows",


### PR DESCRIPTION
https://github.com/libgdx/libgdx/pull/7555/files downgrades LWJGL from 3.3.5 to 3.3.3 to solve the issues with antivirus tools were misreporting problems with LWJGL's JAR files.

These problems have been fixed in LWJGL 3.3.6, as explained in https://github.com/LWJGL/lwjgl3/issues/1005, so I believe it is now safe for libGDX to once again use the latest version.