### PR TITLE
Use `Locale.ROOT` instead of `ROOT_LOCALE`

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/java/util/Locale.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/java/util/Locale.java
@@ -59,8 +59,8 @@ import java.io.Serializable;
  * {@code java.util.spi} mechanisms) are not supported.
  *
  * <p>
- * See <a href="https://developer.android.com/guide/topics/resources/internationalization">Unicode and internationalization support</a>
- * for the versions of ICU (and the corresponding CLDR and Unicode versions) used in various Android releases.
+ * See <a href="https://developer.android.com/guide/topics/resources/internationalization">Unicode and internationalization
+ * support</a> for the versions of ICU (and the corresponding CLDR and Unicode versions) used in various Android releases.
  *
  * <a name="default_locale">
  * <h3>Be wary of the default locale</h3></a>

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/java/util/Locale.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/java/util/Locale.java
@@ -59,45 +59,8 @@ import java.io.Serializable;
  * {@code java.util.spi} mechanisms) are not supported.
  *
  * <p>
- * Here are the versions of ICU (and the corresponding CLDR and Unicode versions) used in various Android releases:
- * <table BORDER="1" WIDTH="100%" CELLPADDING="3" CELLSPACING="0" SUMMARY="">
- * <tr>
- * <td>Cupcake/Donut/Eclair</td>
- * <td>ICU 3.8</td>
- * <td><a href="http://cldr.unicode.org/index/downloads/cldr-1-5">CLDR 1.5</a></td>
- * <td><a href="http://www.unicode.org/versions/Unicode5.0.0/">Unicode 5.0</a></td>
- * </tr>
- * <tr>
- * <td>Froyo</td>
- * <td>ICU 4.2</td>
- * <td><a href="http://cldr.unicode.org/index/downloads/cldr-1-7">CLDR 1.7</a></td>
- * <td><a href="http://www.unicode.org/versions/Unicode5.1.0/">Unicode 5.1</a></td>
- * </tr>
- * <tr>
- * <td>Gingerbread/Honeycomb</td>
- * <td>ICU 4.4</td>
- * <td><a href="http://cldr.unicode.org/index/downloads/cldr-1-8">CLDR 1.8</a></td>
- * <td><a href="http://www.unicode.org/versions/Unicode5.2.0/">Unicode 5.2</a></td>
- * </tr>
- * <tr>
- * <td>Ice Cream Sandwich</td>
- * <td>ICU 4.6</td>
- * <td><a href="http://cldr.unicode.org/index/downloads/cldr-1-9">CLDR 1.9</a></td>
- * <td><a href="http://www.unicode.org/versions/Unicode6.0.0/">Unicode 6.0</a></td>
- * </tr>
- * <tr>
- * <td>Jelly Bean</td>
- * <td>ICU 4.8</td>
- * <td><a href="http://cldr.unicode.org/index/downloads/cldr-2-0">CLDR 2.0</a></td>
- * <td><a href="http://www.unicode.org/versions/Unicode6.0.0/">Unicode 6.0</a></td>
- * </tr>
- * <tr>
- * <td>Jelly Bean MR2</td>
- * <td>ICU 50</td>
- * <td><a href="http://cldr.unicode.org/index/downloads/cldr-21-1">CLDR 22.1</a></td>
- * <td><a href="http://www.unicode.org/versions/Unicode6.2.0/">Unicode 6.2</a></td>
- * </tr>
- * </table>
+ * See <a href="https://developer.android.com/guide/topics/resources/internationalization">Unicode and internationalization support</a>
+ * for the versions of ICU (and the corresponding CLDR and Unicode versions) used in various Android releases.
  *
  * <a name="default_locale">
  * <h3>Be wary of the default locale</h3></a>

--- a/gdx/src/com/badlogic/gdx/utils/I18NBundle.java
+++ b/gdx/src/com/badlogic/gdx/utils/I18NBundle.java
@@ -181,7 +181,7 @@ public class I18NBundle {
 					// Found the bundle for the only candidate locale
 					break;
 				}
-				if (isBaseBundle && baseBundle == null) {
+				if (baseBundle == null) {
 					// Store the base bundle and keep on processing the remaining fallback locales
 					baseBundle = bundle;
 				}

--- a/gdx/src/com/badlogic/gdx/utils/I18NBundle.java
+++ b/gdx/src/com/badlogic/gdx/utils/I18NBundle.java
@@ -67,9 +67,6 @@ public class I18NBundle {
 
 	private static final String DEFAULT_ENCODING = "UTF-8";
 
-	// Locale.ROOT does not exist in Android API level 8
-	private static final Locale ROOT_LOCALE = new Locale("", "", "");
-
 	private static boolean simpleFormatter = false;
 	private static boolean exceptionOnMissingKey = true;
 
@@ -174,7 +171,7 @@ public class I18NBundle {
 			// Check the loaded bundle (if any)
 			if (bundle != null) {
 				Locale bundleLocale = bundle.getLocale(); // WTH? GWT can't access bundle.locale directly
-				boolean isBaseBundle = bundleLocale.equals(ROOT_LOCALE);
+				boolean isBaseBundle = bundleLocale.equals(Locale.ROOT);
 
 				if (!isBaseBundle || bundleLocale.equals(locale)) {
 					// Found the bundle for the requested locale
@@ -263,16 +260,16 @@ public class I18NBundle {
 		String variant = locale.getVariant();
 
 		List<Locale> locales = new ArrayList<Locale>(4);
-		if (variant.length() > 0) {
+		if (!variant.isEmpty()) {
 			locales.add(locale);
 		}
-		if (country.length() > 0) {
+		if (!country.isEmpty()) {
 			locales.add(locales.isEmpty() ? locale : new Locale(language, country));
 		}
-		if (language.length() > 0) {
+		if (!language.isEmpty()) {
 			locales.add(locales.isEmpty() ? locale : new Locale(language));
 		}
-		locales.add(ROOT_LOCALE);
+		locales.add(Locale.ROOT);
 		return locales;
 	}
 
@@ -301,7 +298,7 @@ public class I18NBundle {
 		if (candidateIndex != candidateLocales.size() - 1) {
 			// Load recursively the parent having the next candidate locale
 			parent = loadBundleChain(baseFileHandle, encoding, candidateLocales, candidateIndex + 1, baseBundle);
-		} else if (baseBundle != null && targetLocale.equals(ROOT_LOCALE)) {
+		} else if (baseBundle != null && targetLocale.equals(Locale.ROOT)) {
 			return baseBundle;
 		}
 
@@ -382,19 +379,16 @@ public class I18NBundle {
 	 * @exception NullPointerException if <code>baseFileHandle</code> or <code>locale</code> is <code>null</code> */
 	private static FileHandle toFileHandle (FileHandle baseFileHandle, Locale locale) {
 		StringBuilder sb = new StringBuilder(baseFileHandle.name());
-		if (!locale.equals(ROOT_LOCALE)) {
+		if (!locale.equals(Locale.ROOT)) {
 			String language = locale.getLanguage();
 			String country = locale.getCountry();
 			String variant = locale.getVariant();
-			boolean emptyLanguage = "".equals(language);
-			boolean emptyCountry = "".equals(country);
-			boolean emptyVariant = "".equals(variant);
 
-			if (!(emptyLanguage && emptyCountry && emptyVariant)) {
+			if (!(language.isEmpty() && country.isEmpty() && variant.isEmpty())) {
 				sb.append('_');
-				if (!emptyVariant) {
+				if (!variant.isEmpty()) {
 					sb.append(language).append('_').append(country).append('_').append(variant);
-				} else if (!emptyCountry) {
+				} else if (!country.isEmpty()) {
 					sb.append(language).append('_').append(country);
 				} else {
 					sb.append(language);

--- a/gdx/src/com/badlogic/gdx/utils/I18NBundle.java
+++ b/gdx/src/com/badlogic/gdx/utils/I18NBundle.java
@@ -259,7 +259,7 @@ public class I18NBundle {
 		String country = locale.getCountry();
 		String variant = locale.getVariant();
 
-		List<Locale> locales = new ArrayList<Locale>(4);
+		List<Locale> locales = new ArrayList<>(4);
 		if (!variant.isEmpty()) {
 			locales.add(locale);
 		}
@@ -356,7 +356,7 @@ public class I18NBundle {
 	// NOTE:
 	// This method can't be private otherwise GWT can't access it from loadBundle()
 	protected void load (Reader reader) throws IOException {
-		properties = new ObjectMap<String, String>();
+		properties = new ObjectMap<>();
 		PropertiesUtils.load(properties, reader);
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/I18NMessageTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/I18NMessageTest.java
@@ -52,7 +52,7 @@ public class I18NMessageTest extends GdxTest {
 
 		try {
 			FileHandle bfh = Gdx.files.internal("data/i18n/message1");
-			rb_root = I18NBundle.createBundle(bfh, new Locale("", "", "")); // Locale.ROOT doesn't exist in Android API level 8
+			rb_root = I18NBundle.createBundle(bfh, Locale.ROOT);
 			rb_default = I18NBundle.createBundle(bfh);
 			rb_en = I18NBundle.createBundle(bfh, new Locale("en", "US"));
 			rb_it = I18NBundle.createBundle(bfh, new Locale("it", "IT"));

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/I18NSimpleMessageTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/I18NSimpleMessageTest.java
@@ -52,7 +52,7 @@ public class I18NSimpleMessageTest extends GdxTest {
 
 		try {
 			FileHandle bfh = Gdx.files.internal("data/i18n/message2");
-			rb_root = I18NBundle.createBundle(bfh, new Locale("", "", "")); // Locale.ROOT doesn't exist in Android API level 8
+			rb_root = I18NBundle.createBundle(bfh, Locale.ROOT);
 			rb_default = I18NBundle.createBundle(bfh);
 			rb_en = I18NBundle.createBundle(bfh, new Locale("en", "US"));
 			rb_it = I18NBundle.createBundle(bfh, new Locale("it", "IT"));


### PR DESCRIPTION
Some small changes to the `I18NBundle` class and a trimming down of GWT's `Locale` documentation, because they are old.

Of course, there's more places than this where `String#isEmpty()` could be used. Search for `.length() == 0`, `.length() > 0`, `.equals("")`, and `"".equals` to find other instances. But this isn't very important to change, so I won't do so for unrelated classes in this pull request.