### PR TITLE
Remove `touchSleepTime`

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 [1.14.0]
 - [BREAKING CHANGE] Android: Updated minSDK to 21. Multidex config is no longer required, please check https://developer.android.com/build/multidex.
 - [BREAKING CHANGE] Android: Proguard config line `boolean getUseDefaultContactFilter();` needs to be added. See https://github.com/libgdx/libgdx/pull/7578.
+- [BREAKING CHANGE] Android: Removed `AndroidApplicationConfiguration#touchSleepTime`.
 - API Addition: Allow option to set Box2D native ContactFilter (World#setContactFilter(null)) for performance improvements.
 - API Addition: Added BooleanArray#replaceFirst and BooleanArray#replaceAll
 - API Addition: Added ByteArray#replaceFirst and ByteArray#replaceAll

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplicationConfiguration.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplicationConfiguration.java
@@ -96,7 +96,7 @@ public class AndroidApplicationConfiguration {
 	public int maxNetThreads = Integer.MAX_VALUE;
 
 	/** set this to true to render under the display cutout. Use the Graphics::getSafeInsetXX to get the safe render space */
-	public boolean renderUnderCutout;
+	public boolean renderUnderCutout = false;
 
 	/** The loader used to load native libraries. Override this to use a different loading strategy. */
 	public GdxNativeLoader nativeLoader = new GdxNativeLoader() {

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplicationConfiguration.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplicationConfiguration.java
@@ -67,10 +67,6 @@ public class AndroidApplicationConfiguration {
 	 * Default: {@link SensorManager#SENSOR_DELAY_GAME} (20 ms updates). */
 	public int sensorDelay = SensorManager.SENSOR_DELAY_GAME;
 
-	/** the time in milliseconds to sleep after each event in the touch handler, set this to 16ms to get rid of touch flooding on
-	 * pre Android 2.0 devices. default: 0 **/
-	public int touchSleepTime = 0;
-
 	/** whether to keep the screen on and at full brightness or not while running the application. default: false. Uses
 	 * FLAG_KEEP_SCREEN_ON under the hood. */
 	public boolean useWakelock = false;

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/DefaultAndroidInput.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/DefaultAndroidInput.java
@@ -135,7 +135,6 @@ public class DefaultAndroidInput extends AbstractInput implements AndroidInput, 
 	final Application app;
 	final Context context;
 	protected final AndroidTouchHandler touchHandler;
-	private int sleepTime = 0;
 	protected final AndroidHaptics haptics;
 	private boolean compassAvailable = false;
 	private boolean rotationVectorAvailable = false;
@@ -180,7 +179,6 @@ public class DefaultAndroidInput extends AbstractInput implements AndroidInput, 
 		handle = new Handler();
 		this.app = activity;
 		this.context = context;
-		this.sleepTime = config.touchSleepTime;
 		touchHandler = new AndroidTouchHandler();
 		hasMultitouch = touchHandler.supportsMultitouch(context);
 
@@ -501,12 +499,6 @@ public class DefaultAndroidInput extends AbstractInput implements AndroidInput, 
 		// synchronized in handler.postTouchEvent()
 		touchHandler.onTouch(event, this);
 
-		if (sleepTime != 0) {
-			try {
-				Thread.sleep(sleepTime);
-			} catch (InterruptedException e) {
-			}
-		}
 		return true;
 	}
 


### PR DESCRIPTION
Given how long ago libGDX dropped Android Donut support, I think this can be removed from the app config without so much as a deprecation period. Nobody should still be using this, especially not setting it to 16ms on 90Hz+ devices. It's a hack for a problem long gone.

Once upon a time, I looked into this. It seemed Android 1.x would absolutely batter your app with touch events while the touchscreen was pressed, even if the user's finger wasn't moving, which was bad news for your single-core device without JIT. But I don't have a device old enough to test that on, and it's difficult to buy one for testing since many were updated to Android 2 and sellers don't always have pictures that confirm whether they've been updated. Not that there'd be any point in testing this now - I just find the idea of supporting beyond-ancient Android versions in some of my personal non-libGDX projects interesting.