### PR TITLE
Two GWT emu fixes re: long in DataInputStream.

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/java/io/DataInputStream.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/java/io/DataInputStream.java
@@ -51,7 +51,7 @@ public class DataInputStream extends FilterInputStream implements DataInput {
 	}
 
 	public double readDouble () throws IOException {
-		return Double.longBitsToDouble(readLong());
+		return Numbers.longBitsToDouble(readLong());
 	}
 
 	public float readFloat () throws IOException {
@@ -87,8 +87,8 @@ public class DataInputStream extends FilterInputStream implements DataInput {
 
 	public long readLong () throws IOException {
 		long a = readInt();
-		long b = readInt() & 0x0ffffffff;
-		return (a << 32) | b;
+		long b = readInt();
+		return (a << 32) | (b & 0xffffffffL);
 	}
 
 	public short readShort () throws IOException {

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/java/io/DataOutputStream.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/emu/java/io/DataOutputStream.java
@@ -42,7 +42,7 @@ public class DataOutputStream extends OutputStream implements DataOutput {
 	public void writeBytes (String s) throws IOException {
 		int len = s.length();
 		for (int i = 0; i < len; i++) {
-			os.write(s.charAt(i) & 0xff);
+			os.write(s.charAt(i));
 		}
 	}
 
@@ -56,7 +56,7 @@ public class DataOutputStream extends OutputStream implements DataOutput {
 	}
 
 	public void writeDouble (double v) throws IOException {
-		writeLong(Double.doubleToLongBits(v));
+		writeLong(Numbers.doubleToLongBits(v));
 	}
 
 	public void writeFloat (float v) throws IOException {
@@ -71,7 +71,7 @@ public class DataOutputStream extends OutputStream implements DataOutput {
 	}
 
 	public void writeLong (long v) throws IOException {
-		writeInt((int)(v >> 32L));
+		writeInt((int)(v >> 32));
 		writeInt((int)v);
 	}
 
@@ -84,9 +84,9 @@ public class DataOutputStream extends OutputStream implements DataOutput {
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		for (int i = 0; i < s.length(); i++) {
 			char c = s.charAt(i);
-			if (c > 0 && c < 80) {
+			if (c > 0 && c < 0x80) {
 				baos.write(c);
-			} else if (c < '\u0800') {
+			} else if (c < 0x800) {
 				baos.write(0xc0 | (0x1f & (c >> 6)));
 				baos.write(0x80 | (0x3f & c));
 			} else {


### PR DESCRIPTION
The first change is just using the added-a-few-years-ago Numbers.longBitsToDouble(), which is faster, instead of GWT's slow Double.longBitsToDouble() . There's an extended discussion (with pictures!) of the second change here, https://tommyettinger.github.io/libGDX-GWT-checks/ . The reason the second change looks the way it does now is optimistically hoping that JS will be able to pipeline two non-dependent bit operations before it ORs them. This mostly affects UBJson, but it may affect other places that used DataInputSteam.readLong() on GWT. Long story short, an `L` was missing from a mask literal, and so it wasn't masking an int at all, letting it implicitly promote to long afterwards and sign-extending then if the int was negative.