### PR TITLE
Fix out-of-bounds exception in TexturePacker

### DIFF
--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/texturepacker/TexturePacker.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/texturepacker/TexturePacker.java
@@ -989,7 +989,7 @@ public class TexturePacker {
 
 		public String getScaledPackFileName (String packFileName, int scaleIndex) {
 			// Use suffix if not empty string.
-			if (scaleSuffix[scaleIndex].length() > 0)
+			if ((scaleIndex >= 0 && scaleSuffix.length > scaleIndex) && scaleSuffix[scaleIndex].length() > 0)
 				packFileName += scaleSuffix[scaleIndex];
 			else {
 				// Otherwise if scale != 1 or multiple scales, use subdirectory.

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/texturepacker/TexturePacker.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/texturepacker/TexturePacker.java
@@ -989,7 +989,7 @@ public class TexturePacker {
 
 		public String getScaledPackFileName (String packFileName, int scaleIndex) {
 			// Use suffix if not empty string.
-			if ((scaleIndex >= 0 && scaleSuffix.length > scaleIndex) && scaleSuffix[scaleIndex].length() > 0)
+			if (scaleIndex < scaleSuffix.length && scaleSuffix[scaleIndex].length() > 0)
 				packFileName += scaleSuffix[scaleIndex];
 			else {
 				// Otherwise if scale != 1 or multiple scales, use subdirectory.


### PR DESCRIPTION
When multiple scales are set in the settings, an out-of-bounds exception occurs during the generation of the scaled pack file name, so this issue has been fixed.