### PR TITLE
Use official ANGLE for MetalANGLE

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -20,6 +20,7 @@
 - API Deprecation: Deprecated ReflectionPool and the related Pools#get/Pools#obtain method. Please use the new DefaultPool with the new Pools#get/Pools#obtain methods. They offer more safety and can be used with the java 8 method reference syntax (e.g. Pools.get(MyClass::new))
 - API Deprecation: Deprecated constructors taking a "Class" for Queue/ArrayMap/Array. Please use the constructors utilising "ArraySupplier". They offer more safety and can be used with the java 8 method reference syntax (e.g. MyClass[]::new)
 - iOS: Update to MobiVM 2.3.23
+- iOS: The MetalANGLE backend has been replaced by MetalANGLEKit which uses a newer ANGLE revision
 
 [1.13.1]
 - [BREAKING CHANGE] Android: Since 1.13.0 libGDX requires setting `android.useAndroidX=true` in your gradle.properties file. In 1.13.1 it is NO longer needed to define the `androidx.core:core` dependency in your Android module.

--- a/backends/gdx-backend-robovm-metalangle/build.gradle
+++ b/backends/gdx-backend-robovm-metalangle/build.gradle
@@ -59,7 +59,7 @@ tasks.register('fetchMetalANGLEKit', Download) {
 	doFirst {
 		file("build/tmp").mkdirs();
 	}
-	src 'https://github.com/Berstanio/MetalANGLEKit/releases/download/v0.3-alpha/metalanglekit.zip'
+	src 'https://github.com/Berstanio/MetalANGLEKit/releases/download/v1.0/metalanglekit.zip'
 	dest 'build/tmp/MetalANGLEKit.zip'
 	onlyIfModified true
 	useETag "all"
@@ -69,7 +69,7 @@ tasks.register('verifyMetalANGLEKit', Verify) {
 	dependsOn fetchMetalANGLEKit
 	src 'build/tmp/MetalANGLEKit.zip'
 	algorithm 'SHA-256'
-	checksum '258822176da952c466e45c6a61e855bf5db85fb1eda0077d03d4f43f76e54161'
+	checksum '689361567aff476c5cba1113208f2a80948b8d3e58ce1b1253a57bd62ac127c7'
 }
 
 tasks.register('extractMetalANGLEKit', Copy) {

--- a/backends/gdx-backend-robovm-metalangle/build.gradle
+++ b/backends/gdx-backend-robovm-metalangle/build.gradle
@@ -55,77 +55,37 @@ tasks.register('generate', JavaExec) {
 	outputs.dir 'src/'
 }
 
-tasks.register('fetchMetalANGLE', Download) {
+tasks.register('fetchMetalANGLEKit', Download) {
 	doFirst {
 		file("build/tmp").mkdirs();
 	}
-	src 'https://github.com/kakashidinho/metalangle/releases/download/gles3-0.0.8/MetalANGLE.framework.ios.zip'
-	dest 'build/tmp/MetalANGLE.framework.ios.zip'
+	src 'https://github.com/Berstanio/MetalANGLEKit/releases/download/v0.3-alpha/metalanglekit.zip'
+	dest 'build/tmp/MetalANGLEKit.zip'
 	onlyIfModified true
 	useETag "all"
 }
 
-tasks.register('fetchMetalANGLESimulator', Download) {
-	doFirst {
-		file("build/tmp").mkdirs();
-	}
-	src 'https://github.com/kakashidinho/metalangle/releases/download/gles3-0.0.8/MetalANGLE.framework.ios.simulator.zip'
-	dest 'build/tmp/MetalANGLE.framework.ios.simulator.zip'
-	onlyIfModified true
-	useETag "all"
-}
-
-tasks.register('verifyMetalANGLE', Verify) {
-	dependsOn fetchMetalANGLE
-	src 'build/tmp/MetalANGLE.framework.ios.zip'
+tasks.register('verifyMetalANGLEKit', Verify) {
+	dependsOn fetchMetalANGLEKit
+	src 'build/tmp/MetalANGLEKit.zip'
 	algorithm 'SHA-256'
-	checksum '9b6e7c82d41749266200ed19bb184c4f47df63c4dcde0972186ea557de623018'
+	checksum '258822176da952c466e45c6a61e855bf5db85fb1eda0077d03d4f43f76e54161'
 }
 
-tasks.register('verifyMetalANGLESimulator', Verify) {
-	dependsOn fetchMetalANGLESimulator
-	src 'build/tmp/MetalANGLE.framework.ios.simulator.zip'
-	algorithm 'SHA-256'
-	checksum '63ff063bf7825e2da9a01eda981067eb4eacd42e202c86f448541d2c5bd564a9'
-}
+tasks.register('extractMetalANGLEKit', Copy) {
+	dependsOn verifyMetalANGLEKit
 
-tasks.register('extractMetalANGLE', Copy) {
-	dependsOn verifyMetalANGLE
-	doFirst {
-		file("build/tmp/real").mkdirs();
-	}
-	from zipTree('build/tmp/MetalANGLE.framework.ios.zip')
-	into 'build/tmp/real'
-}
-
-tasks.register('extractMetalANGLESimulator', Copy) {
-	dependsOn verifyMetalANGLESimulator
-	doFirst {
-		file("build/tmp/sim").mkdirs();
-	}
-	from zipTree('build/tmp/MetalANGLE.framework.ios.simulator.zip')
-	into 'build/tmp/sim'
-}
-
-tasks.register('buildMetalANGLE', Exec) {
-	dependsOn extractMetalANGLE, extractMetalANGLESimulator
 	doFirst {
 		delete("res/META-INF/robovm/ios/libs/MetalANGLE.xcframework")
+		delete("res/META-INF/robovm/ios/libs/MetalANGLEKit.xcframework")
 		file("res/META-INF/robovm/ios/libs").mkdirs();
 	}
-	commandLine 'xcodebuild', '-create-xcframework', '-framework', 'build/tmp/real/MetalANGLE.framework', '-framework', 'build/tmp/sim/MetalANGLE.framework', '-output', 'res/META-INF/robovm/ios/libs/MetalANGLE.xcframework'
-	standardOutput = new ByteArrayOutputStream()
-	ext.output = {
-		return standardOutput.toString()
-	}
-
-	inputs.dir 'build/tmp/real/MetalANGLE.framework'
-	inputs.dir 'build/tmp/sim/MetalANGLE.framework'
-	outputs.dir 'res/META-INF/robovm/ios/libs/MetalANGLE.xcframework'
+	from zipTree('build/tmp/MetalANGLEKit.zip')
+	into 'res/META-INF/robovm/ios/libs/MetalANGLEKit.xcframework'
 }
 
 tasks.register('jnigenBuildIOS') {
-	dependsOn buildMetalANGLE
+	dependsOn extractMetalANGLEKit
 }
 
 tasks.register('jnigenBuild') {

--- a/backends/gdx-backend-robovm-metalangle/build.gradle
+++ b/backends/gdx-backend-robovm-metalangle/build.gradle
@@ -59,7 +59,7 @@ tasks.register('fetchMetalANGLEKit', Download) {
 	doFirst {
 		file("build/tmp").mkdirs();
 	}
-	src 'https://github.com/Berstanio/MetalANGLEKit/releases/download/v1.0/metalanglekit.zip'
+	src 'https://github.com/Berstanio/MetalANGLEKit/releases/download/v1.1/metalanglekit.zip'
 	dest 'build/tmp/MetalANGLEKit.zip'
 	onlyIfModified true
 	useETag "all"
@@ -69,19 +69,19 @@ tasks.register('verifyMetalANGLEKit', Verify) {
 	dependsOn fetchMetalANGLEKit
 	src 'build/tmp/MetalANGLEKit.zip'
 	algorithm 'SHA-256'
-	checksum '689361567aff476c5cba1113208f2a80948b8d3e58ce1b1253a57bd62ac127c7'
+	checksum 'b017fb0a7e5ceba771ee80c5a785351037bdb8bc0f548bc32d880eb896403035'
 }
 
 tasks.register('extractMetalANGLEKit', Copy) {
 	dependsOn verifyMetalANGLEKit
 
 	doFirst {
-		delete("res/META-INF/robovm/ios/libs/MetalANGLE.xcframework")
-		delete("res/META-INF/robovm/ios/libs/MetalANGLEKit.xcframework")
+		delete("res/META-INF/robovm/ios/libs/")
+		delete("res/META-INF/robovm/ios/libs/")
 		file("res/META-INF/robovm/ios/libs").mkdirs();
 	}
 	from zipTree('build/tmp/MetalANGLEKit.zip')
-	into 'res/META-INF/robovm/ios/libs/MetalANGLEKit.xcframework'
+	into 'res/META-INF/robovm/ios/libs/'
 }
 
 tasks.register('jnigenBuildIOS') {

--- a/backends/gdx-backend-robovm-metalangle/build.gradle
+++ b/backends/gdx-backend-robovm-metalangle/build.gradle
@@ -59,7 +59,7 @@ tasks.register('fetchMetalANGLEKit', Download) {
 	doFirst {
 		file("build/tmp").mkdirs();
 	}
-	src 'https://github.com/Berstanio/MetalANGLEKit/releases/download/v1.1/metalanglekit.zip'
+	src 'https://github.com/Berstanio/MetalANGLEKit/releases/download/v1.2/metalanglekit.zip'
 	dest 'build/tmp/MetalANGLEKit.zip'
 	onlyIfModified true
 	useETag "all"
@@ -69,7 +69,7 @@ tasks.register('verifyMetalANGLEKit', Verify) {
 	dependsOn fetchMetalANGLEKit
 	src 'build/tmp/MetalANGLEKit.zip'
 	algorithm 'SHA-256'
-	checksum 'b017fb0a7e5ceba771ee80c5a785351037bdb8bc0f548bc32d880eb896403035'
+	checksum '91f2b78208a1d8f59c28e2dc4a2d2a122a2cb2e61dcb853baa339386e6faf4a0'
 }
 
 tasks.register('extractMetalANGLEKit', Copy) {

--- a/backends/gdx-backend-robovm-metalangle/build.gradle
+++ b/backends/gdx-backend-robovm-metalangle/build.gradle
@@ -59,7 +59,7 @@ tasks.register('fetchMetalANGLEKit', Download) {
 	doFirst {
 		file("build/tmp").mkdirs();
 	}
-	src 'https://github.com/Berstanio/MetalANGLEKit/releases/download/v1.2/metalanglekit.zip'
+	src 'https://github.com/libgdx/MetalANGLEKit/releases/download/v1.2/metalanglekit.zip'
 	dest 'build/tmp/MetalANGLEKit.zip'
 	onlyIfModified true
 	useETag "all"

--- a/backends/gdx-backend-robovm-metalangle/res/META-INF/robovm/ios/robovm.xml
+++ b/backends/gdx-backend-robovm-metalangle/res/META-INF/robovm/ios/robovm.xml
@@ -1,10 +1,14 @@
 <config>
     <frameworks>
-        <framework>MetalANGLE</framework>
+        <framework>MetalANGLEKit</framework>
+        <framework>libGLESv2</framework>
+        <framework>libEGL</framework>
         <framework>Metal</framework>
     </frameworks>
     <frameworkPaths>
-        <path variant="device">libs/MetalANGLE.xcframework/ios-arm64_armv7/</path>
-        <path variant="simulator">libs/MetalANGLE.xcframework/ios-arm64_i386_x86_64-simulator/</path>
+        <path variant="device">libs/MetalANGLEKit.xcframework/ios-arm64/</path>
+        <path variant="simulator">libs/MetalANGLEKit.xcframework/ios-arm64_x86_64-simulator/</path>
+        <path variant="device">libs/MetalANGLEKit.xcframework/ios-arm64/MetalANGLEKit.framework/Frameworks/</path>
+        <path variant="simulator">libs/MetalANGLEKit.xcframework/ios-arm64_x86_64-simulator/MetalANGLEKit.framework/Frameworks/</path>
     </frameworkPaths>
 </config>

--- a/backends/gdx-backend-robovm-metalangle/res/META-INF/robovm/ios/robovm.xml
+++ b/backends/gdx-backend-robovm-metalangle/res/META-INF/robovm/ios/robovm.xml
@@ -3,6 +3,7 @@
         <framework>MetalANGLEKit</framework>
         <framework>libGLESv2</framework>
         <framework>libEGL</framework>
+        <framework>libfeature_support</framework>
         <framework>Metal</framework>
     </frameworks>
     <frameworkPaths>

--- a/backends/gdx-backend-robovm-metalangle/res/META-INF/robovm/ios/robovm.xml
+++ b/backends/gdx-backend-robovm-metalangle/res/META-INF/robovm/ios/robovm.xml
@@ -7,9 +7,6 @@
         <framework>Metal</framework>
     </frameworks>
     <frameworkPaths>
-        <path variant="device">libs/MetalANGLEKit.xcframework/ios-arm64/</path>
-        <path variant="simulator">libs/MetalANGLEKit.xcframework/ios-arm64_x86_64-simulator/</path>
-        <path variant="device">libs/MetalANGLEKit.xcframework/ios-arm64/MetalANGLEKit.framework/Frameworks/</path>
-        <path variant="simulator">libs/MetalANGLEKit.xcframework/ios-arm64_x86_64-simulator/MetalANGLEKit.framework/Frameworks/</path>
+        <path>libs/</path>
     </frameworkPaths>
 </config>

--- a/tests/gdx-tests-iosrobovm/build.gradle
+++ b/tests/gdx-tests-iosrobovm/build.gradle
@@ -27,7 +27,7 @@ targetCompatibility = versions.java
 
 dependencies {
 	implementation project(":tests:gdx-tests")
-	implementation project(":backends:gdx-backend-robovm")
+	implementation project(":backends:gdx-backend-robovm-metalangle")
 }
 
 ext {

--- a/tests/gdx-tests-iosrobovm/robovm.xml
+++ b/tests/gdx-tests-iosrobovm/robovm.xml
@@ -49,7 +49,6 @@
     <framework>gdx-box2d</framework>
     <!-- System Frameworks -->
     <framework>UIKit</framework>
-    <framework>OpenGLES</framework>
     <framework>QuartzCore</framework>
     <framework>CoreGraphics</framework>
     <framework>OpenAL</framework>


### PR DESCRIPTION
The MetalANGLE repo, which we use, is currently unmaintained: https://github.com/kakashidinho/metalangle

I made a port of the MetalKit replacement and combined it with the official ANGLE sources: https://github.com/Berstanio/MetalANGLEKit

It is compatibility wise identical to MetalANGLE, the only difference is, that the OpenGLES compatibility backend is removed. This means, that macOS simulator/hackintosh wont be able to run the app in the iPhone simulator anymore.
However, for those the normal OpenGLES libGDX backend is still present.

The new MetalANGLEKit has been tested in two production apps so far.
