### PR TITLE
Hopefully fix labeler labeling everything as android

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -3,12 +3,13 @@
   - any-glob-to-any-file:
     - /**/g3d/**
 android:
-- changed-files:
-  - any-glob-to-any-file:
-    - /**/gdx-backend-android/**
-    - /**/gdx-tests-android/**
-  - all-globs-to-all-files:
-    - '!/**/gdx-tests-android/assets/data/**'
+- all:
+  - changed-files:
+    - any-glob-to-any-file:
+      - /**/gdx-backend-android/**
+      - /**/gdx-tests-android/**
+    - all-globs-to-all-files:
+      - '!/**/gdx-tests-android/assets/data/**'
 audio:
 - changed-files:
   - any-glob-to-any-file:


### PR DESCRIPTION
>  If a base option is provided without a top-level key, then it will default to any.
https://github.com/actions/labeler

So, seems like it's just an "OR" currently and not an exclusion filter.