### PR TITLE
Minor code improvements to DefaultAndroidInput

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/DefaultAndroidInput.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/DefaultAndroidInput.java
@@ -17,6 +17,7 @@
 package com.badlogic.gdx.backends.android;
 
 import android.animation.Animator;
+import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
 import android.app.Activity;
 import android.app.AlertDialog;
@@ -62,6 +63,7 @@ import com.badlogic.gdx.utils.GdxRuntimeException;
 import com.badlogic.gdx.utils.Pool;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 /** An implementation of the {@link Input} interface for Android.
@@ -113,9 +115,9 @@ public class DefaultAndroidInput extends AbstractInput implements AndroidInput, 
 
 	public static final int NUM_TOUCHES = 20;
 
-	ArrayList<OnKeyListener> keyListeners = new ArrayList();
-	ArrayList<KeyEvent> keyEvents = new ArrayList();
-	ArrayList<TouchEvent> touchEvents = new ArrayList();
+	ArrayList<OnKeyListener> keyListeners = new ArrayList<>();
+	ArrayList<KeyEvent> keyEvents = new ArrayList<>();
+	ArrayList<TouchEvent> touchEvents = new ArrayList<>();
 	int[] touchX = new int[NUM_TOUCHES];
 	int[] touchY = new int[NUM_TOUCHES];
 	int[] deltaX = new int[NUM_TOUCHES];
@@ -125,13 +127,13 @@ public class DefaultAndroidInput extends AbstractInput implements AndroidInput, 
 	int[] realId = new int[NUM_TOUCHES];
 	float[] pressure = new float[NUM_TOUCHES];
 	final boolean hasMultitouch;
-	private boolean[] justPressedButtons = new boolean[NUM_TOUCHES];
+	private final boolean[] justPressedButtons = new boolean[NUM_TOUCHES];
 	private SensorManager manager;
 	public boolean accelerometerAvailable = false;
 	protected final float[] accelerometerValues = new float[3];
 	public boolean gyroscopeAvailable = false;
 	protected final float[] gyroscopeValues = new float[3];
-	private Handler handle;
+	private final Handler handle;
 	final Application app;
 	final Context context;
 	protected final AndroidTouchHandler touchHandler;
@@ -156,12 +158,12 @@ public class DefaultAndroidInput extends AbstractInput implements AndroidInput, 
 	private SensorEventListener compassListener;
 	private SensorEventListener rotationVectorListener;
 
-	private final ArrayList<OnGenericMotionListener> genericMotionListeners = new ArrayList();
+	private final ArrayList<OnGenericMotionListener> genericMotionListeners = new ArrayList<>();
 	private final AndroidMouseHandler mouseHandler;
 
 	public DefaultAndroidInput (Application activity, Context context, Object view, AndroidApplicationConfiguration config) {
 		// we hook into View, for LWPs we call onTouch below directly from
-		// within the AndroidLivewallpaperEngine#onTouchEvent() method.
+		// within the AndroidWallpaperEngine#onTouchEvent() method.
 		if (view instanceof View) {
 			View v = (View)view;
 			v.setOnKeyListener(this);
@@ -400,15 +402,11 @@ public class DefaultAndroidInput extends AbstractInput implements AndroidInput, 
 		synchronized (this) {
 			if (justTouched) {
 				justTouched = false;
-				for (int i = 0; i < justPressedButtons.length; i++) {
-					justPressedButtons[i] = false;
-				}
+				Arrays.fill(justPressedButtons, false);
 			}
 			if (keyJustPressed) {
 				keyJustPressed = false;
-				for (int i = 0; i < justPressedKeys.length; i++) {
-					justPressedKeys[i] = false;
-				}
+				Arrays.fill(justPressedKeys, false);
 			}
 
 			if (processor != null) {
@@ -488,6 +486,7 @@ public class DefaultAndroidInput extends AbstractInput implements AndroidInput, 
 
 	boolean requestFocus = true;
 
+	@SuppressLint("ClickableViewAccessibility")
 	@Override
 	public boolean onTouch (View view, MotionEvent event) {
 		if (requestFocus && view != null) {
@@ -501,42 +500,6 @@ public class DefaultAndroidInput extends AbstractInput implements AndroidInput, 
 
 		return true;
 	}
-
-// TODO Seems unused. Delete when confirmed.
-// /** Called in {@link AndroidLiveWallpaperService} on tap
-// * @param x
-// * @param y */
-// public void onTap (int x, int y) {
-// postTap(x, y);
-// }
-//
-// /** Called in {@link AndroidLiveWallpaperService} on drop
-// * @param x
-// * @param y */
-// public void onDrop (int x, int y) {
-// postTap(x, y);
-// }
-//
-// protected void postTap (int x, int y) {
-// synchronized (this) {
-// TouchEvent event = usedTouchEvents.obtain();
-// event.timeStamp = System.nanoTime();
-// event.pointer = 0;
-// event.x = x;
-// event.y = y;
-// event.type = TouchEvent.TOUCH_DOWN;
-// touchEvents.add(event);
-//
-// event = usedTouchEvents.obtain();
-// event.timeStamp = System.nanoTime();
-// event.pointer = 0;
-// event.x = x;
-// event.y = y;
-// event.type = TouchEvent.TOUCH_UP;
-// touchEvents.add(event);
-// }
-// Gdx.app.getGraphics().requestRendering();
-// }
 
 	@Override
 	public boolean onKey (View v, int keyCode, android.view.KeyEvent e) {
@@ -671,9 +634,6 @@ public class DefaultAndroidInput extends AbstractInput implements AndroidInput, 
 		DisplayMetrics metrics = new DisplayMetrics();
 		androidApplication.getWindowManager().getDefaultDisplay().getMetrics(metrics);
 		int usableHeight = metrics.heightPixels;
-		int sdkVersion = android.os.Build.VERSION.SDK_INT;
-		if (sdkVersion < 17) return usableHeight;
-
 		androidApplication.getWindowManager().getDefaultDisplay().getRealMetrics(metrics);
 		int realHeight = metrics.heightPixels;
 
@@ -1027,7 +987,7 @@ public class DefaultAndroidInput extends AbstractInput implements AndroidInput, 
 				final String text = editText.getText().toString();
 				final int selection = editText.getSelectionStart();
 				Gdx.app.postRunnable(new Runnable() {
-					TextInputWrapper wrapper = textInputWrapper;
+					final TextInputWrapper wrapper = textInputWrapper;
 
 					@Override
 					public void run () {
@@ -1136,7 +1096,7 @@ public class DefaultAndroidInput extends AbstractInput implements AndroidInput, 
 	 * <a href= "http://developer.android.com/reference/android/hardware/SensorManager.html#getRotationMatrix(float[], float[],
 	 * float[], float[])" >SensorManager#getRotationMatrix(float[], float[], float[], float[])</a>. Does not manipulate the matrix
 	 * if the platform does not have an accelerometer and compass, or a rotation vector sensor.
-	 * @param matrix */
+	 * @param matrix the device's rotation matrix */
 	public void getRotationMatrix (float[] matrix) {
 		if (rotationVectorAvailable)
 			SensorManager.getRotationMatrixFromVector(matrix, rotationVectorValues);
@@ -1314,7 +1274,7 @@ public class DefaultAndroidInput extends AbstractInput implements AndroidInput, 
 
 		StringBuilder sb = new StringBuilder();
 		for (int i = 0; i < len; i++) {
-			sb.append(i + ":" + realId[i] + " ");
+			sb.append(i).append(":").append(realId[i]).append(" ");
 		}
 		Gdx.app.log("AndroidInput", "Pointer ID lookup failed: " + pointerId + ", " + sb.toString());
 		return -1;


### PR DESCRIPTION
This is a small experiment to test the viability of improving some of the Android backend codebase.

Android backend code is filled with warnings due to deprecations as well as code style/good practices warnings. Changing everything in one go is both risky and very hard to review (and thus unmergeable). The warnings affect both IDEs as well as build (Gradle) console outputs.

Let's try one class and one type of change at a time.

I've started with `DefaultAndroidInput`. Most changes are trivial and I expect to be viewed as positive by the great majority of contributors including adding the diamond operator (except from @NathanSweet) which is already present in this class (and most of libGDX code base except from Scene2d where there's a de facto veto).

If this "easy to review" PRs approach works I'll go through the main Android backend classes.
