### PR TITLE
Bump project target to java 8

### DIFF
--- a/backends/gdx-backend-lwjgl3/build.gradle
+++ b/backends/gdx-backend-lwjgl3/build.gradle
@@ -16,11 +16,11 @@
 
 if (JavaVersion.current().isJava9Compatible()) {
 	compileJava {
-		options.release = versions.javaLwjgl3
+		options.release = versions.java
 	}
 }
-sourceCompatibility = versions.javaLwjgl3
-targetCompatibility = versions.javaLwjgl3
+sourceCompatibility = versions.java
+targetCompatibility = versions.java
 
 dependencies {
 	api libraries.lwjgl3

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -21,8 +21,7 @@ ext {
     gdxnatives = [:]
 }
 
-versions.java = project.hasProperty("javaVersion") ? Integer.parseInt(project.getProperty("javaVersion")) : 7
-versions.javaLwjgl3 = project.hasProperty("javaVersion") ? Integer.parseInt(project.getProperty("javaVersion")) : 8
+versions.java = project.hasProperty("javaVersion") ? Integer.parseInt(project.getProperty("javaVersion")) : 8
 versions.robovm = "2.3.22"
 versions.gwt = "2.11.0"
 versions.gwtPlugin = "1.1.29"

--- a/tests/gdx-tests-iosrobovm/build.gradle
+++ b/tests/gdx-tests-iosrobovm/build.gradle
@@ -22,8 +22,8 @@ buildscript {
 
 apply plugin: "robovm"
 
-sourceCompatibility = '1.7'
-targetCompatibility = '1.7'
+sourceCompatibility = versions.java
+targetCompatibility = versions.java
 
 dependencies {
 	implementation project(":tests:gdx-tests")

--- a/tests/gdx-tests-lwjgl3/build.gradle
+++ b/tests/gdx-tests-lwjgl3/build.gradle
@@ -21,11 +21,11 @@ sourceSets.main.resources.srcDirs = ["../gdx-tests-android/assets"]
 
 if (JavaVersion.current().isJava9Compatible()) {
 	compileJava {
-		options.release = versions.javaLwjgl3
+		options.release = versions.java
 	}
 }
-sourceCompatibility = versions.javaLwjgl3
-targetCompatibility = versions.javaLwjgl3
+sourceCompatibility = versions.java
+targetCompatibility = versions.java
 
 dependencies {
 	implementation project(":tests:gdx-tests")


### PR DESCRIPTION
Fixes https://github.com/libgdx/libgdx/issues/5487

All the discussion happened in the issue.
The main summary is, that new java 8 API's cannot be used. But it is still worth to bump the target, to be able to use java 8 syntax features and allow building with the newest JDK again.
An immidiate improvement to both performance and safety would be being able to merge and apply to the core repo: https://github.com/libgdx/libgdx/pull/7474#issuecomment-2710053369