### PR TITLE
Replace deprecated methods on AndroidAudioDevice and AndroidCursor

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidAudioDevice.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidAudioDevice.java
@@ -16,6 +16,7 @@
 
 package com.badlogic.gdx.backends.android;
 
+import android.media.AudioAttributes;
 import android.media.AudioFormat;
 import android.media.AudioManager;
 import android.media.AudioTrack;
@@ -40,11 +41,15 @@ class AndroidAudioDevice implements AudioDevice {
 
 	AndroidAudioDevice (int samplingRate, boolean isMono) {
 		this.isMono = isMono;
-		int minSize = AudioTrack.getMinBufferSize(samplingRate,
-			isMono ? AudioFormat.CHANNEL_OUT_MONO : AudioFormat.CHANNEL_OUT_STEREO, AudioFormat.ENCODING_PCM_16BIT);
-		track = new AudioTrack(AudioManager.STREAM_MUSIC, samplingRate,
-			isMono ? AudioFormat.CHANNEL_OUT_MONO : AudioFormat.CHANNEL_OUT_STEREO, AudioFormat.ENCODING_PCM_16BIT, minSize,
-			AudioTrack.MODE_STREAM);
+		int channelMask = isMono ? AudioFormat.CHANNEL_OUT_MONO : AudioFormat.CHANNEL_OUT_STEREO;
+		int encoding = AudioFormat.ENCODING_PCM_16BIT;
+		int minSize = AudioTrack.getMinBufferSize(samplingRate, channelMask, encoding);
+		AudioAttributes audioAttributes = new AudioAttributes.Builder().setUsage(AudioAttributes.USAGE_GAME)
+			.setContentType(AudioAttributes.CONTENT_TYPE_MUSIC).build();
+		AudioFormat audioFormat = new AudioFormat.Builder().setSampleRate(samplingRate).setChannelMask(channelMask)
+			.setEncoding(encoding).build();
+		track = new AudioTrack(audioAttributes, audioFormat, minSize, AudioTrack.MODE_STREAM,
+			AudioManager.AUDIO_SESSION_ID_GENERATE);
 		track.play();
 		latency = minSize / (isMono ? 1 : 2);
 	}
@@ -92,7 +97,7 @@ class AndroidAudioDevice implements AudioDevice {
 
 	@Override
 	public void setVolume (float volume) {
-		track.setStereoVolume(volume, volume);
+		track.setVolume(volume);
 	}
 
 	@Override

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidCursor.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidCursor.java
@@ -14,7 +14,7 @@ public class AndroidCursor implements Cursor {
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
 			int type;
 			switch (systemCursor) { //@off
-				case Arrow: type = PointerIcon.TYPE_DEFAULT; break;
+				case Arrow: type = PointerIcon.TYPE_ARROW; break;
 				case Ibeam: type = PointerIcon.TYPE_TEXT; break;
 				case Crosshair: type = PointerIcon.TYPE_CROSSHAIR; break;
 				case Hand: type = PointerIcon.TYPE_HAND; break;


### PR DESCRIPTION
All changes use APIs available since API 21 avoiding the need for conditional version checks.