### PR TITLE
Migrate away from ArrayReflection array instantiation

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -14,6 +14,7 @@
 - API Addition: Added SnapshotArray#replaceFirst and SnapshotArray#replaceAll
 - Android: Fixed rare NPE when `onDestroy` was called
 - API Deprecation: Deprecated ReflectionPool and the related Pools#get/Pools#obtain method. Please use the new DefaultPool with the new Pools#get/Pools#obtain methods. They offer more safety and can be used with the java 8 method reference syntax (e.g. Pools.get(MyClass::new))
+- API Deprecation: Deprecated constructors taking a "Class" for Queue/ArrayMap/Array. Please use the constructors utilising "ArraySupplier". They offer more safety and can be used with the java 8 method reference syntax (e.g. MyClass[]::new)
 
 [1.13.1]
 - [BREAKING CHANGE] Android: Since 1.13.0 libGDX requires setting `android.useAndroidX=true` in your gradle.properties file. In 1.13.1 it is NO longer needed to define the `androidx.core:core` dependency in your Android module.

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplication.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplication.java
@@ -55,8 +55,7 @@ public class AndroidApplication extends Activity implements AndroidApplicationBa
 	protected boolean firstResume = true;
 	protected final Array<Runnable> runnables = new Array<Runnable>();
 	protected final Array<Runnable> executedRunnables = new Array<Runnable>();
-	protected final SnapshotArray<LifecycleListener> lifecycleListeners = new SnapshotArray<LifecycleListener>(
-		LifecycleListener.class);
+	protected final SnapshotArray<LifecycleListener> lifecycleListeners = new SnapshotArray<>(LifecycleListener[]::new);
 	private final Array<AndroidEventListener> androidEventListeners = new Array<AndroidEventListener>();
 	protected int logLevel = LOG_INFO;
 	protected ApplicationLogger applicationLogger;

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidDaydream.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidDaydream.java
@@ -54,8 +54,7 @@ public class AndroidDaydream extends DreamService implements AndroidApplicationB
 	protected boolean firstResume = true;
 	protected final Array<Runnable> runnables = new Array<Runnable>();
 	protected final Array<Runnable> executedRunnables = new Array<Runnable>();
-	protected final SnapshotArray<LifecycleListener> lifecycleListeners = new SnapshotArray<LifecycleListener>(
-		LifecycleListener.class);
+	protected final SnapshotArray<LifecycleListener> lifecycleListeners = new SnapshotArray<>(LifecycleListener[]::new);
 	protected int logLevel = LOG_INFO;
 	protected ApplicationLogger applicationLogger;
 

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidFragmentApplication.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidFragmentApplication.java
@@ -42,8 +42,7 @@ public class AndroidFragmentApplication extends Fragment implements AndroidAppli
 	protected boolean firstResume = true;
 	protected final Array<Runnable> runnables = new Array<Runnable>();
 	protected final Array<Runnable> executedRunnables = new Array<Runnable>();
-	protected final SnapshotArray<LifecycleListener> lifecycleListeners = new SnapshotArray<LifecycleListener>(
-		LifecycleListener.class);
+	protected final SnapshotArray<LifecycleListener> lifecycleListeners = new SnapshotArray<>(LifecycleListener[]::new);
 	private final Array<AndroidEventListener> androidEventListeners = new Array<AndroidEventListener>();
 	protected int logLevel = LOG_INFO;
 	protected ApplicationLogger applicationLogger;

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidLiveWallpaper.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidLiveWallpaper.java
@@ -48,8 +48,7 @@ public class AndroidLiveWallpaper implements AndroidApplicationBase {
 	protected boolean firstResume = true;
 	protected final Array<Runnable> runnables = new Array<Runnable>();
 	protected final Array<Runnable> executedRunnables = new Array<Runnable>();
-	protected final SnapshotArray<LifecycleListener> lifecycleListeners = new SnapshotArray<LifecycleListener>(
-		LifecycleListener.class);
+	protected final SnapshotArray<LifecycleListener> lifecycleListeners = new SnapshotArray<>(LifecycleListener[]::new);
 	protected int logLevel = LOG_INFO;
 	protected ApplicationLogger applicationLogger;
 	protected volatile Color[] wallpaperColors = null;

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglApplication.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglApplication.java
@@ -52,8 +52,7 @@ public class LwjglApplication implements LwjglApplicationBase {
 	protected boolean running = true;
 	protected final Array<Runnable> runnables = new Array<Runnable>();
 	protected final Array<Runnable> executedRunnables = new Array<Runnable>();
-	protected final SnapshotArray<LifecycleListener> lifecycleListeners = new SnapshotArray<LifecycleListener>(
-		LifecycleListener.class);
+	protected final SnapshotArray<LifecycleListener> lifecycleListeners = new SnapshotArray<>(LifecycleListener[]::new);
 	protected int logLevel = LOG_INFO;
 	protected ApplicationLogger applicationLogger;
 	protected String preferencesdir;

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/audio/OpenALLwjglAudio.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/audio/OpenALLwjglAudio.java
@@ -50,7 +50,7 @@ public class OpenALLwjglAudio implements LwjglAudio {
 	private OpenALSound[] recentSounds;
 	private int mostRecentSound = -1;
 
-	Array<OpenALMusic> music = new Array(false, 1, OpenALMusic.class);
+	Array<OpenALMusic> music = new Array<>(false, 1, OpenALMusic[]::new);
 	boolean noDevice = false;
 
 	public OpenALLwjglAudio () {

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALLwjgl3Audio.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALLwjgl3Audio.java
@@ -65,7 +65,7 @@ public class OpenALLwjgl3Audio implements Lwjgl3Audio {
 	private String preferredOutputDevice = null;
 	private Thread observerThread;
 
-	Array<OpenALMusic> music = new Array(false, 1, OpenALMusic.class);
+	Array<OpenALMusic> music = new Array<>(false, 1, OpenALMusic[]::new);
 	long device;
 	long context;
 	boolean noDevice = false;

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/DefaultGwtAudio.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/DefaultGwtAudio.java
@@ -95,7 +95,7 @@ public class DefaultGwtAudio implements GwtAudio {
 
 	@Override
 	public String[] getAvailableOutputDevices () {
-		return outputDeviceLabelsIds.keys().toArray().toArray(String.class);
+		return outputDeviceLabelsIds.keys().toArray().toArray(String[]::new);
 	}
 
 	private native void getUserMedia () /*-{

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/RegionInfluencerPanel.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/flame/RegionInfluencerPanel.java
@@ -70,7 +70,7 @@ public class RegionInfluencerPanel extends InfluencerPanel<RegionInfluencer> imp
 		if (regions.size == 0) return;
 		value.clear();
 		value.setAtlasName(atlasName);
-		value.add((TextureRegion[])regions.toArray(TextureRegion.class));
+		value.add(regions.toArray(TextureRegion[]::new));
 		editor.setTexture(regions.get(0).getTexture());
 		editor.restart();
 	}

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/ktx/KTXProcessor.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/ktx/KTXProcessor.java
@@ -32,7 +32,7 @@ public class KTXProcessor {
 
 	public static void convert (String input, String output, boolean genMipmaps, boolean packETC1, boolean genAlphaAtlas)
 		throws Exception {
-		Array<String> opts = new Array<String>(String.class);
+		Array<String> opts = new Array<>(String[]::new);
 		opts.add(input);
 		opts.add(output);
 		if (genMipmaps) opts.add("-mipmaps");
@@ -43,7 +43,7 @@ public class KTXProcessor {
 
 	public static void convert (String inPx, String inNx, String inPy, String inNy, String inPz, String inNz, String output,
 		boolean genMipmaps, boolean packETC1, boolean genAlphaAtlas) throws Exception {
-		Array<String> opts = new Array<String>(String.class);
+		Array<String> opts = new Array<>(String[]::new);
 		opts.add(inPx);
 		opts.add(inNx);
 		opts.add(inPy);

--- a/gdx/res/com/badlogic/gdx.gwt.xml
+++ b/gdx/res/com/badlogic/gdx.gwt.xml
@@ -412,6 +412,7 @@
 		<include name="utils/Align.java"/>
 		<include name="utils/Array.java"/> <!-- Emulated: Reflection -->
 		<include name="utils/ArrayMap.java"/> <!-- Emulated: Reflection -->
+		<include name="utils/ArraySupplier.java"/>
 		<include name="utils/AtomicQueue.java"/>
 		<include name="utils/Base64Coder.java"/>
 		<include name="utils/BaseJsonReader.java"/>

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/Animation.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/Animation.java
@@ -20,6 +20,8 @@ import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.reflect.ArrayReflection;
 
+import java.util.Arrays;
+
 /**
  * <p>
  * An Animation stores a list of objects representing an animated sequence, e.g. for running or jumping. Each object in the
@@ -54,11 +56,7 @@ public class Animation<T> {
 	 *           correct type of array. Otherwise, it returns an Object[]. */
 	public Animation (float frameDuration, Array<? extends T> keyFrames) {
 		this.frameDuration = frameDuration;
-		Class arrayType = keyFrames.items.getClass().getComponentType();
-		T[] frames = (T[])ArrayReflection.newInstance(arrayType, keyFrames.size);
-		for (int i = 0, n = keyFrames.size; i < n; i++) {
-			frames[i] = keyFrames.get(i);
-		}
+		T[] frames = Arrays.copyOf(keyFrames.items, keyFrames.size);
 		setKeyFrames(frames);
 	}
 

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/Animation.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/Animation.java
@@ -18,7 +18,6 @@ package com.badlogic.gdx.graphics.g2d;
 
 import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.utils.Array;
-import com.badlogic.gdx.utils.reflect.ArrayReflection;
 
 import java.util.Arrays;
 

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/SpriteCache.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/SpriteCache.java
@@ -203,7 +203,7 @@ public class SpriteCache implements Disposable {
 			// New cache.
 			cache.maxCount = cacheCount;
 			cache.textureCount = textures.size;
-			cache.textures = textures.toArray(Texture.class);
+			cache.textures = textures.toArray(Texture[]::new);
 			cache.counts = new int[cache.textureCount];
 			for (int i = 0, n = counts.size; i < n; i++)
 				cache.counts[i] = counts.get(i);

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/TextureAtlas.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/TextureAtlas.java
@@ -155,7 +155,7 @@ public class TextureAtlas implements Disposable {
 	 * uses string comparison to find the regions, so the result should be cached rather than calling this method multiple
 	 * times. */
 	public Array<AtlasRegion> findRegions (String name) {
-		Array<AtlasRegion> matched = new Array(AtlasRegion.class);
+		Array<AtlasRegion> matched = new Array<>(AtlasRegion[]::new);
 		for (int i = 0, n = regions.size; i < n; i++) {
 			AtlasRegion region = regions.get(i);
 			if (region.name.equals(name)) matched.add(new AtlasRegion(region));
@@ -167,7 +167,7 @@ public class TextureAtlas implements Disposable {
 	 * stored rather than calling this method multiple times.
 	 * @see #createSprite(String) */
 	public Array<Sprite> createSprites () {
-		Array sprites = new Array(true, regions.size, Sprite.class);
+		Array sprites = new Array(true, regions.size, Sprite[]::new);
 		for (int i = 0, n = regions.size; i < n; i++)
 			sprites.add(newSprite(regions.get(i)));
 		return sprites;
@@ -201,7 +201,7 @@ public class TextureAtlas implements Disposable {
 	 * than calling this method multiple times.
 	 * @see #createSprite(String) */
 	public Array<Sprite> createSprites (String name) {
-		Array<Sprite> matched = new Array(Sprite.class);
+		Array<Sprite> matched = new Array<>(Sprite[]::new);
 		for (int i = 0, n = regions.size; i < n; i++) {
 			AtlasRegion region = regions.get(i);
 			if (region.name.equals(name)) matched.add(newSprite(region));
@@ -372,7 +372,8 @@ public class TextureAtlas implements Disposable {
 				}
 				// Page and region entries.
 				Page page = null;
-				Array<Object> names = null, values = null;
+				Array<String> names = null;
+				Array<int[]> values = null;
 				while (true) {
 					if (line == null) break;
 					if (line.trim().length() == 0) {
@@ -420,8 +421,8 @@ public class TextureAtlas implements Disposable {
 							region.originalHeight = region.height;
 						}
 						if (names != null && names.size > 0) {
-							region.names = names.toArray(String.class);
-							region.values = values.toArray(int[].class);
+							region.names = names.toArray(String[]::new);
+							region.values = values.toArray(int[][]::new);
 							names.clear();
 							values.clear();
 						}

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/Model.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/Model.java
@@ -172,7 +172,7 @@ public class Model implements Disposable {
 		}
 		for (ObjectMap.Entry<NodePart, ArrayMap<String, Matrix4>> e : nodePartBones.entries()) {
 			if (e.key.invBoneBindTransforms == null)
-				e.key.invBoneBindTransforms = new ArrayMap<Node, Matrix4>(Node.class, Matrix4.class);
+				e.key.invBoneBindTransforms = new ArrayMap<>(Node[]::new, Matrix4[]::new);
 			e.key.invBoneBindTransforms.clear();
 			for (ObjectMap.Entry<String, Matrix4> b : e.value.entries())
 				e.key.invBoneBindTransforms.put(getNode(b.key), new Matrix4(b.value).inv());

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/Model.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/Model.java
@@ -171,8 +171,7 @@ public class Model implements Disposable {
 			nodes.add(loadNode(node));
 		}
 		for (ObjectMap.Entry<NodePart, ArrayMap<String, Matrix4>> e : nodePartBones.entries()) {
-			if (e.key.invBoneBindTransforms == null)
-				e.key.invBoneBindTransforms = new ArrayMap<>(Node[]::new, Matrix4[]::new);
+			if (e.key.invBoneBindTransforms == null) e.key.invBoneBindTransforms = new ArrayMap<>(Node[]::new, Matrix4[]::new);
 			e.key.invBoneBindTransforms.clear();
 			for (ObjectMap.Entry<String, Matrix4> b : e.value.entries())
 				e.key.invBoneBindTransforms.put(getNode(b.key), new Matrix4(b.value).inv());

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/loader/G3dModelLoader.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/loader/G3dModelLoader.java
@@ -328,7 +328,7 @@ public class G3dModelLoader extends ModelLoader<ModelLoader.ModelParameters> {
 
 				JsonValue bones = material.get("bones");
 				if (bones != null) {
-					nodePart.bones = new ArrayMap<String, Matrix4>(true, bones.size, String.class, Matrix4.class);
+					nodePart.bones = new ArrayMap<>(true, bones.size, String[]::new, Matrix4[]::new);
 					int j = 0;
 					for (JsonValue bone = bones.child; bone != null; bone = bone.next, j++) {
 						String nodeId = bone.getString("node", null);

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/loader/G3dModelLoader.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/loader/G3dModelLoader.java
@@ -117,7 +117,7 @@ public class G3dModelLoader extends ModelLoader<ModelLoader.ModelParameters> {
 					jsonPart.indices = meshPart.require("indices").asShortArray();
 					parts.add(jsonPart);
 				}
-				jsonMesh.parts = parts.toArray(ModelMeshPart.class);
+				jsonMesh.parts = parts.toArray(ModelMeshPart[]::new);
 				model.meshes.add(jsonMesh);
 			}
 		}
@@ -168,7 +168,7 @@ public class G3dModelLoader extends ModelLoader<ModelLoader.ModelParameters> {
 					"Unknown vertex attribute '" + attr + "', should be one of position, normal, uv, tangent or binormal");
 			}
 		}
-		return vertexAttributes.toArray(VertexAttribute.class);
+		return vertexAttributes.toArray(VertexAttribute[]::new);
 	}
 
 	protected void parseMaterials (ModelData model, JsonValue json, String materialDir) {

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/loader/ObjLoader.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/loader/ObjLoader.java
@@ -267,7 +267,7 @@ public class ObjLoader extends ModelLoader<ObjLoader.ObjLoaderParameters> {
 			part.primitiveType = GL20.GL_TRIANGLES;
 			ModelMesh mesh = new ModelMesh();
 			mesh.id = meshId;
-			mesh.attributes = attributes.toArray(VertexAttribute.class);
+			mesh.attributes = attributes.toArray(VertexAttribute[]::new);
 			mesh.vertices = finalVerts;
 			mesh.parts = new ModelMeshPart[] {part};
 			data.nodes.add(node);

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/model/NodePart.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/model/NodePart.java
@@ -80,8 +80,7 @@ public class NodePart {
 			bones = null;
 		} else {
 			if (invBoneBindTransforms == null)
-				invBoneBindTransforms = new ArrayMap<Node, Matrix4>(true, other.invBoneBindTransforms.size, Node.class,
-					Matrix4.class);
+				invBoneBindTransforms = new ArrayMap<>(true, other.invBoneBindTransforms.size, Node[]::new, Matrix4[]::new);
 			else
 				invBoneBindTransforms.clear();
 			invBoneBindTransforms.putAll(other.invBoneBindTransforms);

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/particles/ParallelArray.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/particles/ParallelArray.java
@@ -180,7 +180,7 @@ public class ParallelArray {
 	public int size;
 
 	public ParallelArray (int capacity) {
-		arrays = new Array<Channel>(false, 2, Channel.class);
+		arrays = new Array<>(false, 2, Channel[]::new);
 		this.capacity = capacity;
 		size = 0;
 	}

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/particles/ParticleController.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/particles/ParticleController.java
@@ -70,7 +70,7 @@ public class ParticleController implements Json.Serializable, ResourceData.Confi
 	public ParticleController () {
 		transform = new Matrix4();
 		scale = new Vector3(1, 1, 1);
-		influencers = new Array<Influencer>(true, 3, Influencer.class);
+		influencers = new Array<>(true, 3, Influencer[]::new);
 		setTimeStep(DEFAULT_TIME_STEP);
 	}
 

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/particles/ParticleEffect.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/particles/ParticleEffect.java
@@ -33,7 +33,7 @@ public class ParticleEffect implements Disposable, ResourceData.Configurable {
 	private BoundingBox bounds;
 
 	public ParticleEffect () {
-		controllers = new Array<ParticleController>(true, 3, ParticleController.class);
+		controllers = new Array<>(true, 3, ParticleController[]::new);
 	}
 
 	public ParticleEffect (ParticleEffect effect) {

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/particles/ResourceData.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/particles/ResourceData.java
@@ -150,7 +150,7 @@ public class ResourceData<T> implements Json.Serializable {
 
 	public ResourceData () {
 		uniqueData = new ObjectMap<String, SaveData>();
-		data = new Array<SaveData>(true, 3, SaveData.class);
+		data = new Array<>(true, 3, SaveData[]::new);
 		sharedAssets = new Array<AssetData>();
 		currentLoadIndex = 0;
 	}
@@ -212,7 +212,7 @@ public class ResourceData<T> implements Json.Serializable {
 	public void write (Json json) {
 		json.writeValue("unique", uniqueData, ObjectMap.class);
 		json.writeValue("data", data, Array.class, SaveData.class);
-		json.writeValue("assets", sharedAssets.toArray(AssetData.class), AssetData[].class);
+		json.writeValue("assets", sharedAssets.toArray(AssetData[]::new), AssetData[].class);
 		json.writeValue("resource", resource, null);
 	}
 

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/particles/batches/BillboardParticleBatch.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/particles/batches/BillboardParticleBatch.java
@@ -134,7 +134,7 @@ public class BillboardParticleBatch extends BufferedParticleBatch<BillboardContr
 	 * @param depthTestAttribute DepthTest attribute used by the batch */
 	public BillboardParticleBatch (AlignMode mode, boolean useGPU, int capacity, BlendingAttribute blendingAttribute,
 		DepthTestAttribute depthTestAttribute) {
-		super(BillboardControllerRenderData.class);
+		super(BillboardControllerRenderData[]::new);
 		renderables = new Array<Renderable>();
 		renderablePool = new RenderablePool();
 		this.blendingAttribute = blendingAttribute;

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/particles/batches/BufferedParticleBatch.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/particles/batches/BufferedParticleBatch.java
@@ -20,6 +20,7 @@ import com.badlogic.gdx.graphics.Camera;
 import com.badlogic.gdx.graphics.g3d.particles.ParticleSorter;
 import com.badlogic.gdx.graphics.g3d.particles.renderers.ParticleControllerRenderData;
 import com.badlogic.gdx.utils.Array;
+import com.badlogic.gdx.utils.ArraySupplier;
 
 /** Base class of all the batches requiring to buffer {@link ParticleControllerRenderData}
  * @author Inferno */
@@ -29,9 +30,15 @@ public abstract class BufferedParticleBatch<T extends ParticleControllerRenderDa
 	protected ParticleSorter sorter;
 	protected Camera camera;
 
+	@Deprecated
 	protected BufferedParticleBatch (Class<T> type) {
 		this.sorter = new ParticleSorter.Distance();
 		renderData = new com.badlogic.gdx.utils.Array<T>(false, 10, type);
+	}
+
+	protected BufferedParticleBatch (ArraySupplier<T[]> arraySupplier) {
+		this.sorter = new ParticleSorter.Distance();
+		renderData = new com.badlogic.gdx.utils.Array<T>(false, 10, arraySupplier);
 	}
 
 	public void begin () {

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/particles/batches/PointSpriteParticleBatch.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/particles/batches/PointSpriteParticleBatch.java
@@ -86,7 +86,7 @@ public class PointSpriteParticleBatch extends BufferedParticleBatch<PointSpriteC
 
 	public PointSpriteParticleBatch (int capacity, ParticleShader.Config shaderConfig, BlendingAttribute blendingAttribute,
 		DepthTestAttribute depthTestAttribute) {
-		super(PointSpriteControllerRenderData.class);
+		super(PointSpriteControllerRenderData[]::new);
 
 		if (!pointSpritesEnabled) enablePointSprites();
 

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/particles/influencers/DynamicsInfluencer.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/particles/influencers/DynamicsInfluencer.java
@@ -34,18 +34,18 @@ public class DynamicsInfluencer extends Influencer {
 	boolean hasAcceleration, has2dAngularVelocity, has3dAngularVelocity;
 
 	public DynamicsInfluencer () {
-		this.velocities = new Array<DynamicsModifier>(true, 3, DynamicsModifier.class);
+		this.velocities = new Array<>(true, 3, DynamicsModifier[]::new);
 	}
 
 	public DynamicsInfluencer (DynamicsModifier... velocities) {
-		this.velocities = new Array<DynamicsModifier>(true, velocities.length, DynamicsModifier.class);
+		this.velocities = new Array<>(true, velocities.length, DynamicsModifier[]::new);
 		for (DynamicsModifier value : velocities) {
 			this.velocities.add((DynamicsModifier)value.copy());
 		}
 	}
 
 	public DynamicsInfluencer (DynamicsInfluencer velocityInfluencer) {
-		this((DynamicsModifier[])velocityInfluencer.velocities.toArray(DynamicsModifier.class));
+		this(velocityInfluencer.velocities.toArray(DynamicsModifier[]::new));
 	}
 
 	@Override

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/particles/influencers/ModelInfluencer.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/particles/influencers/ModelInfluencer.java
@@ -119,7 +119,7 @@ public abstract class ModelInfluencer extends Influencer {
 	ObjectChannel<ModelInstance> modelChannel;
 
 	public ModelInfluencer () {
-		this.models = new Array<Model>(true, 1, Model.class);
+		this.models = new Array<>(true, 1, Model[]::new);
 	}
 
 	public ModelInfluencer (Model... models) {
@@ -127,7 +127,7 @@ public abstract class ModelInfluencer extends Influencer {
 	}
 
 	public ModelInfluencer (ModelInfluencer influencer) {
-		this((Model[])influencer.models.toArray(Model.class));
+		this(influencer.models.toArray(Model[]::new));
 	}
 
 	@Override

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/particles/influencers/ParticleControllerInfluencer.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/particles/influencers/ParticleControllerInfluencer.java
@@ -163,7 +163,7 @@ public abstract class ParticleControllerInfluencer extends Influencer {
 	ObjectChannel<ParticleController> particleControllerChannel;
 
 	public ParticleControllerInfluencer () {
-		this.templates = new Array<ParticleController>(true, 1, ParticleController.class);
+		this.templates = new Array<>(true, 1, ParticleController[]::new);
 	}
 
 	public ParticleControllerInfluencer (ParticleController... templates) {

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/particles/influencers/RegionInfluencer.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/particles/influencers/RegionInfluencer.java
@@ -208,7 +208,7 @@ public abstract class RegionInfluencer extends Influencer {
 	public String atlasName;
 
 	public RegionInfluencer (int regionsCount) {
-		this.regions = new Array<AspectTextureRegion>(false, regionsCount, AspectTextureRegion.class);
+		this.regions = new Array<>(false, regionsCount, AspectTextureRegion[]::new);
 	}
 
 	public RegionInfluencer () {
@@ -223,7 +223,7 @@ public abstract class RegionInfluencer extends Influencer {
 	/** All the regions must be defined on the same Texture */
 	public RegionInfluencer (TextureRegion... regions) {
 		setAtlasName(null);
-		this.regions = new Array<AspectTextureRegion>(false, regions.length, AspectTextureRegion.class);
+		this.regions = new Array<>(false, regions.length, AspectTextureRegion[]::new);
 		add(regions);
 	}
 

--- a/gdx/src/com/badlogic/gdx/math/CumulativeDistribution.java
+++ b/gdx/src/com/badlogic/gdx/math/CumulativeDistribution.java
@@ -2,7 +2,6 @@
 package com.badlogic.gdx.math;
 
 import com.badlogic.gdx.utils.Array;
-import com.badlogic.gdx.utils.reflect.ArrayReflection;
 
 /** This class represents a cumulative distribution. It can be used in scenarios where there are values with different
  * probabilities and it's required to pick one of those respecting the probability. For example one could represent the frequency
@@ -13,7 +12,7 @@ import com.badlogic.gdx.utils.reflect.ArrayReflection;
  * <a href="http://en.wikipedia.org/wiki/Cumulative_distribution_function">Wikipedia</a> for a detailed explanation.
  * @author Inferno */
 public class CumulativeDistribution<T> {
-	public class CumulativeValue {
+	public static class CumulativeValue<T> {
 		public T value;
 		public float frequency;
 		public float interval;
@@ -25,23 +24,20 @@ public class CumulativeDistribution<T> {
 		}
 	}
 
-	private Array<CumulativeValue> values;
+	private final Array<CumulativeValue<T>> values;
 
 	public CumulativeDistribution () {
-		@SuppressWarnings("unchecked")
-		// It is impossible to create a generic array without reflection (I think)
-		CumulativeValue[] tmp = (CumulativeValue[])ArrayReflection.newInstance(CumulativeValue.class, 10);
-		values = new Array<>(tmp);
+		values = new Array<CumulativeValue<T>>(false, 10, CumulativeValue[]::new);
 	}
 
 	/** Adds a value with a given interval size to the distribution */
 	public void add (T value, float intervalSize) {
-		values.add(new CumulativeValue(value, 0, intervalSize));
+		values.add(new CumulativeValue<>(value, 0, intervalSize));
 	}
 
 	/** Adds a value with interval size equal to zero to the distribution */
 	public void add (T value) {
-		values.add(new CumulativeValue(value, 0, 0));
+		values.add(new CumulativeValue<>(value, 0, 0));
 	}
 
 	/** Generate the cumulative distribution */
@@ -80,7 +76,7 @@ public class CumulativeDistribution<T> {
 	 * @param probability
 	 * @return the value whose interval contains the probability */
 	public T value (float probability) {
-		CumulativeValue value = null;
+		CumulativeValue<T> value = null;
 		int imax = values.size - 1, imin = 0, imid;
 		while (imin <= imax) {
 			imid = imin + ((imax - imin) / 2);
@@ -118,7 +114,7 @@ public class CumulativeDistribution<T> {
 
 	/** Set the interval size on the passed in object. The object must be present in the distribution. */
 	public void setInterval (T obj, float intervalSize) {
-		for (CumulativeValue value : values)
+		for (CumulativeValue<T> value : values)
 			if (value.value == obj) {
 				value.interval = intervalSize;
 				return;

--- a/gdx/src/com/badlogic/gdx/math/CumulativeDistribution.java
+++ b/gdx/src/com/badlogic/gdx/math/CumulativeDistribution.java
@@ -12,7 +12,7 @@ import com.badlogic.gdx.utils.Array;
  * <a href="http://en.wikipedia.org/wiki/Cumulative_distribution_function">Wikipedia</a> for a detailed explanation.
  * @author Inferno */
 public class CumulativeDistribution<T> {
-	public static class CumulativeValue<T> {
+	private static class CumulativeValue<T> {
 		public T value;
 		public float frequency;
 		public float interval;

--- a/gdx/src/com/badlogic/gdx/math/CumulativeDistribution.java
+++ b/gdx/src/com/badlogic/gdx/math/CumulativeDistribution.java
@@ -2,6 +2,7 @@
 package com.badlogic.gdx.math;
 
 import com.badlogic.gdx.utils.Array;
+import com.badlogic.gdx.utils.reflect.ArrayReflection;
 
 /** This class represents a cumulative distribution. It can be used in scenarios where there are values with different
  * probabilities and it's required to pick one of those respecting the probability. For example one could represent the frequency
@@ -27,7 +28,10 @@ public class CumulativeDistribution<T> {
 	private Array<CumulativeValue> values;
 
 	public CumulativeDistribution () {
-		values = new Array<CumulativeValue>(false, 10, CumulativeValue.class);
+		@SuppressWarnings("unchecked")
+		// It is impossible to create a generic array without reflection (I think)
+		CumulativeValue[] tmp = (CumulativeValue[])ArrayReflection.newInstance(CumulativeValue.class, 10);
+		values = new Array<>(tmp);
 	}
 
 	/** Adds a value with a given interval size to the distribution */

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/Group.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/Group.java
@@ -36,7 +36,7 @@ import com.badlogic.gdx.utils.SnapshotArray;
 public class Group extends Actor implements Cullable {
 	static private final Vector2 tmp = new Vector2();
 
-	final SnapshotArray<Actor> children = new SnapshotArray(true, 4, Actor.class);
+	final SnapshotArray<Actor> children = new SnapshotArray<>(true, 4, Actor[]::new);
 	private final Affine2 worldTransform = new Affine2();
 	private final Matrix4 computedTransform = new Matrix4();
 	private final Matrix4 oldTransform = new Matrix4();

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/Stage.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/Stage.java
@@ -78,7 +78,7 @@ public class Stage extends InputAdapter implements Disposable {
 	private int mouseScreenX, mouseScreenY;
 	private @Null Actor mouseOverActor;
 	private @Null Actor keyboardFocus, scrollFocus;
-	final SnapshotArray<TouchFocus> touchFocuses = new SnapshotArray(true, 4, TouchFocus.class);
+	final SnapshotArray<TouchFocus> touchFocuses = new SnapshotArray<>(true, 4, TouchFocus[]::new);
 	private boolean actionsRequestRendering = true;
 
 	private ShapeRenderer debugShapes;

--- a/gdx/src/com/badlogic/gdx/utils/Array.java
+++ b/gdx/src/com/badlogic/gdx/utils/Array.java
@@ -52,8 +52,7 @@ public class Array<T> implements Iterable<T> {
 	 *           memory copy.
 	 * @param capacity Any elements added beyond this will cause the backing array to be grown. */
 	public Array (boolean ordered, int capacity) {
-		// noinspection unchecked
-		this(ordered, capacity, (ArraySupplier<T[]>)ArraySupplier.OBJECT_ARRAY_SUPPLIER);
+		this(ordered, capacity, ArraySupplier.object());
 	}
 
 	/** Creates a new array with {@link #items} with the specified supplier.
@@ -78,7 +77,6 @@ public class Array<T> implements Iterable<T> {
 	 * @deprecated Use {@link Array#Array(boolean, int, ArraySupplier)} instead */
 	@Deprecated
 	public Array (boolean ordered, int capacity, Class arrayType) {
-		// noinspection unchecked
 		this(ordered, capacity, size -> (T[])ArrayReflection.newInstance(arrayType, size));
 	}
 

--- a/gdx/src/com/badlogic/gdx/utils/Array.java
+++ b/gdx/src/com/badlogic/gdx/utils/Array.java
@@ -52,20 +52,42 @@ public class Array<T> implements Iterable<T> {
 	 *           memory copy.
 	 * @param capacity Any elements added beyond this will cause the backing array to be grown. */
 	public Array (boolean ordered, int capacity) {
+        //noinspection unchecked
+        this(ordered, capacity, (ArraySupplier<T[]>)ArraySupplier.OBJECT_ARRAY_SUPPLIER);
+	}
+
+	/** Creates a new array with {@link #items} with the specified supplier.
+	 * @param ordered If false, methods that remove elements may change the order of other elements in the array, which avoids a
+	 *           memory copy.
+	 * @param capacity Any elements added beyond this will cause the backing array to be grown. */
+	public Array (boolean ordered, int capacity, ArraySupplier<T[]> arraySupplier) {
 		this.ordered = ordered;
-		items = (T[])new Object[capacity];
+		items = arraySupplier.get(capacity);
+	}
+
+	/** Creates an ordered array with {@link #items} with the specified supplier and a capacity of 16. */
+	public Array (ArraySupplier<T[]> arraySupplier) {
+		this(true, 16, arraySupplier);
 	}
 
 	/** Creates a new array with {@link #items} of the specified type.
 	 * @param ordered If false, methods that remove elements may change the order of other elements in the array, which avoids a
 	 *           memory copy.
-	 * @param capacity Any elements added beyond this will cause the backing array to be grown. */
+	 * @param capacity Any elements added beyond this will cause the backing array to be grown.
+	 *
+	 * @deprecated Use {@link Array#Array(boolean, int, ArraySupplier)} instead
+	 * */
+	@Deprecated
 	public Array (boolean ordered, int capacity, Class arrayType) {
-		this.ordered = ordered;
-		items = (T[])ArrayReflection.newInstance(arrayType, capacity);
+		// noinspection unchecked
+		this(ordered, capacity, size -> (T[])ArrayReflection.newInstance(arrayType, size));
 	}
 
-	/** Creates an ordered array with {@link #items} of the specified type and a capacity of 16. */
+	/** Creates an ordered array with {@link #items} of the specified type and a capacity of 16.
+	 *
+	 * @deprecated Use {@link Array#Array(ArraySupplier)} instead
+	 * */
+	@Deprecated
 	public Array (Class arrayType) {
 		this(true, 16, arrayType);
 	}
@@ -73,10 +95,10 @@ public class Array<T> implements Iterable<T> {
 	/** Creates a new array containing the elements in the specified array. The new array will have the same type of backing array
 	 * and will be ordered if the specified array is ordered. The capacity is set to the number of elements, so any subsequent
 	 * elements added will cause the backing array to be grown. */
-	public Array (Array<? extends T> array) {
-		this(array.ordered, array.size, array.items.getClass().getComponentType());
+	public Array (Array<T> array) {
+		items = Arrays.copyOf(array.items, array.size);
+		ordered = array.ordered;
 		size = array.size;
-		System.arraycopy(array.items, 0, items, 0, size);
 	}
 
 	/** Creates a new ordered array containing the elements in the specified array. The new array will have the same type of
@@ -91,9 +113,9 @@ public class Array<T> implements Iterable<T> {
 	 * @param ordered If false, methods that remove elements may change the order of other elements in the array, which avoids a
 	 *           memory copy. */
 	public Array (boolean ordered, T[] array, int start, int count) {
-		this(ordered, count, array.getClass().getComponentType());
+		items = Arrays.copyOfRange(array, start, start + count);
+		this.ordered = ordered;
 		size = count;
-		System.arraycopy(array, start, items, 0, size);
 	}
 
 	public void add (T value) {
@@ -466,11 +488,8 @@ public class Array<T> implements Iterable<T> {
 
 	/** Creates a new backing array with the specified size containing the current items. */
 	protected T[] resize (int newSize) {
-		T[] items = this.items;
-		T[] newItems = (T[])ArrayReflection.newInstance(items.getClass().getComponentType(), newSize);
-		System.arraycopy(items, 0, newItems, 0, Math.min(size, newItems.length));
-		this.items = newItems;
-		return newItems;
+		items = Arrays.copyOf(items, newSize);
+		return items;
 	}
 
 	/** Sorts this array. The array elements must implement {@link Comparable}. This method is not thread safe (uses
@@ -570,11 +589,21 @@ public class Array<T> implements Iterable<T> {
 	}
 
 	/** Returns the items as an array. Note the array is typed, so the {@link #Array(Class)} constructor must have been used.
-	 * Otherwise use {@link #toArray(Class)} to specify the array type. */
+	 * Otherwise use {@link #toArray(ArraySupplier)} to specify the array type. */
 	public T[] toArray () {
-		return (T[])toArray(items.getClass().getComponentType());
+		return Arrays.copyOf(items, size);
 	}
 
+	public T[] toArray (ArraySupplier<T[]> arraySupplier) {
+		T[] result = arraySupplier.get(size);
+		System.arraycopy(items, 0, result, 0, size);
+		return result;
+	}
+
+	/**
+	 * @deprecated Use {@link Array#toArray(ArraySupplier)} instead
+	 */
+	@Deprecated
 	public <V> V[] toArray (Class<V> type) {
 		V[] result = (V[])ArrayReflection.newInstance(type, size);
 		System.arraycopy(items, 0, result, 0, size);
@@ -651,12 +680,28 @@ public class Array<T> implements Iterable<T> {
 		return buffer.toString();
 	}
 
-	/** @see #Array(Class) */
+	/** @see #Array(ArraySupplier) */
+	static public <T> Array<T> of (ArraySupplier<T[]> arraySupplier) {
+		return new Array<>(arraySupplier);
+	}
+
+	/** @see #Array(boolean, int, ArraySupplier) */
+	static public <T> Array<T> of (boolean ordered, int capacity, ArraySupplier<T[]> arraySupplier) {
+		return new Array<>(ordered, capacity, arraySupplier);
+	}
+
+	/** @see #Array(Class)
+	 *
+	 * @deprecated Use {@link Array#of(ArraySupplier)}*/
+	@Deprecated
 	static public <T> Array<T> of (Class<T> arrayType) {
 		return new Array(arrayType);
 	}
 
-	/** @see #Array(boolean, int, Class) */
+	/** @see #Array(boolean, int, Class)
+	 *
+	 * @deprecated Use {@link Array#of(boolean, int, ArraySupplier)}*/
+	@Deprecated
 	static public <T> Array<T> of (boolean ordered, int capacity, Class<T> arrayType) {
 		return new Array(ordered, capacity, arrayType);
 	}

--- a/gdx/src/com/badlogic/gdx/utils/Array.java
+++ b/gdx/src/com/badlogic/gdx/utils/Array.java
@@ -52,8 +52,8 @@ public class Array<T> implements Iterable<T> {
 	 *           memory copy.
 	 * @param capacity Any elements added beyond this will cause the backing array to be grown. */
 	public Array (boolean ordered, int capacity) {
-        //noinspection unchecked
-        this(ordered, capacity, (ArraySupplier<T[]>)ArraySupplier.OBJECT_ARRAY_SUPPLIER);
+		// noinspection unchecked
+		this(ordered, capacity, (ArraySupplier<T[]>)ArraySupplier.OBJECT_ARRAY_SUPPLIER);
 	}
 
 	/** Creates a new array with {@link #items} with the specified supplier.
@@ -75,8 +75,7 @@ public class Array<T> implements Iterable<T> {
 	 *           memory copy.
 	 * @param capacity Any elements added beyond this will cause the backing array to be grown.
 	 *
-	 * @deprecated Use {@link Array#Array(boolean, int, ArraySupplier)} instead
-	 * */
+	 * @deprecated Use {@link Array#Array(boolean, int, ArraySupplier)} instead */
 	@Deprecated
 	public Array (boolean ordered, int capacity, Class arrayType) {
 		// noinspection unchecked
@@ -85,8 +84,7 @@ public class Array<T> implements Iterable<T> {
 
 	/** Creates an ordered array with {@link #items} of the specified type and a capacity of 16.
 	 *
-	 * @deprecated Use {@link Array#Array(ArraySupplier)} instead
-	 * */
+	 * @deprecated Use {@link Array#Array(ArraySupplier)} instead */
 	@Deprecated
 	public Array (Class arrayType) {
 		this(true, 16, arrayType);
@@ -600,9 +598,7 @@ public class Array<T> implements Iterable<T> {
 		return result;
 	}
 
-	/**
-	 * @deprecated Use {@link Array#toArray(ArraySupplier)} instead
-	 */
+	/** @deprecated Use {@link Array#toArray(ArraySupplier)} instead */
 	@Deprecated
 	public <V> V[] toArray (Class<V> type) {
 		V[] result = (V[])ArrayReflection.newInstance(type, size);
@@ -692,7 +688,7 @@ public class Array<T> implements Iterable<T> {
 
 	/** @see #Array(Class)
 	 *
-	 * @deprecated Use {@link Array#of(ArraySupplier)}*/
+	 * @deprecated Use {@link Array#of(ArraySupplier)} */
 	@Deprecated
 	static public <T> Array<T> of (Class<T> arrayType) {
 		return new Array(arrayType);
@@ -700,7 +696,7 @@ public class Array<T> implements Iterable<T> {
 
 	/** @see #Array(boolean, int, Class)
 	 *
-	 * @deprecated Use {@link Array#of(boolean, int, ArraySupplier)}*/
+	 * @deprecated Use {@link Array#of(boolean, int, ArraySupplier)} */
 	@Deprecated
 	static public <T> Array<T> of (boolean ordered, int capacity, Class<T> arrayType) {
 		return new Array(ordered, capacity, arrayType);

--- a/gdx/src/com/badlogic/gdx/utils/ArrayMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/ArrayMap.java
@@ -54,8 +54,9 @@ public class ArrayMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 	 *           memory copy.
 	 * @param capacity Any elements added beyond this will cause the backing arrays to be grown. */
 	public ArrayMap (boolean ordered, int capacity) {
-        //noinspection unchecked
-        this(ordered, capacity, (ArraySupplier<K[]>)ArraySupplier.OBJECT_ARRAY_SUPPLIER, (ArraySupplier<V[]>)ArraySupplier.OBJECT_ARRAY_SUPPLIER);
+		// noinspection unchecked
+		this(ordered, capacity, (ArraySupplier<K[]>)ArraySupplier.OBJECT_ARRAY_SUPPLIER,
+			(ArraySupplier<V[]>)ArraySupplier.OBJECT_ARRAY_SUPPLIER);
 	}
 
 	/** Creates a new map with {@link #keys} and {@link #values} with the specified supplier.
@@ -78,18 +79,17 @@ public class ArrayMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 	 *           memory copy.
 	 * @param capacity Any elements added beyond this will cause the backing arrays to be grown.
 	 *
-	 * @deprecated Use {@link ArrayMap#ArrayMap(boolean, int, ArraySupplier, ArraySupplier)} instead
-	 * */
+	 * @deprecated Use {@link ArrayMap#ArrayMap(boolean, int, ArraySupplier, ArraySupplier)} instead */
 	@Deprecated
 	public ArrayMap (boolean ordered, int capacity, Class keyArrayType, Class valueArrayType) {
-        //noinspection unchecked
-        this(ordered, capacity, size -> (K[])ArrayReflection.newInstance(keyArrayType, size), size -> (V[])ArrayReflection.newInstance(valueArrayType, size));
+		// noinspection unchecked
+		this(ordered, capacity, size -> (K[])ArrayReflection.newInstance(keyArrayType, size),
+			size -> (V[])ArrayReflection.newInstance(valueArrayType, size));
 	}
 
 	/** Creates an ordered map with {@link #keys} and {@link #values} of the specified type and a capacity of 16.
 	 *
-	 * @deprecated Use {@link ArrayMap#ArrayMap(ArraySupplier, ArraySupplier)} instead
-	 * */
+	 * @deprecated Use {@link ArrayMap#ArrayMap(ArraySupplier, ArraySupplier)} instead */
 	@Deprecated
 	public ArrayMap (Class keyArrayType, Class valueArrayType) {
 		this(false, 16, keyArrayType, valueArrayType);

--- a/gdx/src/com/badlogic/gdx/utils/ArrayMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/ArrayMap.java
@@ -54,22 +54,43 @@ public class ArrayMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 	 *           memory copy.
 	 * @param capacity Any elements added beyond this will cause the backing arrays to be grown. */
 	public ArrayMap (boolean ordered, int capacity) {
+        //noinspection unchecked
+        this(ordered, capacity, (ArraySupplier<K[]>)ArraySupplier.OBJECT_ARRAY_SUPPLIER, (ArraySupplier<V[]>)ArraySupplier.OBJECT_ARRAY_SUPPLIER);
+	}
+
+	/** Creates a new map with {@link #keys} and {@link #values} with the specified supplier.
+	 * @param ordered If false, methods that remove elements may change the order of other elements in the arrays, which avoids a
+	 *           memory copy.
+	 * @param capacity Any elements added beyond this will cause the backing arrays to be grown. */
+	public ArrayMap (boolean ordered, int capacity, ArraySupplier<K[]> keyArraySupplier, ArraySupplier<V[]> valueArraySupplier) {
 		this.ordered = ordered;
-		keys = (K[])new Object[capacity];
-		values = (V[])new Object[capacity];
+		keys = keyArraySupplier.get(capacity);
+		values = valueArraySupplier.get(capacity);
+	}
+
+	/** Creates an ordered map with {@link #keys} and {@link #values} with the specified supplier and a capacity of 16. */
+	public ArrayMap (ArraySupplier<K[]> keyArraySupplier, ArraySupplier<V[]> valueArraySupplier) {
+		this(false, 16, keyArraySupplier, valueArraySupplier);
 	}
 
 	/** Creates a new map with {@link #keys} and {@link #values} of the specified type.
 	 * @param ordered If false, methods that remove elements may change the order of other elements in the arrays, which avoids a
 	 *           memory copy.
-	 * @param capacity Any elements added beyond this will cause the backing arrays to be grown. */
+	 * @param capacity Any elements added beyond this will cause the backing arrays to be grown.
+	 *
+	 * @deprecated Use {@link ArrayMap#ArrayMap(boolean, int, ArraySupplier, ArraySupplier)} instead
+	 * */
+	@Deprecated
 	public ArrayMap (boolean ordered, int capacity, Class keyArrayType, Class valueArrayType) {
-		this.ordered = ordered;
-		keys = (K[])ArrayReflection.newInstance(keyArrayType, capacity);
-		values = (V[])ArrayReflection.newInstance(valueArrayType, capacity);
+        //noinspection unchecked
+        this(ordered, capacity, size -> (K[])ArrayReflection.newInstance(keyArrayType, size), size -> (V[])ArrayReflection.newInstance(valueArrayType, size));
 	}
 
-	/** Creates an ordered map with {@link #keys} and {@link #values} of the specified type and a capacity of 16. */
+	/** Creates an ordered map with {@link #keys} and {@link #values} of the specified type and a capacity of 16.
+	 *
+	 * @deprecated Use {@link ArrayMap#ArrayMap(ArraySupplier, ArraySupplier)} instead
+	 * */
+	@Deprecated
 	public ArrayMap (Class keyArrayType, Class valueArrayType) {
 		this(false, 16, keyArrayType, valueArrayType);
 	}
@@ -77,11 +98,11 @@ public class ArrayMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 	/** Creates a new map containing the elements in the specified map. The new map will have the same type of backing arrays and
 	 * will be ordered if the specified map is ordered. The capacity is set to the number of elements, so any subsequent elements
 	 * added will cause the backing arrays to be grown. */
-	public ArrayMap (ArrayMap array) {
-		this(array.ordered, array.size, array.keys.getClass().getComponentType(), array.values.getClass().getComponentType());
+	public ArrayMap (ArrayMap<K, V> array) {
+		ordered = array.ordered;
+		keys = Arrays.copyOf(array.keys, array.keys.length);
+		values = Arrays.copyOf(array.values, array.values.length);
 		size = array.size;
-		System.arraycopy(array.keys, 0, keys, 0, size);
-		System.arraycopy(array.values, 0, values, 0, size);
 	}
 
 	public int put (K key, V value) {
@@ -366,13 +387,8 @@ public class ArrayMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 	}
 
 	protected void resize (int newSize) {
-		K[] newKeys = (K[])ArrayReflection.newInstance(keys.getClass().getComponentType(), newSize);
-		System.arraycopy(keys, 0, newKeys, 0, Math.min(size, newKeys.length));
-		this.keys = newKeys;
-
-		V[] newValues = (V[])ArrayReflection.newInstance(values.getClass().getComponentType(), newSize);
-		System.arraycopy(values, 0, newValues, 0, Math.min(size, newValues.length));
-		this.values = newValues;
+		this.keys = Arrays.copyOf(keys, newSize);
+		this.values = Arrays.copyOf(values, newSize);
 	}
 
 	public void reverse () {

--- a/gdx/src/com/badlogic/gdx/utils/ArrayMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/ArrayMap.java
@@ -54,9 +54,7 @@ public class ArrayMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 	 *           memory copy.
 	 * @param capacity Any elements added beyond this will cause the backing arrays to be grown. */
 	public ArrayMap (boolean ordered, int capacity) {
-		// noinspection unchecked
-		this(ordered, capacity, (ArraySupplier<K[]>)ArraySupplier.OBJECT_ARRAY_SUPPLIER,
-			(ArraySupplier<V[]>)ArraySupplier.OBJECT_ARRAY_SUPPLIER);
+		this(ordered, capacity, ArraySupplier.object(), ArraySupplier.object());
 	}
 
 	/** Creates a new map with {@link #keys} and {@link #values} with the specified supplier.
@@ -82,7 +80,6 @@ public class ArrayMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 	 * @deprecated Use {@link ArrayMap#ArrayMap(boolean, int, ArraySupplier, ArraySupplier)} instead */
 	@Deprecated
 	public ArrayMap (boolean ordered, int capacity, Class keyArrayType, Class valueArrayType) {
-		// noinspection unchecked
 		this(ordered, capacity, size -> (K[])ArrayReflection.newInstance(keyArrayType, size),
 			size -> (V[])ArrayReflection.newInstance(valueArrayType, size));
 	}

--- a/gdx/src/com/badlogic/gdx/utils/ArraySupplier.java
+++ b/gdx/src/com/badlogic/gdx/utils/ArraySupplier.java
@@ -1,0 +1,14 @@
+package com.badlogic.gdx.utils;
+
+/** An interface that is used to create arrays. Even tho not annotated with "FunctionalInterface", it can act as
+ * one. <br>
+ * You can use a constructor reference or lambda as a ArraySupplier, such as with {@code MyClass[]::new} or
+ * {@code (size) -> new MyClass[size]}. */
+public interface ArraySupplier<T> {
+    /**
+     * A default array supplier that creates an Object[].
+     */
+    ArraySupplier<?> OBJECT_ARRAY_SUPPLIER = Object[]::new;
+
+    T get (int size);
+}

--- a/gdx/src/com/badlogic/gdx/utils/ArraySupplier.java
+++ b/gdx/src/com/badlogic/gdx/utils/ArraySupplier.java
@@ -1,14 +1,12 @@
+
 package com.badlogic.gdx.utils;
 
-/** An interface that is used to create arrays. Even tho not annotated with "FunctionalInterface", it can act as
- * one. <br>
+/** An interface that is used to create arrays. Even tho not annotated with "FunctionalInterface", it can act as one. <br>
  * You can use a constructor reference or lambda as a ArraySupplier, such as with {@code MyClass[]::new} or
  * {@code (size) -> new MyClass[size]}. */
 public interface ArraySupplier<T> {
-    /**
-     * A default array supplier that creates an Object[].
-     */
-    ArraySupplier<?> OBJECT_ARRAY_SUPPLIER = Object[]::new;
+	/** A default array supplier that creates an Object[]. */
+	ArraySupplier<?> OBJECT_ARRAY_SUPPLIER = Object[]::new;
 
-    T get (int size);
+	T get (int size);
 }

--- a/gdx/src/com/badlogic/gdx/utils/ArraySupplier.java
+++ b/gdx/src/com/badlogic/gdx/utils/ArraySupplier.java
@@ -6,7 +6,13 @@ package com.badlogic.gdx.utils;
  * {@code (size) -> new MyClass[size]}. */
 public interface ArraySupplier<T> {
 	/** A default array supplier that creates an Object[]. */
-	ArraySupplier<?> OBJECT_ARRAY_SUPPLIER = Object[]::new;
+	ArraySupplier<?> ANY = Object[]::new;
+
+	/** Returns a default array supplier that creates an Object[]. */
+	@SuppressWarnings("unchecked")
+	static <T> ArraySupplier<T[]> object () {
+		return (ArraySupplier<T[]>)ANY;
+	}
 
 	T get (int size);
 }

--- a/gdx/src/com/badlogic/gdx/utils/DelayedRemovalArray.java
+++ b/gdx/src/com/badlogic/gdx/utils/DelayedRemovalArray.java
@@ -42,6 +42,11 @@ public class DelayedRemovalArray<T> extends Array<T> {
 		super(array);
 	}
 
+	public DelayedRemovalArray (boolean ordered, int capacity, ArraySupplier<T[]> arraySupplier) {
+		super(ordered, capacity, arraySupplier);
+	}
+
+	@Deprecated
 	public DelayedRemovalArray (boolean ordered, int capacity, Class arrayType) {
 		super(ordered, capacity, arrayType);
 	}
@@ -54,6 +59,11 @@ public class DelayedRemovalArray<T> extends Array<T> {
 		super(ordered, array, startIndex, count);
 	}
 
+	public DelayedRemovalArray (ArraySupplier<T[]> arraySupplier) {
+		super(arraySupplier);
+	}
+
+	@Deprecated
 	public DelayedRemovalArray (Class arrayType) {
 		super(arrayType);
 	}

--- a/gdx/src/com/badlogic/gdx/utils/LongQueue.java
+++ b/gdx/src/com/badlogic/gdx/utils/LongQueue.java
@@ -42,7 +42,6 @@ public class LongQueue {
 
 	/** Creates a new LongQueue which can hold the specified number of values without needing to resize backing array. */
 	public LongQueue (int initialSize) {
-		// noinspection unchecked
 		this.values = new long[initialSize];
 	}
 

--- a/gdx/src/com/badlogic/gdx/utils/Queue.java
+++ b/gdx/src/com/badlogic/gdx/utils/Queue.java
@@ -48,14 +48,13 @@ public class Queue<T> implements Iterable<T> {
 
 	/** Creates a new Queue which can hold the specified number of values without needing to resize backing array. */
 	public Queue (int initialSize) {
-        //noinspection unchecked
-        this(initialSize, (ArraySupplier<T[]>)ArraySupplier.OBJECT_ARRAY_SUPPLIER);
+		// noinspection unchecked
+		this(initialSize, (ArraySupplier<T[]>)ArraySupplier.OBJECT_ARRAY_SUPPLIER);
 	}
 
 	/** Creates a new Queue which can hold the specified number of values without needing to resize backing array. This creates
 	 * backing array of the specified type via reflection, which is necessary only when accessing the backing array directly.
-	 * @deprecated Use {@link Queue#Queue(int, ArraySupplier)} instead
-	 * */
+	 * @deprecated Use {@link Queue#Queue(int, ArraySupplier)} instead */
 	@Deprecated
 	public Queue (int initialSize, Class<T> type) {
 		// noinspection unchecked

--- a/gdx/src/com/badlogic/gdx/utils/Queue.java
+++ b/gdx/src/com/badlogic/gdx/utils/Queue.java
@@ -16,10 +16,11 @@
 
 package com.badlogic.gdx.utils;
 
+import com.badlogic.gdx.utils.reflect.ArrayReflection;
+
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
-
-import com.badlogic.gdx.utils.reflect.ArrayReflection;
 
 /** A resizable, ordered array of objects with efficient add and remove at the beginning and end. Values in the backing array may
  * wrap back to the beginning, making add and remove at the beginning and end O(1) (unless the backing array needs to resize when
@@ -47,15 +48,24 @@ public class Queue<T> implements Iterable<T> {
 
 	/** Creates a new Queue which can hold the specified number of values without needing to resize backing array. */
 	public Queue (int initialSize) {
-		// noinspection unchecked
-		this.values = (T[])new Object[initialSize];
+        //noinspection unchecked
+        this(initialSize, (ArraySupplier<T[]>)ArraySupplier.OBJECT_ARRAY_SUPPLIER);
 	}
 
 	/** Creates a new Queue which can hold the specified number of values without needing to resize backing array. This creates
-	 * backing array of the specified type via reflection, which is necessary only when accessing the backing array directly. */
+	 * backing array of the specified type via reflection, which is necessary only when accessing the backing array directly.
+	 * @deprecated Use {@link Queue#Queue(int, ArraySupplier)} instead
+	 * */
+	@Deprecated
 	public Queue (int initialSize, Class<T> type) {
 		// noinspection unchecked
-		this.values = (T[])ArrayReflection.newInstance(type, initialSize);
+		this(initialSize, size -> (T[])ArrayReflection.newInstance(type, size));
+	}
+
+	/** Creates a new Queue which can hold the specified number of values without needing to resize backing array. This creates
+	 * backing array of the specified type via the supplier, which is necessary only when accessing the backing array directly. */
+	public Queue (int initialSize, ArraySupplier<T[]> arraySupplier) {
+		this.values = arraySupplier.get(initialSize);
 	}
 
 	/** Append given object to the tail. (enqueue to tail) Unless backing array needs resizing, operates in O(1) time.
@@ -112,7 +122,7 @@ public class Queue<T> implements Iterable<T> {
 		final int head = this.head;
 		final int tail = this.tail;
 
-		final T[] newArray = (T[])ArrayReflection.newInstance(values.getClass().getComponentType(), newSize);
+		final T[] newArray = Arrays.copyOf(values, newSize);
 		if (head < tail) {
 			// Continuous
 			System.arraycopy(values, head, newArray, 0, tail - head);

--- a/gdx/src/com/badlogic/gdx/utils/Queue.java
+++ b/gdx/src/com/badlogic/gdx/utils/Queue.java
@@ -48,8 +48,7 @@ public class Queue<T> implements Iterable<T> {
 
 	/** Creates a new Queue which can hold the specified number of values without needing to resize backing array. */
 	public Queue (int initialSize) {
-		// noinspection unchecked
-		this(initialSize, (ArraySupplier<T[]>)ArraySupplier.OBJECT_ARRAY_SUPPLIER);
+		this(initialSize, ArraySupplier.object());
 	}
 
 	/** Creates a new Queue which can hold the specified number of values without needing to resize backing array. This creates
@@ -57,7 +56,6 @@ public class Queue<T> implements Iterable<T> {
 	 * @deprecated Use {@link Queue#Queue(int, ArraySupplier)} instead */
 	@Deprecated
 	public Queue (int initialSize, Class<T> type) {
-		// noinspection unchecked
 		this(initialSize, size -> (T[])ArrayReflection.newInstance(type, size));
 	}
 

--- a/gdx/src/com/badlogic/gdx/utils/SnapshotArray.java
+++ b/gdx/src/com/badlogic/gdx/utils/SnapshotArray.java
@@ -52,6 +52,11 @@ public class SnapshotArray<T> extends Array<T> {
 		super(array);
 	}
 
+	public SnapshotArray (boolean ordered, int capacity, ArraySupplier<T[]> arraySupplier) {
+		super(ordered, capacity, arraySupplier);
+	}
+
+	@Deprecated
 	public SnapshotArray (boolean ordered, int capacity, Class arrayType) {
 		super(ordered, capacity, arrayType);
 	}
@@ -64,6 +69,11 @@ public class SnapshotArray<T> extends Array<T> {
 		super(ordered, array, startIndex, count);
 	}
 
+	public SnapshotArray (ArraySupplier<T[]> arraySupplier) {
+		super(arraySupplier);
+	}
+
+	@Deprecated
 	public SnapshotArray (Class arrayType) {
 		super(arrayType);
 	}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/AnimationTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/AnimationTest.java
@@ -60,7 +60,7 @@ public class AnimationTest extends GdxTest {
 	public void create () {
 		texture = new Texture(Gdx.files.internal("data/walkanim.png"));
 		TextureRegion[] leftWalkFrames = TextureRegion.split(texture, 64, 64)[0];
-		Array<TextureRegion> rightWalkFrames = new Array(TextureRegion.class);
+		Array<TextureRegion> rightWalkFrames = new Array<>(TextureRegion[]::new);
 		for (int i = 0; i < leftWalkFrames.length; i++) {
 			TextureRegion frame = new TextureRegion(leftWalkFrames[i]);
 			frame.flip(true, false);


### PR DESCRIPTION
Since we now target java 8, we can do further improvements by avoiding reflection.

This PR migrates array creation with `ArrayReflection(MyClass.class, 10)` to a functional interface like `MyClass[]::new`.
Avoiding reflection increases type-safety and makes other backends more reliable, as they often have limited reflection capabilities.

This PR migrates Queue/ArrayMap/Array for now, while deprecating the old methods. Some minor other reflection uses have been migrated too.
I also did some minor cleanups on things that I directly encountered, like duplicate generic specification and diamond operators.
