### PR TITLE
Fix permissions on Android tests

### DIFF
--- a/tests/gdx-tests-android/AndroidManifest.xml
+++ b/tests/gdx-tests-android/AndroidManifest.xml
@@ -4,7 +4,6 @@
 	xmlns:tools="http://schemas.android.com/tools"
 	android:installLocation="auto">
 	<uses-permission android:name="android.permission.RECORD_AUDIO"/>
-	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.VIBRATE"/>
 	<uses-permission android:name="android.permission.INTERNET" />
 	<uses-permission android:name="com.android.vending.BILLING" />

--- a/tests/gdx-tests-android/src/com/badlogic/gdx/tests/android/AndroidTestStarter.java
+++ b/tests/gdx-tests-android/src/com/badlogic/gdx/tests/android/AndroidTestStarter.java
@@ -18,16 +18,20 @@ package com.badlogic.gdx.tests.android;
 
 import java.util.List;
 
+import android.Manifest;
 import android.app.ListActivity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
+import android.content.pm.PackageManager;
+import android.os.Build;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.ArrayAdapter;
 import android.widget.ListView;
 
+import androidx.core.content.ContextCompat;
 import com.badlogic.gdx.tests.BackTest;
 import com.badlogic.gdx.tests.utils.GdxTests;
 
@@ -45,6 +49,18 @@ public class AndroidTestStarter extends ListActivity {
 
 		prefs = getSharedPreferences("libgdx-tests", Context.MODE_PRIVATE);
 		getListView().setSelectionFromTop(prefs.getInt("index", 0), prefs.getInt("top", 0));
+
+		requestAudioRecorderPermission();
+	}
+
+	private void requestAudioRecorderPermission () {
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+			boolean hasPermission = (ContextCompat.checkSelfPermission(this,
+				Manifest.permission.RECORD_AUDIO) == PackageManager.PERMISSION_GRANTED);
+			if (!hasPermission) {
+				this.requestPermissions(new String[] {Manifest.permission.RECORD_AUDIO}, 200);
+			}
+		}
 	}
 
 	protected void onListItemClick (ListView listView, View view, int position, long id) {
@@ -65,5 +81,4 @@ public class AndroidTestStarter extends ListActivity {
 
 		startActivity(intent);
 	}
-
 }


### PR DESCRIPTION
Added required runtime permission request for `AudioRecorderTest` (it currently crashes). The permission request is made on app startup. This could be improved in 2 ways:
- We could only request runtime permissions when/if running particular tests that require them 
- Check in the test if the permission has been granted. With the change, if user denies the permission the test will still crash.

Unfortunately I haven't come up with an elegant way to implement this as `AudioRecorderTest` is cross-platform. If anybody has an idea feel free to share.

Removed unnecessary `WRITE_EXTERNAL_PERMISSION` since external folders provided by ContextWrapper don't require it since `KITKAT` (https://developer.android.com/reference/android/content/ContextWrapper#getExternalFilesDir(java.lang.String)).