### PR TITLE
Migrate set/getStyle calls in `Skin#setEnabled` to an interface

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -13,6 +13,7 @@
 - API Addition: Added ShortArray#replaceFirst and ShortArray#replaceAll
 - API Addition: Added SnapshotArray#replaceFirst and SnapshotArray#replaceAll
 - Android: Fixed rare NPE when `onDestroy` was called
+- API Deprecation: Actors that implement `getStyle` and `setStyle` should now implement the `Styleable` interface
 - API Deprecation: Deprecated ReflectionPool and the related Pools#get/Pools#obtain method. Please use the new DefaultPool with the new Pools#get/Pools#obtain methods. They offer more safety and can be used with the java 8 method reference syntax (e.g. Pools.get(MyClass::new))
 
 [1.13.1]

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Button.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Button.java
@@ -41,7 +41,7 @@ import com.badlogic.gdx.utils.Pools;
  * <p>
  * The preferred size of the button is determined by the background and the button contents.
  * @author Nathan Sweet */
-public class Button extends Table implements Disableable {
+public class Button extends Table implements Disableable, Styleable<Button.ButtonStyle> {
 	private ButtonStyle style;
 	boolean isChecked, isDisabled;
 	ButtonGroup buttonGroup;

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Label.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Label.java
@@ -30,7 +30,7 @@ import com.badlogic.gdx.utils.StringBuilder;
  * <p>
  * The preferred size of the label is determined by the actual text bounds, unless {@link #setWrap(boolean) word wrap} is enabled.
  * @author Nathan Sweet */
-public class Label extends Widget {
+public class Label extends Widget implements Styleable<Label.LabelStyle> {
 	static private final Color tempColor = new Color();
 	static private final GlyphLayout prefSizeLayout = new GlyphLayout();
 

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/List.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/List.java
@@ -44,7 +44,7 @@ import com.badlogic.gdx.utils.Pools;
  * The preferred size of the list is determined by the text bounds of the items and the size of the {@link ListStyle#selection}.
  * @author mzechner
  * @author Nathan Sweet */
-public class List<T> extends Widget implements Cullable {
+public class List<T> extends Widget implements Cullable, Styleable<List.ListStyle> {
 	ListStyle style;
 	final Array<T> items = new Array();
 	ArraySelection<T> selection = new ArraySelection(items);

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ProgressBar.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ProgressBar.java
@@ -41,7 +41,7 @@ import com.badlogic.gdx.utils.Pools;
  * width is 140, a relatively arbitrary size. These parameters are reversed for a vertical progress bar.
  * @author mzechner
  * @author Nathan Sweet */
-public class ProgressBar extends Widget implements Disableable {
+public class ProgressBar extends Widget implements Disableable, Styleable<ProgressBar.ProgressBarStyle> {
 	private ProgressBarStyle style;
 	float min, max, stepSize;
 	private float value, animateFromValue;

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ScrollPane.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ScrollPane.java
@@ -45,7 +45,7 @@ import com.badlogic.gdx.utils.Null;
  * scroll pane is typically sized by ignoring the preferred size in one or both directions.
  * @author mzechner
  * @author Nathan Sweet */
-public class ScrollPane extends WidgetGroup {
+public class ScrollPane extends WidgetGroup implements Styleable<ScrollPane.ScrollPaneStyle> {
 	private ScrollPaneStyle style;
 	private Actor actor;
 

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/SelectBox.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/SelectBox.java
@@ -53,7 +53,7 @@ import com.badlogic.gdx.utils.Pools;
  * {@link SelectBoxStyle#background}.
  * @author mzechner
  * @author Nathan Sweet */
-public class SelectBox<T> extends Widget implements Disableable {
+public class SelectBox<T> extends Widget implements Disableable, Styleable<SelectBox.SelectBoxStyle> {
 	static final Vector2 temp = new Vector2();
 
 	SelectBoxStyle style;

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Skin.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Skin.java
@@ -415,23 +415,28 @@ public class Skin implements Disposable {
 	}
 
 	/** Sets the style on the actor to disabled or enabled. This is done by appending "-disabled" to the style name when enabled is
+	 * false, and removing "-disabled" from the style name when enabled is true. If the style was not found in the skin, an
+	 * exception is thrown. */
+	public <V> void setEnabled (Styleable<V> styleable, boolean enabled) {
+		V style = styleable.getStyle();
+
+		// noinspection unchecked
+		Class<V> styleClass = (Class<V>)style.getClass();
+
+		String name = find(style);
+		if (name == null) return;
+		name = name.replace("-disabled", "") + (enabled ? "" : "-disabled");
+		style = get(name, styleClass);
+
+		styleable.setStyle(style);
+	}
+
+	/** Sets the style on the actor to disabled or enabled. This is done by appending "-disabled" to the style name when enabled is
 	 * false, and removing "-disabled" from the style name when enabled is true. A method named "getStyle" is called the actor via
-	 * reflection and the name of that style is found in the skin. If the actor doesn't have a "getStyle" method or the style was
-	 * not found in the skin, no exception is thrown and the actor is left unchanged. */
-	public void setEnabled (Actor actor, boolean enabled) {
-		if (actor instanceof Styleable) {
-			// noinspection unchecked
-			Styleable<Object> styleable = (Styleable<Object>)actor;
-			Object style = styleable.getStyle();
-
-			String name = find(style);
-			if (name == null) return;
-			name = name.replace("-disabled", "") + (enabled ? "" : "-disabled");
-			style = get(name, style.getClass());
-
-			styleable.setStyle(style);
-			return;
-		}
+	 * reflection and the name of that style is found in the skin. If the actor doesn't have a "getStyle" and "setStyle" method the
+	 * actor is left unchanged. If the style was not found in the skin, an exception is thrown. */
+	@Deprecated
+	public void setEnabledReflection (Actor actor, boolean enabled) {
 		// Get current style.
 		Method method = findMethod(actor.getClass(), "getStyle");
 		if (method == null) return;
@@ -453,9 +458,6 @@ public class Skin implements Disposable {
 			method.invoke(actor, style);
 		} catch (Exception ignored) {
 		}
-
-		Gdx.app.error("DEPRECATED",
-			"Setting style on Actor " + actor.getClass().getName() + ", which does not implement 'Styleable' interface");
 	}
 
 	/** Returns the {@link TextureAtlas} passed to this skin constructor, or null. */

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Skin.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Skin.java
@@ -419,6 +419,19 @@ public class Skin implements Disposable {
 	 * reflection and the name of that style is found in the skin. If the actor doesn't have a "getStyle" method or the style was
 	 * not found in the skin, no exception is thrown and the actor is left unchanged. */
 	public void setEnabled (Actor actor, boolean enabled) {
+		if (actor instanceof Styleable) {
+			// noinspection unchecked
+			Styleable<Object> styleable = (Styleable<Object>)actor;
+			Object style = styleable.getStyle();
+
+			String name = find(style);
+			if (name == null) return;
+			name = name.replace("-disabled", "") + (enabled ? "" : "-disabled");
+			style = get(name, style.getClass());
+
+			styleable.setStyle(style);
+			return;
+		}
 		// Get current style.
 		Method method = findMethod(actor.getClass(), "getStyle");
 		if (method == null) return;
@@ -440,6 +453,9 @@ public class Skin implements Disposable {
 			method.invoke(actor, style);
 		} catch (Exception ignored) {
 		}
+
+		Gdx.app.error("[DEPRECATED]",
+			"Setting style on Actor " + actor.getClass().getName() + ", which does not implement 'Styleable' interface");
 	}
 
 	/** Returns the {@link TextureAtlas} passed to this skin constructor, or null. */

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Skin.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Skin.java
@@ -454,7 +454,7 @@ public class Skin implements Disposable {
 		} catch (Exception ignored) {
 		}
 
-		Gdx.app.error("[DEPRECATED]",
+		Gdx.app.error("DEPRECATED",
 			"Setting style on Actor " + actor.getClass().getName() + ", which does not implement 'Styleable' interface");
 	}
 

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Skin.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Skin.java
@@ -420,7 +420,7 @@ public class Skin implements Disposable {
 	public <V> void setEnabled (Styleable<V> styleable, boolean enabled) {
 		V style = styleable.getStyle();
 
-		// noinspection unchecked
+		@SuppressWarnings("unchecked")
 		Class<V> styleClass = (Class<V>)style.getClass();
 
 		String name = find(style);

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/SplitPane.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/SplitPane.java
@@ -43,7 +43,7 @@ import com.badlogic.gdx.utils.Null;
  * are sized depending on the SplitPane size and the {@link #setSplitAmount(float) split position}.
  * @author mzechner
  * @author Nathan Sweet */
-public class SplitPane extends WidgetGroup {
+public class SplitPane extends WidgetGroup implements Styleable<SplitPane.SplitPaneStyle> {
 	SplitPaneStyle style;
 	private @Null Actor firstWidget, secondWidget;
 	boolean vertical;

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Styleable.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Styleable.java
@@ -1,0 +1,13 @@
+
+package com.badlogic.gdx.scenes.scene2d.ui;
+
+/** This interface marks an Actor as Styleable
+ * @param <T> The Style object type */
+public interface Styleable<T> {
+
+	/** Get the current style of the actor */
+	T getStyle ();
+
+	/** Set the current style of the actor */
+	void setStyle (T style);
+}

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextField.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextField.java
@@ -62,7 +62,7 @@ import com.badlogic.gdx.utils.Timer.Task;
  * implementation will bring up the default IME.
  * @author mzechner
  * @author Nathan Sweet */
-public class TextField extends Widget implements Disableable {
+public class TextField extends Widget implements Disableable, Styleable<TextField.TextFieldStyle> {
 	static protected final char BACKSPACE = 8;
 	static protected final char CARRIAGE_RETURN = '\r';
 	static protected final char NEWLINE = '\n';

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextTooltip.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextTooltip.java
@@ -22,7 +22,9 @@ import com.badlogic.gdx.utils.Null;
 
 /** A tooltip that shows a label.
  * @author Nathan Sweet */
-public class TextTooltip extends Tooltip<Label> {
+public class TextTooltip extends Tooltip<Label> implements Styleable<TextTooltip.TextTooltipStyle> {
+	private TextTooltipStyle style;
+
 	public TextTooltip (@Null String text, Skin skin) {
 		this(text, TooltipManager.getInstance(), skin.get(TextTooltipStyle.class));
 	}
@@ -57,6 +59,7 @@ public class TextTooltip extends Tooltip<Label> {
 
 	public void setStyle (TextTooltipStyle style) {
 		if (style == null) throw new NullPointerException("style cannot be null");
+		this.style = style;
 		container.setBackground(style.background);
 		container.maxWidth(style.wrapWidth);
 
@@ -66,6 +69,10 @@ public class TextTooltip extends Tooltip<Label> {
 		Label label = container.getActor();
 		label.setStyle(style.label);
 		label.setWrap(wrap);
+	}
+
+	public TextTooltipStyle getStyle () {
+		return style;
 	}
 
 	/** The style for a text tooltip, see {@link TextTooltip}.

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Touchpad.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Touchpad.java
@@ -37,7 +37,7 @@ import com.badlogic.gdx.utils.Pools;
  * {@link ChangeEvent} is fired when the touchpad knob is moved. Cancelling the event will move the knob to where it was
  * previously.
  * @author Josh Street */
-public class Touchpad extends Widget {
+public class Touchpad extends Widget implements Styleable<Touchpad.TouchpadStyle> {
 	private TouchpadStyle style;
 	boolean touched;
 	boolean resetOnTouchUp = true;

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Tree.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Tree.java
@@ -43,7 +43,7 @@ import com.badlogic.gdx.utils.Null;
  * @param <N> The type of nodes in the tree.
  * @param <V> The type of values for each node.
  * @author Nathan Sweet */
-public class Tree<N extends Node, V> extends WidgetGroup {
+public class Tree<N extends Node, V> extends WidgetGroup implements Styleable<Tree.TreeStyle> {
 	static private final Vector2 tmp = new Vector2();
 
 	TreeStyle style;

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Window.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Window.java
@@ -37,7 +37,7 @@ import com.badlogic.gdx.utils.Null;
  * The preferred size of a window is the preferred size of the title text and the children as laid out by the table. After adding
  * children to the window, it can be convenient to call {@link #pack()} to size the window to the size of the children.
  * @author Nathan Sweet */
-public class Window extends Table {
+public class Window extends Table implements Styleable<Window.WindowStyle> {
 	static private final Vector2 tmpPosition = new Vector2();
 	static private final Vector2 tmpSize = new Vector2();
 	static private final int MOVE = 1 << 5;


### PR DESCRIPTION
This PR replaces the resolution of the `getStyle` and `setStyle` methods in `Skin#setEnabled` with a `Styleable` interface.
The reflection based approach does not work well with shrinker/dead code elimination and is more error prone when it comes to type safety. It also runs risks of duplicate `get/setStyle` methods, especially with subclassing.

The interface added fixes these issue, while retaining full backwards-compatibility. Therefore, this change is non-breaking.
A deprecation warning is issued to users, if the interface is not present and `Skin#setEnabled` is called.

@NathanSweet pinging you as the original author