### PR TITLE
Remove reflection use for lwjgl3 sound/audio creation

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,7 @@
 - [BREAKING CHANGE] Android: Proguard config line `boolean getUseDefaultContactFilter();` needs to be added. See https://github.com/libgdx/libgdx/pull/7578.
 - [BREAKING CHANGE] Android: Removed `AndroidApplicationConfiguration#touchSleepTime`.
 - [BREAKING CHANGE] Skin `setEnabled` now only works with actors that implement `Styleable`. Use `setEnabledReflection` for old behavior or add `Styleable` to your actors.
+- [BREAKING CHANGE] LWJGL3: The signature of `OpenALLwjgl3Audio#registerSound/registerMusic` has changed. To migrate just replace `registerMusic("myMusic", MyMusic.class);` with `registerMusic("myMusic", MyMusic::new);`
 - API Addition: Allow option to set Box2D native ContactFilter (World#setContactFilter(null)) for performance improvements.
 - API Addition: Added BooleanArray#replaceFirst and BooleanArray#replaceAll
 - API Addition: Added ByteArray#replaceFirst and ByteArray#replaceAll

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALLwjgl3Audio.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALLwjgl3Audio.java
@@ -27,6 +27,7 @@ import java.nio.FloatBuffer;
 import java.nio.IntBuffer;
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.BiFunction;
 
 import org.lwjgl.BufferUtils;
 import org.lwjgl.openal.AL;
@@ -58,8 +59,8 @@ public class OpenALLwjgl3Audio implements Lwjgl3Audio {
 	private LongMap<Integer> soundIdToSource;
 	private IntMap<Long> sourceToSoundId;
 	private long nextSoundId = 0;
-	private ObjectMap<String, Class<? extends OpenALSound>> extensionToSoundClass = new ObjectMap();
-	private ObjectMap<String, Class<? extends OpenALMusic>> extensionToMusicClass = new ObjectMap();
+	private ObjectMap<String, BiFunction<OpenALLwjgl3Audio, FileHandle, OpenALSound>> extensionToSoundClass = new ObjectMap<>();
+	private ObjectMap<String, BiFunction<OpenALLwjgl3Audio, FileHandle, OpenALMusic>> extensionToMusicClass = new ObjectMap<>();
 	private OpenALSound[] recentSounds;
 	private int mostRecetSound = -1;
 	private String preferredOutputDevice = null;
@@ -78,12 +79,12 @@ public class OpenALLwjgl3Audio implements Lwjgl3Audio {
 		this.deviceBufferSize = deviceBufferSize;
 		this.deviceBufferCount = deviceBufferCount;
 
-		registerSound("ogg", Ogg.Sound.class);
-		registerMusic("ogg", Ogg.Music.class);
-		registerSound("wav", Wav.Sound.class);
-		registerMusic("wav", Wav.Music.class);
-		registerSound("mp3", Mp3.Sound.class);
-		registerMusic("mp3", Mp3.Music.class);
+		registerSound("ogg", Ogg.Sound::new);
+		registerMusic("ogg", Ogg.Music::new);
+		registerSound("wav", Wav.Sound::new);
+		registerMusic("wav", Wav.Music::new);
+		registerSound("mp3", Mp3.Sound::new);
+		registerMusic("mp3", Mp3.Music::new);
 
 		device = alcOpenDevice((ByteBuffer)null);
 		if (device == 0L) {
@@ -175,16 +176,16 @@ public class OpenALLwjgl3Audio implements Lwjgl3Audio {
 		recentSounds = new OpenALSound[simultaneousSources];
 	}
 
-	public void registerSound (String extension, Class<? extends OpenALSound> soundClass) {
+	public void registerSound (String extension, BiFunction<OpenALLwjgl3Audio, FileHandle, OpenALSound> soundSupplier) {
 		if (extension == null) throw new IllegalArgumentException("extension cannot be null.");
-		if (soundClass == null) throw new IllegalArgumentException("soundClass cannot be null.");
-		extensionToSoundClass.put(extension, soundClass);
+		if (soundSupplier == null) throw new IllegalArgumentException("soundClass cannot be null.");
+		extensionToSoundClass.put(extension, soundSupplier);
 	}
 
-	public void registerMusic (String extension, Class<? extends OpenALMusic> musicClass) {
+	public void registerMusic (String extension, BiFunction<OpenALLwjgl3Audio, FileHandle, OpenALMusic> soundSupplier) {
 		if (extension == null) throw new IllegalArgumentException("extension cannot be null.");
-		if (musicClass == null) throw new IllegalArgumentException("musicClass cannot be null.");
-		extensionToMusicClass.put(extension, musicClass);
+		if (soundSupplier == null) throw new IllegalArgumentException("musicClass cannot be null.");
+		extensionToMusicClass.put(extension, soundSupplier);
 	}
 
 	public OpenALSound newSound (FileHandle file) {
@@ -194,29 +195,20 @@ public class OpenALLwjgl3Audio implements Lwjgl3Audio {
 
 	public OpenALSound newSound (FileHandle file, String extension) {
 		if (file == null) throw new IllegalArgumentException("file cannot be null.");
-		Class<? extends OpenALSound> soundClass = extensionToSoundClass.get(extension);
-		if (soundClass == null) throw new GdxRuntimeException("Unknown file extension for sound: " + file);
-		try {
-			OpenALSound sound = soundClass.getConstructor(new Class[] {OpenALLwjgl3Audio.class, FileHandle.class}).newInstance(this,
-				file);
-			if (sound.getType() != null && !sound.getType().equals(extension)) {
-				return newSound(file, sound.getType());
-			}
-			return sound;
-		} catch (Exception ex) {
-			throw new GdxRuntimeException("Error creating sound " + soundClass.getName() + " for file: " + file, ex);
+		BiFunction<OpenALLwjgl3Audio, FileHandle, OpenALSound> soundSupplier = extensionToSoundClass.get(extension);
+		if (soundSupplier == null) throw new GdxRuntimeException("Unknown file extension for sound: " + file);
+		OpenALSound sound = soundSupplier.apply(this, file);
+		if (sound.getType() != null && !sound.getType().equals(extension)) {
+			return newSound(file, sound.getType());
 		}
+		return sound;
 	}
 
 	public OpenALMusic newMusic (FileHandle file) {
 		if (file == null) throw new IllegalArgumentException("file cannot be null.");
-		Class<? extends OpenALMusic> musicClass = extensionToMusicClass.get(file.extension().toLowerCase());
-		if (musicClass == null) throw new GdxRuntimeException("Unknown file extension for music: " + file);
-		try {
-			return musicClass.getConstructor(new Class[] {OpenALLwjgl3Audio.class, FileHandle.class}).newInstance(this, file);
-		} catch (Exception ex) {
-			throw new GdxRuntimeException("Error creating music " + musicClass.getName() + " for file: " + file, ex);
-		}
+		BiFunction<OpenALLwjgl3Audio, FileHandle, OpenALMusic> musicSupplier = extensionToMusicClass.get(file.extension().toLowerCase());
+		if (musicSupplier == null) throw new GdxRuntimeException("Unknown file extension for music: " + file);
+		return musicSupplier.apply(this, file);
 	}
 
 	@Override

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALLwjgl3Audio.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/OpenALLwjgl3Audio.java
@@ -206,7 +206,8 @@ public class OpenALLwjgl3Audio implements Lwjgl3Audio {
 
 	public OpenALMusic newMusic (FileHandle file) {
 		if (file == null) throw new IllegalArgumentException("file cannot be null.");
-		BiFunction<OpenALLwjgl3Audio, FileHandle, OpenALMusic> musicSupplier = extensionToMusicClass.get(file.extension().toLowerCase());
+		BiFunction<OpenALLwjgl3Audio, FileHandle, OpenALMusic> musicSupplier = extensionToMusicClass
+			.get(file.extension().toLowerCase());
 		if (musicSupplier == null) throw new GdxRuntimeException("Unknown file extension for music: " + file);
 		return musicSupplier.apply(this, file);
 	}


### PR DESCRIPTION
This is a simple change that avoids unnecessary reflection for creating the lwjgl3 sound classes.
Since lwjgl3 requires java 8+, we can safely use the BiFunction here.