### PR TITLE
GlyphLayout: justify text option(s)

### DIFF
--- a/gdx/src/com/badlogic/gdx/utils/Justify.java
+++ b/gdx/src/com/badlogic/gdx/utils/Justify.java
@@ -1,0 +1,92 @@
+
+package com.badlogic.gdx.utils;
+
+public enum Justify {
+	None, WrappedLinesBySpace, WrappedLinesByGlyph, OverflowedLinesBySpace, OverflowedLinesByGlyph, AllLinesBySpace, AllLinesByGlyph;
+
+	public boolean matchWrapping (int wrapping) {
+		switch (this) {
+		case OverflowedLinesBySpace:
+		case OverflowedLinesByGlyph:
+			if (wrapping == Wrapping.wrappingLast) return true;
+			// Fall through.
+		case WrappedLinesBySpace:
+		case WrappedLinesByGlyph:
+			return wrapping == Wrapping.wrapped;
+		case AllLinesBySpace:
+		case AllLinesByGlyph:
+			return true;
+		}
+		return false;
+	}
+
+	public boolean matchChar (int ch) {
+		switch (this) {
+		case WrappedLinesBySpace:
+		case OverflowedLinesBySpace:
+		case AllLinesBySpace:
+			return ch == ' ';
+		case WrappedLinesByGlyph:
+		case OverflowedLinesByGlyph:
+		case AllLinesByGlyph:
+			return true;
+		}
+		return false;
+	}
+
+	public boolean isNone () {
+		return this == None;
+	}
+
+	/** Lines that were wrapped, excluding the last. */
+	public boolean isWrappedLines () {
+		switch (this) {
+		case WrappedLinesBySpace:
+		case WrappedLinesByGlyph:
+			return true;
+		}
+		return false;
+	}
+
+	/** Lines that wrapped, including the last. */
+	public boolean isOverflowedLines () {
+		switch (this) {
+		case OverflowedLinesBySpace:
+		case OverflowedLinesByGlyph:
+			return true;
+		}
+		return false;
+	}
+
+	/** All lines, regardless of wrapping. */
+	public boolean isAllLines () {
+		switch (this) {
+		case AllLinesBySpace:
+		case AllLinesByGlyph:
+			return true;
+		}
+		return false;
+	}
+
+	/** Fill width by padding space glyphs. */
+	public boolean isBySpace () {
+		switch (this) {
+		case WrappedLinesBySpace:
+		case OverflowedLinesBySpace:
+		case AllLinesBySpace:
+			return true;
+		}
+		return false;
+	}
+
+	/** Fill width by padding all glyphs. */
+	public boolean isByGlyph () {
+		switch (this) {
+		case WrappedLinesByGlyph:
+		case OverflowedLinesByGlyph:
+		case AllLinesByGlyph:
+			return true;
+		}
+		return false;
+	}
+}

--- a/gdx/src/com/badlogic/gdx/utils/Wrapping.java
+++ b/gdx/src/com/badlogic/gdx/utils/Wrapping.java
@@ -1,0 +1,8 @@
+
+package com.badlogic.gdx.utils;
+
+public class Wrapping {
+	static public final int none = 0;
+	static public final int wrapped = 1;
+	static public final int wrappingLast = 2;
+}


### PR DESCRIPTION
Initial implementation of adding layout support on GlyphLayout for justified text.

<table>
<tr>
<td>

Which lines to justify:
* wrapped lines except last.
* wrapped lines and last
* all lines

How to expand:
* only changing regular space glyphs
* all glyphs will change to fill the width

<hr>

Additional parameter on `GlyphLayout.setText`. Its previous signature remains, defaulting to use `Justify.None`.

</td>
<td>

<img src="https://github.com/user-attachments/assets/2bec26ac-66f6-46d7-b3af-c2a98f904e18">

</td>
</tr>
</table>

![](https://github.com/user-attachments/assets/8261b400-00ce-4230-8c06-53893096d640)
