### PR TITLE
scene2d: Solve NPEs when clicking with both mouse buttons

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/ActorGestureListener.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/ActorGestureListener.java
@@ -122,9 +122,11 @@ public class ActorGestureListener implements EventListener {
 			else {
 				this.event = event;
 				actor = event.getListenerActor();
-				detector.touchUp(event.getStageX(), event.getStageY(), event.getPointer(), event.getButton());
-				actor.stageToLocalCoordinates(tmpCoords.set(event.getStageX(), event.getStageY()));
-				touchUp(event, tmpCoords.x, tmpCoords.y, event.getPointer(), event.getButton());
+				if (actor != null) {
+					detector.touchUp(event.getStageX(), event.getStageY(), event.getPointer(), event.getButton());
+					actor.stageToLocalCoordinates(tmpCoords.set(event.getStageX(), event.getStageY()));
+					touchUp(event, tmpCoords.x, tmpCoords.y, event.getPointer(), event.getButton());
+				}
 			}
 			this.event = null;
 			actor = null;


### PR DESCRIPTION
As reported [here](https://github.com/yairm210/Unciv/issues/12922), if users click with left AND right mouse buttons, and then release, there will be **two** touchUp events that will be sent. 
The first one will set actor to null; The second will cause a null pointer exception trying to run actor.stageToLocalCoordinates
This resolves the issue