### PR TITLE
Upgrade to MobiVM 2.3.23

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -17,6 +17,7 @@
 - Android: Fixed rare NPE when `onDestroy` was called
 - API Deprecation: Deprecated ReflectionPool and the related Pools#get/Pools#obtain method. Please use the new DefaultPool with the new Pools#get/Pools#obtain methods. They offer more safety and can be used with the java 8 method reference syntax (e.g. Pools.get(MyClass::new))
 - API Deprecation: Deprecated constructors taking a "Class" for Queue/ArrayMap/Array. Please use the constructors utilising "ArraySupplier". They offer more safety and can be used with the java 8 method reference syntax (e.g. MyClass[]::new)
+- iOS: Update to MobiVM 2.3.23
 
 [1.13.1]
 - [BREAKING CHANGE] Android: Since 1.13.0 libGDX requires setting `android.useAndroidX=true` in your gradle.properties file. In 1.13.1 it is NO longer needed to define the `androidx.core:core` dependency in your Android module.

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -22,7 +22,7 @@ ext {
 }
 
 versions.java = project.hasProperty("javaVersion") ? Integer.parseInt(project.getProperty("javaVersion")) : 8
-versions.robovm = "2.3.22"
+versions.robovm = "2.3.23"
 versions.gwt = "2.11.0"
 versions.gwtPlugin = "1.1.29"
 versions.jsinteropAnnotations = "2.0.2"


### PR DESCRIPTION
Fixes provisioning profiles not being found on XCode 16.