### PR TITLE
Remove reflection use in ParallelArray

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -19,6 +19,7 @@
 - Android: Fixed rare NPE when `onDestroy` was called
 - API Deprecation: Deprecated ReflectionPool and the related Pools#get/Pools#obtain method. Please use the new DefaultPool with the new Pools#get/Pools#obtain methods. They offer more safety and can be used with the java 8 method reference syntax (e.g. Pools.get(MyClass::new))
 - API Deprecation: Deprecated constructors taking a "Class" for Queue/ArrayMap/Array. Please use the constructors utilising "ArraySupplier". They offer more safety and can be used with the java 8 method reference syntax (e.g. MyClass[]::new)
+- API Deprecation: Deprecated constructors taking a "Class" for ParallelArray.ChannelDescriptor. Please use the constructors utilising "ArraySupplier". They offer more safety and can be used with the java 8 method reference syntax (e.g. MyClass[]::new)
 - iOS: Update to MobiVM 2.3.23
 
 [1.13.1]

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/particles/ParallelArray.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/particles/ParallelArray.java
@@ -17,8 +17,11 @@
 package com.badlogic.gdx.graphics.g3d.particles;
 
 import com.badlogic.gdx.utils.Array;
+import com.badlogic.gdx.utils.ArraySupplier;
 import com.badlogic.gdx.utils.GdxRuntimeException;
 import com.badlogic.gdx.utils.reflect.ArrayReflection;
+
+import java.util.Arrays;
 
 /** This class represents an group of elements like an array, but the properties of the elements are stored as separate arrays.
  * These arrays are called {@link Channel} and are represented by {@link ChannelDescriptor}. It's not necessary to store primitive
@@ -31,12 +34,22 @@ public class ParallelArray {
 	public static class ChannelDescriptor {
 		public int id;
 		public Class<?> type;
+		public ArraySupplier<?> arraySupplier;
 		public int count;
 
+		@Deprecated
 		public ChannelDescriptor (int id, Class<?> type, int count) {
 			this.id = id;
 			this.type = type;
 			this.count = count;
+			this.arraySupplier = size -> ArrayReflection.newInstance(type, size);
+		}
+
+		public ChannelDescriptor (int id, ArraySupplier<?> arraySupplier, int count) {
+			this.id = id;
+			this.arraySupplier = arraySupplier;
+			this.count = count;
+			this.type = arraySupplier.get(0).getClass().getComponentType();
 		}
 	}
 
@@ -136,12 +149,10 @@ public class ParallelArray {
 
 	@SuppressWarnings("unchecked")
 	public class ObjectChannel<T> extends Channel {
-		Class<T> componentType;
 		public T[] data;
 
-		public ObjectChannel (int id, int strideSize, int size, Class<T> type) {
-			super(id, ArrayReflection.newInstance(type, size * strideSize), strideSize);
-			componentType = type;
+		public ObjectChannel (int id, int strideSize, int size, ArraySupplier<T[]> arraySupplier) {
+			super(id, arraySupplier.get(size * strideSize), strideSize);
 			this.data = (T[])super.data;
 		}
 
@@ -166,9 +177,7 @@ public class ParallelArray {
 
 		@Override
 		public void setCapacity (int requiredCapacity) {
-			T[] newData = (T[])ArrayReflection.newInstance(componentType, strideSize * requiredCapacity);
-			System.arraycopy(data, 0, newData, 0, Math.min(data.length, newData.length));
-			super.data = data = newData;
+			super.data = data = Arrays.copyOf(data, strideSize * requiredCapacity);
 		}
 	}
 
@@ -211,7 +220,7 @@ public class ParallelArray {
 		} else if (channelDescriptor.type == int.class) {
 			return (T)new IntChannel(channelDescriptor.id, channelDescriptor.count, capacity);
 		} else {
-			return (T)new ObjectChannel(channelDescriptor.id, channelDescriptor.count, capacity, channelDescriptor.type);
+			return (T)new ObjectChannel(channelDescriptor.id, channelDescriptor.count, capacity, channelDescriptor.arraySupplier);
 		}
 	}
 

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/particles/ParticleChannels.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/particles/ParticleChannels.java
@@ -120,22 +120,22 @@ public class ParticleChannels {
 
 	// Channels
 	/** Channels of common use like position, life, color, etc... */
-	public static final ChannelDescriptor Life = new ChannelDescriptor(newGlobalId(), float.class, 3);
-	public static final ChannelDescriptor Position = new ChannelDescriptor(newGlobalId(), float.class, 3); // gl units
-	public static final ChannelDescriptor PreviousPosition = new ChannelDescriptor(newGlobalId(), float.class, 3);
-	public static final ChannelDescriptor Color = new ChannelDescriptor(newGlobalId(), float.class, 4);
-	public static final ChannelDescriptor TextureRegion = new ChannelDescriptor(newGlobalId(), float.class, 6);
-	public static final ChannelDescriptor Rotation2D = new ChannelDescriptor(newGlobalId(), float.class, 2);
-	public static final ChannelDescriptor Rotation3D = new ChannelDescriptor(newGlobalId(), float.class, 4);
-	public static final ChannelDescriptor Scale = new ChannelDescriptor(newGlobalId(), float.class, 1);
-	public static final ChannelDescriptor ModelInstance = new ChannelDescriptor(newGlobalId(), ModelInstance.class, 1);
-	public static final ChannelDescriptor ParticleController = new ChannelDescriptor(newGlobalId(), ParticleController.class, 1);
-	public static final ChannelDescriptor Acceleration = new ChannelDescriptor(newGlobalId(), float.class, 3); // gl units/s2
-	public static final ChannelDescriptor AngularVelocity2D = new ChannelDescriptor(newGlobalId(), float.class, 1);
-	public static final ChannelDescriptor AngularVelocity3D = new ChannelDescriptor(newGlobalId(), float.class, 3);
-	public static final ChannelDescriptor Interpolation = new ChannelDescriptor(-1, float.class, 2);
-	public static final ChannelDescriptor Interpolation4 = new ChannelDescriptor(-1, float.class, 4);
-	public static final ChannelDescriptor Interpolation6 = new ChannelDescriptor(-1, float.class, 6);
+	public static final ChannelDescriptor Life = new ChannelDescriptor(newGlobalId(), float[]::new, 3);
+	public static final ChannelDescriptor Position = new ChannelDescriptor(newGlobalId(), float[]::new, 3); // gl units
+	public static final ChannelDescriptor PreviousPosition = new ChannelDescriptor(newGlobalId(), float[]::new, 3);
+	public static final ChannelDescriptor Color = new ChannelDescriptor(newGlobalId(), float[]::new, 4);
+	public static final ChannelDescriptor TextureRegion = new ChannelDescriptor(newGlobalId(), float[]::new, 6);
+	public static final ChannelDescriptor Rotation2D = new ChannelDescriptor(newGlobalId(), float[]::new, 2);
+	public static final ChannelDescriptor Rotation3D = new ChannelDescriptor(newGlobalId(), float[]::new, 4);
+	public static final ChannelDescriptor Scale = new ChannelDescriptor(newGlobalId(), float[]::new, 1);
+	public static final ChannelDescriptor ModelInstance = new ChannelDescriptor(newGlobalId(), ModelInstance[]::new, 1);
+	public static final ChannelDescriptor ParticleController = new ChannelDescriptor(newGlobalId(), ParticleController[]::new, 1);
+	public static final ChannelDescriptor Acceleration = new ChannelDescriptor(newGlobalId(), float[]::new, 3); // gl units/s2
+	public static final ChannelDescriptor AngularVelocity2D = new ChannelDescriptor(newGlobalId(), float[]::new, 1);
+	public static final ChannelDescriptor AngularVelocity3D = new ChannelDescriptor(newGlobalId(), float[]::new, 3);
+	public static final ChannelDescriptor Interpolation = new ChannelDescriptor(-1, float[]::new, 2);
+	public static final ChannelDescriptor Interpolation4 = new ChannelDescriptor(-1, float[]::new, 4);
+	public static final ChannelDescriptor Interpolation6 = new ChannelDescriptor(-1, float[]::new, 6);
 
 	// Offsets
 	/** Offsets to acess a particular value inside a stride of a given channel */


### PR DESCRIPTION
This PR finishes of, what was started in https://github.com/libgdx/libgdx/pull/7605
The only downside I can see is, that an additional object allocation happens, when a `ChannelDescriptor` is allocated. However, this should not be a real issue I think.