### PR TITLE
Add Drawable default interface methods

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -17,6 +17,7 @@
 - API Addition: Actors that implement `getStyle` and `setStyle` should now implement the `Styleable` interface
 - API Addition: Added BitmapFontCache#getPageCount.
 - API Addition: Added TextField#drawBackground, #updateDisplayText is protected.
+- API Addition: Added Drawable default interface methods.
 - Android: Fixed rare NPE when `onDestroy` was called
 - API Deprecation: Deprecated ReflectionPool and the related Pools#get/Pools#obtain method. Please use the new DefaultPool with the new Pools#get/Pools#obtain methods. They offer more safety and can be used with the java 8 method reference syntax (e.g. Pools.get(MyClass::new))
 - API Deprecation: Deprecated constructors taking a "Class" for Queue/ArrayMap/Array. Please use the constructors utilising "ArraySupplier". They offer more safety and can be used with the java 8 method reference syntax (e.g. MyClass[]::new)

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/BaseDrawable.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/BaseDrawable.java
@@ -75,13 +75,6 @@ public class BaseDrawable implements Drawable {
 		this.bottomHeight = bottomHeight;
 	}
 
-	public void setPadding (float topHeight, float leftWidth, float bottomHeight, float rightWidth) {
-		setTopHeight(topHeight);
-		setLeftWidth(leftWidth);
-		setBottomHeight(bottomHeight);
-		setRightWidth(rightWidth);
-	}
-
 	public float getMinWidth () {
 		return minWidth;
 	}
@@ -96,11 +89,6 @@ public class BaseDrawable implements Drawable {
 
 	public void setMinHeight (float minHeight) {
 		this.minHeight = minHeight;
-	}
-
-	public void setMinSize (float minWidth, float minHeight) {
-		setMinWidth(minWidth);
-		setMinHeight(minHeight);
 	}
 
 	public @Null String getName () {

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/Drawable.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/Drawable.java
@@ -42,6 +42,21 @@ public interface Drawable {
 
 	public void setBottomHeight (float bottomHeight);
 
+	default public void setPadding (float topHeight, float leftWidth, float bottomHeight, float rightWidth) {
+		setTopHeight(topHeight);
+		setLeftWidth(leftWidth);
+		setBottomHeight(bottomHeight);
+		setRightWidth(rightWidth);
+	}
+
+	default public void setPadding (float padding) {
+		setPadding(padding, padding, padding, padding);
+	}
+
+	default public void setPadding (Drawable from) {
+		setPadding(from.getTopHeight(), from.getLeftWidth(), from.getBottomHeight(), from.getRightWidth());
+	}
+
 	public float getMinWidth ();
 
 	public void setMinWidth (float minWidth);
@@ -49,4 +64,9 @@ public interface Drawable {
 	public float getMinHeight ();
 
 	public void setMinHeight (float minHeight);
+
+	default public void setMinSize (float minWidth, float minHeight) {
+		setMinWidth(minWidth);
+		setMinHeight(minHeight);
+	}
 }


### PR DESCRIPTION
These methods are just for convenience. There's a very small risk that someone's Drawable already has methods with these names (they'd have to not extend BaseDrawable).

Do all our targets handle default interface methods correctly? I would assume so, but these are the first in libgdx.