### PR TITLE
Replaced fireExit() with fireEnterAndExit() inside actorRemoved() inLWJGL3

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/Stage.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/Stage.java
@@ -599,13 +599,13 @@ public class Stage extends InputAdapter implements Disposable {
 		for (int pointer = 0, n = pointerOverActors.length; pointer < n; pointer++) {
 			if (actor == pointerOverActors[pointer]) {
 				pointerOverActors[pointer] = null;
-				fireExit(actor, pointerScreenX[pointer], pointerScreenY[pointer], pointer);
+				fireEnterAndExit(actor, pointerScreenX[pointer], pointerScreenY[pointer], pointer);
 			}
 		}
 
 		if (actor == mouseOverActor) {
 			mouseOverActor = null;
-			fireExit(actor, mouseScreenX, mouseScreenY, -1);
+			fireEnterAndExit(actor, mouseScreenX, mouseScreenY, -1);
 		}
 	}
 


### PR DESCRIPTION
Issue #7577 

Replaced fireExit() with fireEnterAndExit() in Stage.actorRemoved() to ensure the correct toActor is set in the exit() event when an actor is removed from the stage.

