### PR TITLE
[scene2d.ui] HorizontalGroup and VerticalGroup set transform false by default.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@
 - [BREAKING CHANGE] Android: Removed `AndroidApplicationConfiguration#touchSleepTime`.
 - [BREAKING CHANGE] Skin `setEnabled` now only works with actors that implement `Styleable`. Use `setEnabledReflection` for old behavior or add `Styleable` to your actors.
 - [BREAKING CHANGE] LWJGL3: The signature of `OpenALLwjgl3Audio#registerSound/registerMusic` has changed. To migrate just replace `registerMusic("myMusic", MyMusic.class);` with `registerMusic("myMusic", MyMusic::new);`
+- [BREAKING CHANGE] HorizontalGroup and VerticalGroup set transform false by default.
 - API Addition: Allow option to set Box2D native ContactFilter (World#setContactFilter(null)) for performance improvements.
 - API Addition: Added BooleanArray#replaceFirst and BooleanArray#replaceAll
 - API Addition: Added ByteArray#replaceFirst and ByteArray#replaceAll

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/HorizontalGroup.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/HorizontalGroup.java
@@ -47,6 +47,7 @@ public class HorizontalGroup extends WidgetGroup {
 	private float space, wrapSpace, fill, padTop, padLeft, padBottom, padRight;
 
 	public HorizontalGroup () {
+		setTransform(false);
 		setTouchable(Touchable.childrenOnly);
 	}
 

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/VerticalGroup.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/VerticalGroup.java
@@ -47,6 +47,7 @@ public class VerticalGroup extends WidgetGroup {
 	private float space, wrapSpace, fill, padTop, padLeft, padBottom, padRight;
 
 	public VerticalGroup () {
+		setTransform(false);
 		setTouchable(Touchable.childrenOnly);
 	}
 


### PR DESCRIPTION
HorizontalGroup and VerticalGroup are intended for UI and should have transform set to false, like Table, Container, and Stack. It was just never noticed until now!

This is a breaking change, since someone could be relying on transform being true, though that is probably unlikely.