### PR TITLE
Added task to extentions:gdx-tools build.gradle so buildRunnables can produce a jar for the TiledMapPacker

### DIFF
--- a/extensions/gdx-tools/build.gradle
+++ b/extensions/gdx-tools/build.gradle
@@ -106,7 +106,7 @@ tasks.register('distTiledMapPacker', Jar) {
 
 tasks.register('buildRunnables') {
 	dependsOn("build")
-	dependsOn dist3DParticles, distHiero, distTexturePacker
+	dependsOn dist3DParticles, distHiero, distTexturePacker, distTiledMapPacker
 	doLast {
 		println "Building ye runnables"
 	}


### PR DESCRIPTION
With #7525 completed and merged. As discussed, to get a working runnable for this tool.
I spent some time working on a new section for the TiledMapPacker as well as modifications to all the pages which should reference it in the wiki. You can find my PR in the website repo here https://github.com/libgdx/libgdx.github.io/pull/244.

This PR is simply just a small change to what I think needs to be done in order to get us a built jar for the TiledMapPacker tool.
I'm not gradle guru, so I just did what I saw for the other tools. So correct me if I am incorrect in my assumption.


