### PR TITLE
Duplicate code cleanup in Tiled Map Loaders. Replacement for PR(#7136)

### DIFF
--- a/gdx/src/com/badlogic/gdx/maps/tiled/TmjMapLoader.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/TmjMapLoader.java
@@ -144,32 +144,32 @@ public class TmjMapLoader extends BaseTmjMapLoader<BaseTmjMapLoader.Parameters> 
 		return getTileSetDependencyFileHandle(fileHandles, tmjFile, tileSet);
 	}
 
-	 protected Array<FileHandle> getTileSetDependencyFileHandle (Array<FileHandle> fileHandles, FileHandle tmjFile,
-		 JsonValue tileSet) {
-		  FileHandle tsjFile;
-		  String source = tileSet.getString("source", null);
-		  if (source != null) {
-				tsjFile = getRelativeFileHandle(tmjFile, source);
-				tileSet = json.parse(tsjFile);
-		  } else {
-				tsjFile = tmjFile;
-		  }
-		  if (tileSet.has("image")) {
-				String imageSource = tileSet.getString("image");
-				FileHandle image = getRelativeFileHandle(tsjFile, imageSource);
-				fileHandles.add(image);
-		  } else {
-				JsonValue tiles = tileSet.get("tiles");
-				if (tiles != null) {
-					 for (JsonValue tile : tiles) {
-						  String imageSource = tile.getString("image");
-						  FileHandle image = getRelativeFileHandle(tsjFile, imageSource);
-						  fileHandles.add(image);
-					 }
+	protected Array<FileHandle> getTileSetDependencyFileHandle (Array<FileHandle> fileHandles, FileHandle tmjFile,
+		JsonValue tileSet) {
+		FileHandle tsjFile;
+		String source = tileSet.getString("source", null);
+		if (source != null) {
+			tsjFile = getRelativeFileHandle(tmjFile, source);
+			tileSet = json.parse(tsjFile);
+		} else {
+			tsjFile = tmjFile;
+		}
+		if (tileSet.has("image")) {
+			String imageSource = tileSet.getString("image");
+			FileHandle image = getRelativeFileHandle(tsjFile, imageSource);
+			fileHandles.add(image);
+		} else {
+			JsonValue tiles = tileSet.get("tiles");
+			if (tiles != null) {
+				for (JsonValue tile : tiles) {
+					String imageSource = tile.getString("image");
+					FileHandle image = getRelativeFileHandle(tsjFile, imageSource);
+					fileHandles.add(image);
 				}
-		  }
-		  return fileHandles;
-	 }
+			}
+		}
+		return fileHandles;
+	}
 
 	@Override
 	protected void addStaticTiles (FileHandle tmjFile, ImageResolver imageResolver, TiledMapTileSet tileSet, JsonValue element,

--- a/gdx/src/com/badlogic/gdx/maps/tiled/TmjMapLoader.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/TmjMapLoader.java
@@ -144,44 +144,32 @@ public class TmjMapLoader extends BaseTmjMapLoader<BaseTmjMapLoader.Parameters> 
 		return getTileSetDependencyFileHandle(fileHandles, tmjFile, tileSet);
 	}
 
-	protected Array<FileHandle> getTileSetDependencyFileHandle (Array<FileHandle> fileHandles, FileHandle tmjFile,
-		JsonValue tileSet) {
-		String source = tileSet.getString("source", null);
-		if (source != null) {
-			FileHandle tsxFile = getRelativeFileHandle(tmjFile, source);
-			tileSet = json.parse(tsxFile);
-			if (tileSet.has("image")) {
+	 protected Array<FileHandle> getTileSetDependencyFileHandle (Array<FileHandle> fileHandles, FileHandle tmjFile,
+		 JsonValue tileSet) {
+		  FileHandle tsjFile;
+		  String source = tileSet.getString("source", null);
+		  if (source != null) {
+				tsjFile = getRelativeFileHandle(tmjFile, source);
+				tileSet = json.parse(tsjFile);
+		  } else {
+				tsjFile = tmjFile;
+		  }
+		  if (tileSet.has("image")) {
 				String imageSource = tileSet.getString("image");
-				FileHandle image = getRelativeFileHandle(tsxFile, imageSource);
+				FileHandle image = getRelativeFileHandle(tsjFile, imageSource);
 				fileHandles.add(image);
-			} else {
+		  } else {
 				JsonValue tiles = tileSet.get("tiles");
 				if (tiles != null) {
-					for (JsonValue tile : tiles) {
-						String imageSource = tile.getString("image");
-						FileHandle image = getRelativeFileHandle(tsxFile, imageSource);
-						fileHandles.add(image);
-					}
+					 for (JsonValue tile : tiles) {
+						  String imageSource = tile.getString("image");
+						  FileHandle image = getRelativeFileHandle(tsjFile, imageSource);
+						  fileHandles.add(image);
+					 }
 				}
-			}
-		} else {
-			if (tileSet.has("image")) {
-				String imageSource = tileSet.getString("image");
-				FileHandle image = getRelativeFileHandle(tmjFile, imageSource);
-				fileHandles.add(image);
-			} else {
-				JsonValue tiles = tileSet.get("tiles");
-				if (tiles != null) {
-					for (JsonValue tile : tiles) {
-						String imageSource = tile.getString("image");
-						FileHandle image = getRelativeFileHandle(tmjFile, imageSource);
-						fileHandles.add(image);
-					}
-				}
-			}
-		}
-		return fileHandles;
-	}
+		  }
+		  return fileHandles;
+	 }
 
 	@Override
 	protected void addStaticTiles (FileHandle tmjFile, ImageResolver imageResolver, TiledMapTileSet tileSet, JsonValue element,

--- a/gdx/src/com/badlogic/gdx/maps/tiled/TmxMapLoader.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/TmxMapLoader.java
@@ -133,40 +133,30 @@ public class TmxMapLoader extends BaseTmxMapLoader<TmxMapLoader.Parameters> {
 		return getTileSetDependencyFileHandle(fileHandles, tmxFile, tileset);
 	}
 
-	protected Array<FileHandle> getTileSetDependencyFileHandle (Array<FileHandle> fileHandles, FileHandle tmxFile,
-		Element tileset) {
-		String source = tileset.getAttribute("source", null);
-		if (source != null) {
-			FileHandle tsxFile = getRelativeFileHandle(tmxFile, source);
-			tileset = xml.parse(tsxFile);
-			Element imageElement = tileset.getChildByName("image");
-			if (imageElement != null) {
-				String imageSource = tileset.getChildByName("image").getAttribute("source");
+	 protected Array<FileHandle> getTileSetDependencyFileHandle (Array<FileHandle> fileHandles, FileHandle tmxFile,
+		 Element tileset) {
+		 FileHandle tsxFile;
+		 String source = tileset.getAttribute("source", null);
+		  if (source != null) {
+				tsxFile = getRelativeFileHandle(tmxFile, source);
+				tileset = xml.parse(tsxFile);
+		  } else {
+				tsxFile = tmxFile;
+		  }
+		  Element imageElement = tileset.getChildByName("image");
+		  if (imageElement != null) {
+				String imageSource = imageElement.getAttribute("source");
 				FileHandle image = getRelativeFileHandle(tsxFile, imageSource);
 				fileHandles.add(image);
-			} else {
+		  } else {
 				for (Element tile : tileset.getChildrenByName("tile")) {
-					String imageSource = tile.getChildByName("image").getAttribute("source");
-					FileHandle image = getRelativeFileHandle(tsxFile, imageSource);
-					fileHandles.add(image);
+					 String imageSource = tile.getChildByName("image").getAttribute("source");
+					 FileHandle image = getRelativeFileHandle(tsxFile, imageSource);
+					 fileHandles.add(image);
 				}
-			}
-		} else {
-			Element imageElement = tileset.getChildByName("image");
-			if (imageElement != null) {
-				String imageSource = tileset.getChildByName("image").getAttribute("source");
-				FileHandle image = getRelativeFileHandle(tmxFile, imageSource);
-				fileHandles.add(image);
-			} else {
-				for (Element tile : tileset.getChildrenByName("tile")) {
-					String imageSource = tile.getChildByName("image").getAttribute("source");
-					FileHandle image = getRelativeFileHandle(tmxFile, imageSource);
-					fileHandles.add(image);
-				}
-			}
-		}
-		return fileHandles;
-	}
+		  }
+		  return fileHandles;
+	 }
 
 	@Override
 	protected void addStaticTiles (FileHandle tmxFile, ImageResolver imageResolver, TiledMapTileSet tileSet, Element element,

--- a/gdx/src/com/badlogic/gdx/maps/tiled/TmxMapLoader.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/TmxMapLoader.java
@@ -133,30 +133,30 @@ public class TmxMapLoader extends BaseTmxMapLoader<TmxMapLoader.Parameters> {
 		return getTileSetDependencyFileHandle(fileHandles, tmxFile, tileset);
 	}
 
-	 protected Array<FileHandle> getTileSetDependencyFileHandle (Array<FileHandle> fileHandles, FileHandle tmxFile,
-		 Element tileset) {
-		 FileHandle tsxFile;
-		 String source = tileset.getAttribute("source", null);
-		  if (source != null) {
-				tsxFile = getRelativeFileHandle(tmxFile, source);
-				tileset = xml.parse(tsxFile);
-		  } else {
-				tsxFile = tmxFile;
-		  }
-		  Element imageElement = tileset.getChildByName("image");
-		  if (imageElement != null) {
-				String imageSource = imageElement.getAttribute("source");
+	protected Array<FileHandle> getTileSetDependencyFileHandle (Array<FileHandle> fileHandles, FileHandle tmxFile,
+		Element tileset) {
+		FileHandle tsxFile;
+		String source = tileset.getAttribute("source", null);
+		if (source != null) {
+			tsxFile = getRelativeFileHandle(tmxFile, source);
+			tileset = xml.parse(tsxFile);
+		} else {
+			tsxFile = tmxFile;
+		}
+		Element imageElement = tileset.getChildByName("image");
+		if (imageElement != null) {
+			String imageSource = imageElement.getAttribute("source");
+			FileHandle image = getRelativeFileHandle(tsxFile, imageSource);
+			fileHandles.add(image);
+		} else {
+			for (Element tile : tileset.getChildrenByName("tile")) {
+				String imageSource = tile.getChildByName("image").getAttribute("source");
 				FileHandle image = getRelativeFileHandle(tsxFile, imageSource);
 				fileHandles.add(image);
-		  } else {
-				for (Element tile : tileset.getChildrenByName("tile")) {
-					 String imageSource = tile.getChildByName("image").getAttribute("source");
-					 FileHandle image = getRelativeFileHandle(tsxFile, imageSource);
-					 fileHandles.add(image);
-				}
-		  }
-		  return fileHandles;
-	 }
+			}
+		}
+		return fileHandles;
+	}
 
 	@Override
 	protected void addStaticTiles (FileHandle tmxFile, ImageResolver imageResolver, TiledMapTileSet tileSet, Element element,


### PR DESCRIPTION
This is a replacement for the original one from back in 2023.
The original PR was no longer easily mergeable as the Map Loaders have been changed around a bit since then. But the core code he was trying to optimize still existed, it was just shifted around into a newly added getTileSetDependencyFileHandle method.

I also went ahead and modified the code in the new TmjMapLoader to match as both map loader's shared a similar structure So we got a 2 for 1 clean up deal here.

Other than that there isn't much else to this PR. So this is it, the last of the 2 fixable PRs on the big list. https://github.com/libgdx/libgdx/issues/7488