### PR TITLE
Respect AndroidApplicationConfiguration in BufferFormat creation

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplicationConfiguration.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplicationConfiguration.java
@@ -38,6 +38,9 @@ public class AndroidApplicationConfiguration {
 	/** number of samples for CSAA/MSAA, 2 is a good value **/
 	public int numSamples = 0;
 
+	/** whether coverage sampling anti-aliasing is used. in that case you have to clear the coverage buffer as well! */
+	public boolean coverageSampling = false;
+
 	/** whether to use the accelerometer. default: true **/
 	public boolean useAccelerometer = true;
 

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphics.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphics.java
@@ -94,7 +94,7 @@ public class AndroidGraphics extends AbstractGraphics implements Renderer {
 	private float density = 1;
 
 	protected final AndroidApplicationConfiguration config;
-	private BufferFormat bufferFormat = new BufferFormat(8, 8, 8, 0, 16, 0, 0, false);
+	private BufferFormat bufferFormat;
 	private boolean isContinuous = true;
 
 	public AndroidGraphics (AndroidApplicationBase application, AndroidApplicationConfiguration config,
@@ -104,6 +104,8 @@ public class AndroidGraphics extends AbstractGraphics implements Renderer {
 
 	public AndroidGraphics (AndroidApplicationBase application, AndroidApplicationConfiguration config,
 		ResolutionStrategy resolutionStrategy, boolean focusableView) {
+		bufferFormat = new BufferFormat(config.r, config.g, config.b, config.a,
+			config.depth, config.stencil, config.numSamples, config.coverageSampling);
 		this.config = config;
 		this.app = application;
 		view = createGLSurfaceView(application, resolutionStrategy);

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphics.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphics.java
@@ -104,8 +104,8 @@ public class AndroidGraphics extends AbstractGraphics implements Renderer {
 
 	public AndroidGraphics (AndroidApplicationBase application, AndroidApplicationConfiguration config,
 		ResolutionStrategy resolutionStrategy, boolean focusableView) {
-		bufferFormat = new BufferFormat(config.r, config.g, config.b, config.a,
-			config.depth, config.stencil, config.numSamples, config.coverageSampling);
+		bufferFormat = new BufferFormat(config.r, config.g, config.b, config.a, config.depth, config.stencil, config.numSamples,
+			config.coverageSampling);
 		this.config = config;
 		this.app = application;
 		view = createGLSurfaceView(application, resolutionStrategy);


### PR DESCRIPTION
This PR updates `BufferFormat` to use the provided configuration instead of hardcoded values, as suggested in #7415 by @obigu.

It also adds a `coverageSampling` setting to `AndroidApplicationConfiguration`. While I’m not personally familiar with what it does, users who need it will benefit from having the option. For those who don’t, it remains harmless and has no effect.

**Note:**
The only place where `BufferFormat` is constructed with `coverageSampling` set to anything other than `false` is in [AndroidGraphics#logConfig](https://github.com/libgdx/libgdx/blob/master/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphics.java#L346)