### PR TITLE
Add Vector.One static fields for convenience

### DIFF
--- a/gdx/src/com/badlogic/gdx/math/Vector2.java
+++ b/gdx/src/com/badlogic/gdx/math/Vector2.java
@@ -29,6 +29,7 @@ public class Vector2 implements Serializable, Vector<Vector2> {
 	public final static Vector2 X = new Vector2(1, 0);
 	public final static Vector2 Y = new Vector2(0, 1);
 	public final static Vector2 Zero = new Vector2(0, 0);
+	public final static Vector2 One = new Vector2(1, 1);
 
 	/** the x-component of this vector **/
 	public float x;

--- a/gdx/src/com/badlogic/gdx/math/Vector3.java
+++ b/gdx/src/com/badlogic/gdx/math/Vector3.java
@@ -37,6 +37,7 @@ public class Vector3 implements Serializable, Vector<Vector3> {
 	public final static Vector3 Y = new Vector3(0, 1, 0);
 	public final static Vector3 Z = new Vector3(0, 0, 1);
 	public final static Vector3 Zero = new Vector3(0, 0, 0);
+	public final static Vector3 One = new Vector3(1, 1, 1);
 
 	private final static Matrix4 tmpMat = new Matrix4();
 

--- a/gdx/src/com/badlogic/gdx/math/Vector4.java
+++ b/gdx/src/com/badlogic/gdx/math/Vector4.java
@@ -42,6 +42,7 @@ public class Vector4 implements Serializable, Vector<Vector4> {
 	public final static Vector4 Z = new Vector4(0, 0, 1, 0);
 	public final static Vector4 W = new Vector4(0, 0, 0, 1);
 	public final static Vector4 Zero = new Vector4(0, 0, 0, 0);
+	public final static Vector4 One = new Vector4(1, 1, 1, 1);
 
 	/** Constructs a vector at (0,0,0,0) */
 	public Vector4 () {


### PR DESCRIPTION
Vector classes have static field `Zero` with all fields initialized with 0.
This PR add fields `One` with all fields initialized with 1.