### PR TITLE
fix: Move Pools registration to individual classes for better initialization

### DIFF
--- a/gdx/src/com/badlogic/gdx/Net.java
+++ b/gdx/src/com/badlogic/gdx/Net.java
@@ -33,6 +33,7 @@ import com.badlogic.gdx.net.SocketHints;
 import com.badlogic.gdx.utils.GdxRuntimeException;
 import com.badlogic.gdx.utils.Null;
 import com.badlogic.gdx.utils.Pool.Poolable;
+import com.badlogic.gdx.utils.Pools;
 
 /** Provides methods to perform networking operations, such as simple HTTP get and post requests, and TCP server/client socket
  * communication.
@@ -161,6 +162,9 @@ public interface Net {
 	 * </pre>
 	 */
 	public static class HttpRequest implements Poolable {
+		static {
+			Pools.set(HttpRequest::new);
+		}
 
 		private String httpMethod;
 		private String url;

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/GlyphLayout.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/GlyphLayout.java
@@ -45,6 +45,10 @@ import com.badlogic.gdx.utils.Pools;
  * @author Alexander Dorokhov
  * @author Thomas Creutzenberg */
 public class GlyphLayout implements Poolable {
+	static {
+		Pools.set(GlyphLayout::new);
+	}
+
 	static private final Pool<GlyphRun> glyphRunPool = Pools.get(GlyphRun.class);
 	static private final IntArray colorStack = new IntArray(4);
 	static private final float epsilon = 0.0001f;
@@ -525,6 +529,10 @@ public class GlyphLayout implements Poolable {
 	/** Stores glyphs and positions for a line of text.
 	 * @author Nathan Sweet */
 	static public class GlyphRun implements Poolable {
+		static {
+			Pools.set(GlyphRun::new);
+		}
+
 		public Array<Glyph> glyphs = new Array();
 
 		/** Contains glyphs.size+1 entries:<br>

--- a/gdx/src/com/badlogic/gdx/math/Rectangle.java
+++ b/gdx/src/com/badlogic/gdx/math/Rectangle.java
@@ -17,11 +17,16 @@ import java.io.Serializable;
 
 import com.badlogic.gdx.utils.GdxRuntimeException;
 import com.badlogic.gdx.utils.NumberUtils;
+import com.badlogic.gdx.utils.Pools;
 import com.badlogic.gdx.utils.Scaling;
 
 /** Encapsulates a 2D rectangle defined by its corner point in the bottom left and its extents in x (width) and y (height).
  * @author badlogicgames@gmail.com */
 public class Rectangle implements Serializable, Shape2D {
+	static {
+		Pools.set(Rectangle::new);
+	}
+
 	/** Static temporary rectangle. Use with care! Use only when sure other code will not also use this. */
 	static public final Rectangle tmp = new Rectangle();
 

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/InputEvent.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/InputEvent.java
@@ -19,10 +19,15 @@ package com.badlogic.gdx.scenes.scene2d;
 import com.badlogic.gdx.Input.Buttons;
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.utils.Null;
+import com.badlogic.gdx.utils.Pools;
 
 /** Event for actor input: touch, mouse, touch/mouse actor enter/exit, mouse scroll, and keyboard events.
  * @see InputListener */
 public class InputEvent extends Event {
+	static {
+		Pools.set(InputEvent::new);
+	}
+
 	private Type type;
 	private float stageX, stageY, scrollAmountX, scrollAmountY;
 	private int pointer, button, keyCode;

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/Stage.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/Stage.java
@@ -878,6 +878,10 @@ public class Stage extends InputAdapter implements Disposable {
 	/** Internal class for managing touch focus. Public only for GWT.
 	 * @author Nathan Sweet */
 	public static final class TouchFocus implements Poolable {
+		static {
+			Pools.set(TouchFocus::new);
+		}
+
 		EventListener listener;
 		Actor listenerActor, target;
 		int pointer, button;

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/AddAction.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/AddAction.java
@@ -16,11 +16,16 @@
 
 package com.badlogic.gdx.scenes.scene2d.actions;
 
+import com.badlogic.gdx.utils.Pools;
 import com.badlogic.gdx.scenes.scene2d.Action;
 
 /** Adds an action to an actor.
  * @author Nathan Sweet */
 public class AddAction extends Action {
+	static {
+		Pools.set(AddAction::new);
+	}
+
 	private Action action;
 
 	public boolean act (float delta) {

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/AddListenerAction.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/AddListenerAction.java
@@ -18,10 +18,15 @@ package com.badlogic.gdx.scenes.scene2d.actions;
 
 import com.badlogic.gdx.scenes.scene2d.Action;
 import com.badlogic.gdx.scenes.scene2d.EventListener;
+import com.badlogic.gdx.utils.Pools;
 
 /** Adds a listener to an actor.
  * @author Nathan Sweet */
 public class AddListenerAction extends Action {
+	static {
+		Pools.set(AddListenerAction::new);
+	}
+
 	private EventListener listener;
 	private boolean capture;
 

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/AfterAction.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/AfterAction.java
@@ -19,10 +19,15 @@ package com.badlogic.gdx.scenes.scene2d.actions;
 import com.badlogic.gdx.scenes.scene2d.Action;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.utils.Array;
+import com.badlogic.gdx.utils.Pools;
 
 /** Executes an action only after all other actions on the actor at the time this action's target was set have finished.
  * @author Nathan Sweet */
 public class AfterAction extends DelegateAction {
+	static {
+		Pools.set(AfterAction::new);
+	}
+
 	private Array<Action> waitForActions = new Array(false, 4);
 
 	public void setTarget (Actor target) {

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/AlphaAction.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/AlphaAction.java
@@ -19,11 +19,16 @@ package com.badlogic.gdx.scenes.scene2d.actions;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.utils.Null;
+import com.badlogic.gdx.utils.Pools;
 
 /** Sets the alpha for an actor's color (or a specified color), from the current alpha to the new alpha. Note this action
  * transitions from the alpha at the time the action starts to the specified alpha.
  * @author Nathan Sweet */
 public class AlphaAction extends TemporalAction {
+	static {
+		Pools.set(AlphaAction::new);
+	}
+
 	private float start, end;
 	private @Null Color color;
 

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/ColorAction.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/ColorAction.java
@@ -19,11 +19,16 @@ package com.badlogic.gdx.scenes.scene2d.actions;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.utils.Null;
+import com.badlogic.gdx.utils.Pools;
 
 /** Sets the actor's color (or a specified color), from the current to the new color. Note this action transitions from the color
  * at the time the action starts to the specified color.
  * @author Nathan Sweet */
 public class ColorAction extends TemporalAction {
+	static {
+		Pools.set(ColorAction::new);
+	}
+
 	private float startR, startG, startB, startA;
 	private @Null Color color;
 	private final Color end = new Color();

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/DelayAction.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/DelayAction.java
@@ -16,9 +16,15 @@
 
 package com.badlogic.gdx.scenes.scene2d.actions;
 
+import com.badlogic.gdx.utils.Pools;
+
 /** Delays execution of an action or inserts a pause in a {@link SequenceAction}.
  * @author Nathan Sweet */
 public class DelayAction extends DelegateAction implements FinishableAction {
+	static {
+		Pools.set(DelayAction::new);
+	}
+
 	private float duration, time;
 
 	public DelayAction () {

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/FloatAction.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/FloatAction.java
@@ -18,10 +18,15 @@ package com.badlogic.gdx.scenes.scene2d.actions;
 
 import com.badlogic.gdx.math.Interpolation;
 import com.badlogic.gdx.utils.Null;
+import com.badlogic.gdx.utils.Pools;
 
 /** An action that has a float, whose value is transitioned over time.
  * @author Nathan Sweet */
 public class FloatAction extends TemporalAction {
+	static {
+		Pools.set(FloatAction::new);
+	}
+
 	private float start, end;
 	private float value;
 

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/IntAction.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/IntAction.java
@@ -18,10 +18,15 @@ package com.badlogic.gdx.scenes.scene2d.actions;
 
 import com.badlogic.gdx.math.Interpolation;
 import com.badlogic.gdx.utils.Null;
+import com.badlogic.gdx.utils.Pools;
 
 /** An action that has an int, whose value is transitioned over time.
  * @author Nathan Sweet */
 public class IntAction extends TemporalAction {
+	static {
+		Pools.set(IntAction::new);
+	}
+
 	private int start, end;
 	private int value;
 

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/LayoutAction.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/LayoutAction.java
@@ -20,11 +20,16 @@ import com.badlogic.gdx.scenes.scene2d.Action;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.utils.Layout;
 import com.badlogic.gdx.utils.GdxRuntimeException;
+import com.badlogic.gdx.utils.Pools;
 
 /** Sets an actor's {@link Layout#setLayoutEnabled(boolean) layout} to enabled or disabled. The actor must implements
  * {@link Layout}.
  * @author Nathan Sweet */
 public class LayoutAction extends Action {
+	static {
+		Pools.set(LayoutAction::new);
+	}
+
 	private boolean enabled;
 
 	public void setTarget (Actor actor) {

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/MoveByAction.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/MoveByAction.java
@@ -16,9 +16,15 @@
 
 package com.badlogic.gdx.scenes.scene2d.actions;
 
+import com.badlogic.gdx.utils.Pools;
+
 /** Moves an actor to a relative position.
  * @author Nathan Sweet */
 public class MoveByAction extends RelativeTemporalAction {
+	static {
+		Pools.set(MoveByAction::new);
+	}
+
 	private float amountX, amountY;
 
 	protected void updateRelative (float percentDelta) {

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/MoveToAction.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/MoveToAction.java
@@ -17,10 +17,15 @@
 package com.badlogic.gdx.scenes.scene2d.actions;
 
 import com.badlogic.gdx.utils.Align;
+import com.badlogic.gdx.utils.Pools;
 
 /** Moves an actor from its current position to a specific position.
  * @author Nathan Sweet */
 public class MoveToAction extends TemporalAction {
+	static {
+		Pools.set(MoveToAction::new);
+	}
+
 	private float startX, startY;
 	private float endX, endY;
 	private int alignment = Align.bottomLeft;

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/ParallelAction.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/ParallelAction.java
@@ -20,10 +20,15 @@ import com.badlogic.gdx.scenes.scene2d.Action;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.Pool;
+import com.badlogic.gdx.utils.Pools;
 
 /** Executes a number of actions at the same time.
  * @author Nathan Sweet */
 public class ParallelAction extends Action {
+	static {
+		Pools.set(ParallelAction::new);
+	}
+
 	Array<Action> actions = new Array(4);
 	private boolean complete;
 

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/RemoveAction.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/RemoveAction.java
@@ -17,10 +17,15 @@
 package com.badlogic.gdx.scenes.scene2d.actions;
 
 import com.badlogic.gdx.scenes.scene2d.Action;
+import com.badlogic.gdx.utils.Pools;
 
 /** Removes an action from an actor.
  * @author Nathan Sweet */
 public class RemoveAction extends Action {
+	static {
+		Pools.set(RemoveAction::new);
+	}
+
 	private Action action;
 
 	public boolean act (float delta) {

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/RemoveActorAction.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/RemoveActorAction.java
@@ -17,10 +17,15 @@
 package com.badlogic.gdx.scenes.scene2d.actions;
 
 import com.badlogic.gdx.scenes.scene2d.Action;
+import com.badlogic.gdx.utils.Pools;
 
 /** Removes an actor from the stage.
  * @author Nathan Sweet */
 public class RemoveActorAction extends Action {
+	static {
+		Pools.set(RemoveActorAction::new);
+	}
+
 	private boolean removed;
 
 	public boolean act (float delta) {

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/RemoveListenerAction.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/RemoveListenerAction.java
@@ -18,10 +18,15 @@ package com.badlogic.gdx.scenes.scene2d.actions;
 
 import com.badlogic.gdx.scenes.scene2d.Action;
 import com.badlogic.gdx.scenes.scene2d.EventListener;
+import com.badlogic.gdx.utils.Pools;
 
 /** Removes a listener from an actor.
  * @author Nathan Sweet */
 public class RemoveListenerAction extends Action {
+	static {
+		Pools.set(RemoveListenerAction::new);
+	}
+
 	private EventListener listener;
 	private boolean capture;
 

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/RepeatAction.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/RepeatAction.java
@@ -16,9 +16,15 @@
 
 package com.badlogic.gdx.scenes.scene2d.actions;
 
+import com.badlogic.gdx.utils.Pools;
+
 /** Repeats an action a number of times or forever.
  * @author Nathan Sweet */
 public class RepeatAction extends DelegateAction implements FinishableAction {
+	static {
+		Pools.set(RepeatAction::new);
+	}
+
 	static public final int FOREVER = -1;
 
 	private int repeatCount, executedCount;

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/RotateByAction.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/RotateByAction.java
@@ -16,9 +16,15 @@
 
 package com.badlogic.gdx.scenes.scene2d.actions;
 
+import com.badlogic.gdx.utils.Pools;
+
 /** Sets the actor's rotation from its current value to a relative value.
  * @author Nathan Sweet */
 public class RotateByAction extends RelativeTemporalAction {
+	static {
+		Pools.set(RotateByAction::new);
+	}
+
 	private float amount;
 
 	protected void updateRelative (float percentDelta) {

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/RotateToAction.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/RotateToAction.java
@@ -17,6 +17,7 @@
 package com.badlogic.gdx.scenes.scene2d.actions;
 
 import com.badlogic.gdx.math.MathUtils;
+import com.badlogic.gdx.utils.Pools;
 
 /** Sets the actor's rotation from its current value to a specific value.
  * 
@@ -30,6 +31,10 @@ import com.badlogic.gdx.math.MathUtils;
  * 
  * @author Nathan Sweet */
 public class RotateToAction extends TemporalAction {
+	static {
+		Pools.set(RotateToAction::new);
+	}
+
 	private float start, end;
 
 	private boolean useShortestDirection = false;

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/RunnableAction.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/RunnableAction.java
@@ -18,11 +18,16 @@ package com.badlogic.gdx.scenes.scene2d.actions;
 
 import com.badlogic.gdx.scenes.scene2d.Action;
 import com.badlogic.gdx.utils.Pool;
+import com.badlogic.gdx.utils.Pools;
 
 /** An action that runs a {@link Runnable}. Alternatively, the {@link #run()} method can be overridden instead of setting a
  * runnable.
  * @author Nathan Sweet */
 public class RunnableAction extends Action {
+	static {
+		Pools.set(RunnableAction::new);
+	}
+
 	private Runnable runnable;
 	private boolean ran;
 

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/ScaleByAction.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/ScaleByAction.java
@@ -16,9 +16,15 @@
 
 package com.badlogic.gdx.scenes.scene2d.actions;
 
+import com.badlogic.gdx.utils.Pools;
+
 /** Scales an actor's scale to a relative size.
  * @author Nathan Sweet */
 public class ScaleByAction extends RelativeTemporalAction {
+	static {
+		Pools.set(ScaleByAction::new);
+	}
+
 	private float amountX, amountY;
 
 	protected void updateRelative (float percentDelta) {

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/ScaleToAction.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/ScaleToAction.java
@@ -16,9 +16,15 @@
 
 package com.badlogic.gdx.scenes.scene2d.actions;
 
+import com.badlogic.gdx.utils.Pools;
+
 /** Sets the actor's scale from its current value to a specific value.
  * @author Nathan Sweet */
 public class ScaleToAction extends TemporalAction {
+	static {
+		Pools.set(ScaleToAction::new);
+	}
+
 	private float startX, startY;
 	private float endX, endY;
 

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/SequenceAction.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/SequenceAction.java
@@ -18,10 +18,15 @@ package com.badlogic.gdx.scenes.scene2d.actions;
 
 import com.badlogic.gdx.scenes.scene2d.Action;
 import com.badlogic.gdx.utils.Pool;
+import com.badlogic.gdx.utils.Pools;
 
 /** Executes a number of actions one at a time.
  * @author Nathan Sweet */
 public class SequenceAction extends ParallelAction {
+	static {
+		Pools.set(SequenceAction::new);
+	}
+
 	private int index;
 
 	public SequenceAction () {

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/SizeByAction.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/SizeByAction.java
@@ -16,9 +16,15 @@
 
 package com.badlogic.gdx.scenes.scene2d.actions;
 
+import com.badlogic.gdx.utils.Pools;
+
 /** Moves an actor from its current size to a relative size.
  * @author Nathan Sweet */
 public class SizeByAction extends RelativeTemporalAction {
+	static {
+		Pools.set(SizeByAction::new);
+	}
+
 	private float amountWidth, amountHeight;
 
 	protected void updateRelative (float percentDelta) {

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/SizeToAction.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/SizeToAction.java
@@ -16,9 +16,15 @@
 
 package com.badlogic.gdx.scenes.scene2d.actions;
 
+import com.badlogic.gdx.utils.Pools;
+
 /** Moves an actor from its current size to a specific size.
  * @author Nathan Sweet */
 public class SizeToAction extends TemporalAction {
+	static {
+		Pools.set(SizeToAction::new);
+	}
+
 	private float startWidth, startHeight;
 	private float endWidth, endHeight;
 

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/TimeScaleAction.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/TimeScaleAction.java
@@ -16,9 +16,15 @@
 
 package com.badlogic.gdx.scenes.scene2d.actions;
 
+import com.badlogic.gdx.utils.Pools;
+
 /** Multiplies the delta of an action.
  * @author Nathan Sweet */
 public class TimeScaleAction extends DelegateAction {
+	static {
+		Pools.set(TimeScaleAction::new);
+	}
+
 	private float scale;
 
 	protected boolean delegate (float delta) {

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/TouchableAction.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/TouchableAction.java
@@ -19,10 +19,15 @@ package com.badlogic.gdx.scenes.scene2d.actions;
 import com.badlogic.gdx.scenes.scene2d.Action;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.Touchable;
+import com.badlogic.gdx.utils.Pools;
 
 /** Sets the actor's {@link Actor#setTouchable(Touchable) touchability}.
  * @author Nathan Sweet */
 public class TouchableAction extends Action {
+	static {
+		Pools.set(TouchableAction::new);
+	}
+
 	private Touchable touchable;
 
 	public boolean act (float delta) {

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/VisibleAction.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/VisibleAction.java
@@ -18,10 +18,15 @@ package com.badlogic.gdx.scenes.scene2d.actions;
 
 import com.badlogic.gdx.scenes.scene2d.Action;
 import com.badlogic.gdx.scenes.scene2d.Actor;
+import com.badlogic.gdx.utils.Pools;
 
 /** Sets the actor's {@link Actor#setVisible(boolean) visibility}.
  * @author Nathan Sweet */
 public class VisibleAction extends Action {
+	static {
+		Pools.set(VisibleAction::new);
+	}
+
 	private boolean visible;
 
 	public boolean act (float delta) {

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Table.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Table.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -1270,7 +1270,10 @@ public class Table extends WidgetGroup {
 
 	/** @author Nathan Sweet */
 	static public class DebugRect extends Rectangle {
-		static Pool<DebugRect> pool = Pools.get(DebugRect.class);
+		static {
+			Pools.set(DebugRect::new);
+		}
+		static final Pool<DebugRect> pool = Pools.get(DebugRect.class);
 		Color color;
 	}
 

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/ChangeListener.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/ChangeListener.java
@@ -19,6 +19,7 @@ package com.badlogic.gdx.scenes.scene2d.utils;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.Event;
 import com.badlogic.gdx.scenes.scene2d.EventListener;
+import com.badlogic.gdx.utils.Pools;
 
 /** Listener for {@link ChangeEvent}.
  * @author Nathan Sweet */
@@ -35,5 +36,8 @@ abstract public class ChangeListener implements EventListener {
 	/** Fired when something in an actor has changed. This is a generic event, exactly what changed in an actor will vary.
 	 * @author Nathan Sweet */
 	static public class ChangeEvent extends Event {
+		static {
+			Pools.set(ChangeEvent::new);
+		}
 	}
 }

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/FocusListener.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/FocusListener.java
@@ -20,6 +20,7 @@ import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.Event;
 import com.badlogic.gdx.scenes.scene2d.EventListener;
 import com.badlogic.gdx.utils.Null;
+import com.badlogic.gdx.utils.Pools;
 
 /** Listener for {@link FocusEvent}.
  * @author Nathan Sweet */
@@ -49,6 +50,9 @@ abstract public class FocusListener implements EventListener {
 	/** Fired when an actor gains or loses keyboard or scroll focus. Can be cancelled to prevent losing or gaining focus.
 	 * @author Nathan Sweet */
 	static public class FocusEvent extends Event {
+		static {
+			Pools.set(FocusEvent::new);
+		}
 		private boolean focused;
 		private Type type;
 		private Actor relatedActor;

--- a/gdx/src/com/badlogic/gdx/utils/Array.java
+++ b/gdx/src/com/badlogic/gdx/utils/Array.java
@@ -28,6 +28,10 @@ import com.badlogic.gdx.utils.reflect.ArrayReflection;
  * last element is moved to the removed element's position).
  * @author Nathan Sweet */
 public class Array<T> implements Iterable<T> {
+	static {
+		Pools.set(Array::new);
+	}
+
 	/** Provides direct access to the underlying array. If the Array's generic type is not Object, this field may only be accessed
 	 * if the {@link Array#Array(boolean, int, Class)} constructor was used. */
 	public T[] items;

--- a/gdx/src/com/badlogic/gdx/utils/Pools.java
+++ b/gdx/src/com/badlogic/gdx/utils/Pools.java
@@ -33,62 +33,51 @@ import com.badlogic.gdx.utils.DefaultPool.PoolSupplier;
  * @author Nathan Sweet */
 public class Pools {
 	static private final ObjectMap<Class<?>, Pool<?>> typePools = new ObjectMap<>();
+	static private final ObjectSet<Class<?>> initializedTypes = new ObjectSet<>();
 	static public boolean WARN_ON_REFLECTION_POOL_CREATION = true;
 	static public boolean THROW_ON_REFLECTION_POOL_CREATION = false;
-
-	static {
-		set(Array::new);
-		set(ChangeEvent::new);
-		set(DebugRect::new);
-		set(FocusEvent::new);
-		set(GlyphLayout::new);
-		set(GlyphRun::new);
-		set(HttpRequest::new);
-		set(InputEvent::new);
-		set(Rectangle::new);
-		set(TouchFocus::new);
-
-		// Actions
-		set(AddAction::new);
-		set(AddListenerAction::new);
-		set(AfterAction::new);
-		set(AlphaAction::new);
-		set(ColorAction::new);
-		set(DelayAction::new);
-		set(FloatAction::new);
-		set(IntAction::new);
-		set(LayoutAction::new);
-		set(MoveByAction::new);
-		set(MoveToAction::new);
-		set(ParallelAction::new);
-		set(RemoveAction::new);
-		set(RemoveActorAction::new);
-		set(RemoveListenerAction::new);
-		set(RepeatAction::new);
-		set(RotateByAction::new);
-		set(RotateToAction::new);
-		set(RunnableAction::new);
-		set(ScaleByAction::new);
-		set(ScaleToAction::new);
-		set(SequenceAction::new);
-		set(SizeByAction::new);
-		set(SizeToAction::new);
-		set(TimeScaleAction::new);
-		set(TouchableAction::new);
-		set(VisibleAction::new);
-	}
 
 	/** Returns a new or existing pool for the specified type, stored in a Class to {@link Pool} map. Note the max size is ignored
 	 * if this is not the first time this pool has been requested. */
 	static public <T> Pool<T> get (Class<T> type, int max) {
 		Pool pool = typePools.get(type);
 		if (pool == null) {
-			if (THROW_ON_REFLECTION_POOL_CREATION) throw new RuntimeException(
-				"Please manually define a Pool for " + type + " by calling Pools#set before calling Pools#get");
-			if (WARN_ON_REFLECTION_POOL_CREATION && Gdx.app != null) Gdx.app.error("Pools",
-				"Please manually define a Pool for " + type + " by calling Pools#set before calling Pools#get");
-			pool = new ReflectionPool(type, 4, max);
-			typePools.put(type, pool);
+			// Force class initialization to run static blocks. All poolable libGDX classes have static initializers
+			// that call Pools.set(ClassName::new). This approach avoids manual initialization order management and
+			// prevents pulling in unused classes (unlike a central Pools static block), allowing ProGuard/R8/GraalVM
+			// to strip unused classes while ensuring used ones register their pools before ReflectionPool creation.
+			if (!initializedTypes.contains(type)) {
+				initializedTypes.add(type);
+				try {
+					Class.forName(type.getName(), true, type.getClassLoader());
+				} catch (ClassNotFoundException e) {
+					// This should never happen in normal circumstances since we already have the Class object.
+					// However, it can occur with aggressive code optimization/obfuscation tools that may:
+					// - Remove classes deemed unused (ProGuard/R8 shrinking)
+					// - Merge/inline classes (R8 optimization)
+					// - Transform classes in incompatible ways (GraalVM native-image)
+					// If you encounter this, ensure the class is kept by your obfuscation rules.
+					if (Gdx.app != null) {
+						Gdx.app.error("Pools",
+							"Failed to initialize class " + type.getName() + ". " +
+							"This may occur with code obfuscation, shrinking, class merging (ProGuard/R8), or native compilation (GraalVM). " +
+							"Add keep rules for this class and its constructors.");
+					}
+				}
+				pool = typePools.get(type);
+			}
+			if (pool == null) {
+				if (THROW_ON_REFLECTION_POOL_CREATION) throw new RuntimeException(
+					"No pool registered for type " + type.getName() + ". " +
+					"A ReflectionPool will be created which is slower and will fail if the class is not explicitly included with ProGuard/R8/GraalVM. " +
+					"To fix: Add Pools.set(" + type.getSimpleName() + "::new) - this will automatically keep the class in ProGuard/R8/GraalVM.");
+				if (WARN_ON_REFLECTION_POOL_CREATION && Gdx.app != null) Gdx.app.error("Pools",
+					"No pool registered for type " + type.getName() + ". " +
+					"A ReflectionPool will be created which is slower and will fail if the class is not explicitly included with ProGuard/R8/GraalVM. " +
+					"To fix: Add Pools.set(" + type.getSimpleName() + "::new) - this will automatically keep the class in ProGuard/R8/GraalVM.");
+				pool = new ReflectionPool(type, 4, max);
+				typePools.put(type, pool);
+			}
 		}
 		return pool;
 	}


### PR DESCRIPTION
Problem: unnecessary warnings for internal libGDX classes in `Pools#get()`, static block in `Pools` that will pull in various classes and disallow ProGuard/r8/GraalVM/RoboVM tree shaking.

Refactors the Pools class to use lazy initialization with static blocks in each poolable class instead of a central static block. This approach:
- Fixes Android/desugar compatibility issues
- Ensures proper class initialization order
- Allows ProGuard/R8/GraalVM to strip unused classes
- Prevents pulling in unused classes during startup
- Improves error messages for missing pool registrations

Each poolable class now registers itself via static block with Pools.set(ClassName::new), ensuring the pool is available before use.

See also https://github.com/libgdx/libgdx/pull/7648