### PR TITLE
Added glBlendFuncSeparate support in RenderContext

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g3d/utils/RenderContext.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/utils/RenderContext.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- *
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *   http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/utils/RenderContext.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/utils/RenderContext.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -27,8 +27,10 @@ public class RenderContext {
 	/** used to bind textures **/
 	public final TextureBinder textureBinder;
 	private boolean blending;
-	private int blendSFactor;
-	private int blendDFactor;
+	private int blendSourceRgbFactor;
+	private int blendDestRgbFactor;
+	private int blendSourceAlphaFactor;
+	private int blendDestAlphaFactor;
 	private int depthFunc;
 	private float depthRangeNear;
 	private float depthRangeFar;
@@ -48,7 +50,7 @@ public class RenderContext {
 		Gdx.gl.glDisable(GL20.GL_BLEND);
 		blending = false;
 		Gdx.gl.glDisable(GL20.GL_CULL_FACE);
-		cullFace = blendSFactor = blendDFactor = 0;
+		cullFace = blendSourceRgbFactor = blendDestRgbFactor = blendSourceAlphaFactor = blendDestAlphaFactor = 0;
 		textureBinder.begin();
 	}
 
@@ -88,6 +90,11 @@ public class RenderContext {
 	}
 
 	public void setBlending (final boolean enabled, final int sFactor, final int dFactor) {
+		setBlending(enabled, sFactor, dFactor, sFactor, dFactor);
+	}
+
+	public void setBlending(final boolean enabled, final int sRgbFactor, final int dRgbFactor, final int sAlphaFactor,
+							final int dAlphaFactor) {
 		if (enabled != blending) {
 			blending = enabled;
 			if (enabled)
@@ -95,10 +102,13 @@ public class RenderContext {
 			else
 				Gdx.gl.glDisable(GL20.GL_BLEND);
 		}
-		if (enabled && (blendSFactor != sFactor || blendDFactor != dFactor)) {
-			Gdx.gl.glBlendFunc(sFactor, dFactor);
-			blendSFactor = sFactor;
-			blendDFactor = dFactor;
+		if (enabled && (blendSourceRgbFactor != sRgbFactor || blendDestRgbFactor != dRgbFactor ||
+				blendSourceAlphaFactor != sAlphaFactor || blendDestAlphaFactor != dAlphaFactor)) {
+			Gdx.gl.glBlendFuncSeparate(sRgbFactor, dRgbFactor, sAlphaFactor, dAlphaFactor);
+			blendSourceRgbFactor = sRgbFactor;
+			blendDestRgbFactor = dRgbFactor;
+			blendSourceAlphaFactor = sAlphaFactor;
+			blendDestAlphaFactor = dAlphaFactor;
 		}
 	}
 


### PR DESCRIPTION
We have made changes to extend the RenderContext setBlending so that RGB and alpha factors can be specified individually.
In addition, the setBlending function, which specifies the same factor for RGB and Alpha as before, has been retained for compatibility.

This change overlaps with part of #7095, but since there has been no response for a long time, I created this PR.