### PR TITLE
Nuke Pools class

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,6 @@
 [1.13.6]
 - [BREAKING CHANGE] API: Pools changes in 1.13.5 have been partially reverted. Pools#get/Pools#obtain method return to requiring a Class parameter. Reflection is avoided by using pre-populated Pools for libgdx classes. See https://github.com/libgdx/libgdx/pull/7648
+- [BREAKING CHANGE] API: Pools class is now deprecated and not used internally. Some functionality can be restored by using the new `PoolManager` class
 - API Addition: Added JsonValue#toJson that takes a Writer.
 - API Addition: Added getProgrammaticChangeEvents() to scene2d.ui actors that have setProgrammaticChangeEvents.
 - Fixed crashes when reading the soft buttons bar height on Android.

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/GlyphLayout.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/GlyphLayout.java
@@ -22,12 +22,12 @@ import com.badlogic.gdx.graphics.g2d.BitmapFont.BitmapFontData;
 import com.badlogic.gdx.graphics.g2d.BitmapFont.Glyph;
 import com.badlogic.gdx.utils.Align;
 import com.badlogic.gdx.utils.Array;
+import com.badlogic.gdx.utils.DefaultPool;
 import com.badlogic.gdx.utils.FloatArray;
 import com.badlogic.gdx.utils.IntArray;
 import com.badlogic.gdx.utils.Null;
 import com.badlogic.gdx.utils.Pool;
 import com.badlogic.gdx.utils.Pool.Poolable;
-import com.badlogic.gdx.utils.Pools;
 
 /** Stores {@link GlyphRun runs} of glyphs for a piece of text. The text may contain newlines and color markup tags.
  * <p>
@@ -45,7 +45,7 @@ import com.badlogic.gdx.utils.Pools;
  * @author Alexander Dorokhov
  * @author Thomas Creutzenberg */
 public class GlyphLayout implements Poolable {
-	static private final Pool<GlyphRun> glyphRunPool = Pools.get(GlyphRun.class);
+	static private final Pool<GlyphRun> glyphRunPool = new DefaultPool<>(GlyphRun::new);
 	static private final IntArray colorStack = new IntArray(4);
 	static private final float epsilon = 0.0001f;
 

--- a/gdx/src/com/badlogic/gdx/net/HttpRequestBuilder.java
+++ b/gdx/src/com/badlogic/gdx/net/HttpRequestBuilder.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import com.badlogic.gdx.Net.HttpRequest;
 import com.badlogic.gdx.utils.Base64Coder;
 import com.badlogic.gdx.utils.Json;
-import com.badlogic.gdx.utils.Pools;
 
 /** A builder for {@link HttpRequest}s.
  * 
@@ -50,7 +49,7 @@ public class HttpRequestBuilder {
 			throw new IllegalStateException("A new request has already been started. Call HttpRequestBuilder.build() first.");
 		}
 
-		httpRequest = Pools.obtain(HttpRequest.class);
+		httpRequest = new HttpRequest();
 		httpRequest.setTimeOut(defaultTimeout);
 		return this;
 	}

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/Stage.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/Stage.java
@@ -42,7 +42,7 @@ import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.Disposable;
 import com.badlogic.gdx.utils.Null;
 import com.badlogic.gdx.utils.Pool.Poolable;
-import com.badlogic.gdx.utils.Pools;
+import com.badlogic.gdx.utils.PoolManager;
 import com.badlogic.gdx.utils.Scaling;
 import com.badlogic.gdx.utils.SnapshotArray;
 import com.badlogic.gdx.utils.viewport.ScalingViewport;
@@ -67,6 +67,7 @@ public class Stage extends InputAdapter implements Disposable {
 	/** True if any actor has ever had debug enabled. */
 	static boolean debug;
 
+	protected PoolManager poolManager = new PoolManager(InputEvent::new, FocusEvent::new, TouchFocus::new);
 	private Viewport viewport;
 	private final Batch batch;
 	private boolean ownsBatch;
@@ -219,7 +220,7 @@ public class Stage extends InputAdapter implements Disposable {
 
 		// Exit overLast.
 		if (overLast != null) {
-			InputEvent event = Pools.obtain(InputEvent.class);
+			InputEvent event = poolManager.obtain(InputEvent.class);
 			event.setType(InputEvent.Type.exit);
 			event.setStage(this);
 			event.setStageX(tempCoords.x);
@@ -227,12 +228,12 @@ public class Stage extends InputAdapter implements Disposable {
 			event.setPointer(pointer);
 			event.setRelatedActor(over);
 			overLast.fire(event);
-			Pools.free(event);
+			poolManager.free(event);
 		}
 
 		// Enter over.
 		if (over != null) {
-			InputEvent event = Pools.obtain(InputEvent.class);
+			InputEvent event = poolManager.obtain(InputEvent.class);
 			event.setType(InputEvent.Type.enter);
 			event.setStage(this);
 			event.setStageX(tempCoords.x);
@@ -240,14 +241,14 @@ public class Stage extends InputAdapter implements Disposable {
 			event.setPointer(pointer);
 			event.setRelatedActor(overLast);
 			over.fire(event);
-			Pools.free(event);
+			poolManager.free(event);
 		}
 		return over;
 	}
 
 	private void fireExit (Actor actor, int screenX, int screenY, int pointer) {
 		screenToStageCoordinates(tempCoords.set(screenX, screenY));
-		InputEvent event = Pools.obtain(InputEvent.class);
+		InputEvent event = poolManager.obtain(InputEvent.class);
 		event.setType(InputEvent.Type.exit);
 		event.setStage(this);
 		event.setStageX(tempCoords.x);
@@ -255,7 +256,7 @@ public class Stage extends InputAdapter implements Disposable {
 		event.setPointer(pointer);
 		event.setRelatedActor(actor);
 		actor.fire(event);
-		Pools.free(event);
+		poolManager.free(event);
 	}
 
 	/** Applies a touch down event to the stage and returns true if an actor in the scene {@link Event#handle() handled} the
@@ -269,7 +270,7 @@ public class Stage extends InputAdapter implements Disposable {
 
 		screenToStageCoordinates(tempCoords.set(screenX, screenY));
 
-		InputEvent event = Pools.obtain(InputEvent.class);
+		InputEvent event = poolManager.obtain(InputEvent.class);
 		event.setType(Type.touchDown);
 		event.setStage(this);
 		event.setStageX(tempCoords.x);
@@ -284,7 +285,7 @@ public class Stage extends InputAdapter implements Disposable {
 			target.fire(event);
 
 		boolean handled = event.isHandled();
-		Pools.free(event);
+		poolManager.free(event);
 		return handled;
 	}
 
@@ -300,7 +301,7 @@ public class Stage extends InputAdapter implements Disposable {
 
 		screenToStageCoordinates(tempCoords.set(screenX, screenY));
 
-		InputEvent event = Pools.obtain(InputEvent.class);
+		InputEvent event = poolManager.obtain(InputEvent.class);
 		event.setType(Type.touchDragged);
 		event.setStage(this);
 		event.setStageX(tempCoords.x);
@@ -320,7 +321,7 @@ public class Stage extends InputAdapter implements Disposable {
 		touchFocuses.end();
 
 		boolean handled = event.isHandled();
-		Pools.free(event);
+		poolManager.free(event);
 		return handled;
 	}
 
@@ -335,7 +336,7 @@ public class Stage extends InputAdapter implements Disposable {
 
 		screenToStageCoordinates(tempCoords.set(screenX, screenY));
 
-		InputEvent event = Pools.obtain(InputEvent.class);
+		InputEvent event = poolManager.obtain(InputEvent.class);
 		event.setType(Type.touchUp);
 		event.setStage(this);
 		event.setStageX(tempCoords.x);
@@ -352,12 +353,12 @@ public class Stage extends InputAdapter implements Disposable {
 			event.setTarget(focus.target);
 			event.setListenerActor(focus.listenerActor);
 			if (focus.listener.handle(event)) event.handle();
-			Pools.free(focus);
+			poolManager.free(focus);
 		}
 		touchFocuses.end();
 
 		boolean handled = event.isHandled();
-		Pools.free(event);
+		poolManager.free(event);
 		return handled;
 	}
 
@@ -376,7 +377,7 @@ public class Stage extends InputAdapter implements Disposable {
 
 		screenToStageCoordinates(tempCoords.set(screenX, screenY));
 
-		InputEvent event = Pools.obtain(InputEvent.class);
+		InputEvent event = poolManager.obtain(InputEvent.class);
 		event.setType(Type.mouseMoved);
 		event.setStage(this);
 		event.setStageX(tempCoords.x);
@@ -387,7 +388,7 @@ public class Stage extends InputAdapter implements Disposable {
 
 		target.fire(event);
 		boolean handled = event.isHandled();
-		Pools.free(event);
+		poolManager.free(event);
 		return handled;
 	}
 
@@ -398,7 +399,7 @@ public class Stage extends InputAdapter implements Disposable {
 
 		screenToStageCoordinates(tempCoords.set(mouseScreenX, mouseScreenY));
 
-		InputEvent event = Pools.obtain(InputEvent.class);
+		InputEvent event = poolManager.obtain(InputEvent.class);
 		event.setType(InputEvent.Type.scrolled);
 		event.setStage(this);
 		event.setStageX(tempCoords.x);
@@ -407,7 +408,7 @@ public class Stage extends InputAdapter implements Disposable {
 		event.setScrollAmountY(amountY);
 		target.fire(event);
 		boolean handled = event.isHandled();
-		Pools.free(event);
+		poolManager.free(event);
 		return handled;
 	}
 
@@ -415,13 +416,13 @@ public class Stage extends InputAdapter implements Disposable {
 	 * true if the event was {@link Event#handle() handled}. */
 	public boolean keyDown (int keyCode) {
 		Actor target = keyboardFocus == null ? root : keyboardFocus;
-		InputEvent event = Pools.obtain(InputEvent.class);
+		InputEvent event = poolManager.obtain(InputEvent.class);
 		event.setType(InputEvent.Type.keyDown);
 		event.setStage(this);
 		event.setKeyCode(keyCode);
 		target.fire(event);
 		boolean handled = event.isHandled();
-		Pools.free(event);
+		poolManager.free(event);
 		return handled;
 	}
 
@@ -429,13 +430,13 @@ public class Stage extends InputAdapter implements Disposable {
 	 * if the event was {@link Event#handle() handled}. */
 	public boolean keyUp (int keyCode) {
 		Actor target = keyboardFocus == null ? root : keyboardFocus;
-		InputEvent event = Pools.obtain(InputEvent.class);
+		InputEvent event = poolManager.obtain(InputEvent.class);
 		event.setType(InputEvent.Type.keyUp);
 		event.setStage(this);
 		event.setKeyCode(keyCode);
 		target.fire(event);
 		boolean handled = event.isHandled();
-		Pools.free(event);
+		poolManager.free(event);
 		return handled;
 	}
 
@@ -443,13 +444,13 @@ public class Stage extends InputAdapter implements Disposable {
 	 * true if the event was {@link Event#handle() handled}. */
 	public boolean keyTyped (char character) {
 		Actor target = keyboardFocus == null ? root : keyboardFocus;
-		InputEvent event = Pools.obtain(InputEvent.class);
+		InputEvent event = poolManager.obtain(InputEvent.class);
 		event.setType(InputEvent.Type.keyTyped);
 		event.setStage(this);
 		event.setCharacter(character);
 		target.fire(event);
 		boolean handled = event.isHandled();
-		Pools.free(event);
+		poolManager.free(event);
 		return handled;
 	}
 
@@ -458,7 +459,7 @@ public class Stage extends InputAdapter implements Disposable {
 	 * touchDown}. The specified actors will be used as the {@link Event#getListenerActor() listener actor} and
 	 * {@link Event#getTarget() target} for the touchDragged and touchUp events. */
 	public void addTouchFocus (EventListener listener, Actor listenerActor, Actor target, int pointer, int button) {
-		TouchFocus focus = Pools.obtain(TouchFocus.class);
+		TouchFocus focus = poolManager.obtain(TouchFocus.class);
 		focus.listenerActor = listenerActor;
 		focus.target = target;
 		focus.listener = listener;
@@ -476,7 +477,7 @@ public class Stage extends InputAdapter implements Disposable {
 			if (focus.listener == listener && focus.listenerActor == listenerActor && focus.target == target
 				&& focus.pointer == pointer && focus.button == button) {
 				touchFocuses.removeIndex(i);
-				Pools.free(focus);
+				poolManager.free(focus);
 			}
 		}
 	}
@@ -495,7 +496,7 @@ public class Stage extends InputAdapter implements Disposable {
 			if (!touchFocuses.removeValue(focus, true)) continue; // Touch focus already gone.
 
 			if (event == null) {
-				event = Pools.obtain(InputEvent.class);
+				event = poolManager.obtain(InputEvent.class);
 				event.setType(InputEvent.Type.touchUp);
 				event.setStage(this);
 				event.setStageX(Integer.MIN_VALUE);
@@ -511,7 +512,7 @@ public class Stage extends InputAdapter implements Disposable {
 		}
 		touchFocuses.end();
 
-		if (event != null) Pools.free(event);
+		if (event != null) poolManager.free(event);
 	}
 
 	/** Removes all touch focus listeners, sending a touchUp event to each listener. Listeners typically expect to receive a
@@ -524,7 +525,7 @@ public class Stage extends InputAdapter implements Disposable {
 	/** Cancels touch focus for all listeners except the specified listener.
 	 * @see #cancelTouchFocus() */
 	public void cancelTouchFocusExcept (@Null EventListener exceptListener, @Null Actor exceptActor) {
-		InputEvent event = Pools.obtain(InputEvent.class);
+		InputEvent event = poolManager.obtain(InputEvent.class);
 		event.setType(InputEvent.Type.touchUp);
 		event.setStage(this);
 		event.setStageX(Integer.MIN_VALUE);
@@ -547,7 +548,7 @@ public class Stage extends InputAdapter implements Disposable {
 		}
 		touchFocuses.end();
 
-		Pools.free(event);
+		poolManager.free(event);
 	}
 
 	/** Adds an actor to the root of the stage.
@@ -634,7 +635,7 @@ public class Stage extends InputAdapter implements Disposable {
 	 * @return true if the unfocus and focus events were not cancelled by a {@link FocusListener}. */
 	public boolean setKeyboardFocus (@Null Actor actor) {
 		if (keyboardFocus == actor) return true;
-		FocusEvent event = Pools.obtain(FocusEvent.class);
+		FocusEvent event = poolManager.obtain(FocusEvent.class);
 		event.setStage(this);
 		event.setType(FocusEvent.Type.keyboard);
 		Actor oldKeyboardFocus = keyboardFocus;
@@ -654,7 +655,7 @@ public class Stage extends InputAdapter implements Disposable {
 				if (!success) keyboardFocus = oldKeyboardFocus;
 			}
 		}
-		Pools.free(event);
+		poolManager.free(event);
 		return success;
 	}
 
@@ -669,7 +670,7 @@ public class Stage extends InputAdapter implements Disposable {
 	 * @return true if the unfocus and focus events were not cancelled by a {@link FocusListener}. */
 	public boolean setScrollFocus (@Null Actor actor) {
 		if (scrollFocus == actor) return true;
-		FocusEvent event = Pools.obtain(FocusEvent.class);
+		FocusEvent event = poolManager.obtain(FocusEvent.class);
 		event.setStage(this);
 		event.setType(FocusEvent.Type.scroll);
 		Actor oldScrollFocus = scrollFocus;
@@ -689,7 +690,7 @@ public class Stage extends InputAdapter implements Disposable {
 				if (!success) scrollFocus = oldScrollFocus;
 			}
 		}
-		Pools.free(event);
+		poolManager.free(event);
 		return success;
 	}
 

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/Actions.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/actions/Actions.java
@@ -22,17 +22,54 @@ import com.badlogic.gdx.scenes.scene2d.Action;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.EventListener;
 import com.badlogic.gdx.scenes.scene2d.Touchable;
+import com.badlogic.gdx.utils.DefaultPool.PoolSupplier;
 import com.badlogic.gdx.utils.Null;
 import com.badlogic.gdx.utils.Pool;
-import com.badlogic.gdx.utils.Pools;
+import com.badlogic.gdx.utils.PoolManager;
 
 /** Static convenience methods for using pooled actions, intended for static import.
  * @author Nathan Sweet */
 public class Actions {
 
+	public static final PoolManager ACTION_POOL_MANAGER = new PoolManager();
+
+	static {
+		registerAction(AddAction::new);
+		registerAction(AddListenerAction::new);
+		registerAction(AfterAction::new);
+		registerAction(AlphaAction::new);
+		registerAction(ColorAction::new);
+		registerAction(DelayAction::new);
+		registerAction(FloatAction::new);
+		registerAction(IntAction::new);
+		registerAction(LayoutAction::new);
+		registerAction(MoveByAction::new);
+		registerAction(MoveToAction::new);
+		registerAction(ParallelAction::new);
+		registerAction(RemoveAction::new);
+		registerAction(RemoveActorAction::new);
+		registerAction(RemoveListenerAction::new);
+		registerAction(RepeatAction::new);
+		registerAction(RotateByAction::new);
+		registerAction(RotateToAction::new);
+		registerAction(RunnableAction::new);
+		registerAction(ScaleByAction::new);
+		registerAction(ScaleToAction::new);
+		registerAction(SequenceAction::new);
+		registerAction(SizeByAction::new);
+		registerAction(SizeToAction::new);
+		registerAction(TimeScaleAction::new);
+		registerAction(TouchableAction::new);
+		registerAction(VisibleAction::new);
+	}
+
+	static public <T extends Action> void registerAction (PoolSupplier<T> supplier) {
+		ACTION_POOL_MANAGER.addPool(supplier);
+	}
+
 	/** Returns a new or pooled action of the specified type. */
 	static public <T extends Action> T action (Class<T> type) {
-		Pool<T> pool = Pools.get(type);
+		Pool<T> pool = ACTION_POOL_MANAGER.getPool(type);
 		T action = pool.obtain();
 		action.setPool(pool);
 		return action;

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Button.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Button.java
@@ -28,7 +28,6 @@ import com.badlogic.gdx.scenes.scene2d.utils.Disableable;
 import com.badlogic.gdx.scenes.scene2d.utils.Drawable;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.Null;
-import com.badlogic.gdx.utils.Pools;
 
 /** A button is a {@link Table} with a checked state and additional {@link ButtonStyle style} fields for pressed, unpressed, and
  * checked. Each time a button is clicked, the checked state is toggled. Being a table, a button can contain any other actors.<br>
@@ -121,9 +120,9 @@ public class Button extends Table implements Disableable, Styleable<Button.Butto
 		this.isChecked = isChecked;
 
 		if (fireEvent) {
-			ChangeEvent changeEvent = Pools.obtain(ChangeEvent.class);
+			ChangeEvent changeEvent = poolManager.obtain(ChangeEvent.class);
 			if (fire(changeEvent)) this.isChecked = !isChecked;
-			Pools.free(changeEvent);
+			poolManager.free(changeEvent);
 		}
 	}
 

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/List.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/List.java
@@ -35,7 +35,6 @@ import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.Null;
 import com.badlogic.gdx.utils.ObjectSet;
 import com.badlogic.gdx.utils.Pool;
-import com.badlogic.gdx.utils.Pools;
 
 /** A list (aka list box) displays textual items and highlights the currently selected item.
  * <p>
@@ -179,7 +178,7 @@ public class List<T> extends Widget implements Cullable, Styleable<List.ListStyl
 		itemHeight += selectedDrawable.getTopHeight() + selectedDrawable.getBottomHeight();
 
 		prefWidth = 0;
-		Pool<GlyphLayout> layoutPool = Pools.get(GlyphLayout.class);
+		Pool<GlyphLayout> layoutPool = poolManager.getPool(GlyphLayout.class);
 		GlyphLayout layout = layoutPool.obtain();
 		for (int i = 0; i < items.size; i++) {
 			layout.setText(font, toString(items.get(i)));

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ProgressBar.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/ProgressBar.java
@@ -28,7 +28,6 @@ import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener.ChangeEvent;
 import com.badlogic.gdx.scenes.scene2d.utils.Disableable;
 import com.badlogic.gdx.scenes.scene2d.utils.Drawable;
 import com.badlogic.gdx.utils.Null;
-import com.badlogic.gdx.utils.Pools;
 
 /** A progress bar is a widget that visually displays the progress of some activity or a value within given range. The progress
  * bar has a range (min, max) and a stepping between each value it represents. The percentage of completeness typically starts out
@@ -263,9 +262,9 @@ public class ProgressBar extends Widget implements Disableable, Styleable<Progre
 		this.value = value;
 
 		if (programmaticChangeEvents) {
-			ChangeEvent changeEvent = Pools.obtain(ChangeEvent.class);
+			ChangeEvent changeEvent = poolManager.obtain(ChangeEvent.class);
 			boolean cancelled = fire(changeEvent);
-			Pools.free(changeEvent);
+			poolManager.free(changeEvent);
 			if (cancelled) {
 				this.value = oldValue;
 				return false;

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/SelectBox.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/SelectBox.java
@@ -42,7 +42,6 @@ import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.Null;
 import com.badlogic.gdx.utils.ObjectSet;
 import com.badlogic.gdx.utils.Pool;
-import com.badlogic.gdx.utils.Pools;
 
 /** A select box (aka a drop-down list) allows a user to choose one of a number of values from a list. When inactive, the selected
  * value is displayed. When activated, it shows the list of values that may be selected.
@@ -193,7 +192,7 @@ public class SelectBox<T> extends Widget implements Disableable, Styleable<Selec
 		} else
 			prefHeight = font.getCapHeight() - font.getDescent() * 2;
 
-		Pool<GlyphLayout> layoutPool = Pools.get(GlyphLayout.class);
+		Pool<GlyphLayout> layoutPool = poolManager.getPool(GlyphLayout.class);
 		GlyphLayout layout = layoutPool.obtain();
 		if (selectedPrefWidth) {
 			prefWidth = 0;
@@ -327,13 +326,14 @@ public class SelectBox<T> extends Widget implements Disableable, Styleable<Selec
 	/** Returns the pref width of the select box if the widest item was selected, for use when
 	 * {@link #setSelectedPrefWidth(boolean)} is true. */
 	public float getMaxSelectedPrefWidth () {
-		Pool<GlyphLayout> layoutPool = Pools.get(GlyphLayout.class);
+		Pool<GlyphLayout> layoutPool = poolManager.getPool(GlyphLayout.class);
 		GlyphLayout layout = layoutPool.obtain();
 		float width = 0;
 		for (int i = 0; i < items.size; i++) {
 			layout.setText(style.font, toString(items.get(i)));
 			width = Math.max(layout.width, width);
 		}
+		layoutPool.free(layout);
 		Drawable bg = style.background;
 		if (bg != null) width = Math.max(width + bg.getLeftWidth() + bg.getRightWidth(), bg.getMinWidth());
 		return width;

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Slider.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Slider.java
@@ -27,7 +27,6 @@ import com.badlogic.gdx.scenes.scene2d.InputListener;
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener.ChangeEvent;
 import com.badlogic.gdx.scenes.scene2d.utils.Drawable;
 import com.badlogic.gdx.utils.Null;
-import com.badlogic.gdx.utils.Pools;
 
 /** A slider is a horizontal indicator that allows a user to set a value. The slider has a range (min, max) and a stepping between
  * each value the slider represents.
@@ -82,9 +81,9 @@ public class Slider extends ProgressBar {
 				// The position is invalid when focus is cancelled
 				if (event.isTouchFocusCancel() || !calculatePositionAndValue(x, y)) {
 					// Fire an event on touchUp even if the value didn't change, so listeners can see when a drag ends via isDragging.
-					ChangeEvent changeEvent = Pools.obtain(ChangeEvent.class);
+					ChangeEvent changeEvent = poolManager.obtain(ChangeEvent.class);
 					fire(changeEvent);
-					Pools.free(changeEvent);
+					poolManager.free(changeEvent);
 				}
 			}
 

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Table.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Table.java
@@ -31,9 +31,9 @@ import com.badlogic.gdx.scenes.scene2d.utils.Drawable;
 import com.badlogic.gdx.scenes.scene2d.utils.Layout;
 import com.badlogic.gdx.utils.Align;
 import com.badlogic.gdx.utils.Array;
+import com.badlogic.gdx.utils.DefaultPool;
 import com.badlogic.gdx.utils.Null;
 import com.badlogic.gdx.utils.Pool;
-import com.badlogic.gdx.utils.Pools;
 
 /** A group that sizes and positions children using table constraints.
  * <p>
@@ -1270,10 +1270,7 @@ public class Table extends WidgetGroup {
 
 	/** @author Nathan Sweet */
 	static public class DebugRect extends Rectangle {
-		static {
-			Pools.set(DebugRect::new);
-		}
-		static Pool<DebugRect> pool = Pools.get(DebugRect.class);
+		static Pool<DebugRect> pool = new DefaultPool<>(DebugRect::new);
 		Color color;
 	}
 

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextArea.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextArea.java
@@ -28,7 +28,6 @@ import com.badlogic.gdx.utils.Align;
 import com.badlogic.gdx.utils.IntArray;
 import com.badlogic.gdx.utils.Null;
 import com.badlogic.gdx.utils.Pool;
-import com.badlogic.gdx.utils.Pools;
 
 /** A text input field with multiple lines. */
 public class TextArea extends TextField {
@@ -291,7 +290,7 @@ public class TextArea extends TextField {
 			int lineStart = 0;
 			int lastSpace = 0;
 			char lastCharacter;
-			Pool<GlyphLayout> layoutPool = Pools.get(GlyphLayout.class);
+			Pool<GlyphLayout> layoutPool = poolManager.getPool(GlyphLayout.class);
 			GlyphLayout layout = layoutPool.obtain();
 			for (int i = 0; i < text.length(); i++) {
 				lastCharacter = text.charAt(i);

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextField.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextField.java
@@ -42,7 +42,6 @@ import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.Clipboard;
 import com.badlogic.gdx.utils.FloatArray;
 import com.badlogic.gdx.utils.Null;
-import com.badlogic.gdx.utils.Pools;
 import com.badlogic.gdx.utils.Timer;
 import com.badlogic.gdx.utils.Timer.Task;
 
@@ -644,10 +643,10 @@ public class TextField extends Widget implements Disableable, Styleable<TextFiel
 	boolean changeText (String oldText, String newText) {
 		if (newText.equals(oldText)) return false;
 		text = newText;
-		ChangeEvent changeEvent = Pools.obtain(ChangeEvent.class);
+		ChangeEvent changeEvent = poolManager.obtain(ChangeEvent.class);
 		boolean cancelled = fire(changeEvent);
 		if (cancelled) text = oldText;
-		Pools.free(changeEvent);
+		poolManager.free(changeEvent);
 		return !cancelled;
 	}
 

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Touchpad.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Touchpad.java
@@ -27,7 +27,6 @@ import com.badlogic.gdx.scenes.scene2d.Touchable;
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener.ChangeEvent;
 import com.badlogic.gdx.scenes.scene2d.utils.Drawable;
 import com.badlogic.gdx.utils.Null;
-import com.badlogic.gdx.utils.Pools;
 
 /** An on-screen joystick. The movement area of the joystick is circular, centered on the touchpad, and its size determined by the
  * smaller touchpad dimension.
@@ -109,12 +108,12 @@ public class Touchpad extends Widget implements Styleable<Touchpad.TouchpadStyle
 			}
 		}
 		if (oldPercentX != knobPercent.x || oldPercentY != knobPercent.y) {
-			ChangeEvent changeEvent = Pools.obtain(ChangeEvent.class);
+			ChangeEvent changeEvent = poolManager.obtain(ChangeEvent.class);
 			if (fire(changeEvent)) {
 				knobPercent.set(oldPercentX, oldPercentY);
 				knobPosition.set(oldPositionX, oldPositionY);
 			}
-			Pools.free(changeEvent);
+			poolManager.free(changeEvent);
 		}
 	}
 

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/Selection.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/Selection.java
@@ -6,7 +6,6 @@ import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener.ChangeEvent;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.Null;
 import com.badlogic.gdx.utils.OrderedSet;
-import com.badlogic.gdx.utils.Pools;
 
 import java.util.Iterator;
 
@@ -223,11 +222,11 @@ public class Selection<T> implements Disableable, Iterable<T> {
 	 * @return true if the change should be undone. */
 	public boolean fireChangeEvent () {
 		if (actor == null) return false;
-		ChangeEvent changeEvent = Pools.obtain(ChangeEvent.class);
+		ChangeEvent changeEvent = actor.getPoolManager().obtain(ChangeEvent.class);
 		try {
 			return actor.fire(changeEvent);
 		} finally {
-			Pools.free(changeEvent);
+			actor.getPoolManager().free(changeEvent);
 		}
 	}
 

--- a/gdx/src/com/badlogic/gdx/utils/Pool.java
+++ b/gdx/src/com/badlogic/gdx/utils/Pool.java
@@ -17,7 +17,7 @@
 package com.badlogic.gdx.utils;
 
 /** A pool of objects that can be reused to avoid allocation.
- * @see Pools
+ * @see PoolManager
  * @author Nathan Sweet */
 abstract public class Pool<T> {
 	/** The maximum number of objects that will be pooled. */

--- a/gdx/src/com/badlogic/gdx/utils/PoolManager.java
+++ b/gdx/src/com/badlogic/gdx/utils/PoolManager.java
@@ -1,0 +1,79 @@
+
+package com.badlogic.gdx.utils;
+
+import com.badlogic.gdx.utils.DefaultPool.PoolSupplier;
+
+/** A class that can be used to handle multiple pools together. Explicit pool registration is needed via the constructor or
+ * {@link PoolManager#addPool(PoolSupplier)}/{@link PoolManager#addPool(Pool)}. */
+@SuppressWarnings("unchecked")
+public class PoolManager {
+
+	private final ObjectMap<Class<?>, Pool<?>> typePools = new ObjectMap<>();
+
+	public PoolManager () {
+
+	}
+
+	public PoolManager (PoolSupplier<?>... poolSuppliers) {
+		for (PoolSupplier<?> poolSupplier : poolSuppliers) {
+			addPool(poolSupplier);
+		}
+	}
+
+	public PoolManager (Pool<?>... pools) {
+		for (Pool<?> pool : pools) {
+			addPool(pool);
+		}
+	}
+
+	/** Registers a new pool with the given supplier. Will throw an exception, if a pool for the same class is already
+	 * registered */
+	public <T> void addPool (PoolSupplier<T> poolSupplier) {
+		Class<T> clazz = (Class<T>)poolSupplier.get().getClass();
+		if (typePools.containsKey(clazz)) {
+			throw new GdxRuntimeException("Attempt to add pool with already existing class: " + clazz);
+		}
+
+		typePools.put(clazz, new DefaultPool<>(poolSupplier));
+	}
+
+	/** Registers the new pool. Will throw an exception, if a pool for the same class is already registered */
+	public <T> void addPool (Pool<T> pool) {
+		T object = pool.obtain();
+		if (typePools.containsKey(object.getClass())) {
+			throw new GdxRuntimeException("Attempt to add pool with already existing class: " + object.getClass());
+		}
+
+		typePools.put(object.getClass(), pool);
+		pool.free(object);
+	}
+
+	/** Returns the pool registered for the class. Will throw an exception, if no pool for this class is registered */
+	public <T> Pool<T> getPool (Class<T> clazz) {
+		Pool<T> pool = (Pool<T>)typePools.get(clazz);
+		if (pool == null) {
+			throw new GdxRuntimeException("Attempt to get pool with unknown class: " + clazz);
+		}
+		return pool;
+	}
+
+	/** Returns a new pooled object for the class. Will throw an exception, if no pool for this class is registered. Free with
+	 * {@link PoolManager#free} */
+	public <T> T obtain (Class<T> clazz) {
+		Pool<T> pool = (Pool<T>)typePools.get(clazz);
+		if (pool == null) {
+			throw new GdxRuntimeException("Attempt to get pooled object with unknown class: " + clazz);
+		}
+		return pool.obtain();
+	}
+
+	/** Frees a pooled object. Will throw an exception, if no pool for this class is registered. It is unchecked, whether the
+	 * object was obtained by the registered pool. */
+	public <T> void free (T object) {
+		Pool<T> pool = (Pool<T>)typePools.get(object.getClass());
+		if (pool == null) {
+			throw new GdxRuntimeException("Attempt to free pooled object with unknown class: " + object.getClass());
+		}
+		pool.free(object);
+	}
+}

--- a/gdx/src/com/badlogic/gdx/utils/Pools.java
+++ b/gdx/src/com/badlogic/gdx/utils/Pools.java
@@ -30,7 +30,9 @@ import com.badlogic.gdx.scenes.scene2d.utils.FocusListener.FocusEvent;
 import com.badlogic.gdx.utils.DefaultPool.PoolSupplier;
 
 /** Stores a map of {@link Pool}s by type for convenient static access.
+ * @deprecated Use {@link PoolManager} for bundling pools instead
  * @author Nathan Sweet */
+@Deprecated
 public class Pools {
 	static private final ObjectMap<Class<?>, Pool<?>> typePools = new ObjectMap<>();
 	static public boolean WARN_ON_REFLECTION_POOL_CREATION = true;


### PR DESCRIPTION
As discussed at length in various places, we have multiple problems with the current `Pools` class:
https://github.com/libgdx/libgdx/pull/7666
https://github.com/libgdx/libgdx/pull/7648
https://github.com/libgdx/libgdx/pull/7474

The main issue is, that we can't make it play nice with static analysis tools.

This PR deprecates the `Pools` class and schedules it for removal.
The PR introduces a new, smaller class `PoolManager`, that can be used to manage multiple pools together.
