### PR TITLE
Fix accidental breakage in Array constructor

### DIFF
--- a/gdx/src/com/badlogic/gdx/utils/Array.java
+++ b/gdx/src/com/badlogic/gdx/utils/Array.java
@@ -91,7 +91,7 @@ public class Array<T> implements Iterable<T> {
 	/** Creates a new array containing the elements in the specified array. The new array will have the same type of backing array
 	 * and will be ordered if the specified array is ordered. The capacity is set to the number of elements, so any subsequent
 	 * elements added will cause the backing array to be grown. */
-	public Array (Array<T> array) {
+	public Array (Array<? extends T> array) {
 		items = Arrays.copyOf(array.items, array.size);
 		ordered = array.ordered;
 		size = array.size;


### PR DESCRIPTION
This was accidentally broken in https://github.com/libgdx/libgdx/pull/7605

It should be kept as "? extends T", because the array is cloned and therefore no type issues can occure and it should acceppt sub-types.