### PR TITLE
JsonWriter/String/Matcher improvements

### DIFF
--- a/gdx/src/com/badlogic/gdx/utils/JsonMatcher.java
+++ b/gdx/src/com/badlogic/gdx/utils/JsonMatcher.java
@@ -23,7 +23,8 @@ import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.utils.JsonValue.ValueType;
 import com.badlogic.gdx.utils.JsonWriter.OutputType;
 
-/** Efficient JSON parser that does minimal parsing to extract values matching specified patterns using a single pass.
+/** Efficient JSON parser that extracts values matching specified patterns using a single pass. It conveniently collects values
+ * for processing in batches or at once. Values not collected have minimal overhead, ideal for processing a subset of large JSON.
  * 
  * <h4>Match</h4> Match objects, arrays, or field names (not field values) in the JSON:
  * <ul>
@@ -102,10 +103,11 @@ import com.badlogic.gdx.utils.JsonWriter.OutputType;
  * 
  * <h4>Behavior notes</h4>
  * <ul>
- * <li>reject() prevents further matching at this level or deeper, useful for filtering.
+ * <li>When multiple patterns are added they match in parallel, each with independent capture and processing.
+ * <li>reject() prevents further matching at this level or deeper, useful for filtering. A pattern can reject a different pattern.
  * <li>clear() discards unprocessed captured values.
- * <li>end() prevents further matching and ends parsing. stop() does the same but also clears.
  * <li>start() can be overidden to perform setup just before parsing.
+ * <li>end() prevents further matching and ends parsing. stop() does the same but also clears.
  * <li>If not using {@code *@}, {@code **@}, or {@code []} parsing ends once all specified values are captured.
  * <li>A single capture before processing provides the value directly, multiple captures provide an object.
  * <li>parseRoot(), no patterns, or a {@code ""} pattern captures the entire JSON document.
@@ -161,6 +163,7 @@ public class JsonMatcher extends JsonSkimmer {
 	public JsonMatcher () {
 	}
 
+	/** Adds all of the specified patterns. */
 	public JsonMatcher (String... patterns) {
 		for (String pattern : patterns)
 			addPattern(pattern);


### PR DESCRIPTION
JsonWriter/JsonString performance improvements (follow up to #7683):
* Methods to avoid boxing and conditionals.
* Use stack only for depths < current.
* Avoid comma check after name for set().

JsonMatcher changes from IRL usage:
* Added parseRoot() to return root JsonValue, else it's awkward to use.
* start() for init before parsing.
* Patterns constructor, convenience.
* Javadoc.

---

Can be used with `var` this way:
```
var matcher = new JsonMatcher("(message,access_token)") {
   String error, accessToken;
   protected void process (JsonValue value) {
      error = value.getString("message", null);
      accessToken = value.getString("access_token", null);
   }
};
matcher.parse(json);
if (matcher.error != null) fail(matcher.error);
return matcher.accessToken;
```

---

For another example, I get 120KB of JSON from a weather web service. I start parsing at the part I want, grabbing the first 24 hours out of 200+, then stop before parsing fails due to starting in the middle:
```
String data = ...
int start = data.indexOf("\"hourly\":");
if (start == -1) throw error("Hourly data not found.");
start += 9;
data.getChars(start, start + 11000, chars, 0);
hourlyForecast.parse(chars, 0, chars.length);
...
private final char[] chars = new char[11000];
private final JsonMatcher hourlyForecast = new JsonMatcher("*@/(precip,precip_probability)") {
   int count;
   protected void process (JsonValue value) {
      float rain = value.getFloat("precip"); // mm per hour.
      float chance = value.getInt("precip_probability") / 100f;
      ...
      if (++count == 24) {
         count = 0;
         stop();
      }
   }
};
```