### PR TITLE
Support for integer arrays `glUniform_iv` functions in ShaderProgram

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,7 @@
 - API Addition: Added JsonValue#toJson that takes a Writer.
 - API Addition: Added getProgrammaticChangeEvents() to scene2d.ui actors that have setProgrammaticChangeEvents.
 - API Addition: Added JsonMatcher, extracts values with pattern matching.
+- API Addition: Added setUniform_iv functions in ShaderProgram to set uniform integer arrays
 - Fixed crashes when reading the soft buttons bar height on Android.
 - Multi sample FBOs can now be used with OpenGL ES 3.0+ instead of OpenGL ES 3.1+
 

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/ShaderProgram.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/ShaderProgram.java
@@ -383,6 +383,58 @@ public class ShaderProgram implements Disposable {
 		gl.glUniform4i(location, value1, value2, value3, value4);
 	}
 
+	public void setUniform1iv (String name, int[] values, int offset, int length) {
+		GL20 gl = Gdx.gl20;
+		checkManaged();
+		int location = fetchUniformLocation(name);
+		gl.glUniform1iv(location, length, values, offset);
+	}
+
+	public void setUniform1iv (int location, int[] values, int offset, int length) {
+		GL20 gl = Gdx.gl20;
+		checkManaged();
+		gl.glUniform1iv(location, length, values, offset);
+	}
+
+	public void setUniform2iv (String name, int[] values, int offset, int length) {
+		GL20 gl = Gdx.gl20;
+		checkManaged();
+		int location = fetchUniformLocation(name);
+		gl.glUniform2iv(location, length / 2, values, offset);
+	}
+
+	public void setUniform2iv (int location, int[] values, int offset, int length) {
+		GL20 gl = Gdx.gl20;
+		checkManaged();
+		gl.glUniform2iv(location, length / 2, values, offset);
+	}
+
+	public void setUniform3iv (String name, int[] values, int offset, int length) {
+		GL20 gl = Gdx.gl20;
+		checkManaged();
+		int location = fetchUniformLocation(name);
+		gl.glUniform3iv(location, length / 3, values, offset);
+	}
+
+	public void setUniform3iv (int location, int[] values, int offset, int length) {
+		GL20 gl = Gdx.gl20;
+		checkManaged();
+		gl.glUniform3iv(location, length / 3, values, offset);
+	}
+
+	public void setUniform4iv (String name, int[] values, int offset, int length) {
+		GL20 gl = Gdx.gl20;
+		checkManaged();
+		int location = fetchUniformLocation(name);
+		gl.glUniform4iv(location, length / 4, values, offset);
+	}
+
+	public void setUniform4iv (int location, int[] values, int offset, int length) {
+		GL20 gl = Gdx.gl20;
+		checkManaged();
+		gl.glUniform4iv(location, length / 4, values, offset);
+	}
+
 	/** Sets the uniform with the given name. The {@link ShaderProgram} must be bound for this to work.
 	 *
 	 * @param name the name of the uniform


### PR DESCRIPTION
Adding convenience functions in `ShaderProgram` to input integer arrays into a shader program without needing to call OpenGL directly. Directly matches the already present `glUniform_fv` functions.

Important use case: array of texture sent to the shader, for example with cascaded shadow maps
