### PR TITLE
Small but Important fix to the TmjMapLoader.

### DIFF
--- a/gdx/src/com/badlogic/gdx/maps/tiled/TmjMapLoader.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/TmjMapLoader.java
@@ -109,7 +109,7 @@ public class TmjMapLoader extends BaseTmjMapLoader<BaseTmjMapLoader.Parameters> 
 		Array<FileHandle> fileHandles = new Array<>();
 
 		// TileSet descriptors
-		for (JsonValue tileSet : root.get("tileSets")) {
+		for (JsonValue tileSet : root.get("tilesets")) {
 			getTileSetDependencyFileHandle(fileHandles, tmjFile, tileSet);
 		}
 


### PR DESCRIPTION
While checking out the leftover Tiled PRs, after rebasing I noticed the TMJ map tests were failing.

This was because of a change to the JsonValue class, recently on August 8th.
A new method, JsonValue.getIgnoreCase()  was added and the case insensitivity from .get() was removed.

In the TmjMapLoader we were mistakenly using "tileSets" instead of the proper "tilesets".

But since the original JsonValue.get() was always comparing with equalsIgnoreCase. It just "worked" anyways.

But it was wrong to be checking against that string, it should be looking for "tilesets". So I have fixed it.

If you are wondering why I did not instead change it to use the newly added JsonValue.getIgnoreCase() method. It is because the tmx loader IS case sensitive so we should keep functionality the same.

That is all. But this should most definitely be merged before the next release or the TMJ maps will begin breaking.