### PR TITLE
Fix ANR/crash in AndroidGraphics.destroy() due to infinite wait()

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphics.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphics.java
@@ -428,6 +428,20 @@ public class AndroidGraphics extends AbstractGraphics implements Renderer {
 			running = false;
 			destroy = true;
 
+            view.queueEvent(new Runnable() {
+                @Override
+                public void run () {
+                    if (!destroy) {
+                        // destroy event already picked up by onDrawFrame
+                        return;
+                    }
+
+                    // it's ok to call ApplicationListener's events
+                    // from onDrawFrame because it's executing in GL thread
+                    onDrawFrame(null);
+                }
+            });
+
 			while (destroy) {
 				try {
 					synch.wait();


### PR DESCRIPTION
### Summary
This PR resolves an ANR/crash in `AndroidGraphics.destroy()` ([#7626](https://github.com/libgdx/libgdx/issues/7626)) caused by an infinite `wait()` when `onDrawFrame()` is never invoked

### Technical Details
- The fix follows the same approach already used in the `pause()` method: it manually enqueues a call to `onDrawFrame`.
- This ensures that `destroy()` can complete without blocking indefinitely.
- It applies the same logic introduced in [PR #6745](https://github.com/libgdx/libgdx/pull/6745), but that PR was closed without being merged.