### PR TITLE
Allow Creation of HexagonTiledMapRenderer with empty TiledMap. BugFix - Fixes Issue #7024

### DIFF
--- a/gdx/src/com/badlogic/gdx/maps/tiled/renderers/HexagonalTiledMapRenderer.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/renderers/HexagonalTiledMapRenderer.java
@@ -90,17 +90,21 @@ public class HexagonalTiledMapRenderer extends BatchTiledMapRenderer {
 				length = map.getProperties().get("tilewidth", Integer.class);
 				if (length != null) {
 					hexSideLength = 0.5f * length.intValue();
-				} else {
+				} else if (map.getLayers().size() > 0) {
 					TiledMapTileLayer tmtl = (TiledMapTileLayer)map.getLayers().get(0);
 					hexSideLength = 0.5f * tmtl.getTileWidth();
+				} else {
+					hexSideLength = 0f;
 				}
 			} else {
 				length = map.getProperties().get("tileheight", Integer.class);
 				if (length != null) {
 					hexSideLength = 0.5f * length.intValue();
-				} else {
-					TiledMapTileLayer tmtl = (TiledMapTileLayer)map.getLayers().get(0);
+				} else if (map.getLayers().size() > 0) {
+					TiledMapTileLayer tmtl = (TiledMapTileLayer) map.getLayers().get(0);
 					hexSideLength = 0.5f * tmtl.getTileHeight();
+				} else {
+					hexSideLength = 0f;
 				}
 			}
 		}
@@ -407,6 +411,30 @@ public class HexagonalTiledMapRenderer extends BatchTiledMapRenderer {
 				}
 			}
 		}
+	}
+
+	public boolean isStaggerAxisX() {
+		return staggerAxisX;
+	}
+
+	public void setStaggerAxisX(boolean staggerAxisX) {
+		this.staggerAxisX = staggerAxisX;
+	}
+
+	public boolean isStaggerIndexEven() {
+		return staggerIndexEven;
+	}
+
+	public void setStaggerIndexEven(boolean staggerIndexEven) {
+		this.staggerIndexEven = staggerIndexEven;
+	}
+
+	public float getHexSideLength() {
+		return hexSideLength;
+	}
+
+	public void setHexSideLength(float hexSideLength) {
+		this.hexSideLength = hexSideLength;
 	}
 
 }

--- a/gdx/src/com/badlogic/gdx/maps/tiled/renderers/HexagonalTiledMapRenderer.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/renderers/HexagonalTiledMapRenderer.java
@@ -101,7 +101,7 @@ public class HexagonalTiledMapRenderer extends BatchTiledMapRenderer {
 				if (length != null) {
 					hexSideLength = 0.5f * length.intValue();
 				} else if (map.getLayers().size() > 0) {
-					TiledMapTileLayer tmtl = (TiledMapTileLayer) map.getLayers().get(0);
+					TiledMapTileLayer tmtl = (TiledMapTileLayer)map.getLayers().get(0);
 					hexSideLength = 0.5f * tmtl.getTileHeight();
 				} else {
 					hexSideLength = 0f;
@@ -413,27 +413,27 @@ public class HexagonalTiledMapRenderer extends BatchTiledMapRenderer {
 		}
 	}
 
-	public boolean isStaggerAxisX() {
+	public boolean isStaggerAxisX () {
 		return staggerAxisX;
 	}
 
-	public void setStaggerAxisX(boolean staggerAxisX) {
+	public void setStaggerAxisX (boolean staggerAxisX) {
 		this.staggerAxisX = staggerAxisX;
 	}
 
-	public boolean isStaggerIndexEven() {
+	public boolean isStaggerIndexEven () {
 		return staggerIndexEven;
 	}
 
-	public void setStaggerIndexEven(boolean staggerIndexEven) {
+	public void setStaggerIndexEven (boolean staggerIndexEven) {
 		this.staggerIndexEven = staggerIndexEven;
 	}
 
-	public float getHexSideLength() {
+	public float getHexSideLength () {
 		return hexSideLength;
 	}
 
-	public void setHexSideLength(float hexSideLength) {
+	public void setHexSideLength (float hexSideLength) {
 		this.hexSideLength = hexSideLength;
 	}
 


### PR DESCRIPTION
I somehow missed this issue during the cleanup. It's a very simple fix.
All of the other map render's allow for their creation with an empty "new TiledMap()" being passed in.

But since the HexagonTiledMapRenderer is a bit different, it pulls out some properties during the init() process when attempting to do so with the HexagonTiledMapRenderer it crashes with:
Caused by: java.lang.IndexOutOfBoundsException: index can't be >= size: 0 >= 0
        at com.badlogic.gdx.utils.Array.get(Array.java:155)
        at com.badlogic.gdx.maps.MapLayers.get(MapLayers.java:31)
        at com.badlogic.gdx.maps.tiled.renderers.HexagonalTiledMapRenderer.init(HexagonalTiledMapRenderer.java:89)
        at com.badlogic.gdx.maps.tiled.renderers.HexagonalTiledMapRenderer.<init>(HexagonalTiledMapRenderer.java:43)
        
This is because as a fallback, when length is null which happens when we can not find "tilewidth" or "tileheight" in the map properties. We attempt to grab it from the layers. But if the user is creating a fresh TiledMap object with nothing else added to it this will fail because there is of course, no layers to get.
 
My thought process was just to simply add a check to see if we have the layers to even pull from. Otherwise we just set to default.  By passing this crash scenario and allowing any user to build as they please.
And as was suggested in the issue, since these variables would need to be populated to be used. I added in the proper getters and setters so they are accessible to for the user to set themselves.

Let me know if this is deemed unnecessary or a good thing to add in to resolve the issue.
 