### PR TITLE
Add a constructor taking a TextureData array to FileTextureArrayData

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/glutils/FileTextureArrayData.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/FileTextureArrayData.java
@@ -60,7 +60,7 @@ public class FileTextureArrayData implements TextureArrayData {
 		int width = -1;
 		int height = -1;
 		for (TextureData data : textureDatas) {
-			data.prepare();
+			if (!data.isPrepared()) data.prepare();
 			if (width == -1) {
 				width = data.getWidth();
 				height = data.getHeight();

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/FileTextureArrayData.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/FileTextureArrayData.java
@@ -43,6 +43,13 @@ public class FileTextureArrayData implements TextureArrayData {
 		}
 	}
 
+	public FileTextureArrayData (Pixmap.Format format, boolean useMipMaps, TextureData[] textureDatas) {
+		this.format = format;
+		this.useMipMaps = useMipMaps;
+		this.depth = textureDatas.length;
+		this.textureDatas = textureDatas;
+	}
+
 	@Override
 	public boolean isPrepared () {
 		return prepared;


### PR DESCRIPTION
This PR just adds a new constructor to `FileTextureArrayData` which takes a `TextureData[]` instead of file handles.

It also adds a check to `FileTextureArrayData.prepare()` to make it work with already prepared texture data instances, like `PixmapTextureData`.

I'm not completely sure if `FileTextureArrayData` is the right place to add this, because I'm actually using it for `PixmapTextureData`. But it seems to be an easy extensions and is already mentioned in (#7573).