### PR TITLE
Add return values to InputProcessor#removeProcessor

### DIFF
--- a/gdx/src/com/badlogic/gdx/InputMultiplexer.java
+++ b/gdx/src/com/badlogic/gdx/InputMultiplexer.java
@@ -47,10 +47,8 @@ public class InputMultiplexer implements InputProcessor {
 		processors.add(processor);
 	}
 
-	/** 
-	 * Removes the given processor, using identity comparison (==)
-	 * @returns true if the processor was found and removed, false otherwise 
-	 */
+	/** Removes the given processor, using identity comparison (==)
+	 * @returns true if the processor was found and removed, false otherwise */
 	public boolean removeProcessor (InputProcessor processor) {
 		return processors.removeValue(processor, true);
 	}


### PR DESCRIPTION
If someone tries to remove an `InputProcessor` from an `InputMultiplexer` that is not actually added as a processor, it will silently do nothing.

This change (not tested) adds two return values to the two different `InputMultiplexer#removeProcessor()` methods: one returning the boolean, and one returning the processor removed at the given index.

Also adds a couple of JavaDocs.