### PR TITLE
Calculate cachedOrientation for android KeyboardHeightObserver on startup

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/keyboardheight/AndroidXKeyboardHeightProvider.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/keyboardheight/AndroidXKeyboardHeightProvider.java
@@ -40,6 +40,9 @@ public class AndroidXKeyboardHeightProvider implements KeyboardHeightProvider {
 	@Override
 	public void start () {
 		this.view = activity.findViewById(android.R.id.content);
+		// We do this, to not dispatch changes that are not changes on first run
+		cachedOrientation = activity.getResources().getConfiguration().orientation;
+
 		ViewCompat.setOnApplyWindowInsetsListener(view, new OnApplyWindowInsetsListener() {
 			@NotNull
 			@Override

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/keyboardheight/StandardKeyboardHeightProvider.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/keyboardheight/StandardKeyboardHeightProvider.java
@@ -104,6 +104,8 @@ public class StandardKeyboardHeightProvider extends PopupWindow implements Keybo
 	@Override
 	public void start () {
 		parentView = activity.findViewById(android.R.id.content);
+		// We do this, to not dispatch changes that are not changes on first run
+		cachedOrientation = activity.getResources().getConfiguration().orientation;
 		if (!isShowing() && parentView.getWindowToken() != null) {
 			setBackgroundDrawable(new ColorDrawable(0));
 			showAtLocation(parentView, Gravity.NO_GRAVITY, 0, 0);


### PR DESCRIPTION
Small followup fix for https://github.com/libgdx/libgdx/pull/7670

This ensures, that the first recognised keyboard change is really a change in values, and not some android internal relayout.