### PR TITLE
A draft fix for backspace and tab keypress on DefaultGwtInput

### DIFF
--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/DefaultGwtInput.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/DefaultGwtInput.java
@@ -788,35 +788,15 @@ public class DefaultGwtInput extends AbstractInput implements GwtInput {
 						processor.keyDown(code);
 					}
 				}
-// if (code == Keys.BACKSPACE) {
-// if (processor != null) {
-// processor.keyDown(code);
-// processor.keyTyped('\b');
-// }
-// } else {
-// if (!pressedKeys[code]) {
-// pressedKeySet.add(code);
-// pressedKeyCount++;
-// pressedKeys[code] = true;
-// keyJustPressed = true;
-// justPressedKeys[code] = true;
-// if (processor != null) {
-// processor.keyDown(code);
-// }
-// }
-// }
 			}
 
 			if (e.getType().equals("keypress")) {
 				// Gdx.app.log("DefaultGwtInput", "keypress");
 				char c = (char)e.getCharCode();
-				// usually, browsers don't send a keypress event for tab, so we emulate it in
-				// keyup event. Just in case this changes in the future, we sort this out here
-				// to avoid sending the event twice.
+				// usually, browsers don't send a keypress event for tab and backspace.
+				// but the capture listener creates those events, so here just handle
+				// them as normal keys.
 				if (processor != null) processor.keyTyped(c);
-// if (c != '\t') {
-// if (processor != null) processor.keyTyped(c);
-// }
 			}
 
 			if (e.getType().equals("keyup")) {
@@ -825,11 +805,6 @@ public class DefaultGwtInput extends AbstractInput implements GwtInput {
 				if (isCatchKey(code)) {
 					e.preventDefault();
 				}
-// if (processor != null && code == Keys.TAB) {
-// // js does not raise keypress event for tab, so emulate this here for
-// // platform-independant behaviour
-// processor.keyTyped('\t');
-// }
 				if (pressedKeys[code]) {
 					pressedKeySet.remove(code);
 					pressedKeyCount--;


### PR DESCRIPTION
After checking #7219 and #7504 , seems the most urgent need of the problem is to make gwt's `TAB` and `BACKSPACE` response totally the same as the one in lwjgl/lwjgl3. But this is hard to tackle because most of the browsers won't send `keypressed` event for functional keys like `TAB` and `BACKSPACE`.

This PR tries to fix this by listening the `keydown` event and use `e.repeat` to distinguish whether it's the initial press or the auto-repeat. If this is a "initial press" we do nothing as a normal `keydown` event; if this is a "auto-repeat", we dispatch a `keypress` event for the key instead. So that `TAB` and `BACKSPACE` could also be captured as usual keys.

I have basically verified it on my pc, and it works well. These two keys are captured just like those in lwjgl3.

Existing problems/questions:
- Apparantly this solution breaks the original logic so they may need more tests.
- though `repeat` property is commonly used in nowaday browsers, there are still edge cases in legacy embedded webviews or older mobile browsers where this property might be missing. I just skipped the change so I don't know how those will behave. Maybe need further changes.
- need some tests in different devices and envs (Sorry i still don't know how to test these on a Android device like in #7504 )

Request Changes are welcome.