### PR TITLE
Fix ApplicationListener#dispose call on Android backend

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplication.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplication.java
@@ -248,11 +248,6 @@ public class AndroidApplication extends Activity implements AndroidApplicationBa
 
 		input.onPause();
 
-		if (isFinishing()) {
-			graphics.clearManagedCaches();
-			graphics.destroy();
-		}
-
 		AndroidGraphics.enforceContinuousRendering = isContinuousEnforced;
 		graphics.setContinuousRendering(isContinuous);
 
@@ -300,6 +295,8 @@ public class AndroidApplication extends Activity implements AndroidApplicationBa
 	@Override
 	protected void onDestroy () {
 		keyboardHeightProvider.close();
+		graphics.clearManagedCaches();
+		graphics.destroy();
 		super.onDestroy();
 	}
 


### PR DESCRIPTION
Fix for issue [#7727](https://github.com/libgdx/libgdx/issues/7727).

I basically moved
```
graphics.clearManagedCaches();
graphics.destroy();
```
block from `AndroidApplication#onPause()` to `AndroidApplication#onDestroy()` method.

As mentioned in the issue description `AndroidGraphics#destroy()` manages `ApllicationListener` lifecycle calls, but it also manages `LifecycleListener` calls. There is no need to change logic of that, but I believe `AndroidGraphics#destroy()` call is placed in a wrong method. To make it work like described in the issue there is a need to initiate disposing in `AndroidApplication#onDestroy()`. Also we have to remove `graphics.destroy()` from `AndroidApplication#onPause()`, because that method would be called twice when pressing "Back" key.

The solution was tested on the demo application on Android emulator and `ApplicationListener#dispose()` is now executed both after pressing the “Back” button and after closing/killing the app from the Recents Screen.
