### PR TITLE
fix: prevent delta time from being negative

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphics.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphics.java
@@ -455,6 +455,7 @@ public class AndroidGraphics extends AbstractGraphics implements Renderer {
 	@Override
 	public void onDrawFrame (javax.microedition.khronos.opengles.GL10 gl) {
 		long time = System.nanoTime();
+		if (lastFrameTime > time) lastFrameTime = time;
 		// After pause deltaTime can have somewhat huge value that destabilizes the mean, so let's cut it off
 		if (!resume) {
 			deltaTime = (time - lastFrameTime) / 1000000000.0f;

--- a/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/mock/graphics/MockGraphics.java
+++ b/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/mock/graphics/MockGraphics.java
@@ -259,6 +259,7 @@ public class MockGraphics extends AbstractGraphics {
 
 	public void updateTime () {
 		long time = System.nanoTime();
+		if (lastTime == -1 || lastTime > time) lastTime = time;
 		deltaTime = (time - lastTime) / 1000000000.0f;
 		lastTime = time;
 

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGraphics.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGraphics.java
@@ -208,13 +208,14 @@ public class LwjglGraphics extends AbstractGraphics {
 	}
 
 	void updateTime () {
-		long time;
+		long time = System.nanoTime();
+		if (lastTime == -1 || lastTime > time) lastTime = time;
 		if (resetDeltaTime) {
 			resetDeltaTime = false;
-			time = lastTime;
-		} else
-			time = System.nanoTime();
-		deltaTime = (time - lastTime) / 1000000000.0f;
+			deltaTime = 0;
+		} else {
+			deltaTime = (time - lastTime) / 1000000000.0f;
+		}
 		lastTime = time;
 
 		if (time - frameStart >= 1000000000) {

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Graphics.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Graphics.java
@@ -156,12 +156,13 @@ public class Lwjgl3Graphics extends AbstractGraphics implements Disposable {
 
 	void update () {
 		long time = System.nanoTime();
-		if (lastFrameTime == -1) lastFrameTime = time;
+		if (lastFrameTime == -1 || lastFrameTime > time) lastFrameTime = time;
 		if (resetDeltaTime) {
 			resetDeltaTime = false;
 			deltaTime = 0;
-		} else
+		} else {
 			deltaTime = (time - lastFrameTime) / 1000000000.0f;
+		}
 		lastFrameTime = time;
 
 		if (time - frameCounterStart >= 1000000000) {

--- a/backends/gdx-backend-robovm-metalangle/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
+++ b/backends/gdx-backend-robovm-metalangle/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
@@ -248,6 +248,7 @@ public class IOSGraphics extends AbstractGraphics {
 			return;
 		}
 		long time = System.nanoTime();
+		if (lastFrameTime > time) lastFrameTime = time;
 		if (!resume) {
 			deltaTime = (time - lastFrameTime) / 1000000000.0f;
 		} else {

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSGraphics.java
@@ -255,6 +255,7 @@ public class IOSGraphics extends AbstractGraphics {
 		}
 
 		long time = System.nanoTime();
+		if (lastFrameTime > time) lastFrameTime = time;
 		if (!resume) {
 			deltaTime = (time - lastFrameTime) / 1000000000.0f;
 		} else {

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtGraphics.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtGraphics.java
@@ -544,6 +544,7 @@ public class GwtGraphics extends AbstractGraphics {
 
 	public void update () {
 		long currTimeStamp = System.currentTimeMillis();
+		if (lastTimeStamp > currTimeStamp) lastTimeStamp = currTimeStamp;
 		deltaTime = (currTimeStamp - lastTimeStamp) / 1000.0f;
 		lastTimeStamp = currTimeStamp;
 		time += deltaTime;


### PR DESCRIPTION
* some multicore devices have unstable clocks leading to inconsistent nanoTime values
* currentTimeMillis could change with clock synchronization
* LwjglGraphics is now more consistent with Lwjgl3Graphics