### PR TITLE
Update Libgdx to Jnigen 3.X. Add Windows AArch64 windows support.

### DIFF
--- a/.github/actions/build-linux-natives/entrypoint.sh
+++ b/.github/actions/build-linux-natives/entrypoint.sh
@@ -37,7 +37,7 @@ apt-get -yq --force-yes install gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf 
 apt-get -yq --force-yes install gcc-riscv64-linux-gnu g++-riscv64-linux-gnu libc6-dev-riscv64-cross
 
 # Build Linux natives
-./gradlew jniGen jnigenBuildLinux64 jnigenBuildLinuxARM jnigenBuildLinuxARM64 jnigenBuildLinuxRISCV64 --no-daemon
+./gradlew jniGen jnigenBuildAllLinux --no-daemon
 
 # Pack artifacts
 find .  -name "*.a" -o -name "*.dll" -o -name "*.dylib" -o -name "*.so" | grep "libs" > native-files-list

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -15,77 +15,6 @@ on:
 
 jobs:
 
-  natives-ios:
-    runs-on: macos-15
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-          submodules: 'recursive'
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'zulu'
-          java-version: '17'
-
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
-
-      - name: Build iOS natives
-        run: |
-          /usr/bin/xcodebuild -version
-          ./gradlew jniGen jnigenBuildIOS
-          ./backends/gdx-backend-robovm/build-objectal.sh
-
-      - name: Pack artifacts
-        run: |
-          find .  -name "*.a" -o -name "*.dll" -o -name "*.dylib" -o -name "*.so" -o -name "*.xcframework"  | grep "libs" > native-files-list
-          zip -r natives-ios -@ < native-files-list
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: natives-ios.zip
-          path: natives-ios.zip
-
-  natives-macos:
-    runs-on: macos-15
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-          submodules: 'recursive'
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'zulu'
-          java-version: '17'
-
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
-
-      - name: Build macOS natives
-        run: |
-          /usr/bin/xcodebuild -version
-          ./gradlew jniGen jnigenBuildMacOsX64 jnigenBuildMacOsXARM64
-
-      - name: Pack artifacts
-        run: |
-          # Needed starting with Xcode 15 to run multiple instances of the same app
-          find . -name "*.dylib" | grep "libs" | while read dylib; do
-            codesign -s - -f "$dylib"
-          done
-          find .  -name "*.a" -o -name "*.dll" -o -name "*.dylib" -o -name "*.so" | grep "libs" > native-files-list
-          zip natives-macos -@ < native-files-list
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: natives-macos.zip
-          path: natives-macos.zip
-
   natives-linux:
     runs-on: ubuntu-22.04
     steps:
@@ -104,7 +33,7 @@ jobs:
           name: natives-linux.zip
           path: natives-linux.zip
 
-  natives-windows:
+  natives-windows-cross:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
@@ -128,18 +57,19 @@ jobs:
 
       - name: Build Windows natives
         run: |
-          ./gradlew jniGen jnigenBuildWindows64 jnigenBuildWindows
+          ./gradlew jniGen jnigenBuildAllWindows --info 
 
       - name: Pack artifacts
         run: |
           find .  -name "*.a" -o -name "*.dll" -o -name "*.dylib" -o -name "*.so" | grep "libs" > native-files-list
-          zip natives-windows -@ < native-files-list
+          zip natives-windows-cross -@ < native-files-list
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: natives-windows.zip
-          path: natives-windows.zip
+          name: natives-windows-cross.zip
+          path: natives-windows-cross.zip
+
 
   natives-android:
     runs-on: ubuntu-22.04
@@ -167,7 +97,7 @@ jobs:
 
       - name: Build Android natives
         run: |
-          ./gradlew jniGen jnigenBuildAndroid
+          ./gradlew jniGen jnigenBuildAllAndroid 
 
       - name: Pack artifacts
         run: |
@@ -180,15 +110,20 @@ jobs:
           name: natives-android.zip
           path: natives-android.zip
 
-  pack-natives:
-    runs-on: ubuntu-22.04
-    needs: [natives-macos, natives-linux, natives-windows, natives-ios, natives-android]
-    env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_EC2_METADATA_DISABLED: true
+
+  natives-mac:
+    runs-on: macos-14
     steps:
-      - uses: actions/checkout@v2
+      - name: Setup Xcode SDK
+        run: |
+          # See https://github.com/actions/virtual-environments/issues/2557
+          sudo mv /Library/Developer/CommandLineTools/SDKs/* /tmp
+          sudo mv /Applications/Xcode.app /Applications/Xcode.app.bak
+          sudo mv /Applications/Xcode_15.4.0.app /Applications/Xcode.app
+          sudo xcode-select -switch /Applications/Xcode.app
+          /usr/bin/xcodebuild -version
+
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: 'recursive'
@@ -199,49 +134,164 @@ jobs:
           distribution: 'zulu'
           java-version: '17'
 
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
 
-      - name: Download natives-ios artifact
-        uses: actions/download-artifact@v4
+      - name: Initialize jnigen
+        run: ./gradlew jnigen
+      - name: Build natives
+        run: |
+          ./gradlew jnigenBuildAllIOS jnigenBuildAllMacOsX
+          ./backends/gdx-backend-robovm/build-objectal.sh
+
+      - name: Pack artifacts
+        run: |
+          find .  -name "*.a" -o -name "*.dll" -o -name "*.dylib" -o -name "*.so" -o -name "*.xcframework" | grep "libs" > native-files-list
+          zip natives-mac -@ < native-files-list
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
         with:
-          name: natives-ios.zip
+          name: natives-mac.zip
+          path: natives-mac.zip
 
-      - name: Download natives-macos artifact
-        uses: actions/download-artifact@v4
+  natives-windows-msvc:
+    runs-on: windows-latest
+    steps:
+      - name: Add VCVarsall To path
+        shell: pwsh
+        run: |
+          echo "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+
+      - uses: actions/checkout@v4
         with:
-          name: natives-macos.zip
+          fetch-depth: 0
+          submodules: 'recursive'
 
-      - name: Download natives-linux artifact
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+
+
+      - name: Initialize jnigen
+        run: ./gradlew jnigen
+      - name: Build natives
+        run: ./gradlew jnigenBuildAllWindows
+
+      - name: Choco install Zip
+        run: choco install zip
+
+      - name: Pack artifacts
+        shell: bash
+        run: |
+          find .  -name "*.a" -o -name "*.dll" -o -name "*.dylib" -o -name "*.so" | grep "libs" > native-files-list
+          zip natives-windows-msvc -@ < native-files-list
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: natives-windows-msvc.zip
+          path: natives-windows-msvc.zip
+
+
+  package:
+    runs-on: ubuntu-latest
+    needs: [natives-android, natives-linux, natives-mac, natives-windows-cross, natives-windows-msvc]
+    env:
+      ORG_GRADLE_PROJECT_MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+      ORG_GRADLE_PROJECT_MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_EC2_METADATA_DISABLED: true
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: 'recursive'
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+
+      - name: Download Artifacts from linux
+        if: success() && needs.natives-linux.result == 'success'
         uses: actions/download-artifact@v4
         with:
           name: natives-linux.zip
+      - name: Unzip artifacts
+        run: unzip -o natives-linux.zip
 
-      - name: Download natives-windows artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: natives-windows.zip
-
-      - name: Download natives-android artifact
+      - name: Download Artifacts from android
+        if: success() && needs.natives-android.result == 'success'
         uses: actions/download-artifact@v4
         with:
           name: natives-android.zip
+      - name: Unzip artifacts
+        run: unzip -o natives-android.zip
 
-      - name: Unpack natives
-        run: |
-          unzip -o natives-ios.zip
-          unzip -o natives-macos.zip
-          unzip -o natives-linux.zip
-          unzip -o natives-windows.zip
-          unzip -o natives-android.zip
+      - name: Download Artifacts from mac
+        if: success() && needs.natives-mac.result == 'success'
+        uses: actions/download-artifact@v4
+        with:
+          name: natives-mac.zip
+      - name: Unzip artifacts
+        run: unzip -o natives-mac.zip
 
-      - name: Pack desktop natives
+      - name: Download Artifacts from windows cross
+        if: success() && needs.natives-windows-cross.result == 'success'
+        uses: actions/download-artifact@v4
+        with:
+          name: natives-windows-cross.zip
+      - name: Unzip artifacts
+        run: unzip -o natives-windows-cross.zip
+
+      - name: Download Artifacts from windows msvc
+        if: success() && needs.natives-windows-msvc.result == 'success'
+        uses: actions/download-artifact@v4
+        with:
+          name: natives-windows-msvc.zip
+      - name: Unzip artifacts
+        run: unzip -o natives-windows-msvc.zip
+
+      - name: Fetch External natives
+        run: ./gradlew fetchExternalNatives
+
+      - name: Package All
+        run: ./gradlew jnigenPackageAll --info -Ppackaging
+
+      - name: Snapshot build deploy
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository_owner == 'libgdx'
         run: |
-          ./gradlew jniGen
-          ant -f gdx/jni/build.xml pack-natives
-          ant -f extensions/gdx-box2d/gdx-box2d/jni/build.xml pack-natives
-          ant -f extensions/gdx-freetype/jni/build.xml pack-natives
-          ant -f extensions/gdx-bullet/jni/build.xml pack-natives
+          ./gradlew publish -Ppackaging
+
+      - name: Import GPG key
+        if: (github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.release)) && github.repository_owner == 'libgdx'
+        id: import_gpg
+        uses: crazy-max/ghaction-import-gpg@1c6a9e9d3594f2d743f1b1dd7669ab0dfdffa922
+        with:
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+
+      - name: Release build deploy
+        if: (github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.release)) && github.repository_owner == 'libgdx'
+        run: |
+          export GRADLE_OPTS="-Xmx8g"
+          ./gradlew publish -Ppackaging -PRELEASE -Psigning.gnupg.keyId=${{ secrets.GPG_KEYID }} -Psigning.gnupg.passphrase=${{ secrets.GPG_PASSPHRASE }} -Psigning.gnupg.keyName=${{ secrets.GPG_KEYID }}
+
+
+
+      - name: Build Runnables
+        run: |
+          ./gradlew buildRunnables build
+
+      - name: Upload Runnable artifacts to S3
+        if: env.AWS_ACCESS_KEY_ID != null
+        run: |
+          aws s3 cp ./extensions/gdx-tools/build/libs/ s3://libgdx-nightlies/libgdx-runnables/ --recursive
+
 
       - name: Pack natives
         run: |
@@ -258,88 +308,3 @@ jobs:
         if: env.AWS_ACCESS_KEY_ID != null
         run: |
           aws s3 cp natives.zip s3://libgdx-nightlies/libgdx-nightlies/natives.zip
-
-  publish:
-    runs-on: ubuntu-22.04
-    needs: pack-natives
-    env:
-      ORG_GRADLE_PROJECT_MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-      ORG_GRADLE_PROJECT_MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-          submodules: 'recursive'
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'zulu'
-          java-version: '17'
-
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
-
-      - name: Download natives artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: natives.zip
-
-      - name: Unpack natives
-        run: |
-          unzip -o natives.zip
-
-      - name: Fetch external natives
-        run: |
-          ./gradlew fetchExternalNatives
-
-      - name: Snapshot build deploy
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository_owner == 'libgdx'
-        run: |
-          ./gradlew build publish
-
-      - name: Import GPG key
-        if: (github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.release)) && github.repository_owner == 'libgdx'
-        id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@1c6a9e9d3594f2d743f1b1dd7669ab0dfdffa922
-        with:
-          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.GPG_PASSPHRASE }}
-
-      - name: Release build deploy
-        if: (github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.release)) && github.repository_owner == 'libgdx'
-        run: |
-          export GRADLE_OPTS="-Xmx8g"
-          ./gradlew build publish -PRELEASE -Psigning.gnupg.keyId=${{ secrets.GPG_KEYID }} -Psigning.gnupg.passphrase=${{ secrets.GPG_PASSPHRASE }} -Psigning.gnupg.keyName=${{ secrets.GPG_KEYID }}
-
-  build-and-upload-runnables:
-    runs-on: ubuntu-22.04
-    needs: pack-natives
-    env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_EC2_METADATA_DISABLED: true
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-          submodules: 'recursive'
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'zulu'
-          java-version: '17'
-
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
-
-      - name: Build Runnables
-        run: |
-          ./gradlew clean fetchNatives
-          ./gradlew buildRunnables build
-
-      - name: Upload artifacts to S3
-        if: env.AWS_ACCESS_KEY_ID != null
-        run: |
-          aws s3 cp ./extensions/gdx-tools/build/libs/ s3://libgdx-nightlies/libgdx-runnables/ --recursive

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Build Windows natives
         run: |
-          ./gradlew jniGen jnigenBuildAllWindows --info 
+          ./gradlew jniGen jnigenBuildWindows_x86_32 jnigenBuildWindows_x86_64
 
       - name: Pack artifacts
         run: |
@@ -69,7 +69,6 @@ jobs:
         with:
           name: natives-windows-cross.zip
           path: natives-windows-cross.zip
-
 
   natives-android:
     runs-on: ubuntu-22.04
@@ -177,7 +176,7 @@ jobs:
       - name: Initialize jnigen
         run: ./gradlew jnigen
       - name: Build natives
-        run: ./gradlew jnigenBuildAllWindows
+        run: ./gradlew jnigenBuildWindows_Arm_64
 
       - name: Choco install Zip
         run: choco install zip
@@ -260,12 +259,12 @@ jobs:
         run: ./gradlew fetchExternalNatives
 
       - name: Package All
-        run: ./gradlew jnigenPackageAll --info -Ppackaging
+        run: ./gradlew jnigenPackageAll
 
       - name: Snapshot build deploy
         if: github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository_owner == 'libgdx'
         run: |
-          ./gradlew publish -Ppackaging
+          ./gradlew publish
 
       - name: Import GPG key
         if: (github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.release)) && github.repository_owner == 'libgdx'
@@ -279,9 +278,7 @@ jobs:
         if: (github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.release)) && github.repository_owner == 'libgdx'
         run: |
           export GRADLE_OPTS="-Xmx8g"
-          ./gradlew publish -Ppackaging -PRELEASE -Psigning.gnupg.keyId=${{ secrets.GPG_KEYID }} -Psigning.gnupg.passphrase=${{ secrets.GPG_PASSPHRASE }} -Psigning.gnupg.keyName=${{ secrets.GPG_KEYID }}
-
-
+          ./gradlew publish -PRELEASE -Psigning.gnupg.keyId=${{ secrets.GPG_KEYID }} -Psigning.gnupg.passphrase=${{ secrets.GPG_PASSPHRASE }} -Psigning.gnupg.keyName=${{ secrets.GPG_KEYID }}
 
       - name: Build Runnables
         run: |

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglCanvas.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglCanvas.java
@@ -22,6 +22,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import com.badlogic.gdx.backends.lwjgl.audio.LwjglAudio;
+import com.badlogic.gdx.jnigen.commons.HostDetection;
+import com.badlogic.gdx.jnigen.commons.Os;
 import com.badlogic.gdx.utils.*;
 import org.lwjgl.opengl.AWTGLCanvas;
 import org.lwjgl.opengl.Display;
@@ -93,7 +95,7 @@ public class LwjglCanvas implements LwjglApplicationBase {
 				scaleX = (float)transform.getScaleX();
 				scaleY = (float)transform.getScaleY();
 
-				if (SharedLibraryLoader.os == Os.MacOsX) {
+				if (HostDetection.os == Os.MacOsX) {
 					EventQueue.invokeLater(new Runnable() {
 						public void run () {
 							create();

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglCursor.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglCursor.java
@@ -4,20 +4,20 @@ package com.badlogic.gdx.backends.lwjgl;
 import java.nio.ByteOrder;
 import java.nio.IntBuffer;
 
-import com.badlogic.gdx.utils.Os;
+import com.badlogic.gdx.jnigen.commons.HostDetection;
+import com.badlogic.gdx.jnigen.commons.Os;
 import org.lwjgl.LWJGLException;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Cursor;
 import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.utils.GdxRuntimeException;
-import com.badlogic.gdx.utils.SharedLibraryLoader;
 
 public class LwjglCursor implements Cursor {
 	org.lwjgl.input.Cursor lwjglCursor = null;
 
 	public LwjglCursor (Pixmap pixmap, int xHotspot, int yHotspot) {
-		if (((LwjglGraphics)Gdx.graphics).canvas != null && SharedLibraryLoader.os == Os.MacOsX) {
+		if (((LwjglGraphics)Gdx.graphics).canvas != null && HostDetection.os == Os.MacOsX) {
 			return;
 		}
 		try {

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGraphics.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGraphics.java
@@ -24,7 +24,8 @@ import java.nio.ByteBuffer;
 import com.badlogic.gdx.AbstractGraphics;
 import com.badlogic.gdx.Application;
 import com.badlogic.gdx.graphics.glutils.GLVersion;
-import com.badlogic.gdx.utils.Os;
+import com.badlogic.gdx.jnigen.commons.HostDetection;
+import com.badlogic.gdx.jnigen.commons.Os;
 import org.lwjgl.LWJGLException;
 import org.lwjgl.input.Mouse;
 import org.lwjgl.opengl.ContextAttribs;
@@ -44,7 +45,6 @@ import com.badlogic.gdx.graphics.Pixmap.Blending;
 import com.badlogic.gdx.graphics.Pixmap.Format;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.GdxRuntimeException;
-import com.badlogic.gdx.utils.SharedLibraryLoader;
 
 /** An implementation of the {@link Graphics} interface based on Lwjgl.
  * @author mzechner */
@@ -737,7 +737,7 @@ public class LwjglGraphics extends AbstractGraphics {
 
 	@Override
 	public void setCursor (com.badlogic.gdx.graphics.Cursor cursor) {
-		if (canvas != null && SharedLibraryLoader.os == Os.MacOsX) {
+		if (canvas != null && HostDetection.os == Os.MacOsX) {
 			return;
 		}
 		try {
@@ -749,7 +749,7 @@ public class LwjglGraphics extends AbstractGraphics {
 
 	@Override
 	public void setSystemCursor (SystemCursor systemCursor) {
-		if (canvas != null && SharedLibraryLoader.os == Os.MacOsX) {
+		if (canvas != null && HostDetection.os == Os.MacOsX) {
 			return;
 		}
 		try {

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglNativesLoader.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglNativesLoader.java
@@ -16,12 +16,14 @@
 
 package com.badlogic.gdx.backends.lwjgl;
 
-import static com.badlogic.gdx.utils.SharedLibraryLoader.*;
-
+import com.badlogic.gdx.jnigen.loader.SharedLibraryLoader;
 import com.badlogic.gdx.utils.*;
 
 import java.io.File;
 import java.lang.reflect.Method;
+
+import static com.badlogic.gdx.jnigen.commons.HostDetection.bitness;
+import static com.badlogic.gdx.jnigen.commons.HostDetection.os;
 
 public final class LwjglNativesLoader {
 	static public boolean load = true;

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
@@ -27,6 +27,8 @@ import com.badlogic.gdx.backends.lwjgl3.audio.Lwjgl3Audio;
 import com.badlogic.gdx.backends.lwjgl3.audio.OpenALLwjgl3Audio;
 import com.badlogic.gdx.graphics.glutils.GLVersion;
 
+import com.badlogic.gdx.jnigen.commons.HostDetection;
+import com.badlogic.gdx.jnigen.commons.Os;
 import com.badlogic.gdx.utils.*;
 import org.lwjgl.glfw.GLFW;
 import org.lwjgl.glfw.GLFWErrorCallback;
@@ -56,7 +58,6 @@ import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.Clipboard;
 import com.badlogic.gdx.utils.GdxRuntimeException;
 import com.badlogic.gdx.utils.ObjectMap;
-import com.badlogic.gdx.utils.SharedLibraryLoader;
 
 public class Lwjgl3Application implements Lwjgl3ApplicationBase {
 	private final Lwjgl3ApplicationConfiguration config;
@@ -83,8 +84,7 @@ public class Lwjgl3Application implements Lwjgl3ApplicationBase {
 			Lwjgl3NativesLoader.load();
 			errorCallback = GLFWErrorCallback.createPrint(Lwjgl3ApplicationConfiguration.errorStream);
 			GLFW.glfwSetErrorCallback(errorCallback);
-			if (SharedLibraryLoader.os == Os.MacOsX)
-				GLFW.glfwInitHint(GLFW.GLFW_ANGLE_PLATFORM_TYPE, GLFW.GLFW_ANGLE_PLATFORM_TYPE_METAL);
+			if (HostDetection.os == Os.MacOsX) GLFW.glfwInitHint(GLFW.GLFW_ANGLE_PLATFORM_TYPE, GLFW.GLFW_ANGLE_PLATFORM_TYPE_METAL);
 			GLFW.glfwInitHint(GLFW.GLFW_JOYSTICK_HAT_BUTTONS, GLFW.GLFW_FALSE);
 			if (!GLFW.glfwInit()) {
 				throw new GdxRuntimeException("Unable to initialize GLFW");
@@ -486,7 +486,7 @@ public class Lwjgl3Application implements Lwjgl3ApplicationBase {
 			|| config.glEmulation == Lwjgl3ApplicationConfiguration.GLEmulation.GL32) {
 			GLFW.glfwWindowHint(GLFW.GLFW_CONTEXT_VERSION_MAJOR, config.gles30ContextMajorVersion);
 			GLFW.glfwWindowHint(GLFW.GLFW_CONTEXT_VERSION_MINOR, config.gles30ContextMinorVersion);
-			if (SharedLibraryLoader.os == Os.MacOsX) {
+			if (HostDetection.os == Os.MacOsX) {
 				// hints mandatory on OS X for GL 3.2+ context creation, but fail on Windows if the
 				// WGL_ARB_create_context extension is not available
 				// see: http://www.glfw.org/docs/latest/compat.html

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3ApplicationConfiguration.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3ApplicationConfiguration.java
@@ -21,8 +21,8 @@ import java.nio.IntBuffer;
 
 import com.badlogic.gdx.ApplicationListener;
 import com.badlogic.gdx.LifecycleListener;
-import com.badlogic.gdx.utils.Os;
-import com.badlogic.gdx.utils.SharedLibraryLoader;
+import com.badlogic.gdx.jnigen.commons.HostDetection;
+import com.badlogic.gdx.jnigen.commons.Os;
 import org.lwjgl.BufferUtils;
 import org.lwjgl.PointerBuffer;
 import org.lwjgl.glfw.GLFW;
@@ -243,7 +243,7 @@ public class Lwjgl3ApplicationConfiguration extends Lwjgl3WindowConfiguration {
 	 *
 	 * @see <a href= "https://libgdx.com/news/2021/07/devlog-7-lwjgl3#do-i-need-to-do-anything-else"> Documentation</a> */
 	public static void useGlfwAsync () {
-		if (SharedLibraryLoader.os == Os.MacOsX) {
+		if (HostDetection.os == Os.MacOsX) {
 			Configuration.GLFW_LIBRARY_NAME.set("glfw_async");
 		}
 	}

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Net.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Net.java
@@ -20,6 +20,8 @@ import java.awt.Desktop;
 import java.net.URI;
 
 import com.badlogic.gdx.Net;
+import com.badlogic.gdx.jnigen.commons.HostDetection;
+import com.badlogic.gdx.jnigen.commons.Os;
 import com.badlogic.gdx.net.NetJavaImpl;
 import com.badlogic.gdx.net.NetJavaServerSocketImpl;
 import com.badlogic.gdx.net.NetJavaSocketImpl;
@@ -27,8 +29,6 @@ import com.badlogic.gdx.net.ServerSocket;
 import com.badlogic.gdx.net.ServerSocketHints;
 import com.badlogic.gdx.net.Socket;
 import com.badlogic.gdx.net.SocketHints;
-import com.badlogic.gdx.utils.Os;
-import com.badlogic.gdx.utils.SharedLibraryLoader;
 
 /** LWJGL implementation of the {@link Net} API, it could be reused in other Desktop backends since it doesn't depend on LWJGL.
  * @author acoppes */
@@ -72,7 +72,7 @@ public class Lwjgl3Net implements Net {
 
 	@Override
 	public boolean openURI (String uri) {
-		if (SharedLibraryLoader.os == Os.MacOsX) {
+		if (HostDetection.os == Os.MacOsX) {
 			try {
 				(new ProcessBuilder("open", (new URI(uri).toString()))).start();
 				return true;
@@ -86,7 +86,7 @@ public class Lwjgl3Net implements Net {
 			} catch (Throwable t) {
 				return false;
 			}
-		} else if (SharedLibraryLoader.os == Os.Linux) {
+		} else if (HostDetection.os == Os.Linux) {
 			try {
 				(new ProcessBuilder("xdg-open", (new URI(uri).toString()))).start();
 				return true;

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Window.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Window.java
@@ -19,7 +19,8 @@ package com.badlogic.gdx.backends.lwjgl3;
 import java.nio.IntBuffer;
 
 import com.badlogic.gdx.*;
-import com.badlogic.gdx.utils.Os;
+import com.badlogic.gdx.jnigen.commons.HostDetection;
+import com.badlogic.gdx.jnigen.commons.Os;
 import org.lwjgl.BufferUtils;
 import org.lwjgl.glfw.GLFW;
 import org.lwjgl.glfw.GLFWDropCallback;
@@ -33,7 +34,6 @@ import org.lwjgl.glfw.GLFWWindowRefreshCallback;
 import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.Disposable;
-import com.badlogic.gdx.utils.SharedLibraryLoader;
 
 public class Lwjgl3Window implements Disposable {
 	private long windowHandle;
@@ -313,7 +313,7 @@ public class Lwjgl3Window implements Disposable {
 	}
 
 	static void setIcon (long windowHandle, String[] imagePaths, Files.FileType imageFileType) {
-		if (SharedLibraryLoader.os == Os.MacOsX) return;
+		if (HostDetection.os == Os.MacOsX) return;
 
 		Pixmap[] pixmaps = new Pixmap[imagePaths.length];
 		for (int i = 0; i < imagePaths.length; i++) {
@@ -328,7 +328,7 @@ public class Lwjgl3Window implements Disposable {
 	}
 
 	static void setIcon (long windowHandle, Pixmap[] images) {
-		if (SharedLibraryLoader.os == Os.MacOsX) return;
+		if (HostDetection.os == Os.MacOsX) return;
 		if (GLFW.glfwGetPlatform() == GLFW.GLFW_PLATFORM_WAYLAND) return;
 
 		GLFWImage.Buffer buffer = GLFWImage.malloc(images.length);

--- a/build.gradle
+++ b/build.gradle
@@ -19,10 +19,14 @@ buildscript {
 	repositories {
 		mavenCentral()
 		gradlePluginPortal()
+		maven {
+			url "https://oss.sonatype.org/content/repositories/snapshots/"
+		}
+		maven { url "https://central.sonatype.com/repository/maven-snapshots/" }
 	}
 	dependencies {
 		classpath "com.diffplug.spotless:spotless-plugin-gradle:${versions.spotless}"
-		classpath "com.badlogicgames.gdx:gdx-jnigen-gradle:2.5.2"
+		classpath "com.badlogicgames.jnigen:jnigen-gradle:3.1.2-SNAPSHOT"
 		classpath 'org.jreleaser:jreleaser-gradle-plugin:1.18.0'
 	}
 }
@@ -53,7 +57,7 @@ ext {
 }
 
 allprojects {
-	group = 'com.badlogicgames.gdx'
+	group = project.getProperty("group") ? project.getProperty("group") : "com.badlogicgames.gdx"
 	version = project.getProperty('version') + (isReleaseBuild() ? "" : "-SNAPSHOT")
 
 	buildscript {
@@ -65,6 +69,9 @@ allprojects {
 			maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
 			maven { url "https://oss.sonatype.org/content/repositories/releases/" }
 			maven { url "https://central.sonatype.com/repository/maven-snapshots/" }
+		}
+		dependencies {
+			classpath "com.badlogicgames.jnigen:jnigen-gradle:3.1.2-SNAPSHOT"
 		}
 	}
 
@@ -205,11 +212,36 @@ tasks.register('fetchGdxNativesZIP', Download) {
 	useETag "all"
 }
 
-tasks.register('fetchNatives', Copy) {
+tasks.register("unzipNatives", Copy) {
 	dependsOn fetchGdxNativesZIP
 	from zipTree("build/natives.zip")
 	into "."
 	doNotTrackState("Don't track state")
+}
+
+tasks.register('fetchNatives') {
+	dependsOn unzipNatives
+}
+
+
+//Hook up jnigen tasks to fetch natives task.
+//Once natives have been unzipped, jnigen can package these up into jars
+//We then can depend on them as artifact references for test dependencies
+project.afterEvaluate {
+	subprojects {
+		afterEvaluate { project ->
+			if (project.plugins.hasPlugin("com.badlogicgames.jnigen.jnigen-gradle")) {
+				[
+					project.tasks.jnigenPackageAllAndroid,
+					project.tasks.jnigenPackageAllIOS,
+					project.tasks.jnigenPackageAllDesktop
+				].forEach { packageTask ->
+					fetchNatives.dependsOn(packageTask)
+					packageTask.mustRunAfter(unzipNatives)
+				}
+			}
+		}
+	}
 }
 
 apply from: rootProject.file('publish.gradle')

--- a/extensions/gdx-box2d/gdx-box2d/build.gradle
+++ b/extensions/gdx-box2d/gdx-box2d/build.gradle
@@ -1,3 +1,5 @@
+import com.badlogic.gdx.jnigen.commons.HostDetection
+
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
  *
@@ -14,21 +16,57 @@
  * limitations under the License.
  ******************************************************************************/
 
-apply plugin: "com.badlogicgames.gdx.gdx-jnigen"
+apply plugin: "com.badlogicgames.jnigen.jnigen-gradle"
 jnigen {
 	sharedLibName = "gdx-box2d"
-	add(Windows, x32)
-	add(Windows, x64)
-	add(Linux, x64)
-	add(Linux, x32, ARM)
-	add(Linux, x64, ARM)
-	add(Linux, x64, RISCV)
-	add(MacOsX, x64)
-	add(MacOsX, x64, ARM)
-	add(Android)
-	add(IOS)
+	multiThreadedCompile = true
+
+	all {
+		cppIncludes = ["jni/Box2D/**/*.cpp"]
+		headerDirs = ["jni"]
+	}
+
+	//Little hack to avoid duplicate builds. Only register MSVC on windows host
+	//Other hosts will ignore MSVC and build with mingw
+	def isPackaging = project.hasProperty("packaging")
+
+	if (isPackaging) {
+		addWindows(x64, ARM, MSVC)
+		addWindows(x32, x86)
+		addWindows(x64, x86)
+	} else {
+		if (HostDetection.os === Windows) {
+			addWindows(x64, ARM, MSVC)
+		} else {
+			addWindows(x32, x86)
+			addWindows(x64, x86)
+		}
+	}
+
+	addLinux(x64, x86)
+	addLinux(x32, ARM)
+	addLinux(x64, ARM)
+	addLinux(x64, RISCV)
+	addMac(x64, x86)
+	addMac(x64, ARM)
+	addAndroid()
+	addIOS()
 
 	robovm {
 		forceLinkClasses "com.badlogic.gdx.physics.box2d.*"
+	}
+}
+
+artifacts {
+	[
+		jnigenPackageAllAndroid,
+		jnigenPackageAllIOS,
+		jnigenPackageAllDesktop
+	].forEach {packageTask ->
+		packageTask.getOutputs().getFiles().each { file ->
+			archives(file) {
+				builtBy(packageTask)
+			}
+		}
 	}
 }

--- a/extensions/gdx-box2d/gdx-box2d/build.gradle
+++ b/extensions/gdx-box2d/gdx-box2d/build.gradle
@@ -26,22 +26,9 @@ jnigen {
 		headerDirs = ["jni"]
 	}
 
-	//Little hack to avoid duplicate builds. Only register MSVC on windows host
-	//Other hosts will ignore MSVC and build with mingw
-	def isPackaging = project.hasProperty("packaging")
-
-	if (isPackaging) {
-		addWindows(x64, ARM, MSVC)
-		addWindows(x32, x86)
-		addWindows(x64, x86)
-	} else {
-		if (HostDetection.os === Windows) {
-			addWindows(x64, ARM, MSVC)
-		} else {
-			addWindows(x32, x86)
-			addWindows(x64, x86)
-		}
-	}
+	addWindows(x64, ARM, MSVC)
+	addWindows(x32, x86)
+	addWindows(x64, x86)
 
 	addLinux(x64, x86)
 	addLinux(x32, ARM)

--- a/extensions/gdx-box2d/gdx-box2d/src/com/badlogic/gdx/physics/box2d/Box2D.java
+++ b/extensions/gdx-box2d/gdx-box2d/src/com/badlogic/gdx/physics/box2d/Box2D.java
@@ -16,7 +16,7 @@
 
 package com.badlogic.gdx.physics.box2d;
 
-import com.badlogic.gdx.utils.SharedLibraryLoader;
+import com.badlogic.gdx.jnigen.loader.SharedLibraryLoader;
 
 /** This class's only purpose is to initialize Box2D by calling its {@link #init()} method.
  * @author Daniel Holderbaum */

--- a/extensions/gdx-box2d/gdx-box2d/src/com/badlogic/gdx/physics/box2d/World.java
+++ b/extensions/gdx-box2d/gdx-box2d/src/com/badlogic/gdx/physics/box2d/World.java
@@ -18,6 +18,7 @@ package com.badlogic.gdx.physics.box2d;
 
 import java.util.Iterator;
 
+import com.badlogic.gdx.jnigen.loader.SharedLibraryLoader;
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.physics.box2d.JointDef.JointType;
 import com.badlogic.gdx.physics.box2d.joints.DistanceJoint;
@@ -47,7 +48,6 @@ import com.badlogic.gdx.utils.Disposable;
 import com.badlogic.gdx.utils.GdxRuntimeException;
 import com.badlogic.gdx.utils.LongMap;
 import com.badlogic.gdx.utils.Pool;
-import com.badlogic.gdx.utils.SharedLibraryLoader;
 
 /** The world class manages all physics entities, dynamic simulation, and asynchronous queries. The world also contains efficient
  * memory management facilities.

--- a/extensions/gdx-bullet/build.gradle
+++ b/extensions/gdx-bullet/build.gradle
@@ -1,3 +1,6 @@
+import com.badlogic.gdx.jnigen.commons.HostDetection
+import com.badlogic.gdx.jnigen.commons.Os
+
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
  *
@@ -33,60 +36,93 @@ dependencies {
 	api project(":gdx")
 }
 
-apply plugin: "com.badlogicgames.gdx.gdx-jnigen"
+apply plugin: "com.badlogicgames.jnigen.jnigen-gradle"
 jnigen {
 	sharedLibName = "gdx-bullet"
+	multiThreadedCompile = true
+
+
 	nativeCodeGenerator {
-		sourceDir = "src"
+		sourceDirs = ["src"]
 	}
 	all {
-		headerDirs = [
-			"src/bullet/",
-			"src/custom/",
-			"src/extras/Serialize/",
-			"src/extras/"
+		cppIncludes = [
+			"jni/src/**/*.cpp",
+			"jni/swig-src/**/*.cpp"
 		]
 		cExcludes = [
-			"src/bullet/BulletMultiThreaded/GpuSoftBodySolvers/**"
+			"jni/src/bullet/BulletMultiThreaded/GpuSoftBodySolvers/**"
 		]
 		cppExcludes = [
-			"src/bullet/BulletMultiThreaded/GpuSoftBodySolvers/**"
+			"jni/src/bullet/BulletMultiThreaded/GpuSoftBodySolvers/**"
+		]
+
+		headerDirs = [
+			//Bullet
+			"jni/src/bullet/",
+			"jni/src/custom/",
+			"jni/src/extras/",
+			"jni/src/extras/Serialize",
 		]
 
 		// SWIG doesn't emit strict aliasing compliant code
-		cppFlags += " -fno-strict-aliasing";
+		cppFlags += ["-fno-strict-aliasing"]
 		// SWIG directors aren't clearly documented to require RTTI, but SWIG
 		// normally generates a small number of dynamic_casts for director code.
 		// gdx-bullet's swig build.xml replaces these with static C casts so we
 		// can compile without RTTI and save some disk space. It seems to work
 		// with these static casts.
-		cppFlags += " -fno-rtti";
+		cppFlags += ["-fno-rtti"]
 		// Disable profiling (it's on by default). If you change this, you
 		// must regenerate the SWIG wrappers with the changed value.
-		cppFlags += " -DBT_NO_PROFILE";
+		cppFlags += ["-DBT_NO_PROFILE"]
 		//Bullet 2 compatibility with inverse dynamics
-		cppFlags += " -DBT_USE_INVERSE_DYNAMICS_WITH_BULLET2";
+		cppFlags += [
+			"-DBT_USE_INVERSE_DYNAMICS_WITH_BULLET2"
+		]
 	}
-	add(Windows, x32)
-	add(Windows, x64)
-	add(Linux, x64)
-	add(Linux, x32, ARM)
-	add(Linux, x64, ARM)
-	add(Linux, x64, RISCV)
-	add(MacOsX, x64)
-	add(MacOsX, x64, ARM)
-	add(Android) {
-		cppFlags += " -fexceptions"
-		androidApplicationMk += "APP_STL := c++_static";
+
+	//Little hack to avoid duplicate builds. Only register MSVC on windows host
+	//Other hosts will ignore MSVC and build with mingw
+	def isPackaging = project.hasProperty("packaging")
+
+	if (isPackaging) {
+		//        addWindows(x64, ARM, MSVC)
+		addWindows(x32, x86)
+		addWindows(x64, x86)
+	} else {
+		if (HostDetection.os === Windows) {
+			//            addWindows(x64, ARM, MSVC)
+		} else {
+			addWindows(x32, x86)
+			addWindows(x64, x86)
+		}
 	}
-	add(IOS) {
-		cppFlags += " -stdlib=libc++";
+
+	addLinux(x64, x86)
+	addLinux(x32, ARM)
+	addLinux(x64, ARM)
+	addLinux(x64, RISCV)
+	addMac(x64, x86)
+	addMac(x64, ARM)
+	addAndroid() {
+		cppFlags += ["-fexceptions"]
+		androidApplicationMk += ["APP_STL := c++_static"]
+		if (HostDetection.os == Os.Windows) {
+			androidAndroidMk += [
+				"LOCAL_SHORT_COMMANDS := true"
+			]
+			androidApplicationMk += ["APP_SHORT_COMMANDS := true"]
+		}
+	}
+	addIOS() {
+		cppFlags += ["-stdlib=libc++"]
 	}
 
 	robovm {
 		forceLinkClasses "com.badlogic.gdx.physics.bullet.collision.CollisionJNI", "com.badlogic.gdx.physics.bullet.dynamics.DynamicsJNI",
 				"com.badlogic.gdx.physics.bullet.extras.ExtrasJNI", "com.badlogic.gdx.physics.bullet.linearmath.LinearMathJNI",
-				"com.badlogic.gdx.physics.bullet.softbody.SoftbodyJNI",  "com.badlogic.gdx.physics.bullet.collision.btBroadphaseAabbCallback",
+				"com.badlogic.gdx.physics.bullet.softbody.SoftbodyJNI", "com.badlogic.gdx.physics.bullet.collision.btBroadphaseAabbCallback",
 				"com.badlogic.gdx.physics.bullet.collision.btBroadphaseRayCallback", "com.badlogic.gdx.physics.bullet.collision.btConvexTriangleCallback",
 				"com.badlogic.gdx.physics.bullet.collision.btGhostPairCallback", "com.badlogic.gdx.physics.bullet.collision.btInternalTriangleIndexCallback",
 				"com.badlogic.gdx.physics.bullet.collision.btNodeOverlapCallback", "com.badlogic.gdx.physics.bullet.collision.btOverlapCallback",
@@ -98,8 +134,22 @@ jnigen {
 				"com.badlogic.gdx.physics.bullet.collision.RayResultCallback", "com.badlogic.gdx.physics.bullet.collision.ClosestRayResultCallback",
 				"com.badlogic.gdx.physics.bullet.collision.AllHitsRayResultCallback", "com.badlogic.gdx.physics.bullet.collision.ConvexResultCallback",
 				"com.badlogic.gdx.physics.bullet.collision.LocalConvexResult", "com.badlogic.gdx.physics.bullet.collision.ContactResultCallback",
-				"com.badlogic.gdx.physics.bullet.dynamics.InternalTickCallback",  "com.badlogic.gdx.physics.bullet.extras.btBulletWorldImporter",
+				"com.badlogic.gdx.physics.bullet.dynamics.InternalTickCallback", "com.badlogic.gdx.physics.bullet.extras.btBulletWorldImporter",
 				"com.badlogic.gdx.physics.bullet.linearmath.btIDebugDraw", "com.badlogic.gdx.physics.bullet.linearmath.btMotionState",
 				"com.badlogic.gdx.physics.bullet.DebugDrawer"
+	}
+}
+
+artifacts {
+	[
+		jnigenPackageAllAndroid,
+		jnigenPackageAllIOS,
+		jnigenPackageAllDesktop
+	].forEach {packageTask ->
+		packageTask.getOutputs().getFiles().each { file ->
+			archives(file) {
+				builtBy(packageTask)
+			}
+		}
 	}
 }

--- a/extensions/gdx-bullet/build.gradle
+++ b/extensions/gdx-bullet/build.gradle
@@ -82,22 +82,10 @@ jnigen {
 		]
 	}
 
-	//Little hack to avoid duplicate builds. Only register MSVC on windows host
-	//Other hosts will ignore MSVC and build with mingw
-	def isPackaging = project.hasProperty("packaging")
 
-	if (isPackaging) {
-		//        addWindows(x64, ARM, MSVC)
-		addWindows(x32, x86)
-		addWindows(x64, x86)
-	} else {
-		if (HostDetection.os === Windows) {
-			//            addWindows(x64, ARM, MSVC)
-		} else {
-			addWindows(x32, x86)
-			addWindows(x64, x86)
-		}
-	}
+	//        addWindows(x64, ARM, MSVC)
+	addWindows(x32, x86)
+	addWindows(x64, x86)
 
 	addLinux(x64, x86)
 	addLinux(x32, ARM)

--- a/extensions/gdx-bullet/src/com/badlogic/gdx/physics/bullet/Bullet.java
+++ b/extensions/gdx-bullet/src/com/badlogic/gdx/physics/bullet/Bullet.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 
 import com.badlogic.gdx.graphics.g3d.model.MeshPart;
 import com.badlogic.gdx.graphics.g3d.model.Node;
+import com.badlogic.gdx.jnigen.loader.SharedLibraryLoader;
 import com.badlogic.gdx.math.Matrix4;
 import com.badlogic.gdx.physics.bullet.collision.btBvhTriangleMeshShape;
 import com.badlogic.gdx.physics.bullet.collision.btCollisionShape;
@@ -29,7 +30,6 @@ import com.badlogic.gdx.physics.bullet.linearmath.LinearMathConstants;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.GdxRuntimeException;
 import com.badlogic.gdx.utils.Pool;
-import com.badlogic.gdx.utils.SharedLibraryLoader;
 
 public class Bullet {
 	/** The version of the Bullet library used by this wrapper. */

--- a/extensions/gdx-freetype/build.gradle
+++ b/extensions/gdx-freetype/build.gradle
@@ -1,3 +1,5 @@
+import com.badlogic.gdx.jnigen.commons.HostDetection
+
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
  *
@@ -18,84 +20,130 @@ dependencies {
 	api project(":gdx")
 }
 
-apply plugin: "com.badlogicgames.gdx.gdx-jnigen"
+apply plugin: "com.badlogicgames.jnigen.jnigen-gradle"
 jnigen {
 	sharedLibName = "gdx-freetype"
+	multiThreadedCompile = true
+
 	all {
-		headerDirs = ["freetype/include"]
+		headerDirs = ["jni/freetype/include/"]
 		cIncludes = [
 			// BASE
-			"freetype/src/base/ftsystem.c",
-			"freetype/src/base/ftinit.c",
-			"freetype/src/base/ftdebug.c",
-			"freetype/src/base/ftbase.c",
-			"freetype/src/base/ftbbox.c",
-			"freetype/src/base/ftglyph.c",
-			"freetype/src/base/ftbdf.c",
-			"freetype/src/base/ftbitmap.c",
-			"freetype/src/base/ftcid.c",
-			"freetype/src/base/ftfstype.c",
-			"freetype/src/base/ftgasp.c",
-			"freetype/src/base/ftgxval.c",
-			"freetype/src/base/ftmm.c",
-			"freetype/src/base/ftotval.c",
-			"freetype/src/base/ftpatent.c",
-			"freetype/src/base/ftpfr.c",
-			"freetype/src/base/ftstroke.c",
-			"freetype/src/base/ftsynth.c",
-			"freetype/src/base/fttype1.c",
-			"freetype/src/base/ftwinfnt.c",
-			"freetype/src/base/ftxf86.c",
+			"jni/freetype/src/base/ftsystem.c",
+			"jni/freetype/src/base/ftinit.c",
+			"jni/freetype/src/base/ftdebug.c",
+			"jni/freetype/src/base/ftbase.c",
+			"jni/freetype/src/base/ftbbox.c",
+			"jni/freetype/src/base/ftglyph.c",
+			"jni/freetype/src/base/ftbdf.c",
+			"jni/freetype/src/base/ftbitmap.c",
+			"jni/freetype/src/base/ftcid.c",
+			"jni/freetype/src/base/ftfstype.c",
+			"jni/freetype/src/base/ftgasp.c",
+			"jni/freetype/src/base/ftgxval.c",
+			"jni/freetype/src/base/ftmm.c",
+			"jni/freetype/src/base/ftotval.c",
+			"jni/freetype/src/base/ftpatent.c",
+			"jni/freetype/src/base/ftpfr.c",
+			"jni/freetype/src/base/ftstroke.c",
+			"jni/freetype/src/base/ftsynth.c",
+			"jni/freetype/src/base/fttype1.c",
+			"jni/freetype/src/base/ftwinfnt.c",
+			"jni/freetype/src/base/ftxf86.c",
 			// "freetype/src/base/ftmac.c",
 
 			// DRIVERS
-			"freetype/src/bdf/bdf.c",
-			"freetype/src/cff/cff.c",
-			"freetype/src/cid/type1cid.c",
-			"freetype/src/pcf/pcf.c",
-			"freetype/src/pfr/pfr.c",
-			"freetype/src/sdf/sdf.c",
-			"freetype/src/sfnt/sfnt.c",
-			"freetype/src/truetype/truetype.c",
-			"freetype/src/type1/type1.c",
-			"freetype/src/type42/type42.c",
-			"freetype/src/winfonts/winfnt.c",
+			"jni/freetype/src/bdf/bdf.c",
+			"jni/freetype/src/cff/cff.c",
+			"jni/freetype/src/cid/type1cid.c",
+			"jni/freetype/src/pcf/pcf.c",
+			"jni/freetype/src/pfr/pfr.c",
+			"jni/freetype/src/sdf/sdf.c",
+			"jni/freetype/src/sfnt/sfnt.c",
+			"jni/freetype/src/truetype/truetype.c",
+			"jni/freetype/src/type1/type1.c",
+			"jni/freetype/src/type42/type42.c",
+			"jni/freetype/src/winfonts/winfnt.c",
 			// RASTERIZERS
-			"freetype/src/raster/raster.c",
-			"freetype/src/smooth/smooth.c",
+			"jni/freetype/src/raster/raster.c",
+			"jni/freetype/src/smooth/smooth.c",
 			// AUX
-			"freetype/src/autofit/autofit.c",
-			"freetype/src/cache/ftcache.c",
-			"freetype/src/gzip/ftgzip.c",
-			"freetype/src/lzw/ftlzw.c",
-			"freetype/src/bzip2/ftbzip2.c",
-			"freetype/src/gxvalid/gxvalid.c",
-			"freetype/src/otvalid/otvalid.c",
-			"freetype/src/psaux/psaux.c",
-			"freetype/src/pshinter/pshinter.c",
-			"freetype/src/psnames/psnames.c",
-			"freetype/src/svg/svg.c",
+			"jni/freetype/src/autofit/autofit.c",
+			"jni/freetype/src/cache/ftcache.c",
+			"jni/freetype/src/gzip/ftgzip.c",
+			"jni/freetype/src/lzw/ftlzw.c",
+			"jni/freetype/src/bzip2/ftbzip2.c",
+			"jni/freetype/src/gxvalid/gxvalid.c",
+			"jni/freetype/src/otvalid/otvalid.c",
+			"jni/freetype/src/psaux/psaux.c",
+			"jni/freetype/src/pshinter/pshinter.c",
+			"jni/freetype/src/psnames/psnames.c",
+			"jni/freetype/src/svg/svg.c",
 		]
 
-		cppExcludes = ["freetype/subprojects/"]
+		cppExcludes = ["jni/freetype/subprojects/"]
 
-		cFlags += " -DFT2_BUILD_LIBRARY "
-		cFlags += System.getenv("CC_FLAGS") ?: ""
-		cppFlags += " -DFT2_BUILD_LIBRARY "
-		cppFlags += System.getenv("CPP_FLAGS") ?: ""
+		cFlags += ["-DFT2_BUILD_LIBRARY"]
+		if (System.getenv("CC_FLAGS") != null) {
+			cFlags += [System.getenv("CC_FLAGS")]
+		}
+		cppFlags += ["-DFT2_BUILD_LIBRARY"]
+		if (System.getenv("CPP_FLAGS") != null) {
+			cppFlags += [System.getenv("CPP_FLAGS")]
+		}
 	}
-	add(Windows, x32)
-	add(Windows, x64)
-	add(Linux, x64)
-	add(Linux, x32, ARM)
-	add(Linux, x64, ARM)
-	add(Linux, x64, RISCV)
-	add(MacOsX, x64) {
-		linkerFlags += " -framework CoreServices -framework Carbon"
+
+	//Little hack to avoid duplicate builds. Only register MSVC on windows host
+	//Other hosts will ignore MSVC and build with mingw
+	def isPackaging = project.hasProperty("packaging")
+
+	if (isPackaging) {
+		addWindows(x64, ARM, MSVC)
+		addWindows(x32, x86)
+		addWindows(x64, x86)
+	} else {
+		if (HostDetection.os === Windows) {
+			addWindows(x64, ARM, MSVC)
+		} else {
+			addWindows(x32, x86)
+			addWindows(x64, x86)
+		}
 	}
-	add(MacOsX, x64, ARM) {
-		linkerFlags += " -framework CoreServices -framework Carbon"
+
+	addLinux(x64, x86)
+	addLinux(x32, ARM)
+	addLinux(x64, ARM)
+	addLinux(x64, RISCV)
+	addMac(x64, x86) {
+		linkerFlags += [
+			"-framework",
+			"CoreServices",
+			"-framework",
+			"Carbon"
+		]
 	}
-	add(Android)
-	add(IOS)
+	addMac(x64, ARM) {
+		linkerFlags += [
+			"-framework",
+			"CoreServices",
+			"-framework",
+			"Carbon"
+		]
+	}
+	addAndroid()
+	addIOS()
+}
+
+artifacts {
+	[
+		jnigenPackageAllAndroid,
+		jnigenPackageAllIOS,
+		jnigenPackageAllDesktop
+	].forEach {packageTask ->
+		packageTask.getOutputs().getFiles().each { file ->
+			archives(file) {
+				builtBy(packageTask)
+			}
+		}
+	}
 }

--- a/extensions/gdx-freetype/build.gradle
+++ b/extensions/gdx-freetype/build.gradle
@@ -93,22 +93,9 @@ jnigen {
 		}
 	}
 
-	//Little hack to avoid duplicate builds. Only register MSVC on windows host
-	//Other hosts will ignore MSVC and build with mingw
-	def isPackaging = project.hasProperty("packaging")
-
-	if (isPackaging) {
-		addWindows(x64, ARM, MSVC)
-		addWindows(x32, x86)
-		addWindows(x64, x86)
-	} else {
-		if (HostDetection.os === Windows) {
-			addWindows(x64, ARM, MSVC)
-		} else {
-			addWindows(x32, x86)
-			addWindows(x64, x86)
-		}
-	}
+	addWindows(x64, ARM, MSVC)
+	addWindows(x32, x86)
+	addWindows(x64, x86)
 
 	addLinux(x64, x86)
 	addLinux(x32, ARM)

--- a/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeType.java
+++ b/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeType.java
@@ -26,11 +26,11 @@ import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.Pixmap.Blending;
 import com.badlogic.gdx.graphics.Pixmap.Format;
+import com.badlogic.gdx.jnigen.loader.SharedLibraryLoader;
 import com.badlogic.gdx.utils.BufferUtils;
 import com.badlogic.gdx.utils.Disposable;
 import com.badlogic.gdx.utils.GdxRuntimeException;
 import com.badlogic.gdx.utils.LongMap;
-import com.badlogic.gdx.utils.SharedLibraryLoader;
 import com.badlogic.gdx.utils.StreamUtils;
 
 public class FreeType {

--- a/extensions/gdx-tools/build.gradle
+++ b/extensions/gdx-tools/build.gradle
@@ -18,7 +18,6 @@ dependencies {
 	api project(":backends:gdx-backend-lwjgl")
 	api project(":extensions:gdx-freetype")
 	api project(":backends:gdx-backend-headless")
-	api testnatives.desktop
 }
 
 sourceSets.main.resources.srcDirs = ["assets"]

--- a/gdx/build.gradle
+++ b/gdx/build.gradle
@@ -1,3 +1,5 @@
+import com.badlogic.gdx.jnigen.commons.HostDetection
+
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
  *
@@ -85,7 +87,7 @@ task validateIOSHeader {
 
 dependencies {
 	testImplementation libraries.junit
-	api "com.badlogicgames.gdx:gdx-jnigen-loader:2.5.2"
+	api "com.badlogicgames.jnigen:jnigen-loader:3.1.2-SNAPSHOT"
 }
 
 test {
@@ -97,30 +99,71 @@ test {
 
 processResources.duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 
-apply plugin: "com.badlogicgames.gdx.gdx-jnigen"
+apply plugin: "com.badlogicgames.jnigen.jnigen-gradle"
 jnigen {
 	sharedLibName = "gdx"
-	temporaryDir = "../target/native"
+	multiThreadedCompile = true
+
 	all {
-		cppExcludes = ["iosgl/**"]
+		headerDirs = [
+			"jni",
+			"jni/etc1",
+			"jni/gdx2d"
+		]
+		cIncludes = ["jni/gdx2d/*.c"]
+		cppIncludes = ["jni/etc1/*.cpp"]
 	}
-	add(Windows, x32)
-	add(Windows, x64)
-	add(Linux, x64)
-	add(Linux, x32, ARM)
-	add(Linux, x64, ARM)
-	add(Linux, x64, RISCV)
-	add(Android) {
-		linkerFlags += " -llog"
+
+	//Little hack to avoid duplicate builds. Only register MSVC on windows host
+	//Other hosts will ignore MSVC and build with mingw
+	def isPackaging = project.hasProperty("packaging")
+
+	if (isPackaging) {
+		addWindows(x64, ARM, MSVC)
+		addWindows(x32, x86)
+		addWindows(x64, x86)
+	} else {
+		if (HostDetection.os === Windows) {
+			addWindows(x64, ARM, MSVC)
+		} else {
+			addWindows(x32, x86)
+			addWindows(x64, x86)
+		}
 	}
-	add(MacOsX, x64)
-	add(MacOsX, x64, ARM)
-	add(IOS) {
-		headerDirs = ["iosgl"]
-		cppExcludes = []
-		linkerFlags += " -undefined dynamic_lookup "
+
+
+	addLinux(x64, x86)
+	addLinux(x32, ARM)
+	addLinux(x64, ARM)
+	addLinux(x64, RISCV)
+	addAndroid() {
+		linkerFlags += ["-llog"]
+	}
+	addMac(x64, x86)
+	addMac(x64, ARM)
+	addIOS() {
+		headerDirs += ["jni/iosgl"]
+		cppIncludes = ["jni/iosgl/*.cpp"]
+		linkerFlags += [
+			"-undefined",
+			"dynamic_lookup"
+		]
 	}
 	robovm {
-		extraXCFramework("libs/ObjectAL.xcframework")
+		extraXCFramework("../../libs/ios32/ObjectAL.xcframework")
+	}
+}
+
+artifacts {
+	[
+		jnigenPackageAllAndroid,
+		jnigenPackageAllIOS,
+		jnigenPackageAllDesktop
+	].forEach {packageTask ->
+		packageTask.getOutputs().getFiles().each { file ->
+			archives(file) {
+				builtBy(packageTask)
+			}
+		}
 	}
 }

--- a/gdx/build.gradle
+++ b/gdx/build.gradle
@@ -114,23 +114,9 @@ jnigen {
 		cppIncludes = ["jni/etc1/*.cpp"]
 	}
 
-	//Little hack to avoid duplicate builds. Only register MSVC on windows host
-	//Other hosts will ignore MSVC and build with mingw
-	def isPackaging = project.hasProperty("packaging")
-
-	if (isPackaging) {
-		addWindows(x64, ARM, MSVC)
-		addWindows(x32, x86)
-		addWindows(x64, x86)
-	} else {
-		if (HostDetection.os === Windows) {
-			addWindows(x64, ARM, MSVC)
-		} else {
-			addWindows(x32, x86)
-			addWindows(x64, x86)
-		}
-	}
-
+	addWindows(x64, ARM, MSVC)
+	addWindows(x32, x86)
+	addWindows(x64, x86)
 
 	addLinux(x64, x86)
 	addLinux(x32, ARM)

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/UIUtils.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/UIUtils.java
@@ -4,18 +4,18 @@ package com.badlogic.gdx.scenes.scene2d.utils;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input.Buttons;
 import com.badlogic.gdx.Input.Keys;
-import com.badlogic.gdx.utils.Os;
-import com.badlogic.gdx.utils.SharedLibraryLoader;
+import com.badlogic.gdx.jnigen.commons.HostDetection;
+import com.badlogic.gdx.jnigen.commons.Os;
 
 public final class UIUtils {
 	private UIUtils () {
 	}
 
-	static public boolean isAndroid = SharedLibraryLoader.os == Os.Android;
-	static public boolean isMac = SharedLibraryLoader.os == Os.MacOsX;
-	static public boolean isWindows = SharedLibraryLoader.os == Os.Windows;
-	static public boolean isLinux = SharedLibraryLoader.os == Os.Linux;
-	static public boolean isIos = SharedLibraryLoader.os == Os.IOS;
+	static public boolean isAndroid = HostDetection.os == Os.Android;
+	static public boolean isMac = HostDetection.os == Os.MacOsX;
+	static public boolean isWindows = HostDetection.os == Os.Windows;
+	static public boolean isLinux = HostDetection.os == Os.Linux;
+	static public boolean isIos = HostDetection.os == Os.IOS;
 
 	static public boolean left () {
 		return Gdx.input.isButtonPressed(Buttons.LEFT);

--- a/gdx/src/com/badlogic/gdx/utils/GdxNativesLoader.java
+++ b/gdx/src/com/badlogic/gdx/utils/GdxNativesLoader.java
@@ -16,6 +16,8 @@
 
 package com.badlogic.gdx.utils;
 
+import com.badlogic.gdx.jnigen.loader.SharedLibraryLoader;
+
 public class GdxNativesLoader {
 	static public boolean disableNativesLoading = false;
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,8 +3,8 @@ org.gradle.jvmargs=-Xms128m -Xmx2000m
 org.gradle.configureondemand=false
 android.useAndroidX=true
 
-group=com.badlogicgames.gdx
-version=1.14.1
+group=com.asidik.libgdx
+version=1.14.1-JNIGEN3
 POM_NAME=libGDX
 POM_DESCRIPTION=Android/Desktop/iOS/HTML5 game development framework
 POM_URL=https://github.com/libgdx/libgdx

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,8 +3,8 @@ org.gradle.jvmargs=-Xms128m -Xmx2000m
 org.gradle.configureondemand=false
 android.useAndroidX=true
 
-group=com.asidik.libgdx
-version=1.14.1-JNIGEN3
+group=com.badlogicgames.gdx
+version=1.14.1
 POM_NAME=libGDX
 POM_DESCRIPTION=Android/Desktop/iOS/HTML5 game development framework
 POM_URL=https://github.com/libgdx/libgdx

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -17,7 +17,6 @@
 ext {
     versions = [:]
     libraries = [:]
-    testnatives = [:]
     gdxnatives = [:]
 }
 
@@ -61,6 +60,7 @@ libraries.lwjgl3 = [
         "org.lwjgl:lwjgl:${versions.lwjgl3}:natives-macos-arm64",
         "org.lwjgl:lwjgl:${versions.lwjgl3}:natives-windows",
         "org.lwjgl:lwjgl:${versions.lwjgl3}:natives-windows-x86",
+        "org.lwjgl:lwjgl:${versions.lwjgl3}:natives-windows-arm64",
         "org.lwjgl:lwjgl-glfw:${versions.lwjgl3}",
         "org.lwjgl:lwjgl-glfw:${versions.lwjgl3}:natives-linux",
         "org.lwjgl:lwjgl-glfw:${versions.lwjgl3}:natives-linux-arm32",
@@ -70,6 +70,7 @@ libraries.lwjgl3 = [
         "org.lwjgl:lwjgl-glfw:${versions.lwjgl3}:natives-macos-arm64",
         "org.lwjgl:lwjgl-glfw:${versions.lwjgl3}:natives-windows",
         "org.lwjgl:lwjgl-glfw:${versions.lwjgl3}:natives-windows-x86",
+        "org.lwjgl:lwjgl-glfw:${versions.lwjgl3}:natives-windows-arm64",
         "org.lwjgl:lwjgl-jemalloc:${versions.lwjgl3}",
         "org.lwjgl:lwjgl-jemalloc:${versions.lwjgl3}:natives-linux",
         "org.lwjgl:lwjgl-jemalloc:${versions.lwjgl3}:natives-linux-arm32",
@@ -79,6 +80,7 @@ libraries.lwjgl3 = [
         "org.lwjgl:lwjgl-jemalloc:${versions.lwjgl3}:natives-macos-arm64",
         "org.lwjgl:lwjgl-jemalloc:${versions.lwjgl3}:natives-windows",
         "org.lwjgl:lwjgl-jemalloc:${versions.lwjgl3}:natives-windows-x86",
+        "org.lwjgl:lwjgl-jemalloc:${versions.lwjgl3}:natives-windows-arm64",
         "org.lwjgl:lwjgl-openal:${versions.lwjgl3}",
         "org.lwjgl:lwjgl-openal:${versions.lwjgl3}:natives-linux",
         "org.lwjgl:lwjgl-openal:${versions.lwjgl3}:natives-linux-arm32",
@@ -88,6 +90,7 @@ libraries.lwjgl3 = [
         "org.lwjgl:lwjgl-openal:${versions.lwjgl3}:natives-macos-arm64",
         "org.lwjgl:lwjgl-openal:${versions.lwjgl3}:natives-windows",
         "org.lwjgl:lwjgl-openal:${versions.lwjgl3}:natives-windows-x86",
+        "org.lwjgl:lwjgl-openal:${versions.lwjgl3}:natives-windows-arm64",
         "org.lwjgl:lwjgl-opengl:${versions.lwjgl3}",
         "org.lwjgl:lwjgl-opengl:${versions.lwjgl3}:natives-linux",
         "org.lwjgl:lwjgl-opengl:${versions.lwjgl3}:natives-linux-arm32",
@@ -97,6 +100,7 @@ libraries.lwjgl3 = [
         "org.lwjgl:lwjgl-opengl:${versions.lwjgl3}:natives-macos-arm64",
         "org.lwjgl:lwjgl-opengl:${versions.lwjgl3}:natives-windows",
         "org.lwjgl:lwjgl-opengl:${versions.lwjgl3}:natives-windows-x86",
+        "org.lwjgl:lwjgl-opengl:${versions.lwjgl3}:natives-windows-arm64",
         "org.lwjgl:lwjgl-stb:${versions.lwjgl3}",
         "org.lwjgl:lwjgl-stb:${versions.lwjgl3}:natives-linux",
         "org.lwjgl:lwjgl-stb:${versions.lwjgl3}:natives-linux-arm32",
@@ -106,6 +110,7 @@ libraries.lwjgl3 = [
         "org.lwjgl:lwjgl-stb:${versions.lwjgl3}:natives-macos-arm64",
         "org.lwjgl:lwjgl-stb:${versions.lwjgl3}:natives-windows",
         "org.lwjgl:lwjgl-stb:${versions.lwjgl3}:natives-windows-x86",
+        "org.lwjgl:lwjgl-stb:${versions.lwjgl3}:natives-windows-arm64",
         "com.badlogicgames.jlayer:jlayer:${versions.jlayer}",
         "org.jcraft:jorbis:${versions.jorbis}"
 ]
@@ -120,6 +125,7 @@ libraries.lwjgl3GLES = [
         "org.lwjgl:lwjgl-opengles:${versions.lwjgl3}:natives-macos-arm64",
         "org.lwjgl:lwjgl-opengles:${versions.lwjgl3}:natives-windows",
         "org.lwjgl:lwjgl-opengles:${versions.lwjgl3}:natives-windows-x86",
+        "org.lwjgl:lwjgl-opengles:${versions.lwjgl3}:natives-windows-arm64",
         "org.lwjgl:lwjgl-egl:${versions.lwjgl3}",
 ]
 
@@ -148,13 +154,6 @@ libraries.compileOnly.gwt = [
 
 libraries.junit = [
         "junit:junit:${versions.junit}"
-]
-
-testnatives.desktop = [
-        files("gdx/libs/gdx-natives.jar"),
-        files("extensions/gdx-box2d/gdx-box2d/libs/gdx-box2d-natives.jar"),
-        files("extensions/gdx-bullet/libs/gdx-bullet-natives.jar"),
-        files("extensions/gdx-freetype/libs/gdx-freetype-natives.jar")
 ]
 
 gdxnatives.desktop = [

--- a/publish.gradle
+++ b/publish.gradle
@@ -23,17 +23,7 @@ configure([
 		afterEvaluate {
 			publishing {
 				publications {
-					mavenJava(MavenPublication) {
-						//Most normal java projects
-						if(components.findByName("java") != null)
-							from components.java
-
-						//Android
-						if(components.findByName("release") != null) {
-							from components.release
-						}
-
-
+					withType(MavenPublication) {
 						pom {
 							name = POM_NAME
 							if(!POM_DESCRIPTION.isEmpty())
@@ -59,50 +49,13 @@ configure([
 							}
 						}
 					}
-					//Libgdx natives all follow the "$name-platform" artifact structure.
-					if(project.tasks.findByName('jnigen')) {
-						mavenPlatform(MavenPublication) {
-							artifactId = artifactId + "-platform"
-							if(project.tasks.findByName('jnigenJarNativesDesktop'))
-								artifact jnigenJarNativesDesktop { }
+					register("mavenJava", MavenPublication) {
+						if(components.findByName("java") != null)
+							from components.java
 
-							[
-								'arm64-v8a',
-								'armeabi-v7a',
-								'x86_64',
-								'x86'
-							].each { id ->
-								if(project.tasks.findByName("jnigenJarNativesAndroid${id}"))
-									artifact "jnigenJarNativesAndroid${id}" { }
-							}
-
-							if(project.tasks.findByName('jnigenJarNativesIOS'))
-								artifact jnigenJarNativesIOS { }
-
-							pom {
-								name = POM_NAME + " Native Libraries"
-								if(!POM_DESCRIPTION.isEmpty())
-									description = POM_DESCRIPTION
-								url = POM_URL
-								licenses {
-									license {
-										name = POM_LICENCE_NAME
-										url = POM_LICENCE_URL
-										distribution = POM_LICENCE_DIST
-									}
-								}
-								developers {
-									developer {
-										id = "libGDX Developers"
-										url = "https://github.com/libgdx/libgdx/graphs/contributors"
-									}
-								}
-								scm {
-									connection = POM_SCM_CONNECTION
-									developerConnection = POM_SCM_DEV_CONNECTION
-									url = POM_SCM_URL
-								}
-							}
+						//Android
+						if(components.findByName("release") != null) {
+							from components.release
 						}
 					}
 				}
@@ -124,12 +77,10 @@ configure([
 				}
 			}
 
+			def publishing = extensions.getByType(PublishingExtension)
 			signing {
 				useGpgCmd()
-				sign publishing.publications.mavenJava
-
-				if(project.tasks.findByName('jnigen'))
-					sign publishing.publications.mavenPlatform
+				sign publishing.publications
 			}
 
 			//Simply using "required" in signing block doesn't work because taskGraph isn't ready yet.

--- a/tests/gdx-tests-lwjgl/build.gradle
+++ b/tests/gdx-tests-lwjgl/build.gradle
@@ -22,7 +22,11 @@ sourceSets.main.resources.srcDirs = ["../gdx-tests-android/assets"]
 dependencies {
 	implementation project(":tests:gdx-tests")
 	implementation project(":backends:gdx-backend-lwjgl")
-	implementation testnatives.desktop
+
+	implementation project(path: ":gdx", configuration: "archives")
+	implementation project(path: ":extensions:gdx-box2d-parent:gdx-box2d", configuration: "archives")
+	implementation project(path: ":extensions:gdx-bullet", configuration: "archives")
+	implementation project(path: ":extensions:gdx-freetype", configuration: "archives")
 }
 
 tasks.register('launchTestsLwjgl', JavaExec) {

--- a/tests/gdx-tests-lwjgl/src/com/badlogic/gdx/tests/lwjgl/LwjglTestStarter.java
+++ b/tests/gdx-tests-lwjgl/src/com/badlogic/gdx/tests/lwjgl/LwjglTestStarter.java
@@ -41,12 +41,12 @@ import com.badlogic.gdx.backends.lwjgl.LwjglFiles;
 import com.badlogic.gdx.backends.lwjgl.LwjglPreferences;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.glutils.ShaderProgram;
+import com.badlogic.gdx.jnigen.commons.HostDetection;
+import com.badlogic.gdx.jnigen.commons.Os;
 import com.badlogic.gdx.tests.utils.CommandLineOptions;
 import com.badlogic.gdx.tests.utils.GdxTest;
 import com.badlogic.gdx.tests.utils.GdxTestWrapper;
 import com.badlogic.gdx.tests.utils.GdxTests;
-import com.badlogic.gdx.utils.Os;
-import com.badlogic.gdx.utils.SharedLibraryLoader;
 
 public class LwjglTestStarter extends JFrame {
 	static CommandLineOptions options;
@@ -78,7 +78,7 @@ public class LwjglTestStarter extends JFrame {
 		config.forceExit = false;
 		if (useGL30) {
 			config.useGL30 = true;
-			if (SharedLibraryLoader.os != Os.MacOsX) {
+			if (HostDetection.os != Os.MacOsX) {
 				config.gles30ContextMajorVersion = 4;
 				config.gles30ContextMinorVersion = 3;
 			}

--- a/tests/gdx-tests-lwjgl3/build.gradle
+++ b/tests/gdx-tests-lwjgl3/build.gradle
@@ -31,7 +31,11 @@ dependencies {
 	implementation project(":tests:gdx-tests")
 	implementation project(":backends:gdx-backend-lwjgl3")
 	implementation project(":extensions:gdx-lwjgl3-angle")
-	implementation testnatives.desktop
+
+	implementation project(path: ":gdx", configuration: "archives")
+	implementation project(path: ":extensions:gdx-box2d-parent:gdx-box2d", configuration: "archives")
+	implementation project(path: ":extensions:gdx-bullet", configuration: "archives")
+	implementation project(path: ":extensions:gdx-freetype", configuration: "archives")
 }
 
 tasks.register('launchTestsLwjgl3', JavaExec) {

--- a/tests/gdx-tests-lwjgl3/src/com/badlogic/gdx/tests/lwjgl3/Lwjgl3TestStarter.java
+++ b/tests/gdx-tests-lwjgl3/src/com/badlogic/gdx/tests/lwjgl3/Lwjgl3TestStarter.java
@@ -26,6 +26,8 @@ import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Graphics;
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3WindowConfiguration;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.glutils.ShaderProgram;
+import com.badlogic.gdx.jnigen.commons.HostDetection;
+import com.badlogic.gdx.jnigen.commons.Os;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.scenes.scene2d.ui.ScrollPane;
@@ -36,9 +38,7 @@ import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
 import com.badlogic.gdx.tests.utils.CommandLineOptions;
 import com.badlogic.gdx.tests.utils.GdxTestWrapper;
 import com.badlogic.gdx.tests.utils.GdxTests;
-import com.badlogic.gdx.utils.Os;
 import com.badlogic.gdx.utils.ScreenUtils;
-import com.badlogic.gdx.utils.SharedLibraryLoader;
 import com.badlogic.gdx.utils.viewport.ScreenViewport;
 
 public class Lwjgl3TestStarter {
@@ -66,7 +66,7 @@ public class Lwjgl3TestStarter {
 		} else if (options.gl31) {
 			config.setOpenGLEmulation(Lwjgl3ApplicationConfiguration.GLEmulation.GL31, 4, 5);
 		} else if (options.gl30) {
-			if (SharedLibraryLoader.os == Os.MacOsX) {
+			if (HostDetection.os == Os.MacOsX) {
 				config.setOpenGLEmulation(Lwjgl3ApplicationConfiguration.GLEmulation.GL30, 3, 2);
 			} else {
 				config.setOpenGLEmulation(Lwjgl3ApplicationConfiguration.GLEmulation.GL30, 4, 3);
@@ -75,7 +75,7 @@ public class Lwjgl3TestStarter {
 			config.setOpenGLEmulation(Lwjgl3ApplicationConfiguration.GLEmulation.ANGLE_GLES20, 0, 0);
 			// Use CPU sync if ANGLE is enabled on macOS, otherwise the framerate gets halfed
 			// by each new open window.
-			if (SharedLibraryLoader.os == Os.MacOsX) {
+			if (HostDetection.os == Os.MacOsX) {
 				config.useVsync(false);
 				config.setForegroundFPS(60);
 			}


### PR DESCRIPTION


Windows AArch64 support added by adding lwjgl3 related dependencies, and adding a AArch64 target to our native builds via MSVC Build target toolchain in jnigen. Bullet currently not supported.


Breaking changes here, anyone consuming shared library loader should also change their jnigen version to 3.x version to use the same loader.