### PR TITLE
model/Node id null/uninitialized change to empty string

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g3d/model/Node.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/model/Node.java
@@ -29,7 +29,7 @@ import com.badlogic.gdx.utils.GdxRuntimeException;
  * child nodes. Optionally a node can specify a {@link MeshPart} and a {@link Material} to be applied to the mesh part.
  * @author badlogic */
 public class Node {
-	/** the id, depending on use might be empty string or not unique string or unique string **/
+	/** The node's id; must not be null, and defaults to an empty String **/
 	public String id = "";
 	/** Whether this node should inherit the transformation of its parent node, defaults to true. When this flag is false the value
 	 * of {@link #globalTransform} will be the same as the value of {@link #localTransform} causing the transform to be independent

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/model/Node.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/model/Node.java
@@ -30,7 +30,7 @@ import com.badlogic.gdx.utils.GdxRuntimeException;
  * @author badlogic */
 public class Node {
 	/** the id, may be null, FIXME is this unique? **/
-	public String id;
+	public String id = "";
 	/** Whether this node should inherit the transformation of its parent node, defaults to true. When this flag is false the value
 	 * of {@link #globalTransform} will be the same as the value of {@link #localTransform} causing the transform to be independent
 	 * of its parent transform. */

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/model/Node.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/model/Node.java
@@ -29,7 +29,7 @@ import com.badlogic.gdx.utils.GdxRuntimeException;
  * child nodes. Optionally a node can specify a {@link MeshPart} and a {@link Material} to be applied to the mesh part.
  * @author badlogic */
 public class Node {
-	/** the id, may be null, FIXME is this unique? **/
+	/** the id, depending on use might be empty string or not unique string or unique string **/
 	public String id = "";
 	/** Whether this node should inherit the transformation of its parent node, defaults to true. When this flag is false the value
 	 * of {@link #globalTransform} will be the same as the value of {@link #localTransform} causing the transform to be independent


### PR DESCRIPTION
The method `getNode` crashes if Node id is not initialized or null.
I fought it might be good idea to have node id be empty string by default so if a another pice of code wants to do node.id.equals() it won't crash https://github.com/pietru2004/libgdx/blob/98f51139ceac623c70ecffd67ee704329a4363b4/gdx/src/com/badlogic/gdx/graphics/g3d/model/Node.java#L298