### PR TITLE
Fix #7761 (Maven Central/Snapshot badges).

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 
 [![GitHub Actions Build Status](https://img.shields.io/github/actions/workflow/status/libgdx/libgdx/build-publish.yml?branch=master&label=GitHub%20Actions)](https://github.com/libgdx/libgdx/actions?query=workflow%3A%22Build+and+Publish%22)
 
-[![Latest Version](https://img.shields.io/nexus/r/com.badlogicgames.gdx/gdx?nexusVersion=2&server=https%3A%2F%2Foss.sonatype.org&label=Version)](https://search.maven.org/artifact/com.badlogicgames.gdx/gdx)
-[![Snapshots](https://img.shields.io/nexus/s/com.badlogicgames.gdx/gdx?server=https%3A%2F%2Foss.sonatype.org&label=Snapshots)](https://oss.sonatype.org/#nexus-search;gav~com.badlogicgames.gdx~gdx~~~~kw,versionexpand)
+[![Latest Version](https://img.shields.io/maven-central/v/com.badlogicgames.gdx/gdx?label=Version)](https://search.maven.org/artifact/com.badlogicgames.gdx/gdx)
+[![Snapshots](https://img.shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Fcentral.sonatype.com%2Frepository%2Fmaven-snapshots%2Fcom%2Fbadlogicgames%2Fgdx%2Fgdx%2Fmaven-metadata.xml&label=Snapshots)](https://central.sonatype.com/repository/maven-snapshots/com/badlogicgames/gdx/gdx/maven-metadata.xml)
 
 [![Discord Chat](https://img.shields.io/discord/348229412858101762?logo=discord)](https://libgdx.com/community/discord/)
 


### PR DESCRIPTION
This updates the shields.io badges using a similar strategy to the one used by other Maven Central-targeting projects. Because the Sonatype Snapshots shield doesn't currently work, we use the Maven Metadata shield to get the latest snapshot version. The Snapshot link also didn't go to any version newer than 1.13.2-SNAPSHOT, which is I suppose the last one that went to oss.sonatype.org . I managed to figure this out in part by looking at how [kotest](https://github.com/kotest/kotest/blob/master/README.md?plain=1) does it in their README.md, but I didn't do things the same way exactly.

This looks like this now: 
<img width="354" height="277" alt="Preview of new Shields" src="https://github.com/user-attachments/assets/809d5bd6-f42b-46f1-87e6-3846f9d262e3" />
