### PR TITLE
Json can't read back CharArray in some cases.

### DIFF
--- a/gdx/src/com/badlogic/gdx/utils/JsonValue.java
+++ b/gdx/src/com/badlogic/gdx/utils/JsonValue.java
@@ -373,11 +373,11 @@ public class JsonValue implements Iterable<JsonValue> {
 		case stringValue:
 			return stringValue.length() == 0 ? 0 : stringValue.charAt(0);
 		case doubleValue:
-			return (char)(doubleValue + '0');
+			return (char)(doubleValue);
 		case longValue:
-			return (char)(longValue + '0');
+			return (char)(longValue);
 		case booleanValue:
-			return longValue != 0 ? '1' : '0';
+			return longValue != 0 ? '\u0001' : '\u0000';
 		}
 		throw new IllegalStateException("Value cannot be converted to char: " + type);
 	}
@@ -636,7 +636,7 @@ public class JsonValue implements Iterable<JsonValue> {
 				v = (char)value.longValue;
 				break;
 			case booleanValue:
-				v = value.longValue != 0 ? (char)1 : 0;
+				v = value.longValue != 0 ? '\u0001' : '\u0000';
 				break;
 			default:
 				throw new IllegalStateException("Value cannot be converted to char: " + value.type);

--- a/gdx/src/com/badlogic/gdx/utils/JsonWriter.java
+++ b/gdx/src/com/badlogic/gdx/utils/JsonWriter.java
@@ -313,7 +313,8 @@ public class JsonWriter extends Writer {
 			if (this == OutputType.minimal && !string.equals("true") && !string.equals("false") && !string.equals("null")
 				&& !string.contains("//") && !string.contains("/*")) {
 				int length = string.length();
-				if (length > 0 && string.charAt(length - 1) != ' ' && minimalValuePattern.matcher(string).matches()) return string;
+				if (length > 0 && string.charAt(length - 1) != ' ' && !(value instanceof Character)
+					&& minimalValuePattern.matcher(string).matches()) return string;
 			}
 			return quote ? escapeQuote(string) : '"' + string + '"';
 		}

--- a/gdx/test/com/badlogic/gdx/utils/JsonTest.java
+++ b/gdx/test/com/badlogic/gdx/utils/JsonTest.java
@@ -25,11 +25,8 @@ public class JsonTest {
 	@Test
 	public void testCharFromNumber () {
 		Json json = new Json();
-		// Behavior here changed because minimal syntax doesn't distinguish between a bare String containing a digit
-		// and a JSON Number. Any numbers that aren't digits 0-9 won't be converted to chars like they did before,
-		// which simply would cast the numerical value to char.
-		char value = json.fromJson(char.class, "9");
-		assertEquals('9', value);
+		char value = json.fromJson(char.class, "90");
+		assertEquals('Z', value);
 	}
 
 	@Test


### PR DESCRIPTION
Any CharArray containing the chars `'}'` or any digits from `'0'` to `'9'` won't be written correctly for round-trip reads by the minimal OutputType. The reads of JSON produced by libGDX 1.14.0 from any CharArray containing these chars will result in a SerializationException being thrown. I added several automated tests for this, and I believe I have it fixed now in `JsonWriter`. I know `Json` can now round-trip write and read CharArray instances containing these chars, but I can't vouch for `JsonString`, since I've never used it.

The fix considers the initial closing curly brace `'}'` invalid as a bare String even in minimal `OutputType`, where before, it was bare in minimal but quoted in other `OutputType`s. Digit chars presented a different problem; they are written as bare Strings, but are read back as JSON Number types, which get converted to `char` by their codepoint (as if being cast from an `int`). This means that the digit `'0'` would be written as the bare String `0` and read back as the same value as `'\u0000'`, not `'0'`. Similarly, the digit `'7'` is read as a tab char, `'\u0007'`. This fixes the case where the initial char in a String is a digit by quoting that String, so it won't be read as a Number.

There are better fixes available for CharArray, but I don't know of any for `char`s in general. A `CharArray` implements `CharSequence`, and has a constructor available that creates a `CharArray` from a `String`. `CharArray` could implement `Json.Serializable` and write itself as an object containing a String, and could read from that type of object to create itself from that String. In the tests, this goes from a JSON String with length=313 (using minimal mode, but quoting digits and the closing curly braces in addition to the chars it quoted before; this also writes every char in the CharArray's capacity, even ones greater than its size) to a JSON String with length=99 (though this isn't wrapped in an object). This isn't implemented here because I seem to recall `Json.Serializable` being discouraged from use, for unclear reasons. Json could also opt to serialize CharArray or CharSequence types in general as Strings with small wrapping objects.

This probably changes some output's ability to round-trip serialize and deserialize with the same exact JSON String in transit, if it used minimal mode before. It should only add quotes around questionably-bare Strings, so it shouldn't ever produce invalid minimal-mode JSON, though it certainly does without this PR. Other OutputTypes are unaffected.