### PR TITLE
Don't set Android cutout mode on Android 35+

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplication.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidApplication.java
@@ -202,9 +202,16 @@ public class AndroidApplication extends Activity implements AndroidApplicationBa
 
 	@TargetApi(Build.VERSION_CODES.P)
 	private void setLayoutInDisplayCutoutMode (boolean render) {
-		if (render && getVersion() >= Build.VERSION_CODES.P) {
-			WindowManager.LayoutParams lp = getWindow().getAttributes();
+		if (!render || Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
+			return;
+		}
+		WindowManager.LayoutParams lp = getWindow().getAttributes();
+		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+			// Use SHORT_EDGES only for Android 9 (API 28) and 10 (API 29)
 			lp.layoutInDisplayCutoutMode = WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES;
+		} else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+			// Use ALWAYS for Android 11 through 14 (it's already default on 15+ and not recommended to be set).
+			lp.layoutInDisplayCutoutMode = WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_ALWAYS;
 		}
 	}
 


### PR DESCRIPTION
Since Android 35 edge-to-edge is default and the cutout modes that were created on Android 28 are ignored (they are always set to [LAYOUT_IN_DISPLAY_CUTOUT_MODE_ALWAYS](https://developer.android.com/reference/android/view/WindowManager.LayoutParams#LAYOUT_IN_DISPLAY_CUTOUT_MODE_ALWAYS) which is the default behaviour. See related documentation https://developer.android.com/develop/ui/views/layout/display-cutout

Even if not deprecated on the official docs, there's a warning appearing on Google Play if you upload an app that  targets 35 (which is now required) and sets it

<img width="1418" height="193" alt="image" src="https://github.com/user-attachments/assets/a2b59421-34f5-44f4-be82-9b975f2eae73" />

The other change is a small change of behaviour for versions 11 to 14 in which the superior (all edges) LAYOUT_IN_DISPLAY_CUTOUT_MODE_ALWAYS can be used and should be our setting considering `renderUnderCutout` in `AndroidApplicationConfiguration` doesn't limit it to specific cutouts (in the real world I don't think there are many pre Android 35 devices with cutouts on the large edge).

