### PR TITLE
Fix password flag on GLSurfaceView causing screen recording issues

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/DefaultAndroidInput.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/DefaultAndroidInput.java
@@ -328,7 +328,7 @@ public class DefaultAndroidInput extends AbstractInput implements AndroidInput, 
 		default:
 			if (defaultDisableAutocorrection) {
 				inputType = InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS
-					| InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD;
+					| InputType.TYPE_TEXT_VARIATION_URI;
 			} else {
 				inputType = InputType.TYPE_CLASS_TEXT;
 			}


### PR DESCRIPTION
A fix for #7754 

I am assuming TYPE_TEXT_VARIATION_VISIBLE_PASSWORD was used to prevent auto correction. Since it causes screen recording issues on specific vendors I changed it to use the subset TYPE_TEXT_VARIATION_URI instead which does not include TYPE_TEXT_VARIATION_PASSWORD. In my testing it makes no difference, but due to lack of documentation it'd be great if some more people could test it.