### PR TITLE
Add field to prevent touch propagation in drag-based actors [VISUAL E.G.]

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Slider.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Slider.java
@@ -73,8 +73,7 @@ public class Slider extends ProgressBar {
 				if (draggingPointer != -1) return false;
 				draggingPointer = pointer;
 				calculatePositionAndValue(x, y);
-				if (preventTouchPropagation)
-					event.stop();
+				if (preventTouchPropagation) event.stop();
 				return true;
 			}
 
@@ -244,14 +243,13 @@ public class Slider extends ProgressBar {
 		setValue(min + (max - min) * visualInterpolationInverse.apply(percent));
 	}
 
-	public boolean isPreventTouchPropagation() {
+	public boolean isPreventTouchPropagation () {
 		return preventTouchPropagation;
 	}
 
-	/** Prevents internal touchDown events from propagating to parental hierarchy.
-	 * This stops parents from cancelling them (as in the case of {@link ScrollPane},
-	 * which would otherwise lead to unexpected behavior. */
-	public void setPreventTouchPropagation(boolean preventTouchPropagation) {
+	/** Prevents internal touchDown events from propagating to parental hierarchy. This stops parents from cancelling them (as in
+	 * the case of {@link ScrollPane}, which would otherwise lead to unexpected behavior. */
+	public void setPreventTouchPropagation (boolean preventTouchPropagation) {
 		this.preventTouchPropagation = preventTouchPropagation;
 	}
 

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Slider.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Slider.java
@@ -44,6 +44,7 @@ public class Slider extends ProgressBar {
 	private Interpolation visualInterpolationInverse = Interpolation.linear;
 	private float[] snapValues;
 	private float threshold;
+	boolean preventTouchPropagation;
 
 	public Slider (float min, float max, float stepSize, boolean vertical, Skin skin) {
 		this(min, max, stepSize, vertical, skin.get("default-" + (vertical ? "vertical" : "horizontal"), SliderStyle.class));
@@ -72,6 +73,8 @@ public class Slider extends ProgressBar {
 				if (draggingPointer != -1) return false;
 				draggingPointer = pointer;
 				calculatePositionAndValue(x, y);
+				if (preventTouchPropagation)
+					event.stop();
 				return true;
 			}
 
@@ -239,6 +242,17 @@ public class Slider extends ProgressBar {
 	 * @see #setVisualInterpolation(Interpolation) */
 	public void setVisualPercent (float percent) {
 		setValue(min + (max - min) * visualInterpolationInverse.apply(percent));
+	}
+
+	public boolean isPreventTouchPropagation() {
+		return preventTouchPropagation;
+	}
+
+	/** Prevents internal touchDown events from propagating to parental hierarchy.
+	 * This stops parents from cancelling them (as in the case of {@link ScrollPane},
+	 * which would otherwise lead to unexpected behavior. */
+	public void setPreventTouchPropagation(boolean preventTouchPropagation) {
+		this.preventTouchPropagation = preventTouchPropagation;
 	}
 
 	/** The style for a slider, see {@link Slider}.

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextField.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextField.java
@@ -157,14 +157,13 @@ public class TextField extends Widget implements Disableable, Styleable<TextFiel
 		return new TextFieldClickListener();
 	}
 
-	public boolean isPreventTouchPropagation() {
+	public boolean isPreventTouchPropagation () {
 		return preventTouchPropagation;
 	}
 
-	/** Prevents internal touchDown events from propagating to parental hierarchy.
-	 * This stops parents from cancelling them (as in the case of {@link ScrollPane},
-	 * which would otherwise lead to unexpected behavior. */
-	public void setPreventTouchPropagation(boolean preventTouchPropagation) {
+	/** Prevents internal touchDown events from propagating to parental hierarchy. This stops parents from cancelling them (as in
+	 * the case of {@link ScrollPane}, which would otherwise lead to unexpected behavior. */
+	public void setPreventTouchPropagation (boolean preventTouchPropagation) {
 		this.preventTouchPropagation = preventTouchPropagation;
 	}
 
@@ -1049,8 +1048,7 @@ public class TextField extends Widget implements Disableable, Styleable<TextFiel
 			if (stage != null) stage.setKeyboardFocus(TextField.this);
 			keyboard.show(TextField.this);
 			hasSelection = true;
-			if (preventTouchPropagation)
-				event.stop();
+			if (preventTouchPropagation) event.stop();
 			return true;
 		}
 

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextField.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextField.java
@@ -95,6 +95,7 @@ public class TextField extends Widget implements Disableable, Styleable<TextFiel
 	protected CharSequence displayText;
 	Clipboard clipboard;
 	InputListener inputListener;
+	boolean preventTouchPropagation;
 	@Null TextFieldListener listener;
 	@Null TextFieldFilter filter;
 	OnscreenKeyboard keyboard = DEFAULT_ONSCREEN_KEYBOARD;
@@ -154,6 +155,17 @@ public class TextField extends Widget implements Disableable, Styleable<TextFiel
 
 	protected InputListener createInputListener () {
 		return new TextFieldClickListener();
+	}
+
+	public boolean isPreventTouchPropagation() {
+		return preventTouchPropagation;
+	}
+
+	/** Prevents internal touchDown events from propagating to parental hierarchy.
+	 * This stops parents from cancelling them (as in the case of {@link ScrollPane},
+	 * which would otherwise lead to unexpected behavior. */
+	public void setPreventTouchPropagation(boolean preventTouchPropagation) {
+		this.preventTouchPropagation = preventTouchPropagation;
 	}
 
 	protected int letterUnderCursor (float x) {
@@ -1037,6 +1049,8 @@ public class TextField extends Widget implements Disableable, Styleable<TextFiel
 			if (stage != null) stage.setKeyboardFocus(TextField.this);
 			keyboard.show(TextField.this);
 			hasSelection = true;
+			if (preventTouchPropagation)
+				event.stop();
 			return true;
 		}
 

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Touchpad.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Touchpad.java
@@ -73,8 +73,7 @@ public class Touchpad extends Widget implements Styleable<Touchpad.TouchpadStyle
 				if (touched) return false;
 				touched = true;
 				calculatePositionAndValue(x, y, false);
-				if (preventTouchPropagation)
-					event.stop();
+				if (preventTouchPropagation) event.stop();
 				return true;
 			}
 
@@ -195,14 +194,13 @@ public class Touchpad extends Widget implements Styleable<Touchpad.TouchpadStyle
 		this.resetOnTouchUp = reset;
 	}
 
-	public boolean isPreventTouchPropagation() {
+	public boolean isPreventTouchPropagation () {
 		return preventTouchPropagation;
 	}
 
-	/** Prevents internal touchDown events from propagating to parental hierarchy.
-	 * This stops parents from cancelling them (as in the case of {@link ScrollPane},
-	 * which would otherwise lead to unexpected behavior. */
-	public void setPreventTouchPropagation(boolean preventTouchPropagation) {
+	/** Prevents internal touchDown events from propagating to parental hierarchy. This stops parents from cancelling them (as in
+	 * the case of {@link ScrollPane}, which would otherwise lead to unexpected behavior. */
+	public void setPreventTouchPropagation (boolean preventTouchPropagation) {
 		this.preventTouchPropagation = preventTouchPropagation;
 	}
 

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Touchpad.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/Touchpad.java
@@ -40,6 +40,7 @@ public class Touchpad extends Widget implements Styleable<Touchpad.TouchpadStyle
 	private TouchpadStyle style;
 	boolean touched;
 	boolean resetOnTouchUp = true;
+	boolean preventTouchPropagation;
 	private float deadzoneRadius;
 	private final Circle knobBounds = new Circle(0, 0, 0);
 	private final Circle touchBounds = new Circle(0, 0, 0);
@@ -72,6 +73,8 @@ public class Touchpad extends Widget implements Styleable<Touchpad.TouchpadStyle
 				if (touched) return false;
 				touched = true;
 				calculatePositionAndValue(x, y, false);
+				if (preventTouchPropagation)
+					event.stop();
 				return true;
 			}
 
@@ -190,6 +193,17 @@ public class Touchpad extends Widget implements Styleable<Touchpad.TouchpadStyle
 	/** @param reset Whether to reset the knob to the center on touch up. */
 	public void setResetOnTouchUp (boolean reset) {
 		this.resetOnTouchUp = reset;
+	}
+
+	public boolean isPreventTouchPropagation() {
+		return preventTouchPropagation;
+	}
+
+	/** Prevents internal touchDown events from propagating to parental hierarchy.
+	 * This stops parents from cancelling them (as in the case of {@link ScrollPane},
+	 * which would otherwise lead to unexpected behavior. */
+	public void setPreventTouchPropagation(boolean preventTouchPropagation) {
+		this.preventTouchPropagation = preventTouchPropagation;
 	}
 
 	/** @param deadzoneRadius The distance in pixels from the center of the touchpad required for the knob to be moved. */

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/PreventTouchPropagationTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/PreventTouchPropagationTest.java
@@ -1,0 +1,125 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogic.gdx.tests;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.scenes.scene2d.Actor;
+import com.badlogic.gdx.scenes.scene2d.Stage;
+import com.badlogic.gdx.scenes.scene2d.ui.CheckBox;
+import com.badlogic.gdx.scenes.scene2d.ui.Label;
+import com.badlogic.gdx.scenes.scene2d.ui.ScrollPane;
+import com.badlogic.gdx.scenes.scene2d.ui.Skin;
+import com.badlogic.gdx.scenes.scene2d.ui.Slider;
+import com.badlogic.gdx.scenes.scene2d.ui.Table;
+import com.badlogic.gdx.scenes.scene2d.ui.TextArea;
+import com.badlogic.gdx.scenes.scene2d.ui.TextField;
+import com.badlogic.gdx.scenes.scene2d.ui.Touchpad;
+import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
+import com.badlogic.gdx.tests.utils.GdxTest;
+
+public class PreventTouchPropagationTest extends GdxTest {
+    static final int ACTOR_DIMENSION = 100;
+
+    Stage stage;
+    ScrollPane pane;
+
+    CheckBox checkBox;
+
+    // Affected actors
+    TextField textField;
+    TextArea textArea;
+    Slider slider;
+    Touchpad touchpad;
+
+    public void create () {
+        stage = new Stage();
+        Gdx.input.setInputProcessor(stage);
+
+        Skin skin = new Skin(Gdx.files.internal("data/uiskin.json"));
+
+        checkBox = new CheckBox("Prevent touch propagation", skin);
+        checkBox.addListener(new ChangeListener() {
+            @Override
+            public void changed(ChangeEvent event, Actor actor) {
+                boolean isChecked = checkBox.isChecked();
+                textField.setPreventTouchPropagation(isChecked);
+                textArea.setPreventTouchPropagation(isChecked);
+                slider.setPreventTouchPropagation(isChecked);
+                touchpad.setPreventTouchPropagation(isChecked);
+            }
+        });
+
+        textField = new TextField("What", skin);
+        textArea = new TextArea("Dude", skin);
+        slider = new Slider(0, 10, 1, false, skin);
+        touchpad = new Touchpad(20, skin);
+        //touchpad.setBounds(15, 15, 100, 100);
+
+        pane = new ScrollPane(new Table() {
+            {
+                add(textField).width(ACTOR_DIMENSION);
+                row();
+                addFillerLabels(this, skin, 5);
+                add(textArea).size(ACTOR_DIMENSION);
+                row();
+                addFillerLabels(this, skin, 5);
+                add(slider).width(ACTOR_DIMENSION);
+                row();
+                addFillerLabels(this, skin, 5);
+                add(touchpad).size(ACTOR_DIMENSION);
+            }
+        });
+
+        stage.addActor(new Table() {
+            {
+                setFillParent(true);
+
+                add(new Label("Drag on the the actors in the ScrollPane to see how they behave with/without preventTouchPropagation.", skin) {
+                    {
+                        setWrap(true);
+                    }
+                }).prefWidth(390);
+                add(checkBox).expandX().right();
+
+                row().padTop(15);
+                add(pane).grow().colspan(2);
+            }
+        });
+    }
+
+    public void addFillerLabels(Table table, Skin skin, int count) {
+        for (int i = 0; i < count; i++) {
+            table.add(new Label("cheese " + i, skin));
+            table.row();
+        }
+    }
+
+    public void render () {
+        Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+        stage.act(Gdx.graphics.getDeltaTime());
+        stage.draw();
+    }
+
+    public void resize (int width, int height) {
+        stage.getViewport().update(width, height, true);
+    }
+
+    public void dispose () {
+        stage.dispose();
+    }
+}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/PreventTouchPropagationTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/PreventTouchPropagationTest.java
@@ -83,7 +83,8 @@ public class PreventTouchPropagationTest extends GdxTest {
                 addFillerLabels(this, skin, 5);
                 add(touchpad).size(ACTOR_DIMENSION);
             }
-        });
+        }, skin);
+        pane.setFadeScrollBars(false);
 
         stage.addActor(new Table() {
             {

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/PreventTouchPropagationTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/PreventTouchPropagationTest.java
@@ -33,94 +33,95 @@ import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
 import com.badlogic.gdx.tests.utils.GdxTest;
 
 public class PreventTouchPropagationTest extends GdxTest {
-    static final int ACTOR_DIMENSION = 100;
+	static final int ACTOR_DIMENSION = 100;
 
-    Stage stage;
-    ScrollPane pane;
+	Stage stage;
+	ScrollPane pane;
 
-    CheckBox checkBox;
+	CheckBox checkBox;
 
-    // Affected actors
-    TextField textField;
-    TextArea textArea;
-    Slider slider;
-    Touchpad touchpad;
+	// Affected actors
+	TextField textField;
+	TextArea textArea;
+	Slider slider;
+	Touchpad touchpad;
 
-    public void create () {
-        stage = new Stage();
-        Gdx.input.setInputProcessor(stage);
+	public void create () {
+		stage = new Stage();
+		Gdx.input.setInputProcessor(stage);
 
-        Skin skin = new Skin(Gdx.files.internal("data/uiskin.json"));
+		Skin skin = new Skin(Gdx.files.internal("data/uiskin.json"));
 
-        checkBox = new CheckBox("Prevent touch propagation", skin);
-        checkBox.addListener(new ChangeListener() {
-            @Override
-            public void changed(ChangeEvent event, Actor actor) {
-                boolean isChecked = checkBox.isChecked();
-                textField.setPreventTouchPropagation(isChecked);
-                textArea.setPreventTouchPropagation(isChecked);
-                slider.setPreventTouchPropagation(isChecked);
-                touchpad.setPreventTouchPropagation(isChecked);
-            }
-        });
+		checkBox = new CheckBox("Prevent touch propagation", skin);
+		checkBox.addListener(new ChangeListener() {
+			@Override
+			public void changed (ChangeEvent event, Actor actor) {
+				boolean isChecked = checkBox.isChecked();
+				textField.setPreventTouchPropagation(isChecked);
+				textArea.setPreventTouchPropagation(isChecked);
+				slider.setPreventTouchPropagation(isChecked);
+				touchpad.setPreventTouchPropagation(isChecked);
+			}
+		});
 
-        textField = new TextField("This is a long line, and will continue to be long until the line is done.", skin);
-        textArea = new TextArea("The quick brown fox jumps over the lazy dog.", skin);
-        slider = new Slider(0, 10, 1, false, skin);
-        touchpad = new Touchpad(20, skin);
-        //touchpad.setBounds(15, 15, 100, 100);
+		textField = new TextField("This is a long line, and will continue to be long until the line is done.", skin);
+		textArea = new TextArea("The quick brown fox jumps over the lazy dog.", skin);
+		slider = new Slider(0, 10, 1, false, skin);
+		touchpad = new Touchpad(20, skin);
+		// touchpad.setBounds(15, 15, 100, 100);
 
-        pane = new ScrollPane(new Table() {
-            {
-                add(textField).width(ACTOR_DIMENSION);
-                row();
-                addFillerLabels(this, skin, 5);
-                add(textArea).size(ACTOR_DIMENSION);
-                row();
-                addFillerLabels(this, skin, 5);
-                add(slider).width(ACTOR_DIMENSION);
-                row();
-                addFillerLabels(this, skin, 5);
-                add(touchpad).size(ACTOR_DIMENSION);
-            }
-        }, skin);
-        pane.setFadeScrollBars(false);
+		pane = new ScrollPane(new Table() {
+			{
+				add(textField).width(ACTOR_DIMENSION);
+				row();
+				addFillerLabels(this, skin, 5);
+				add(textArea).size(ACTOR_DIMENSION);
+				row();
+				addFillerLabels(this, skin, 5);
+				add(slider).width(ACTOR_DIMENSION);
+				row();
+				addFillerLabels(this, skin, 5);
+				add(touchpad).size(ACTOR_DIMENSION);
+			}
+		}, skin);
+		pane.setFadeScrollBars(false);
 
-        stage.addActor(new Table() {
-            {
-                setFillParent(true);
+		stage.addActor(new Table() {
+			{
+				setFillParent(true);
 
-                add(new Label("Drag on the the actors in the ScrollPane to see how they behave with/without preventTouchPropagation.", skin) {
-                    {
-                        setWrap(true);
-                    }
-                }).prefWidth(390);
-                add(checkBox).expandX().right();
+				add(new Label("Drag on the the actors in the ScrollPane to see how they behave with/without preventTouchPropagation.",
+					skin) {
+					{
+						setWrap(true);
+					}
+				}).prefWidth(390);
+				add(checkBox).expandX().right();
 
-                row().padTop(15);
-                add(pane).grow().colspan(2);
-            }
-        });
-    }
+				row().padTop(15);
+				add(pane).grow().colspan(2);
+			}
+		});
+	}
 
-    public void addFillerLabels(Table table, Skin skin, int count) {
-        for (int i = 0; i < count; i++) {
-            table.add(new Label("cheese " + i, skin));
-            table.row();
-        }
-    }
+	public void addFillerLabels (Table table, Skin skin, int count) {
+		for (int i = 0; i < count; i++) {
+			table.add(new Label("cheese " + i, skin));
+			table.row();
+		}
+	}
 
-    public void render () {
-        Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-        stage.act(Gdx.graphics.getDeltaTime());
-        stage.draw();
-    }
+	public void render () {
+		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		stage.act(Gdx.graphics.getDeltaTime());
+		stage.draw();
+	}
 
-    public void resize (int width, int height) {
-        stage.getViewport().update(width, height, true);
-    }
+	public void resize (int width, int height) {
+		stage.getViewport().update(width, height, true);
+	}
 
-    public void dispose () {
-        stage.dispose();
-    }
+	public void dispose () {
+		stage.dispose();
+	}
 }

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/PreventTouchPropagationTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/PreventTouchPropagationTest.java
@@ -64,8 +64,8 @@ public class PreventTouchPropagationTest extends GdxTest {
             }
         });
 
-        textField = new TextField("What", skin);
-        textArea = new TextArea("Dude", skin);
+        textField = new TextField("This is a long line, and will continue to be long until the line is done.", skin);
+        textArea = new TextArea("The quick brown fox jumps over the lazy dog.", skin);
         slider = new Slider(0, 10, 1, false, skin);
         touchpad = new Touchpad(20, skin);
         //touchpad.setBounds(15, 15, 100, 100);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
@@ -252,6 +252,7 @@ public class GdxTests {
 		PolygonRegionTest.class,
 		PolygonSpriteTest.class,
 		PreferencesTest.class,
+		PreventTouchPropagationTest.class,
 		ProjectTest.class,
 		ProjectiveTextureTest.class,
 		ReflectionTest.class,


### PR DESCRIPTION
Some Scene2d actors that implement drag functionality (`TextField`/`TextArea` for selecting, `Slider` for value adjustment, and `Touchpad` for, well, touchpadding), don't really behave properly while in the context of a `ScrollPane`.  By that I mean the drag gets interrupted by the `ScrollPane`'s own `ClickListener`, which causes the event it receives to be `stop()`-ed.

This PR adds a `preventTouchPropagation` field in said drag-capable actors.  When enabled, `event.stop()` is called within their own internal `ClickListener#touchDown`, preventing aforementioned issue.

Resolves:
- #7594.

https://github.com/user-attachments/assets/17c784a8-87ed-4f4a-ae1e-e2269c0fcb62
