### PR TITLE
Fix NPE in AndroidDaydream.onConfigurationChanged when input is null

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidDaydream.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidDaydream.java
@@ -282,7 +282,17 @@ public class AndroidDaydream extends DreamService implements AndroidApplicationB
 		super.onConfigurationChanged(config);
 		boolean keyboardAvailable = false;
 		if (config.hardKeyboardHidden == Configuration.HARDKEYBOARDHIDDEN_NO) keyboardAvailable = true;
-		input.setKeyboardAvailable(keyboardAvailable);
+		final boolean finalKeyboardAvailable = keyboardAvailable;
+		if (input != null) {
+			input.setKeyboardAvailable(keyboardAvailable);
+		} else {
+			postRunnable(new Runnable() {
+				@Override
+				public void run () {
+					input.setKeyboardAvailable(finalKeyboardAvailable);
+				}
+			});
+		}
 	}
 
 	@Override


### PR DESCRIPTION
Fixes #6633

## Problem
onConfigurationChanged fires before input is initialized on Android 11 
Samsung devices, causing a frequent NullPointerException.

## Fix
Added a null check for input before calling setKeyboardAvailable(). If input is null, the call is deferred via postRunnable() so it still executes once input is initialized.