### PR TITLE
Add background FPS support to LWJGL3 backend

### DIFF
--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
@@ -176,7 +176,10 @@ public class Lwjgl3Application implements Lwjgl3ApplicationBase {
 					window.makeCurrent();
 					currentWindow = window;
 				}
-				if (targetFramerate == -2) targetFramerate = window.getConfig().foregroundFPS;
+				if (targetFramerate == -2) {
+					boolean focused = GLFW.glfwGetWindowAttrib(window.getWindowHandle(), GLFW.GLFW_FOCUSED) == GLFW.GLFW_TRUE;
+					targetFramerate = focused ? window.getConfig().foregroundFPS : window.getConfig().backgroundFPS;
+				}
 				synchronized (lifecycleListeners) {
 					haveWindowsRendered |= window.update();
 				}


### PR DESCRIPTION
This PR adds background FPS support to the LWJGL3 backend.

Issue #6638 explains that LWJGL3 has setIdleFPS(), but it is not the same as the old LWJGL backend's backgroundFPS setting. This can confuse users who are moving from the old LWJGL backend to LWJGL3.

This change adds a backgroundFPS configuration value and a setBackgroundFPS() method to Lwjgl3ApplicationConfiguration. It also updates the LWJGL3 application loop so the backend uses foregroundFPS when the window is focused and backgroundFPS when the window is not focused.

This is meant to provide a clearer equivalent to the old LWJGL backgroundFPS setting.

Fixes #6638