### PR TITLE
TextField, enforce cursor/selection invariants on text change.

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextField.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextField.java
@@ -472,7 +472,9 @@ public class TextField extends Widget implements Disableable, Styleable<TextFiel
 		visibleTextStart = Math.min(visibleTextStart, glyphPositions.size - 1);
 		visibleTextEnd = MathUtils.clamp(visibleTextEnd, visibleTextStart, glyphPositions.size - 1);
 
-		if (selectionStart > newDisplayText.length()) selectionStart = textLength;
+		if (cursor > textLength) cursor = textLength;
+		if (selectionStart > textLength) selectionStart = textLength;
+		if (selectionStart == cursor) hasSelection = false;
 	}
 
 	/** Copies the contents of this TextField to the {@link Clipboard} implementation set on this TextField. */


### PR DESCRIPTION
TextField requires `cursor` and `selectionStart` to be valid indices into `text`, and if `hasSelection` the two must differ. This PR enforces those invariants when text changes.

bdbcd7b24 in 2021 was an incomplete attempt at keeping the state consistent but I see crash reports like:
```
java.lang.StringIndexOutOfBoundsException: begin 0, end 4, length 0
   at java.lang.String.checkBoundsBeginEnd(String.java)
   at java.lang.String.substring(String.java)
   at scene2d.ui.TextField.copy(TextField.java:481)
   at scene2d.ui.TextField$TextFieldClickListener.keyDown(TextField.java:1091)
```