### PR TITLE
Deserialized Strings are interned

### DIFF
--- a/gdx/src/com/badlogic/gdx/utils/Json.java
+++ b/gdx/src/com/badlogic/gdx/utils/Json.java
@@ -1141,7 +1141,7 @@ public class Json {
 				if (type == int.class || type == Integer.class) return (T)(Integer)jsonData.asInt();
 				if (type == long.class || type == Long.class) return (T)(Long)jsonData.asLong();
 				if (type == double.class || type == Double.class) return (T)(Double)jsonData.asDouble();
-				if (type == String.class) return (T)jsonData.asString();
+				if (type == String.class) return (T)jsonData.asString().intern();
 				if (type == short.class || type == Short.class) return (T)(Short)jsonData.asShort();
 				if (type == byte.class || type == Byte.class) return (T)(Byte)jsonData.asByte();
 				if (type == char.class || type == Character.class) return (T)(Character)jsonData.asChar();
@@ -1160,7 +1160,7 @@ public class Json {
 
 		if (jsonData.isString()) {
 			String string = jsonData.asString();
-			if (type == null || type == String.class) return (T)string;
+			if (type == null || type == String.class) return (T)string.intern();
 			try {
 				if (type == int.class || type == Integer.class) return (T)Integer.valueOf(string);
 				if (type == float.class || type == Float.class) return (T)Float.valueOf(string);


### PR DESCRIPTION
This slows deserialization slightly, but reduces memory used by deserialized objects, which can be dramatic.

Specifically, when deserializing an Unciv saved game after the game ends, I'm seeing about a full Megabyte of wasted memory from duplicate strings in heap dumps