### PR TITLE
Fixed stuck over state when ClickListener is cancelled

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+[1.14.2]
+- Fixed stuck over state when ClickListener is cancelled.
+
 [1.14.1]
 - [BREAKING CHANGE] iOS: Removed IOSAudio#willTerminate to be replaced by new Audio#dispose.
 - [BREAKING CHANGE] API: The `open/closeTextInputField` API has undergone a bigger rewrite:

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/ClickListener.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/ClickListener.java
@@ -37,7 +37,7 @@ public class ClickListener extends InputListener {
 	private int pressedPointer = -1;
 	private int pressedButton = -1;
 	private int button;
-	private boolean pressed, over, cancelled;
+	private boolean pressed, over, cancelled, cancelledOver;
 	private long visualPressedTime;
 	private long tapCountInterval = (long)(0.4f * 1000000000l);
 	private int tapCount;
@@ -91,22 +91,35 @@ public class ClickListener extends InputListener {
 			pressed = false;
 			pressedPointer = -1;
 			pressedButton = -1;
+			if (cancelled) over = cancelledOver;
 			cancelled = false;
 		}
 	}
 
 	public void enter (InputEvent event, float x, float y, int pointer, @Null Actor fromActor) {
-		if (pointer == -1 && !cancelled) over = true;
+		if (pointer == -1) {
+			if (!cancelled)
+				over = true;
+			else
+				cancelledOver = true;
+		}
 	}
 
 	public void exit (InputEvent event, float x, float y, int pointer, @Null Actor toActor) {
-		if (pointer == -1 && !cancelled) over = false;
+		if (pointer == -1) {
+			if (!cancelled)
+				over = false;
+			else
+				cancelledOver = false;
+		}
 	}
 
-	/** If a touch down is being monitored, the drag and touch up events are ignored until the next touch up. */
+	/** If a touch down is being monitored, the over state and drag and touch up events are ignored until the next touch up. */
 	public void cancel () {
-		if (pressedPointer == -1) return;
+		if (pressedPointer == -1 || cancelled) return;
 		cancelled = true;
+		cancelledOver = over;
+		over = false;
 		pressed = false;
 	}
 


### PR DESCRIPTION
When ClickListener is cancelled during press/drag, enter/exit is ignored until touch up. This means the value of `over` (usually true) is stuck until next enter.

With this fix we set `over` to false on cancel and maintain the real over state separately in `cancelledOver`. On touch up we restore the real `over` state and everything resumes working as normal, no stuck/lost over state.