### PR TITLE
BitmapFontCache.clear() should reset glyphCount.

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFontCache.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFontCache.java
@@ -310,6 +310,7 @@ public class BitmapFontCache {
 		y = 0;
 		pooledLayouts.flush();
 		layouts.clear();
+		glyphCount = 0;
 		for (int i = 0, n = idx.length; i < n; i++) {
 			if (pageGlyphIndices != null) pageGlyphIndices[i].clear();
 			idx[i] = 0;


### PR DESCRIPTION
tl;dr This is a one-line change that fixes a missing reset of mutable state in BitmapFontCache.

Without this change, every time the BitmapFontCache is cleared and text is added again, the items in pageGlyphIndices get larger every time, which breaks some color handling at the very least. You can reproduce the bug by changing line 98 of BitmapFontTest from `true` to `false`; without this PR and with that line change, the cached multi-color text doesn't render at all. With this PR and that line change, it renders correctly. This fixes #7793 .