### PR TITLE
Minor oversight in CHANGES

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -14,6 +14,7 @@
                         - `TextInputWrapper#setText/setPosition` have been removed and replaced with `writeResults`
                         - `TextInputWrapper#shouldClose` has been removed and should now be handled over the close callback
 - [BREAKING CHANGE] API: `TextField.OnscreenKeyboard` has been refactored. `OnscreenKeyboard#show(boolean)` has been split of in `OnscreenKeyboard#show(TextField)` and `OnscreenKeyboard#close()`.
+- [BREAKING CHANGE] API: `TextField.next` has changed return type. Overrides might need rewriting.
 - [BREAKING CHANGE] API: `Json#ignoreUnknownField()` parameters changed to provide more information. Use `object.getClass()` and `value.name` for the old values.
 - API Addition: `Input#KeyboardHeightObserver` was extended by `onKeyboardShow` and `onKeyboardHide`. See javadocs for more info.
 - API Addition: `Input#isTextInputFieldOpened` has been added, to check, whether an InputField opened by `openTextInputField` is open


### PR DESCRIPTION
... after all, the signature change to `TextField.next` will result in clients not even compiling (https://github.com/libgdx/libgdx/pull/7671). Oh, by the way, the "Check out our blog post on version 1.14.1" link on the [releases page](https://github.com/libgdx/libgdx/releases) is misleading, there's no such blog entry.