### PR TITLE
Fix lwjgl3 OGG memory leak

### DIFF
--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/Ogg.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/Ogg.java
@@ -17,7 +17,6 @@
 package com.badlogic.gdx.backends.lwjgl3.audio;
 
 import com.badlogic.gdx.files.FileHandle;
-import com.badlogic.gdx.utils.BufferUtils;
 import com.badlogic.gdx.utils.GdxRuntimeException;
 import com.badlogic.gdx.utils.StreamUtils;
 import org.lwjgl.stb.STBVorbis;
@@ -82,8 +81,7 @@ public class Ogg {
 					final IntBuffer sampleRateBuffer = stack.mallocInt(1);
 
 					// decode
-					final ShortBuffer decodedData = STBVorbis.stb_vorbis_decode_memory(encodedData, channelsBuffer,
-							sampleRateBuffer);
+					final ShortBuffer decodedData = STBVorbis.stb_vorbis_decode_memory(encodedData, channelsBuffer, sampleRateBuffer);
 					if (decodedData == null) {
 						throw new GdxRuntimeException("Error decoding OGG file: " + file);
 					}

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/Ogg.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/Ogg.java
@@ -22,6 +22,7 @@ import com.badlogic.gdx.utils.GdxRuntimeException;
 import com.badlogic.gdx.utils.StreamUtils;
 import org.lwjgl.stb.STBVorbis;
 import org.lwjgl.system.MemoryStack;
+import org.lwjgl.system.libc.LibCStdlib;
 
 import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
@@ -80,13 +81,17 @@ public class Ogg {
 
 				// decode
 				final ShortBuffer decodedData = STBVorbis.stb_vorbis_decode_memory(encodedData, channelsBuffer, sampleRateBuffer);
-				int channels = channelsBuffer.get(0);
-				int sampleRate = sampleRateBuffer.get(0);
 				if (decodedData == null) {
 					throw new GdxRuntimeException("Error decoding OGG file: " + file);
 				}
+				try {
+					int channels = channelsBuffer.get(0);
+					int sampleRate = sampleRateBuffer.get(0);
 
-				setup(decodedData, channels, 16, sampleRate);
+					setup(decodedData, channels, 16, sampleRate);
+				} finally {
+					LibCStdlib.free(decodedData);
+				}
 			}
 		}
 	}

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/Ogg.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/audio/Ogg.java
@@ -22,6 +22,7 @@ import com.badlogic.gdx.utils.GdxRuntimeException;
 import com.badlogic.gdx.utils.StreamUtils;
 import org.lwjgl.stb.STBVorbis;
 import org.lwjgl.system.MemoryStack;
+import org.lwjgl.system.MemoryUtil;
 import org.lwjgl.system.libc.LibCStdlib;
 
 import java.nio.ByteBuffer;
@@ -71,27 +72,32 @@ public class Ogg {
 
 			// put the encoded audio data in a ByteBuffer
 			byte[] streamData = file.readBytes();
-			ByteBuffer encodedData = BufferUtils.newByteBuffer(streamData.length);
-			encodedData.put(streamData);
-			encodedData.flip();
+			ByteBuffer encodedData = MemoryUtil.memAlloc(streamData.length);
+			try {
+				encodedData.put(streamData);
+				encodedData.flip();
 
-			try (MemoryStack stack = MemoryStack.stackPush()) {
-				final IntBuffer channelsBuffer = stack.mallocInt(1);
-				final IntBuffer sampleRateBuffer = stack.mallocInt(1);
+				try (MemoryStack stack = MemoryStack.stackPush()) {
+					final IntBuffer channelsBuffer = stack.mallocInt(1);
+					final IntBuffer sampleRateBuffer = stack.mallocInt(1);
 
-				// decode
-				final ShortBuffer decodedData = STBVorbis.stb_vorbis_decode_memory(encodedData, channelsBuffer, sampleRateBuffer);
-				if (decodedData == null) {
-					throw new GdxRuntimeException("Error decoding OGG file: " + file);
+					// decode
+					final ShortBuffer decodedData = STBVorbis.stb_vorbis_decode_memory(encodedData, channelsBuffer,
+							sampleRateBuffer);
+					if (decodedData == null) {
+						throw new GdxRuntimeException("Error decoding OGG file: " + file);
+					}
+					try {
+						int channels = channelsBuffer.get(0);
+						int sampleRate = sampleRateBuffer.get(0);
+
+						setup(decodedData, channels, 16, sampleRate);
+					} finally {
+						LibCStdlib.free(decodedData);
+					}
 				}
-				try {
-					int channels = channelsBuffer.get(0);
-					int sampleRate = sampleRateBuffer.get(0);
-
-					setup(decodedData, channels, 16, sampleRate);
-				} finally {
-					LibCStdlib.free(decodedData);
-				}
+			} finally {
+				MemoryUtil.memFree(encodedData);
 			}
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/libgdx/libgdx/issues/7712

Free pattern derived from lwgjl3 docs:
```java
    /**
     * Decode an entire file and output the data interleaved into a {@code malloc()ed} buffer stored in {@code *output}. When you're done with it, just
     * {@link LibCStdlib#free} the pointer returned in {@code *output}.
     *
     * @param filename    the file name
     * @param channels    returns the number of channels
     * @param sample_rate returns the sample rate
     *
     * @return the number of samples decoded, or -1 if the file could not be opened or was not an ogg vorbis file
     */
    @Nullable
    @NativeType("int")
    public static ShortBuffer stb_vorbis_decode_filename(@NativeType("char const *") CharSequence filename, @NativeType("int *") IntBuffer channels, @NativeType("int *") IntBuffer sample_rate) 
[...]

    /**
     * In-memory version of {@link #stb_vorbis_decode_filename decode_filename}.
     *
     * @param mem         the data to decode
     * @param channels    returns the number of channels
     * @param sample_rate returns the sample rate
     */
    @Nullable
    @NativeType("int")
    public static ShortBuffer stb_vorbis_decode_memory(@NativeType("unsigned char const *") ByteBuffer mem, @NativeType("int *") IntBuffer channels, @NativeType("int *") IntBuffer sample_rate) {
```
Verified it does not leak memory enymore.

The allocated DirectByteBuffer has been replaced with an explicit lifecycle tracked.