### PR TITLE
Change default BULLET char from Windows-1252 to Unicode.

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextField.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextField.java
@@ -71,7 +71,11 @@ public class TextField extends Widget implements Disableable, Styleable<TextFiel
 	static protected final char NEWLINE = '\n';
 	static protected final char TAB = '\t';
 	static protected final char DELETE = 127;
-	static protected final char BULLET = 149;
+	/** This is the default char used in password fields, a Unicode bullet at code point 0x2022. If you need the
+	 * Windows-1252 codepage for legacy support, you can call {@link #setPasswordCharacter(char)} with the char at code
+	 * point 0x0095. Note that the default BitmapFont constructed with {@link BitmapFont#BitmapFont()} does not contain
+	 * any bullet char, so if you use that, you should call {@code field.setPasswordCharacter('*');} instead. */
+	static protected final char BULLET = '\u2022'; // Unicode bullet character
 
 	static public OnscreenKeyboard DEFAULT_ONSCREEN_KEYBOARD = new DefaultOnscreenKeyboard();
 
@@ -842,8 +846,10 @@ public class TextField extends Widget implements Disableable, Styleable<TextFiel
 		return passwordMode;
 	}
 
-	/** Sets the password character for the text field. The character must be present in the {@link BitmapFont}. Default is 149
-	 * (bullet). */
+	/** Sets the password character for the text field. The character must be present in the {@link BitmapFont}.
+	 * Default is Unicode 0x2022 (a bullet).
+	 * Note that the default BitmapFont constructed with {@link BitmapFont#BitmapFont()} does not contain any bullet
+	 * char, so if you use that, you should call {@code field.setPasswordCharacter('*');} instead. */
 	public void setPasswordCharacter (char passwordCharacter) {
 		this.passwordCharacter = passwordCharacter;
 		if (passwordMode) updateDisplayText();

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextField.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/ui/TextField.java
@@ -71,10 +71,10 @@ public class TextField extends Widget implements Disableable, Styleable<TextFiel
 	static protected final char NEWLINE = '\n';
 	static protected final char TAB = '\t';
 	static protected final char DELETE = 127;
-	/** This is the default char used in password fields, a Unicode bullet at code point 0x2022. If you need the
-	 * Windows-1252 codepage for legacy support, you can call {@link #setPasswordCharacter(char)} with the char at code
-	 * point 0x0095. Note that the default BitmapFont constructed with {@link BitmapFont#BitmapFont()} does not contain
-	 * any bullet char, so if you use that, you should call {@code field.setPasswordCharacter('*');} instead. */
+	/** This is the default char used in password fields, a Unicode bullet at code point 0x2022. If you need the Windows-1252
+	 * codepage for legacy support, you can call {@link #setPasswordCharacter(char)} with the char at code point 0x0095. Note that
+	 * the default BitmapFont constructed with {@link BitmapFont#BitmapFont()} does not contain any bullet char, so if you use
+	 * that, you should call {@code field.setPasswordCharacter('*');} instead. */
 	static protected final char BULLET = '\u2022'; // Unicode bullet character
 
 	static public OnscreenKeyboard DEFAULT_ONSCREEN_KEYBOARD = new DefaultOnscreenKeyboard();
@@ -846,10 +846,9 @@ public class TextField extends Widget implements Disableable, Styleable<TextFiel
 		return passwordMode;
 	}
 
-	/** Sets the password character for the text field. The character must be present in the {@link BitmapFont}.
-	 * Default is Unicode 0x2022 (a bullet).
-	 * Note that the default BitmapFont constructed with {@link BitmapFont#BitmapFont()} does not contain any bullet
-	 * char, so if you use that, you should call {@code field.setPasswordCharacter('*');} instead. */
+	/** Sets the password character for the text field. The character must be present in the {@link BitmapFont}. Default is Unicode
+	 * 0x2022 (a bullet). Note that the default BitmapFont constructed with {@link BitmapFont#BitmapFont()} does not contain any
+	 * bullet char, so if you use that, you should call {@code field.setPasswordCharacter('*');} instead. */
 	public void setPasswordCharacter (char passwordCharacter) {
 		this.passwordCharacter = passwordCharacter;
 		if (passwordMode) updateDisplayText();


### PR DESCRIPTION
This changes the default char used in password fields from code point 149 or 0x0095, which is not a displayable Unicode char, to Unicode code point 0x2022 . This also documents that a zero-arg constructor BitmapFont can't display that char by default, and how to make it display correctly in that common case. I tried to avoid using any non-ASCII chars in the Javadocs, because those can sometimes display incorrectly if users have their fonts set up a certain way.