### PR TITLE
Add putMissing() to maps.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@
 - Added ShewchukExactPredicates, for floating-error resistant orient2d/incircle/orient3d/insphere tests
 - Improved DelaunayTriangulator to handle all non-degenerate inputs using ShewchukExactPredicates
 - Improved performance of DelaunayTriangulator by ~2x on regular inputs
+- Added putMissing() to maps.
 
 [1.14.1]
 - [BREAKING CHANGE] iOS: Removed IOSAudio#willTerminate to be replaced by new Audio#dispose.

--- a/gdx/src/com/badlogic/gdx/utils/ArrayMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/ArrayMap.java
@@ -127,6 +127,15 @@ public class ArrayMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 		return index;
 	}
 
+	public @Null V putMissing (K key, @Null V value) {
+		int index = indexOfKey(key);
+		if (index != -1) return values[index];
+		if (size == keys.length) resize(Math.max(8, (int)(size * 1.75f)));
+		keys[size] = key;
+		values[size++] = value;
+		return null;
+	}
+
 	public void putAll (ArrayMap<? extends K, ? extends V> map) {
 		putAll(map, 0, map.size);
 	}

--- a/gdx/src/com/badlogic/gdx/utils/IntFloatMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/IntFloatMap.java
@@ -182,6 +182,42 @@ public class IntFloatMap implements Iterable<IntFloatMap.Entry> {
 		return defaultValue;
 	}
 
+	public void putMissing (int key, float value) {
+		if (key == 0) {
+			if (!hasZeroValue) {
+				zeroValue = value;
+				hasZeroValue = true;
+				size++;
+			}
+			return;
+		}
+		int i = locateKey(key);
+		if (i >= 0) return; // Existing key was found.
+		i = -(i + 1); // Empty space was found.
+		keyTable[i] = key;
+		valueTable[i] = value;
+		if (++size >= threshold) resize(keyTable.length << 1);
+	}
+
+	public float putMissing (int key, float value, float defaultValue) {
+		if (key == 0) {
+			if (!hasZeroValue) {
+				zeroValue = value;
+				hasZeroValue = true;
+				size++;
+				return defaultValue;
+			}
+			return zeroValue;
+		}
+		int i = locateKey(key);
+		if (i >= 0) return valueTable[i]; // Existing key was found.
+		i = -(i + 1); // Empty space was found.
+		keyTable[i] = key;
+		valueTable[i] = value;
+		if (++size >= threshold) resize(keyTable.length << 1);
+		return defaultValue;
+	}
+
 	public void putAll (IntFloatMap map) {
 		ensureCapacity(map.size);
 		if (map.hasZeroValue) put(0, map.zeroValue);

--- a/gdx/src/com/badlogic/gdx/utils/IntIntMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/IntIntMap.java
@@ -179,6 +179,42 @@ public class IntIntMap implements Iterable<IntIntMap.Entry> {
 		return defaultValue;
 	}
 
+	public void putMissing (int key, int value) {
+		if (key == 0) {
+			if (!hasZeroValue) {
+				zeroValue = value;
+				hasZeroValue = true;
+				size++;
+			}
+			return;
+		}
+		int i = locateKey(key);
+		if (i >= 0) return; // Existing key was found.
+		i = -(i + 1); // Empty space was found.
+		keyTable[i] = key;
+		valueTable[i] = value;
+		if (++size >= threshold) resize(keyTable.length << 1);
+	}
+
+	public int putMissing (int key, int value, int defaultValue) {
+		if (key == 0) {
+			if (!hasZeroValue) {
+				zeroValue = value;
+				hasZeroValue = true;
+				size++;
+				return defaultValue;
+			}
+			return zeroValue;
+		}
+		int i = locateKey(key);
+		if (i >= 0) return valueTable[i]; // Existing key was found.
+		i = -(i + 1); // Empty space was found.
+		keyTable[i] = key;
+		valueTable[i] = value;
+		if (++size >= threshold) resize(keyTable.length << 1);
+		return defaultValue;
+	}
+
 	public void putAll (IntIntMap map) {
 		ensureCapacity(map.size);
 		if (map.hasZeroValue) put(0, map.zeroValue);

--- a/gdx/src/com/badlogic/gdx/utils/IntMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/IntMap.java
@@ -159,6 +159,25 @@ public class IntMap<V> implements Iterable<IntMap.Entry<V>> {
 		return null;
 	}
 
+	public @Null V putMissing (int key, @Null V value) {
+		if (key == 0) {
+			V oldValue = zeroValue;
+			if (!hasZeroValue) {
+				zeroValue = value;
+				hasZeroValue = true;
+				size++;
+			}
+			return oldValue;
+		}
+		int i = locateKey(key);
+		if (i >= 0) return valueTable[i]; // Existing key was found.
+		i = -(i + 1); // Empty space was found.
+		keyTable[i] = key;
+		valueTable[i] = value;
+		if (++size >= threshold) resize(keyTable.length << 1);
+		return null;
+	}
+
 	public void putAll (IntMap<? extends V> map) {
 		ensureCapacity(map.size);
 		if (map.hasZeroValue) put(0, map.zeroValue);

--- a/gdx/src/com/badlogic/gdx/utils/LongMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/LongMap.java
@@ -158,6 +158,25 @@ public class LongMap<V> implements Iterable<LongMap.Entry<V>> {
 		return null;
 	}
 
+	public @Null V putMissing (long key, @Null V value) {
+		if (key == 0) {
+			V oldValue = zeroValue;
+			if (!hasZeroValue) {
+				zeroValue = value;
+				hasZeroValue = true;
+				size++;
+			}
+			return oldValue;
+		}
+		int i = locateKey(key);
+		if (i >= 0) return valueTable[i]; // Existing key was found.
+		i = -(i + 1); // Empty space was found.
+		keyTable[i] = key;
+		valueTable[i] = value;
+		if (++size >= threshold) resize(keyTable.length << 1);
+		return null;
+	}
+
 	public void putAll (LongMap<? extends V> map) {
 		ensureCapacity(map.size);
 		if (map.hasZeroValue) put(0, map.zeroValue);

--- a/gdx/src/com/badlogic/gdx/utils/ObjectFloatMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/ObjectFloatMap.java
@@ -160,6 +160,25 @@ public class ObjectFloatMap<K> implements Iterable<ObjectFloatMap.Entry<K>> {
 		return defaultValue;
 	}
 
+	public void putMissing (K key, float value) {
+		int i = locateKey(key);
+		if (i >= 0) return; // Existing key was found.
+		i = -(i + 1); // Empty space was found.
+		keyTable[i] = key;
+		valueTable[i] = value;
+		if (++size >= threshold) resize(keyTable.length << 1);
+	}
+
+	public float putMissing (K key, float value, float defaultValue) {
+		int i = locateKey(key);
+		if (i >= 0) return valueTable[i]; // Existing key was found.
+		i = -(i + 1); // Empty space was found.
+		keyTable[i] = key;
+		valueTable[i] = value;
+		if (++size >= threshold) resize(keyTable.length << 1);
+		return defaultValue;
+	}
+
 	public void putAll (ObjectFloatMap<? extends K> map) {
 		ensureCapacity(map.size);
 		K[] keyTable = map.keyTable;

--- a/gdx/src/com/badlogic/gdx/utils/ObjectIntMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/ObjectIntMap.java
@@ -159,6 +159,25 @@ public class ObjectIntMap<K> implements Iterable<ObjectIntMap.Entry<K>> {
 		return defaultValue;
 	}
 
+	public void putMissing (K key, int value) {
+		int i = locateKey(key);
+		if (i >= 0) return; // Existing key was found.
+		i = -(i + 1); // Empty space was found.
+		keyTable[i] = key;
+		valueTable[i] = value;
+		if (++size >= threshold) resize(keyTable.length << 1);
+	}
+
+	public int putMissing (K key, int value, int defaultValue) {
+		int i = locateKey(key);
+		if (i >= 0) return valueTable[i]; // Existing key was found.
+		i = -(i + 1); // Empty space was found.
+		keyTable[i] = key;
+		valueTable[i] = value;
+		if (++size >= threshold) resize(keyTable.length << 1);
+		return defaultValue;
+	}
+
 	public void putAll (ObjectIntMap<? extends K> map) {
 		ensureCapacity(map.size);
 		K[] keyTable = map.keyTable;

--- a/gdx/src/com/badlogic/gdx/utils/ObjectLongMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/ObjectLongMap.java
@@ -159,6 +159,25 @@ public class ObjectLongMap<K> implements Iterable<ObjectLongMap.Entry<K>> {
 		return defaultValue;
 	}
 
+	public void putMissing (K key, long value) {
+		int i = locateKey(key);
+		if (i >= 0) return; // Existing key was found.
+		i = -(i + 1); // Empty space was found.
+		keyTable[i] = key;
+		valueTable[i] = value;
+		if (++size >= threshold) resize(keyTable.length << 1);
+	}
+
+	public long putMissing (K key, long value, long defaultValue) {
+		int i = locateKey(key);
+		if (i >= 0) return valueTable[i]; // Existing key was found.
+		i = -(i + 1); // Empty space was found.
+		keyTable[i] = key;
+		valueTable[i] = value;
+		if (++size >= threshold) resize(keyTable.length << 1);
+		return defaultValue;
+	}
+
 	public void putAll (ObjectLongMap<? extends K> map) {
 		ensureCapacity(map.size);
 		K[] keyTable = map.keyTable;

--- a/gdx/src/com/badlogic/gdx/utils/ObjectMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/ObjectMap.java
@@ -149,6 +149,16 @@ public class ObjectMap<K, V> implements Iterable<ObjectMap.Entry<K, V>> {
 		return null;
 	}
 
+	public @Null V putMissing (K key, @Null V value) {
+		int i = locateKey(key);
+		if (i >= 0) return valueTable[i]; // Existing key was found.
+		i = -(i + 1); // Empty space was found.
+		keyTable[i] = key;
+		valueTable[i] = value;
+		if (++size >= threshold) resize(keyTable.length << 1);
+		return null;
+	}
+
 	public void putAll (ObjectMap<? extends K, ? extends V> map) {
 		ensureCapacity(map.size);
 		K[] keyTable = map.keyTable;

--- a/gdx/src/com/badlogic/gdx/utils/OrderedMap.java
+++ b/gdx/src/com/badlogic/gdx/utils/OrderedMap.java
@@ -84,6 +84,17 @@ public class OrderedMap<K, V> extends ObjectMap<K, V> {
 		return null;
 	}
 
+	public @Null V putMissing (K key, @Null V value) {
+		int i = locateKey(key);
+		if (i >= 0) return valueTable[i]; // Existing key was found.
+		i = -(i + 1); // Empty space was found.
+		keyTable[i] = key;
+		valueTable[i] = value;
+		keys.add(key);
+		if (++size >= threshold) resize(keyTable.length << 1);
+		return null;
+	}
+
 	public <T extends K> void putAll (OrderedMap<T, ? extends V> map) {
 		ensureCapacity(map.size);
 		K[] keys = map.keys.items;


### PR DESCRIPTION
I needed LongMap `putMissing()` to do this in 1 lookup:
```
if (!map.containsKey(key)) map.put(key, value); // 2 lookups when missing.
map.putMissing(key, value); // Same with 1 lookup.
```
If you need the existing value and it could be null:
```
existing = map.containsKey(key) ? map.get(key) : map.put(key, value); // 2 lookups.
existing = map.putMissing(key, value); // Same with 1 lookup.
```
It's useful for the other maps, so here we are.

Open to other naming. JDK naming for similar is `putIfAbsent`. Having `If` in a method name isn't great IMHO and the semantics differ: the JDK method stores the value when a key exists storing null. We allow null values and treat them as any other, so `putMissing` is based on whether the key exists, regardless of whether the current value is null.