### PR TITLE
Handle unavailable primary monitor when centering window

### DIFF
--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
@@ -27,7 +27,6 @@ import com.badlogic.gdx.backends.lwjgl3.audio.Lwjgl3Audio;
 import com.badlogic.gdx.backends.lwjgl3.audio.OpenALLwjgl3Audio;
 import com.badlogic.gdx.graphics.glutils.GLVersion;
 
-import com.badlogic.gdx.utils.*;
 import org.lwjgl.glfw.GLFW;
 import org.lwjgl.glfw.GLFWErrorCallback;
 import org.lwjgl.opengl.AMDDebugOutput;
@@ -39,6 +38,7 @@ import org.lwjgl.opengl.GLCapabilities;
 import org.lwjgl.opengl.GLUtil;
 import org.lwjgl.opengl.KHRDebug;
 import org.lwjgl.system.Callback;
+import org.lwjgl.system.MemoryUtil;
 
 import com.badlogic.gdx.Application;
 import com.badlogic.gdx.ApplicationListener;
@@ -57,6 +57,7 @@ import com.badlogic.gdx.utils.Clipboard;
 import com.badlogic.gdx.utils.GdxRuntimeException;
 import com.badlogic.gdx.utils.ObjectMap;
 import com.badlogic.gdx.utils.SharedLibraryLoader;
+import com.badlogic.gdx.utils.Os;
 
 public class Lwjgl3Application implements Lwjgl3ApplicationBase {
 	private final Lwjgl3ApplicationConfiguration config;
@@ -553,9 +554,15 @@ public class Lwjgl3Application implements Lwjgl3ApplicationBase {
 						monitorHandle = config.maximizedMonitor.monitorHandle;
 					}
 
-					GridPoint2 newPos = Lwjgl3ApplicationConfiguration.calculateCenteredWindowPosition(
-						Lwjgl3ApplicationConfiguration.toLwjgl3Monitor(monitorHandle), windowWidth, windowHeight);
-					GLFW.glfwSetWindowPos(windowHandle, newPos.x, newPos.y);
+					// If the primary monitor is unavailable, use (0, 0) as a fallback
+					if (monitorHandle == MemoryUtil.NULL) {
+						GLFW.glfwSetWindowPos(windowHandle, 0, 0);
+					} else {
+						GridPoint2 newPos = Lwjgl3ApplicationConfiguration.calculateCenteredWindowPosition(
+							Lwjgl3ApplicationConfiguration.toLwjgl3Monitor(monitorHandle), windowWidth, windowHeight);
+						GLFW.glfwSetWindowPos(windowHandle, newPos.x, newPos.y);
+					}
+
 				} else {
 					GLFW.glfwSetWindowPos(windowHandle, config.windowX, config.windowY);
 				}

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
@@ -38,7 +38,6 @@ import org.lwjgl.opengl.GLCapabilities;
 import org.lwjgl.opengl.GLUtil;
 import org.lwjgl.opengl.KHRDebug;
 import org.lwjgl.system.Callback;
-import org.lwjgl.system.MemoryUtil;
 
 import com.badlogic.gdx.Application;
 import com.badlogic.gdx.ApplicationListener;
@@ -555,7 +554,7 @@ public class Lwjgl3Application implements Lwjgl3ApplicationBase {
 					}
 
 					// If the primary monitor is unavailable, use (0, 0) as a fallback
-					if (monitorHandle == MemoryUtil.NULL) {
+					if (monitorHandle == 0) {
 						GLFW.glfwSetWindowPos(windowHandle, 0, 0);
 					} else {
 						GridPoint2 newPos = Lwjgl3ApplicationConfiguration.calculateCenteredWindowPosition(


### PR DESCRIPTION
Fixes #7794

According to the GLFW documentation, `glfwGetPrimaryMonitor()` returns `NULL` if no monitors are found or if an error occurs. This change guards against that case:
https://www.glfw.org/docs/latest/group__monitor.html#gac3adb24947eb709e1874028272e5dfc5

This change checks whether the primary monitor handle is `MemoryUtil.NULL` before attempting to center the window, preventing an invalid handle from being passed to `toLwjgl3Monitor()`.

When the primary monitor is unavailable, the window falls back to position `(0, 0)`.

I couldn't reproduce the macOS-specific scenario because I don't have access to macOS hardware, so I'd appreciate verification from someone who can reproduce the issue.