### PR TITLE
Fix ActorGestureListener touchUp NPE

### DIFF
--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/ActorGestureListener.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/ActorGestureListener.java
@@ -119,6 +119,7 @@ public class ActorGestureListener implements EventListener {
 			return true;
 		case touchUp:
 			boolean touchFocusCancel = event.isTouchFocusCancel();
+			if (event.getPointer() <= 1) activeTouches--;
 			if (touchFocusCancel)
 				detector.reset();
 			else {
@@ -131,7 +132,6 @@ public class ActorGestureListener implements EventListener {
 				final float preservedTouchY = tmpCoords.y;
 
 				detector.touchUp(event.getStageX(), event.getStageY(), event.getPointer(), event.getButton());
-				if (event.getPointer() <= 1) activeTouches--;
 				touchUp(event, preservedTouchX, preservedTouchY, event.getPointer(), event.getButton());
 			}
 			if (activeTouches == 0) {

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/ActorGestureListener.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/ActorGestureListener.java
@@ -122,9 +122,14 @@ public class ActorGestureListener implements EventListener {
 			else {
 				this.event = event;
 				actor = event.getListenerActor();
-				detector.touchUp(event.getStageX(), event.getStageY(), event.getPointer(), event.getButton());
+
 				actor.stageToLocalCoordinates(tmpCoords.set(event.getStageX(), event.getStageY()));
-				touchUp(event, tmpCoords.x, tmpCoords.y, event.getPointer(), event.getButton());
+				// Preserve the touch coordinates before a possible reentrant callback modifies tmpCoords
+				final float preservedTouchX = tmpCoords.x;
+				final float preservedTouchY = tmpCoords.y;
+
+				detector.touchUp(event.getStageX(), event.getStageY(), event.getPointer(), event.getButton());
+				touchUp(event, preservedTouchX, preservedTouchY, event.getPointer(), event.getButton());
 			}
 			this.event = null;
 			actor = null;

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/ActorGestureListener.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/ActorGestureListener.java
@@ -35,7 +35,7 @@ public class ActorGestureListener implements EventListener {
 	private final GestureDetector detector;
 	InputEvent event;
 	Actor actor, touchDownTarget;
-	private int activeTouches = 0;
+	private int activeTouches;
 
 	/** @see GestureDetector#GestureDetector(com.badlogic.gdx.input.GestureDetector.GestureListener) */
 	public ActorGestureListener () {
@@ -119,7 +119,6 @@ public class ActorGestureListener implements EventListener {
 			return true;
 		case touchUp:
 			boolean touchFocusCancel = event.isTouchFocusCancel();
-			if (event.getPointer() <= 1) activeTouches--;
 			if (touchFocusCancel)
 				detector.reset();
 			else {
@@ -128,12 +127,12 @@ public class ActorGestureListener implements EventListener {
 
 				actor.stageToLocalCoordinates(tmpCoords.set(event.getStageX(), event.getStageY()));
 				// Preserve the touch coordinates before a possible reentrant callback modifies tmpCoords
-				final float preservedTouchX = tmpCoords.x;
-				final float preservedTouchY = tmpCoords.y;
+				float touchUpX = tmpCoords.x, touchUpY = tmpCoords.y;
 
 				detector.touchUp(event.getStageX(), event.getStageY(), event.getPointer(), event.getButton());
-				touchUp(event, preservedTouchX, preservedTouchY, event.getPointer(), event.getButton());
+				touchUp(event, touchUpX, touchUpY, event.getPointer(), event.getButton());
 			}
+			if (event.getPointer() <= 1) activeTouches--;
 			if (activeTouches == 0) {
 				this.event = null;
 				actor = null;

--- a/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/ActorGestureListener.java
+++ b/gdx/src/com/badlogic/gdx/scenes/scene2d/utils/ActorGestureListener.java
@@ -35,6 +35,7 @@ public class ActorGestureListener implements EventListener {
 	private final GestureDetector detector;
 	InputEvent event;
 	Actor actor, touchDownTarget;
+	private int activeTouches = 0;
 
 	/** @see GestureDetector#GestureDetector(com.badlogic.gdx.input.GestureDetector.GestureListener) */
 	public ActorGestureListener () {
@@ -110,6 +111,7 @@ public class ActorGestureListener implements EventListener {
 			actor = event.getListenerActor();
 			touchDownTarget = event.getTarget();
 			detector.touchDown(event.getStageX(), event.getStageY(), event.getPointer(), event.getButton());
+			if (event.getPointer() <= 1) activeTouches++;
 			actor.stageToLocalCoordinates(tmpCoords.set(event.getStageX(), event.getStageY()));
 			touchDown(event, tmpCoords.x, tmpCoords.y, event.getPointer(), event.getButton());
 			if (event.getTouchFocus()) event.getStage().addTouchFocus(this, event.getListenerActor(), event.getTarget(),
@@ -129,11 +131,14 @@ public class ActorGestureListener implements EventListener {
 				final float preservedTouchY = tmpCoords.y;
 
 				detector.touchUp(event.getStageX(), event.getStageY(), event.getPointer(), event.getButton());
+				if (event.getPointer() <= 1) activeTouches--;
 				touchUp(event, preservedTouchX, preservedTouchY, event.getPointer(), event.getButton());
 			}
-			this.event = null;
-			actor = null;
-			touchDownTarget = null;
+			if (activeTouches == 0) {
+				this.event = null;
+				actor = null;
+				touchDownTarget = null;
+			}
 			return !touchFocusCancel;
 		case touchDragged:
 			this.event = event;

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ActorGestureListenerPointerTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ActorGestureListenerPointerTest.java
@@ -1,0 +1,102 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogic.gdx.tests;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.math.Vector2;
+import com.badlogic.gdx.scenes.scene2d.Stage;
+import com.badlogic.gdx.scenes.scene2d.ui.ScrollPane;
+import com.badlogic.gdx.scenes.scene2d.ui.Skin;
+import com.badlogic.gdx.scenes.scene2d.ui.Table;
+import com.badlogic.gdx.tests.utils.GdxTest;
+import com.badlogic.gdx.utils.ScreenUtils;
+
+/** Regression test for the multiple-pointer crash reported in issue #7660. */
+public class ActorGestureListenerPointerTest extends GdxTest {
+
+	private Stage stage;
+	private Skin skin;
+
+	private ScrollPane firstPane;
+	private ScrollPane secondPane;
+
+	private boolean inputTriggered = false;
+
+	public void create () {
+
+		stage = new Stage();
+		skin = new Skin(Gdx.files.internal("data/uiskin.json"));
+
+		firstPane = new ScrollPane(new Table(), skin);
+		secondPane = new ScrollPane(new Table(), skin);
+
+		Table table = new Table();
+		table.setFillParent(true);
+		table.add(firstPane).grow();
+		table.add(secondPane).grow();
+
+		Gdx.input.setInputProcessor(stage);
+		stage.addActor(table);
+
+	}
+
+	public void render () {
+		update(Gdx.graphics.getDeltaTime());
+		draw();
+	}
+
+	public void resize (int width, int height) {
+		stage.getViewport().update(width, height, true);
+	}
+
+	@Override
+	public void dispose () {
+		stage.dispose();
+		skin.dispose();
+	}
+
+	private void update (float deltaTime) {
+
+		stage.act(Gdx.graphics.getDeltaTime());
+
+		if (inputTriggered) return;
+
+		Vector2 firstPanePosition = firstPane.localToScreenCoordinates(new Vector2(5, 5));
+		Vector2 secondPanePosition = secondPane.localToScreenCoordinates(new Vector2(5, 5));
+
+		// First touch
+		stage.touchDown((int)firstPanePosition.x, (int)firstPanePosition.y, 0, 0);
+
+		// Second touch
+		stage.touchDown((int)secondPanePosition.x, (int)secondPanePosition.y, 1, 0);
+
+		// Third touch (ignored)
+		stage.touchDown((int)firstPanePosition.x + 5, (int)firstPanePosition.y, 2, 0);
+
+		// Release ignored third touch
+		stage.touchUp((int)firstPanePosition.x + 5, (int)firstPanePosition.y, 2, 0);
+
+		inputTriggered = true;
+
+	}
+
+	private void draw () {
+		ScreenUtils.clear(1f, 1f, 1f, 1f);
+		stage.draw();
+	}
+
+}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ActorGestureListenerTouchUpTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ActorGestureListenerTouchUpTest.java
@@ -1,0 +1,105 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogic.gdx.tests;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.math.Vector2;
+import com.badlogic.gdx.scenes.scene2d.InputEvent;
+import com.badlogic.gdx.scenes.scene2d.Stage;
+import com.badlogic.gdx.scenes.scene2d.Touchable;
+import com.badlogic.gdx.scenes.scene2d.ui.Dialog;
+import com.badlogic.gdx.scenes.scene2d.ui.Skin;
+import com.badlogic.gdx.scenes.scene2d.ui.Table;
+import com.badlogic.gdx.scenes.scene2d.utils.ActorGestureListener;
+import com.badlogic.gdx.tests.utils.GdxTest;
+import com.badlogic.gdx.utils.ScreenUtils;
+
+/** Regression test for the ActorGestureListener touchUp reentrancy bug reported in issue #7660. */
+public class ActorGestureListenerTouchUpTest extends GdxTest {
+
+	private Stage stage;
+	private Skin skin;
+	private Table table;
+
+	private boolean inputTriggered = false;
+
+	@Override
+	public void create () {
+
+		stage = new Stage();
+		skin = new Skin(Gdx.files.internal("data/uiskin.json"));
+
+		table = new Table();
+		table.addListener(new ActorGestureListener() {
+			@Override
+			public void tap (InputEvent event, float x, float y, int count, int button) {
+				super.tap(event, x, y, count, button);
+				Dialog dialog = new Dialog("TouchUp", skin);
+				dialog.show(stage);
+			}
+		});
+		table.setFillParent(true);
+		table.setTouchable(Touchable.enabled);
+
+		Gdx.input.setInputProcessor(stage);
+		stage.addActor(table);
+
+	}
+
+	@Override
+	public void render () {
+		update(Gdx.graphics.getDeltaTime());
+		draw();
+	}
+
+	@Override
+	public void resize (int width, int height) {
+		stage.getViewport().update(width, height, true);
+	}
+
+	@Override
+	public void dispose () {
+		stage.dispose();
+		skin.dispose();
+	}
+
+	private void update (float deltaTime) {
+
+		stage.act(deltaTime);
+
+		if (inputTriggered) return;
+		final Vector2 screenTableCoords = table.localToScreenCoordinates(new Vector2(10, 10));
+
+		// First touch
+		stage.touchDown((int)screenTableCoords.x, (int)screenTableCoords.y, 0, 0);
+
+		// Second touch
+		stage.touchDown((int)screenTableCoords.x + 5, (int)screenTableCoords.y + 5, 0, 1);
+
+		// Release second touch (Before the fix this reproduces the NPE)
+		stage.touchUp((int)screenTableCoords.x + 5, (int)screenTableCoords.y + 5, 0, 1);
+
+		inputTriggered = true;
+
+	}
+
+	private void draw () {
+		ScreenUtils.clear(0, 0, 0, 1);
+		stage.draw();
+	}
+
+}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ActorGestureListenerTouchUpTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ActorGestureListenerTouchUpTest.java
@@ -21,8 +21,6 @@ import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.scenes.scene2d.InputEvent;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.scenes.scene2d.Touchable;
-import com.badlogic.gdx.scenes.scene2d.ui.Dialog;
-import com.badlogic.gdx.scenes.scene2d.ui.Skin;
 import com.badlogic.gdx.scenes.scene2d.ui.Table;
 import com.badlogic.gdx.scenes.scene2d.utils.ActorGestureListener;
 import com.badlogic.gdx.tests.utils.GdxTest;
@@ -32,24 +30,24 @@ import com.badlogic.gdx.utils.ScreenUtils;
 public class ActorGestureListenerTouchUpTest extends GdxTest {
 
 	private Stage stage;
-	private Skin skin;
 	private Table table;
-
-	private boolean inputTriggered = false;
+	private boolean inputTriggered;
 
 	@Override
 	public void create () {
 
 		stage = new Stage();
-		skin = new Skin(Gdx.files.internal("data/uiskin.json"));
 
 		table = new Table();
 		table.addListener(new ActorGestureListener() {
 			@Override
 			public void tap (InputEvent event, float x, float y, int count, int button) {
-				super.tap(event, x, y, count, button);
-				Dialog dialog = new Dialog("TouchUp", skin);
-				dialog.show(stage);
+				stage.cancelTouchFocus();
+			}
+
+			@Override
+			public void panStop (InputEvent event, float x, float y, int pointer, int button) {
+				stage.cancelTouchFocus();
 			}
 		});
 		table.setFillParent(true);
@@ -74,7 +72,6 @@ public class ActorGestureListenerTouchUpTest extends GdxTest {
 	@Override
 	public void dispose () {
 		stage.dispose();
-		skin.dispose();
 	}
 
 	private void update (float deltaTime) {
@@ -84,14 +81,16 @@ public class ActorGestureListenerTouchUpTest extends GdxTest {
 		if (inputTriggered) return;
 		final Vector2 screenTableCoords = table.localToScreenCoordinates(new Vector2(10, 10));
 
-		// First touch
-		stage.touchDown((int)screenTableCoords.x, (int)screenTableCoords.y, 0, 0);
+		int x = (int)screenTableCoords.x, y = (int)screenTableCoords.y;
 
-		// Second touch
-		stage.touchDown((int)screenTableCoords.x + 5, (int)screenTableCoords.y + 5, 0, 1);
+		stage.touchDown(x, y, 0, 0);
+		stage.touchDown(x + 5, y + 5, 0, 1);
+		stage.touchUp(x + 5, y + 5, 0, 1);
 
-		// Release second touch (Before the fix this reproduces the NPE)
-		stage.touchUp((int)screenTableCoords.x + 5, (int)screenTableCoords.y + 5, 0, 1);
+		stage.touchDown(x, y, 0, 0);
+		stage.touchDown(x + 5, y + 5, 0, 1);
+		stage.touchDragged(x + 80, y + 80, 0);
+		stage.touchUp(x + 80, y + 80, 0, 0);
 
 		inputTriggered = true;
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
@@ -114,6 +114,7 @@ public class GdxTests {
 		AccelerometerTest.class,
 		ActionSequenceTest.class,
 		ActionTest.class,
+		ActorGestureListenerPointerTest.class,
 		ActorGestureListenerTouchUpTest.class,
 		Affine2Test.class,
 		AlphaTest.class,

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTests.java
@@ -114,6 +114,7 @@ public class GdxTests {
 		AccelerometerTest.class,
 		ActionSequenceTest.class,
 		ActionTest.class,
+		ActorGestureListenerTouchUpTest.class,
 		Affine2Test.class,
 		AlphaTest.class,
 		Animation3DTest.class,


### PR DESCRIPTION
Fixes #7660.

`ActorGestureListener.handle()` invokes `GestureDetector.touchUp()`, which may trigger a reentrant callback. During that callback, the shared temporary coordinates (`tmpCoords`) can be modified before `ActorGestureListener.touchUp()` is invoked.

This change preserves the converted touch coordinates before invoking `GestureDetector.touchUp()`, preventing the reentrant callback from affecting the coordinates used by `ActorGestureListener.touchUp()`.

A regression test (`ActorGestureListenerTouchUpTest`) has been added. The test reproduces the issue before the fix and runs successfully after the fix. The test is based on the reproduction shared by @lucas-viva in the discussion on #7660.