### PR TITLE
add() with 5-8 parameters for arrays

### DIFF
--- a/gdx/src/com/badlogic/gdx/utils/Array.java
+++ b/gdx/src/com/badlogic/gdx/utils/Array.java
@@ -139,12 +139,62 @@ public class Array<T> implements Iterable<T> {
 
 	public void add (T value1, T value2, T value3, T value4) {
 		T[] items = this.items;
-		if (size + 3 >= items.length) items = resize(Math.max(8, (int)(size * 1.8f))); // 1.75 isn't enough when size=5.
+		if (size + 3 >= items.length) items = resize(Math.max(9, (int)(size * 1.75f)));
 		items[size] = value1;
 		items[size + 1] = value2;
 		items[size + 2] = value3;
 		items[size + 3] = value4;
 		size += 4;
+	}
+
+	public void add (T value1, T value2, T value3, T value4, T value5) {
+		T[] items = this.items;
+		if (size + 4 >= items.length) items = resize(Math.max(11, (int)(size * 1.75f)));
+		items[size] = value1;
+		items[size + 1] = value2;
+		items[size + 2] = value3;
+		items[size + 3] = value4;
+		items[size + 4] = value5;
+		size += 5;
+	}
+
+	public void add (T value1, T value2, T value3, T value4, T value5, T value6) {
+		T[] items = this.items;
+		if (size + 5 >= items.length) items = resize(Math.max(13, (int)(size * 1.75f)));
+		items[size] = value1;
+		items[size + 1] = value2;
+		items[size + 2] = value3;
+		items[size + 3] = value4;
+		items[size + 4] = value5;
+		items[size + 5] = value6;
+		size += 6;
+	}
+
+	public void add (T value1, T value2, T value3, T value4, T value5, T value6, T value7) {
+		T[] items = this.items;
+		if (size + 6 >= items.length) items = resize(Math.max(16, (int)(size * 1.75f)));
+		items[size] = value1;
+		items[size + 1] = value2;
+		items[size + 2] = value3;
+		items[size + 3] = value4;
+		items[size + 4] = value5;
+		items[size + 5] = value6;
+		items[size + 6] = value7;
+		size += 7;
+	}
+
+	public void add (T value1, T value2, T value3, T value4, T value5, T value6, T value7, T value8) {
+		T[] items = this.items;
+		if (size + 7 >= items.length) items = resize(Math.max(18, (int)(size * 1.75f)));
+		items[size] = value1;
+		items[size + 1] = value2;
+		items[size + 2] = value3;
+		items[size + 3] = value4;
+		items[size + 4] = value5;
+		items[size + 5] = value6;
+		items[size + 6] = value7;
+		items[size + 7] = value8;
+		size += 8;
 	}
 
 	public void addAll (Array<? extends T> array) {

--- a/gdx/src/com/badlogic/gdx/utils/Array.java
+++ b/gdx/src/com/badlogic/gdx/utils/Array.java
@@ -381,8 +381,7 @@ public class Array<T> implements Iterable<T> {
 			int i = Math.max(lastIndex, end + 1);
 			System.arraycopy(items, i, items, start, n - i);
 		}
-		for (int i = lastIndex; i < n; i++)
-			items[i] = null;
+		Arrays.fill(items, lastIndex, n, null);
 		size = n - count;
 	}
 
@@ -573,8 +572,7 @@ public class Array<T> implements Iterable<T> {
 	public void truncate (int newSize) {
 		if (newSize < 0) throw new IllegalArgumentException("newSize must be >= 0: " + newSize);
 		if (size <= newSize) return;
-		for (int i = newSize; i < size; i++)
-			items[i] = null;
+		Arrays.fill(items, newSize, size, null);
 		size = newSize;
 	}
 

--- a/gdx/src/com/badlogic/gdx/utils/BooleanArray.java
+++ b/gdx/src/com/badlogic/gdx/utils/BooleanArray.java
@@ -99,12 +99,64 @@ public class BooleanArray {
 
 	public void add (boolean value1, boolean value2, boolean value3, boolean value4) {
 		boolean[] items = this.items;
-		if (size + 3 >= items.length) items = resize(Math.max(8, (int)(size * 1.8f))); // 1.75 isn't enough when size=5.
+		if (size + 3 >= items.length) items = resize(Math.max(9, (int)(size * 1.75f)));
 		items[size] = value1;
 		items[size + 1] = value2;
 		items[size + 2] = value3;
 		items[size + 3] = value4;
 		size += 4;
+	}
+
+	public void add (boolean value1, boolean value2, boolean value3, boolean value4, boolean value5) {
+		boolean[] items = this.items;
+		if (size + 4 >= items.length) items = resize(Math.max(11, (int)(size * 1.75f)));
+		items[size] = value1;
+		items[size + 1] = value2;
+		items[size + 2] = value3;
+		items[size + 3] = value4;
+		items[size + 4] = value5;
+		size += 5;
+	}
+
+	public void add (boolean value1, boolean value2, boolean value3, boolean value4, boolean value5, boolean value6) {
+		boolean[] items = this.items;
+		if (size + 5 >= items.length) items = resize(Math.max(13, (int)(size * 1.75f)));
+		items[size] = value1;
+		items[size + 1] = value2;
+		items[size + 2] = value3;
+		items[size + 3] = value4;
+		items[size + 4] = value5;
+		items[size + 5] = value6;
+		size += 6;
+	}
+
+	public void add (boolean value1, boolean value2, boolean value3, boolean value4, boolean value5, boolean value6,
+		boolean value7) {
+		boolean[] items = this.items;
+		if (size + 6 >= items.length) items = resize(Math.max(16, (int)(size * 1.75f)));
+		items[size] = value1;
+		items[size + 1] = value2;
+		items[size + 2] = value3;
+		items[size + 3] = value4;
+		items[size + 4] = value5;
+		items[size + 5] = value6;
+		items[size + 6] = value7;
+		size += 7;
+	}
+
+	public void add (boolean value1, boolean value2, boolean value3, boolean value4, boolean value5, boolean value6,
+		boolean value7, boolean value8) {
+		boolean[] items = this.items;
+		if (size + 7 >= items.length) items = resize(Math.max(18, (int)(size * 1.75f)));
+		items[size] = value1;
+		items[size + 1] = value2;
+		items[size + 2] = value3;
+		items[size + 3] = value4;
+		items[size + 4] = value5;
+		items[size + 5] = value6;
+		items[size + 6] = value7;
+		items[size + 7] = value8;
+		size += 8;
 	}
 
 	public void addAll (BooleanArray array) {

--- a/gdx/src/com/badlogic/gdx/utils/ByteArray.java
+++ b/gdx/src/com/badlogic/gdx/utils/ByteArray.java
@@ -97,12 +97,62 @@ public class ByteArray {
 
 	public void add (byte value1, byte value2, byte value3, byte value4) {
 		byte[] items = this.items;
-		if (size + 3 >= items.length) items = resize(Math.max(8, (int)(size * 1.8f))); // 1.75 isn't enough when size=5.
+		if (size + 3 >= items.length) items = resize(Math.max(9, (int)(size * 1.75f)));
 		items[size] = value1;
 		items[size + 1] = value2;
 		items[size + 2] = value3;
 		items[size + 3] = value4;
 		size += 4;
+	}
+
+	public void add (byte value1, byte value2, byte value3, byte value4, byte value5) {
+		byte[] items = this.items;
+		if (size + 4 >= items.length) items = resize(Math.max(11, (int)(size * 1.75f)));
+		items[size] = value1;
+		items[size + 1] = value2;
+		items[size + 2] = value3;
+		items[size + 3] = value4;
+		items[size + 4] = value5;
+		size += 5;
+	}
+
+	public void add (byte value1, byte value2, byte value3, byte value4, byte value5, byte value6) {
+		byte[] items = this.items;
+		if (size + 5 >= items.length) items = resize(Math.max(13, (int)(size * 1.75f)));
+		items[size] = value1;
+		items[size + 1] = value2;
+		items[size + 2] = value3;
+		items[size + 3] = value4;
+		items[size + 4] = value5;
+		items[size + 5] = value6;
+		size += 6;
+	}
+
+	public void add (byte value1, byte value2, byte value3, byte value4, byte value5, byte value6, byte value7) {
+		byte[] items = this.items;
+		if (size + 6 >= items.length) items = resize(Math.max(16, (int)(size * 1.75f)));
+		items[size] = value1;
+		items[size + 1] = value2;
+		items[size + 2] = value3;
+		items[size + 3] = value4;
+		items[size + 4] = value5;
+		items[size + 5] = value6;
+		items[size + 6] = value7;
+		size += 7;
+	}
+
+	public void add (byte value1, byte value2, byte value3, byte value4, byte value5, byte value6, byte value7, byte value8) {
+		byte[] items = this.items;
+		if (size + 7 >= items.length) items = resize(Math.max(18, (int)(size * 1.75f)));
+		items[size] = value1;
+		items[size + 1] = value2;
+		items[size + 2] = value3;
+		items[size + 3] = value4;
+		items[size + 4] = value5;
+		items[size + 5] = value6;
+		items[size + 6] = value7;
+		items[size + 7] = value8;
+		size += 8;
 	}
 
 	public void addAll (ByteArray array) {

--- a/gdx/src/com/badlogic/gdx/utils/CharArray.java
+++ b/gdx/src/com/badlogic/gdx/utils/CharArray.java
@@ -177,6 +177,56 @@ public class CharArray implements CharSequence, Appendable {
 		size += 4;
 	}
 
+	public void add (char value1, char value2, char value3, char value4, char value5) {
+		if (size + 4 >= items.length) resizeBuffer(size + 5);
+		char[] items = this.items;
+		items[size] = value1;
+		items[size + 1] = value2;
+		items[size + 2] = value3;
+		items[size + 3] = value4;
+		items[size + 4] = value5;
+		size += 5;
+	}
+
+	public void add (char value1, char value2, char value3, char value4, char value5, char value6) {
+		if (size + 5 >= items.length) resizeBuffer(size + 6);
+		char[] items = this.items;
+		items[size] = value1;
+		items[size + 1] = value2;
+		items[size + 2] = value3;
+		items[size + 3] = value4;
+		items[size + 4] = value5;
+		items[size + 5] = value6;
+		size += 6;
+	}
+
+	public void add (char value1, char value2, char value3, char value4, char value5, char value6, char value7) {
+		if (size + 6 >= items.length) resizeBuffer(size + 7);
+		char[] items = this.items;
+		items[size] = value1;
+		items[size + 1] = value2;
+		items[size + 2] = value3;
+		items[size + 3] = value4;
+		items[size + 4] = value5;
+		items[size + 5] = value6;
+		items[size + 6] = value7;
+		size += 7;
+	}
+
+	public void add (char value1, char value2, char value3, char value4, char value5, char value6, char value7, char value8) {
+		if (size + 7 >= items.length) resizeBuffer(size + 8);
+		char[] items = this.items;
+		items[size] = value1;
+		items[size + 1] = value2;
+		items[size + 2] = value3;
+		items[size + 3] = value4;
+		items[size + 4] = value5;
+		items[size + 5] = value6;
+		items[size + 6] = value7;
+		items[size + 7] = value8;
+		size += 8;
+	}
+
 	public void addAll (CharArray array) {
 		addAll(array.items, 0, array.size);
 	}

--- a/gdx/src/com/badlogic/gdx/utils/FloatArray.java
+++ b/gdx/src/com/badlogic/gdx/utils/FloatArray.java
@@ -97,12 +97,63 @@ public class FloatArray {
 
 	public void add (float value1, float value2, float value3, float value4) {
 		float[] items = this.items;
-		if (size + 3 >= items.length) items = resize(Math.max(8, (int)(size * 1.8f))); // 1.75 isn't enough when size=5.
+		if (size + 3 >= items.length) items = resize(Math.max(9, (int)(size * 1.75f)));
 		items[size] = value1;
 		items[size + 1] = value2;
 		items[size + 2] = value3;
 		items[size + 3] = value4;
 		size += 4;
+	}
+
+	public void add (float value1, float value2, float value3, float value4, float value5) {
+		float[] items = this.items;
+		if (size + 4 >= items.length) items = resize(Math.max(11, (int)(size * 1.75f)));
+		items[size] = value1;
+		items[size + 1] = value2;
+		items[size + 2] = value3;
+		items[size + 3] = value4;
+		items[size + 4] = value5;
+		size += 5;
+	}
+
+	public void add (float value1, float value2, float value3, float value4, float value5, float value6) {
+		float[] items = this.items;
+		if (size + 5 >= items.length) items = resize(Math.max(13, (int)(size * 1.75f)));
+		items[size] = value1;
+		items[size + 1] = value2;
+		items[size + 2] = value3;
+		items[size + 3] = value4;
+		items[size + 4] = value5;
+		items[size + 5] = value6;
+		size += 6;
+	}
+
+	public void add (float value1, float value2, float value3, float value4, float value5, float value6, float value7) {
+		float[] items = this.items;
+		if (size + 6 >= items.length) items = resize(Math.max(16, (int)(size * 1.75f)));
+		items[size] = value1;
+		items[size + 1] = value2;
+		items[size + 2] = value3;
+		items[size + 3] = value4;
+		items[size + 4] = value5;
+		items[size + 5] = value6;
+		items[size + 6] = value7;
+		size += 7;
+	}
+
+	public void add (float value1, float value2, float value3, float value4, float value5, float value6, float value7,
+		float value8) {
+		float[] items = this.items;
+		if (size + 7 >= items.length) items = resize(Math.max(18, (int)(size * 1.75f)));
+		items[size] = value1;
+		items[size + 1] = value2;
+		items[size + 2] = value3;
+		items[size + 3] = value4;
+		items[size + 4] = value5;
+		items[size + 5] = value6;
+		items[size + 6] = value7;
+		items[size + 7] = value8;
+		size += 8;
 	}
 
 	public void addAll (FloatArray array) {

--- a/gdx/src/com/badlogic/gdx/utils/IntArray.java
+++ b/gdx/src/com/badlogic/gdx/utils/IntArray.java
@@ -97,12 +97,62 @@ public class IntArray {
 
 	public void add (int value1, int value2, int value3, int value4) {
 		int[] items = this.items;
-		if (size + 3 >= items.length) items = resize(Math.max(8, (int)(size * 1.8f))); // 1.75 isn't enough when size=5.
+		if (size + 3 >= items.length) items = resize(Math.max(9, (int)(size * 1.75f)));
 		items[size] = value1;
 		items[size + 1] = value2;
 		items[size + 2] = value3;
 		items[size + 3] = value4;
 		size += 4;
+	}
+
+	public void add (int value1, int value2, int value3, int value4, int value5) {
+		int[] items = this.items;
+		if (size + 4 >= items.length) items = resize(Math.max(11, (int)(size * 1.75f)));
+		items[size] = value1;
+		items[size + 1] = value2;
+		items[size + 2] = value3;
+		items[size + 3] = value4;
+		items[size + 4] = value5;
+		size += 5;
+	}
+
+	public void add (int value1, int value2, int value3, int value4, int value5, int value6) {
+		int[] items = this.items;
+		if (size + 5 >= items.length) items = resize(Math.max(13, (int)(size * 1.75f)));
+		items[size] = value1;
+		items[size + 1] = value2;
+		items[size + 2] = value3;
+		items[size + 3] = value4;
+		items[size + 4] = value5;
+		items[size + 5] = value6;
+		size += 6;
+	}
+
+	public void add (int value1, int value2, int value3, int value4, int value5, int value6, int value7) {
+		int[] items = this.items;
+		if (size + 6 >= items.length) items = resize(Math.max(16, (int)(size * 1.75f)));
+		items[size] = value1;
+		items[size + 1] = value2;
+		items[size + 2] = value3;
+		items[size + 3] = value4;
+		items[size + 4] = value5;
+		items[size + 5] = value6;
+		items[size + 6] = value7;
+		size += 7;
+	}
+
+	public void add (int value1, int value2, int value3, int value4, int value5, int value6, int value7, int value8) {
+		int[] items = this.items;
+		if (size + 7 >= items.length) items = resize(Math.max(18, (int)(size * 1.75f)));
+		items[size] = value1;
+		items[size + 1] = value2;
+		items[size + 2] = value3;
+		items[size + 3] = value4;
+		items[size + 4] = value5;
+		items[size + 5] = value6;
+		items[size + 6] = value7;
+		items[size + 7] = value8;
+		size += 8;
 	}
 
 	public void addAll (IntArray array) {

--- a/gdx/src/com/badlogic/gdx/utils/LongArray.java
+++ b/gdx/src/com/badlogic/gdx/utils/LongArray.java
@@ -97,12 +97,62 @@ public class LongArray {
 
 	public void add (long value1, long value2, long value3, long value4) {
 		long[] items = this.items;
-		if (size + 3 >= items.length) items = resize(Math.max(8, (int)(size * 1.8f))); // 1.75 isn't enough when size=5.
+		if (size + 3 >= items.length) items = resize(Math.max(9, (int)(size * 1.75f)));
 		items[size] = value1;
 		items[size + 1] = value2;
 		items[size + 2] = value3;
 		items[size + 3] = value4;
 		size += 4;
+	}
+
+	public void add (long value1, long value2, long value3, long value4, long value5) {
+		long[] items = this.items;
+		if (size + 4 >= items.length) items = resize(Math.max(11, (int)(size * 1.75f)));
+		items[size] = value1;
+		items[size + 1] = value2;
+		items[size + 2] = value3;
+		items[size + 3] = value4;
+		items[size + 4] = value5;
+		size += 5;
+	}
+
+	public void add (long value1, long value2, long value3, long value4, long value5, long value6) {
+		long[] items = this.items;
+		if (size + 5 >= items.length) items = resize(Math.max(13, (int)(size * 1.75f)));
+		items[size] = value1;
+		items[size + 1] = value2;
+		items[size + 2] = value3;
+		items[size + 3] = value4;
+		items[size + 4] = value5;
+		items[size + 5] = value6;
+		size += 6;
+	}
+
+	public void add (long value1, long value2, long value3, long value4, long value5, long value6, long value7) {
+		long[] items = this.items;
+		if (size + 6 >= items.length) items = resize(Math.max(16, (int)(size * 1.75f)));
+		items[size] = value1;
+		items[size + 1] = value2;
+		items[size + 2] = value3;
+		items[size + 3] = value4;
+		items[size + 4] = value5;
+		items[size + 5] = value6;
+		items[size + 6] = value7;
+		size += 7;
+	}
+
+	public void add (long value1, long value2, long value3, long value4, long value5, long value6, long value7, long value8) {
+		long[] items = this.items;
+		if (size + 7 >= items.length) items = resize(Math.max(18, (int)(size * 1.75f)));
+		items[size] = value1;
+		items[size + 1] = value2;
+		items[size + 2] = value3;
+		items[size + 3] = value4;
+		items[size + 4] = value5;
+		items[size + 5] = value6;
+		items[size + 6] = value7;
+		items[size + 7] = value8;
+		size += 8;
 	}
 
 	public void addAll (LongArray array) {

--- a/gdx/src/com/badlogic/gdx/utils/Queue.java
+++ b/gdx/src/com/badlogic/gdx/utils/Queue.java
@@ -317,17 +317,11 @@ public class Queue<T> implements Iterable<T> {
 
 		if (head < tail) {
 			// Continuous
-			for (int i = head; i < tail; i++) {
-				values[i] = null;
-			}
+			Arrays.fill(values, head, tail, null);
 		} else {
 			// Wrapped
-			for (int i = head; i < values.length; i++) {
-				values[i] = null;
-			}
-			for (int i = 0; i < tail; i++) {
-				values[i] = null;
-			}
+			Arrays.fill(values, head, values.length, null);
+			Arrays.fill(values, 0, tail, null);
 		}
 		this.head = 0;
 		this.tail = 0;

--- a/gdx/src/com/badlogic/gdx/utils/ShortArray.java
+++ b/gdx/src/com/badlogic/gdx/utils/ShortArray.java
@@ -104,12 +104,63 @@ public class ShortArray {
 
 	public void add (short value1, short value2, short value3, short value4) {
 		short[] items = this.items;
-		if (size + 3 >= items.length) items = resize(Math.max(8, (int)(size * 1.8f))); // 1.75 isn't enough when size=5.
+		if (size + 3 >= items.length) items = resize(Math.max(9, (int)(size * 1.75f)));
 		items[size] = value1;
 		items[size + 1] = value2;
 		items[size + 2] = value3;
 		items[size + 3] = value4;
 		size += 4;
+	}
+
+	public void add (short value1, short value2, short value3, short value4, short value5) {
+		short[] items = this.items;
+		if (size + 4 >= items.length) items = resize(Math.max(11, (int)(size * 1.75f)));
+		items[size] = value1;
+		items[size + 1] = value2;
+		items[size + 2] = value3;
+		items[size + 3] = value4;
+		items[size + 4] = value5;
+		size += 5;
+	}
+
+	public void add (short value1, short value2, short value3, short value4, short value5, short value6) {
+		short[] items = this.items;
+		if (size + 5 >= items.length) items = resize(Math.max(13, (int)(size * 1.75f)));
+		items[size] = value1;
+		items[size + 1] = value2;
+		items[size + 2] = value3;
+		items[size + 3] = value4;
+		items[size + 4] = value5;
+		items[size + 5] = value6;
+		size += 6;
+	}
+
+	public void add (short value1, short value2, short value3, short value4, short value5, short value6, short value7) {
+		short[] items = this.items;
+		if (size + 6 >= items.length) items = resize(Math.max(16, (int)(size * 1.75f)));
+		items[size] = value1;
+		items[size + 1] = value2;
+		items[size + 2] = value3;
+		items[size + 3] = value4;
+		items[size + 4] = value5;
+		items[size + 5] = value6;
+		items[size + 6] = value7;
+		size += 7;
+	}
+
+	public void add (short value1, short value2, short value3, short value4, short value5, short value6, short value7,
+		short value8) {
+		short[] items = this.items;
+		if (size + 7 >= items.length) items = resize(Math.max(18, (int)(size * 1.75f)));
+		items[size] = value1;
+		items[size + 1] = value2;
+		items[size + 2] = value3;
+		items[size + 3] = value4;
+		items[size + 4] = value5;
+		items[size + 5] = value6;
+		items[size + 6] = value7;
+		items[size + 7] = value8;
+		size += 8;
 	}
 
 	public void addAll (ShortArray array) {


### PR DESCRIPTION
This adds `add()` methods with 5-8 parameters to all arrays. Occasionally I'm annoyed it doesn't go up to 8. Adds a little clutter but is convenient.

FWIW, MeshBuilder has 1-4,6,8.