### PR TITLE
Allow ShaderProgram to use an explicit Application

### DIFF
--- a/gdx/src/com/badlogic/gdx/graphics/glutils/ShaderProgram.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/ShaderProgram.java
@@ -148,18 +148,36 @@ public class ShaderProgram implements Disposable {
 	/** reference count **/
 	private int refCount = 0;
 
+	/** application this shader is managed by and resolves GL from **/
+	private final Application app;
+
+	private GL20 gl20 () {
+		return app.getGraphics().getGL20();
+	}
+
 	/** Constructs a new ShaderProgram and immediately compiles it.
 	 *
 	 * @param vertexShader the vertex shader
 	 * @param fragmentShader the fragment shader */
 
 	public ShaderProgram (String vertexShader, String fragmentShader) {
+		this(Gdx.app, vertexShader, fragmentShader);
+	}
+
+	/** Constructs a new ShaderProgram and immediately compiles it.
+	 *
+	 * @param app the application used to resolve the current GL20 instance and manage this shader
+	 * @param vertexShader the vertex shader
+	 * @param fragmentShader the fragment shader */
+	public ShaderProgram (Application app, String vertexShader, String fragmentShader) {
+		if (app == null) throw new IllegalArgumentException("application must not be null");
 		if (vertexShader == null) throw new IllegalArgumentException("vertex shader must not be null");
 		if (fragmentShader == null) throw new IllegalArgumentException("fragment shader must not be null");
 
 		if (prependVertexCode != null && prependVertexCode.length() > 0) vertexShader = prependVertexCode + vertexShader;
 		if (prependFragmentCode != null && prependFragmentCode.length() > 0) fragmentShader = prependFragmentCode + fragmentShader;
 
+		this.app = app;
 		this.vertexShaderSource = vertexShader;
 		this.fragmentShaderSource = fragmentShader;
 		this.matrix = BufferUtils.newFloatBuffer(16);
@@ -168,12 +186,16 @@ public class ShaderProgram implements Disposable {
 		if (isCompiled()) {
 			fetchAttributes();
 			fetchUniforms();
-			addManagedShader(Gdx.app, this);
+			addManagedShader(app, this);
 		}
 	}
 
 	public ShaderProgram (FileHandle vertexShader, FileHandle fragmentShader) {
-		this(vertexShader.readString(), fragmentShader.readString());
+		this(Gdx.app, vertexShader, fragmentShader);
+	}
+
+	public ShaderProgram (Application app, FileHandle vertexShader, FileHandle fragmentShader) {
+		this(app, vertexShader.readString(), fragmentShader.readString());
 	}
 
 	/** Loads and compiles the shaders, creates a new program and links the shaders.
@@ -199,7 +221,7 @@ public class ShaderProgram implements Disposable {
 	}
 
 	private int loadShader (int type, String source) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		IntBuffer intbuf = BufferUtils.newIntBuffer(1);
 
 		int shader = gl.glCreateShader(type);
@@ -225,13 +247,13 @@ public class ShaderProgram implements Disposable {
 	}
 
 	protected int createProgram () {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		int program = gl.glCreateProgram();
 		return program != 0 ? program : -1;
 	}
 
 	private int linkProgram (int program) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		if (program == -1) return -1;
 
 		gl.glAttachShader(program, vertexShaderHandle);
@@ -248,7 +270,7 @@ public class ShaderProgram implements Disposable {
 // Gdx.gl20.glGetProgramiv(program, GL20.GL_INFO_LOG_LENGTH, intbuf);
 // int infoLogLength = intbuf.get(0);
 // if (infoLogLength > 1) {
-			log = Gdx.gl20.glGetProgramInfoLog(program);
+			log = gl20().glGetProgramInfoLog(program);
 // }
 			return -1;
 		}
@@ -265,7 +287,7 @@ public class ShaderProgram implements Disposable {
 // Gdx.gl20.glGetProgramiv(program, GL20.GL_INFO_LOG_LENGTH, intbuf);
 // int infoLogLength = intbuf.get(0);
 // if (infoLogLength > 1) {
-			log = Gdx.gl20.glGetProgramInfoLog(program);
+			log = gl20().glGetProgramInfoLog(program);
 // }
 			return log;
 		} else {
@@ -279,7 +301,7 @@ public class ShaderProgram implements Disposable {
 	}
 
 	private int fetchAttributeLocation (String name) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		// -2 == not yet cached
 		// -1 == cached but not found
 		int location;
@@ -299,7 +321,7 @@ public class ShaderProgram implements Disposable {
 		// -1 == cached but not found
 		int location;
 		if ((location = uniforms.get(name, -2)) == -2) {
-			location = Gdx.gl20.glGetUniformLocation(program, name);
+			location = gl20().glGetUniformLocation(program, name);
 			if (location == -1 && pedantic) {
 				if (isCompiled) throw new IllegalArgumentException("No uniform with name '" + name + "' in shader");
 				throw new IllegalStateException("An attempted fetch uniform from uncompiled shader \n" + getLog());
@@ -314,14 +336,14 @@ public class ShaderProgram implements Disposable {
 	 * @param name the name of the uniform
 	 * @param value the value */
 	public void setUniformi (String name, int value) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		int location = fetchUniformLocation(name);
 		gl.glUniform1i(location, value);
 	}
 
 	public void setUniformi (int location, int value) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		gl.glUniform1i(location, value);
 	}
@@ -332,14 +354,14 @@ public class ShaderProgram implements Disposable {
 	 * @param value1 the first value
 	 * @param value2 the second value */
 	public void setUniformi (String name, int value1, int value2) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		int location = fetchUniformLocation(name);
 		gl.glUniform2i(location, value1, value2);
 	}
 
 	public void setUniformi (int location, int value1, int value2) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		gl.glUniform2i(location, value1, value2);
 	}
@@ -351,14 +373,14 @@ public class ShaderProgram implements Disposable {
 	 * @param value2 the second value
 	 * @param value3 the third value */
 	public void setUniformi (String name, int value1, int value2, int value3) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		int location = fetchUniformLocation(name);
 		gl.glUniform3i(location, value1, value2, value3);
 	}
 
 	public void setUniformi (int location, int value1, int value2, int value3) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		gl.glUniform3i(location, value1, value2, value3);
 	}
@@ -371,66 +393,66 @@ public class ShaderProgram implements Disposable {
 	 * @param value3 the third value
 	 * @param value4 the fourth value */
 	public void setUniformi (String name, int value1, int value2, int value3, int value4) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		int location = fetchUniformLocation(name);
 		gl.glUniform4i(location, value1, value2, value3, value4);
 	}
 
 	public void setUniformi (int location, int value1, int value2, int value3, int value4) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		gl.glUniform4i(location, value1, value2, value3, value4);
 	}
 
 	public void setUniform1iv (String name, int[] values, int offset, int length) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		int location = fetchUniformLocation(name);
 		gl.glUniform1iv(location, length, values, offset);
 	}
 
 	public void setUniform1iv (int location, int[] values, int offset, int length) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		gl.glUniform1iv(location, length, values, offset);
 	}
 
 	public void setUniform2iv (String name, int[] values, int offset, int length) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		int location = fetchUniformLocation(name);
 		gl.glUniform2iv(location, length / 2, values, offset);
 	}
 
 	public void setUniform2iv (int location, int[] values, int offset, int length) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		gl.glUniform2iv(location, length / 2, values, offset);
 	}
 
 	public void setUniform3iv (String name, int[] values, int offset, int length) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		int location = fetchUniformLocation(name);
 		gl.glUniform3iv(location, length / 3, values, offset);
 	}
 
 	public void setUniform3iv (int location, int[] values, int offset, int length) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		gl.glUniform3iv(location, length / 3, values, offset);
 	}
 
 	public void setUniform4iv (String name, int[] values, int offset, int length) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		int location = fetchUniformLocation(name);
 		gl.glUniform4iv(location, length / 4, values, offset);
 	}
 
 	public void setUniform4iv (int location, int[] values, int offset, int length) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		gl.glUniform4iv(location, length / 4, values, offset);
 	}
@@ -440,14 +462,14 @@ public class ShaderProgram implements Disposable {
 	 * @param name the name of the uniform
 	 * @param value the value */
 	public void setUniformf (String name, float value) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		int location = fetchUniformLocation(name);
 		gl.glUniform1f(location, value);
 	}
 
 	public void setUniformf (int location, float value) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		gl.glUniform1f(location, value);
 	}
@@ -458,14 +480,14 @@ public class ShaderProgram implements Disposable {
 	 * @param value1 the first value
 	 * @param value2 the second value */
 	public void setUniformf (String name, float value1, float value2) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		int location = fetchUniformLocation(name);
 		gl.glUniform2f(location, value1, value2);
 	}
 
 	public void setUniformf (int location, float value1, float value2) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		gl.glUniform2f(location, value1, value2);
 	}
@@ -477,14 +499,14 @@ public class ShaderProgram implements Disposable {
 	 * @param value2 the second value
 	 * @param value3 the third value */
 	public void setUniformf (String name, float value1, float value2, float value3) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		int location = fetchUniformLocation(name);
 		gl.glUniform3f(location, value1, value2, value3);
 	}
 
 	public void setUniformf (int location, float value1, float value2, float value3) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		gl.glUniform3f(location, value1, value2, value3);
 	}
@@ -497,66 +519,66 @@ public class ShaderProgram implements Disposable {
 	 * @param value3 the third value
 	 * @param value4 the fourth value */
 	public void setUniformf (String name, float value1, float value2, float value3, float value4) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		int location = fetchUniformLocation(name);
 		gl.glUniform4f(location, value1, value2, value3, value4);
 	}
 
 	public void setUniformf (int location, float value1, float value2, float value3, float value4) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		gl.glUniform4f(location, value1, value2, value3, value4);
 	}
 
 	public void setUniform1fv (String name, float[] values, int offset, int length) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		int location = fetchUniformLocation(name);
 		gl.glUniform1fv(location, length, values, offset);
 	}
 
 	public void setUniform1fv (int location, float[] values, int offset, int length) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		gl.glUniform1fv(location, length, values, offset);
 	}
 
 	public void setUniform2fv (String name, float[] values, int offset, int length) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		int location = fetchUniformLocation(name);
 		gl.glUniform2fv(location, length / 2, values, offset);
 	}
 
 	public void setUniform2fv (int location, float[] values, int offset, int length) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		gl.glUniform2fv(location, length / 2, values, offset);
 	}
 
 	public void setUniform3fv (String name, float[] values, int offset, int length) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		int location = fetchUniformLocation(name);
 		gl.glUniform3fv(location, length / 3, values, offset);
 	}
 
 	public void setUniform3fv (int location, float[] values, int offset, int length) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		gl.glUniform3fv(location, length / 3, values, offset);
 	}
 
 	public void setUniform4fv (String name, float[] values, int offset, int length) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		int location = fetchUniformLocation(name);
 		gl.glUniform4fv(location, length / 4, values, offset);
 	}
 
 	public void setUniform4fv (int location, float[] values, int offset, int length) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		gl.glUniform4fv(location, length / 4, values, offset);
 	}
@@ -583,7 +605,7 @@ public class ShaderProgram implements Disposable {
 	}
 
 	public void setUniformMatrix (int location, Matrix4 matrix, boolean transpose) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		gl.glUniformMatrix4fv(location, 1, transpose, matrix.val, 0);
 	}
@@ -610,7 +632,7 @@ public class ShaderProgram implements Disposable {
 	}
 
 	public void setUniformMatrix (int location, Matrix3 matrix, boolean transpose) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		gl.glUniformMatrix3fv(location, 1, transpose, matrix.val, 0);
 	}
@@ -621,7 +643,7 @@ public class ShaderProgram implements Disposable {
 	 * @param buffer buffer containing the matrix data
 	 * @param transpose whether the uniform matrix should be transposed */
 	public void setUniformMatrix3fv (String name, FloatBuffer buffer, int count, boolean transpose) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		((Buffer)buffer).position(0);
 		int location = fetchUniformLocation(name);
@@ -634,7 +656,7 @@ public class ShaderProgram implements Disposable {
 	 * @param buffer buffer containing the matrix data
 	 * @param transpose whether the uniform matrix should be transposed */
 	public void setUniformMatrix4fv (String name, FloatBuffer buffer, int count, boolean transpose) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		((Buffer)buffer).position(0);
 		int location = fetchUniformLocation(name);
@@ -642,7 +664,7 @@ public class ShaderProgram implements Disposable {
 	}
 
 	public void setUniformMatrix4fv (int location, float[] values, int offset, int length) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		gl.glUniformMatrix4fv(location, length / 16, false, values, offset);
 	}
@@ -709,7 +731,7 @@ public class ShaderProgram implements Disposable {
 	 * @param stride the stride in bytes between successive attributes
 	 * @param buffer the buffer containing the vertex attributes. */
 	public void setVertexAttribute (String name, int size, int type, boolean normalize, int stride, Buffer buffer) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		int location = fetchAttributeLocation(name);
 		if (location == -1) return;
@@ -717,7 +739,7 @@ public class ShaderProgram implements Disposable {
 	}
 
 	public void setVertexAttribute (int location, int size, int type, boolean normalize, int stride, Buffer buffer) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		gl.glVertexAttribPointer(location, size, type, normalize, stride, buffer);
 	}
@@ -732,7 +754,7 @@ public class ShaderProgram implements Disposable {
 	 * @param stride the stride in bytes between successive attributes
 	 * @param offset byte offset into the vertex buffer object bound to GL20.GL_ARRAY_BUFFER. */
 	public void setVertexAttribute (String name, int size, int type, boolean normalize, int stride, int offset) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		int location = fetchAttributeLocation(name);
 		if (location == -1) return;
@@ -740,7 +762,7 @@ public class ShaderProgram implements Disposable {
 	}
 
 	public void setVertexAttribute (int location, int size, int type, boolean normalize, int stride, int offset) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		gl.glVertexAttribPointer(location, size, type, normalize, stride, offset);
 	}
@@ -752,7 +774,7 @@ public class ShaderProgram implements Disposable {
 	}
 
 	public void bind () {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		gl.glUseProgram(program);
 	}
@@ -764,19 +786,19 @@ public class ShaderProgram implements Disposable {
 
 	/** Disposes all resources associated with this shader. Must be called when the shader is no longer used. */
 	public void dispose () {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		gl.glUseProgram(0);
 		gl.glDeleteShader(vertexShaderHandle);
 		gl.glDeleteShader(fragmentShaderHandle);
 		gl.glDeleteProgram(program);
-		if (shaders.get(Gdx.app) != null) shaders.get(Gdx.app).removeValue(this, true);
+		if (shaders.get(app) != null) shaders.get(app).removeValue(this, true);
 	}
 
 	/** Disables the vertex attribute with the given name
 	 *
 	 * @param name the vertex attribute name */
 	public void disableVertexAttribute (String name) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		int location = fetchAttributeLocation(name);
 		if (location == -1) return;
@@ -784,7 +806,7 @@ public class ShaderProgram implements Disposable {
 	}
 
 	public void disableVertexAttribute (int location) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		gl.glDisableVertexAttribArray(location);
 	}
@@ -793,7 +815,7 @@ public class ShaderProgram implements Disposable {
 	 *
 	 * @param name the vertex attribute name */
 	public void enableVertexAttribute (String name) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		int location = fetchAttributeLocation(name);
 		if (location == -1) return;
@@ -801,7 +823,7 @@ public class ShaderProgram implements Disposable {
 	}
 
 	public void enableVertexAttribute (int location) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		gl.glEnableVertexAttribArray(location);
 	}
@@ -823,7 +845,7 @@ public class ShaderProgram implements Disposable {
 	/** Invalidates all shaders so the next time they are used new handles are generated
 	 * @param app */
 	public static void invalidateAllShaderPrograms (Application app) {
-		if (Gdx.gl20 == null) return;
+		if (app.getGraphics().getGL20() == null) return;
 
 		Array<ShaderProgram> shaderArray = shaders.get(app);
 		if (shaderArray == null) return;
@@ -852,7 +874,12 @@ public class ShaderProgram implements Disposable {
 
 	/** @return the number of managed shader programs currently loaded */
 	public static int getNumManagedShaderPrograms () {
-		return shaders.get(Gdx.app).size;
+		return getNumManagedShaderPrograms(Gdx.app);
+	}
+
+	/** @return the number of managed shader programs currently loaded for the given application */
+	public static int getNumManagedShaderPrograms (Application app) {
+		return shaders.get(app).size;
 	}
 
 	/** Sets the given attribute
@@ -863,7 +890,7 @@ public class ShaderProgram implements Disposable {
 	 * @param value3 the third value
 	 * @param value4 the fourth value */
 	public void setAttributef (String name, float value1, float value2, float value3, float value4) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		int location = fetchAttributeLocation(name);
 		gl.glVertexAttrib4f(location, value1, value2, value3, value4);
 	}
@@ -872,8 +899,9 @@ public class ShaderProgram implements Disposable {
 	IntBuffer type = BufferUtils.newIntBuffer(1);
 
 	private void fetchUniforms () {
+		GL20 gl = gl20();
 		((Buffer)params).clear();
-		Gdx.gl20.glGetProgramiv(program, GL20.GL_ACTIVE_UNIFORMS, params);
+		gl.glGetProgramiv(program, GL20.GL_ACTIVE_UNIFORMS, params);
 		int numUniforms = params.get(0);
 
 		uniformNames = new String[numUniforms];
@@ -882,8 +910,8 @@ public class ShaderProgram implements Disposable {
 			((Buffer)params).clear();
 			params.put(0, 1);
 			((Buffer)type).clear();
-			String name = Gdx.gl20.glGetActiveUniform(program, i, params, type);
-			int location = Gdx.gl20.glGetUniformLocation(program, name);
+			String name = gl.glGetActiveUniform(program, i, params, type);
+			int location = gl.glGetUniformLocation(program, name);
 			uniforms.put(name, location);
 			uniformTypes.put(name, type.get(0));
 			uniformSizes.put(name, params.get(0));
@@ -892,8 +920,9 @@ public class ShaderProgram implements Disposable {
 	}
 
 	private void fetchAttributes () {
+		GL20 gl = gl20();
 		((Buffer)params).clear();
-		Gdx.gl20.glGetProgramiv(program, GL20.GL_ACTIVE_ATTRIBUTES, params);
+		gl.glGetProgramiv(program, GL20.GL_ACTIVE_ATTRIBUTES, params);
 		int numAttributes = params.get(0);
 
 		attributeNames = new String[numAttributes];
@@ -902,8 +931,8 @@ public class ShaderProgram implements Disposable {
 			((Buffer)params).clear();
 			params.put(0, 1);
 			((Buffer)type).clear();
-			String name = Gdx.gl20.glGetActiveAttrib(program, i, params, type);
-			int location = Gdx.gl20.glGetAttribLocation(program, name);
+			String name = gl.glGetActiveAttrib(program, i, params, type);
+			int location = gl.glGetAttribLocation(program, name);
 			attributes.put(name, location);
 			attributeTypes.put(name, type.get(0));
 			attributeSizes.put(name, params.get(0));


### PR DESCRIPTION
  ShaderProgram currently relies on global `Gdx.app` / `Gdx.gl20`. I want to pass Application explicitly so I can manage my own application lifecycle without depending on global state.

  Add optional Application-accepting constructors to ShaderProgram. When an Application is supplied it is used to register the managed shader and to resolve the current GL20 via
  `app.getGraphics().getGL20()` (read on each use, so context recreation / backend GL replacement still works).

  The existing constructors delegate through `Gdx.app`, so current code is unchanged.