### PR TITLE
Make iOSPreferences flush atomic

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,6 @@
 [1.14.3]
 - API Addition: add() with 5-8 parameters for arrays.
-- iOS: Made iOS Preferences flush() implementation atomic and asynchronous (see #7833)
+- iOS: Made iOS Preferences flush() implementation atomic (see #7833)
 
 [1.14.2]
 - [BREAKING CHANGE] Revert InputMultiplexer and set addAll return types that were breaking changes in 1.14.1. #7805

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,6 @@
 [1.14.3]
 - API Addition: add() with 5-8 parameters for arrays.
+- iOS: Made iOS Preferences flush() implementation atomic and asynchronous (see #7833)
 
 [1.14.2]
 - [BREAKING CHANGE] Revert InputMultiplexer and set addAll return types that were breaking changes in 1.14.1. #7805

--- a/backends/gdx-backend-robovm-metalangle/src/com/badlogic/gdx/backends/iosrobovm/IOSPreferences.java
+++ b/backends/gdx-backend-robovm-metalangle/src/com/badlogic/gdx/backends/iosrobovm/IOSPreferences.java
@@ -6,9 +6,7 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import org.robovm.apple.dispatch.DispatchQueue;
 import org.robovm.apple.foundation.NSAutoreleasePool;
-import org.robovm.apple.foundation.NSDictionary;
 import org.robovm.apple.foundation.NSMutableDictionary;
 import org.robovm.apple.foundation.NSNumber;
 import org.robovm.apple.foundation.NSObject;
@@ -174,18 +172,10 @@ public class IOSPreferences implements Preferences {
 
 	@Override
 	public void flush () {
-		// Safe to do shallow copy because dictionary only contains immutable objects
-		final NSDictionary dataToSave = (NSDictionary)nsDictionary.copy();
-		DispatchQueue.getGlobalQueue(DispatchQueue.PRIORITY_DEFAULT, 0).async(new Runnable() {
-
-			@Override
-			public void run () {
-				NSAutoreleasePool pool = new NSAutoreleasePool();
-				if (!dataToSave.write(file, true)) {
-					Gdx.app.error("IOSPreferences", "Failed to write NSDictionary atomically to " + file);
-				}
-				pool.close();
-			}
-		});
+		NSAutoreleasePool pool = new NSAutoreleasePool();
+		if (!nsDictionary.write(file, true)) {
+			Gdx.app.error("IOSPreferences", "Failed to write NSDictionary atomically to " + file);
+		}
+		pool.close();
 	}
 }

--- a/backends/gdx-backend-robovm-metalangle/src/com/badlogic/gdx/backends/iosrobovm/IOSPreferences.java
+++ b/backends/gdx-backend-robovm-metalangle/src/com/badlogic/gdx/backends/iosrobovm/IOSPreferences.java
@@ -6,7 +6,9 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import org.robovm.apple.dispatch.DispatchQueue;
 import org.robovm.apple.foundation.NSAutoreleasePool;
+import org.robovm.apple.foundation.NSDictionary;
 import org.robovm.apple.foundation.NSMutableDictionary;
 import org.robovm.apple.foundation.NSNumber;
 import org.robovm.apple.foundation.NSObject;
@@ -172,10 +174,18 @@ public class IOSPreferences implements Preferences {
 
 	@Override
 	public void flush () {
-		NSAutoreleasePool pool = new NSAutoreleasePool();
-		if (!nsDictionary.write(file, false)) {
-			Gdx.app.debug("IOSPreferences", "Failed to write NSDictionary to file " + file);
-		}
-		pool.close();
+		// Safe to do shallow copy because dictionary only contains immutable objects
+		final NSDictionary dataToSave = (NSDictionary)nsDictionary.copy();
+		DispatchQueue.getGlobalQueue(DispatchQueue.PRIORITY_DEFAULT, 0).async(new Runnable() {
+
+			@Override
+			public void run () {
+				NSAutoreleasePool pool = new NSAutoreleasePool();
+				if (!dataToSave.write(file, true)) {
+					Gdx.app.error("IOSPreferences", "Failed to write NSDictionary atomically to " + file);
+				}
+				pool.close();
+			}
+		});
 	}
 }

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSPreferences.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSPreferences.java
@@ -21,9 +21,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import org.robovm.apple.dispatch.DispatchQueue;
 import org.robovm.apple.foundation.NSAutoreleasePool;
-import org.robovm.apple.foundation.NSDictionary;
 import org.robovm.apple.foundation.NSMutableDictionary;
 import org.robovm.apple.foundation.NSNumber;
 import org.robovm.apple.foundation.NSObject;
@@ -187,17 +185,10 @@ public class IOSPreferences implements Preferences {
 
 	@Override
 	public void flush () {
-		// Safe to do shallow copy because dictionary only contains immutable objects
-		final NSDictionary dataToSave = (NSDictionary)nsDictionary.copy();
-		DispatchQueue.getGlobalQueue(DispatchQueue.PRIORITY_DEFAULT, 0).async(new Runnable() {
-			@Override
-			public void run () {
-				NSAutoreleasePool pool = new NSAutoreleasePool();
-				if (!dataToSave.write(file, true)) {
-					Gdx.app.error("IOSPreferences", "Failed to write NSDictionary atomically to " + file);
-				}
-				pool.close();
-			}
-		});
+		NSAutoreleasePool pool = new NSAutoreleasePool();
+		if (!nsDictionary.write(file, true)) {
+			Gdx.app.error("IOSPreferences", "Failed to write NSDictionary atomically to " + file);
+		}
+		pool.close();
 	}
 }

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSPreferences.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSPreferences.java
@@ -21,7 +21,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import org.robovm.apple.dispatch.DispatchQueue;
 import org.robovm.apple.foundation.NSAutoreleasePool;
+import org.robovm.apple.foundation.NSDictionary;
 import org.robovm.apple.foundation.NSMutableDictionary;
 import org.robovm.apple.foundation.NSNumber;
 import org.robovm.apple.foundation.NSObject;
@@ -185,10 +187,17 @@ public class IOSPreferences implements Preferences {
 
 	@Override
 	public void flush () {
-		NSAutoreleasePool pool = new NSAutoreleasePool();
-		if (!nsDictionary.write(file, false)) {
-			Gdx.app.debug("IOSPreferences", "Failed to write NSDictionary to file " + file);
-		}
-		pool.close();
+		// Safe to do shallow copy because dictionary only contains immutable objects
+		final NSDictionary dataToSave = (NSDictionary)nsDictionary.copy();
+		DispatchQueue.getGlobalQueue(DispatchQueue.PRIORITY_DEFAULT, 0).async(new Runnable() {
+			@Override
+			public void run () {
+				NSAutoreleasePool pool = new NSAutoreleasePool();
+				if (!dataToSave.write(file, true)) {
+					Gdx.app.error("IOSPreferences", "Failed to write NSDictionary atomically to " + file);
+				}
+				pool.close();
+			}
+		});
 	}
 }


### PR DESCRIPTION
`IOSPreferences` `flush` implementation, compared to Android's i neither atomic nor asynchronous. This can lead to save file corruption issues as well as performance issues due to writing occurring on main thread. This PR fixes ~~both issues.~~ atomicity.

The fix has the problem that it's still using a deprecated `NSDictionary` `write()` method under the hood. 
Current MobiVM is missing the binding for the non deprecated write method and a fix should be under way.
https://developer.apple.com/documentation/foundation/nsdictionary?language=objc#Storing-Dictionaries. In any case, even if the non deprecated method was available now it's not a simple switch as it doesn't guarantee atomicity. The solution might be to convert the `NSDictionary` to `NSData` and use the atomic write method available for that format but it will require more investigation.

So, recommended course of action would be to merge this soon while we wait for MobiVM fix and think about how to make it both non-deprecated and atomic.