### PR TITLE
Make Gdx optional via explicit Graphics (and module) injection

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,5 @@
 [1.14.3]
+- API Addition: ShaderProgram constructors that take Graphics; existing constructors use Gdx.graphics.
 - API Change: Managed GL resources (ShaderProgram, Texture, Cubemap, TextureArray, Texture3D, Mesh, GLFrameBuffer) are keyed by Graphics instead of Application.
 - API Addition: ApplicationListener#create(Application); backends call it, default delegates to create().
 - API Addition: ApplicationAdapter/Game bind graphics/audio/input/files/net/gl* from create(Application).

--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,5 @@
 [1.14.3]
+- API Addition: SpriteBatch/PolygonSpriteBatch/SpriteCache constructors that take Graphics; existing constructors use Gdx.graphics.
 - API Addition: GLFrameBuffer/FrameBuffer/FloatFrameBuffer/FrameBufferCubemap constructors and builders that take Graphics; existing APIs use Gdx.graphics.
 - API Addition: Mesh and Vertex/Index/Instance buffer object constructors that take Graphics; existing constructors use Gdx.graphics.
 - API Addition: GLTexture/Texture/Cubemap/TextureArray/Texture3D constructors that take Graphics; existing constructors use Gdx.graphics.

--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,5 @@
 [1.14.3]
+- API Addition: GLFrameBuffer/FrameBuffer/FloatFrameBuffer/FrameBufferCubemap constructors and builders that take Graphics; existing APIs use Gdx.graphics.
 - API Addition: Mesh and Vertex/Index/Instance buffer object constructors that take Graphics; existing constructors use Gdx.graphics.
 - API Addition: GLTexture/Texture/Cubemap/TextureArray/Texture3D constructors that take Graphics; existing constructors use Gdx.graphics.
 - API Addition: ShaderProgram constructors that take Graphics; existing constructors use Gdx.graphics.

--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,5 @@
 [1.14.3]
+- API Addition: ScreenUtils/Pixmap.createFromFrameBuffer/ShapeRenderer/ImmediateModeRenderer20 and custom TextureData types take Graphics; existing APIs use Gdx.graphics.
 - API Addition: RenderContext/DefaultTextureBinder/HdpiUtils/MipMapGenerator APIs that take Graphics; existing APIs use Gdx.graphics.
 - API Addition: SpriteBatch/PolygonSpriteBatch/SpriteCache constructors that take Graphics; existing constructors use Gdx.graphics.
 - API Addition: GLFrameBuffer/FrameBuffer/FloatFrameBuffer/FrameBufferCubemap constructors and builders that take Graphics; existing APIs use Gdx.graphics.

--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,5 @@
 [1.14.3]
+- API Addition: GLTexture/Texture/Cubemap/TextureArray/Texture3D constructors that take Graphics; existing constructors use Gdx.graphics.
 - API Addition: ShaderProgram constructors that take Graphics; existing constructors use Gdx.graphics.
 - API Change: Managed GL resources (ShaderProgram, Texture, Cubemap, TextureArray, Texture3D, Mesh, GLFrameBuffer) are keyed by Graphics instead of Application.
 - API Addition: ApplicationListener#create(Application); backends call it, default delegates to create().

--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,5 @@
 [1.14.3]
+- API Addition: ApplicationListener#create(Application); backends call it, default delegates to create().
 - API Addition: add() with 5-8 parameters for arrays.
 
 [1.14.2]

--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,5 @@
 [1.14.3]
+- API Addition: Mesh and Vertex/Index/Instance buffer object constructors that take Graphics; existing constructors use Gdx.graphics.
 - API Addition: GLTexture/Texture/Cubemap/TextureArray/Texture3D constructors that take Graphics; existing constructors use Gdx.graphics.
 - API Addition: ShaderProgram constructors that take Graphics; existing constructors use Gdx.graphics.
 - API Change: Managed GL resources (ShaderProgram, Texture, Cubemap, TextureArray, Texture3D, Mesh, GLFrameBuffer) are keyed by Graphics instead of Application.

--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,5 @@
 [1.14.3]
+- API Change: Managed GL resources (ShaderProgram, Texture, Cubemap, TextureArray, Texture3D, Mesh, GLFrameBuffer) are keyed by Graphics instead of Application.
 - API Addition: ApplicationListener#create(Application); backends call it, default delegates to create().
 - API Addition: ApplicationAdapter/Game bind graphics/audio/input/files/net/gl* from create(Application).
 - API Addition: add() with 5-8 parameters for arrays.

--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,5 @@
 [1.14.3]
+- API Addition: RenderContext/DefaultTextureBinder/HdpiUtils/MipMapGenerator APIs that take Graphics; existing APIs use Gdx.graphics.
 - API Addition: SpriteBatch/PolygonSpriteBatch/SpriteCache constructors that take Graphics; existing constructors use Gdx.graphics.
 - API Addition: GLFrameBuffer/FrameBuffer/FloatFrameBuffer/FrameBufferCubemap constructors and builders that take Graphics; existing APIs use Gdx.graphics.
 - API Addition: Mesh and Vertex/Index/Instance buffer object constructors that take Graphics; existing constructors use Gdx.graphics.

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,6 @@
 [1.14.3]
 - API Addition: ApplicationListener#create(Application); backends call it, default delegates to create().
+- API Addition: ApplicationAdapter/Game bind graphics/audio/input/files/net/gl* from create(Application).
 - API Addition: add() with 5-8 parameters for arrays.
 
 [1.14.2]

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphics.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphics.java
@@ -312,7 +312,7 @@ public class AndroidGraphics extends AbstractGraphics implements Renderer {
 		updateSafeAreaInsets();
 		gl.glViewport(0, 0, this.width, this.height);
 		if (created == false) {
-			app.getApplicationListener().create();
+			app.getApplicationListener().create(app);
 			created = true;
 			synchronized (this) {
 				running = true;

--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphics.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGraphics.java
@@ -329,12 +329,12 @@ public class AndroidGraphics extends AbstractGraphics implements Renderer {
 		updatePpi();
 		updateSafeAreaInsets();
 
-		Mesh.invalidateAllMeshes(app);
-		Texture.invalidateAllTextures(app);
-		Cubemap.invalidateAllCubemaps(app);
-		TextureArray.invalidateAllTextureArrays(app);
-		ShaderProgram.invalidateAllShaderPrograms(app);
-		FrameBuffer.invalidateAllFrameBuffers(app);
+		Mesh.invalidateAllMeshes(this);
+		Texture.invalidateAllTextures(this);
+		Cubemap.invalidateAllCubemaps(this);
+		TextureArray.invalidateAllTextureArrays(this);
+		ShaderProgram.invalidateAllShaderPrograms(this);
+		FrameBuffer.invalidateAllFrameBuffers(this);
 
 		logManagedCachesStatus();
 
@@ -581,12 +581,12 @@ public class AndroidGraphics extends AbstractGraphics implements Renderer {
 	}
 
 	public void clearManagedCaches () {
-		Mesh.clearAllMeshes(app);
-		Texture.clearAllTextures(app);
-		Cubemap.clearAllCubemaps(app);
-		TextureArray.clearAllTextureArrays(app);
-		ShaderProgram.clearAllShaderPrograms(app);
-		FrameBuffer.clearAllFrameBuffers(app);
+		Mesh.clearAllMeshes(this);
+		Texture.clearAllTextures(this);
+		Cubemap.clearAllCubemaps(this);
+		TextureArray.clearAllTextureArrays(this);
+		ShaderProgram.clearAllShaderPrograms(this);
+		FrameBuffer.clearAllFrameBuffers(this);
 
 		logManagedCachesStatus();
 	}

--- a/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/HeadlessApplication.java
+++ b/backends/gdx-backend-headless/src/com/badlogic/gdx/backends/headless/HeadlessApplication.java
@@ -105,7 +105,7 @@ public class HeadlessApplication implements Application {
 	protected void mainLoop () {
 		Array<LifecycleListener> lifecycleListeners = this.lifecycleListeners;
 
-		listener.create();
+		listener.create(this);
 
 		// unlike LwjglApplication, a headless application will eat up CPU in this while loop
 		// it is up to the implementation to call Thread.sleep as necessary

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglAWTCanvas.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglAWTCanvas.java
@@ -236,7 +236,7 @@ public class LwjglAWTCanvas implements Application {
 			setGlobals();
 			graphics.initiateGL();
 			canvas.setVSyncEnabled(graphics.config.vSyncEnabled);
-			listener.create();
+			listener.create(this);
 			lastWidth = Math.max(1, graphics.getWidth());
 			lastHeight = Math.max(1, graphics.getHeight());
 			listener.resize(lastWidth, lastHeight);

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglApplication.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglApplication.java
@@ -146,7 +146,7 @@ public class LwjglApplication implements LwjglApplicationBase {
 			throw new GdxRuntimeException(e);
 		}
 
-		listener.create();
+		listener.create(this);
 		graphics.resize = true;
 
 		int lastWidth = graphics.getWidth();

--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglCanvas.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglCanvas.java
@@ -210,7 +210,7 @@ public class LwjglCanvas implements LwjglApplicationBase {
 		try {
 			graphics.setupDisplay();
 
-			listener.create();
+			listener.create(this);
 			listener.resize(Math.max(1, graphics.getWidth()), Math.max(1, graphics.getHeight()));
 
 			start();

--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Window.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Window.java
@@ -461,7 +461,7 @@ public class Lwjgl3Window implements Disposable {
 
 	void initializeListener () {
 		if (!listenerInitialized) {
-			listener.create();
+			listener.create(application);
 			listener.resize(graphics.getWidth(), graphics.getHeight());
 			listenerInitialized = true;
 		}

--- a/backends/gdx-backend-robovm-metalangle/src/com/badlogic/gdx/backends/iosrobovm/IOSApplication.java
+++ b/backends/gdx-backend-robovm-metalangle/src/com/badlogic/gdx/backends/iosrobovm/IOSApplication.java
@@ -147,7 +147,7 @@ public class IOSApplication implements Application {
 		Gdx.app.debug("IOSApplication", "created");
 		// Trigger first render, special case that is caught and returned
 		this.graphics.view.display();
-		listener.create();
+		listener.create(this);
 		listener.resize(this.graphics.getWidth(), this.graphics.getHeight());
 		// make sure the OpenGL view has contents before displaying it
 		this.graphics.view.display();

--- a/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSApplication.java
+++ b/backends/gdx-backend-robovm/src/com/badlogic/gdx/backends/iosrobovm/IOSApplication.java
@@ -157,7 +157,7 @@ public class IOSApplication implements Application {
 		// Trigger first render, special case that is caught and returned
 		this.graphics.view.display();
 
-		listener.create();
+		listener.create(this);
 		listener.resize(this.graphics.getWidth(), this.graphics.getHeight());
 
 		// make sure the OpenGL view has contents before displaying it

--- a/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplication.java
+++ b/backends/gdx-backends-gwt/src/com/badlogic/gdx/backends/gwt/GwtApplication.java
@@ -230,7 +230,7 @@ public abstract class GwtApplication implements EntryPoint, Application {
 
 		// tell listener about app creation
 		try {
-			listener.create();
+			listener.create(this);
 			listener.resize(graphics.getWidth(), graphics.getHeight());
 		} catch (Throwable t) {
 			error("GwtApplication", "exception: " + t.getMessage(), t);

--- a/gdx/src/com/badlogic/gdx/ApplicationAdapter.java
+++ b/gdx/src/com/badlogic/gdx/ApplicationAdapter.java
@@ -19,8 +19,17 @@ package com.badlogic.gdx;
 /** Convenience implementation of {@link ApplicationListener}. Derive from this and only override what you need.
  * @author mzechner */
 public abstract class ApplicationAdapter implements ApplicationListener {
+	/** The {@link Application} passed to {@link #create(Application)}, or {@code null} if only {@link #create()} was used. */
+	protected Application app;
+
 	@Override
 	public void create () {
+	}
+
+	@Override
+	public void create (Application app) {
+		this.app = app;
+		create();
 	}
 
 	@Override

--- a/gdx/src/com/badlogic/gdx/ApplicationAdapter.java
+++ b/gdx/src/com/badlogic/gdx/ApplicationAdapter.java
@@ -16,11 +16,26 @@
 
 package com.badlogic.gdx;
 
+import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.GL30;
+import com.badlogic.gdx.graphics.GL31;
+import com.badlogic.gdx.graphics.GL32;
+
 /** Convenience implementation of {@link ApplicationListener}. Derive from this and only override what you need.
  * @author mzechner */
 public abstract class ApplicationAdapter implements ApplicationListener {
-	/** The {@link Application} passed to {@link #create(Application)}, or {@code null} if only {@link #create()} was used. */
+	/** Set by {@link #create(Application)}; prefer these over {@link Gdx} statics. */
 	protected Application app;
+	protected Graphics graphics;
+	protected Audio audio;
+	protected Input input;
+	protected Files files;
+	protected Net net;
+	protected GL20 gl;
+	protected GL20 gl20;
+	protected GL30 gl30;
+	protected GL31 gl31;
+	protected GL32 gl32;
 
 	@Override
 	public void create () {
@@ -28,8 +43,27 @@ public abstract class ApplicationAdapter implements ApplicationListener {
 
 	@Override
 	public void create (Application app) {
-		this.app = app;
+		bind(app);
 		create();
+	}
+
+	protected void bind (Application app) {
+		this.app = app;
+		this.graphics = app.getGraphics();
+		this.audio = app.getAudio();
+		this.input = app.getInput();
+		this.files = app.getFiles();
+		this.net = app.getNet();
+		refreshGl();
+	}
+
+	protected void refreshGl () {
+		if (graphics == null) return;
+		gl32 = graphics.getGL32();
+		gl31 = gl32 != null ? gl32 : graphics.getGL31();
+		gl30 = gl31 != null ? gl31 : graphics.getGL30();
+		gl20 = gl30 != null ? gl30 : graphics.getGL20();
+		gl = gl20;
 	}
 
 	@Override

--- a/gdx/src/com/badlogic/gdx/ApplicationListener.java
+++ b/gdx/src/com/badlogic/gdx/ApplicationListener.java
@@ -30,8 +30,17 @@ package com.badlogic.gdx;
  * 
  * @author mzechner */
 public interface ApplicationListener {
-	/** Called when the {@link Application} is first created. */
+	/** Called when the {@link Application} is first created. Prefer {@link #create(Application)}. */
 	public void create ();
+
+	/** Called when the {@link Application} is first created, with the application instance.
+	 * <p>
+	 * Default implementation delegates to {@link #create()} for backwards compatibility. Override this method to receive the
+	 * {@link Application} without relying on {@link Gdx} statics. Backends invoke this overload.
+	 * @param app the application */
+	default void create (Application app) {
+		create();
+	}
 
 	/** Called when the {@link Application} is resized. This can happen at any point during a non-paused state but will never
 	 * happen before a call to {@link #create()}.

--- a/gdx/src/com/badlogic/gdx/Game.java
+++ b/gdx/src/com/badlogic/gdx/Game.java
@@ -26,7 +26,19 @@ package com.badlogic.gdx;
  * </p>
  */
 public abstract class Game implements ApplicationListener {
+	/** The {@link Application} passed to {@link #create(Application)}, or {@code null} if only {@link #create()} was used. */
+	protected Application app;
 	protected Screen screen;
+
+	@Override
+	public void create () {
+	}
+
+	@Override
+	public void create (Application app) {
+		this.app = app;
+		create();
+	}
 
 	@Override
 	public void dispose () {

--- a/gdx/src/com/badlogic/gdx/Game.java
+++ b/gdx/src/com/badlogic/gdx/Game.java
@@ -16,6 +16,11 @@
 
 package com.badlogic.gdx;
 
+import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.GL30;
+import com.badlogic.gdx.graphics.GL31;
+import com.badlogic.gdx.graphics.GL32;
+
 /**
  * <p>
  * An {@link ApplicationListener} that delegates to a {@link Screen}. This allows an application to easily have multiple screens.
@@ -26,8 +31,18 @@ package com.badlogic.gdx;
  * </p>
  */
 public abstract class Game implements ApplicationListener {
-	/** The {@link Application} passed to {@link #create(Application)}, or {@code null} if only {@link #create()} was used. */
+	/** Set by {@link #create(Application)}; prefer these over {@link Gdx} statics. */
 	protected Application app;
+	protected Graphics graphics;
+	protected Audio audio;
+	protected Input input;
+	protected Files files;
+	protected Net net;
+	protected GL20 gl;
+	protected GL20 gl20;
+	protected GL30 gl30;
+	protected GL31 gl31;
+	protected GL32 gl32;
 	protected Screen screen;
 
 	@Override
@@ -36,8 +51,27 @@ public abstract class Game implements ApplicationListener {
 
 	@Override
 	public void create (Application app) {
-		this.app = app;
+		bind(app);
 		create();
+	}
+
+	protected void bind (Application app) {
+		this.app = app;
+		this.graphics = app.getGraphics();
+		this.audio = app.getAudio();
+		this.input = app.getInput();
+		this.files = app.getFiles();
+		this.net = app.getNet();
+		refreshGl();
+	}
+
+	protected void refreshGl () {
+		if (graphics == null) return;
+		gl32 = graphics.getGL32();
+		gl31 = gl32 != null ? gl32 : graphics.getGL31();
+		gl30 = gl31 != null ? gl31 : graphics.getGL30();
+		gl20 = gl30 != null ? gl30 : graphics.getGL20();
+		gl = gl20;
 	}
 
 	@Override
@@ -57,7 +91,7 @@ public abstract class Game implements ApplicationListener {
 
 	@Override
 	public void render () {
-		if (screen != null) screen.render(Gdx.graphics.getDeltaTime());
+		if (screen != null) screen.render(graphics.getDeltaTime());
 	}
 
 	@Override
@@ -73,7 +107,7 @@ public abstract class Game implements ApplicationListener {
 		this.screen = screen;
 		if (this.screen != null) {
 			this.screen.show();
-			this.screen.resize(Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+			this.screen.resize(graphics.getWidth(), graphics.getHeight());
 		}
 	}
 

--- a/gdx/src/com/badlogic/gdx/graphics/Cubemap.java
+++ b/gdx/src/com/badlogic/gdx/graphics/Cubemap.java
@@ -19,7 +19,7 @@ package com.badlogic.gdx.graphics;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.badlogic.gdx.Application;
+import com.badlogic.gdx.Graphics;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.assets.AssetLoaderParameters.LoadedCallback;
 import com.badlogic.gdx.assets.AssetManager;
@@ -37,7 +37,7 @@ import com.badlogic.gdx.utils.GdxRuntimeException;
  * @author Xoppa */
 public class Cubemap extends GLTexture {
 	private static AssetManager assetManager;
-	final static Map<Application, Array<Cubemap>> managedCubemaps = new HashMap<Application, Array<Cubemap>>();
+	final static Map<Graphics, Array<Cubemap>> managedCubemaps = new HashMap<Graphics, Array<Cubemap>>();
 
 	/** Enum to identify each side of a Cubemap */
 	public enum CubemapSide {
@@ -93,7 +93,7 @@ public class Cubemap extends GLTexture {
 		super(GL20.GL_TEXTURE_CUBE_MAP);
 		this.data = data;
 		load(data);
-		if (data.isManaged()) addManagedCubemap(Gdx.app, this);
+		if (data.isManaged()) addManagedCubemap(Gdx.graphics, this);
 	}
 
 	/** Construct a Cubemap with the specified texture files for the sides, does not generate mipmaps. */
@@ -193,24 +193,24 @@ public class Cubemap extends GLTexture {
 		// removal from the asset manager.
 		if (glHandle == 0) return;
 		delete();
-		if (data.isManaged()) if (managedCubemaps.get(Gdx.app) != null) managedCubemaps.get(Gdx.app).removeValue(this, true);
+		if (data.isManaged()) if (managedCubemaps.get(Gdx.graphics) != null) managedCubemaps.get(Gdx.graphics).removeValue(this, true);
 	}
 
-	private static void addManagedCubemap (Application app, Cubemap cubemap) {
-		Array<Cubemap> managedCubemapArray = managedCubemaps.get(app);
+	private static void addManagedCubemap (Graphics graphics, Cubemap cubemap) {
+		Array<Cubemap> managedCubemapArray = managedCubemaps.get(graphics);
 		if (managedCubemapArray == null) managedCubemapArray = new Array<Cubemap>();
 		managedCubemapArray.add(cubemap);
-		managedCubemaps.put(app, managedCubemapArray);
+		managedCubemaps.put(graphics, managedCubemapArray);
 	}
 
 	/** Clears all managed cubemaps. This is an internal method. Do not use it! */
-	public static void clearAllCubemaps (Application app) {
-		managedCubemaps.remove(app);
+	public static void clearAllCubemaps (Graphics graphics) {
+		managedCubemaps.remove(graphics);
 	}
 
 	/** Invalidate all managed cubemaps. This is an internal method. Do not use it! */
-	public static void invalidateAllCubemaps (Application app) {
-		Array<Cubemap> managedCubemapArray = managedCubemaps.get(app);
+	public static void invalidateAllCubemaps (Graphics graphics) {
+		Array<Cubemap> managedCubemapArray = managedCubemaps.get(graphics);
 		if (managedCubemapArray == null) return;
 
 		if (assetManager == null) {
@@ -277,9 +277,9 @@ public class Cubemap extends GLTexture {
 
 	public static String getManagedStatus () {
 		StringBuilder builder = new StringBuilder();
-		builder.append("Managed cubemap/app: { ");
-		for (Application app : managedCubemaps.keySet()) {
-			builder.append(managedCubemaps.get(app).size);
+		builder.append("Managed cubemap/graphics: { ");
+		for (Graphics graphics : managedCubemaps.keySet()) {
+			builder.append(managedCubemaps.get(graphics).size);
 			builder.append(" ");
 		}
 		builder.append("}");
@@ -288,7 +288,7 @@ public class Cubemap extends GLTexture {
 
 	/** @return the number of managed cubemaps currently loaded */
 	public static int getNumManagedCubemaps () {
-		return managedCubemaps.get(Gdx.app).size;
+		return managedCubemaps.get(Gdx.graphics).size;
 	}
 
 }

--- a/gdx/src/com/badlogic/gdx/graphics/Cubemap.java
+++ b/gdx/src/com/badlogic/gdx/graphics/Cubemap.java
@@ -144,7 +144,13 @@ public class Cubemap extends GLTexture {
 	/** Construct a Cubemap with the specified {@link TextureData}'s for the sides */
 	public Cubemap (TextureData positiveX, TextureData negativeX, TextureData positiveY, TextureData negativeY,
 		TextureData positiveZ, TextureData negativeZ) {
-		this(new FacedCubemapData(positiveX, negativeX, positiveY, negativeY, positiveZ, negativeZ));
+		this(Gdx.graphics, positiveX, negativeX, positiveY, negativeY, positiveZ, negativeZ);
+	}
+
+	/** Construct a Cubemap with the specified {@link TextureData}'s for the sides */
+	public Cubemap (Graphics graphics, TextureData positiveX, TextureData negativeX, TextureData positiveY, TextureData negativeY,
+		TextureData positiveZ, TextureData negativeZ) {
+		this(graphics, new FacedCubemapData(positiveX, negativeX, positiveY, negativeY, positiveZ, negativeZ));
 	}
 
 	/** Sets the sides of this cubemap to the specified {@link CubemapData}. */

--- a/gdx/src/com/badlogic/gdx/graphics/Cubemap.java
+++ b/gdx/src/com/badlogic/gdx/graphics/Cubemap.java
@@ -88,12 +88,17 @@ public class Cubemap extends GLTexture {
 
 	protected CubemapData data;
 
-	/** Construct a Cubemap based on the given CubemapData. */
+	/** Construct a Cubemap based on the given CubemapData using {@link Gdx#graphics}. */
 	public Cubemap (CubemapData data) {
-		super(GL20.GL_TEXTURE_CUBE_MAP);
+		this(Gdx.graphics, data);
+	}
+
+	/** Construct a Cubemap based on the given CubemapData. */
+	public Cubemap (Graphics graphics, CubemapData data) {
+		super(graphics, GL20.GL_TEXTURE_CUBE_MAP);
 		this.data = data;
 		load(data);
-		if (data.isManaged()) addManagedCubemap(Gdx.graphics, this);
+		if (data.isManaged()) addManagedCubemap(graphics, this);
 	}
 
 	/** Construct a Cubemap with the specified texture files for the sides, does not generate mipmaps. */
@@ -150,7 +155,7 @@ public class Cubemap extends GLTexture {
 		unsafeSetWrap(uWrap, vWrap, true);
 		unsafeSetAnisotropicFilter(anisotropicFilterLevel, true);
 		data.consumeCubemapData();
-		Gdx.gl.glBindTexture(glTarget, 0);
+		gl().glBindTexture(glTarget, 0);
 	}
 
 	public CubemapData getCubemapData () {
@@ -165,7 +170,7 @@ public class Cubemap extends GLTexture {
 	@Override
 	protected void reload () {
 		if (!isManaged()) throw new GdxRuntimeException("Tried to reload an unmanaged Cubemap");
-		glHandle = Gdx.gl.glGenTexture();
+		glHandle = gl().glGenTexture();
 		load(data);
 	}
 
@@ -193,7 +198,7 @@ public class Cubemap extends GLTexture {
 		// removal from the asset manager.
 		if (glHandle == 0) return;
 		delete();
-		if (data.isManaged()) if (managedCubemaps.get(Gdx.graphics) != null) managedCubemaps.get(Gdx.graphics).removeValue(this, true);
+		if (data.isManaged()) if (managedCubemaps.get(graphics) != null) managedCubemaps.get(graphics).removeValue(this, true);
 	}
 
 	private static void addManagedCubemap (Graphics graphics, Cubemap cubemap) {
@@ -258,7 +263,7 @@ public class Cubemap extends GLTexture {
 
 					// unload the c, create a new gl handle then reload it.
 					assetManager.unload(fileName);
-					cubemap.glHandle = Gdx.gl.glGenTexture();
+					cubemap.glHandle = graphics.getGL20().glGenTexture();
 					assetManager.load(fileName, Cubemap.class, params);
 				}
 			}

--- a/gdx/src/com/badlogic/gdx/graphics/GLTexture.java
+++ b/gdx/src/com/badlogic/gdx/graphics/GLTexture.java
@@ -217,7 +217,7 @@ public abstract class GLTexture implements Disposable {
 	 * @param force True to always set the value, even if it is the same as the current values.
 	 * @return The actual level set, which may be lower than the provided value due to device limitations. */
 	public float unsafeSetAnisotropicFilter (float level, boolean force) {
-		float max = getMaxAnisotropicFilterLevel();
+		float max = getMaxAnisotropicFilterLevel(graphics);
 		if (max == 1f) return 1f;
 		level = Math.min(level, max);
 		if (!force && MathUtils.isEqual(level, anisotropicFilterLevel, 0.1f)) return anisotropicFilterLevel;
@@ -230,7 +230,7 @@ public abstract class GLTexture implements Disposable {
 	 * @param level The desired level of filtering. The maximum level supported by the device up to this value will be used.
 	 * @return The actual level set, which may be lower than the provided value due to device limitations. */
 	public float setAnisotropicFilter (float level) {
-		float max = getMaxAnisotropicFilterLevel();
+		float max = getMaxAnisotropicFilterLevel(graphics);
 		if (max == 1f) return 1f;
 		level = Math.min(level, max);
 		if (MathUtils.isEqual(level, anisotropicFilterLevel, 0.1f)) return level;
@@ -246,12 +246,16 @@ public abstract class GLTexture implements Disposable {
 
 	/** @return The maximum supported anisotropic filtering level supported by the device. */
 	public static float getMaxAnisotropicFilterLevel () {
+		return getMaxAnisotropicFilterLevel(Gdx.graphics);
+	}
+
+	public static float getMaxAnisotropicFilterLevel (Graphics graphics) {
 		if (maxAnisotropicFilterLevel > 0) return maxAnisotropicFilterLevel;
-		if (Gdx.graphics.supportsExtension("GL_EXT_texture_filter_anisotropic")) {
+		if (graphics.supportsExtension("GL_EXT_texture_filter_anisotropic")) {
 			FloatBuffer buffer = BufferUtils.newFloatBuffer(16);
 			((Buffer)buffer).position(0);
 			((Buffer)buffer).limit(buffer.capacity());
-			Gdx.gl20.glGetFloatv(GL20.GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT, buffer);
+			graphics.getGL20().glGetFloatv(GL20.GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT, buffer);
 			return maxAnisotropicFilterLevel = buffer.get(0);
 		}
 		return maxAnisotropicFilterLevel = 1f;
@@ -271,10 +275,18 @@ public abstract class GLTexture implements Disposable {
 	}
 
 	protected static void uploadImageData (int target, TextureData data) {
-		uploadImageData(target, data, 0);
+		uploadImageData(Gdx.graphics, target, data, 0);
+	}
+
+	protected static void uploadImageData (Graphics graphics, int target, TextureData data) {
+		uploadImageData(graphics, target, data, 0);
 	}
 
 	public static void uploadImageData (int target, TextureData data, int miplevel) {
+		uploadImageData(Gdx.graphics, target, data, miplevel);
+	}
+
+	public static void uploadImageData (Graphics graphics, int target, TextureData data, int miplevel) {
 		if (data == null) {
 			// FIXME: remove texture on target?
 			return;
@@ -301,11 +313,12 @@ public abstract class GLTexture implements Disposable {
 			disposePixmap = true;
 		}
 
-		Gdx.gl.glPixelStorei(GL20.GL_UNPACK_ALIGNMENT, 1);
+		GL20 gl = graphics.getGL20();
+		gl.glPixelStorei(GL20.GL_UNPACK_ALIGNMENT, 1);
 		if (data.useMipMaps()) {
-			MipMapGenerator.generateMipMap(target, pixmap, pixmap.getWidth(), pixmap.getHeight());
+			MipMapGenerator.generateMipMap(graphics, target, pixmap, pixmap.getWidth(), pixmap.getHeight());
 		} else {
-			Gdx.gl.glTexImage2D(target, miplevel, pixmap.getGLInternalFormat(), pixmap.getWidth(), pixmap.getHeight(), 0,
+			gl.glTexImage2D(target, miplevel, pixmap.getGLInternalFormat(), pixmap.getWidth(), pixmap.getHeight(), 0,
 				pixmap.getGLFormat(), pixmap.getGLType(), pixmap.getPixels());
 		}
 		if (disposePixmap) pixmap.dispose();

--- a/gdx/src/com/badlogic/gdx/graphics/GLTexture.java
+++ b/gdx/src/com/badlogic/gdx/graphics/GLTexture.java
@@ -17,6 +17,7 @@
 package com.badlogic.gdx.graphics;
 
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Graphics;
 import com.badlogic.gdx.graphics.Pixmap.Blending;
 import com.badlogic.gdx.graphics.Texture.TextureFilter;
 import com.badlogic.gdx.graphics.Texture.TextureWrap;
@@ -35,6 +36,8 @@ import java.nio.FloatBuffer;
 public abstract class GLTexture implements Disposable {
 	/** The target of this texture, used when binding the texture, e.g. GL_TEXTURE_2D */
 	public final int glTarget;
+	/** {@link Graphics} this texture is associated with and resolves GL from */
+	protected final Graphics graphics;
 	protected int glHandle;
 	protected TextureFilter minFilter = TextureFilter.Nearest;
 	protected TextureFilter magFilter = TextureFilter.Nearest;
@@ -52,12 +55,34 @@ public abstract class GLTexture implements Disposable {
 	/** @return the depth of the texture in pixels */
 	public abstract int getDepth ();
 
-	/** Generates a new OpenGL texture with the specified target. */
-	public GLTexture (int glTarget) {
-		this(glTarget, Gdx.gl.glGenTexture());
+	protected GL20 gl () {
+		return graphics.getGL20();
 	}
 
+	protected GL30 gl30 () {
+		return graphics.getGL30();
+	}
+
+	/** Generates a new OpenGL texture with the specified target using {@link Gdx#graphics}. */
+	public GLTexture (int glTarget) {
+		this(Gdx.graphics, glTarget);
+	}
+
+	/** Generates a new OpenGL texture with the specified target. */
+	public GLTexture (Graphics graphics, int glTarget) {
+		this(graphics, glTarget, graphics.getGL20().glGenTexture());
+	}
+
+	/** Creates a GLTexture for an existing handle using {@link Gdx#graphics}. */
 	public GLTexture (int glTarget, int glHandle) {
+		this(Gdx.graphics, glTarget, glHandle);
+	}
+
+	/** Creates a GLTexture for an existing handle.
+	 * @param graphics the graphics instance used to resolve GL */
+	public GLTexture (Graphics graphics, int glTarget, int glHandle) {
+		if (graphics == null) throw new IllegalArgumentException("graphics must not be null");
+		this.graphics = graphics;
 		this.glTarget = glTarget;
 		this.glHandle = glHandle;
 	}
@@ -70,14 +95,15 @@ public abstract class GLTexture implements Disposable {
 	/** Binds this texture. The texture will be bound to the currently active texture unit specified via
 	 * {@link GL20#glActiveTexture(int)}. */
 	public void bind () {
-		Gdx.gl.glBindTexture(glTarget, glHandle);
+		gl().glBindTexture(glTarget, glHandle);
 	}
 
 	/** Binds the texture to the given texture unit. Sets the currently active texture unit via {@link GL20#glActiveTexture(int)}.
 	 * @param unit the unit (0 to MAX_TEXTURE_UNITS). */
 	public void bind (int unit) {
-		Gdx.gl.glActiveTexture(GL20.GL_TEXTURE0 + unit);
-		Gdx.gl.glBindTexture(glTarget, glHandle);
+		GL20 gl = gl();
+		gl.glActiveTexture(GL20.GL_TEXTURE0 + unit);
+		gl.glBindTexture(glTarget, glHandle);
 	}
 
 	/** @return The {@link Texture.TextureFilter} used for minification. */
@@ -117,25 +143,28 @@ public abstract class GLTexture implements Disposable {
 	 * @param v the v wrap
 	 * @param force True to always set the values, even if they are the same as the current values. */
 	public void unsafeSetWrap (TextureWrap u, TextureWrap v, boolean force) {
+		GL20 gl = gl();
 		if (u != null && (force || uWrap != u)) {
-			Gdx.gl.glTexParameteri(glTarget, GL20.GL_TEXTURE_WRAP_S, u.getGLEnum());
+			gl.glTexParameteri(glTarget, GL20.GL_TEXTURE_WRAP_S, u.getGLEnum());
 			uWrap = u;
 		}
 		if (v != null && (force || vWrap != v)) {
-			Gdx.gl.glTexParameteri(glTarget, GL20.GL_TEXTURE_WRAP_T, v.getGLEnum());
+			gl.glTexParameteri(glTarget, GL20.GL_TEXTURE_WRAP_T, v.getGLEnum());
 			vWrap = v;
 		}
 	}
 
-	/** Sets the {@link TextureWrap} for this texture on the u and v axis. This will bind this texture!
+	/** Sets the {@link TextureWrap} for this texture on the u and v axis. Applies the filters to the given texture immediately,
+	 * so this texture must be bound for the method to have any effect.
 	 * @param u the u wrap
 	 * @param v the v wrap */
 	public void setWrap (TextureWrap u, TextureWrap v) {
 		this.uWrap = u;
 		this.vWrap = v;
 		bind();
-		Gdx.gl.glTexParameteri(glTarget, GL20.GL_TEXTURE_WRAP_S, u.getGLEnum());
-		Gdx.gl.glTexParameteri(glTarget, GL20.GL_TEXTURE_WRAP_T, v.getGLEnum());
+		GL20 gl = gl();
+		gl.glTexParameteri(glTarget, GL20.GL_TEXTURE_WRAP_S, u.getGLEnum());
+		gl.glTexParameteri(glTarget, GL20.GL_TEXTURE_WRAP_T, v.getGLEnum());
 	}
 
 	/** Sets the {@link TextureFilter} for this texture for minification and magnification. Assumes the texture is bound and
@@ -152,29 +181,31 @@ public abstract class GLTexture implements Disposable {
 	 * @param magFilter the magnification filter
 	 * @param force True to always set the values, even if they are the same as the current values. */
 	public void unsafeSetFilter (TextureFilter minFilter, TextureFilter magFilter, boolean force) {
+		GL20 gl = gl();
 		if (minFilter != null && (force || this.minFilter != minFilter)) {
-			Gdx.gl.glTexParameteri(glTarget, GL20.GL_TEXTURE_MIN_FILTER, minFilter.getGLEnum());
+			gl.glTexParameteri(glTarget, GL20.GL_TEXTURE_MIN_FILTER, minFilter.getGLEnum());
 			this.minFilter = minFilter;
 		}
 		if (magFilter != null && (force || this.magFilter != magFilter)) {
-			Gdx.gl.glTexParameteri(glTarget, GL20.GL_TEXTURE_MAG_FILTER, magFilter.getGLEnum());
+			gl.glTexParameteri(glTarget, GL20.GL_TEXTURE_MAG_FILTER, magFilter.getGLEnum());
 			this.magFilter = magFilter;
 		}
 	}
 
-	/** Sets the {@link TextureFilter} for this texture for minification and magnification. This will bind this texture!
+	/** Sets the {@link TextureFilter} for this texture for minification and magnification. Applies the filters to the given
+	 * texture immediately, so this texture must be bound for the method to have any effect.
 	 * @param minFilter the minification filter
 	 * @param magFilter the magnification filter */
 	public void setFilter (TextureFilter minFilter, TextureFilter magFilter) {
 		this.minFilter = minFilter;
 		this.magFilter = magFilter;
 		bind();
-		Gdx.gl.glTexParameteri(glTarget, GL20.GL_TEXTURE_MIN_FILTER, minFilter.getGLEnum());
-		Gdx.gl.glTexParameteri(glTarget, GL20.GL_TEXTURE_MAG_FILTER, magFilter.getGLEnum());
+		GL20 gl = gl();
+		gl.glTexParameteri(glTarget, GL20.GL_TEXTURE_MIN_FILTER, minFilter.getGLEnum());
+		gl.glTexParameteri(glTarget, GL20.GL_TEXTURE_MAG_FILTER, magFilter.getGLEnum());
 	}
 
 	/** Sets the anisotropic filter level for the texture. Assumes the texture is bound and active!
-	 *
 	 * @param level The desired level of filtering. The maximum level supported by the device up to this value will be used.
 	 * @return The actual level set, which may be lower than the provided value due to device limitations. */
 	public float unsafeSetAnisotropicFilter (float level) {
@@ -182,7 +213,6 @@ public abstract class GLTexture implements Disposable {
 	}
 
 	/** Sets the anisotropic filter level for the texture. Assumes the texture is bound and active!
-	 *
 	 * @param level The desired level of filtering. The maximum level supported by the device up to this value will be used.
 	 * @param force True to always set the value, even if it is the same as the current values.
 	 * @return The actual level set, which may be lower than the provided value due to device limitations. */
@@ -191,12 +221,12 @@ public abstract class GLTexture implements Disposable {
 		if (max == 1f) return 1f;
 		level = Math.min(level, max);
 		if (!force && MathUtils.isEqual(level, anisotropicFilterLevel, 0.1f)) return anisotropicFilterLevel;
-		Gdx.gl20.glTexParameterf(GL20.GL_TEXTURE_2D, GL20.GL_TEXTURE_MAX_ANISOTROPY_EXT, level);
+		gl().glTexParameterf(GL20.GL_TEXTURE_2D, GL20.GL_TEXTURE_MAX_ANISOTROPY_EXT, level);
 		return anisotropicFilterLevel = level;
 	}
 
-	/** Sets the anisotropic filter level for the texture. This will bind the texture!
-	 *
+	/** Sets the anisotropic filter level for the texture. Applies the changes to the texture immediately, so this texture must be
+	 * bound for the method to have any effect.
 	 * @param level The desired level of filtering. The maximum level supported by the device up to this value will be used.
 	 * @return The actual level set, which may be lower than the provided value due to device limitations. */
 	public float setAnisotropicFilter (float level) {
@@ -205,7 +235,7 @@ public abstract class GLTexture implements Disposable {
 		level = Math.min(level, max);
 		if (MathUtils.isEqual(level, anisotropicFilterLevel, 0.1f)) return level;
 		bind();
-		Gdx.gl20.glTexParameterf(GL20.GL_TEXTURE_2D, GL20.GL_TEXTURE_MAX_ANISOTROPY_EXT, level);
+		gl().glTexParameterf(GL20.GL_TEXTURE_2D, GL20.GL_TEXTURE_MAX_ANISOTROPY_EXT, level);
 		return anisotropicFilterLevel = level;
 	}
 
@@ -230,7 +260,7 @@ public abstract class GLTexture implements Disposable {
 	/** Destroys the OpenGL Texture as specified by the glHandle. */
 	protected void delete () {
 		if (glHandle != 0) {
-			Gdx.gl.glDeleteTexture(glHandle);
+			gl().glDeleteTexture(glHandle);
 			glHandle = 0;
 		}
 	}

--- a/gdx/src/com/badlogic/gdx/graphics/GLTexture.java
+++ b/gdx/src/com/badlogic/gdx/graphics/GLTexture.java
@@ -296,6 +296,7 @@ public abstract class GLTexture implements Disposable {
 
 		final TextureDataType type = data.getType();
 		if (type == TextureDataType.Custom) {
+			data.setGraphics(graphics);
 			data.consumeCustomData(target);
 			return;
 		}

--- a/gdx/src/com/badlogic/gdx/graphics/Mesh.java
+++ b/gdx/src/com/badlogic/gdx/graphics/Mesh.java
@@ -76,6 +76,7 @@ public class Mesh implements Disposable {
 	/** list of all meshes **/
 	static final Map<Graphics, Array<Mesh>> meshes = new HashMap<Graphics, Array<Mesh>>();
 
+	protected final Graphics graphics;
 	protected final VertexData vertices;
 	protected final IndexData indices;
 	protected boolean autoBind = true;
@@ -84,12 +85,25 @@ public class Mesh implements Disposable {
 	protected InstanceData instances;
 	protected boolean isInstanced = false;
 
+	private GL20 gl20 () {
+		return graphics.getGL20();
+	}
+
+	private GL30 gl30 () {
+		return graphics.getGL30();
+	}
+
 	protected Mesh (VertexData vertices, IndexData indices, boolean isVertexArray) {
+		this(Gdx.graphics, vertices, indices, isVertexArray);
+	}
+
+	protected Mesh (Graphics graphics, VertexData vertices, IndexData indices, boolean isVertexArray) {
+		this.graphics = graphics;
 		this.vertices = vertices;
 		this.indices = indices;
 		this.isVertexArray = isVertexArray;
 
-		addManagedMesh(Gdx.graphics, this);
+		addManagedMesh(graphics, this);
 	}
 
 	/** Creates a new Mesh with the given attributes.
@@ -100,11 +114,16 @@ public class Mesh implements Disposable {
 	 * @param attributes the {@link VertexAttribute}s. Each vertex attribute defines one property of a vertex such as position,
 	 *           normal or texture coordinate */
 	public Mesh (boolean isStatic, int maxVertices, int maxIndices, VertexAttribute... attributes) {
+		this(Gdx.graphics, isStatic, maxVertices, maxIndices, attributes);
+	}
+
+	public Mesh (Graphics graphics, boolean isStatic, int maxVertices, int maxIndices, VertexAttribute... attributes) {
+		this.graphics = graphics;
 		vertices = makeVertexBuffer(isStatic, maxVertices, new VertexAttributes(attributes));
-		indices = new IndexBufferObject(isStatic, maxIndices);
+		indices = new IndexBufferObject(graphics, isStatic, maxIndices);
 		isVertexArray = false;
 
-		addManagedMesh(Gdx.graphics, this);
+		addManagedMesh(graphics, this);
 	}
 
 	/** Creates a new Mesh with the given attributes.
@@ -115,11 +134,16 @@ public class Mesh implements Disposable {
 	 * @param attributes the {@link VertexAttributes}. Each vertex attribute defines one property of a vertex such as position,
 	 *           normal or texture coordinate */
 	public Mesh (boolean isStatic, int maxVertices, int maxIndices, VertexAttributes attributes) {
+		this(Gdx.graphics, isStatic, maxVertices, maxIndices, attributes);
+	}
+
+	public Mesh (Graphics graphics, boolean isStatic, int maxVertices, int maxIndices, VertexAttributes attributes) {
+		this.graphics = graphics;
 		vertices = makeVertexBuffer(isStatic, maxVertices, attributes);
-		indices = new IndexBufferObject(isStatic, maxIndices);
+		indices = new IndexBufferObject(graphics, isStatic, maxIndices);
 		isVertexArray = false;
 
-		addManagedMesh(Gdx.graphics, this);
+		addManagedMesh(graphics, this);
 	}
 
 	/** Creates a new Mesh with the given attributes. Adds extra optimizations for dynamic (frequently modified) meshes.
@@ -133,18 +157,24 @@ public class Mesh implements Disposable {
 	 *
 	 * @author Jaroslaw Wisniewski <j.wisniewski@appsisle.com> **/
 	public Mesh (boolean staticVertices, boolean staticIndices, int maxVertices, int maxIndices, VertexAttributes attributes) {
+		this(Gdx.graphics, staticVertices, staticIndices, maxVertices, maxIndices, attributes);
+	}
+
+	public Mesh (Graphics graphics, boolean staticVertices, boolean staticIndices, int maxVertices, int maxIndices,
+		VertexAttributes attributes) {
+		this.graphics = graphics;
 		vertices = makeVertexBuffer(staticVertices, maxVertices, attributes);
-		indices = new IndexBufferObject(staticIndices, maxIndices);
+		indices = new IndexBufferObject(graphics, staticIndices, maxIndices);
 		isVertexArray = false;
 
-		addManagedMesh(Gdx.graphics, this);
+		addManagedMesh(graphics, this);
 	}
 
 	private VertexData makeVertexBuffer (boolean isStatic, int maxVertices, VertexAttributes vertexAttributes) {
-		if (Gdx.gl30 != null) {
-			return new VertexBufferObjectWithVAO(isStatic, maxVertices, vertexAttributes);
+		if (gl30() != null) {
+			return new VertexBufferObjectWithVAO(graphics, isStatic, maxVertices, vertexAttributes);
 		} else {
-			return new VertexBufferObject(isStatic, maxVertices, vertexAttributes);
+			return new VertexBufferObject(graphics, isStatic, maxVertices, vertexAttributes);
 		}
 	}
 
@@ -157,7 +187,12 @@ public class Mesh implements Disposable {
 	 * @param attributes the {@link VertexAttribute}s. Each vertex attribute defines one property of a vertex such as position,
 	 *           normal or texture coordinate */
 	public Mesh (VertexDataType type, boolean isStatic, int maxVertices, int maxIndices, VertexAttribute... attributes) {
-		this(type, isStatic, maxVertices, maxIndices, new VertexAttributes(attributes));
+		this(Gdx.graphics, type, isStatic, maxVertices, maxIndices, attributes);
+	}
+
+	public Mesh (Graphics graphics, VertexDataType type, boolean isStatic, int maxVertices, int maxIndices,
+		VertexAttribute... attributes) {
+		this(graphics, type, isStatic, maxVertices, maxIndices, new VertexAttributes(attributes));
 	}
 
 	/** Creates a new Mesh with the given attributes. This is an expert method with no error checking. Use at your own risk.
@@ -168,20 +203,26 @@ public class Mesh implements Disposable {
 	 * @param maxIndices the maximum number of indices this mesh can hold
 	 * @param attributes the {@link VertexAttributes}. */
 	public Mesh (VertexDataType type, boolean isStatic, int maxVertices, int maxIndices, VertexAttributes attributes) {
+		this(Gdx.graphics, type, isStatic, maxVertices, maxIndices, attributes);
+	}
+
+	public Mesh (Graphics graphics, VertexDataType type, boolean isStatic, int maxVertices, int maxIndices,
+		VertexAttributes attributes) {
+		this.graphics = graphics;
 		switch (type) {
 		case VertexBufferObject:
-			vertices = new VertexBufferObject(isStatic, maxVertices, attributes);
-			indices = new IndexBufferObject(isStatic, maxIndices);
+			vertices = new VertexBufferObject(graphics, isStatic, maxVertices, attributes);
+			indices = new IndexBufferObject(graphics, isStatic, maxIndices);
 			isVertexArray = false;
 			break;
 		case VertexBufferObjectSubData:
-			vertices = new VertexBufferObjectSubData(isStatic, maxVertices, attributes);
-			indices = new IndexBufferObjectSubData(isStatic, maxIndices);
+			vertices = new VertexBufferObjectSubData(graphics, isStatic, maxVertices, attributes);
+			indices = new IndexBufferObjectSubData(graphics, isStatic, maxIndices);
 			isVertexArray = false;
 			break;
 		case VertexBufferObjectWithVAO:
-			vertices = new VertexBufferObjectWithVAO(isStatic, maxVertices, attributes);
-			indices = new IndexBufferObjectSubData(isStatic, maxIndices);
+			vertices = new VertexBufferObjectWithVAO(graphics, isStatic, maxVertices, attributes);
+			indices = new IndexBufferObjectSubData(graphics, isStatic, maxIndices);
 			isVertexArray = false;
 			break;
 		case VertexArray:
@@ -192,13 +233,13 @@ public class Mesh implements Disposable {
 			break;
 		}
 
-		addManagedMesh(Gdx.graphics, this);
+		addManagedMesh(graphics, this);
 	}
 
 	public Mesh enableInstancedRendering (boolean isStatic, int maxInstances, VertexAttribute... attributes) {
 		if (!isInstanced) {
 			isInstanced = true;
-			instances = new InstanceBufferObject(isStatic, maxInstances, attributes);
+			instances = new InstanceBufferObject(graphics, isStatic, maxInstances, attributes);
 		} else {
 			throw new GdxRuntimeException("Trying to enable InstancedRendering on same Mesh instance twice."
 				+ " Use disableInstancedRendering to clean up old InstanceData first");
@@ -629,10 +670,10 @@ public class Mesh implements Disposable {
 				int oldPosition = buffer.position();
 				int oldLimit = buffer.limit();
 				((Buffer)buffer).position(offset);
-				Gdx.gl20.glDrawElements(primitiveType, count, GL20.GL_UNSIGNED_SHORT, buffer);
+				gl20().glDrawElements(primitiveType, count, GL20.GL_UNSIGNED_SHORT, buffer);
 				((Buffer)buffer).position(oldPosition);
 			} else {
-				Gdx.gl20.glDrawArrays(primitiveType, offset, count);
+				gl20().glDrawArrays(primitiveType, offset, count);
 			}
 		} else {
 			int numInstances = 0;
@@ -645,15 +686,15 @@ public class Mesh implements Disposable {
 				}
 
 				if (isInstanced && numInstances > 0) {
-					Gdx.gl30.glDrawElementsInstanced(primitiveType, count, GL20.GL_UNSIGNED_SHORT, offset * 2, numInstances);
+					gl30().glDrawElementsInstanced(primitiveType, count, GL20.GL_UNSIGNED_SHORT, offset * 2, numInstances);
 				} else {
-					Gdx.gl20.glDrawElements(primitiveType, count, GL20.GL_UNSIGNED_SHORT, offset * 2);
+					gl20().glDrawElements(primitiveType, count, GL20.GL_UNSIGNED_SHORT, offset * 2);
 				}
 			} else {
 				if (isInstanced && numInstances > 0) {
-					Gdx.gl30.glDrawArraysInstanced(primitiveType, offset, count, numInstances);
+					gl30().glDrawArraysInstanced(primitiveType, offset, count, numInstances);
 				} else {
-					Gdx.gl20.glDrawArrays(primitiveType, offset, count);
+					gl20().glDrawArrays(primitiveType, offset, count);
 				}
 			}
 		}
@@ -663,7 +704,7 @@ public class Mesh implements Disposable {
 
 	/** Frees all resources associated with this Mesh */
 	public void dispose () {
-		if (meshes.get(Gdx.graphics) != null) meshes.get(Gdx.graphics).removeValue(this, true);
+		if (meshes.get(graphics) != null) meshes.get(graphics).removeValue(this, true);
 		vertices.dispose();
 		if (instances != null) instances.dispose();
 		indices.dispose();

--- a/gdx/src/com/badlogic/gdx/graphics/Mesh.java
+++ b/gdx/src/com/badlogic/gdx/graphics/Mesh.java
@@ -22,7 +22,7 @@ import java.nio.ShortBuffer;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.badlogic.gdx.Application;
+import com.badlogic.gdx.Graphics;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.VertexAttributes.Usage;
 import com.badlogic.gdx.graphics.glutils.IndexArray;
@@ -74,7 +74,7 @@ public class Mesh implements Disposable {
 	}
 
 	/** list of all meshes **/
-	static final Map<Application, Array<Mesh>> meshes = new HashMap<Application, Array<Mesh>>();
+	static final Map<Graphics, Array<Mesh>> meshes = new HashMap<Graphics, Array<Mesh>>();
 
 	protected final VertexData vertices;
 	protected final IndexData indices;
@@ -89,7 +89,7 @@ public class Mesh implements Disposable {
 		this.indices = indices;
 		this.isVertexArray = isVertexArray;
 
-		addManagedMesh(Gdx.app, this);
+		addManagedMesh(Gdx.graphics, this);
 	}
 
 	/** Creates a new Mesh with the given attributes.
@@ -104,7 +104,7 @@ public class Mesh implements Disposable {
 		indices = new IndexBufferObject(isStatic, maxIndices);
 		isVertexArray = false;
 
-		addManagedMesh(Gdx.app, this);
+		addManagedMesh(Gdx.graphics, this);
 	}
 
 	/** Creates a new Mesh with the given attributes.
@@ -119,7 +119,7 @@ public class Mesh implements Disposable {
 		indices = new IndexBufferObject(isStatic, maxIndices);
 		isVertexArray = false;
 
-		addManagedMesh(Gdx.app, this);
+		addManagedMesh(Gdx.graphics, this);
 	}
 
 	/** Creates a new Mesh with the given attributes. Adds extra optimizations for dynamic (frequently modified) meshes.
@@ -137,7 +137,7 @@ public class Mesh implements Disposable {
 		indices = new IndexBufferObject(staticIndices, maxIndices);
 		isVertexArray = false;
 
-		addManagedMesh(Gdx.app, this);
+		addManagedMesh(Gdx.graphics, this);
 	}
 
 	private VertexData makeVertexBuffer (boolean isStatic, int maxVertices, VertexAttributes vertexAttributes) {
@@ -192,7 +192,7 @@ public class Mesh implements Disposable {
 			break;
 		}
 
-		addManagedMesh(Gdx.app, this);
+		addManagedMesh(Gdx.graphics, this);
 	}
 
 	public Mesh enableInstancedRendering (boolean isStatic, int maxInstances, VertexAttribute... attributes) {
@@ -663,7 +663,7 @@ public class Mesh implements Disposable {
 
 	/** Frees all resources associated with this Mesh */
 	public void dispose () {
-		if (meshes.get(Gdx.app) != null) meshes.get(Gdx.app).removeValue(this, true);
+		if (meshes.get(Gdx.graphics) != null) meshes.get(Gdx.graphics).removeValue(this, true);
 		vertices.dispose();
 		if (instances != null) instances.dispose();
 		indices.dispose();
@@ -975,17 +975,17 @@ public class Mesh implements Disposable {
 		return indices.getBuffer(forWriting);
 	}
 
-	private static void addManagedMesh (Application app, Mesh mesh) {
-		Array<Mesh> managedResources = meshes.get(app);
+	private static void addManagedMesh (Graphics graphics, Mesh mesh) {
+		Array<Mesh> managedResources = meshes.get(graphics);
 		if (managedResources == null) managedResources = new Array<Mesh>();
 		managedResources.add(mesh);
-		meshes.put(app, managedResources);
+		meshes.put(graphics, managedResources);
 	}
 
 	/** Invalidates all meshes so the next time they are rendered new VBO handles are generated.
-	 * @param app */
-	public static void invalidateAllMeshes (Application app) {
-		Array<Mesh> meshesArray = meshes.get(app);
+	 * @param graphics the graphics instance whose meshes should be invalidated */
+	public static void invalidateAllMeshes (Graphics graphics) {
+		Array<Mesh> meshesArray = meshes.get(graphics);
 		if (meshesArray == null) return;
 		for (int i = 0; i < meshesArray.size; i++) {
 			meshesArray.get(i).vertices.invalidate();
@@ -994,16 +994,16 @@ public class Mesh implements Disposable {
 	}
 
 	/** Will clear the managed mesh cache. I wouldn't use this if i was you :) */
-	public static void clearAllMeshes (Application app) {
-		meshes.remove(app);
+	public static void clearAllMeshes (Graphics graphics) {
+		meshes.remove(graphics);
 	}
 
 	public static String getManagedStatus () {
 		StringBuilder builder = new StringBuilder();
 		int i = 0;
-		builder.append("Managed meshes/app: { ");
-		for (Application app : meshes.keySet()) {
-			builder.append(meshes.get(app).size);
+		builder.append("Managed meshes/graphics: { ");
+		for (Graphics graphics : meshes.keySet()) {
+			builder.append(meshes.get(graphics).size);
 			builder.append(" ");
 		}
 		builder.append("}");

--- a/gdx/src/com/badlogic/gdx/graphics/Pixmap.java
+++ b/gdx/src/com/badlogic/gdx/graphics/Pixmap.java
@@ -17,6 +17,7 @@
 package com.badlogic.gdx.graphics;
 
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Graphics;
 import com.badlogic.gdx.Net;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.g2d.Gdx2DPixmap;
@@ -97,11 +98,16 @@ public class Pixmap implements Disposable {
 	 * @param h framebuffer region height
 	 * @return the pixmap */
 	public static Pixmap createFromFrameBuffer (int x, int y, int w, int h) {
-		Gdx.gl.glPixelStorei(GL20.GL_PACK_ALIGNMENT, 1);
+		return createFromFrameBuffer(Gdx.graphics, x, y, w, h);
+	}
+
+	public static Pixmap createFromFrameBuffer (Graphics graphics, int x, int y, int w, int h) {
+		GL20 gl = graphics.getGL20();
+		gl.glPixelStorei(GL20.GL_PACK_ALIGNMENT, 1);
 
 		final Pixmap pixmap = new Pixmap(w, h, Format.RGBA8888);
 		ByteBuffer pixels = pixmap.getPixels();
-		Gdx.gl.glReadPixels(x, y, w, h, GL20.GL_RGBA, GL20.GL_UNSIGNED_BYTE, pixels);
+		gl.glReadPixels(x, y, w, h, GL20.GL_RGBA, GL20.GL_UNSIGNED_BYTE, pixels);
 
 		return pixmap;
 	}

--- a/gdx/src/com/badlogic/gdx/graphics/Texture.java
+++ b/gdx/src/com/badlogic/gdx/graphics/Texture.java
@@ -19,7 +19,7 @@ package com.badlogic.gdx.graphics;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.badlogic.gdx.Application;
+import com.badlogic.gdx.Graphics;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.assets.AssetLoaderParameters.LoadedCallback;
 import com.badlogic.gdx.assets.AssetManager;
@@ -47,7 +47,7 @@ import com.badlogic.gdx.utils.GdxRuntimeException;
  * @author badlogicgames@gmail.com */
 public class Texture extends GLTexture {
 	private static AssetManager assetManager;
-	final static Map<Application, Array<Texture>> managedTextures = new HashMap<Application, Array<Texture>>();
+	final static Map<Graphics, Array<Texture>> managedTextures = new HashMap<Graphics, Array<Texture>>();
 
 	public enum TextureFilter {
 		/** Fetch the nearest texel that best maps to the pixel on screen. */
@@ -149,7 +149,7 @@ public class Texture extends GLTexture {
 	protected Texture (int glTarget, int glHandle, TextureData data) {
 		super(glTarget, glHandle);
 		load(data);
-		if (data.isManaged()) addManagedTexture(Gdx.app, this);
+		if (data.isManaged()) addManagedTexture(Gdx.graphics, this);
 	}
 
 	public void load (TextureData data) {
@@ -223,7 +223,7 @@ public class Texture extends GLTexture {
 		// removal from the asset manager.
 		if (glHandle == 0) return;
 		delete();
-		if (data.isManaged()) if (managedTextures.get(Gdx.app) != null) managedTextures.get(Gdx.app).removeValue(this, true);
+		if (data.isManaged()) if (managedTextures.get(Gdx.graphics) != null) managedTextures.get(Gdx.graphics).removeValue(this, true);
 	}
 
 	public String toString () {
@@ -231,21 +231,21 @@ public class Texture extends GLTexture {
 		return super.toString();
 	}
 
-	private static void addManagedTexture (Application app, Texture texture) {
-		Array<Texture> managedTextureArray = managedTextures.get(app);
+	private static void addManagedTexture (Graphics graphics, Texture texture) {
+		Array<Texture> managedTextureArray = managedTextures.get(graphics);
 		if (managedTextureArray == null) managedTextureArray = new Array<Texture>();
 		managedTextureArray.add(texture);
-		managedTextures.put(app, managedTextureArray);
+		managedTextures.put(graphics, managedTextureArray);
 	}
 
 	/** Clears all managed textures. This is an internal method. Do not use it! */
-	public static void clearAllTextures (Application app) {
-		managedTextures.remove(app);
+	public static void clearAllTextures (Graphics graphics) {
+		managedTextures.remove(graphics);
 	}
 
 	/** Invalidate all managed textures. This is an internal method. Do not use it! */
-	public static void invalidateAllTextures (Application app) {
-		Array<Texture> managedTextureArray = managedTextures.get(app);
+	public static void invalidateAllTextures (Graphics graphics) {
+		Array<Texture> managedTextureArray = managedTextures.get(graphics);
 		if (managedTextureArray == null) return;
 
 		if (assetManager == null) {
@@ -313,9 +313,9 @@ public class Texture extends GLTexture {
 
 	public static String getManagedStatus () {
 		StringBuilder builder = new StringBuilder();
-		builder.append("Managed textures/app: { ");
-		for (Application app : managedTextures.keySet()) {
-			builder.append(managedTextures.get(app).size);
+		builder.append("Managed textures/graphics: { ");
+		for (Graphics graphics : managedTextures.keySet()) {
+			builder.append(managedTextures.get(graphics).size);
 			builder.append(" ");
 		}
 		builder.append("}");
@@ -324,6 +324,6 @@ public class Texture extends GLTexture {
 
 	/** @return the number of managed textures currently loaded */
 	public static int getNumManagedTextures () {
-		return managedTextures.get(Gdx.app).size;
+		return managedTextures.get(Gdx.graphics).size;
 	}
 }

--- a/gdx/src/com/badlogic/gdx/graphics/Texture.java
+++ b/gdx/src/com/badlogic/gdx/graphics/Texture.java
@@ -200,7 +200,7 @@ public class Texture extends GLTexture {
 		if (!data.isPrepared()) data.prepare();
 
 		bind();
-		uploadImageData(GL20.GL_TEXTURE_2D, data);
+		uploadImageData(graphics, GL20.GL_TEXTURE_2D, data);
 
 		unsafeSetFilter(minFilter, magFilter, true);
 		unsafeSetWrap(uWrap, vWrap, true);

--- a/gdx/src/com/badlogic/gdx/graphics/Texture.java
+++ b/gdx/src/com/badlogic/gdx/graphics/Texture.java
@@ -111,45 +111,85 @@ public class Texture extends GLTexture {
 	}
 
 	public Texture (String internalPath) {
-		this(Gdx.files.internal(internalPath));
+		this(Gdx.graphics, Gdx.files.internal(internalPath));
+	}
+
+	public Texture (Graphics graphics, String internalPath) {
+		this(graphics, Gdx.files.internal(internalPath));
 	}
 
 	public Texture (FileHandle file) {
-		this(file, null, false);
+		this(Gdx.graphics, file, null, false);
+	}
+
+	public Texture (Graphics graphics, FileHandle file) {
+		this(graphics, file, null, false);
 	}
 
 	public Texture (FileHandle file, boolean useMipMaps) {
-		this(file, null, useMipMaps);
+		this(Gdx.graphics, file, null, useMipMaps);
+	}
+
+	public Texture (Graphics graphics, FileHandle file, boolean useMipMaps) {
+		this(graphics, file, null, useMipMaps);
 	}
 
 	public Texture (FileHandle file, Format format, boolean useMipMaps) {
-		this(TextureData.Factory.loadFromFile(file, format, useMipMaps));
+		this(Gdx.graphics, file, format, useMipMaps);
+	}
+
+	public Texture (Graphics graphics, FileHandle file, Format format, boolean useMipMaps) {
+		this(graphics, TextureData.Factory.loadFromFile(file, format, useMipMaps));
 	}
 
 	public Texture (Pixmap pixmap) {
-		this(new PixmapTextureData(pixmap, null, false, false));
+		this(Gdx.graphics, new PixmapTextureData(pixmap, null, false, false));
+	}
+
+	public Texture (Graphics graphics, Pixmap pixmap) {
+		this(graphics, new PixmapTextureData(pixmap, null, false, false));
 	}
 
 	public Texture (Pixmap pixmap, boolean useMipMaps) {
-		this(new PixmapTextureData(pixmap, null, useMipMaps, false));
+		this(Gdx.graphics, new PixmapTextureData(pixmap, null, useMipMaps, false));
+	}
+
+	public Texture (Graphics graphics, Pixmap pixmap, boolean useMipMaps) {
+		this(graphics, new PixmapTextureData(pixmap, null, useMipMaps, false));
 	}
 
 	public Texture (Pixmap pixmap, Format format, boolean useMipMaps) {
-		this(new PixmapTextureData(pixmap, format, useMipMaps, false));
+		this(Gdx.graphics, new PixmapTextureData(pixmap, format, useMipMaps, false));
+	}
+
+	public Texture (Graphics graphics, Pixmap pixmap, Format format, boolean useMipMaps) {
+		this(graphics, new PixmapTextureData(pixmap, format, useMipMaps, false));
 	}
 
 	public Texture (int width, int height, Format format) {
-		this(new PixmapTextureData(new Pixmap(width, height, format), null, false, true));
+		this(Gdx.graphics, new PixmapTextureData(new Pixmap(width, height, format), null, false, true));
+	}
+
+	public Texture (Graphics graphics, int width, int height, Format format) {
+		this(graphics, new PixmapTextureData(new Pixmap(width, height, format), null, false, true));
 	}
 
 	public Texture (TextureData data) {
-		this(GL20.GL_TEXTURE_2D, Gdx.gl.glGenTexture(), data);
+		this(Gdx.graphics, data);
+	}
+
+	public Texture (Graphics graphics, TextureData data) {
+		this(graphics, GL20.GL_TEXTURE_2D, graphics.getGL20().glGenTexture(), data);
 	}
 
 	protected Texture (int glTarget, int glHandle, TextureData data) {
-		super(glTarget, glHandle);
+		this(Gdx.graphics, glTarget, glHandle, data);
+	}
+
+	protected Texture (Graphics graphics, int glTarget, int glHandle, TextureData data) {
+		super(graphics, glTarget, glHandle);
 		load(data);
-		if (data.isManaged()) addManagedTexture(Gdx.graphics, this);
+		if (data.isManaged()) addManagedTexture(graphics, this);
 	}
 
 	public void load (TextureData data) {
@@ -165,7 +205,7 @@ public class Texture extends GLTexture {
 		unsafeSetFilter(minFilter, magFilter, true);
 		unsafeSetWrap(uWrap, vWrap, true);
 		unsafeSetAnisotropicFilter(anisotropicFilterLevel, true);
-		Gdx.gl.glBindTexture(glTarget, 0);
+		gl().glBindTexture(glTarget, 0);
 	}
 
 	/** Used internally to reload after context loss. Creates a new GL handle then calls {@link #load(TextureData)}. Use this only
@@ -173,7 +213,7 @@ public class Texture extends GLTexture {
 	@Override
 	protected void reload () {
 		if (!isManaged()) throw new GdxRuntimeException("Tried to reload unmanaged Texture");
-		glHandle = Gdx.gl.glGenTexture();
+		glHandle = gl().glGenTexture();
 		load(data);
 	}
 
@@ -187,7 +227,7 @@ public class Texture extends GLTexture {
 		if (data.isManaged()) throw new GdxRuntimeException("can't draw to a managed texture");
 
 		bind();
-		Gdx.gl.glTexSubImage2D(glTarget, 0, x, y, pixmap.getWidth(), pixmap.getHeight(), pixmap.getGLFormat(), pixmap.getGLType(),
+		gl().glTexSubImage2D(glTarget, 0, x, y, pixmap.getWidth(), pixmap.getHeight(), pixmap.getGLFormat(), pixmap.getGLType(),
 			pixmap.getPixels());
 	}
 
@@ -223,7 +263,7 @@ public class Texture extends GLTexture {
 		// removal from the asset manager.
 		if (glHandle == 0) return;
 		delete();
-		if (data.isManaged()) if (managedTextures.get(Gdx.graphics) != null) managedTextures.get(Gdx.graphics).removeValue(this, true);
+		if (data.isManaged()) if (managedTextures.get(graphics) != null) managedTextures.get(graphics).removeValue(this, true);
 	}
 
 	public String toString () {
@@ -294,7 +334,7 @@ public class Texture extends GLTexture {
 
 					// unload the texture, create a new gl handle then reload it.
 					assetManager.unload(fileName);
-					texture.glHandle = Gdx.gl.glGenTexture();
+					texture.glHandle = graphics.getGL20().glGenTexture();
 					assetManager.load(fileName, Texture.class, params);
 				}
 			}

--- a/gdx/src/com/badlogic/gdx/graphics/Texture3D.java
+++ b/gdx/src/com/badlogic/gdx/graphics/Texture3D.java
@@ -19,7 +19,7 @@ package com.badlogic.gdx.graphics;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.badlogic.gdx.Application;
+import com.badlogic.gdx.Graphics;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Texture.TextureWrap;
 import com.badlogic.gdx.graphics.glutils.CustomTexture3DData;
@@ -30,7 +30,7 @@ import com.badlogic.gdx.utils.GdxRuntimeException;
  * @author mgsx */
 public class Texture3D extends GLTexture {
 
-	final static Map<Application, Array<Texture3D>> managedTexture3Ds = new HashMap<Application, Array<Texture3D>>();
+	final static Map<Graphics, Array<Texture3D>> managedTexture3Ds = new HashMap<Graphics, Array<Texture3D>>();
 
 	private Texture3DData data;
 
@@ -49,7 +49,7 @@ public class Texture3D extends GLTexture {
 
 		load(data);
 
-		if (data.isManaged()) addManagedTexture(Gdx.app, this);
+		if (data.isManaged()) addManagedTexture(Gdx.graphics, this);
 	}
 
 	private void load (Texture3DData data) {
@@ -105,21 +105,21 @@ public class Texture3D extends GLTexture {
 		load(data);
 	}
 
-	private static void addManagedTexture (Application app, Texture3D texture) {
-		Array<Texture3D> managedTextureArray = managedTexture3Ds.get(app);
+	private static void addManagedTexture (Graphics graphics, Texture3D texture) {
+		Array<Texture3D> managedTextureArray = managedTexture3Ds.get(graphics);
 		if (managedTextureArray == null) managedTextureArray = new Array<Texture3D>();
 		managedTextureArray.add(texture);
-		managedTexture3Ds.put(app, managedTextureArray);
+		managedTexture3Ds.put(graphics, managedTextureArray);
 	}
 
 	/** Clears all managed TextureArrays. This is an internal method. Do not use it! */
-	public static void clearAllTextureArrays (Application app) {
-		managedTexture3Ds.remove(app);
+	public static void clearAllTextureArrays (Graphics graphics) {
+		managedTexture3Ds.remove(graphics);
 	}
 
 	/** Invalidate all managed TextureArrays. This is an internal method. Do not use it! */
-	public static void invalidateAllTextureArrays (Application app) {
-		Array<Texture3D> managedTextureArray = managedTexture3Ds.get(app);
+	public static void invalidateAllTextureArrays (Graphics graphics) {
+		Array<Texture3D> managedTextureArray = managedTexture3Ds.get(graphics);
 		if (managedTextureArray == null) return;
 
 		for (int i = 0; i < managedTextureArray.size; i++) {
@@ -130,9 +130,9 @@ public class Texture3D extends GLTexture {
 
 	public static String getManagedStatus () {
 		StringBuilder builder = new StringBuilder();
-		builder.append("Managed TextureArrays/app: { ");
-		for (Application app : managedTexture3Ds.keySet()) {
-			builder.append(managedTexture3Ds.get(app).size);
+		builder.append("Managed TextureArrays/graphics: { ");
+		for (Graphics graphics : managedTexture3Ds.keySet()) {
+			builder.append(managedTexture3Ds.get(graphics).size);
 			builder.append(" ");
 		}
 		builder.append("}");
@@ -141,7 +141,7 @@ public class Texture3D extends GLTexture {
 
 	/** @return the number of managed Texture3D currently loaded */
 	public static int getNumManagedTextures3D () {
-		return managedTexture3Ds.get(Gdx.app).size;
+		return managedTexture3Ds.get(Gdx.graphics).size;
 	}
 
 	public void setWrap (TextureWrap u, TextureWrap v, TextureWrap r) {

--- a/gdx/src/com/badlogic/gdx/graphics/Texture3D.java
+++ b/gdx/src/com/badlogic/gdx/graphics/Texture3D.java
@@ -41,15 +41,19 @@ public class Texture3D extends GLTexture {
 	}
 
 	public Texture3D (Texture3DData data) {
-		super(GL30.GL_TEXTURE_3D, Gdx.gl.glGenTexture());
+		this(Gdx.graphics, data);
+	}
 
-		if (Gdx.gl30 == null) {
+	public Texture3D (Graphics graphics, Texture3DData data) {
+		super(graphics, GL30.GL_TEXTURE_3D);
+
+		if (graphics.getGL30() == null) {
 			throw new GdxRuntimeException("Texture3D requires a device running with GLES 3.0 compatibilty");
 		}
 
 		load(data);
 
-		if (data.isManaged()) addManagedTexture(Gdx.graphics, this);
+		if (data.isManaged()) addManagedTexture(graphics, this);
 	}
 
 	private void load (Texture3DData data) {
@@ -66,7 +70,7 @@ public class Texture3D extends GLTexture {
 		setFilter(minFilter, magFilter);
 		setWrap(uWrap, vWrap, rWrap);
 
-		Gdx.gl.glBindTexture(glTarget, 0);
+		gl().glBindTexture(glTarget, 0);
 	}
 
 	public Texture3DData getData () {
@@ -101,7 +105,7 @@ public class Texture3D extends GLTexture {
 	@Override
 	protected void reload () {
 		if (!isManaged()) throw new GdxRuntimeException("Tried to reload an unmanaged TextureArray");
-		glHandle = Gdx.gl.glGenTexture();
+		glHandle = gl().glGenTexture();
 		load(data);
 	}
 
@@ -147,13 +151,13 @@ public class Texture3D extends GLTexture {
 	public void setWrap (TextureWrap u, TextureWrap v, TextureWrap r) {
 		this.rWrap = r;
 		super.setWrap(u, v);
-		Gdx.gl.glTexParameteri(glTarget, GL30.GL_TEXTURE_WRAP_R, r.getGLEnum());
+		gl().glTexParameteri(glTarget, GL30.GL_TEXTURE_WRAP_R, r.getGLEnum());
 	}
 
 	public void unsafeSetWrap (TextureWrap u, TextureWrap v, TextureWrap r, boolean force) {
 		unsafeSetWrap(u, v, force);
 		if (r != null && (force || rWrap != r)) {
-			Gdx.gl.glTexParameteri(glTarget, GL30.GL_TEXTURE_WRAP_R, u.getGLEnum());
+			gl().glTexParameteri(glTarget, GL30.GL_TEXTURE_WRAP_R, u.getGLEnum());
 			rWrap = r;
 		}
 	}

--- a/gdx/src/com/badlogic/gdx/graphics/TextureArray.java
+++ b/gdx/src/com/badlogic/gdx/graphics/TextureArray.java
@@ -50,15 +50,19 @@ public class TextureArray extends GLTexture {
 	}
 
 	public TextureArray (TextureArrayData data) {
-		super(GL30.GL_TEXTURE_2D_ARRAY, Gdx.gl.glGenTexture());
+		this(Gdx.graphics, data);
+	}
 
-		if (Gdx.gl30 == null) {
+	public TextureArray (Graphics graphics, TextureArrayData data) {
+		super(graphics, GL30.GL_TEXTURE_2D_ARRAY);
+
+		if (graphics.getGL30() == null) {
 			throw new GdxRuntimeException("TextureArray requires a device running with GLES 3.0 compatibilty");
 		}
 
 		load(data);
 
-		if (data.isManaged()) addManagedTexture(Gdx.graphics, this);
+		if (data.isManaged()) addManagedTexture(graphics, this);
 	}
 
 	private static FileHandle[] getInternalHandles (String... internalPaths) {
@@ -75,7 +79,7 @@ public class TextureArray extends GLTexture {
 		this.data = data;
 
 		bind();
-		Gdx.gl30.glTexImage3D(GL30.GL_TEXTURE_2D_ARRAY, 0, data.getInternalFormat(), data.getWidth(), data.getHeight(),
+		gl30().glTexImage3D(GL30.GL_TEXTURE_2D_ARRAY, 0, data.getInternalFormat(), data.getWidth(), data.getHeight(),
 			data.getDepth(), 0, data.getInternalFormat(), data.getGLType(), null);
 
 		if (!data.isPrepared()) data.prepare();
@@ -84,7 +88,7 @@ public class TextureArray extends GLTexture {
 
 		setFilter(minFilter, magFilter);
 		setWrap(uWrap, vWrap);
-		Gdx.gl.glBindTexture(glTarget, 0);
+		gl().glBindTexture(glTarget, 0);
 	}
 
 	@Override
@@ -110,7 +114,7 @@ public class TextureArray extends GLTexture {
 	@Override
 	protected void reload () {
 		if (!isManaged()) throw new GdxRuntimeException("Tried to reload an unmanaged TextureArray");
-		glHandle = Gdx.gl.glGenTexture();
+		glHandle = gl().glGenTexture();
 		load(data);
 	}
 

--- a/gdx/src/com/badlogic/gdx/graphics/TextureArray.java
+++ b/gdx/src/com/badlogic/gdx/graphics/TextureArray.java
@@ -16,7 +16,7 @@
 
 package com.badlogic.gdx.graphics;
 
-import com.badlogic.gdx.Application;
+import com.badlogic.gdx.Graphics;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.utils.Array;
@@ -29,7 +29,7 @@ import java.util.Map;
  * @author Tomski */
 public class TextureArray extends GLTexture {
 
-	final static Map<Application, Array<TextureArray>> managedTextureArrays = new HashMap<Application, Array<TextureArray>>();
+	final static Map<Graphics, Array<TextureArray>> managedTextureArrays = new HashMap<Graphics, Array<TextureArray>>();
 
 	private TextureArrayData data;
 
@@ -58,7 +58,7 @@ public class TextureArray extends GLTexture {
 
 		load(data);
 
-		if (data.isManaged()) addManagedTexture(Gdx.app, this);
+		if (data.isManaged()) addManagedTexture(Gdx.graphics, this);
 	}
 
 	private static FileHandle[] getInternalHandles (String... internalPaths) {
@@ -114,21 +114,21 @@ public class TextureArray extends GLTexture {
 		load(data);
 	}
 
-	private static void addManagedTexture (Application app, TextureArray texture) {
-		Array<TextureArray> managedTextureArray = managedTextureArrays.get(app);
+	private static void addManagedTexture (Graphics graphics, TextureArray texture) {
+		Array<TextureArray> managedTextureArray = managedTextureArrays.get(graphics);
 		if (managedTextureArray == null) managedTextureArray = new Array<TextureArray>();
 		managedTextureArray.add(texture);
-		managedTextureArrays.put(app, managedTextureArray);
+		managedTextureArrays.put(graphics, managedTextureArray);
 	}
 
 	/** Clears all managed TextureArrays. This is an internal method. Do not use it! */
-	public static void clearAllTextureArrays (Application app) {
-		managedTextureArrays.remove(app);
+	public static void clearAllTextureArrays (Graphics graphics) {
+		managedTextureArrays.remove(graphics);
 	}
 
 	/** Invalidate all managed TextureArrays. This is an internal method. Do not use it! */
-	public static void invalidateAllTextureArrays (Application app) {
-		Array<TextureArray> managedTextureArray = managedTextureArrays.get(app);
+	public static void invalidateAllTextureArrays (Graphics graphics) {
+		Array<TextureArray> managedTextureArray = managedTextureArrays.get(graphics);
 		if (managedTextureArray == null) return;
 
 		for (int i = 0; i < managedTextureArray.size; i++) {
@@ -139,9 +139,9 @@ public class TextureArray extends GLTexture {
 
 	public static String getManagedStatus () {
 		StringBuilder builder = new StringBuilder();
-		builder.append("Managed TextureArrays/app: { ");
-		for (Application app : managedTextureArrays.keySet()) {
-			builder.append(managedTextureArrays.get(app).size);
+		builder.append("Managed TextureArrays/graphics: { ");
+		for (Graphics graphics : managedTextureArrays.keySet()) {
+			builder.append(managedTextureArrays.get(graphics).size);
 			builder.append(" ");
 		}
 		builder.append("}");
@@ -150,7 +150,7 @@ public class TextureArray extends GLTexture {
 
 	/** @return the number of managed TextureArrays currently loaded */
 	public static int getNumManagedTextureArrays () {
-		return managedTextureArrays.get(Gdx.app).size;
+		return managedTextureArrays.get(Gdx.graphics).size;
 	}
 
 }

--- a/gdx/src/com/badlogic/gdx/graphics/TextureData.java
+++ b/gdx/src/com/badlogic/gdx/graphics/TextureData.java
@@ -17,6 +17,7 @@
 package com.badlogic.gdx.graphics;
 
 import com.badlogic.gdx.files.FileHandle;
+import com.badlogic.gdx.Graphics;
 import com.badlogic.gdx.graphics.Pixmap.Format;
 import com.badlogic.gdx.graphics.glutils.ETC1TextureData;
 import com.badlogic.gdx.graphics.glutils.FileTextureData;
@@ -69,6 +70,11 @@ public interface TextureData {
 	 * must preceed a call to this method. Any internal data structures created in {@link #prepare()} should be disposed of
 	 * here. */
 	public void consumeCustomData (int target);
+
+	/** Called by {@link GLTexture} before {@link #consumeCustomData(int)} so custom uploaders can resolve GL without
+	 * {@link com.badlogic.gdx.Gdx}. Default is a no-op. */
+	default void setGraphics (Graphics graphics) {
+	}
 
 	/** @return the width of the pixel data */
 	public int getWidth ();

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/PolygonSpriteBatch.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/PolygonSpriteBatch.java
@@ -19,6 +19,7 @@ package com.badlogic.gdx.graphics.g2d;
 import static com.badlogic.gdx.graphics.g2d.Sprite.*;
 
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Graphics;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Mesh;
@@ -56,6 +57,12 @@ import com.badlogic.gdx.math.Matrix4;
  * @author Stefan Bachmann
  * @author Nathan Sweet */
 public class PolygonSpriteBatch implements PolygonBatch {
+	private final Graphics graphics;
+
+	private GL20 gl20 () {
+		return graphics.getGL20();
+	}
+
 	private Mesh mesh;
 
 	private final float[] vertices;
@@ -94,21 +101,33 @@ public class PolygonSpriteBatch implements PolygonBatch {
 	/** Constructs a PolygonSpriteBatch with the default shader, 2000 vertices, and 4000 triangles.
 	 * @see #PolygonSpriteBatch(int, int, ShaderProgram) */
 	public PolygonSpriteBatch () {
-		this(2000, null);
+		this(Gdx.graphics, 2000, null);
+	}
+
+	public PolygonSpriteBatch (Graphics graphics) {
+		this(graphics, 2000, null);
 	}
 
 	/** Constructs a PolygonSpriteBatch with the default shader, size vertices, and size * 2 triangles.
 	 * @param size The max number of vertices and number of triangles in a single batch. Max of 32767.
 	 * @see #PolygonSpriteBatch(int, int, ShaderProgram) */
 	public PolygonSpriteBatch (int size) {
-		this(size, size * 2, null);
+		this(Gdx.graphics, size, size * 2, null);
+	}
+
+	public PolygonSpriteBatch (Graphics graphics, int size) {
+		this(graphics, size, size * 2, null);
 	}
 
 	/** Constructs a PolygonSpriteBatch with the specified shader, size vertices and size * 2 triangles.
 	 * @param size The max number of vertices and number of triangles in a single batch. Max of 32767.
 	 * @see #PolygonSpriteBatch(int, int, ShaderProgram) */
 	public PolygonSpriteBatch (int size, ShaderProgram defaultShader) {
-		this(size, size * 2, defaultShader);
+		this(Gdx.graphics, size, size * 2, defaultShader);
+	}
+
+	public PolygonSpriteBatch (Graphics graphics, int size, ShaderProgram defaultShader) {
+		this(graphics, size, size * 2, defaultShader);
 	}
 
 	/** Constructs a new PolygonSpriteBatch. Sets the projection matrix to an orthographic projection with y-axis point upwards,
@@ -122,15 +141,21 @@ public class PolygonSpriteBatch implements PolygonBatch {
 	 * @param defaultShader The default shader to use. This is not owned by the PolygonSpriteBatch and must be disposed separately.
 	 *           May be null to use the default shader. */
 	public PolygonSpriteBatch (int maxVertices, int maxTriangles, ShaderProgram defaultShader) {
+		this(Gdx.graphics, maxVertices, maxTriangles, defaultShader);
+	}
+
+	public PolygonSpriteBatch (Graphics graphics, int maxVertices, int maxTriangles, ShaderProgram defaultShader) {
 		// 32767 is max vertex index.
 		if (maxVertices > 32767)
 			throw new IllegalArgumentException("Can't have more than 32767 vertices per batch: " + maxVertices);
 
+		this.graphics = graphics;
+
 		Mesh.VertexDataType vertexDataType = Mesh.VertexDataType.VertexArray;
-		if (Gdx.gl30 != null) {
+		if (graphics.getGL30() != null) {
 			vertexDataType = VertexDataType.VertexBufferObjectWithVAO;
 		}
-		mesh = new Mesh(vertexDataType, false, maxVertices, maxTriangles * 3,
+		mesh = new Mesh(graphics, vertexDataType, false, maxVertices, maxTriangles * 3,
 			new VertexAttribute(Usage.Position, 2, ShaderProgram.POSITION_ATTRIBUTE),
 			new VertexAttribute(Usage.ColorPacked, 4, ShaderProgram.COLOR_ATTRIBUTE),
 			new VertexAttribute(Usage.TextureCoordinates, 2, ShaderProgram.TEXCOORD_ATTRIBUTE + "0"));
@@ -139,12 +164,12 @@ public class PolygonSpriteBatch implements PolygonBatch {
 		triangles = new short[maxTriangles * 3];
 
 		if (defaultShader == null) {
-			shader = SpriteBatch.createDefaultShader();
+			shader = SpriteBatch.createDefaultShader(graphics);
 			ownsShader = true;
 		} else
 			shader = defaultShader;
 
-		projectionMatrix.setToOrtho2D(0, 0, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+		projectionMatrix.setToOrtho2D(0, 0, graphics.getWidth(), graphics.getHeight());
 	}
 
 	@Override
@@ -152,7 +177,7 @@ public class PolygonSpriteBatch implements PolygonBatch {
 		if (drawing) throw new IllegalStateException("PolygonSpriteBatch.end must be called before begin.");
 		renderCalls = 0;
 
-		Gdx.gl.glDepthMask(false);
+		gl20().glDepthMask(false);
 		if (customShader != null)
 			customShader.bind();
 		else
@@ -169,7 +194,7 @@ public class PolygonSpriteBatch implements PolygonBatch {
 		lastTexture = null;
 		drawing = false;
 
-		GL20 gl = Gdx.gl;
+		GL20 gl = gl20();
 		gl.glDepthMask(true);
 		if (isBlendingEnabled()) gl.glDisable(GL20.GL_BLEND);
 	}
@@ -1209,10 +1234,10 @@ public class PolygonSpriteBatch implements PolygonBatch {
 		mesh.setVertices(vertices, 0, vertexIndex);
 		mesh.setIndices(triangles, 0, trianglesInBatch);
 		if (blendingDisabled) {
-			Gdx.gl.glDisable(GL20.GL_BLEND);
+			gl20().glDisable(GL20.GL_BLEND);
 		} else {
-			Gdx.gl.glEnable(GL20.GL_BLEND);
-			if (blendSrcFunc != -1) Gdx.gl.glBlendFuncSeparate(blendSrcFunc, blendDstFunc, blendSrcFuncAlpha, blendDstFuncAlpha);
+			gl20().glEnable(GL20.GL_BLEND);
+			if (blendSrcFunc != -1) gl20().glBlendFuncSeparate(blendSrcFunc, blendDstFunc, blendSrcFuncAlpha, blendDstFuncAlpha);
 		}
 
 		mesh.render(customShader != null ? customShader : shader, GL20.GL_TRIANGLES, 0, trianglesInBatch);

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/SpriteBatch.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/SpriteBatch.java
@@ -17,6 +17,7 @@
 package com.badlogic.gdx.graphics.g2d;
 
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Graphics;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Mesh;
@@ -46,6 +47,12 @@ public class SpriteBatch implements Batch {
 	@Deprecated public static VertexDataType overrideVertexType = null;
 
 	private VertexDataType currentDataType;
+
+	private final Graphics graphics;
+
+	private GL20 gl20 () {
+		return graphics.getGL20();
+	}
 
 	private Mesh mesh;
 
@@ -85,13 +92,21 @@ public class SpriteBatch implements Batch {
 	/** Constructs a new SpriteBatch with a size of 1000, one buffer, and the default shader.
 	 * @see SpriteBatch#SpriteBatch(int, ShaderProgram) */
 	public SpriteBatch () {
-		this(1000, null);
+		this(Gdx.graphics, 1000, null);
+	}
+
+	public SpriteBatch (Graphics graphics) {
+		this(graphics, 1000, null);
 	}
 
 	/** Constructs a SpriteBatch with one buffer and the default shader.
 	 * @see SpriteBatch#SpriteBatch(int, ShaderProgram) */
 	public SpriteBatch (int size) {
-		this(size, null);
+		this(Gdx.graphics, size, null);
+	}
+
+	public SpriteBatch (Graphics graphics, int size) {
+		this(graphics, size, null);
 	}
 
 	/** Constructs a new SpriteBatch. Sets the projection matrix to an orthographic projection with y-axis point upwards, x-axis
@@ -103,10 +118,17 @@ public class SpriteBatch implements Batch {
 	 * @param size The max number of sprites in a single batch. Max of 8191.
 	 * @param defaultShader The default shader to use. This is not owned by the SpriteBatch and must be disposed separately. */
 	public SpriteBatch (int size, ShaderProgram defaultShader) {
+		this(Gdx.graphics, size, defaultShader);
+	}
+
+	public SpriteBatch (Graphics graphics, int size, ShaderProgram defaultShader) {
 		// 32767 is max vertex index, so 32767 / 4 vertices per sprite = 8191 sprites max.
 		if (size > 8191) throw new IllegalArgumentException("Can't have more than 8191 sprites per batch: " + size);
 
-		VertexDataType vertexDataType = (Gdx.gl30 != null) ? VertexDataType.VertexBufferObjectWithVAO : defaultVertexDataType;
+		this.graphics = graphics;
+
+		VertexDataType vertexDataType = (graphics.getGL30() != null) ? VertexDataType.VertexBufferObjectWithVAO
+			: defaultVertexDataType;
 
 		if (overrideVertexType != null) {
 			vertexDataType = overrideVertexType;
@@ -114,12 +136,12 @@ public class SpriteBatch implements Batch {
 
 		currentDataType = vertexDataType;
 
-		mesh = new Mesh(currentDataType, false, size * 4, size * 6,
+		mesh = new Mesh(graphics, currentDataType, false, size * 4, size * 6,
 			new VertexAttribute(Usage.Position, 2, ShaderProgram.POSITION_ATTRIBUTE),
 			new VertexAttribute(Usage.ColorPacked, 4, ShaderProgram.COLOR_ATTRIBUTE),
 			new VertexAttribute(Usage.TextureCoordinates, 2, ShaderProgram.TEXCOORD_ATTRIBUTE + "0"));
 
-		projectionMatrix.setToOrtho2D(0, 0, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+		projectionMatrix.setToOrtho2D(0, 0, graphics.getWidth(), graphics.getHeight());
 
 		vertices = new float[size * Sprite.SPRITE_SIZE];
 
@@ -137,7 +159,7 @@ public class SpriteBatch implements Batch {
 		mesh.setIndices(indices);
 
 		if (defaultShader == null) {
-			shader = createDefaultShader();
+			shader = createDefaultShader(graphics);
 			ownsShader = true;
 		} else
 			shader = defaultShader;
@@ -151,6 +173,11 @@ public class SpriteBatch implements Batch {
 
 	/** Returns a new instance of the default shader used by SpriteBatch for GL2 when no shader is specified. */
 	static public ShaderProgram createDefaultShader () {
+		return createDefaultShader(Gdx.graphics);
+	}
+
+	/** Returns a new instance of the default shader used by SpriteBatch for GL2 when no shader is specified. */
+	static public ShaderProgram createDefaultShader (Graphics graphics) {
 		String vertexShader = "attribute vec4 " + ShaderProgram.POSITION_ATTRIBUTE + ";\n" //
 			+ "attribute vec4 " + ShaderProgram.COLOR_ATTRIBUTE + ";\n" //
 			+ "attribute vec2 " + ShaderProgram.TEXCOORD_ATTRIBUTE + "0;\n" //
@@ -179,7 +206,7 @@ public class SpriteBatch implements Batch {
 			+ "  gl_FragColor = v_color * texture2D(u_texture, v_texCoords);\n" //
 			+ "}";
 
-		ShaderProgram shader = new ShaderProgram(vertexShader, fragmentShader);
+		ShaderProgram shader = new ShaderProgram(graphics, vertexShader, fragmentShader);
 		if (!shader.isCompiled()) throw new IllegalArgumentException("Error compiling shader: " + shader.getLog());
 		return shader;
 	}
@@ -189,7 +216,7 @@ public class SpriteBatch implements Batch {
 		if (drawing) throw new IllegalStateException("SpriteBatch.end must be called before begin.");
 		renderCalls = 0;
 
-		Gdx.gl.glDepthMask(false);
+		gl20().glDepthMask(false);
 		if (customShader != null)
 			customShader.bind();
 		else
@@ -206,7 +233,7 @@ public class SpriteBatch implements Batch {
 		lastTexture = null;
 		drawing = false;
 
-		GL20 gl = Gdx.gl;
+		GL20 gl = gl20();
 		gl.glDepthMask(true);
 		if (isBlendingEnabled()) gl.glDisable(GL20.GL_BLEND);
 	}
@@ -984,10 +1011,10 @@ public class SpriteBatch implements Batch {
 		}
 
 		if (blendingDisabled) {
-			Gdx.gl.glDisable(GL20.GL_BLEND);
+			gl20().glDisable(GL20.GL_BLEND);
 		} else {
-			Gdx.gl.glEnable(GL20.GL_BLEND);
-			if (blendSrcFunc != -1) Gdx.gl.glBlendFuncSeparate(blendSrcFunc, blendDstFunc, blendSrcFuncAlpha, blendDstFuncAlpha);
+			gl20().glEnable(GL20.GL_BLEND);
+			if (blendSrcFunc != -1) gl20().glBlendFuncSeparate(blendSrcFunc, blendDstFunc, blendSrcFuncAlpha, blendDstFuncAlpha);
 		}
 
 		mesh.render(customShader != null ? customShader : shader, GL20.GL_TRIANGLES, 0, count);

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/SpriteCache.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/SpriteCache.java
@@ -24,6 +24,7 @@ import java.nio.FloatBuffer;
 
 import com.badlogic.gdx.ApplicationListener;
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Graphics;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Mesh;
@@ -69,6 +70,12 @@ import com.badlogic.gdx.utils.IntArray;
 public class SpriteCache implements Disposable {
 	static private final float[] tempVertices = new float[VERTEX_SIZE * 6];
 
+	private final Graphics graphics;
+
+	private GL20 gl20 () {
+		return graphics.getGL20();
+	}
+
 	private final Mesh mesh;
 	private boolean drawing;
 	private final Matrix4 transformMatrix = new Matrix4();
@@ -95,7 +102,11 @@ public class SpriteCache implements Disposable {
 
 	/** Creates a cache that uses indexed geometry and can contain up to 1000 images. */
 	public SpriteCache () {
-		this(1000, false);
+		this(Gdx.graphics, 1000, false);
+	}
+
+	public SpriteCache (Graphics graphics) {
+		this(graphics, 1000, false);
 	}
 
 	/** Creates a cache with the specified size, using a default shader if OpenGL ES 2.0 is being used.
@@ -103,7 +114,11 @@ public class SpriteCache implements Disposable {
 	 *           Max of 8191 if indices are used.
 	 * @param useIndices If true, indexed geometry will be used. */
 	public SpriteCache (int size, boolean useIndices) {
-		this(size, createDefaultShader(), useIndices);
+		this(Gdx.graphics, size, useIndices);
+	}
+
+	public SpriteCache (Graphics graphics, int size, boolean useIndices) {
+		this(graphics, size, createDefaultShader(graphics), useIndices);
 	}
 
 	/** Creates a cache with the specified size and OpenGL ES 2.0 shader.
@@ -111,11 +126,16 @@ public class SpriteCache implements Disposable {
 	 *           Max of 8191 if indices are used.
 	 * @param useIndices If true, indexed geometry will be used. */
 	public SpriteCache (int size, ShaderProgram shader, boolean useIndices) {
+		this(Gdx.graphics, size, shader, useIndices);
+	}
+
+	public SpriteCache (Graphics graphics, int size, ShaderProgram shader, boolean useIndices) {
+		this.graphics = graphics;
 		this.shader = shader;
 
 		if (useIndices && size > 8191) throw new IllegalArgumentException("Can't have more than 8191 sprites per batch: " + size);
 
-		mesh = new Mesh(true, size * (useIndices ? 4 : 6), useIndices ? size * 6 : 0,
+		mesh = new Mesh(graphics, true, size * (useIndices ? 4 : 6), useIndices ? size * 6 : 0,
 			new VertexAttribute(Usage.Position, 2, ShaderProgram.POSITION_ATTRIBUTE),
 			new VertexAttribute(Usage.ColorPacked, 4, ShaderProgram.COLOR_ATTRIBUTE),
 			new VertexAttribute(Usage.TextureCoordinates, 2, ShaderProgram.TEXCOORD_ATTRIBUTE + "0"));
@@ -136,7 +156,7 @@ public class SpriteCache implements Disposable {
 			mesh.setIndices(indices);
 		}
 
-		projectionMatrix.setToOrtho2D(0, 0, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+		projectionMatrix.setToOrtho2D(0, 0, graphics.getWidth(), graphics.getHeight());
 	}
 
 	/** Sets the color used to tint images when they are added to the SpriteCache. Default is {@link Color#WHITE}. */
@@ -855,7 +875,7 @@ public class SpriteCache implements Disposable {
 		renderCalls = 0;
 		combinedMatrix.set(projectionMatrix).mul(transformMatrix);
 
-		Gdx.gl20.glDepthMask(false);
+		gl20().glDepthMask(false);
 
 		if (customShader != null) {
 			customShader.bind();
@@ -878,7 +898,7 @@ public class SpriteCache implements Disposable {
 		if (!drawing) throw new IllegalStateException("begin must be called before end.");
 		drawing = false;
 
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		gl.glDepthMask(true);
 		if (customShader != null)
 			mesh.unbind(customShader);
@@ -979,6 +999,10 @@ public class SpriteCache implements Disposable {
 	}
 
 	static ShaderProgram createDefaultShader () {
+		return createDefaultShader(Gdx.graphics);
+	}
+
+	static ShaderProgram createDefaultShader (Graphics graphics) {
 		String vertexShader = "attribute vec4 " + ShaderProgram.POSITION_ATTRIBUTE + ";\n" //
 			+ "attribute vec4 " + ShaderProgram.COLOR_ATTRIBUTE + ";\n" //
 			+ "attribute vec2 " + ShaderProgram.TEXCOORD_ATTRIBUTE + "0;\n" //
@@ -1003,7 +1027,7 @@ public class SpriteCache implements Disposable {
 			+ "{\n" //
 			+ "  gl_FragColor = v_color * texture2D(u_texture, v_texCoords);\n" //
 			+ "}";
-		ShaderProgram shader = new ShaderProgram(vertexShader, fragmentShader);
+		ShaderProgram shader = new ShaderProgram(graphics, vertexShader, fragmentShader);
 		if (!shader.isCompiled()) throw new IllegalArgumentException("Error compiling shader: " + shader.getLog());
 		return shader;
 	}

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/utils/DefaultTextureBinder.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/utils/DefaultTextureBinder.java
@@ -19,6 +19,7 @@ package com.badlogic.gdx.graphics.g3d.utils;
 import java.nio.IntBuffer;
 
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Graphics;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.GLTexture;
 import com.badlogic.gdx.utils.BufferUtils;
@@ -42,26 +43,44 @@ public final class DefaultTextureBinder implements TextureBinder {
 	private int[] unitsLRU;
 	/** The method of binding to use */
 	private final int method;
+	private final Graphics graphics;
 	/** Flag to indicate the current texture is reused */
 	private boolean reused;
 
 	private int reuseCount = 0; // TODO remove debug code
 	private int bindCount = 0; // TODO remove debug code
 
+	private GL20 gl20 () {
+		return graphics.getGL20();
+	}
+
 	/** Uses all available texture units and reuse weight of 3 */
 	public DefaultTextureBinder (final int method) {
-		this(method, 0);
+		this(Gdx.graphics, method, 0);
+	}
+
+	public DefaultTextureBinder (Graphics graphics, final int method) {
+		this(graphics, method, 0);
 	}
 
 	/** Uses all remaining texture units and reuse weight of 3 */
 	public DefaultTextureBinder (final int method, final int offset) {
-		this(method, offset, -1);
+		this(Gdx.graphics, method, offset, -1);
+	}
+
+	public DefaultTextureBinder (Graphics graphics, final int method, final int offset) {
+		this(graphics, method, offset, -1);
 	}
 
 	public DefaultTextureBinder (final int method, final int offset, int count) {
-		final int max = Math.min(getMaxTextureUnits(), MAX_GLES_UNITS);
+		this(Gdx.graphics, method, offset, count);
+	}
+
+	public DefaultTextureBinder (Graphics graphics, final int method, final int offset, int count) {
+		final int max = Math.min(getMaxTextureUnits(graphics), MAX_GLES_UNITS);
 		if (count < 0) count = max - offset;
 		if (offset < 0 || count < 0 || (offset + count) > max) throw new GdxRuntimeException("Illegal arguments");
+		this.graphics = graphics;
 		this.method = method;
 		this.offset = offset;
 		this.count = count;
@@ -69,9 +88,9 @@ public final class DefaultTextureBinder implements TextureBinder {
 		this.unitsLRU = (method == LRU) ? new int[count] : null;
 	}
 
-	private static int getMaxTextureUnits () {
+	private static int getMaxTextureUnits (Graphics graphics) {
 		IntBuffer buffer = BufferUtils.newIntBuffer(16);
-		Gdx.gl.glGetIntegerv(GL20.GL_MAX_TEXTURE_IMAGE_UNITS, buffer);
+		graphics.getGL20().glGetIntegerv(GL20.GL_MAX_TEXTURE_IMAGE_UNITS, buffer);
 		return buffer.get(0);
 	}
 
@@ -90,7 +109,7 @@ public final class DefaultTextureBinder implements TextureBinder {
 		 * Gdx.gl.glActiveTexture(GL20.GL_TEXTURE0 + offset + i); Gdx.gl.glBindTexture(GL20.GL_TEXTURE_2D, 0); textures[i] = null; }
 		 * }
 		 */
-		Gdx.gl.glActiveTexture(GL20.GL_TEXTURE0);
+		gl20().glActiveTexture(GL20.GL_TEXTURE0);
 	}
 
 	@Override
@@ -127,7 +146,7 @@ public final class DefaultTextureBinder implements TextureBinder {
 			if (rebind)
 				texture.bind(result);
 			else
-				Gdx.gl.glActiveTexture(GL20.GL_TEXTURE0 + result);
+				gl20().glActiveTexture(GL20.GL_TEXTURE0 + result);
 		} else
 			bindCount++;
 		texture.unsafeSetWrap(textureDesc.uWrap, textureDesc.vWrap);

--- a/gdx/src/com/badlogic/gdx/graphics/g3d/utils/RenderContext.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g3d/utils/RenderContext.java
@@ -17,6 +17,7 @@
 package com.badlogic.gdx.graphics.g3d.utils;
 
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Graphics;
 import com.badlogic.gdx.graphics.GL20;
 
 /** Manages OpenGL state and tries to reduce state changes. Uses a {@link TextureBinder} to reduce texture binds as well. Call
@@ -26,6 +27,7 @@ import com.badlogic.gdx.graphics.GL20;
 public class RenderContext {
 	/** used to bind textures **/
 	public final TextureBinder textureBinder;
+	private final Graphics graphics;
 	private boolean blending;
 	private int blendSourceRgbFactor;
 	private int blendDestRgbFactor;
@@ -37,34 +39,43 @@ public class RenderContext {
 	private boolean depthMask;
 	private int cullFace;
 
+	private GL20 gl20 () {
+		return graphics.getGL20();
+	}
+
 	public RenderContext (TextureBinder textures) {
+		this(Gdx.graphics, textures);
+	}
+
+	public RenderContext (Graphics graphics, TextureBinder textures) {
+		this.graphics = graphics;
 		this.textureBinder = textures;
 	}
 
 	/** Sets up the render context, must be matched with a call to {@link #end()}. */
 	public void begin () {
-		Gdx.gl.glDisable(GL20.GL_DEPTH_TEST);
+		gl20().glDisable(GL20.GL_DEPTH_TEST);
 		depthFunc = 0;
-		Gdx.gl.glDepthMask(true);
+		gl20().glDepthMask(true);
 		depthMask = true;
-		Gdx.gl.glDisable(GL20.GL_BLEND);
+		gl20().glDisable(GL20.GL_BLEND);
 		blending = false;
-		Gdx.gl.glDisable(GL20.GL_CULL_FACE);
+		gl20().glDisable(GL20.GL_CULL_FACE);
 		cullFace = blendSourceRgbFactor = blendDestRgbFactor = blendSourceAlphaFactor = blendDestAlphaFactor = 0;
 		textureBinder.begin();
 	}
 
 	/** Resets all changed OpenGL states to their defaults. */
 	public void end () {
-		if (depthFunc != 0) Gdx.gl.glDisable(GL20.GL_DEPTH_TEST);
-		if (!depthMask) Gdx.gl.glDepthMask(true);
-		if (blending) Gdx.gl.glDisable(GL20.GL_BLEND);
-		if (cullFace > 0) Gdx.gl.glDisable(GL20.GL_CULL_FACE);
+		if (depthFunc != 0) gl20().glDisable(GL20.GL_DEPTH_TEST);
+		if (!depthMask) gl20().glDepthMask(true);
+		if (blending) gl20().glDisable(GL20.GL_BLEND);
+		if (cullFace > 0) gl20().glDisable(GL20.GL_CULL_FACE);
 		textureBinder.end();
 	}
 
 	public void setDepthMask (final boolean depthMask) {
-		if (this.depthMask != depthMask) Gdx.gl.glDepthMask(this.depthMask = depthMask);
+		if (this.depthMask != depthMask) gl20().glDepthMask(this.depthMask = depthMask);
 	}
 
 	public void setDepthTest (final int depthFunction) {
@@ -77,15 +88,15 @@ public class RenderContext {
 		if (depthFunc != depthFunction) {
 			depthFunc = depthFunction;
 			if (enabled) {
-				Gdx.gl.glEnable(GL20.GL_DEPTH_TEST);
-				Gdx.gl.glDepthFunc(depthFunction);
+				gl20().glEnable(GL20.GL_DEPTH_TEST);
+				gl20().glDepthFunc(depthFunction);
 			} else
-				Gdx.gl.glDisable(GL20.GL_DEPTH_TEST);
+				gl20().glDisable(GL20.GL_DEPTH_TEST);
 		}
 		if (enabled) {
-			if (!wasEnabled || depthFunc != depthFunction) Gdx.gl.glDepthFunc(depthFunc = depthFunction);
+			if (!wasEnabled || depthFunc != depthFunction) gl20().glDepthFunc(depthFunc = depthFunction);
 			if (!wasEnabled || this.depthRangeNear != depthRangeNear || this.depthRangeFar != depthRangeFar)
-				Gdx.gl.glDepthRangef(this.depthRangeNear = depthRangeNear, this.depthRangeFar = depthRangeFar);
+				gl20().glDepthRangef(this.depthRangeNear = depthRangeNear, this.depthRangeFar = depthRangeFar);
 		}
 	}
 
@@ -98,13 +109,13 @@ public class RenderContext {
 		if (enabled != blending) {
 			blending = enabled;
 			if (enabled)
-				Gdx.gl.glEnable(GL20.GL_BLEND);
+				gl20().glEnable(GL20.GL_BLEND);
 			else
-				Gdx.gl.glDisable(GL20.GL_BLEND);
+				gl20().glDisable(GL20.GL_BLEND);
 		}
 		if (enabled && (blendSourceRgbFactor != sRgbFactor || blendDestRgbFactor != dRgbFactor
 			|| blendSourceAlphaFactor != sAlphaFactor || blendDestAlphaFactor != dAlphaFactor)) {
-			Gdx.gl.glBlendFuncSeparate(sRgbFactor, dRgbFactor, sAlphaFactor, dAlphaFactor);
+			gl20().glBlendFuncSeparate(sRgbFactor, dRgbFactor, sAlphaFactor, dAlphaFactor);
 			blendSourceRgbFactor = sRgbFactor;
 			blendDestRgbFactor = dRgbFactor;
 			blendSourceAlphaFactor = sAlphaFactor;
@@ -116,10 +127,10 @@ public class RenderContext {
 		if (face != cullFace) {
 			cullFace = face;
 			if ((face == GL20.GL_FRONT) || (face == GL20.GL_BACK) || (face == GL20.GL_FRONT_AND_BACK)) {
-				Gdx.gl.glEnable(GL20.GL_CULL_FACE);
-				Gdx.gl.glCullFace(face);
+				gl20().glEnable(GL20.GL_CULL_FACE);
+				gl20().glCullFace(face);
 			} else
-				Gdx.gl.glDisable(GL20.GL_CULL_FACE);
+				gl20().glDisable(GL20.GL_CULL_FACE);
 		}
 	}
 }

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/ETC1TextureData.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/ETC1TextureData.java
@@ -17,6 +17,7 @@
 package com.badlogic.gdx.graphics.glutils;
 
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Graphics;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Pixmap;
@@ -32,19 +33,39 @@ public class ETC1TextureData implements TextureData {
 	int width = 0;
 	int height = 0;
 	boolean isPrepared = false;
+	private Graphics graphics = Gdx.graphics;
 
 	public ETC1TextureData (FileHandle file) {
-		this(file, false);
+		this(Gdx.graphics, file, false);
+	}
+
+	public ETC1TextureData (Graphics graphics, FileHandle file) {
+		this(graphics, file, false);
 	}
 
 	public ETC1TextureData (FileHandle file, boolean useMipMaps) {
+		this(Gdx.graphics, file, useMipMaps);
+	}
+
+	public ETC1TextureData (Graphics graphics, FileHandle file, boolean useMipMaps) {
+		this.graphics = graphics;
 		this.file = file;
 		this.useMipMaps = useMipMaps;
 	}
 
 	public ETC1TextureData (ETC1Data encodedImage, boolean useMipMaps) {
+		this(Gdx.graphics, encodedImage, useMipMaps);
+	}
+
+	public ETC1TextureData (Graphics graphics, ETC1Data encodedImage, boolean useMipMaps) {
+		this.graphics = graphics;
 		this.data = encodedImage;
 		this.useMipMaps = useMipMaps;
+	}
+
+	@Override
+	public void setGraphics (Graphics graphics) {
+		this.graphics = graphics;
 	}
 
 	@Override
@@ -73,17 +94,18 @@ public class ETC1TextureData implements TextureData {
 	public void consumeCustomData (int target) {
 		if (!isPrepared) throw new GdxRuntimeException("Call prepare() before calling consumeCompressedData()");
 
-		if (!Gdx.graphics.supportsExtension("GL_OES_compressed_ETC1_RGB8_texture")) {
+		GL20 gl = graphics.getGL20();
+		if (!graphics.supportsExtension("GL_OES_compressed_ETC1_RGB8_texture")) {
 			Pixmap pixmap = ETC1.decodeImage(data, Format.RGB565);
-			Gdx.gl.glTexImage2D(target, 0, pixmap.getGLInternalFormat(), pixmap.getWidth(), pixmap.getHeight(), 0,
+			gl.glTexImage2D(target, 0, pixmap.getGLInternalFormat(), pixmap.getWidth(), pixmap.getHeight(), 0,
 				pixmap.getGLFormat(), pixmap.getGLType(), pixmap.getPixels());
-			if (useMipMaps) MipMapGenerator.generateMipMap(target, pixmap, pixmap.getWidth(), pixmap.getHeight());
+			if (useMipMaps) MipMapGenerator.generateMipMap(graphics, target, pixmap, pixmap.getWidth(), pixmap.getHeight());
 			pixmap.dispose();
 			useMipMaps = false;
 		} else {
-			Gdx.gl.glCompressedTexImage2D(target, 0, ETC1.ETC1_RGB8_OES, width, height, 0,
+			gl.glCompressedTexImage2D(target, 0, ETC1.ETC1_RGB8_OES, width, height, 0,
 				data.compressedData.capacity() - data.dataOffset, data.compressedData);
-			if (useMipMaps()) Gdx.gl20.glGenerateMipmap(GL20.GL_TEXTURE_2D);
+			if (useMipMaps()) gl.glGenerateMipmap(GL20.GL_TEXTURE_2D);
 		}
 		data.dispose();
 		data = null;

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/FloatFrameBuffer.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/FloatFrameBuffer.java
@@ -64,7 +64,7 @@ public class FloatFrameBuffer extends FrameBuffer {
 
 	@Override
 	protected Texture createTexture (FrameBufferTextureAttachmentSpec attachmentSpec) {
-		FloatTextureData data = new FloatTextureData(bufferBuilder.width, bufferBuilder.height, attachmentSpec.internalFormat,
+		FloatTextureData data = new FloatTextureData(graphics, bufferBuilder.width, bufferBuilder.height, attachmentSpec.internalFormat,
 			attachmentSpec.format, attachmentSpec.type, attachmentSpec.isGpuOnly);
 		Texture result = new Texture(graphics, data);
 		if (Gdx.app.getType() == ApplicationType.Desktop || Gdx.app.getType() == ApplicationType.Applet)

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/FloatFrameBuffer.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/FloatFrameBuffer.java
@@ -18,6 +18,7 @@ package com.badlogic.gdx.graphics.glutils;
 
 import com.badlogic.gdx.Application.ApplicationType;
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Graphics;
 import com.badlogic.gdx.graphics.GL30;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.Texture.TextureFilter;
@@ -47,11 +48,16 @@ public class FloatFrameBuffer extends FrameBuffer {
 	 * @param hasDepth whether to attach a depth buffer
 	 * @throws GdxRuntimeException in case the FrameBuffer could not be created */
 	public FloatFrameBuffer (int width, int height, boolean hasDepth) {
-		checkExtensions();
-		FloatFrameBufferBuilder bufferBuilder = new FloatFrameBufferBuilder(width, height);
+		this(Gdx.graphics, width, height, hasDepth);
+	}
+
+	public FloatFrameBuffer (Graphics graphics, int width, int height, boolean hasDepth) {
+		checkExtensions(graphics);
+		FloatFrameBufferBuilder bufferBuilder = new FloatFrameBufferBuilder(graphics, width, height);
 		bufferBuilder.addFloatAttachment(GL30.GL_RGBA32F, GL30.GL_RGBA, GL30.GL_FLOAT, false);
 		if (hasDepth) bufferBuilder.addBasicDepthRenderBuffer();
 		this.bufferBuilder = bufferBuilder;
+		this.graphics = graphics;
 
 		build();
 	}
@@ -60,7 +66,7 @@ public class FloatFrameBuffer extends FrameBuffer {
 	protected Texture createTexture (FrameBufferTextureAttachmentSpec attachmentSpec) {
 		FloatTextureData data = new FloatTextureData(bufferBuilder.width, bufferBuilder.height, attachmentSpec.internalFormat,
 			attachmentSpec.format, attachmentSpec.type, attachmentSpec.isGpuOnly);
-		Texture result = new Texture(data);
+		Texture result = new Texture(graphics, data);
 		if (Gdx.app.getType() == ApplicationType.Desktop || Gdx.app.getType() == ApplicationType.Applet)
 			result.setFilter(TextureFilter.Linear, TextureFilter.Linear);
 		else
@@ -72,9 +78,13 @@ public class FloatFrameBuffer extends FrameBuffer {
 
 	/** Check for support for any required extensions on the current platform. */
 	private void checkExtensions () {
-		if (Gdx.graphics.isGL30Available() && Gdx.app.getType() == ApplicationType.WebGL) {
+		checkExtensions(graphics != null ? graphics : Gdx.graphics);
+	}
+
+	private void checkExtensions (Graphics graphics) {
+		if (graphics.isGL30Available() && Gdx.app.getType() == ApplicationType.WebGL) {
 			// For WebGL2, Rendering to a Floating Point Texture requires this extension
-			if (!Gdx.graphics.supportsExtension("EXT_color_buffer_float"))
+			if (!graphics.supportsExtension("EXT_color_buffer_float"))
 				throw new GdxRuntimeException("Extension EXT_color_buffer_float not supported!");
 		}
 	}

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/FloatTextureData.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/FloatTextureData.java
@@ -20,6 +20,7 @@ import java.nio.FloatBuffer;
 
 import com.badlogic.gdx.Application.ApplicationType;
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Graphics;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.GL30;
 import com.badlogic.gdx.graphics.Pixmap;
@@ -42,14 +43,25 @@ public class FloatTextureData implements TextureData {
 
 	boolean isPrepared = false;
 	FloatBuffer buffer;
+	private Graphics graphics = Gdx.graphics;
 
 	public FloatTextureData (int w, int h, int internalFormat, int format, int type, boolean isGpuOnly) {
+		this(Gdx.graphics, w, h, internalFormat, format, type, isGpuOnly);
+	}
+
+	public FloatTextureData (Graphics graphics, int w, int h, int internalFormat, int format, int type, boolean isGpuOnly) {
+		this.graphics = graphics;
 		this.width = w;
 		this.height = h;
 		this.internalFormat = internalFormat;
 		this.format = format;
 		this.type = type;
 		this.isGpuOnly = isGpuOnly;
+	}
+
+	@Override
+	public void setGraphics (Graphics graphics) {
+		this.graphics = graphics;
 	}
 
 	@Override
@@ -67,7 +79,7 @@ public class FloatTextureData implements TextureData {
 		if (isPrepared) throw new GdxRuntimeException("Already prepared");
 		if (!isGpuOnly) {
 			int amountOfFloats = 4;
-			if (Gdx.graphics.getGLVersion().getType().equals(GLVersion.Type.OpenGL)) {
+			if (graphics.getGLVersion().getType().equals(GLVersion.Type.OpenGL)) {
 				if (internalFormat == GL30.GL_RGBA16F || internalFormat == GL30.GL_RGBA32F) amountOfFloats = 4;
 				if (internalFormat == GL30.GL_RGB16F || internalFormat == GL30.GL_RGB32F) amountOfFloats = 3;
 				if (internalFormat == GL30.GL_RG16F || internalFormat == GL30.GL_RG32F) amountOfFloats = 2;
@@ -80,24 +92,25 @@ public class FloatTextureData implements TextureData {
 
 	@Override
 	public void consumeCustomData (int target) {
+		GL20 gl = graphics.getGL20();
 		if (Gdx.app.getType() == ApplicationType.Android || Gdx.app.getType() == ApplicationType.iOS
-			|| (Gdx.app.getType() == ApplicationType.WebGL && !Gdx.graphics.isGL30Available())) {
+			|| (Gdx.app.getType() == ApplicationType.WebGL && !graphics.isGL30Available())) {
 
-			if (!Gdx.graphics.supportsExtension("OES_texture_float"))
+			if (!graphics.supportsExtension("OES_texture_float"))
 				throw new GdxRuntimeException("Extension OES_texture_float not supported!");
 
 			// GLES and WebGL defines texture format by 3rd and 8th argument,
 			// so to get a float texture one needs to supply GL_RGBA and GL_FLOAT there.
-			Gdx.gl.glTexImage2D(target, 0, GL20.GL_RGBA, width, height, 0, GL20.GL_RGBA, GL20.GL_FLOAT, buffer);
+			gl.glTexImage2D(target, 0, GL20.GL_RGBA, width, height, 0, GL20.GL_RGBA, GL20.GL_FLOAT, buffer);
 
 		} else {
-			if (!Gdx.graphics.isGL30Available()) {
-				if (!Gdx.graphics.supportsExtension("GL_ARB_texture_float"))
+			if (!graphics.isGL30Available()) {
+				if (!graphics.supportsExtension("GL_ARB_texture_float"))
 					throw new GdxRuntimeException("Extension GL_ARB_texture_float not supported!");
 			}
 			// in desktop OpenGL the texture format is defined only by the third argument,
 			// hence we need to use GL_RGBA32F there (this constant is unavailable in GLES/WebGL)
-			Gdx.gl.glTexImage2D(target, 0, internalFormat, width, height, 0, format, GL20.GL_FLOAT, buffer);
+			gl.glTexImage2D(target, 0, internalFormat, width, height, 0, format, GL20.GL_FLOAT, buffer);
 		}
 	}
 

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/FrameBuffer.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/FrameBuffer.java
@@ -17,6 +17,7 @@
 package com.badlogic.gdx.graphics.glutils;
 
 import com.badlogic.gdx.Application;
+import com.badlogic.gdx.Graphics;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Pixmap;
@@ -55,7 +56,11 @@ public class FrameBuffer extends GLFrameBuffer<Texture> {
 
 	/** Creates a new FrameBuffer having the given dimensions and potentially a depth buffer attached. */
 	public FrameBuffer (Pixmap.Format format, int width, int height, boolean hasDepth) {
-		this(format, width, height, hasDepth, false);
+		this(Gdx.graphics, format, width, height, hasDepth, false);
+	}
+
+	public FrameBuffer (Graphics graphics, Pixmap.Format format, int width, int height, boolean hasDepth) {
+		this(graphics, format, width, height, hasDepth, false);
 	}
 
 	/** Creates a new FrameBuffer having the given dimensions and potentially a depth and a stencil buffer attached.
@@ -67,11 +72,16 @@ public class FrameBuffer extends GLFrameBuffer<Texture> {
 	 * @param hasDepth whether to attach a depth buffer
 	 * @throws com.badlogic.gdx.utils.GdxRuntimeException in case the FrameBuffer could not be created */
 	public FrameBuffer (Pixmap.Format format, int width, int height, boolean hasDepth, boolean hasStencil) {
-		FrameBufferBuilder frameBufferBuilder = new FrameBufferBuilder(width, height);
+		this(Gdx.graphics, format, width, height, hasDepth, hasStencil);
+	}
+
+	public FrameBuffer (Graphics graphics, Pixmap.Format format, int width, int height, boolean hasDepth, boolean hasStencil) {
+		FrameBufferBuilder frameBufferBuilder = new FrameBufferBuilder(graphics, width, height);
 		frameBufferBuilder.addBasicColorTextureAttachment(format);
 		if (hasDepth) frameBufferBuilder.addBasicDepthRenderBuffer();
 		if (hasStencil) frameBufferBuilder.addBasicStencilRenderBuffer();
 		this.bufferBuilder = frameBufferBuilder;
+		this.graphics = graphics;
 
 		build();
 	}
@@ -80,7 +90,7 @@ public class FrameBuffer extends GLFrameBuffer<Texture> {
 	protected Texture createTexture (FrameBufferTextureAttachmentSpec attachmentSpec) {
 		GLOnlyTextureData data = new GLOnlyTextureData(bufferBuilder.width, bufferBuilder.height, 0, attachmentSpec.internalFormat,
 			attachmentSpec.format, attachmentSpec.type);
-		Texture result = new Texture(data);
+		Texture result = new Texture(graphics, data);
 		// Filtering support for depth textures on WebGL is spotty https://github.com/KhronosGroup/OpenGL-API/issues/84
 		boolean webGLDepth = attachmentSpec.isDepth && Gdx.app.getType() == Application.ApplicationType.WebGL;
 		if (!webGLDepth) {
@@ -97,7 +107,7 @@ public class FrameBuffer extends GLFrameBuffer<Texture> {
 
 	@Override
 	protected void attachFrameBufferColorTexture (Texture texture) {
-		Gdx.gl20.glFramebufferTexture2D(GL20.GL_FRAMEBUFFER, GL20.GL_COLOR_ATTACHMENT0, GL20.GL_TEXTURE_2D,
+		graphics.getGL20().glFramebufferTexture2D(GL20.GL_FRAMEBUFFER, GL20.GL_COLOR_ATTACHMENT0, GL20.GL_TEXTURE_2D,
 			texture.getTextureObjectHandle(), 0);
 	}
 

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/FrameBuffer.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/FrameBuffer.java
@@ -88,8 +88,8 @@ public class FrameBuffer extends GLFrameBuffer<Texture> {
 
 	@Override
 	protected Texture createTexture (FrameBufferTextureAttachmentSpec attachmentSpec) {
-		GLOnlyTextureData data = new GLOnlyTextureData(bufferBuilder.width, bufferBuilder.height, 0, attachmentSpec.internalFormat,
-			attachmentSpec.format, attachmentSpec.type);
+		GLOnlyTextureData data = new GLOnlyTextureData(graphics, bufferBuilder.width, bufferBuilder.height, 0,
+			attachmentSpec.internalFormat, attachmentSpec.format, attachmentSpec.type);
 		Texture result = new Texture(graphics, data);
 		// Filtering support for depth textures on WebGL is spotty https://github.com/KhronosGroup/OpenGL-API/issues/84
 		boolean webGLDepth = attachmentSpec.isDepth && Gdx.app.getType() == Application.ApplicationType.WebGL;

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/FrameBufferCubemap.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/FrameBufferCubemap.java
@@ -17,6 +17,7 @@
 package com.badlogic.gdx.graphics.glutils;
 
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Graphics;
 import com.badlogic.gdx.graphics.Cubemap;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Pixmap;
@@ -85,7 +86,11 @@ public class FrameBufferCubemap extends GLFrameBuffer<Cubemap> {
 	 * @param height
 	 * @param hasDepth */
 	public FrameBufferCubemap (Pixmap.Format format, int width, int height, boolean hasDepth) {
-		this(format, width, height, hasDepth, false);
+		this(Gdx.graphics, format, width, height, hasDepth, false);
+	}
+
+	public FrameBufferCubemap (Graphics graphics, Pixmap.Format format, int width, int height, boolean hasDepth) {
+		this(graphics, format, width, height, hasDepth, false);
 	}
 
 	/** Creates a new FrameBuffer having the given dimensions and potentially a depth and a stencil buffer attached.
@@ -98,11 +103,16 @@ public class FrameBufferCubemap extends GLFrameBuffer<Cubemap> {
 	 * @param hasStencil whether to attach a stencil buffer
 	 * @throws com.badlogic.gdx.utils.GdxRuntimeException in case the FrameBuffer could not be created */
 	public FrameBufferCubemap (Pixmap.Format format, int width, int height, boolean hasDepth, boolean hasStencil) {
-		FrameBufferCubemapBuilder frameBufferBuilder = new FrameBufferCubemapBuilder(width, height);
+		this(Gdx.graphics, format, width, height, hasDepth, hasStencil);
+	}
+
+	public FrameBufferCubemap (Graphics graphics, Pixmap.Format format, int width, int height, boolean hasDepth, boolean hasStencil) {
+		FrameBufferCubemapBuilder frameBufferBuilder = new FrameBufferCubemapBuilder(graphics, width, height);
 		frameBufferBuilder.addBasicColorTextureAttachment(format);
 		if (hasDepth) frameBufferBuilder.addBasicDepthRenderBuffer();
 		if (hasStencil) frameBufferBuilder.addBasicStencilRenderBuffer();
 		this.bufferBuilder = frameBufferBuilder;
+		this.graphics = graphics;
 
 		build();
 	}
@@ -111,7 +121,7 @@ public class FrameBufferCubemap extends GLFrameBuffer<Cubemap> {
 	protected Cubemap createTexture (FrameBufferTextureAttachmentSpec attachmentSpec) {
 		GLOnlyTextureData data = new GLOnlyTextureData(bufferBuilder.width, bufferBuilder.height, 0, attachmentSpec.internalFormat,
 			attachmentSpec.format, attachmentSpec.type);
-		Cubemap result = new Cubemap(data, data, data, data, data, data);
+		Cubemap result = new Cubemap(graphics, data, data, data, data, data, data);
 		result.setFilter(TextureFilter.Linear, TextureFilter.Linear);
 		result.setWrap(TextureWrap.ClampToEdge, TextureWrap.ClampToEdge);
 		return result;
@@ -124,7 +134,7 @@ public class FrameBufferCubemap extends GLFrameBuffer<Cubemap> {
 
 	@Override
 	protected void attachFrameBufferColorTexture (Cubemap texture) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = graphics.getGL20();
 		int glHandle = texture.getTextureObjectHandle();
 		Cubemap.CubemapSide[] sides = Cubemap.CubemapSide.values();
 		for (Cubemap.CubemapSide side : sides) {
@@ -157,7 +167,7 @@ public class FrameBufferCubemap extends GLFrameBuffer<Cubemap> {
 	/** Bind the side, making it active to render on. Should be called in between a call to {@link #begin()} and {@link #end()}.
 	 * @param side The side to bind */
 	protected void bindSide (final Cubemap.CubemapSide side) {
-		Gdx.gl20.glFramebufferTexture2D(GL20.GL_FRAMEBUFFER, GL20.GL_COLOR_ATTACHMENT0, side.glEnum,
+		graphics.getGL20().glFramebufferTexture2D(GL20.GL_FRAMEBUFFER, GL20.GL_COLOR_ATTACHMENT0, side.glEnum,
 			getColorBufferTexture().getTextureObjectHandle(), 0);
 	}
 

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/FrameBufferCubemap.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/FrameBufferCubemap.java
@@ -119,8 +119,8 @@ public class FrameBufferCubemap extends GLFrameBuffer<Cubemap> {
 
 	@Override
 	protected Cubemap createTexture (FrameBufferTextureAttachmentSpec attachmentSpec) {
-		GLOnlyTextureData data = new GLOnlyTextureData(bufferBuilder.width, bufferBuilder.height, 0, attachmentSpec.internalFormat,
-			attachmentSpec.format, attachmentSpec.type);
+		GLOnlyTextureData data = new GLOnlyTextureData(graphics, bufferBuilder.width, bufferBuilder.height, 0,
+			attachmentSpec.internalFormat, attachmentSpec.format, attachmentSpec.type);
 		Cubemap result = new Cubemap(graphics, data, data, data, data, data, data);
 		result.setFilter(TextureFilter.Linear, TextureFilter.Linear);
 		result.setWrap(TextureWrap.ClampToEdge, TextureWrap.ClampToEdge);

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/GLFrameBuffer.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/GLFrameBuffer.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import com.badlogic.gdx.Application;
+import com.badlogic.gdx.Graphics;
 import com.badlogic.gdx.Application.ApplicationType;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
@@ -55,7 +56,7 @@ import com.badlogic.gdx.utils.IntArray;
  * @author mzechner, realitix */
 public abstract class GLFrameBuffer<T extends GLTexture> implements Disposable {
 	/** the frame buffers **/
-	protected final static Map<Application, Array<GLFrameBuffer>> buffers = new HashMap<Application, Array<GLFrameBuffer>>();
+	protected final static Map<Graphics, Array<GLFrameBuffer>> buffers = new HashMap<Graphics, Array<GLFrameBuffer>>();
 
 	protected final static int GL_DEPTH24_STENCIL8_OES = 0x88F0;
 
@@ -306,7 +307,7 @@ public abstract class GLFrameBuffer<T extends GLTexture> implements Disposable {
 			throw new IllegalStateException("Frame buffer couldn't be constructed: unknown error " + result);
 		}
 
-		addManagedFrameBuffer(Gdx.app, this);
+		addManagedFrameBuffer(Gdx.graphics, this);
 	}
 
 	private void checkValidBuilder () {
@@ -362,7 +363,7 @@ public abstract class GLFrameBuffer<T extends GLTexture> implements Disposable {
 
 		gl.glDeleteFramebuffer(framebufferHandle);
 
-		if (buffers.get(Gdx.app) != null) buffers.get(Gdx.app).removeValue(this, true);
+		if (buffers.get(Gdx.graphics) != null) buffers.get(Gdx.graphics).removeValue(this, true);
 	}
 
 	/** Makes the frame buffer current so everything gets drawn to it. */
@@ -541,33 +542,33 @@ public abstract class GLFrameBuffer<T extends GLTexture> implements Disposable {
 		return bufferBuilder.width;
 	}
 
-	private static void addManagedFrameBuffer (Application app, GLFrameBuffer frameBuffer) {
-		Array<GLFrameBuffer> managedResources = buffers.get(app);
+	private static void addManagedFrameBuffer (Graphics graphics, GLFrameBuffer frameBuffer) {
+		Array<GLFrameBuffer> managedResources = buffers.get(graphics);
 		if (managedResources == null) managedResources = new Array<GLFrameBuffer>();
 		managedResources.add(frameBuffer);
-		buffers.put(app, managedResources);
+		buffers.put(graphics, managedResources);
 	}
 
 	/** Invalidates all frame buffers. This can be used when the OpenGL context is lost to rebuild all managed frame buffers. This
 	 * assumes that the texture attached to this buffer has already been rebuild! Use with care. */
-	public static void invalidateAllFrameBuffers (Application app) {
+	public static void invalidateAllFrameBuffers (Graphics graphics) {
 		if (Gdx.gl20 == null) return;
 
-		Array<GLFrameBuffer> bufferArray = buffers.get(app);
+		Array<GLFrameBuffer> bufferArray = buffers.get(graphics);
 		if (bufferArray == null) return;
 		for (int i = 0; i < bufferArray.size; i++) {
 			bufferArray.get(i).build();
 		}
 	}
 
-	public static void clearAllFrameBuffers (Application app) {
-		buffers.remove(app);
+	public static void clearAllFrameBuffers (Graphics graphics) {
+		buffers.remove(graphics);
 	}
 
 	public static StringBuilder getManagedStatus (final StringBuilder builder) {
-		builder.append("Managed buffers/app: { ");
-		for (Application app : buffers.keySet()) {
-			builder.append(buffers.get(app).size);
+		builder.append("Managed buffers/graphics: { ");
+		for (Graphics graphics : buffers.keySet()) {
+			builder.append(buffers.get(graphics).size);
 			builder.append(" ");
 		}
 		builder.append("}");

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/GLFrameBuffer.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/GLFrameBuffer.java
@@ -88,12 +88,24 @@ public abstract class GLFrameBuffer<T extends GLTexture> implements Disposable {
 
 	private IntBuffer defaultDrawBuffers;
 
+	/** {@link Graphics} this framebuffer is managed by and resolves GL from **/
+	protected Graphics graphics;
+
+	private GL20 gl20 () {
+		return graphics.getGL20();
+	}
+
+	private GL30 gl30 () {
+		return graphics.getGL30();
+	}
+
 	GLFrameBuffer () {
 	}
 
 	/** Creates a GLFrameBuffer from the specifications provided by bufferBuilder **/
 	protected GLFrameBuffer (GLFrameBufferBuilder<? extends GLFrameBuffer<T>> bufferBuilder) {
 		this.bufferBuilder = bufferBuilder;
+		this.graphics = bufferBuilder.graphics != null ? bufferBuilder.graphics : Gdx.graphics;
 		build();
 	}
 
@@ -117,7 +129,7 @@ public abstract class GLFrameBuffer<T extends GLTexture> implements Disposable {
 	protected abstract void attachFrameBufferColorTexture (T texture);
 
 	protected void build () {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 
 		checkValidBuilder();
 
@@ -143,7 +155,7 @@ public abstract class GLFrameBuffer<T extends GLTexture> implements Disposable {
 			depthbufferHandle = gl.glGenRenderbuffer();
 			gl.glBindRenderbuffer(GL20.GL_RENDERBUFFER, depthbufferHandle);
 			if (bufferBuilder.samples > 0) {
-				Gdx.gl30.glRenderbufferStorageMultisample(GL20.GL_RENDERBUFFER, bufferBuilder.samples,
+				gl30().glRenderbufferStorageMultisample(GL20.GL_RENDERBUFFER, bufferBuilder.samples,
 					bufferBuilder.depthRenderBufferSpec.internalFormat, width, height);
 			} else {
 				gl.glRenderbufferStorage(GL20.GL_RENDERBUFFER, bufferBuilder.depthRenderBufferSpec.internalFormat, width, height);
@@ -154,7 +166,7 @@ public abstract class GLFrameBuffer<T extends GLTexture> implements Disposable {
 			stencilbufferHandle = gl.glGenRenderbuffer();
 			gl.glBindRenderbuffer(GL20.GL_RENDERBUFFER, stencilbufferHandle);
 			if (bufferBuilder.samples > 0) {
-				Gdx.gl30.glRenderbufferStorageMultisample(GL20.GL_RENDERBUFFER, bufferBuilder.samples,
+				gl30().glRenderbufferStorageMultisample(GL20.GL_RENDERBUFFER, bufferBuilder.samples,
 					bufferBuilder.stencilRenderBufferSpec.internalFormat, width, height);
 			} else {
 				gl.glRenderbufferStorage(GL20.GL_RENDERBUFFER, bufferBuilder.stencilRenderBufferSpec.internalFormat, width, height);
@@ -165,7 +177,7 @@ public abstract class GLFrameBuffer<T extends GLTexture> implements Disposable {
 			depthStencilPackedBufferHandle = gl.glGenRenderbuffer();
 			gl.glBindRenderbuffer(GL20.GL_RENDERBUFFER, depthStencilPackedBufferHandle);
 			if (bufferBuilder.samples > 0) {
-				Gdx.gl30.glRenderbufferStorageMultisample(GL20.GL_RENDERBUFFER, bufferBuilder.samples,
+				gl30().glRenderbufferStorageMultisample(GL20.GL_RENDERBUFFER, bufferBuilder.samples,
 					bufferBuilder.packedStencilDepthRenderBufferSpec.internalFormat, width, height);
 			} else {
 				gl.glRenderbufferStorage(GL20.GL_RENDERBUFFER, bufferBuilder.packedStencilDepthRenderBufferSpec.internalFormat, width,
@@ -202,12 +214,12 @@ public abstract class GLFrameBuffer<T extends GLTexture> implements Disposable {
 			int colorbufferHandle = gl.glGenRenderbuffer();
 			gl.glBindRenderbuffer(GL20.GL_RENDERBUFFER, colorbufferHandle);
 			if (bufferBuilder.samples > 0) {
-				Gdx.gl30.glRenderbufferStorageMultisample(GL20.GL_RENDERBUFFER, bufferBuilder.samples, colorBufferSpec.internalFormat,
+				gl30().glRenderbufferStorageMultisample(GL20.GL_RENDERBUFFER, bufferBuilder.samples, colorBufferSpec.internalFormat,
 					width, height);
 			} else {
 				gl.glRenderbufferStorage(GL20.GL_RENDERBUFFER, colorBufferSpec.internalFormat, width, height);
 			}
-			Gdx.gl.glFramebufferRenderbuffer(GL20.GL_FRAMEBUFFER, GL20.GL_COLOR_ATTACHMENT0 + colorAttachmentCounter,
+			gl20().glFramebufferRenderbuffer(GL20.GL_FRAMEBUFFER, GL20.GL_COLOR_ATTACHMENT0 + colorAttachmentCounter,
 				GL20.GL_RENDERBUFFER, colorbufferHandle);
 			colorBufferHandles.add(colorbufferHandle);
 			colorAttachmentCounter++;
@@ -219,7 +231,7 @@ public abstract class GLFrameBuffer<T extends GLTexture> implements Disposable {
 				defaultDrawBuffers.put(GL30.GL_COLOR_ATTACHMENT0 + i);
 			}
 			((Buffer)defaultDrawBuffers).position(0);
-			Gdx.gl30.glDrawBuffers(colorAttachmentCounter, defaultDrawBuffers);
+			gl30().glDrawBuffers(colorAttachmentCounter, defaultDrawBuffers);
 		} else if (bufferBuilder.textureAttachmentSpecs.size > 0) {
 			attachFrameBufferColorTexture(textureAttachments.first());
 		}
@@ -245,8 +257,8 @@ public abstract class GLFrameBuffer<T extends GLTexture> implements Disposable {
 		int result = gl.glCheckFramebufferStatus(GL20.GL_FRAMEBUFFER);
 
 		if (result == GL20.GL_FRAMEBUFFER_UNSUPPORTED && bufferBuilder.hasDepthRenderBuffer && bufferBuilder.hasStencilRenderBuffer
-			&& (Gdx.graphics.supportsExtension("GL_OES_packed_depth_stencil")
-				|| Gdx.graphics.supportsExtension("GL_EXT_packed_depth_stencil"))) {
+			&& (graphics.supportsExtension("GL_OES_packed_depth_stencil")
+				|| graphics.supportsExtension("GL_EXT_packed_depth_stencil"))) {
 			if (bufferBuilder.hasDepthRenderBuffer) {
 				gl.glDeleteRenderbuffer(depthbufferHandle);
 				depthbufferHandle = 0;
@@ -264,7 +276,7 @@ public abstract class GLFrameBuffer<T extends GLTexture> implements Disposable {
 			hasDepthStencilPackedBuffer = true;
 			gl.glBindRenderbuffer(GL20.GL_RENDERBUFFER, depthStencilPackedBufferHandle);
 			if (bufferBuilder.samples > 0) {
-				Gdx.gl30.glRenderbufferStorageMultisample(GL20.GL_RENDERBUFFER, bufferBuilder.samples, GL_DEPTH24_STENCIL8_OES, width,
+				gl30().glRenderbufferStorageMultisample(GL20.GL_RENDERBUFFER, bufferBuilder.samples, GL_DEPTH24_STENCIL8_OES, width,
 					height);
 			} else {
 				gl.glRenderbufferStorage(GL20.GL_RENDERBUFFER, GL_DEPTH24_STENCIL8_OES, width, height);
@@ -307,23 +319,23 @@ public abstract class GLFrameBuffer<T extends GLTexture> implements Disposable {
 			throw new IllegalStateException("Frame buffer couldn't be constructed: unknown error " + result);
 		}
 
-		addManagedFrameBuffer(Gdx.graphics, this);
+		addManagedFrameBuffer(graphics, this);
 	}
 
 	private void checkValidBuilder () {
 
-		if (bufferBuilder.samples > 0 && !Gdx.graphics.isGL30Available()) {
+		if (bufferBuilder.samples > 0 && !graphics.isGL30Available()) {
 			throw new GdxRuntimeException("Framebuffer multisample requires GLES 3.0+");
 		}
 		if (bufferBuilder.samples > 0 && bufferBuilder.textureAttachmentSpecs.size > 0) {
 			throw new GdxRuntimeException("Framebuffer multisample with texture attachments not yet supported");
 		}
 
-		boolean runningGL30 = Gdx.graphics.isGL30Available();
+		boolean runningGL30 = graphics.isGL30Available();
 
 		if (!runningGL30) {
-			final boolean supportsPackedDepthStencil = Gdx.graphics.supportsExtension("GL_OES_packed_depth_stencil")
-				|| Gdx.graphics.supportsExtension("GL_EXT_packed_depth_stencil");
+			final boolean supportsPackedDepthStencil = graphics.supportsExtension("GL_OES_packed_depth_stencil")
+				|| graphics.supportsExtension("GL_EXT_packed_depth_stencil");
 
 			if (bufferBuilder.hasPackedStencilDepthRenderBuffer && !supportsPackedDepthStencil) {
 				throw new GdxRuntimeException("Packed Stencil/Render render buffers are not available on GLES 2.0");
@@ -335,7 +347,7 @@ public abstract class GLFrameBuffer<T extends GLTexture> implements Disposable {
 				if (spec.isDepth) throw new GdxRuntimeException("Depth texture FrameBuffer Attachment not available on GLES 2.0");
 				if (spec.isStencil) throw new GdxRuntimeException("Stencil texture FrameBuffer Attachment not available on GLES 2.0");
 				if (spec.isFloat) {
-					if (!Gdx.graphics.supportsExtension("OES_texture_float")) {
+					if (!graphics.supportsExtension("OES_texture_float")) {
 						throw new GdxRuntimeException("Float texture FrameBuffer Attachment not available on GLES 2.0");
 					}
 				}
@@ -351,7 +363,7 @@ public abstract class GLFrameBuffer<T extends GLTexture> implements Disposable {
 	/** Releases all resources associated with the FrameBuffer. */
 	@Override
 	public void dispose () {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 
 		for (T texture : textureAttachments) {
 			disposeColorTexture(texture);
@@ -363,17 +375,22 @@ public abstract class GLFrameBuffer<T extends GLTexture> implements Disposable {
 
 		gl.glDeleteFramebuffer(framebufferHandle);
 
-		if (buffers.get(Gdx.graphics) != null) buffers.get(Gdx.graphics).removeValue(this, true);
+		if (buffers.get(graphics) != null) buffers.get(graphics).removeValue(this, true);
 	}
 
 	/** Makes the frame buffer current so everything gets drawn to it. */
 	public void bind () {
-		Gdx.gl20.glBindFramebuffer(GL20.GL_FRAMEBUFFER, framebufferHandle);
+		gl20().glBindFramebuffer(GL20.GL_FRAMEBUFFER, framebufferHandle);
 	}
 
 	/** Unbinds the framebuffer, all drawing will be performed to the normal framebuffer from here on. */
 	public static void unbind () {
-		Gdx.gl20.glBindFramebuffer(GL20.GL_FRAMEBUFFER, defaultFramebufferHandle);
+		unbind(Gdx.graphics);
+	}
+
+	/** Unbinds the framebuffer using the given {@link Graphics}. */
+	public static void unbind (Graphics graphics) {
+		graphics.getGL20().glBindFramebuffer(GL20.GL_FRAMEBUFFER, defaultFramebufferHandle);
 	}
 
 	/** Binds the frame buffer and sets the viewport accordingly, so everything gets drawn to it. */
@@ -384,12 +401,12 @@ public abstract class GLFrameBuffer<T extends GLTexture> implements Disposable {
 
 	/** Sets viewport to the dimensions of framebuffer. Called by {@link #begin()}. */
 	protected void setFrameBufferViewport () {
-		Gdx.gl20.glViewport(0, 0, bufferBuilder.width, bufferBuilder.height);
+		gl20().glViewport(0, 0, bufferBuilder.width, bufferBuilder.height);
 	}
 
 	/** Unbinds the framebuffer, all drawing will be performed to the normal framebuffer from here on. */
 	public void end () {
-		end(0, 0, Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight());
+		end(0, 0, graphics.getBackBufferWidth(), graphics.getBackBufferHeight());
 	}
 
 	/** Unbinds the framebuffer and sets viewport sizes, all drawing will be performed to the normal framebuffer from here on.
@@ -399,8 +416,8 @@ public abstract class GLFrameBuffer<T extends GLTexture> implements Disposable {
 	 * @param width the width of the viewport in pixels
 	 * @param height the height of the viewport in pixels */
 	public void end (int x, int y, int width, int height) {
-		unbind();
-		Gdx.gl20.glViewport(x, y, width, height);
+		unbind(graphics);
+		gl20().glViewport(x, y, width, height);
 	}
 
 	private IntBuffer drawBuffersForTransfer;
@@ -436,7 +453,7 @@ public abstract class GLFrameBuffer<T extends GLTexture> implements Disposable {
 
 		if (drawBuffersForTransfer == null) {
 			// set it to max color attachments
-			Gdx.gl.glGetIntegerv(GL30.GL_MAX_COLOR_ATTACHMENTS, drawBuffersForTransfer = BufferUtils.newIntBuffer(1));
+			gl20().glGetIntegerv(GL30.GL_MAX_COLOR_ATTACHMENTS, drawBuffersForTransfer = BufferUtils.newIntBuffer(1));
 			drawBuffersForTransfer = BufferUtils.newIntBuffer(drawBuffersForTransfer.get(0));
 		}
 
@@ -444,8 +461,8 @@ public abstract class GLFrameBuffer<T extends GLTexture> implements Disposable {
 			throw new IllegalArgumentException("source and destination frame buffers must have same size.");
 		}
 
-		Gdx.gl.glBindFramebuffer(GL30.GL_READ_FRAMEBUFFER, framebufferHandle);
-		Gdx.gl.glBindFramebuffer(GL30.GL_DRAW_FRAMEBUFFER, destination.framebufferHandle);
+		gl20().glBindFramebuffer(GL30.GL_READ_FRAMEBUFFER, framebufferHandle);
+		gl20().glBindFramebuffer(GL30.GL_DRAW_FRAMEBUFFER, destination.framebufferHandle);
 
 		if ((copyBits & GL20.GL_COLOR_BUFFER_BIT) == GL20.GL_COLOR_BUFFER_BIT) {
 			int totalColorAttachments = 0;
@@ -459,7 +476,7 @@ public abstract class GLFrameBuffer<T extends GLTexture> implements Disposable {
 			drawBuffersForTransfer.clear();
 			for (FrameBufferTextureAttachmentSpec attachment : destination.bufferBuilder.textureAttachmentSpecs) {
 				if (attachment.isColorTexture()) {
-					Gdx.gl30.glReadBuffer(GL30.GL_COLOR_ATTACHMENT0 + colorBufferIndex);
+					gl30().glReadBuffer(GL30.GL_COLOR_ATTACHMENT0 + colorBufferIndex);
 
 					// Webgl doesn't like it when you put a single out of order buffer in for glDrawBuffers
 					// Must be sequential.
@@ -478,9 +495,9 @@ public abstract class GLFrameBuffer<T extends GLTexture> implements Disposable {
 					}
 					drawBuffersForTransfer.flip();
 
-					Gdx.gl30.glDrawBuffers(drawBuffersForTransfer.limit(), drawBuffersForTransfer);
+					gl30().glDrawBuffers(drawBuffersForTransfer.limit(), drawBuffersForTransfer);
 
-					Gdx.gl30.glBlitFramebuffer(0, 0, getWidth(), getHeight(), 0, 0, destination.getWidth(), destination.getHeight(),
+					gl30().glBlitFramebuffer(0, 0, getWidth(), getHeight(), 0, 0, destination.getWidth(), destination.getHeight(),
 						copyBits, GL20.GL_NEAREST);
 
 					copyBits = GL20.GL_COLOR_BUFFER_BIT;
@@ -491,17 +508,17 @@ public abstract class GLFrameBuffer<T extends GLTexture> implements Disposable {
 
 		// case of depth and/or stencil only
 		if (copyBits != GL20.GL_COLOR_BUFFER_BIT) {
-			Gdx.gl30.glBlitFramebuffer(0, 0, getWidth(), getHeight(), 0, 0, destination.getWidth(), destination.getHeight(),
+			gl30().glBlitFramebuffer(0, 0, getWidth(), getHeight(), 0, 0, destination.getWidth(), destination.getHeight(),
 				copyBits, GL20.GL_NEAREST);
 		}
 
 		// restore draw buffers for destination (in case of MRT only)
 		if (destination.defaultDrawBuffers != null) {
-			Gdx.gl30.glDrawBuffers(destination.defaultDrawBuffers.limit(), destination.defaultDrawBuffers);
+			gl30().glDrawBuffers(destination.defaultDrawBuffers.limit(), destination.defaultDrawBuffers);
 		}
 
-		Gdx.gl.glBindFramebuffer(GL30.GL_READ_FRAMEBUFFER, 0);
-		Gdx.gl.glBindFramebuffer(GL30.GL_DRAW_FRAMEBUFFER, 0);
+		gl20().glBindFramebuffer(GL30.GL_READ_FRAMEBUFFER, 0);
+		gl20().glBindFramebuffer(GL30.GL_DRAW_FRAMEBUFFER, 0);
 	}
 
 	/** @return The OpenGL handle of the framebuffer (see {@link GL20#glGenFramebuffer()}) */
@@ -552,7 +569,7 @@ public abstract class GLFrameBuffer<T extends GLTexture> implements Disposable {
 	/** Invalidates all frame buffers. This can be used when the OpenGL context is lost to rebuild all managed frame buffers. This
 	 * assumes that the texture attached to this buffer has already been rebuild! Use with care. */
 	public static void invalidateAllFrameBuffers (Graphics graphics) {
-		if (Gdx.gl20 == null) return;
+		if (graphics == null || graphics.getGL20() == null) return;
 
 		Array<GLFrameBuffer> bufferArray = buffers.get(graphics);
 		if (bufferArray == null) return;
@@ -605,6 +622,7 @@ public abstract class GLFrameBuffer<T extends GLTexture> implements Disposable {
 	}
 
 	public static abstract class GLFrameBufferBuilder<U extends GLFrameBuffer<? extends GLTexture>> {
+		public Graphics graphics;
 		public int width, height, samples;
 
 		public Array<FrameBufferTextureAttachmentSpec> textureAttachmentSpecs = new Array<FrameBufferTextureAttachmentSpec>();
@@ -619,10 +637,19 @@ public abstract class GLFrameBuffer<T extends GLTexture> implements Disposable {
 		public boolean hasPackedStencilDepthRenderBuffer;
 
 		public GLFrameBufferBuilder (int width, int height) {
-			this(width, height, 0);
+			this(Gdx.graphics, width, height, 0);
+		}
+
+		public GLFrameBufferBuilder (Graphics graphics, int width, int height) {
+			this(graphics, width, height, 0);
 		}
 
 		public GLFrameBufferBuilder (int width, int height, int samples) {
+			this(Gdx.graphics, width, height, samples);
+		}
+
+		public GLFrameBufferBuilder (Graphics graphics, int width, int height, int samples) {
+			this.graphics = graphics;
 			this.width = width;
 			this.height = height;
 			this.samples = samples;
@@ -706,8 +733,16 @@ public abstract class GLFrameBuffer<T extends GLTexture> implements Disposable {
 			super(width, height);
 		}
 
+		public FrameBufferBuilder (Graphics graphics, int width, int height) {
+			super(graphics, width, height);
+		}
+
 		public FrameBufferBuilder (int width, int height, int samples) {
 			super(width, height, samples);
+		}
+
+		public FrameBufferBuilder (Graphics graphics, int width, int height, int samples) {
+			super(graphics, width, height, samples);
 		}
 
 		@Override
@@ -721,8 +756,16 @@ public abstract class GLFrameBuffer<T extends GLTexture> implements Disposable {
 			super(width, height);
 		}
 
+		public FloatFrameBufferBuilder (Graphics graphics, int width, int height) {
+			super(graphics, width, height);
+		}
+
 		public FloatFrameBufferBuilder (int width, int height, int samples) {
 			super(width, height, samples);
+		}
+
+		public FloatFrameBufferBuilder (Graphics graphics, int width, int height, int samples) {
+			super(graphics, width, height, samples);
 		}
 
 		@Override
@@ -736,8 +779,16 @@ public abstract class GLFrameBuffer<T extends GLTexture> implements Disposable {
 			super(width, height);
 		}
 
+		public FrameBufferCubemapBuilder (Graphics graphics, int width, int height) {
+			super(graphics, width, height);
+		}
+
 		public FrameBufferCubemapBuilder (int width, int height, int samples) {
 			super(width, height, samples);
+		}
+
+		public FrameBufferCubemapBuilder (Graphics graphics, int width, int height, int samples) {
+			super(graphics, width, height, samples);
 		}
 
 		@Override

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/GLOnlyTextureData.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/GLOnlyTextureData.java
@@ -17,6 +17,7 @@
 package com.badlogic.gdx.graphics.glutils;
 
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Graphics;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.Pixmap.Format;
@@ -31,6 +32,7 @@ public class GLOnlyTextureData implements TextureData {
 	int width = 0;
 	int height = 0;
 	boolean isPrepared = false;
+	private Graphics graphics = Gdx.graphics;
 
 	/** properties of opengl texture */
 	int mipLevel = 0;
@@ -49,12 +51,22 @@ public class GLOnlyTextureData implements TextureData {
 	 *           {@link GL20#GL_UNSIGNED_BYTE}, {@link GL20#GL_UNSIGNED_SHORT_5_6_5}, {@link GL20#GL_UNSIGNED_SHORT_4_4_4_4}, and
 	 *           {@link GL20#GL_UNSIGNED_SHORT_5_5_5_1}. */
 	public GLOnlyTextureData (int width, int height, int mipMapLevel, int internalFormat, int format, int type) {
+		this(Gdx.graphics, width, height, mipMapLevel, internalFormat, format, type);
+	}
+
+	public GLOnlyTextureData (Graphics graphics, int width, int height, int mipMapLevel, int internalFormat, int format, int type) {
+		this.graphics = graphics;
 		this.width = width;
 		this.height = height;
 		this.mipLevel = mipMapLevel;
 		this.internalFormat = internalFormat;
 		this.format = format;
 		this.type = type;
+	}
+
+	@Override
+	public void setGraphics (Graphics graphics) {
+		this.graphics = graphics;
 	}
 
 	@Override
@@ -75,7 +87,7 @@ public class GLOnlyTextureData implements TextureData {
 
 	@Override
 	public void consumeCustomData (int target) {
-		Gdx.gl.glTexImage2D(target, mipLevel, internalFormat, width, height, 0, format, type, null);
+		graphics.getGL20().glTexImage2D(target, mipLevel, internalFormat, width, height, 0, format, type, null);
 	}
 
 	@Override

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/HdpiUtils.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/HdpiUtils.java
@@ -17,6 +17,7 @@
 package com.badlogic.gdx.graphics.glutils;
 
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Graphics;
 import com.badlogic.gdx.graphics.GL20;
 
 /** To deal with HDPI monitors properly, use the glViewport and glScissor functions of this class instead of directly calling
@@ -49,42 +50,68 @@ public class HdpiUtils {
 	/** Calls {@link GL20#glScissor(int, int, int, int)}, expecting the coordinates and sizes given in logical coordinates and
 	 * automatically converts them to backbuffer coordinates, which may be bigger on HDPI screens. */
 	public static void glScissor (int x, int y, int width, int height) {
-		if (mode == HdpiMode.Logical && (Gdx.graphics.getWidth() != Gdx.graphics.getBackBufferWidth()
-			|| Gdx.graphics.getHeight() != Gdx.graphics.getBackBufferHeight())) {
-			Gdx.gl.glScissor(toBackBufferX(x), toBackBufferY(y), toBackBufferX(width), toBackBufferY(height));
+		glScissor(Gdx.graphics, x, y, width, height);
+	}
+
+	public static void glScissor (Graphics graphics, int x, int y, int width, int height) {
+		if (mode == HdpiMode.Logical && (graphics.getWidth() != graphics.getBackBufferWidth()
+			|| graphics.getHeight() != graphics.getBackBufferHeight())) {
+			graphics.getGL20().glScissor(toBackBufferX(graphics, x), toBackBufferY(graphics, y), toBackBufferX(graphics, width),
+				toBackBufferY(graphics, height));
 		} else {
-			Gdx.gl.glScissor(x, y, width, height);
+			graphics.getGL20().glScissor(x, y, width, height);
 		}
 	}
 
 	/** Calls {@link GL20#glViewport(int, int, int, int)}, expecting the coordinates and sizes given in logical coordinates and
 	 * automatically converts them to backbuffer coordinates, which may be bigger on HDPI screens. */
 	public static void glViewport (int x, int y, int width, int height) {
-		if (mode == HdpiMode.Logical && (Gdx.graphics.getWidth() != Gdx.graphics.getBackBufferWidth()
-			|| Gdx.graphics.getHeight() != Gdx.graphics.getBackBufferHeight())) {
-			Gdx.gl.glViewport(toBackBufferX(x), toBackBufferY(y), toBackBufferX(width), toBackBufferY(height));
+		glViewport(Gdx.graphics, x, y, width, height);
+	}
+
+	public static void glViewport (Graphics graphics, int x, int y, int width, int height) {
+		if (mode == HdpiMode.Logical && (graphics.getWidth() != graphics.getBackBufferWidth()
+			|| graphics.getHeight() != graphics.getBackBufferHeight())) {
+			graphics.getGL20().glViewport(toBackBufferX(graphics, x), toBackBufferY(graphics, y), toBackBufferX(graphics, width),
+				toBackBufferY(graphics, height));
 		} else {
-			Gdx.gl.glViewport(x, y, width, height);
+			graphics.getGL20().glViewport(x, y, width, height);
 		}
 	}
 
 	/** Converts an x-coordinate given in backbuffer coordinates to logical screen coordinates. */
 	public static int toLogicalX (int backBufferX) {
-		return (int)(backBufferX * Gdx.graphics.getWidth() / (float)Gdx.graphics.getBackBufferWidth());
+		return toLogicalX(Gdx.graphics, backBufferX);
+	}
+
+	public static int toLogicalX (Graphics graphics, int backBufferX) {
+		return (int)(backBufferX * graphics.getWidth() / (float)graphics.getBackBufferWidth());
 	}
 
 	/** Converts an y-coordinate given in backbuffer coordinates to logical screen coordinates. */
 	public static int toLogicalY (int backBufferY) {
-		return (int)(backBufferY * Gdx.graphics.getHeight() / (float)Gdx.graphics.getBackBufferHeight());
+		return toLogicalY(Gdx.graphics, backBufferY);
+	}
+
+	public static int toLogicalY (Graphics graphics, int backBufferY) {
+		return (int)(backBufferY * graphics.getHeight() / (float)graphics.getBackBufferHeight());
 	}
 
 	/** Converts an x-coordinate given in logical screen coordinates to backbuffer coordinates. */
 	public static int toBackBufferX (int logicalX) {
-		return (int)(logicalX * Gdx.graphics.getBackBufferWidth() / (float)Gdx.graphics.getWidth());
+		return toBackBufferX(Gdx.graphics, logicalX);
+	}
+
+	public static int toBackBufferX (Graphics graphics, int logicalX) {
+		return (int)(logicalX * graphics.getBackBufferWidth() / (float)graphics.getWidth());
 	}
 
 	/** Converts an y-coordinate given in logical screen coordinates to backbuffer coordinates. */
 	public static int toBackBufferY (int logicalY) {
-		return (int)(logicalY * Gdx.graphics.getBackBufferHeight() / (float)Gdx.graphics.getHeight());
+		return toBackBufferY(Gdx.graphics, logicalY);
+	}
+
+	public static int toBackBufferY (Graphics graphics, int logicalY) {
+		return (int)(logicalY * graphics.getBackBufferHeight() / (float)graphics.getHeight());
 	}
 }

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/ImmediateModeRenderer20.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/ImmediateModeRenderer20.java
@@ -16,6 +16,8 @@
 
 package com.badlogic.gdx.graphics.glutils;
 
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Graphics;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Mesh;
 import com.badlogic.gdx.graphics.VertexAttribute;
@@ -47,23 +49,42 @@ public class ImmediateModeRenderer20 implements ImmediateModeRenderer {
 	private final String[] shaderUniformNames;
 
 	public ImmediateModeRenderer20 (boolean hasNormals, boolean hasColors, int numTexCoords) {
-		this(5000, hasNormals, hasColors, numTexCoords, createDefaultShader(hasNormals, hasColors, numTexCoords));
+		this(Gdx.graphics, 5000, hasNormals, hasColors, numTexCoords,
+			createDefaultShader(Gdx.graphics, hasNormals, hasColors, numTexCoords));
+		ownsShader = true;
+	}
+
+	public ImmediateModeRenderer20 (Graphics graphics, boolean hasNormals, boolean hasColors, int numTexCoords) {
+		this(graphics, 5000, hasNormals, hasColors, numTexCoords,
+			createDefaultShader(graphics, hasNormals, hasColors, numTexCoords));
 		ownsShader = true;
 	}
 
 	public ImmediateModeRenderer20 (int maxVertices, boolean hasNormals, boolean hasColors, int numTexCoords) {
-		this(maxVertices, hasNormals, hasColors, numTexCoords, createDefaultShader(hasNormals, hasColors, numTexCoords));
+		this(Gdx.graphics, maxVertices, hasNormals, hasColors, numTexCoords,
+			createDefaultShader(Gdx.graphics, hasNormals, hasColors, numTexCoords));
+		ownsShader = true;
+	}
+
+	public ImmediateModeRenderer20 (Graphics graphics, int maxVertices, boolean hasNormals, boolean hasColors, int numTexCoords) {
+		this(graphics, maxVertices, hasNormals, hasColors, numTexCoords,
+			createDefaultShader(graphics, hasNormals, hasColors, numTexCoords));
 		ownsShader = true;
 	}
 
 	public ImmediateModeRenderer20 (int maxVertices, boolean hasNormals, boolean hasColors, int numTexCoords,
+		ShaderProgram shader) {
+		this(Gdx.graphics, maxVertices, hasNormals, hasColors, numTexCoords, shader);
+	}
+
+	public ImmediateModeRenderer20 (Graphics graphics, int maxVertices, boolean hasNormals, boolean hasColors, int numTexCoords,
 		ShaderProgram shader) {
 		this.maxVertices = maxVertices;
 		this.numTexCoords = numTexCoords;
 		this.shader = shader;
 
 		VertexAttribute[] attribs = buildVertexAttributes(hasNormals, hasColors, numTexCoords);
-		mesh = new Mesh(false, maxVertices, 0, attribs);
+		mesh = new Mesh(graphics, false, maxVertices, 0, attribs);
 
 		vertices = new float[maxVertices * (mesh.getVertexAttributes().vertexSize / 4)];
 		vertexSize = mesh.getVertexAttributes().vertexSize / 4;
@@ -236,9 +257,13 @@ public class ImmediateModeRenderer20 implements ImmediateModeRenderer {
 
 	/** Returns a new instance of the default shader used by SpriteBatch for GL2 when no shader is specified. */
 	static public ShaderProgram createDefaultShader (boolean hasNormals, boolean hasColors, int numTexCoords) {
+		return createDefaultShader(Gdx.graphics, hasNormals, hasColors, numTexCoords);
+	}
+
+	static public ShaderProgram createDefaultShader (Graphics graphics, boolean hasNormals, boolean hasColors, int numTexCoords) {
 		String vertexShader = createVertexShader(hasNormals, hasColors, numTexCoords);
 		String fragmentShader = createFragmentShader(hasNormals, hasColors, numTexCoords);
-		ShaderProgram program = new ShaderProgram(vertexShader, fragmentShader);
+		ShaderProgram program = new ShaderProgram(graphics, vertexShader, fragmentShader);
 		if (!program.isCompiled()) throw new GdxRuntimeException("Error compiling shader: " + program.getLog());
 		return program;
 	}

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/IndexBufferObject.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/IndexBufferObject.java
@@ -21,6 +21,7 @@ import java.nio.ByteBuffer;
 import java.nio.ShortBuffer;
 
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Graphics;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.utils.BufferUtils;
 import com.badlogic.gdx.utils.GdxRuntimeException;
@@ -47,6 +48,13 @@ import com.badlogic.gdx.utils.GdxRuntimeException;
  *
  * @author mzechner, Thorsten Schleinzer */
 public class IndexBufferObject implements IndexData {
+
+	private final Graphics graphics;
+
+	private GL20 gl20 () {
+		return graphics.getGL20();
+	}
+
 	final ShortBuffer buffer;
 	final ByteBuffer byteBuffer;
 	final boolean ownsBuffer;
@@ -63,7 +71,11 @@ public class IndexBufferObject implements IndexData {
 	 *
 	 * @param maxIndices the maximum number of indices this buffer can hold */
 	public IndexBufferObject (int maxIndices) {
-		this(true, maxIndices);
+		this(Gdx.graphics, true, maxIndices);
+	}
+
+	public IndexBufferObject (Graphics graphics, int maxIndices) {
+		this(graphics, true, maxIndices);
 	}
 
 	/** Creates a new IndexBufferObject.
@@ -71,6 +83,11 @@ public class IndexBufferObject implements IndexData {
 	 * @param isStatic whether the index buffer is static
 	 * @param maxIndices the maximum number of indices this buffer can hold */
 	public IndexBufferObject (boolean isStatic, int maxIndices) {
+		this(Gdx.graphics, isStatic, maxIndices);
+	}
+
+	public IndexBufferObject (Graphics graphics, boolean isStatic, int maxIndices) {
+		this.graphics = graphics;
 
 		empty = maxIndices == 0;
 		if (empty) {
@@ -84,11 +101,16 @@ public class IndexBufferObject implements IndexData {
 		ownsBuffer = true;
 		((Buffer)buffer).flip();
 		((Buffer)byteBuffer).flip();
-		bufferHandle = Gdx.gl20.glGenBuffer();
+		bufferHandle = gl20().glGenBuffer();
 		usage = isStatic ? GL20.GL_STATIC_DRAW : GL20.GL_DYNAMIC_DRAW;
 	}
 
 	public IndexBufferObject (boolean isStatic, ByteBuffer data) {
+		this(Gdx.graphics, isStatic, data);
+	}
+
+	public IndexBufferObject (Graphics graphics, boolean isStatic, ByteBuffer data) {
+		this.graphics = graphics;
 
 		empty = data.limit() == 0;
 		byteBuffer = data;
@@ -96,7 +118,7 @@ public class IndexBufferObject implements IndexData {
 
 		buffer = byteBuffer.asShortBuffer();
 		ownsBuffer = false;
-		bufferHandle = Gdx.gl20.glGenBuffer();
+		bufferHandle = gl20().glGenBuffer();
 		usage = isStatic ? GL20.GL_STATIC_DRAW : GL20.GL_DYNAMIC_DRAW;
 	}
 
@@ -132,7 +154,7 @@ public class IndexBufferObject implements IndexData {
 		((Buffer)byteBuffer).limit(count << 1);
 
 		if (isBound) {
-			Gdx.gl20.glBufferData(GL20.GL_ELEMENT_ARRAY_BUFFER, byteBuffer.limit(), byteBuffer, usage);
+			gl20().glBufferData(GL20.GL_ELEMENT_ARRAY_BUFFER, byteBuffer.limit(), byteBuffer, usage);
 			isDirty = false;
 		}
 	}
@@ -148,7 +170,7 @@ public class IndexBufferObject implements IndexData {
 		((Buffer)byteBuffer).limit(buffer.limit() << 1);
 
 		if (isBound) {
-			Gdx.gl20.glBufferData(GL20.GL_ELEMENT_ARRAY_BUFFER, byteBuffer.limit(), byteBuffer, usage);
+			gl20().glBufferData(GL20.GL_ELEMENT_ARRAY_BUFFER, byteBuffer.limit(), byteBuffer, usage);
 			isDirty = false;
 		}
 	}
@@ -163,7 +185,7 @@ public class IndexBufferObject implements IndexData {
 		((Buffer)buffer).position(0);
 
 		if (isBound) {
-			Gdx.gl20.glBufferData(GL20.GL_ELEMENT_ARRAY_BUFFER, byteBuffer.limit(), byteBuffer, usage);
+			gl20().glBufferData(GL20.GL_ELEMENT_ARRAY_BUFFER, byteBuffer.limit(), byteBuffer, usage);
 			isDirty = false;
 		}
 	}
@@ -186,10 +208,10 @@ public class IndexBufferObject implements IndexData {
 	public void bind () {
 		if (bufferHandle == 0) throw new GdxRuntimeException("No buffer allocated!");
 
-		Gdx.gl20.glBindBuffer(GL20.GL_ELEMENT_ARRAY_BUFFER, bufferHandle);
+		gl20().glBindBuffer(GL20.GL_ELEMENT_ARRAY_BUFFER, bufferHandle);
 		if (isDirty) {
 			((Buffer)byteBuffer).limit(buffer.limit() * 2);
-			Gdx.gl20.glBufferData(GL20.GL_ELEMENT_ARRAY_BUFFER, byteBuffer.limit(), byteBuffer, usage);
+			gl20().glBufferData(GL20.GL_ELEMENT_ARRAY_BUFFER, byteBuffer.limit(), byteBuffer, usage);
 			isDirty = false;
 		}
 		isBound = true;
@@ -197,20 +219,20 @@ public class IndexBufferObject implements IndexData {
 
 	/** Unbinds this IndexBufferObject. */
 	public void unbind () {
-		Gdx.gl20.glBindBuffer(GL20.GL_ELEMENT_ARRAY_BUFFER, 0);
+		gl20().glBindBuffer(GL20.GL_ELEMENT_ARRAY_BUFFER, 0);
 		isBound = false;
 	}
 
 	/** Invalidates the IndexBufferObject so a new OpenGL buffer handle is created. Use this in case of a context loss. */
 	public void invalidate () {
-		bufferHandle = Gdx.gl20.glGenBuffer();
+		bufferHandle = gl20().glGenBuffer();
 		isDirty = true;
 	}
 
 	/** Disposes this IndexBufferObject and all its associated OpenGL resources. */
 	public void dispose () {
-		Gdx.gl20.glBindBuffer(GL20.GL_ELEMENT_ARRAY_BUFFER, 0);
-		Gdx.gl20.glDeleteBuffer(bufferHandle);
+		gl20().glBindBuffer(GL20.GL_ELEMENT_ARRAY_BUFFER, 0);
+		gl20().glDeleteBuffer(bufferHandle);
 		bufferHandle = 0;
 
 		if (ownsBuffer) {

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/IndexBufferObjectSubData.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/IndexBufferObjectSubData.java
@@ -21,6 +21,7 @@ import java.nio.ByteBuffer;
 import java.nio.ShortBuffer;
 
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Graphics;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.utils.BufferUtils;
 import com.badlogic.gdx.utils.GdxRuntimeException;
@@ -42,6 +43,13 @@ import com.badlogic.gdx.utils.GdxRuntimeException;
  *
  * @author mzechner */
 public class IndexBufferObjectSubData implements IndexData {
+
+	private final Graphics graphics;
+
+	private GL20 gl20 () {
+		return graphics.getGL20();
+	}
+
 	final ShortBuffer buffer;
 	final ByteBuffer byteBuffer;
 	int bufferHandle;
@@ -55,6 +63,11 @@ public class IndexBufferObjectSubData implements IndexData {
 	 * @param isStatic whether the index buffer is static
 	 * @param maxIndices the maximum number of indices this buffer can hold */
 	public IndexBufferObjectSubData (boolean isStatic, int maxIndices) {
+		this(Gdx.graphics, isStatic, maxIndices);
+	}
+
+	public IndexBufferObjectSubData (Graphics graphics, boolean isStatic, int maxIndices) {
+		this.graphics = graphics;
 		byteBuffer = BufferUtils.newByteBuffer(maxIndices * 2);
 		isDirect = true;
 
@@ -69,6 +82,11 @@ public class IndexBufferObjectSubData implements IndexData {
 	 *
 	 * @param maxIndices the maximum number of indices this buffer can hold */
 	public IndexBufferObjectSubData (int maxIndices) {
+		this(Gdx.graphics, maxIndices);
+	}
+
+	public IndexBufferObjectSubData (Graphics graphics, int maxIndices) {
+		this.graphics = graphics;
 		byteBuffer = BufferUtils.newByteBuffer(maxIndices * 2);
 		this.isDirect = true;
 
@@ -80,10 +98,10 @@ public class IndexBufferObjectSubData implements IndexData {
 	}
 
 	private int createBufferObject () {
-		int result = Gdx.gl20.glGenBuffer();
-		Gdx.gl20.glBindBuffer(GL20.GL_ELEMENT_ARRAY_BUFFER, result);
-		Gdx.gl20.glBufferData(GL20.GL_ELEMENT_ARRAY_BUFFER, byteBuffer.capacity(), null, usage);
-		Gdx.gl20.glBindBuffer(GL20.GL_ELEMENT_ARRAY_BUFFER, 0);
+		int result = gl20().glGenBuffer();
+		gl20().glBindBuffer(GL20.GL_ELEMENT_ARRAY_BUFFER, result);
+		gl20().glBufferData(GL20.GL_ELEMENT_ARRAY_BUFFER, byteBuffer.capacity(), null, usage);
+		gl20().glBindBuffer(GL20.GL_ELEMENT_ARRAY_BUFFER, 0);
 		return result;
 	}
 
@@ -119,7 +137,7 @@ public class IndexBufferObjectSubData implements IndexData {
 		((Buffer)byteBuffer).limit(count << 1);
 
 		if (isBound) {
-			Gdx.gl20.glBufferSubData(GL20.GL_ELEMENT_ARRAY_BUFFER, 0, byteBuffer.limit(), byteBuffer);
+			gl20().glBufferSubData(GL20.GL_ELEMENT_ARRAY_BUFFER, 0, byteBuffer.limit(), byteBuffer);
 			isDirty = false;
 		}
 	}
@@ -135,7 +153,7 @@ public class IndexBufferObjectSubData implements IndexData {
 		((Buffer)byteBuffer).limit(buffer.limit() << 1);
 
 		if (isBound) {
-			Gdx.gl20.glBufferSubData(GL20.GL_ELEMENT_ARRAY_BUFFER, 0, byteBuffer.limit(), byteBuffer);
+			gl20().glBufferSubData(GL20.GL_ELEMENT_ARRAY_BUFFER, 0, byteBuffer.limit(), byteBuffer);
 			isDirty = false;
 		}
 	}
@@ -150,7 +168,7 @@ public class IndexBufferObjectSubData implements IndexData {
 		((Buffer)buffer).position(0);
 
 		if (isBound) {
-			Gdx.gl20.glBufferSubData(GL20.GL_ELEMENT_ARRAY_BUFFER, 0, byteBuffer.limit(), byteBuffer);
+			gl20().glBufferSubData(GL20.GL_ELEMENT_ARRAY_BUFFER, 0, byteBuffer.limit(), byteBuffer);
 			isDirty = false;
 		}
 	}
@@ -173,10 +191,10 @@ public class IndexBufferObjectSubData implements IndexData {
 	public void bind () {
 		if (bufferHandle == 0) throw new GdxRuntimeException("IndexBufferObject cannot be used after it has been disposed.");
 
-		Gdx.gl20.glBindBuffer(GL20.GL_ELEMENT_ARRAY_BUFFER, bufferHandle);
+		gl20().glBindBuffer(GL20.GL_ELEMENT_ARRAY_BUFFER, bufferHandle);
 		if (isDirty) {
 			((Buffer)byteBuffer).limit(buffer.limit() * 2);
-			Gdx.gl20.glBufferSubData(GL20.GL_ELEMENT_ARRAY_BUFFER, 0, byteBuffer.limit(), byteBuffer);
+			gl20().glBufferSubData(GL20.GL_ELEMENT_ARRAY_BUFFER, 0, byteBuffer.limit(), byteBuffer);
 			isDirty = false;
 		}
 		isBound = true;
@@ -184,7 +202,7 @@ public class IndexBufferObjectSubData implements IndexData {
 
 	/** Unbinds this IndexBufferObject. */
 	public void unbind () {
-		Gdx.gl20.glBindBuffer(GL20.GL_ELEMENT_ARRAY_BUFFER, 0);
+		gl20().glBindBuffer(GL20.GL_ELEMENT_ARRAY_BUFFER, 0);
 		isBound = false;
 	}
 
@@ -196,7 +214,7 @@ public class IndexBufferObjectSubData implements IndexData {
 
 	/** Disposes this IndexBufferObject and all its associated OpenGL resources. */
 	public void dispose () {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		gl.glBindBuffer(GL20.GL_ELEMENT_ARRAY_BUFFER, 0);
 		gl.glDeleteBuffer(bufferHandle);
 		bufferHandle = 0;

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/InstanceBufferObject.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/InstanceBufferObject.java
@@ -17,7 +17,9 @@
 package com.badlogic.gdx.graphics.glutils;
 
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Graphics;
 import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.GL30;
 import com.badlogic.gdx.graphics.VertexAttribute;
 import com.badlogic.gdx.graphics.VertexAttributes;
 import com.badlogic.gdx.utils.BufferUtils;
@@ -33,6 +35,16 @@ import java.nio.FloatBuffer;
  * @author mrdlink */
 public class InstanceBufferObject implements InstanceData {
 
+	private final Graphics graphics;
+
+	private GL20 gl20 () {
+		return graphics.getGL20();
+	}
+
+	private GL30 gl30 () {
+		return graphics.getGL30();
+	}
+
 	private VertexAttributes attributes;
 	private FloatBuffer buffer;
 	private ByteBuffer byteBuffer;
@@ -43,14 +55,23 @@ public class InstanceBufferObject implements InstanceData {
 	boolean isBound = false;
 
 	public InstanceBufferObject (boolean isStatic, int numVertices, VertexAttribute... attributes) {
-		this(isStatic, numVertices, new VertexAttributes(attributes));
+		this(Gdx.graphics, isStatic, numVertices, attributes);
+	}
+
+	public InstanceBufferObject (Graphics graphics, boolean isStatic, int numVertices, VertexAttribute... attributes) {
+		this(graphics, isStatic, numVertices, new VertexAttributes(attributes));
 	}
 
 	public InstanceBufferObject (boolean isStatic, int numVertices, VertexAttributes instanceAttributes) {
-		if (Gdx.gl30 == null)
+		this(Gdx.graphics, isStatic, numVertices, instanceAttributes);
+	}
+
+	public InstanceBufferObject (Graphics graphics, boolean isStatic, int numVertices, VertexAttributes instanceAttributes) {
+		this.graphics = graphics;
+		if (gl30() == null)
 			throw new GdxRuntimeException("InstanceBufferObject requires a device running with GLES 3.0 compatibilty");
 
-		bufferHandle = Gdx.gl20.glGenBuffer();
+		bufferHandle = gl20().glGenBuffer();
 
 		ByteBuffer data = BufferUtils.newUnsafeByteBuffer(instanceAttributes.vertexSize * numVertices);
 		((Buffer)data).limit(0);
@@ -111,8 +132,8 @@ public class InstanceBufferObject implements InstanceData {
 
 	private void bufferChanged () {
 		if (isBound) {
-			Gdx.gl20.glBufferData(GL20.GL_ARRAY_BUFFER, byteBuffer.limit(), null, usage);
-			Gdx.gl20.glBufferData(GL20.GL_ARRAY_BUFFER, byteBuffer.limit(), byteBuffer, usage);
+			gl20().glBufferData(GL20.GL_ARRAY_BUFFER, byteBuffer.limit(), null, usage);
+			gl20().glBufferData(GL20.GL_ARRAY_BUFFER, byteBuffer.limit(), byteBuffer, usage);
 			isDirty = false;
 		}
 	}
@@ -181,7 +202,7 @@ public class InstanceBufferObject implements InstanceData {
 
 	@Override
 	public void bind (ShaderProgram shader, int[] locations) {
-		final GL20 gl = Gdx.gl20;
+		final GL20 gl = gl20();
 
 		gl.glBindBuffer(GL20.GL_ARRAY_BUFFER, bufferHandle);
 		if (isDirty) {
@@ -201,7 +222,7 @@ public class InstanceBufferObject implements InstanceData {
 
 				shader.setVertexAttribute(location + unitOffset, attribute.numComponents, attribute.type, attribute.normalized,
 					attributes.vertexSize, attribute.offset);
-				Gdx.gl30.glVertexAttribDivisor(location + unitOffset, 1);
+				gl30().glVertexAttribDivisor(location + unitOffset, 1);
 			}
 
 		} else {
@@ -214,7 +235,7 @@ public class InstanceBufferObject implements InstanceData {
 
 				shader.setVertexAttribute(location + unitOffset, attribute.numComponents, attribute.type, attribute.normalized,
 					attributes.vertexSize, attribute.offset);
-				Gdx.gl30.glVertexAttribDivisor(location + unitOffset, 1);
+				gl30().glVertexAttribDivisor(location + unitOffset, 1);
 			}
 		}
 		isBound = true;
@@ -230,7 +251,7 @@ public class InstanceBufferObject implements InstanceData {
 
 	@Override
 	public void unbind (final ShaderProgram shader, final int[] locations) {
-		final GL20 gl = Gdx.gl20;
+		final GL20 gl = gl20();
 		final int numAttributes = attributes.size();
 		if (locations == null) {
 			for (int i = 0; i < numAttributes; i++) {
@@ -256,14 +277,14 @@ public class InstanceBufferObject implements InstanceData {
 	/** Invalidates the InstanceBufferObject so a new OpenGL buffer handle is created. Use this in case of a context loss. */
 	@Override
 	public void invalidate () {
-		bufferHandle = Gdx.gl20.glGenBuffer();
+		bufferHandle = gl20().glGenBuffer();
 		isDirty = true;
 	}
 
 	/** Disposes of all resources this InstanceBufferObject uses. */
 	@Override
 	public void dispose () {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		gl.glBindBuffer(GL20.GL_ARRAY_BUFFER, 0);
 		gl.glDeleteBuffer(bufferHandle);
 		bufferHandle = 0;

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/InstanceBufferObjectSubData.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/InstanceBufferObjectSubData.java
@@ -17,7 +17,9 @@
 package com.badlogic.gdx.graphics.glutils;
 
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Graphics;
 import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.GL30;
 import com.badlogic.gdx.graphics.VertexAttribute;
 import com.badlogic.gdx.graphics.VertexAttributes;
 import com.badlogic.gdx.utils.BufferUtils;
@@ -32,6 +34,16 @@ import java.nio.FloatBuffer;
  *
  * @author mrdlink */
 public class InstanceBufferObjectSubData implements InstanceData {
+
+	private final Graphics graphics;
+
+	private GL20 gl20 () {
+		return graphics.getGL20();
+	}
+
+	private GL30 gl30 () {
+		return graphics.getGL30();
+	}
 
 	final VertexAttributes attributes;
 	final FloatBuffer buffer;
@@ -49,7 +61,11 @@ public class InstanceBufferObjectSubData implements InstanceData {
 	 * @param numInstances the maximum number of vertices
 	 * @param instanceAttributes the {@link VertexAttributes}. */
 	public InstanceBufferObjectSubData (boolean isStatic, int numInstances, VertexAttribute... instanceAttributes) {
-		this(isStatic, numInstances, new VertexAttributes(instanceAttributes));
+		this(Gdx.graphics, isStatic, numInstances, instanceAttributes);
+	}
+
+	public InstanceBufferObjectSubData (Graphics graphics, boolean isStatic, int numInstances, VertexAttribute... instanceAttributes) {
+		this(graphics, isStatic, numInstances, new VertexAttributes(instanceAttributes));
 	}
 
 	/** Constructs a new interleaved InstanceBufferObject.
@@ -58,6 +74,11 @@ public class InstanceBufferObjectSubData implements InstanceData {
 	 * @param numInstances the maximum number of vertices
 	 * @param instanceAttributes the {@link VertexAttribute}s. */
 	public InstanceBufferObjectSubData (boolean isStatic, int numInstances, VertexAttributes instanceAttributes) {
+		this(Gdx.graphics, isStatic, numInstances, instanceAttributes);
+	}
+
+	public InstanceBufferObjectSubData (Graphics graphics, boolean isStatic, int numInstances, VertexAttributes instanceAttributes) {
+		this.graphics = graphics;
 		this.isStatic = isStatic;
 		this.attributes = instanceAttributes;
 		byteBuffer = BufferUtils.newByteBuffer(this.attributes.vertexSize * numInstances);
@@ -71,10 +92,10 @@ public class InstanceBufferObjectSubData implements InstanceData {
 	}
 
 	private int createBufferObject () {
-		int result = Gdx.gl20.glGenBuffer();
-		Gdx.gl20.glBindBuffer(GL20.GL_ARRAY_BUFFER, result);
-		Gdx.gl20.glBufferData(GL20.GL_ARRAY_BUFFER, byteBuffer.capacity(), null, usage);
-		Gdx.gl20.glBindBuffer(GL20.GL_ARRAY_BUFFER, 0);
+		int result = gl20().glGenBuffer();
+		gl20().glBindBuffer(GL20.GL_ARRAY_BUFFER, result);
+		gl20().glBufferData(GL20.GL_ARRAY_BUFFER, byteBuffer.capacity(), null, usage);
+		gl20().glBindBuffer(GL20.GL_ARRAY_BUFFER, 0);
 		return result;
 	}
 
@@ -115,8 +136,8 @@ public class InstanceBufferObjectSubData implements InstanceData {
 
 	private void bufferChanged () {
 		if (isBound) {
-			Gdx.gl20.glBufferData(GL20.GL_ARRAY_BUFFER, byteBuffer.limit(), null, usage);
-			Gdx.gl20.glBufferSubData(GL20.GL_ARRAY_BUFFER, 0, byteBuffer.limit(), byteBuffer);
+			gl20().glBufferData(GL20.GL_ARRAY_BUFFER, byteBuffer.limit(), null, usage);
+			gl20().glBufferSubData(GL20.GL_ARRAY_BUFFER, 0, byteBuffer.limit(), byteBuffer);
 			isDirty = false;
 		}
 	}
@@ -196,7 +217,7 @@ public class InstanceBufferObjectSubData implements InstanceData {
 
 	@Override
 	public void bind (final ShaderProgram shader, final int[] locations) {
-		final GL20 gl = Gdx.gl20;
+		final GL20 gl = gl20();
 
 		gl.glBindBuffer(GL20.GL_ARRAY_BUFFER, bufferHandle);
 		if (isDirty) {
@@ -216,7 +237,7 @@ public class InstanceBufferObjectSubData implements InstanceData {
 
 				shader.setVertexAttribute(location + unitOffset, attribute.numComponents, attribute.type, attribute.normalized,
 					attributes.vertexSize, attribute.offset);
-				Gdx.gl30.glVertexAttribDivisor(location + unitOffset, 1);
+				gl30().glVertexAttribDivisor(location + unitOffset, 1);
 			}
 		} else {
 			for (int i = 0; i < numAttributes; i++) {
@@ -228,7 +249,7 @@ public class InstanceBufferObjectSubData implements InstanceData {
 
 				shader.setVertexAttribute(location + unitOffset, attribute.numComponents, attribute.type, attribute.normalized,
 					attributes.vertexSize, attribute.offset);
-				Gdx.gl30.glVertexAttribDivisor(location + unitOffset, 1);
+				gl30().glVertexAttribDivisor(location + unitOffset, 1);
 			}
 		}
 		isBound = true;
@@ -244,7 +265,7 @@ public class InstanceBufferObjectSubData implements InstanceData {
 
 	@Override
 	public void unbind (final ShaderProgram shader, final int[] locations) {
-		final GL20 gl = Gdx.gl20;
+		final GL20 gl = gl20();
 		final int numAttributes = attributes.size();
 		if (locations == null) {
 			for (int i = 0; i < numAttributes; i++) {
@@ -276,7 +297,7 @@ public class InstanceBufferObjectSubData implements InstanceData {
 	/** Disposes of all resources this InstanceBufferObject uses. */
 	@Override
 	public void dispose () {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		gl.glBindBuffer(GL20.GL_ARRAY_BUFFER, 0);
 		gl.glDeleteBuffer(bufferHandle);
 		bufferHandle = 0;

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/KTXTextureData.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/KTXTextureData.java
@@ -10,6 +10,7 @@ import java.nio.IntBuffer;
 import java.util.zip.GZIPInputStream;
 
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Graphics;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.Cubemap;
 import com.badlogic.gdx.graphics.CubemapData;
@@ -54,10 +55,21 @@ public class KTXTextureData implements TextureData, CubemapData {
 
 	// Whether to generate mipmaps if they are not included in the file
 	private boolean useMipMaps;
+	private Graphics graphics = Gdx.graphics;
 
 	public KTXTextureData (FileHandle file, boolean genMipMaps) {
+		this(Gdx.graphics, file, genMipMaps);
+	}
+
+	public KTXTextureData (Graphics graphics, FileHandle file, boolean genMipMaps) {
+		this.graphics = graphics;
 		this.file = file;
 		this.useMipMaps = genMipMaps;
+	}
+
+	@Override
+	public void setGraphics (Graphics graphics) {
+		this.graphics = graphics;
 	}
 
 	@Override
@@ -217,9 +229,9 @@ public class KTXTextureData implements TextureData, CubemapData {
 		}
 
 		// KTX files require an unpack alignment of 4
-		Gdx.gl.glGetIntegerv(GL20.GL_UNPACK_ALIGNMENT, buffer);
+		graphics.getGL20().glGetIntegerv(GL20.GL_UNPACK_ALIGNMENT, buffer);
 		int previousUnpackAlignment = buffer.get(0);
-		if (previousUnpackAlignment != 4) Gdx.gl.glPixelStorei(GL20.GL_UNPACK_ALIGNMENT, 4);
+		if (previousUnpackAlignment != 4) graphics.getGL20().glPixelStorei(GL20.GL_UNPACK_ALIGNMENT, 4);
 		int glInternalFormat = this.glInternalFormat;
 		int glFormat = this.glFormat;
 		int pos = imagePos;
@@ -247,23 +259,23 @@ public class KTXTextureData implements TextureData, CubemapData {
 					if (numberOfArrayElements > 0) pixelHeight = numberOfArrayElements;
 					if (compressed) {
 						if (glInternalFormat == ETC1.ETC1_RGB8_OES) {
-							if (!Gdx.graphics.supportsExtension("GL_OES_compressed_ETC1_RGB8_texture")) {
+							if (!graphics.supportsExtension("GL_OES_compressed_ETC1_RGB8_texture")) {
 								ETC1Data etcData = new ETC1Data(pixelWidth, pixelHeight, data, 0);
 								Pixmap pixmap = ETC1.decodeImage(etcData, Format.RGB888);
-								Gdx.gl.glTexImage2D(target + face, level, pixmap.getGLInternalFormat(), pixmap.getWidth(),
+								graphics.getGL20().glTexImage2D(target + face, level, pixmap.getGLInternalFormat(), pixmap.getWidth(),
 									pixmap.getHeight(), 0, pixmap.getGLFormat(), pixmap.getGLType(), pixmap.getPixels());
 								pixmap.dispose();
 							} else {
-								Gdx.gl.glCompressedTexImage2D(target + face, level, glInternalFormat, pixelWidth, pixelHeight, 0,
+								graphics.getGL20().glCompressedTexImage2D(target + face, level, glInternalFormat, pixelWidth, pixelHeight, 0,
 									faceLodSize, data);
 							}
 						} else {
 							// Try to load (no software unpacking fallback)
-							Gdx.gl.glCompressedTexImage2D(target + face, level, glInternalFormat, pixelWidth, pixelHeight, 0,
+							graphics.getGL20().glCompressedTexImage2D(target + face, level, glInternalFormat, pixelWidth, pixelHeight, 0,
 								faceLodSize, data);
 						}
 					} else
-						Gdx.gl.glTexImage2D(target + face, level, glInternalFormat, pixelWidth, pixelHeight, 0, glFormat, glType, data);
+						graphics.getGL20().glTexImage2D(target + face, level, glInternalFormat, pixelWidth, pixelHeight, 0, glFormat, glType, data);
 				} else if (textureDimensions == 3) {
 					if (numberOfArrayElements > 0) pixelDepth = numberOfArrayElements;
 					// if (compressed)
@@ -275,8 +287,8 @@ public class KTXTextureData implements TextureData, CubemapData {
 				}
 			}
 		}
-		if (previousUnpackAlignment != 4) Gdx.gl.glPixelStorei(GL20.GL_UNPACK_ALIGNMENT, previousUnpackAlignment);
-		if (useMipMaps()) Gdx.gl.glGenerateMipmap(target);
+		if (previousUnpackAlignment != 4) graphics.getGL20().glPixelStorei(GL20.GL_UNPACK_ALIGNMENT, previousUnpackAlignment);
+		if (useMipMaps()) graphics.getGL20().glGenerateMipmap(target);
 
 		// dispose data once transfered to GPU
 		disposePreparedData();

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/MipMapGenerator.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/MipMapGenerator.java
@@ -18,6 +18,7 @@ package com.badlogic.gdx.graphics.glutils;
 
 import com.badlogic.gdx.Application.ApplicationType;
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Graphics;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.Pixmap.Blending;
@@ -40,48 +41,58 @@ public class MipMapGenerator {
 	 * <code>disposePixmap</code> is true, the pixmap will be disposed at the end of the method.
 	 * @param pixmap the Pixmap */
 	public static void generateMipMap (Pixmap pixmap, int textureWidth, int textureHeight) {
-		generateMipMap(GL20.GL_TEXTURE_2D, pixmap, textureWidth, textureHeight);
+		generateMipMap(Gdx.graphics, GL20.GL_TEXTURE_2D, pixmap, textureWidth, textureHeight);
+	}
+
+	public static void generateMipMap (Graphics graphics, Pixmap pixmap, int textureWidth, int textureHeight) {
+		generateMipMap(graphics, GL20.GL_TEXTURE_2D, pixmap, textureWidth, textureHeight);
 	}
 
 	/** Sets the image data of the {@link Texture} based on the {@link Pixmap}. The texture must be bound for this to work. If
 	 * <code>disposePixmap</code> is true, the pixmap will be disposed at the end of the method. */
 	public static void generateMipMap (int target, Pixmap pixmap, int textureWidth, int textureHeight) {
+		generateMipMap(Gdx.graphics, target, pixmap, textureWidth, textureHeight);
+	}
+
+	public static void generateMipMap (Graphics graphics, int target, Pixmap pixmap, int textureWidth, int textureHeight) {
 		if (!useHWMipMap) {
-			generateMipMapCPU(target, pixmap, textureWidth, textureHeight);
+			generateMipMapCPU(graphics, target, pixmap, textureWidth, textureHeight);
 			return;
 		}
 
 		if (Gdx.app.getType() == ApplicationType.Android || Gdx.app.getType() == ApplicationType.WebGL
 			|| Gdx.app.getType() == ApplicationType.iOS) {
-			generateMipMapGLES20(target, pixmap);
+			generateMipMapGLES20(graphics, target, pixmap);
 		} else {
-			generateMipMapDesktop(target, pixmap, textureWidth, textureHeight);
+			generateMipMapDesktop(graphics, target, pixmap, textureWidth, textureHeight);
 		}
 	}
 
-	private static void generateMipMapGLES20 (int target, Pixmap pixmap) {
-		Gdx.gl.glTexImage2D(target, 0, pixmap.getGLInternalFormat(), pixmap.getWidth(), pixmap.getHeight(), 0, pixmap.getGLFormat(),
+	private static void generateMipMapGLES20 (Graphics graphics, int target, Pixmap pixmap) {
+		GL20 gl = graphics.getGL20();
+		gl.glTexImage2D(target, 0, pixmap.getGLInternalFormat(), pixmap.getWidth(), pixmap.getHeight(), 0, pixmap.getGLFormat(),
 			pixmap.getGLType(), pixmap.getPixels());
-		Gdx.gl20.glGenerateMipmap(target);
+		gl.glGenerateMipmap(target);
 	}
 
-	private static void generateMipMapDesktop (int target, Pixmap pixmap, int textureWidth, int textureHeight) {
-		if (Gdx.graphics.supportsExtension("GL_ARB_framebuffer_object")
-			|| Gdx.graphics.supportsExtension("GL_EXT_framebuffer_object")
-			|| Gdx.gl20.getClass().getName().equals("com.badlogic.gdx.backends.lwjgl3.angle.Lwjgl3GLES20") // LWJGL3ANGLE
-			|| Gdx.gl30 != null) {
-			Gdx.gl.glTexImage2D(target, 0, pixmap.getGLInternalFormat(), pixmap.getWidth(), pixmap.getHeight(), 0,
-				pixmap.getGLFormat(), pixmap.getGLType(), pixmap.getPixels());
-			Gdx.gl20.glGenerateMipmap(target);
+	private static void generateMipMapDesktop (Graphics graphics, int target, Pixmap pixmap, int textureWidth, int textureHeight) {
+		GL20 gl = graphics.getGL20();
+		if (graphics.supportsExtension("GL_ARB_framebuffer_object") || graphics.supportsExtension("GL_EXT_framebuffer_object")
+			|| gl.getClass().getName().equals("com.badlogic.gdx.backends.lwjgl3.angle.Lwjgl3GLES20") // LWJGL3ANGLE
+			|| graphics.getGL30() != null) {
+			gl.glTexImage2D(target, 0, pixmap.getGLInternalFormat(), pixmap.getWidth(), pixmap.getHeight(), 0, pixmap.getGLFormat(),
+				pixmap.getGLType(), pixmap.getPixels());
+			gl.glGenerateMipmap(target);
 		} else {
-			generateMipMapCPU(target, pixmap, textureWidth, textureHeight);
+			generateMipMapCPU(graphics, target, pixmap, textureWidth, textureHeight);
 		}
 	}
 
-	private static void generateMipMapCPU (int target, Pixmap pixmap, int textureWidth, int textureHeight) {
-		Gdx.gl.glTexImage2D(target, 0, pixmap.getGLInternalFormat(), pixmap.getWidth(), pixmap.getHeight(), 0, pixmap.getGLFormat(),
+	private static void generateMipMapCPU (Graphics graphics, int target, Pixmap pixmap, int textureWidth, int textureHeight) {
+		GL20 gl = graphics.getGL20();
+		gl.glTexImage2D(target, 0, pixmap.getGLInternalFormat(), pixmap.getWidth(), pixmap.getHeight(), 0, pixmap.getGLFormat(),
 			pixmap.getGLType(), pixmap.getPixels());
-		if ((Gdx.gl20 == null) && textureWidth != textureHeight)
+		if ((gl == null) && textureWidth != textureHeight)
 			throw new GdxRuntimeException("texture width and height must be square when using mipmapping.");
 		int width = pixmap.getWidth() / 2;
 		int height = pixmap.getHeight() / 2;
@@ -95,7 +106,7 @@ public class MipMapGenerator {
 			if (level > 1) pixmap.dispose();
 			pixmap = tmp;
 
-			Gdx.gl.glTexImage2D(target, level, pixmap.getGLInternalFormat(), pixmap.getWidth(), pixmap.getHeight(), 0,
+			gl.glTexImage2D(target, level, pixmap.getGLInternalFormat(), pixmap.getWidth(), pixmap.getHeight(), 0,
 				pixmap.getGLFormat(), pixmap.getGLType(), pixmap.getPixels());
 
 			width = pixmap.getWidth() / 2;

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/ShaderProgram.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/ShaderProgram.java
@@ -22,7 +22,7 @@ import java.nio.ByteOrder;
 import java.nio.FloatBuffer;
 import java.nio.IntBuffer;
 
-import com.badlogic.gdx.Application;
+import com.badlogic.gdx.Graphics;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.Color;
@@ -91,8 +91,8 @@ public class ShaderProgram implements Disposable {
 	 * as-is, you should include a newline (`\n`) if needed. */
 	public static String prependFragmentCode = "";
 
-	/** the list of currently available shaders **/
-	private final static ObjectMap<Application, Array<ShaderProgram>> shaders = new ObjectMap<Application, Array<ShaderProgram>>();
+	/** the list of currently available shaders, keyed by the {@link Graphics} instance that owns the GL context **/
+	private final static ObjectMap<Graphics, Array<ShaderProgram>> shaders = new ObjectMap<Graphics, Array<ShaderProgram>>();
 
 	/** the log **/
 	private String log = "";
@@ -168,7 +168,7 @@ public class ShaderProgram implements Disposable {
 		if (isCompiled()) {
 			fetchAttributes();
 			fetchUniforms();
-			addManagedShader(Gdx.app, this);
+			addManagedShader(Gdx.graphics, this);
 		}
 	}
 
@@ -769,7 +769,7 @@ public class ShaderProgram implements Disposable {
 		gl.glDeleteShader(vertexShaderHandle);
 		gl.glDeleteShader(fragmentShaderHandle);
 		gl.glDeleteProgram(program);
-		if (shaders.get(Gdx.app) != null) shaders.get(Gdx.app).removeValue(this, true);
+		if (shaders.get(Gdx.graphics) != null) shaders.get(Gdx.graphics).removeValue(this, true);
 	}
 
 	/** Disables the vertex attribute with the given name
@@ -813,19 +813,19 @@ public class ShaderProgram implements Disposable {
 		}
 	}
 
-	private void addManagedShader (Application app, ShaderProgram shaderProgram) {
-		Array<ShaderProgram> managedResources = shaders.get(app);
+	private void addManagedShader (Graphics graphics, ShaderProgram shaderProgram) {
+		Array<ShaderProgram> managedResources = shaders.get(graphics);
 		if (managedResources == null) managedResources = new Array<ShaderProgram>();
 		managedResources.add(shaderProgram);
-		shaders.put(app, managedResources);
+		shaders.put(graphics, managedResources);
 	}
 
 	/** Invalidates all shaders so the next time they are used new handles are generated
-	 * @param app */
-	public static void invalidateAllShaderPrograms (Application app) {
+	 * @param graphics the graphics instance whose shaders should be invalidated */
+	public static void invalidateAllShaderPrograms (Graphics graphics) {
 		if (Gdx.gl20 == null) return;
 
-		Array<ShaderProgram> shaderArray = shaders.get(app);
+		Array<ShaderProgram> shaderArray = shaders.get(graphics);
 		if (shaderArray == null) return;
 
 		for (int i = 0; i < shaderArray.size; i++) {
@@ -834,16 +834,16 @@ public class ShaderProgram implements Disposable {
 		}
 	}
 
-	public static void clearAllShaderPrograms (Application app) {
-		shaders.remove(app);
+	public static void clearAllShaderPrograms (Graphics graphics) {
+		shaders.remove(graphics);
 	}
 
 	public static String getManagedStatus () {
 		StringBuilder builder = new StringBuilder();
 		int i = 0;
-		builder.append("Managed shaders/app: { ");
-		for (Application app : shaders.keys()) {
-			builder.append(shaders.get(app).size);
+		builder.append("Managed shaders/graphics: { ");
+		for (Graphics graphics : shaders.keys()) {
+			builder.append(shaders.get(graphics).size);
 			builder.append(" ");
 		}
 		builder.append("}");
@@ -852,7 +852,7 @@ public class ShaderProgram implements Disposable {
 
 	/** @return the number of managed shader programs currently loaded */
 	public static int getNumManagedShaderPrograms () {
-		return shaders.get(Gdx.app).size;
+		return shaders.get(Gdx.graphics).size;
 	}
 
 	/** Sets the given attribute

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/ShaderProgram.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/ShaderProgram.java
@@ -148,18 +148,35 @@ public class ShaderProgram implements Disposable {
 	/** reference count **/
 	private int refCount = 0;
 
-	/** Constructs a new ShaderProgram and immediately compiles it.
+	/** {@link Graphics} this shader is managed by and resolves GL from **/
+	private final Graphics graphics;
+
+	private GL20 gl20 () {
+		return graphics.getGL20();
+	}
+
+	/** Constructs a new ShaderProgram and immediately compiles it using {@link Gdx#graphics}.
 	 *
 	 * @param vertexShader the vertex shader
 	 * @param fragmentShader the fragment shader */
-
 	public ShaderProgram (String vertexShader, String fragmentShader) {
+		this(Gdx.graphics, vertexShader, fragmentShader);
+	}
+
+	/** Constructs a new ShaderProgram and immediately compiles it.
+	 *
+	 * @param graphics the graphics instance used to resolve the current {@link GL20} and manage this shader
+	 * @param vertexShader the vertex shader
+	 * @param fragmentShader the fragment shader */
+	public ShaderProgram (Graphics graphics, String vertexShader, String fragmentShader) {
+		if (graphics == null) throw new IllegalArgumentException("graphics must not be null");
 		if (vertexShader == null) throw new IllegalArgumentException("vertex shader must not be null");
 		if (fragmentShader == null) throw new IllegalArgumentException("fragment shader must not be null");
 
 		if (prependVertexCode != null && prependVertexCode.length() > 0) vertexShader = prependVertexCode + vertexShader;
 		if (prependFragmentCode != null && prependFragmentCode.length() > 0) fragmentShader = prependFragmentCode + fragmentShader;
 
+		this.graphics = graphics;
 		this.vertexShaderSource = vertexShader;
 		this.fragmentShaderSource = fragmentShader;
 		this.matrix = BufferUtils.newFloatBuffer(16);
@@ -168,12 +185,19 @@ public class ShaderProgram implements Disposable {
 		if (isCompiled()) {
 			fetchAttributes();
 			fetchUniforms();
-			addManagedShader(Gdx.graphics, this);
+			addManagedShader(graphics, this);
 		}
 	}
 
+	/** Constructs a new ShaderProgram from file handles using {@link Gdx#graphics}. */
 	public ShaderProgram (FileHandle vertexShader, FileHandle fragmentShader) {
-		this(vertexShader.readString(), fragmentShader.readString());
+		this(Gdx.graphics, vertexShader, fragmentShader);
+	}
+
+	/** Constructs a new ShaderProgram from file handles.
+	 * @param graphics the graphics instance used to resolve GL and manage this shader */
+	public ShaderProgram (Graphics graphics, FileHandle vertexShader, FileHandle fragmentShader) {
+		this(graphics, vertexShader.readString(), fragmentShader.readString());
 	}
 
 	/** Loads and compiles the shaders, creates a new program and links the shaders.
@@ -199,7 +223,7 @@ public class ShaderProgram implements Disposable {
 	}
 
 	private int loadShader (int type, String source) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		IntBuffer intbuf = BufferUtils.newIntBuffer(1);
 
 		int shader = gl.glCreateShader(type);
@@ -225,13 +249,13 @@ public class ShaderProgram implements Disposable {
 	}
 
 	protected int createProgram () {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		int program = gl.glCreateProgram();
 		return program != 0 ? program : -1;
 	}
 
 	private int linkProgram (int program) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		if (program == -1) return -1;
 
 		gl.glAttachShader(program, vertexShaderHandle);
@@ -245,10 +269,10 @@ public class ShaderProgram implements Disposable {
 		gl.glGetProgramiv(program, GL20.GL_LINK_STATUS, intbuf);
 		int linked = intbuf.get(0);
 		if (linked == 0) {
-// Gdx.gl20.glGetProgramiv(program, GL20.GL_INFO_LOG_LENGTH, intbuf);
+// gl20().glGetProgramiv(program, GL20.GL_INFO_LOG_LENGTH, intbuf);
 // int infoLogLength = intbuf.get(0);
 // if (infoLogLength > 1) {
-			log = Gdx.gl20.glGetProgramInfoLog(program);
+			log = gl20().glGetProgramInfoLog(program);
 // }
 			return -1;
 		}
@@ -262,10 +286,10 @@ public class ShaderProgram implements Disposable {
 	 *         have an effect. */
 	public String getLog () {
 		if (isCompiled) {
-// Gdx.gl20.glGetProgramiv(program, GL20.GL_INFO_LOG_LENGTH, intbuf);
+// gl20().glGetProgramiv(program, GL20.GL_INFO_LOG_LENGTH, intbuf);
 // int infoLogLength = intbuf.get(0);
 // if (infoLogLength > 1) {
-			log = Gdx.gl20.glGetProgramInfoLog(program);
+			log = gl20().glGetProgramInfoLog(program);
 // }
 			return log;
 		} else {
@@ -279,7 +303,7 @@ public class ShaderProgram implements Disposable {
 	}
 
 	private int fetchAttributeLocation (String name) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		// -2 == not yet cached
 		// -1 == cached but not found
 		int location;
@@ -299,7 +323,7 @@ public class ShaderProgram implements Disposable {
 		// -1 == cached but not found
 		int location;
 		if ((location = uniforms.get(name, -2)) == -2) {
-			location = Gdx.gl20.glGetUniformLocation(program, name);
+			location = gl20().glGetUniformLocation(program, name);
 			if (location == -1 && pedantic) {
 				if (isCompiled) throw new IllegalArgumentException("No uniform with name '" + name + "' in shader");
 				throw new IllegalStateException("An attempted fetch uniform from uncompiled shader \n" + getLog());
@@ -314,14 +338,14 @@ public class ShaderProgram implements Disposable {
 	 * @param name the name of the uniform
 	 * @param value the value */
 	public void setUniformi (String name, int value) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		int location = fetchUniformLocation(name);
 		gl.glUniform1i(location, value);
 	}
 
 	public void setUniformi (int location, int value) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		gl.glUniform1i(location, value);
 	}
@@ -332,14 +356,14 @@ public class ShaderProgram implements Disposable {
 	 * @param value1 the first value
 	 * @param value2 the second value */
 	public void setUniformi (String name, int value1, int value2) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		int location = fetchUniformLocation(name);
 		gl.glUniform2i(location, value1, value2);
 	}
 
 	public void setUniformi (int location, int value1, int value2) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		gl.glUniform2i(location, value1, value2);
 	}
@@ -351,14 +375,14 @@ public class ShaderProgram implements Disposable {
 	 * @param value2 the second value
 	 * @param value3 the third value */
 	public void setUniformi (String name, int value1, int value2, int value3) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		int location = fetchUniformLocation(name);
 		gl.glUniform3i(location, value1, value2, value3);
 	}
 
 	public void setUniformi (int location, int value1, int value2, int value3) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		gl.glUniform3i(location, value1, value2, value3);
 	}
@@ -371,66 +395,66 @@ public class ShaderProgram implements Disposable {
 	 * @param value3 the third value
 	 * @param value4 the fourth value */
 	public void setUniformi (String name, int value1, int value2, int value3, int value4) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		int location = fetchUniformLocation(name);
 		gl.glUniform4i(location, value1, value2, value3, value4);
 	}
 
 	public void setUniformi (int location, int value1, int value2, int value3, int value4) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		gl.glUniform4i(location, value1, value2, value3, value4);
 	}
 
 	public void setUniform1iv (String name, int[] values, int offset, int length) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		int location = fetchUniformLocation(name);
 		gl.glUniform1iv(location, length, values, offset);
 	}
 
 	public void setUniform1iv (int location, int[] values, int offset, int length) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		gl.glUniform1iv(location, length, values, offset);
 	}
 
 	public void setUniform2iv (String name, int[] values, int offset, int length) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		int location = fetchUniformLocation(name);
 		gl.glUniform2iv(location, length / 2, values, offset);
 	}
 
 	public void setUniform2iv (int location, int[] values, int offset, int length) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		gl.glUniform2iv(location, length / 2, values, offset);
 	}
 
 	public void setUniform3iv (String name, int[] values, int offset, int length) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		int location = fetchUniformLocation(name);
 		gl.glUniform3iv(location, length / 3, values, offset);
 	}
 
 	public void setUniform3iv (int location, int[] values, int offset, int length) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		gl.glUniform3iv(location, length / 3, values, offset);
 	}
 
 	public void setUniform4iv (String name, int[] values, int offset, int length) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		int location = fetchUniformLocation(name);
 		gl.glUniform4iv(location, length / 4, values, offset);
 	}
 
 	public void setUniform4iv (int location, int[] values, int offset, int length) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		gl.glUniform4iv(location, length / 4, values, offset);
 	}
@@ -440,14 +464,14 @@ public class ShaderProgram implements Disposable {
 	 * @param name the name of the uniform
 	 * @param value the value */
 	public void setUniformf (String name, float value) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		int location = fetchUniformLocation(name);
 		gl.glUniform1f(location, value);
 	}
 
 	public void setUniformf (int location, float value) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		gl.glUniform1f(location, value);
 	}
@@ -458,14 +482,14 @@ public class ShaderProgram implements Disposable {
 	 * @param value1 the first value
 	 * @param value2 the second value */
 	public void setUniformf (String name, float value1, float value2) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		int location = fetchUniformLocation(name);
 		gl.glUniform2f(location, value1, value2);
 	}
 
 	public void setUniformf (int location, float value1, float value2) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		gl.glUniform2f(location, value1, value2);
 	}
@@ -477,14 +501,14 @@ public class ShaderProgram implements Disposable {
 	 * @param value2 the second value
 	 * @param value3 the third value */
 	public void setUniformf (String name, float value1, float value2, float value3) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		int location = fetchUniformLocation(name);
 		gl.glUniform3f(location, value1, value2, value3);
 	}
 
 	public void setUniformf (int location, float value1, float value2, float value3) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		gl.glUniform3f(location, value1, value2, value3);
 	}
@@ -497,66 +521,66 @@ public class ShaderProgram implements Disposable {
 	 * @param value3 the third value
 	 * @param value4 the fourth value */
 	public void setUniformf (String name, float value1, float value2, float value3, float value4) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		int location = fetchUniformLocation(name);
 		gl.glUniform4f(location, value1, value2, value3, value4);
 	}
 
 	public void setUniformf (int location, float value1, float value2, float value3, float value4) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		gl.glUniform4f(location, value1, value2, value3, value4);
 	}
 
 	public void setUniform1fv (String name, float[] values, int offset, int length) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		int location = fetchUniformLocation(name);
 		gl.glUniform1fv(location, length, values, offset);
 	}
 
 	public void setUniform1fv (int location, float[] values, int offset, int length) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		gl.glUniform1fv(location, length, values, offset);
 	}
 
 	public void setUniform2fv (String name, float[] values, int offset, int length) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		int location = fetchUniformLocation(name);
 		gl.glUniform2fv(location, length / 2, values, offset);
 	}
 
 	public void setUniform2fv (int location, float[] values, int offset, int length) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		gl.glUniform2fv(location, length / 2, values, offset);
 	}
 
 	public void setUniform3fv (String name, float[] values, int offset, int length) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		int location = fetchUniformLocation(name);
 		gl.glUniform3fv(location, length / 3, values, offset);
 	}
 
 	public void setUniform3fv (int location, float[] values, int offset, int length) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		gl.glUniform3fv(location, length / 3, values, offset);
 	}
 
 	public void setUniform4fv (String name, float[] values, int offset, int length) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		int location = fetchUniformLocation(name);
 		gl.glUniform4fv(location, length / 4, values, offset);
 	}
 
 	public void setUniform4fv (int location, float[] values, int offset, int length) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		gl.glUniform4fv(location, length / 4, values, offset);
 	}
@@ -583,7 +607,7 @@ public class ShaderProgram implements Disposable {
 	}
 
 	public void setUniformMatrix (int location, Matrix4 matrix, boolean transpose) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		gl.glUniformMatrix4fv(location, 1, transpose, matrix.val, 0);
 	}
@@ -610,7 +634,7 @@ public class ShaderProgram implements Disposable {
 	}
 
 	public void setUniformMatrix (int location, Matrix3 matrix, boolean transpose) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		gl.glUniformMatrix3fv(location, 1, transpose, matrix.val, 0);
 	}
@@ -621,7 +645,7 @@ public class ShaderProgram implements Disposable {
 	 * @param buffer buffer containing the matrix data
 	 * @param transpose whether the uniform matrix should be transposed */
 	public void setUniformMatrix3fv (String name, FloatBuffer buffer, int count, boolean transpose) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		((Buffer)buffer).position(0);
 		int location = fetchUniformLocation(name);
@@ -634,7 +658,7 @@ public class ShaderProgram implements Disposable {
 	 * @param buffer buffer containing the matrix data
 	 * @param transpose whether the uniform matrix should be transposed */
 	public void setUniformMatrix4fv (String name, FloatBuffer buffer, int count, boolean transpose) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		((Buffer)buffer).position(0);
 		int location = fetchUniformLocation(name);
@@ -642,7 +666,7 @@ public class ShaderProgram implements Disposable {
 	}
 
 	public void setUniformMatrix4fv (int location, float[] values, int offset, int length) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		gl.glUniformMatrix4fv(location, length / 16, false, values, offset);
 	}
@@ -709,7 +733,7 @@ public class ShaderProgram implements Disposable {
 	 * @param stride the stride in bytes between successive attributes
 	 * @param buffer the buffer containing the vertex attributes. */
 	public void setVertexAttribute (String name, int size, int type, boolean normalize, int stride, Buffer buffer) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		int location = fetchAttributeLocation(name);
 		if (location == -1) return;
@@ -717,7 +741,7 @@ public class ShaderProgram implements Disposable {
 	}
 
 	public void setVertexAttribute (int location, int size, int type, boolean normalize, int stride, Buffer buffer) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		gl.glVertexAttribPointer(location, size, type, normalize, stride, buffer);
 	}
@@ -732,7 +756,7 @@ public class ShaderProgram implements Disposable {
 	 * @param stride the stride in bytes between successive attributes
 	 * @param offset byte offset into the vertex buffer object bound to GL20.GL_ARRAY_BUFFER. */
 	public void setVertexAttribute (String name, int size, int type, boolean normalize, int stride, int offset) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		int location = fetchAttributeLocation(name);
 		if (location == -1) return;
@@ -740,7 +764,7 @@ public class ShaderProgram implements Disposable {
 	}
 
 	public void setVertexAttribute (int location, int size, int type, boolean normalize, int stride, int offset) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		gl.glVertexAttribPointer(location, size, type, normalize, stride, offset);
 	}
@@ -752,7 +776,7 @@ public class ShaderProgram implements Disposable {
 	}
 
 	public void bind () {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		gl.glUseProgram(program);
 	}
@@ -764,19 +788,19 @@ public class ShaderProgram implements Disposable {
 
 	/** Disposes all resources associated with this shader. Must be called when the shader is no longer used. */
 	public void dispose () {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		gl.glUseProgram(0);
 		gl.glDeleteShader(vertexShaderHandle);
 		gl.glDeleteShader(fragmentShaderHandle);
 		gl.glDeleteProgram(program);
-		if (shaders.get(Gdx.graphics) != null) shaders.get(Gdx.graphics).removeValue(this, true);
+		if (shaders.get(graphics) != null) shaders.get(graphics).removeValue(this, true);
 	}
 
 	/** Disables the vertex attribute with the given name
 	 *
 	 * @param name the vertex attribute name */
 	public void disableVertexAttribute (String name) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		int location = fetchAttributeLocation(name);
 		if (location == -1) return;
@@ -784,7 +808,7 @@ public class ShaderProgram implements Disposable {
 	}
 
 	public void disableVertexAttribute (int location) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		gl.glDisableVertexAttribArray(location);
 	}
@@ -793,7 +817,7 @@ public class ShaderProgram implements Disposable {
 	 *
 	 * @param name the vertex attribute name */
 	public void enableVertexAttribute (String name) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		int location = fetchAttributeLocation(name);
 		if (location == -1) return;
@@ -801,7 +825,7 @@ public class ShaderProgram implements Disposable {
 	}
 
 	public void enableVertexAttribute (int location) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		checkManaged();
 		gl.glEnableVertexAttribArray(location);
 	}
@@ -823,7 +847,7 @@ public class ShaderProgram implements Disposable {
 	/** Invalidates all shaders so the next time they are used new handles are generated
 	 * @param graphics the graphics instance whose shaders should be invalidated */
 	public static void invalidateAllShaderPrograms (Graphics graphics) {
-		if (Gdx.gl20 == null) return;
+		if (graphics == null || graphics.getGL20() == null) return;
 
 		Array<ShaderProgram> shaderArray = shaders.get(graphics);
 		if (shaderArray == null) return;
@@ -863,7 +887,7 @@ public class ShaderProgram implements Disposable {
 	 * @param value3 the third value
 	 * @param value4 the fourth value */
 	public void setAttributef (String name, float value1, float value2, float value3, float value4) {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		int location = fetchAttributeLocation(name);
 		gl.glVertexAttrib4f(location, value1, value2, value3, value4);
 	}
@@ -873,7 +897,7 @@ public class ShaderProgram implements Disposable {
 
 	private void fetchUniforms () {
 		((Buffer)params).clear();
-		Gdx.gl20.glGetProgramiv(program, GL20.GL_ACTIVE_UNIFORMS, params);
+		gl20().glGetProgramiv(program, GL20.GL_ACTIVE_UNIFORMS, params);
 		int numUniforms = params.get(0);
 
 		uniformNames = new String[numUniforms];
@@ -882,8 +906,8 @@ public class ShaderProgram implements Disposable {
 			((Buffer)params).clear();
 			params.put(0, 1);
 			((Buffer)type).clear();
-			String name = Gdx.gl20.glGetActiveUniform(program, i, params, type);
-			int location = Gdx.gl20.glGetUniformLocation(program, name);
+			String name = gl20().glGetActiveUniform(program, i, params, type);
+			int location = gl20().glGetUniformLocation(program, name);
 			uniforms.put(name, location);
 			uniformTypes.put(name, type.get(0));
 			uniformSizes.put(name, params.get(0));
@@ -893,7 +917,7 @@ public class ShaderProgram implements Disposable {
 
 	private void fetchAttributes () {
 		((Buffer)params).clear();
-		Gdx.gl20.glGetProgramiv(program, GL20.GL_ACTIVE_ATTRIBUTES, params);
+		gl20().glGetProgramiv(program, GL20.GL_ACTIVE_ATTRIBUTES, params);
 		int numAttributes = params.get(0);
 
 		attributeNames = new String[numAttributes];
@@ -902,8 +926,8 @@ public class ShaderProgram implements Disposable {
 			((Buffer)params).clear();
 			params.put(0, 1);
 			((Buffer)type).clear();
-			String name = Gdx.gl20.glGetActiveAttrib(program, i, params, type);
-			int location = Gdx.gl20.glGetAttribLocation(program, name);
+			String name = gl20().glGetActiveAttrib(program, i, params, type);
+			int location = gl20().glGetAttribLocation(program, name);
 			attributes.put(name, location);
 			attributeTypes.put(name, type.get(0));
 			attributeSizes.put(name, params.get(0));

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/ShapeRenderer.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/ShapeRenderer.java
@@ -17,6 +17,7 @@
 package com.badlogic.gdx.graphics.glutils;
 
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Graphics;
 import com.badlogic.gdx.graphics.Camera;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
@@ -104,20 +105,32 @@ public class ShapeRenderer implements Disposable {
 	private float defaultRectLineWidth = 0.75f;
 
 	public ShapeRenderer () {
-		this(5000);
+		this(Gdx.graphics, 5000);
+	}
+
+	public ShapeRenderer (Graphics graphics) {
+		this(graphics, 5000);
 	}
 
 	public ShapeRenderer (int maxVertices) {
-		this(maxVertices, null);
+		this(Gdx.graphics, maxVertices, null);
+	}
+
+	public ShapeRenderer (Graphics graphics, int maxVertices) {
+		this(graphics, maxVertices, null);
 	}
 
 	public ShapeRenderer (int maxVertices, ShaderProgram defaultShader) {
+		this(Gdx.graphics, maxVertices, defaultShader);
+	}
+
+	public ShapeRenderer (Graphics graphics, int maxVertices, ShaderProgram defaultShader) {
 		if (defaultShader == null) {
-			renderer = new ImmediateModeRenderer20(maxVertices, false, true, 0);
+			renderer = new ImmediateModeRenderer20(graphics, maxVertices, false, true, 0);
 		} else {
-			renderer = new ImmediateModeRenderer20(maxVertices, false, true, 0, defaultShader);
+			renderer = new ImmediateModeRenderer20(graphics, maxVertices, false, true, 0, defaultShader);
 		}
-		projectionMatrix.setToOrtho2D(0, 0, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+		projectionMatrix.setToOrtho2D(0, 0, graphics.getWidth(), graphics.getHeight());
 		matrixDirty = true;
 	}
 

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/VertexBufferObject.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/VertexBufferObject.java
@@ -21,6 +21,7 @@ import java.nio.ByteBuffer;
 import java.nio.FloatBuffer;
 
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Graphics;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.VertexAttribute;
 import com.badlogic.gdx.graphics.VertexAttributes;
@@ -40,6 +41,13 @@ import com.badlogic.gdx.utils.GdxRuntimeException;
  *
  * @author mzechner, Dave Clayton <contact@redskyforge.com> */
 public class VertexBufferObject implements VertexData {
+
+	private final Graphics graphics;
+
+	private GL20 gl20 () {
+		return graphics.getGL20();
+	}
+
 	private VertexAttributes attributes;
 	private FloatBuffer buffer;
 	private ByteBuffer byteBuffer;
@@ -55,7 +63,11 @@ public class VertexBufferObject implements VertexData {
 	 * @param numVertices the maximum number of vertices
 	 * @param attributes the {@link VertexAttribute}s. */
 	public VertexBufferObject (boolean isStatic, int numVertices, VertexAttribute... attributes) {
-		this(isStatic, numVertices, new VertexAttributes(attributes));
+		this(Gdx.graphics, isStatic, numVertices, attributes);
+	}
+
+	public VertexBufferObject (Graphics graphics, boolean isStatic, int numVertices, VertexAttribute... attributes) {
+		this(graphics, isStatic, numVertices, new VertexAttributes(attributes));
 	}
 
 	/** Constructs a new interleaved VertexBufferObject.
@@ -64,7 +76,12 @@ public class VertexBufferObject implements VertexData {
 	 * @param numVertices the maximum number of vertices
 	 * @param attributes the {@link VertexAttributes}. */
 	public VertexBufferObject (boolean isStatic, int numVertices, VertexAttributes attributes) {
-		bufferHandle = Gdx.gl20.glGenBuffer();
+		this(Gdx.graphics, isStatic, numVertices, attributes);
+	}
+
+	public VertexBufferObject (Graphics graphics, boolean isStatic, int numVertices, VertexAttributes attributes) {
+		this.graphics = graphics;
+		bufferHandle = gl20().glGenBuffer();
 
 		ByteBuffer data = BufferUtils.newUnsafeByteBuffer(attributes.vertexSize * numVertices);
 		((Buffer)data).limit(0);
@@ -73,7 +90,12 @@ public class VertexBufferObject implements VertexData {
 	}
 
 	protected VertexBufferObject (int usage, ByteBuffer data, boolean ownsBuffer, VertexAttributes attributes) {
-		bufferHandle = Gdx.gl20.glGenBuffer();
+		this(Gdx.graphics, usage, data, ownsBuffer, attributes);
+	}
+
+	protected VertexBufferObject (Graphics graphics, int usage, ByteBuffer data, boolean ownsBuffer, VertexAttributes attributes) {
+		this.graphics = graphics;
+		bufferHandle = gl20().glGenBuffer();
 
 		setBuffer(data, ownsBuffer, attributes);
 		setUsage(usage);
@@ -131,7 +153,7 @@ public class VertexBufferObject implements VertexData {
 
 	private void bufferChanged () {
 		if (isBound) {
-			Gdx.gl20.glBufferData(GL20.GL_ARRAY_BUFFER, byteBuffer.limit(), byteBuffer, usage);
+			gl20().glBufferData(GL20.GL_ARRAY_BUFFER, byteBuffer.limit(), byteBuffer, usage);
 			isDirty = false;
 		}
 	}
@@ -178,7 +200,7 @@ public class VertexBufferObject implements VertexData {
 
 	@Override
 	public void bind (ShaderProgram shader, int[] locations) {
-		final GL20 gl = Gdx.gl20;
+		final GL20 gl = gl20();
 
 		gl.glBindBuffer(GL20.GL_ARRAY_BUFFER, bufferHandle);
 		if (isDirty) {
@@ -223,7 +245,7 @@ public class VertexBufferObject implements VertexData {
 
 	@Override
 	public void unbind (final ShaderProgram shader, final int[] locations) {
-		final GL20 gl = Gdx.gl20;
+		final GL20 gl = gl20();
 		final int numAttributes = attributes.size();
 		if (locations == null) {
 			for (int i = 0; i < numAttributes; i++) {
@@ -242,14 +264,14 @@ public class VertexBufferObject implements VertexData {
 	/** Invalidates the VertexBufferObject so a new OpenGL buffer handle is created. Use this in case of a context loss. */
 	@Override
 	public void invalidate () {
-		bufferHandle = Gdx.gl20.glGenBuffer();
+		bufferHandle = gl20().glGenBuffer();
 		isDirty = true;
 	}
 
 	/** Disposes of all resources this VertexBufferObject uses. */
 	@Override
 	public void dispose () {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		gl.glBindBuffer(GL20.GL_ARRAY_BUFFER, 0);
 		gl.glDeleteBuffer(bufferHandle);
 		bufferHandle = 0;

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/VertexBufferObjectSubData.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/VertexBufferObjectSubData.java
@@ -21,6 +21,7 @@ import java.nio.ByteBuffer;
 import java.nio.FloatBuffer;
 
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Graphics;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.VertexAttribute;
 import com.badlogic.gdx.graphics.VertexAttributes;
@@ -40,6 +41,13 @@ import com.badlogic.gdx.utils.GdxRuntimeException;
  *
  * @author mzechner */
 public class VertexBufferObjectSubData implements VertexData {
+
+	private final Graphics graphics;
+
+	private GL20 gl20 () {
+		return graphics.getGL20();
+	}
+
 	final VertexAttributes attributes;
 	final FloatBuffer buffer;
 	final ByteBuffer byteBuffer;
@@ -56,7 +64,11 @@ public class VertexBufferObjectSubData implements VertexData {
 	 * @param numVertices the maximum number of vertices
 	 * @param attributes the {@link VertexAttributes}. */
 	public VertexBufferObjectSubData (boolean isStatic, int numVertices, VertexAttribute... attributes) {
-		this(isStatic, numVertices, new VertexAttributes(attributes));
+		this(Gdx.graphics, isStatic, numVertices, attributes);
+	}
+
+	public VertexBufferObjectSubData (Graphics graphics, boolean isStatic, int numVertices, VertexAttribute... attributes) {
+		this(graphics, isStatic, numVertices, new VertexAttributes(attributes));
 	}
 
 	/** Constructs a new interleaved VertexBufferObject.
@@ -65,6 +77,11 @@ public class VertexBufferObjectSubData implements VertexData {
 	 * @param numVertices the maximum number of vertices
 	 * @param attributes the {@link VertexAttribute}s. */
 	public VertexBufferObjectSubData (boolean isStatic, int numVertices, VertexAttributes attributes) {
+		this(Gdx.graphics, isStatic, numVertices, attributes);
+	}
+
+	public VertexBufferObjectSubData (Graphics graphics, boolean isStatic, int numVertices, VertexAttributes attributes) {
+		this.graphics = graphics;
 		this.isStatic = isStatic;
 		this.attributes = attributes;
 		byteBuffer = BufferUtils.newByteBuffer(this.attributes.vertexSize * numVertices);
@@ -78,10 +95,10 @@ public class VertexBufferObjectSubData implements VertexData {
 	}
 
 	private int createBufferObject () {
-		int result = Gdx.gl20.glGenBuffer();
-		Gdx.gl20.glBindBuffer(GL20.GL_ARRAY_BUFFER, result);
-		Gdx.gl20.glBufferData(GL20.GL_ARRAY_BUFFER, byteBuffer.capacity(), null, usage);
-		Gdx.gl20.glBindBuffer(GL20.GL_ARRAY_BUFFER, 0);
+		int result = gl20().glGenBuffer();
+		gl20().glBindBuffer(GL20.GL_ARRAY_BUFFER, result);
+		gl20().glBufferData(GL20.GL_ARRAY_BUFFER, byteBuffer.capacity(), null, usage);
+		gl20().glBindBuffer(GL20.GL_ARRAY_BUFFER, 0);
 		return result;
 	}
 
@@ -116,7 +133,7 @@ public class VertexBufferObjectSubData implements VertexData {
 
 	private void bufferChanged () {
 		if (isBound) {
-			Gdx.gl20.glBufferSubData(GL20.GL_ARRAY_BUFFER, 0, byteBuffer.limit(), byteBuffer);
+			gl20().glBufferSubData(GL20.GL_ARRAY_BUFFER, 0, byteBuffer.limit(), byteBuffer);
 			isDirty = false;
 		}
 	}
@@ -163,7 +180,7 @@ public class VertexBufferObjectSubData implements VertexData {
 
 	@Override
 	public void bind (final ShaderProgram shader, final int[] locations) {
-		final GL20 gl = Gdx.gl20;
+		final GL20 gl = gl20();
 
 		gl.glBindBuffer(GL20.GL_ARRAY_BUFFER, bufferHandle);
 		if (isDirty) {
@@ -207,7 +224,7 @@ public class VertexBufferObjectSubData implements VertexData {
 
 	@Override
 	public void unbind (final ShaderProgram shader, final int[] locations) {
-		final GL20 gl = Gdx.gl20;
+		final GL20 gl = gl20();
 		final int numAttributes = attributes.size();
 		if (locations == null) {
 			for (int i = 0; i < numAttributes; i++) {
@@ -232,7 +249,7 @@ public class VertexBufferObjectSubData implements VertexData {
 	/** Disposes of all resources this VertexBufferObject uses. */
 	@Override
 	public void dispose () {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20();
 		gl.glBindBuffer(GL20.GL_ARRAY_BUFFER, 0);
 		gl.glDeleteBuffer(bufferHandle);
 		bufferHandle = 0;

--- a/gdx/src/com/badlogic/gdx/graphics/glutils/VertexBufferObjectWithVAO.java
+++ b/gdx/src/com/badlogic/gdx/graphics/glutils/VertexBufferObjectWithVAO.java
@@ -7,6 +7,7 @@ import java.nio.FloatBuffer;
 import java.nio.IntBuffer;
 
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Graphics;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.GL30;
 import com.badlogic.gdx.graphics.VertexAttribute;
@@ -33,6 +34,16 @@ import com.badlogic.gdx.utils.IntArray;
  * Code adapted from {@link VertexBufferObject}.
  * @author mzechner, Dave Clayton <contact@redskyforge.com>, Nate Austin <nate.austin gmail> */
 public class VertexBufferObjectWithVAO implements VertexData {
+
+	private final Graphics graphics;
+
+	private GL20 gl20 () {
+		return graphics.getGL20();
+	}
+
+	private GL30 gl30 () {
+		return graphics.getGL30();
+	}
 	final static IntBuffer tmpHandle = BufferUtils.newIntBuffer(1);
 
 	final VertexAttributes attributes;
@@ -53,7 +64,11 @@ public class VertexBufferObjectWithVAO implements VertexData {
 	 * @param numVertices the maximum number of vertices
 	 * @param attributes the {@link com.badlogic.gdx.graphics.VertexAttribute}s. */
 	public VertexBufferObjectWithVAO (boolean isStatic, int numVertices, VertexAttribute... attributes) {
-		this(isStatic, numVertices, new VertexAttributes(attributes));
+		this(Gdx.graphics, isStatic, numVertices, attributes);
+	}
+
+	public VertexBufferObjectWithVAO (Graphics graphics, boolean isStatic, int numVertices, VertexAttribute... attributes) {
+		this(graphics, isStatic, numVertices, new VertexAttributes(attributes));
 	}
 
 	/** Constructs a new interleaved VertexBufferObjectWithVAO.
@@ -62,6 +77,11 @@ public class VertexBufferObjectWithVAO implements VertexData {
 	 * @param numVertices the maximum number of vertices
 	 * @param attributes the {@link VertexAttributes}. */
 	public VertexBufferObjectWithVAO (boolean isStatic, int numVertices, VertexAttributes attributes) {
+		this(Gdx.graphics, isStatic, numVertices, attributes);
+	}
+
+	public VertexBufferObjectWithVAO (Graphics graphics, boolean isStatic, int numVertices, VertexAttributes attributes) {
+		this.graphics = graphics;
 		this.isStatic = isStatic;
 		this.attributes = attributes;
 
@@ -70,12 +90,17 @@ public class VertexBufferObjectWithVAO implements VertexData {
 		ownsBuffer = true;
 		((Buffer)buffer).flip();
 		((Buffer)byteBuffer).flip();
-		bufferHandle = Gdx.gl20.glGenBuffer();
+		bufferHandle = gl20().glGenBuffer();
 		usage = isStatic ? GL20.GL_STATIC_DRAW : GL20.GL_DYNAMIC_DRAW;
 		createVAO();
 	}
 
 	public VertexBufferObjectWithVAO (boolean isStatic, ByteBuffer unmanagedBuffer, VertexAttributes attributes) {
+		this(Gdx.graphics, isStatic, unmanagedBuffer, attributes);
+	}
+
+	public VertexBufferObjectWithVAO (Graphics graphics, boolean isStatic, ByteBuffer unmanagedBuffer, VertexAttributes attributes) {
+		this.graphics = graphics;
 		this.isStatic = isStatic;
 		this.attributes = attributes;
 
@@ -84,7 +109,7 @@ public class VertexBufferObjectWithVAO implements VertexData {
 		buffer = byteBuffer.asFloatBuffer();
 		((Buffer)buffer).flip();
 		((Buffer)byteBuffer).flip();
-		bufferHandle = Gdx.gl20.glGenBuffer();
+		bufferHandle = gl20().glGenBuffer();
 		usage = isStatic ? GL20.GL_STATIC_DRAW : GL20.GL_DYNAMIC_DRAW;
 		createVAO();
 	}
@@ -120,8 +145,8 @@ public class VertexBufferObjectWithVAO implements VertexData {
 
 	private void bufferChanged () {
 		if (isBound) {
-			Gdx.gl20.glBindBuffer(GL20.GL_ARRAY_BUFFER, bufferHandle);
-			Gdx.gl20.glBufferData(GL20.GL_ARRAY_BUFFER, byteBuffer.limit(), byteBuffer, usage);
+			gl20().glBindBuffer(GL20.GL_ARRAY_BUFFER, bufferHandle);
+			gl20().glBufferData(GL20.GL_ARRAY_BUFFER, byteBuffer.limit(), byteBuffer, usage);
 			isDirty = false;
 		}
 	}
@@ -156,7 +181,7 @@ public class VertexBufferObjectWithVAO implements VertexData {
 
 	@Override
 	public void bind (ShaderProgram shader, int[] locations) {
-		GL30 gl = Gdx.gl30;
+		GL30 gl = gl30();
 
 		gl.glBindVertexArray(vaoHandle);
 
@@ -188,7 +213,7 @@ public class VertexBufferObjectWithVAO implements VertexData {
 		}
 
 		if (!stillValid) {
-			Gdx.gl.glBindBuffer(GL20.GL_ARRAY_BUFFER, bufferHandle);
+			gl20().glBindBuffer(GL20.GL_ARRAY_BUFFER, bufferHandle);
 			unbindAttributes(shader);
 			this.cachedLocations.clear();
 
@@ -245,7 +270,7 @@ public class VertexBufferObjectWithVAO implements VertexData {
 
 	@Override
 	public void unbind (final ShaderProgram shader, final int[] locations) {
-		GL30 gl = Gdx.gl30;
+		GL30 gl = gl30();
 		gl.glBindVertexArray(0);
 		isBound = false;
 	}
@@ -253,7 +278,7 @@ public class VertexBufferObjectWithVAO implements VertexData {
 	/** Invalidates the VertexBufferObject so a new OpenGL buffer handle is created. Use this in case of a context loss. */
 	@Override
 	public void invalidate () {
-		bufferHandle = Gdx.gl30.glGenBuffer();
+		bufferHandle = gl30().glGenBuffer();
 		createVAO();
 		isDirty = true;
 	}
@@ -261,7 +286,7 @@ public class VertexBufferObjectWithVAO implements VertexData {
 	/** Disposes of all resources this VertexBufferObject uses. */
 	@Override
 	public void dispose () {
-		GL30 gl = Gdx.gl30;
+		GL30 gl = gl30();
 
 		gl.glBindBuffer(GL20.GL_ARRAY_BUFFER, 0);
 		gl.glDeleteBuffer(bufferHandle);
@@ -274,7 +299,7 @@ public class VertexBufferObjectWithVAO implements VertexData {
 
 	private void createVAO () {
 		((Buffer)tmpHandle).clear();
-		Gdx.gl30.glGenVertexArrays(1, tmpHandle);
+		gl30().glGenVertexArrays(1, tmpHandle);
 		vaoHandle = tmpHandle.get();
 	}
 
@@ -283,7 +308,7 @@ public class VertexBufferObjectWithVAO implements VertexData {
 			((Buffer)tmpHandle).clear();
 			tmpHandle.put(vaoHandle);
 			((Buffer)tmpHandle).flip();
-			Gdx.gl30.glDeleteVertexArrays(1, tmpHandle);
+			gl30().glDeleteVertexArrays(1, tmpHandle);
 			vaoHandle = -1;
 		}
 	}

--- a/gdx/src/com/badlogic/gdx/utils/ScreenUtils.java
+++ b/gdx/src/com/badlogic/gdx/utils/ScreenUtils.java
@@ -20,6 +20,7 @@ import java.nio.Buffer;
 import java.nio.ByteBuffer;
 
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Graphics;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Pixmap;
@@ -38,25 +39,41 @@ public final class ScreenUtils {
 	/** Clears the color buffers with the specified Color.
 	 * @param color Color to clear the color buffers with. */
 	public static void clear (Color color) {
-		clear(color.r, color.g, color.b, color.a, false);
+		clear(Gdx.graphics, color.r, color.g, color.b, color.a, false);
+	}
+
+	public static void clear (Graphics graphics, Color color) {
+		clear(graphics, color.r, color.g, color.b, color.a, false);
 	}
 
 	/** Clears the color buffers with the specified color. */
 	public static void clear (float r, float g, float b, float a) {
-		clear(r, g, b, a, false);
+		clear(Gdx.graphics, r, g, b, a, false);
+	}
+
+	public static void clear (Graphics graphics, float r, float g, float b, float a) {
+		clear(graphics, r, g, b, a, false);
 	}
 
 	/** Clears the color buffers and optionally the depth buffer.
 	 * @param color Color to clear the color buffers with.
 	 * @param clearDepth Clears the depth buffer if true. */
 	public static void clear (Color color, boolean clearDepth) {
-		clear(color.r, color.g, color.b, color.a, clearDepth);
+		clear(Gdx.graphics, color.r, color.g, color.b, color.a, clearDepth);
+	}
+
+	public static void clear (Graphics graphics, Color color, boolean clearDepth) {
+		clear(graphics, color.r, color.g, color.b, color.a, clearDepth);
 	}
 
 	/** Clears the color buffers and optionally the depth buffer.
 	 * @param clearDepth Clears the depth buffer if true. */
 	public static void clear (float r, float g, float b, float a, boolean clearDepth) {
-		clear(r, g, b, a, clearDepth, false);
+		clear(Gdx.graphics, r, g, b, a, clearDepth, false);
+	}
+
+	public static void clear (Graphics graphics, float r, float g, float b, float a, boolean clearDepth) {
+		clear(graphics, r, g, b, a, clearDepth, false);
 	}
 
 	/** Clears the color buffers, optionally the depth buffer and whether to apply antialiasing (requires to set number of samples
@@ -65,11 +82,17 @@ public final class ScreenUtils {
 	 * @param clearDepth Clears the depth buffer if true.
 	 * @param applyAntialiasing applies multi-sampling for antialiasing if true. */
 	public static void clear (float r, float g, float b, float a, boolean clearDepth, boolean applyAntialiasing) {
-		Gdx.gl.glClearColor(r, g, b, a);
+		clear(Gdx.graphics, r, g, b, a, clearDepth, applyAntialiasing);
+	}
+
+	public static void clear (Graphics graphics, float r, float g, float b, float a, boolean clearDepth,
+		boolean applyAntialiasing) {
+		GL20 gl = graphics.getGL20();
+		gl.glClearColor(r, g, b, a);
 		int mask = GL20.GL_COLOR_BUFFER_BIT;
 		if (clearDepth) mask = mask | GL20.GL_DEPTH_BUFFER_BIT;
-		if (applyAntialiasing && Gdx.graphics.getBufferFormat().coverageSampling) mask = mask | GL20.GL_COVERAGE_BUFFER_BIT_NV;
-		Gdx.gl.glClear(mask);
+		if (applyAntialiasing && graphics.getBufferFormat().coverageSampling) mask = mask | GL20.GL_COVERAGE_BUFFER_BIT_NV;
+		gl.glClear(mask);
 	}
 
 	/** Returns the current framebuffer contents as a {@link TextureRegion} with a width and height equal to the current screen
@@ -77,9 +100,13 @@ public final class ScreenUtils {
 	 * accessed via {@link TextureRegion#getTexture}. The texture is not managed and has to be reloaded manually on a context loss.
 	 * The returned TextureRegion is flipped along the Y axis by default. */
 	public static TextureRegion getFrameBufferTexture () {
-		final int w = Gdx.graphics.getBackBufferWidth();
-		final int h = Gdx.graphics.getBackBufferHeight();
-		return getFrameBufferTexture(0, 0, w, h);
+		return getFrameBufferTexture(Gdx.graphics);
+	}
+
+	public static TextureRegion getFrameBufferTexture (Graphics graphics) {
+		final int w = graphics.getBackBufferWidth();
+		final int h = graphics.getBackBufferHeight();
+		return getFrameBufferTexture(graphics, 0, 0, w, h);
 	}
 
 	/** Returns a portion of the current framebuffer contents specified by x, y, width and height as a {@link TextureRegion} with
@@ -93,14 +120,18 @@ public final class ScreenUtils {
 	 * @param w the width of the framebuffer contents to capture
 	 * @param h the height of the framebuffer contents to capture */
 	public static TextureRegion getFrameBufferTexture (int x, int y, int w, int h) {
+		return getFrameBufferTexture(Gdx.graphics, x, y, w, h);
+	}
+
+	public static TextureRegion getFrameBufferTexture (Graphics graphics, int x, int y, int w, int h) {
 		final int potW = MathUtils.nextPowerOfTwo(w);
 		final int potH = MathUtils.nextPowerOfTwo(h);
 
-		final Pixmap pixmap = Pixmap.createFromFrameBuffer(x, y, w, h);
+		final Pixmap pixmap = Pixmap.createFromFrameBuffer(graphics, x, y, w, h);
 		final Pixmap potPixmap = new Pixmap(potW, potH, Format.RGBA8888);
 		potPixmap.setBlending(Blending.None);
 		potPixmap.drawPixmap(pixmap, 0, 0);
-		Texture texture = new Texture(potPixmap);
+		Texture texture = new Texture(graphics, potPixmap);
 		TextureRegion textureRegion = new TextureRegion(texture, 0, h, w, -h);
 		potPixmap.dispose();
 		pixmap.dispose();
@@ -121,9 +152,13 @@ public final class ScreenUtils {
 	 *
 	 * @param flipY whether to flip pixels along Y axis */
 	public static byte[] getFrameBufferPixels (boolean flipY) {
-		final int w = Gdx.graphics.getBackBufferWidth();
-		final int h = Gdx.graphics.getBackBufferHeight();
-		return getFrameBufferPixels(0, 0, w, h, flipY);
+		return getFrameBufferPixels(Gdx.graphics, flipY);
+	}
+
+	public static byte[] getFrameBufferPixels (Graphics graphics, boolean flipY) {
+		final int w = graphics.getBackBufferWidth();
+		final int h = graphics.getBackBufferHeight();
+		return getFrameBufferPixels(graphics, 0, 0, w, h, flipY);
 	}
 
 	/** Returns a portion of the current framebuffer contents specified by x, y, width and height, as a byte[] array with a length
@@ -135,9 +170,14 @@ public final class ScreenUtils {
 	 *
 	 * @param flipY whether to flip pixels along Y axis */
 	public static byte[] getFrameBufferPixels (int x, int y, int w, int h, boolean flipY) {
-		Gdx.gl.glPixelStorei(GL20.GL_PACK_ALIGNMENT, 1);
+		return getFrameBufferPixels(Gdx.graphics, x, y, w, h, flipY);
+	}
+
+	public static byte[] getFrameBufferPixels (Graphics graphics, int x, int y, int w, int h, boolean flipY) {
+		GL20 gl = graphics.getGL20();
+		gl.glPixelStorei(GL20.GL_PACK_ALIGNMENT, 1);
 		final ByteBuffer pixels = BufferUtils.newByteBuffer(w * h * 4);
-		Gdx.gl.glReadPixels(x, y, w, h, GL20.GL_RGBA, GL20.GL_UNSIGNED_BYTE, pixels);
+		gl.glReadPixels(x, y, w, h, GL20.GL_RGBA, GL20.GL_UNSIGNED_BYTE, pixels);
 		final int numBytes = w * h * 4;
 		byte[] lines = new byte[numBytes];
 		if (flipY) {

--- a/tests/gdx-tests-lwjgl3/src/com/badlogic/gdx/tests/lwjgl3/MultiWindowCursorTest.java
+++ b/tests/gdx-tests-lwjgl3/src/com/badlogic/gdx/tests/lwjgl3/MultiWindowCursorTest.java
@@ -18,7 +18,11 @@ public class MultiWindowCursorTest {
 
 		@Override
 		public void create () {
-			listener.create();
+		}
+
+		@Override
+		public void create (Application app) {
+			listener.create(app);
 			if (MathUtils.randomBoolean()) {
 				Cursor.SystemCursor[] systemCursors = Cursor.SystemCursor.values();
 				Cursor.SystemCursor systemCursor = systemCursors[MathUtils.random(systemCursors.length - 1)];

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/AbstractTestWrapper.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/AbstractTestWrapper.java
@@ -52,12 +52,12 @@ public abstract class AbstractTestWrapper extends GdxTest {
 	@Override
 	public void create () {
 		Instancer[] tests = getTestList();
-		Gdx.app.setLogLevel(Application.LOG_DEBUG);
-		Gdx.app.log("GdxTestGwt", "Setting up for " + tests.length + " tests.");
+		app.setLogLevel(Application.LOG_DEBUG);
+		app.log("GdxTestGwt", "Setting up for " + tests.length + " tests.");
 
 		ui = new Stage(new ExtendViewport(480, 320));
-		skin = new Skin(Gdx.files.internal("data/uiskin.json"));
-		font = new BitmapFont(Gdx.files.internal("data/lsans-15.fnt"), false);
+		skin = new Skin(files.internal("data/uiskin.json"));
+		font = new BitmapFont(files.internal("data/lsans-15.fnt"), false);
 		container = new Table();
 		ui.addActor(container);
 		container.debug();
@@ -78,11 +78,11 @@ public abstract class AbstractTestWrapper extends GdxTest {
 			button.addListener(new ChangeListener() {
 				@Override
 				public void changed (ChangeEvent event, Actor actor) {
-					((InputWrapper)Gdx.input).multiplexer.removeProcessor(ui);
+					((InputWrapper)input).multiplexer.removeProcessor(ui);
 					test = instancer.instance();
-					Gdx.app.log("GdxTestGwt", "Clicked on " + test.getClass().getName());
-					test.create();
-					test.resize(Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+					app.log("GdxTestGwt", "Clicked on " + test.getClass().getName());
+					test.create(app);
+					test.resize(graphics.getWidth(), graphics.getHeight());
 				}
 			});
 			table.add(button).growX();
@@ -91,12 +91,12 @@ public abstract class AbstractTestWrapper extends GdxTest {
 		container.add(new Label("Click on a test to start it, press ESC or tap the upper left corner to close it.",
 			new LabelStyle(font, Color.WHITE))).pad(5, 5, 5, 5);
 
-		Gdx.input = new InputWrapper(Gdx.input) {
+		input = new InputWrapper(input) {
 			@Override
 			public boolean keyUp (int keycode) {
 				if (keycode == Keys.ESCAPE) {
 					if (test != null) {
-						Gdx.app.log("GdxTestGwt", "Exiting current test.");
+						app.log("GdxTestGwt", "Exiting current test.");
 						dispose = true;
 					}
 				}
@@ -105,7 +105,7 @@ public abstract class AbstractTestWrapper extends GdxTest {
 
 			@Override
 			public boolean touchDown (int screenX, int screenY, int pointer, int button) {
-				if (screenX < Gdx.graphics.getWidth() / 10.0 && screenY < Gdx.graphics.getHeight() / 10.0) {
+				if (screenX < graphics.getWidth() / 10.0 && screenY < graphics.getHeight() / 10.0) {
 					if (test != null) {
 						dispose = true;
 					}
@@ -113,24 +113,26 @@ public abstract class AbstractTestWrapper extends GdxTest {
 				return false;
 			}
 		};
-		((InputWrapper)Gdx.input).multiplexer.addProcessor(ui);
+		// Keep Gdx.input in sync until framework code no longer reads the static.
+		Gdx.input = input;
+		((InputWrapper)input).multiplexer.addProcessor(ui);
 
-		Gdx.app.log("GdxTestGwt", "Test picker UI setup complete.");
+		app.log("GdxTestGwt", "Test picker UI setup complete.");
 	}
 
 	public void render () {
 		if (test == null) {
 			ScreenUtils.clear(0, 0, 0, 0);
-			ui.act(Gdx.graphics.getDeltaTime());
+			ui.act(graphics.getDeltaTime());
 			ui.draw();
 		} else {
 			if (dispose) {
 				test.pause();
 				test.dispose();
 				test = null;
-				ui.getViewport().update(Gdx.graphics.getWidth(), Gdx.graphics.getHeight(), true);
-				Gdx.graphics.setVSync(true);
-				InputWrapper wrapper = ((InputWrapper)Gdx.input);
+				ui.getViewport().update(graphics.getWidth(), graphics.getHeight(), true);
+				graphics.setVSync(true);
+				InputWrapper wrapper = ((InputWrapper)input);
 				wrapper.multiplexer.addProcessor(ui);
 				wrapper.multiplexer.removeProcessor(wrapper.lastProcessor);
 				wrapper.lastProcessor = null;

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/AccelerometerTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/AccelerometerTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
@@ -28,19 +27,19 @@ public class AccelerometerTest extends GdxTest {
 
 	@Override
 	public void create () {
-		font = new BitmapFont(Gdx.files.internal("data/lsans-15.fnt"), false);
+		font = new BitmapFont(files.internal("data/lsans-15.fnt"), false);
 		batch = new SpriteBatch();
 	}
 
 	@Override
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		batch.begin();
 		font.draw(batch,
-			"accel: [" + Gdx.input.getAccelerometerX() + "," + Gdx.input.getAccelerometerY() + "," + Gdx.input.getAccelerometerZ()
-				+ "]\n" + "gyros: [" + Gdx.input.getGyroscopeX() + "," + Gdx.input.getGyroscopeY() + "," + Gdx.input.getGyroscopeZ()
-				+ "]\n" + "orientation: " + Gdx.input.getNativeOrientation() + "\n" + "rotation: " + Gdx.input.getRotation() + "\n"
-				+ "wh: " + Gdx.graphics.getDisplayMode() + "\n",
+			"accel: [" + input.getAccelerometerX() + "," + input.getAccelerometerY() + "," + input.getAccelerometerZ()
+				+ "]\n" + "gyros: [" + input.getGyroscopeX() + "," + input.getGyroscopeY() + "," + input.getGyroscopeZ()
+				+ "]\n" + "orientation: " + input.getNativeOrientation() + "\n" + "rotation: " + input.getRotation() + "\n"
+				+ "wh: " + graphics.getDisplayMode() + "\n",
 			0, 100);
 		batch.end();
 	}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ActionSequenceTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ActionSequenceTest.java
@@ -20,7 +20,6 @@ import static com.badlogic.gdx.scenes.scene2d.actions.Actions.moveBy;
 import static com.badlogic.gdx.scenes.scene2d.actions.Actions.parallel;
 import static com.badlogic.gdx.scenes.scene2d.actions.Actions.sequence;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.Texture.TextureFilter;
@@ -41,7 +40,7 @@ public class ActionSequenceTest extends GdxTest implements Runnable {
 	@Override
 	public void create () {
 		stage = new Stage();
-		texture = new Texture(Gdx.files.internal("data/badlogic.jpg"), false);
+		texture = new Texture(files.internal("data/badlogic.jpg"), false);
 		texture.setFilter(TextureFilter.Linear, TextureFilter.Linear);
 		img = new Image(new TextureRegion(texture));
 		img.setSize(100, 100);
@@ -69,9 +68,9 @@ public class ActionSequenceTest extends GdxTest implements Runnable {
 
 	@Override
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 
-		stage.act(Math.min(Gdx.graphics.getDeltaTime(), 1 / 30f));
+		stage.act(Math.min(graphics.getDeltaTime(), 1 / 30f));
 		stage.draw();
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ActionTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ActionTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.Texture.TextureFilter;
@@ -33,7 +32,7 @@ public class ActionTest extends GdxTest {
 	@Override
 	public void create () {
 		stage = new Stage();
-		texture = new Texture(Gdx.files.internal("data/badlogic.jpg"), false);
+		texture = new Texture(files.internal("data/badlogic.jpg"), false);
 		texture.setFilter(TextureFilter.Linear, TextureFilter.Linear);
 		final Image img = new Image(new TextureRegion(texture));
 		img.setSize(100, 100);
@@ -56,8 +55,8 @@ public class ActionTest extends GdxTest {
 
 	@Override
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-		stage.act(Math.min(Gdx.graphics.getDeltaTime(), 1 / 30f));
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		stage.act(Math.min(graphics.getDeltaTime(), 1 / 30f));
 		stage.draw();
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ActorGestureListenerPointerTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ActorGestureListenerPointerTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.scenes.scene2d.ui.ScrollPane;
@@ -39,7 +38,7 @@ public class ActorGestureListenerPointerTest extends GdxTest {
 	public void create () {
 
 		stage = new Stage();
-		skin = new Skin(Gdx.files.internal("data/uiskin.json"));
+		skin = new Skin(files.internal("data/uiskin.json"));
 
 		firstPane = new ScrollPane(new Table(), skin);
 		secondPane = new ScrollPane(new Table(), skin);
@@ -49,13 +48,13 @@ public class ActorGestureListenerPointerTest extends GdxTest {
 		table.add(firstPane).grow();
 		table.add(secondPane).grow();
 
-		Gdx.input.setInputProcessor(stage);
+		input.setInputProcessor(stage);
 		stage.addActor(table);
 
 	}
 
 	public void render () {
-		update(Gdx.graphics.getDeltaTime());
+		update(graphics.getDeltaTime());
 		draw();
 	}
 
@@ -71,7 +70,7 @@ public class ActorGestureListenerPointerTest extends GdxTest {
 
 	private void update (float deltaTime) {
 
-		stage.act(Gdx.graphics.getDeltaTime());
+		stage.act(graphics.getDeltaTime());
 
 		if (inputTriggered) return;
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ActorGestureListenerTouchUpTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ActorGestureListenerTouchUpTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.scenes.scene2d.InputEvent;
 import com.badlogic.gdx.scenes.scene2d.Stage;
@@ -53,14 +52,14 @@ public class ActorGestureListenerTouchUpTest extends GdxTest {
 		table.setFillParent(true);
 		table.setTouchable(Touchable.enabled);
 
-		Gdx.input.setInputProcessor(stage);
+		input.setInputProcessor(stage);
 		stage.addActor(table);
 
 	}
 
 	@Override
 	public void render () {
-		update(Gdx.graphics.getDeltaTime());
+		update(graphics.getDeltaTime());
 		draw();
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/AlphaTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/AlphaTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.Pixmap.Format;
@@ -43,14 +42,14 @@ public class AlphaTest extends GdxTest {
 
 	@Override
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		batch.begin();
-		batch.draw(texture, 0, 0, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+		batch.draw(texture, 0, 0, graphics.getWidth(), graphics.getHeight());
 		batch.end();
 
-		Pixmap pixmap = Pixmap.createFromFrameBuffer(0, 0, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+		Pixmap pixmap = Pixmap.createFromFrameBuffer(0, 0, graphics.getWidth(), graphics.getHeight());
 		int color = pixmap.getPixel(0, pixmap.getHeight() - 1);
-		Gdx.app.log("AlphaTest", Integer.toHexString(color));
+		app.log("AlphaTest", Integer.toHexString(color));
 		pixmap.dispose();
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/AnimationTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/AnimationTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.FPSLogger;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.Animation;
@@ -44,8 +43,8 @@ public class AnimationTest extends GdxTest {
 		public void update (float deltaTime) {
 			stateTime += deltaTime;
 			pos.x = pos.x + (headsLeft ? -VELOCITY * deltaTime : VELOCITY * deltaTime);
-			if (pos.x < -64) pos.x = Gdx.graphics.getWidth();
-			if (pos.x > Gdx.graphics.getWidth() + 64) pos.x = -64;
+			if (pos.x < -64) pos.x = graphics.getWidth();
+			if (pos.x > graphics.getWidth() + 64) pos.x = -64;
 		}
 	}
 
@@ -58,7 +57,7 @@ public class AnimationTest extends GdxTest {
 
 	@Override
 	public void create () {
-		texture = new Texture(Gdx.files.internal("data/walkanim.png"));
+		texture = new Texture(files.internal("data/walkanim.png"));
 		TextureRegion[] leftWalkFrames = TextureRegion.split(texture, 64, 64)[0];
 		Array<TextureRegion> rightWalkFrames = new Array<>(TextureRegion[]::new);
 		for (int i = 0; i < leftWalkFrames.length; i++) {
@@ -71,12 +70,12 @@ public class AnimationTest extends GdxTest {
 
 		TextureRegion[] rightRegions = rightWalk.getKeyFrames(); // testing backing array type
 		TextureRegion firstRightRegion = rightRegions[0];
-		Gdx.app.log("AnimationTest",
+		app.log("AnimationTest",
 			"First right walk region is " + firstRightRegion.getRegionWidth() + "x" + firstRightRegion.getRegionHeight());
 
 		cavemen = new Caveman[100];
 		for (int i = 0; i < 100; i++) {
-			cavemen[i] = new Caveman((float)Math.random() * Gdx.graphics.getWidth(), (float)Math.random() * Gdx.graphics.getHeight(),
+			cavemen[i] = new Caveman((float)Math.random() * graphics.getWidth(), (float)Math.random() * graphics.getHeight(),
 				Math.random() > 0.5 ? true : false);
 		}
 		batch = new SpriteBatch();
@@ -96,7 +95,7 @@ public class AnimationTest extends GdxTest {
 		batch.end();
 
 		for (int i = 0; i < cavemen.length; i++) {
-			cavemen[i].update(Gdx.graphics.getDeltaTime());
+			cavemen[i].update(graphics.getDeltaTime());
 		}
 
 		fpsLog.log();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/AnnotationTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/AnnotationTest.java
@@ -21,7 +21,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.util.Arrays;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
@@ -151,9 +150,9 @@ public class AnnotationTest extends GdxTest {
 
 	@Override
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		batch.begin();
-		font.draw(batch, message, 20, Gdx.graphics.getHeight() - 20);
+		font.draw(batch, message, 20, graphics.getHeight() - 20);
 		batch.end();
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/AssetManagerTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/AssetManagerTest.java
@@ -17,7 +17,6 @@
 package com.badlogic.gdx.tests;
 
 import com.badlogic.gdx.Application;
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.assets.AssetDescriptor;
 import com.badlogic.gdx.assets.AssetErrorListener;
 import com.badlogic.gdx.assets.AssetManager;
@@ -54,7 +53,7 @@ public class AssetManagerTest extends GdxTest implements AssetErrorListener {
 	float elapsed = 0;
 
 	public void create () {
-		Gdx.app.setLogLevel(Application.LOG_ERROR);
+		app.setLogLevel(Application.LOG_ERROR);
 
 		Resolution[] resolutions = {new Resolution(320, 480, ".320480"), new Resolution(480, 800, ".480800"),
 			new Resolution(480, 856, ".480854")};
@@ -65,7 +64,7 @@ public class AssetManagerTest extends GdxTest implements AssetErrorListener {
 		load();
 		Texture.setAssetManager(manager);
 		batch = new SpriteBatch();
-		font = new BitmapFont(Gdx.files.internal("data/font.fnt"), false);
+		font = new BitmapFont(files.internal("data/font.fnt"), false);
 		skin = new Skin();
 
 	}
@@ -83,17 +82,17 @@ public class AssetManagerTest extends GdxTest implements AssetErrorListener {
 	private ShaderProgram shader;
 
 	private void load () {
-// Gdx.app.setLogLevel(Logger.DEBUG);
+// app.setLogLevel(Logger.DEBUG);
 		start = TimeUtils.nanoTime();
 		tex1 = new Texture("data/animation.png");
-		tex2 = new TextureAtlas(Gdx.files.internal("data/pack.atlas"));
-		font2 = new BitmapFont(Gdx.files.internal("data/verdana39.fnt"), false);
+		tex2 = new TextureAtlas(files.internal("data/pack.atlas"));
+		font2 = new BitmapFont(files.internal("data/verdana39.fnt"), false);
 // tex3 = new Texture("data/test.etc1");
-// map = TiledLoader.createMap(Gdx.files.internal("data/tiledmap/tilemap csv.tmx"));
-// atlas = new TileAtlas(map, Gdx.files.internal("data/tiledmap/"));
+// map = TiledLoader.createMap(files.internal("data/tiledmap/tilemap csv.tmx"));
+// atlas = new TileAtlas(map, files.internal("data/tiledmap/"));
 // renderer = new TileMapRenderer(map, atlas, 8, 8);
-		shader = new ShaderProgram(Gdx.files.internal("data/g2d/batchCommon.vert").readString(),
-			Gdx.files.internal("data/g2d/monochrome.frag").readString());
+		shader = new ShaderProgram(files.internal("data/g2d/batchCommon.vert").readString(),
+			files.internal("data/g2d/monochrome.frag").readString());
 		System.out.println("plain took: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
 
 		start = TimeUtils.nanoTime();
@@ -146,11 +145,11 @@ public class AssetManagerTest extends GdxTest implements AssetErrorListener {
 	private void invalidateTexture (Texture texture) {
 		IntBuffer buffer = BufferUtils.newIntBuffer(1);
 		buffer.put(0, texture.getTextureObjectHandle());
-		Gdx.gl.glDeleteTextures(1, buffer);
+		gl.glDeleteTextures(1, buffer);
 	}
 
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 
 		boolean result = manager.update(16);
 		if (result) {
@@ -159,7 +158,7 @@ public class AssetManagerTest extends GdxTest implements AssetErrorListener {
 				System.out.println("took: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
 				elapsed = 0;
 			} else {
-				elapsed += Gdx.graphics.getDeltaTime();
+				elapsed += graphics.getDeltaTime();
 				if (elapsed > 0.2f) {
 					unload();
 					load();
@@ -205,8 +204,8 @@ public class AssetManagerTest extends GdxTest implements AssetErrorListener {
 		font.draw(batch, "loaded: " + manager.getProgress() + ", reloads: " + reloads, 0, 30);
 		batch.end();
 
-// if(Gdx.input.justTouched()) {
-// Texture.invalidateAllTextures(Gdx.app);
+// if(input.justTouched()) {
+// Texture.invalidateAllTextures(app);
 // diagnosed = false;
 // unload();
 // load();
@@ -215,7 +214,7 @@ public class AssetManagerTest extends GdxTest implements AssetErrorListener {
 
 	@Override
 	public void error (AssetDescriptor asset, Throwable throwable) {
-		Gdx.app.error("AssetManagerTest", "Couldn't load asset: " + asset, (Exception)throwable);
+		app.error("AssetManagerTest", "Couldn't load asset: " + asset, (Exception)throwable);
 	}
 
 	@Override

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/AtlasIssueTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/AtlasIssueTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.graphics.g2d.Sprite;
@@ -34,17 +33,17 @@ public class AtlasIssueTest extends GdxTest {
 	public void create () {
 		batch = new SpriteBatch();
 		batch.setProjectionMatrix(new Matrix4().setToOrtho2D(0, 0, 855, 480));
-		atlas = new TextureAtlas(Gdx.files.internal("data/issue_pack"), Gdx.files.internal("data/"));
+		atlas = new TextureAtlas(files.internal("data/issue_pack"), files.internal("data/"));
 		sprite = atlas.createSprite("map");
-		font = new BitmapFont(Gdx.files.internal("data/font.fnt"), Gdx.files.internal("data/font.png"), false);
-		Gdx.gl.glClearColor(0, 1, 0, 1);
+		font = new BitmapFont(files.internal("data/font.fnt"), files.internal("data/font.png"), false);
+		gl.glClearColor(0, 1, 0, 1);
 	}
 
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		batch.begin();
 		sprite.draw(batch);
-		font.draw(batch, "fps:" + Gdx.graphics.getFramesPerSecond(), 26, 65);
+		font.draw(batch, "fps:" + graphics.getFramesPerSecond(), 26, 65);
 		batch.end();
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/AudioChangeDeviceTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/AudioChangeDeviceTest.java
@@ -1,7 +1,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.audio.Sound;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.scenes.scene2d.Actor;
@@ -24,23 +23,23 @@ public class AudioChangeDeviceTest extends GdxTest {
 	@Override
 	public void create () {
 		stage = new Stage();
-		Gdx.input.setInputProcessor(stage);
-		skin = new Skin(Gdx.files.internal("data/uiskin.json"));
+		input.setInputProcessor(stage);
+		skin = new Skin(files.internal("data/uiskin.json"));
 		final SelectBox<String> selectBox = new SelectBox<>(skin);
-		List<String> tmp = new ArrayList<>(Arrays.asList(Gdx.audio.getAvailableOutputDevices()));
+		List<String> tmp = new ArrayList<>(Arrays.asList(audio.getAvailableOutputDevices()));
 		tmp.add(0, "Auto");
 		selectBox.setItems(tmp.toArray(new String[0]));
-		sound = Gdx.audio.newSound(Gdx.files.internal("data").child("bubblepop-stereo-left-only.wav"));
+		sound = audio.newSound(files.internal("data").child("bubblepop-stereo-left-only.wav"));
 		sound.loop();
 		selectBox.addListener(new ChangeListener() {
 
 			@Override
 			public void changed (ChangeEvent event, Actor actor) {
 				if (selectBox.getSelected().equals("Auto")) {
-					Gdx.app.getAudio().switchOutputDevice(null);
+					app.getAudio().switchOutputDevice(null);
 					return;
 				}
-				Gdx.app.getAudio().switchOutputDevice(selectBox.getSelected());
+				app.getAudio().switchOutputDevice(selectBox.getSelected());
 			}
 		});
 		selectBox.setWidth(200);
@@ -51,8 +50,8 @@ public class AudioChangeDeviceTest extends GdxTest {
 
 	@Override
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-		stage.act(Gdx.graphics.getDeltaTime());
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		stage.act(graphics.getDeltaTime());
 		stage.draw();
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/AudioDeviceTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/AudioDeviceTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.audio.AudioDevice;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.scenes.scene2d.Actor;
@@ -40,7 +39,7 @@ public class AudioDeviceTest extends GdxTest {
 	@Override
 	public void create () {
 
-		skin = new Skin(Gdx.files.internal("data/uiskin.json"));
+		skin = new Skin(files.internal("data/uiskin.json"));
 		ui = new Stage(new FitViewport(640, 400));
 
 		Table table = new Table(skin);
@@ -54,7 +53,7 @@ public class AudioDeviceTest extends GdxTest {
 
 		ui.addActor(table);
 
-		Gdx.input.setInputProcessor(ui);
+		input.setInputProcessor(ui);
 
 		pan.addListener(new ChangeListener() {
 			public void changed (ChangeEvent event, Actor actor) {
@@ -65,7 +64,7 @@ public class AudioDeviceTest extends GdxTest {
 
 		if (thread == null) {
 			final int samplingFrequency = 44100;
-			final AudioDevice device = Gdx.app.getAudio().newAudioDevice(samplingFrequency, false);
+			final AudioDevice device = app.getAudio().newAudioDevice(samplingFrequency, false);
 			thread = new Thread(new Runnable() {
 				@Override
 				public void run () {
@@ -99,8 +98,8 @@ public class AudioDeviceTest extends GdxTest {
 
 	@Override
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-		ui.act(Gdx.graphics.getDeltaTime());
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		ui.act(graphics.getDeltaTime());
 		ui.draw();
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/AudioRecorderTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/AudioRecorderTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.audio.AudioDevice;
 import com.badlogic.gdx.audio.AudioRecorder;
 import com.badlogic.gdx.graphics.GL20;
@@ -29,8 +28,8 @@ public class AudioRecorderTest extends GdxTest {
 
 	@Override
 	public void create () {
-		device = Gdx.audio.newAudioDevice(44100, true);
-		recorder = Gdx.audio.newAudioRecorder(44100, true);
+		device = audio.newAudioDevice(44100, true);
+		recorder = audio.newAudioRecorder(44100, true);
 
 		Thread t = new Thread(new Runnable() {
 
@@ -48,7 +47,7 @@ public class AudioRecorderTest extends GdxTest {
 
 	@Override
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 	}
 
 	@Override
@@ -59,7 +58,7 @@ public class AudioRecorderTest extends GdxTest {
 
 	@Override
 	public void resume () {
-		device = Gdx.audio.newAudioDevice(44100, true);
-		recorder = Gdx.audio.newAudioRecorder(44100, true);
+		device = audio.newAudioDevice(44100, true);
+		recorder = audio.newAudioRecorder(44100, true);
 	}
 }

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/BackTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/BackTest.java
@@ -1,7 +1,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.InputAdapter;
 import com.badlogic.gdx.graphics.Color;
@@ -26,15 +25,15 @@ public class BackTest extends GdxTest {
 	public void create () {
 		batch = new SpriteBatch();
 		font = new BitmapFont();
-		Gdx.input.setInputProcessor(new InputAdapter() {
+		input.setInputProcessor(new InputAdapter() {
 
 			@Override
 			public boolean touchDown (int screenX, int screenY, int pointer, int button) {
-				int screenWidth = Gdx.graphics.getBackBufferWidth();
+				int screenWidth = graphics.getBackBufferWidth();
 				float safeZone = screenWidth * .1f;
 				if (screenX >= safeZone && screenX < screenWidth - safeZone) {
 					stackDepth++;
-					Gdx.input.setCatchKey(Input.Keys.BACK, stackDepth > 0);
+					input.setCatchKey(Input.Keys.BACK, stackDepth > 0);
 					return true;
 				}
 				return false;
@@ -44,7 +43,7 @@ public class BackTest extends GdxTest {
 			public boolean keyDown (int keycode) {
 				if (keycode == Input.Keys.BACK) {
 					stackDepth--;
-					Gdx.input.setCatchKey(Input.Keys.BACK, stackDepth > 0);
+					input.setCatchKey(Input.Keys.BACK, stackDepth > 0);
 					return true;
 				}
 				return false;

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/BigMeshTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/BigMeshTest.java
@@ -1,7 +1,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Camera;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
@@ -139,8 +138,8 @@ public class BigMeshTest extends GdxTest {
 	public void render () {
 		ScreenUtils.clear(0, 0, 0, 0, true);
 
-		camera.viewportWidth = Gdx.graphics.getWidth();
-		camera.viewportHeight = Gdx.graphics.getHeight();
+		camera.viewportWidth = graphics.getWidth();
+		camera.viewportHeight = graphics.getHeight();
 		camera.update();
 
 		batch.begin(camera);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/BitmapFontAlignmentTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/BitmapFontAlignmentTest.java
@@ -17,7 +17,6 @@
 package com.badlogic.gdx.tests;
 
 import com.badlogic.gdx.Files.FileType;
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.InputAdapter;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Texture;
@@ -42,7 +41,7 @@ public class BitmapFontAlignmentTest extends GdxTest {
 
 	@Override
 	public void create () {
-		Gdx.input.setInputProcessor(new InputAdapter() {
+		input.setInputProcessor(new InputAdapter() {
 			public boolean touchDown (int x, int y, int pointer, int newParam) {
 				renderMode = (renderMode + 1) % 6;
 				return false;
@@ -50,13 +49,13 @@ public class BitmapFontAlignmentTest extends GdxTest {
 		});
 
 		spriteBatch = new SpriteBatch();
-		texture = new Texture(Gdx.files.internal("data/badlogic.jpg"));
+		texture = new Texture(files.internal("data/badlogic.jpg"));
 		logoSprite = new Sprite(texture);
 		logoSprite.setColor(1, 1, 1, 0.6f);
 		logoSprite.setBounds(50, 100, 400, 100);
 
-		font = new BitmapFont(Gdx.files.getFileHandle("data/verdana39.fnt", FileType.Internal),
-			Gdx.files.getFileHandle("data/verdana39.png", FileType.Internal), false);
+		font = new BitmapFont(files.getFileHandle("data/verdana39.fnt", FileType.Internal),
+			files.getFileHandle("data/verdana39.png", FileType.Internal), false);
 		cache = font.newFontCache();
 		layout = new GlyphLayout();
 	}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/BitmapFontAtlasRegionTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/BitmapFontAtlasRegionTest.java
@@ -1,7 +1,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.assets.AssetManager;
 import com.badlogic.gdx.assets.loaders.BitmapFontLoader.BitmapFontParameter;
 import com.badlogic.gdx.graphics.Color;
@@ -47,12 +46,12 @@ public class BitmapFontAtlasRegionTest extends GdxTest {
 		this.fonts[2].setColor(Color.GREEN);
 		this.testStrings = new String[] {"I'm loaded from an atlas!", "I, too, am loaded from an atlas", "I'm with stupid ^"};
 
-		Gdx.gl.glClearColor(1, 1, 1, 1);
+		gl.glClearColor(1, 1, 1, 1);
 	}
 
 	@Override
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 
 		batch.begin();
 
@@ -74,9 +73,9 @@ public class BitmapFontAtlasRegionTest extends GdxTest {
 		for (int i = 0; i < loaded.size; ++i) {
 			String asset = loaded.get(i);
 			if (this.assets.isLoaded(asset)) {
-				Gdx.app.error(name, asset + " not properly disposed of!");
+				app.error(name, asset + " not properly disposed of!");
 			} else {
-				Gdx.app.log(name, asset + " disposed of OK");
+				app.log(name, asset + " disposed of OK");
 			}
 		}
 	}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/BitmapFontFlipTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/BitmapFontFlipTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.InputAdapter;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
@@ -41,7 +40,7 @@ public class BitmapFontFlipTest extends GdxTest {
 
 	@Override
 	public void create () {
-		Gdx.input.setInputProcessor(new InputAdapter() {
+		input.setInputProcessor(new InputAdapter() {
 			public boolean touchDown (int x, int y, int pointer, int newParam) {
 				renderMode = (renderMode + 1) % 4;
 				return false;
@@ -49,15 +48,15 @@ public class BitmapFontFlipTest extends GdxTest {
 		});
 
 		spriteBatch = new SpriteBatch();
-		spriteBatch.setProjectionMatrix(new Matrix4().setToOrtho(0, Gdx.graphics.getWidth(), Gdx.graphics.getHeight(), 0, 0, 1));
+		spriteBatch.setProjectionMatrix(new Matrix4().setToOrtho(0, graphics.getWidth(), graphics.getHeight(), 0, 0, 1));
 
-		texture = new Texture(Gdx.files.internal("data/badlogic.jpg"));
+		texture = new Texture(files.internal("data/badlogic.jpg"));
 		logoSprite = new Sprite(texture);
 		logoSprite.flip(false, true);
 		logoSprite.setPosition(0, 320 - 256);
 		logoSprite.setColor(1, 1, 1, 0.5f);
 
-		font = new BitmapFont(Gdx.files.internal("data/verdana39.fnt"), Gdx.files.internal("data/verdana39.png"), true);
+		font = new BitmapFont(files.internal("data/verdana39.fnt"), files.internal("data/verdana39.png"), true);
 
 		cache1 = font.newFontCache();
 		cache2 = font.newFontCache();
@@ -97,9 +96,9 @@ public class BitmapFontFlipTest extends GdxTest {
 
 	@Override
 	public void render () {
-		red.a = (red.a + Gdx.graphics.getDeltaTime() * 0.1f) % 1;
+		red.a = (red.a + graphics.getDeltaTime() * 0.1f) % 1;
 
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		spriteBatch.begin();
 		logoSprite.draw(spriteBatch);
 		switch (renderMode) {

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/BitmapFontMetricsTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/BitmapFontMetricsTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.graphics.g2d.GlyphLayout;
@@ -38,17 +37,17 @@ public class BitmapFontMetricsTest extends GdxTest {
 		spriteBatch = new SpriteBatch();
 		atlas = new TextureAtlas("data/pack.atlas");
 		smallFont = new BitmapFont();
-		font = new BitmapFont(Gdx.files.internal("data/verdana39.fnt"), atlas.findRegion("verdana39"), false);
-		font = new BitmapFont(Gdx.files.internal("data/lsans-32-pad.fnt"), false);
+		font = new BitmapFont(files.internal("data/verdana39.fnt"), atlas.findRegion("verdana39"), false);
+		font = new BitmapFont(files.internal("data/lsans-32-pad.fnt"), false);
 		renderer = new ShapeRenderer();
 		renderer.setProjectionMatrix(spriteBatch.getProjectionMatrix());
 	}
 
 	@Override
 	public void render () {
-		// red.a = (red.a + Gdx.graphics.getDeltaTime() * 0.1f) % 1;
+		// red.a = (red.a + graphics.getDeltaTime() * 0.1f) % 1;
 
-		int viewHeight = Gdx.graphics.getHeight();
+		int viewHeight = graphics.getHeight();
 
 		ScreenUtils.clear(1, 1, 1, 1);
 		spriteBatch.begin();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/BitmapFontTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/BitmapFontTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Colors;
 import com.badlogic.gdx.graphics.GL20;
@@ -50,14 +49,14 @@ public class BitmapFontTest extends GdxTest {
 	@Override
 	public void create () {
 		spriteBatch = new SpriteBatch();
-		// font = new BitmapFont(Gdx.files.internal("data/verdana39.fnt"), false);
-		font = new BitmapFont(Gdx.files.internal("data/lsans-32-pad.fnt"), false);
+		// font = new BitmapFont(files.internal("data/verdana39.fnt"), false);
+		font = new BitmapFont(files.internal("data/lsans-32-pad.fnt"), false);
 		smallFont = new BitmapFont(); // uses LSans 15, the default
-		// font = new FreeTypeFontGenerator(Gdx.files.internal("data/lsans.ttf")).generateFont(new FreeTypeFontParameter());
+		// font = new FreeTypeFontGenerator(files.internal("data/lsans.ttf")).generateFont(new FreeTypeFontParameter());
 		font.getData().markupEnabled = true;
 		font.getData().breakChars = new char[] {'-'};
 
-		multiPageFont = new BitmapFont(Gdx.files.internal("data/multipagefont.fnt"));
+		multiPageFont = new BitmapFont(files.internal("data/multipagefont.fnt"));
 
 		// Add user defined color
 		Colors.put("PERU", Color.valueOf("CD853F"));
@@ -67,7 +66,7 @@ public class BitmapFontTest extends GdxTest {
 
 		stage = new Stage(new ScreenViewport());
 
-		Skin skin = new Skin(Gdx.files.internal("data/uiskin.json"));
+		Skin skin = new Skin(files.internal("data/uiskin.json"));
 
 		BitmapFont labelFont = skin.get("default-font", BitmapFont.class);
 		labelFont.getData().markupEnabled = true;
@@ -88,9 +87,9 @@ public class BitmapFontTest extends GdxTest {
 
 	@Override
 	public void render () {
-		// red.a = (red.a + Gdx.graphics.getDeltaTime() * 0.1f) % 1;
+		// red.a = (red.a + graphics.getDeltaTime() * 0.1f) % 1;
 
-		int viewHeight = Gdx.graphics.getHeight();
+		int viewHeight = graphics.getHeight();
 
 		ScreenUtils.clear(0, 0, 0, 1);
 
@@ -104,7 +103,7 @@ public class BitmapFontTest extends GdxTest {
 			font.getData().setScale(2f);
 			renderer.begin(ShapeRenderer.ShapeType.Line);
 			renderer.setColor(0, 1, 0, 1);
-			float w = Gdx.input.getX() - 10;
+			float w = input.getX() - 10;
 			// w = 855;
 			renderer.rect(10, 10, w, 500);
 			renderer.end();
@@ -125,8 +124,8 @@ public class BitmapFontTest extends GdxTest {
 			font.draw(spriteBatch, layout, 10, 10 + meowy);
 			spriteBatch.end();
 
-			Gdx.gl.glEnable(GL20.GL_BLEND);
-			Gdx.gl.glBlendFunc(GL20.GL_ONE, GL20.GL_ONE);
+			gl.glEnable(GL20.GL_BLEND);
+			gl.glBlendFunc(GL20.GL_ONE, GL20.GL_ONE);
 			renderer.begin(ShapeRenderer.ShapeType.Line);
 			float c = 0.8f;
 
@@ -160,7 +159,7 @@ public class BitmapFontTest extends GdxTest {
 			label.setWrap(true);
 // label.setEllipsis(true);
 			label.setAlignment(Align.center, Align.right);
-			label.setWidth(Gdx.input.getX() - label.getX());
+			label.setWidth(input.getX() - label.getX());
 			label.setHeight(label.getPrefHeight());
 		} else {
 			// Test various font features.
@@ -242,7 +241,7 @@ public class BitmapFontTest extends GdxTest {
 			renderer.end();
 		}
 
-		stage.act(Gdx.graphics.getDeltaTime());
+		stage.act(graphics.getDeltaTime());
 		stage.draw();
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/Box2DCharacterControllerTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/Box2DCharacterControllerTest.java
@@ -17,7 +17,6 @@
 package com.badlogic.gdx.tests;
 
 import com.badlogic.gdx.ApplicationListener;
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.Input.Keys;
 import com.badlogic.gdx.graphics.GL20;
@@ -66,9 +65,9 @@ public class Box2DCharacterControllerTest extends GdxTest implements Application
 		renderer = new Box2DDebugRenderer();
 		cam = new OrthographicCamera(28, 20);
 		createWorld();
-		Gdx.input.setInputProcessor(this);
+		input.setInputProcessor(this);
 		batch = new SpriteBatch();
-		font = new BitmapFont(Gdx.files.internal("data/lsans-15.fnt"), false);
+		font = new BitmapFont(files.internal("data/lsans-15.fnt"), false);
 	}
 
 	@Override
@@ -183,14 +182,14 @@ public class Box2DCharacterControllerTest extends GdxTest implements Application
 
 	@Override
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		cam.position.set(player.getPosition().x, player.getPosition().y, 0);
 		cam.update();
 		renderer.render(world, cam.combined);
 
 		Vector2 vel = player.getLinearVelocity();
 		Vector2 pos = player.getPosition();
-		boolean grounded = isPlayerGrounded(Gdx.graphics.getDeltaTime());
+		boolean grounded = isPlayerGrounded(graphics.getDeltaTime());
 		if (grounded) {
 			lastGroundTime = TimeUtils.nanoTime();
 		} else {
@@ -206,8 +205,8 @@ public class Box2DCharacterControllerTest extends GdxTest implements Application
 		}
 
 		// calculate stilltime & damp
-		if (!Gdx.input.isKeyPressed(Keys.A) && !Gdx.input.isKeyPressed(Keys.D)) {
-			stillTime += Gdx.graphics.getDeltaTime();
+		if (!input.isKeyPressed(Keys.A) && !input.isKeyPressed(Keys.D)) {
+			stillTime += graphics.getDeltaTime();
 			player.setLinearVelocity(vel.x * 0.9f, vel.y);
 		} else {
 			stillTime = 0;
@@ -218,7 +217,7 @@ public class Box2DCharacterControllerTest extends GdxTest implements Application
 			playerPhysicsFixture.setFriction(0f);
 			playerSensorFixture.setFriction(0f);
 		} else {
-			if (!Gdx.input.isKeyPressed(Keys.A) && !Gdx.input.isKeyPressed(Keys.D) && stillTime > 0.2) {
+			if (!input.isKeyPressed(Keys.A) && !input.isKeyPressed(Keys.D) && stillTime > 0.2) {
 				playerPhysicsFixture.setFriction(1000f);
 				playerSensorFixture.setFriction(1000f);
 			} else {
@@ -242,12 +241,12 @@ public class Box2DCharacterControllerTest extends GdxTest implements Application
 		}
 
 		// apply left impulse, but only if max velocity is not reached yet
-		if (Gdx.input.isKeyPressed(Keys.A) && vel.x > -MAX_VELOCITY) {
+		if (input.isKeyPressed(Keys.A) && vel.x > -MAX_VELOCITY) {
 			player.applyLinearImpulse(-2f, 0, pos.x, pos.y, true);
 		}
 
 		// apply right impulse, but only if max velocity is not reached yet
-		if (Gdx.input.isKeyPressed(Keys.D) && vel.x < MAX_VELOCITY) {
+		if (input.isKeyPressed(Keys.D) && vel.x < MAX_VELOCITY) {
 			player.applyLinearImpulse(2f, 0, pos.x, pos.y, true);
 		}
 
@@ -266,12 +265,12 @@ public class Box2DCharacterControllerTest extends GdxTest implements Application
 		// update platforms
 		for (int i = 0; i < platforms.size; i++) {
 			Platform platform = platforms.get(i);
-			platform.update(Math.max(1 / 30.0f, Gdx.graphics.getDeltaTime()));
+			platform.update(Math.max(1 / 30.0f, graphics.getDeltaTime()));
 		}
 
 		// le step...
-		world.step(Gdx.graphics.getDeltaTime(), 4, 4);
-// accum += Gdx.graphics.getDeltaTime();
+		world.step(graphics.getDeltaTime(), 4, 4);
+// accum += graphics.getDeltaTime();
 // while(accum > TICK) {
 // accum -= TICK;
 // world.step(TICK, 4, 4);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/Box2DTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/Box2DTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.InputProcessor;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
@@ -104,15 +103,15 @@ public class Box2DTest extends GdxTest implements InputProcessor {
 
 		// next we create a SpriteBatch and a font
 		batch = new SpriteBatch();
-		font = new BitmapFont(Gdx.files.internal("data/lsans-15.fnt"), false);
+		font = new BitmapFont(files.internal("data/lsans-15.fnt"), false);
 		font.setColor(Color.RED);
-		textureRegion = new TextureRegion(new Texture(Gdx.files.internal("data/badlogicsmall.jpg")));
+		textureRegion = new TextureRegion(new Texture(files.internal("data/badlogicsmall.jpg")));
 
 		// next we create out physics world.
 		createPhysicsWorld();
 
 		// register ourselfs as an InputProcessor
-		Gdx.input.setInputProcessor(this);
+		input.setInputProcessor(this);
 	}
 
 	private void createPhysicsWorld () {
@@ -237,12 +236,12 @@ public class Box2DTest extends GdxTest implements InputProcessor {
 		// instance. Normally you'll want to fix the time
 		// step.
 		long start = TimeUtils.nanoTime();
-		world.step(Gdx.graphics.getDeltaTime(), 8, 3);
+		world.step(graphics.getDeltaTime(), 8, 3);
 		float updateTime = (TimeUtils.nanoTime() - start) / 1000000000.0f;
 
 		// next we clear the color buffer and set the camera
 		// matrices
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		camera.update();
 
 		// next we render the ground body
@@ -297,9 +296,9 @@ public class Box2DTest extends GdxTest implements InputProcessor {
 		// finally we render the time it took to update the world
 		// for this we have to set the projection matrix again, so
 		// we work in pixel coordinates
-		batch.getProjectionMatrix().setToOrtho2D(0, 0, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+		batch.getProjectionMatrix().setToOrtho2D(0, 0, graphics.getWidth(), graphics.getHeight());
 		batch.begin();
-		font.draw(batch, "fps: " + Gdx.graphics.getFramesPerSecond() + " update time: " + updateTime, 0, 20);
+		font.draw(batch, "fps: " + graphics.getFramesPerSecond() + " update time: " + updateTime, 0, 20);
 		batch.end();
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/Box2DTestCollection.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/Box2DTestCollection.java
@@ -16,8 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Application;
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.InputMultiplexer;
 import com.badlogic.gdx.InputProcessor;
 import com.badlogic.gdx.input.GestureDetector;
@@ -50,8 +48,7 @@ public class Box2DTestCollection extends GdxTest implements InputProcessor, Gest
 		new ConveyorBelt()};
 
 	private int testIndex = 0;
-
-	private Application app = null;
+	private boolean started;
 
 	@Override
 	public void render () {
@@ -60,16 +57,15 @@ public class Box2DTestCollection extends GdxTest implements InputProcessor, Gest
 
 	@Override
 	public void create () {
-		if (this.app == null) {
-			this.app = Gdx.app;
-			Box2DTest test = tests[testIndex];
-			test.create();
+		if (!started) {
+			started = true;
+			tests[testIndex].create(app);
 		}
 
 		InputMultiplexer multiplexer = new InputMultiplexer();
 		multiplexer.addProcessor(this);
 		multiplexer.addProcessor(new GestureDetector(this));
-		Gdx.input.setInputProcessor(multiplexer);
+		input.setInputProcessor(multiplexer);
 	}
 
 	@Override
@@ -136,7 +132,7 @@ public class Box2DTestCollection extends GdxTest implements InputProcessor, Gest
 		testIndex++;
 		if (testIndex >= tests.length) testIndex = 0;
 		Box2DTest test = tests[testIndex];
-		test.create();
+		test.create(app);
 		app.log("TestCollection", "created test '" + tests[testIndex].getClass().getName());
 		return false;
 	}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/Bresenham2Test.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/Bresenham2Test.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Pixmap;
@@ -109,8 +108,8 @@ public class Bresenham2Test extends GdxTest {
 
 	@Override
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-		int x = Gdx.input.getX() >> 2, y = Gdx.input.getY() >> 2;
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		int x = input.getX() >> 2, y = input.getY() >> 2;
 		if ((lastX != x || lastY != y) && x >= 0 && x < 160 && y >= 0 && y < 120) {
 			lastX = x;
 			lastY = y;

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/BufferUtilsTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/BufferUtilsTest.java
@@ -19,7 +19,6 @@ package com.badlogic.gdx.tests;
 import java.nio.*;
 
 import com.badlogic.gdx.Application.ApplicationType;
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.tests.utils.GdxTest;
 import com.badlogic.gdx.utils.BufferUtils;
 import com.badlogic.gdx.utils.GdxRuntimeException;
@@ -109,7 +108,7 @@ public class BufferUtilsTest extends GdxTest {
 		checkFloat(fb.get(), 7);
 		checkFloat(fb.get(), 8);
 
-		if (Gdx.app.getType() != ApplicationType.WebGL) { // gwt throws: NYI: Numbers.doubleToRawLongBits
+		if (app.getType() != ApplicationType.WebGL) { // gwt throws: NYI: Numbers.doubleToRawLongBits
 			((Buffer)db).position(4);
 			BufferUtils.copy(new double[] {1, 2, 3, 4}, 0, db, 4);
 			checkFloat(db.get(), 1);
@@ -156,7 +155,7 @@ public class BufferUtilsTest extends GdxTest {
 			for (int i = 0; i < len; i++)
 				bb.put(bytes[i]);
 		}
-		Gdx.app.log("BufferUtilsTest", "ByteBuffer relative put: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
+		app.log("BufferUtilsTest", "ByteBuffer relative put: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
 
 		// absolute put
 		start = TimeUtils.nanoTime();
@@ -165,7 +164,7 @@ public class BufferUtilsTest extends GdxTest {
 			for (int i = 0; i < len; i++)
 				bb.put(i, bytes[i]);
 		}
-		Gdx.app.log("BufferUtilsTest", "ByteBuffer absolute put: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
+		app.log("BufferUtilsTest", "ByteBuffer absolute put: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
 
 		// bulk put
 		start = TimeUtils.nanoTime();
@@ -173,7 +172,7 @@ public class BufferUtilsTest extends GdxTest {
 			((Buffer)bb).clear();
 			bb.put(bytes);
 		}
-		Gdx.app.log("BufferUtilsTest", "ByteBuffer bulk put: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
+		app.log("BufferUtilsTest", "ByteBuffer bulk put: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
 
 		// JNI put
 		start = TimeUtils.nanoTime();
@@ -181,7 +180,7 @@ public class BufferUtilsTest extends GdxTest {
 			((Buffer)bb).clear();
 			BufferUtils.copy(bytes, 0, bb, len);
 		}
-		Gdx.app.log("BufferUtilsTest", "ByteBuffer native bulk put: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
+		app.log("BufferUtilsTest", "ByteBuffer native bulk put: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
 	}
 
 	private void benchShort () {
@@ -196,7 +195,7 @@ public class BufferUtilsTest extends GdxTest {
 			for (int i = 0; i < len; i++)
 				sb.put(shorts[i]);
 		}
-		Gdx.app.log("BufferUtilsTest", "ShortBuffer relative put: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
+		app.log("BufferUtilsTest", "ShortBuffer relative put: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
 
 		// absolute put
 		start = TimeUtils.nanoTime();
@@ -205,7 +204,7 @@ public class BufferUtilsTest extends GdxTest {
 			for (int i = 0; i < len; i++)
 				sb.put(i, shorts[i]);
 		}
-		Gdx.app.log("BufferUtilsTest", "ShortBuffer absolute put: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
+		app.log("BufferUtilsTest", "ShortBuffer absolute put: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
 
 		// bulk put
 		start = TimeUtils.nanoTime();
@@ -213,7 +212,7 @@ public class BufferUtilsTest extends GdxTest {
 			((Buffer)sb).clear();
 			sb.put(shorts);
 		}
-		Gdx.app.log("BufferUtilsTest", "ShortBuffer bulk put: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
+		app.log("BufferUtilsTest", "ShortBuffer bulk put: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
 
 		// JNI put
 		start = TimeUtils.nanoTime();
@@ -221,7 +220,7 @@ public class BufferUtilsTest extends GdxTest {
 			((Buffer)sb).clear();
 			BufferUtils.copy(shorts, 0, sb, len);
 		}
-		Gdx.app.log("BufferUtilsTest", "ShortBuffer native bulk put: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
+		app.log("BufferUtilsTest", "ShortBuffer native bulk put: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
 	}
 
 	private void benchInt () {
@@ -236,7 +235,7 @@ public class BufferUtilsTest extends GdxTest {
 			for (int i = 0; i < len; i++)
 				ib.put(ints[i]);
 		}
-		Gdx.app.log("BufferUtilsTest", "IntBuffer relative put: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
+		app.log("BufferUtilsTest", "IntBuffer relative put: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
 
 		// absolute put
 		start = TimeUtils.nanoTime();
@@ -245,7 +244,7 @@ public class BufferUtilsTest extends GdxTest {
 			for (int i = 0; i < len; i++)
 				ib.put(i, ints[i]);
 		}
-		Gdx.app.log("BufferUtilsTest", "IntBuffer absolute put: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
+		app.log("BufferUtilsTest", "IntBuffer absolute put: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
 
 		// bulk put
 		start = TimeUtils.nanoTime();
@@ -253,7 +252,7 @@ public class BufferUtilsTest extends GdxTest {
 			((Buffer)ib).clear();
 			ib.put(ints);
 		}
-		Gdx.app.log("BufferUtilsTest", "IntBuffer bulk put: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
+		app.log("BufferUtilsTest", "IntBuffer bulk put: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
 
 		// JNI put
 		start = TimeUtils.nanoTime();
@@ -261,7 +260,7 @@ public class BufferUtilsTest extends GdxTest {
 			((Buffer)ib).clear();
 			BufferUtils.copy(ints, 0, ib, len);
 		}
-		Gdx.app.log("BufferUtilsTest", "IntBuffer native bulk put: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
+		app.log("BufferUtilsTest", "IntBuffer native bulk put: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
 	}
 
 	private void benchLong () {
@@ -276,7 +275,7 @@ public class BufferUtilsTest extends GdxTest {
 			for (int i = 0; i < len; i++)
 				lb.put(longs[i]);
 		}
-		Gdx.app.log("BufferUtilsTest", "LongBuffer relative put: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
+		app.log("BufferUtilsTest", "LongBuffer relative put: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
 
 		// absolute put
 		start = TimeUtils.nanoTime();
@@ -285,7 +284,7 @@ public class BufferUtilsTest extends GdxTest {
 			for (int i = 0; i < len; i++)
 				lb.put(i, longs[i]);
 		}
-		Gdx.app.log("BufferUtilsTest", "LongBuffer absolute put: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
+		app.log("BufferUtilsTest", "LongBuffer absolute put: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
 
 		// bulk put
 		start = TimeUtils.nanoTime();
@@ -293,7 +292,7 @@ public class BufferUtilsTest extends GdxTest {
 			((Buffer)lb).clear();
 			lb.put(longs);
 		}
-		Gdx.app.log("BufferUtilsTest", "LongBuffer bulk put: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
+		app.log("BufferUtilsTest", "LongBuffer bulk put: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
 
 		// JNI put
 		start = TimeUtils.nanoTime();
@@ -301,7 +300,7 @@ public class BufferUtilsTest extends GdxTest {
 			((Buffer)lb).clear();
 			BufferUtils.copy(longs, 0, lb, len);
 		}
-		Gdx.app.log("BufferUtilsTest", "LongBuffer native bulk put: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
+		app.log("BufferUtilsTest", "LongBuffer native bulk put: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
 	}
 
 	private void benchFloat () {
@@ -316,7 +315,7 @@ public class BufferUtilsTest extends GdxTest {
 			for (int i = 0; i < len; i++)
 				fb.put(floats[i]);
 		}
-		Gdx.app.log("BufferUtilsTest", "FloatBuffer relative put: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
+		app.log("BufferUtilsTest", "FloatBuffer relative put: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
 
 		// absolute put
 		start = TimeUtils.nanoTime();
@@ -325,7 +324,7 @@ public class BufferUtilsTest extends GdxTest {
 			for (int i = 0; i < len; i++)
 				fb.put(i, floats[i]);
 		}
-		Gdx.app.log("BufferUtilsTest", "FloatBuffer absolute put: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
+		app.log("BufferUtilsTest", "FloatBuffer absolute put: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
 
 		// bulk put
 		start = TimeUtils.nanoTime();
@@ -333,7 +332,7 @@ public class BufferUtilsTest extends GdxTest {
 			((Buffer)fb).clear();
 			fb.put(floats);
 		}
-		Gdx.app.log("BufferUtilsTest", "FloatBuffer bulk put: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
+		app.log("BufferUtilsTest", "FloatBuffer bulk put: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
 
 		// JNI put
 		start = TimeUtils.nanoTime();
@@ -341,7 +340,7 @@ public class BufferUtilsTest extends GdxTest {
 			((Buffer)fb).clear();
 			BufferUtils.copy(floats, 0, fb, len);
 		}
-		Gdx.app.log("BufferUtilsTest", "FloatBuffer native bulk put: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
+		app.log("BufferUtilsTest", "FloatBuffer native bulk put: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
 	}
 
 	private void benchDouble () {
@@ -356,7 +355,7 @@ public class BufferUtilsTest extends GdxTest {
 			for (int i = 0; i < len; i++)
 				db.put(doubles[i]);
 		}
-		Gdx.app.log("BufferUtilsTest", "DoubleBuffer relative put: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
+		app.log("BufferUtilsTest", "DoubleBuffer relative put: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
 
 		// absolute put
 		start = TimeUtils.nanoTime();
@@ -365,7 +364,7 @@ public class BufferUtilsTest extends GdxTest {
 			for (int i = 0; i < len; i++)
 				db.put(i, doubles[i]);
 		}
-		Gdx.app.log("BufferUtilsTest", "DoubleBuffer absolute put: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
+		app.log("BufferUtilsTest", "DoubleBuffer absolute put: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
 
 		// bulk put
 		start = TimeUtils.nanoTime();
@@ -373,7 +372,7 @@ public class BufferUtilsTest extends GdxTest {
 			((Buffer)db).clear();
 			db.put(doubles);
 		}
-		Gdx.app.log("BufferUtilsTest", "DoubleBuffer bulk put: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
+		app.log("BufferUtilsTest", "DoubleBuffer bulk put: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
 
 		// JNI put
 		start = TimeUtils.nanoTime();
@@ -381,19 +380,19 @@ public class BufferUtilsTest extends GdxTest {
 			((Buffer)db).clear();
 			BufferUtils.copy(doubles, 0, db, len);
 		}
-		Gdx.app.log("BufferUtilsTest", "DoubleBuffer bulk put: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
+		app.log("BufferUtilsTest", "DoubleBuffer bulk put: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
 	}
 
 	private void checkInt (long val1, long val2) {
 		if (val1 != val2) {
-			Gdx.app.error("BufferUtilsTest", "checkInt failed: " + val1 + " != " + val2);
+			app.error("BufferUtilsTest", "checkInt failed: " + val1 + " != " + val2);
 			throw new GdxRuntimeException("Error, val1 != val2");
 		}
 	}
 
 	private void checkFloat (double val1, double val2) {
 		if (val1 != val2) {
-			Gdx.app.error("BufferUtilsTest", "checkFloat failed: " + val1 + " != " + val2);
+			app.error("BufferUtilsTest", "checkFloat failed: " + val1 + " != " + val2);
 			throw new GdxRuntimeException("Error, val1 != val2");
 		}
 	}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/BulletTestCollection.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/BulletTestCollection.java
@@ -16,8 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Application;
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input.Keys;
 import com.badlogic.gdx.InputMultiplexer;
 import com.badlogic.gdx.InputProcessor;
@@ -45,7 +43,7 @@ public class BulletTestCollection extends GdxTest implements InputProcessor, Ges
 
 	protected int testIndex = 0;
 
-	private Application app = null;
+	private boolean started;
 
 	private BitmapFont font;
 	private Stage hud;
@@ -66,9 +64,9 @@ public class BulletTestCollection extends GdxTest implements InputProcessor, Ges
 
 	@Override
 	public void create () {
-		if (app == null) {
-			app = Gdx.app;
-			tests[testIndex].create();
+		if (!started) {
+			started = true;
+			tests[testIndex].create(app);
 		}
 
 		cameraController = new CameraInputController(tests[testIndex].camera);
@@ -76,9 +74,9 @@ public class BulletTestCollection extends GdxTest implements InputProcessor, Ges
 		cameraController.autoUpdate = false;
 		cameraController.forwardTarget = false;
 		cameraController.translateTarget = false;
-		Gdx.input.setInputProcessor(new InputMultiplexer(cameraController, this, new GestureDetector(this)));
+		input.setInputProcessor(new InputMultiplexer(cameraController, this, new GestureDetector(this)));
 
-		font = new BitmapFont(Gdx.files.internal("data/lsans-15.fnt"), false);
+		font = new BitmapFont(files.internal("data/lsans-15.fnt"), false);
 		hud = new Stage();
 		hud.addActor(fpsLabel = new Label(" ", new Label.LabelStyle(font, Color.WHITE)));
 		fpsLabel.setPosition(0, 0);
@@ -98,7 +96,7 @@ public class BulletTestCollection extends GdxTest implements InputProcessor, Ges
 	@Override
 	public void dispose () {
 		tests[testIndex].dispose();
-		app = null;
+		started = false;
 	}
 
 	public void next () {
@@ -113,7 +111,7 @@ public class BulletTestCollection extends GdxTest implements InputProcessor, Ges
 		System.gc();
 		testIndex++;
 		if (testIndex >= tests.length) testIndex = 0;
-		tests[testIndex].create();
+		tests[testIndex].create(app);
 		cameraController.camera = tests[testIndex].camera;
 		app.log("TestCollection", "created test '" + tests[testIndex].getClass().getName() + "'");
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ClipboardTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ClipboardTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.scenes.scene2d.ui.Skin;
@@ -36,39 +35,39 @@ public class ClipboardTest extends GdxTest {
 	@Override
 	public void create () {
 		stage = new Stage();
-		Skin skin = new Skin(Gdx.files.internal("data/uiskin.json"));
+		Skin skin = new Skin(files.internal("data/uiskin.json"));
 		textArea = new TextArea("", skin);
 		buttonCopy = new TextButton("Copy", skin);
 		buttonPaste = new TextButton("Paste", skin);
-		buttonHasContents = new TextButton("Has Contents: " + Gdx.app.getClipboard().hasContents(), skin);
+		buttonHasContents = new TextButton("Has Contents: " + app.getClipboard().hasContents(), skin);
 
-		textArea.setSize(Gdx.graphics.getWidth() / 3f, Gdx.graphics.getHeight() / 3f);
+		textArea.setSize(graphics.getWidth() / 3f, graphics.getHeight() / 3f);
 
-		textArea.setPosition(Gdx.graphics.getWidth() / 2f - textArea.getWidth() / 2f,
-			Gdx.graphics.getHeight() / 2f - textArea.getHeight() / 2f);
-		buttonCopy.setPosition(Gdx.graphics.getWidth() / 4f - buttonCopy.getWidth() / 2f,
-			Gdx.graphics.getHeight() / 4f - buttonCopy.getHeight() / 2f);
-		buttonPaste.setPosition(3 * Gdx.graphics.getWidth() / 4f - buttonPaste.getWidth() / 2f,
-			Gdx.graphics.getHeight() / 4f - buttonPaste.getHeight() / 2f);
-		buttonHasContents.setPosition(Gdx.graphics.getWidth() / 2f - buttonHasContents.getWidth() / 2f,
-			Gdx.graphics.getHeight() / 4f - buttonHasContents.getHeight() / 2f);
+		textArea.setPosition(graphics.getWidth() / 2f - textArea.getWidth() / 2f,
+			graphics.getHeight() / 2f - textArea.getHeight() / 2f);
+		buttonCopy.setPosition(graphics.getWidth() / 4f - buttonCopy.getWidth() / 2f,
+			graphics.getHeight() / 4f - buttonCopy.getHeight() / 2f);
+		buttonPaste.setPosition(3 * graphics.getWidth() / 4f - buttonPaste.getWidth() / 2f,
+			graphics.getHeight() / 4f - buttonPaste.getHeight() / 2f);
+		buttonHasContents.setPosition(graphics.getWidth() / 2f - buttonHasContents.getWidth() / 2f,
+			graphics.getHeight() / 4f - buttonHasContents.getHeight() / 2f);
 
 		buttonCopy.addListener(new ChangeListener() {
 			@Override
 			public void changed (ChangeEvent event, Actor actor) {
-				Gdx.app.getClipboard().setContents(textArea.getText());
+				app.getClipboard().setContents(textArea.getText());
 			}
 		});
 		buttonPaste.addListener(new ChangeListener() {
 			@Override
 			public void changed (ChangeEvent event, Actor actor) {
-				textArea.setText(Gdx.app.getClipboard().getContents());
+				textArea.setText(app.getClipboard().getContents());
 			}
 		});
 		buttonHasContents.addListener(new ChangeListener() {
 			@Override
 			public void changed (ChangeEvent event, Actor actor) {
-				buttonHasContents.setText("Has Contents: " + Gdx.app.getClipboard().hasContents());
+				buttonHasContents.setText("Has Contents: " + app.getClipboard().hasContents());
 			}
 		});
 
@@ -77,7 +76,7 @@ public class ClipboardTest extends GdxTest {
 		stage.addActor(buttonPaste);
 		stage.addActor(buttonHasContents);
 
-		Gdx.input.setInputProcessor(stage);
+		input.setInputProcessor(stage);
 	}
 
 	@Override

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ColorTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ColorTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.scenes.scene2d.Stage;
@@ -32,10 +31,10 @@ public class ColorTest extends GdxTest {
 	@Override
 	public void create () {
 		stage = new Stage(new ScreenViewport());
-		Gdx.input.setInputProcessor(stage);
+		input.setInputProcessor(stage);
 
-		Skin skin = new Skin(Gdx.files.internal("data/uiskin.json"));
-		skin.add("default", new BitmapFont(Gdx.files.internal("data/lsans-32.fnt"), false));
+		Skin skin = new Skin(files.internal("data/uiskin.json"));
+		skin.add("default", new BitmapFont(files.internal("data/lsans-32.fnt"), false));
 
 		Table root = new Table();
 		stage.addActor(root);
@@ -92,7 +91,7 @@ public class ColorTest extends GdxTest {
 	public void render () {
 		ScreenUtils.clear(0.2f, 0.2f, 0.2f, 1);
 
-		stage.act(Math.min(Gdx.graphics.getDeltaTime(), 1 / 30f));
+		stage.act(Math.min(graphics.getDeltaTime(), 1 / 30f));
 		stage.draw();
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ComplexActionTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ComplexActionTest.java
@@ -23,7 +23,6 @@ import static com.badlogic.gdx.scenes.scene2d.actions.Actions.rotateBy;
 import static com.badlogic.gdx.scenes.scene2d.actions.Actions.scaleTo;
 import static com.badlogic.gdx.scenes.scene2d.actions.Actions.sequence;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.Texture.TextureFilter;
@@ -45,7 +44,7 @@ public class ComplexActionTest extends GdxTest {
 		Action complexAction = forever(sequence(parallel(rotateBy(180, 2), scaleTo(1.4f, 1.4f, 2), alpha(0.7f, 2)),
 			parallel(rotateBy(180, 2), scaleTo(1.0f, 1.0f, 2), alpha(1.0f, 2))));
 
-		texture = new Texture(Gdx.files.internal("data/badlogic.jpg"), false);
+		texture = new Texture(files.internal("data/badlogic.jpg"), false);
 		texture.setFilter(TextureFilter.Linear, TextureFilter.Linear);
 
 		final Image img1 = new Image(new TextureRegion(texture));
@@ -67,8 +66,8 @@ public class ComplexActionTest extends GdxTest {
 
 	@Override
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-		stage.act(Math.min(Gdx.graphics.getDeltaTime(), 1 / 30f));
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		stage.act(Math.min(graphics.getDeltaTime(), 1 / 30f));
 		stage.draw();
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ContainerTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ContainerTest.java
@@ -1,7 +1,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.scenes.scene2d.Stage;
@@ -20,12 +19,12 @@ public class ContainerTest extends GdxTest {
 
 	@Override
 	public void create () {
-		skin = new Skin(Gdx.files.internal("data/uiskin.json"));
+		skin = new Skin(files.internal("data/uiskin.json"));
 		stage = new Stage();
-		Gdx.input.setInputProcessor(stage);
+		input.setInputProcessor(stage);
 
 		TextureRegionDrawable logo = new TextureRegionDrawable(
-			new TextureRegion(new Texture(Gdx.files.internal("data/badlogic.jpg"))));
+			new TextureRegion(new Texture(files.internal("data/badlogic.jpg"))));
 
 		Table root = new Table();
 		root.setFillParent(true);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/CoordinatesTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/CoordinatesTest.java
@@ -1,7 +1,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Camera;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
@@ -47,9 +46,9 @@ public class CoordinatesTest extends GdxTest {
 	@Override
 	public void create () {
 
-		skin = new Skin(Gdx.files.internal("data/uiskin.json"));
+		skin = new Skin(files.internal("data/uiskin.json"));
 		TextureRegionDrawable logo = new TextureRegionDrawable(
-			new TextureRegion(new Texture(Gdx.files.internal("data/badlogic.jpg"))));
+			new TextureRegion(new Texture(files.internal("data/badlogic.jpg"))));
 
 		stageViewport = new FitViewport(500, 500);
 		stageViewport = new Viewport() {
@@ -62,10 +61,10 @@ public class CoordinatesTest extends GdxTest {
 		stageViewport.setCamera(new OrthographicCamera());
 		gameViewport = new FitViewport(100, 100);
 
-		camera = new OrthographicCamera(Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+		camera = new OrthographicCamera(graphics.getWidth(), graphics.getHeight());
 
 		stage = new Stage(stageViewport);
-		Gdx.input.setInputProcessor(stage);
+		input.setInputProcessor(stage);
 
 		shapeRenderer = new ShapeRenderer();
 
@@ -102,11 +101,11 @@ public class CoordinatesTest extends GdxTest {
 	@Override
 	public void render () {
 
-		final float screenHeight = Gdx.graphics.getHeight();
+		final float screenHeight = graphics.getHeight();
 
 		// display screen coordinates for actor, stage, viewport, and camera
-		int pointerX = Gdx.input.getX();
-		int pointerY = Gdx.input.getY();
+		int pointerX = input.getX();
+		int pointerY = input.getY();
 		inScreenLabel.setText("input: " + pointerX + " " + pointerY);
 
 		gameViewport.unproject(vec2.set(pointerX, pointerY));
@@ -143,12 +142,12 @@ public class CoordinatesTest extends GdxTest {
 		ScreenUtils.clear(0.2f, 0.2f, 0.2f, 1);
 
 		// clear viewport virtual screen with lighter color
-		Gdx.gl.glEnable(GL20.GL_SCISSOR_TEST);
-		Gdx.gl.glScissor(gameViewport.getScreenX(), gameViewport.getScreenY(), gameViewport.getScreenWidth(),
+		gl.glEnable(GL20.GL_SCISSOR_TEST);
+		gl.glScissor(gameViewport.getScreenX(), gameViewport.getScreenY(), gameViewport.getScreenWidth(),
 			gameViewport.getScreenHeight());
-		Gdx.gl.glClearColor(0.5f, 0.5f, 0.5f, 1);
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-		Gdx.gl.glDisable(GL20.GL_SCISSOR_TEST);
+		gl.glClearColor(0.5f, 0.5f, 0.5f, 1);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl.glDisable(GL20.GL_SCISSOR_TEST);
 
 		// test stage world coordinates
 		img.setPosition(stWorldX, stWorldY);
@@ -165,7 +164,7 @@ public class CoordinatesTest extends GdxTest {
 		shapeRenderer.end();
 
 		// test camera world coordinates
-		HdpiUtils.glViewport(0, 0, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+		HdpiUtils.glViewport(0, 0, graphics.getWidth(), graphics.getHeight());
 		shapeRenderer.setProjectionMatrix(camera.combined);
 		shapeRenderer.begin(ShapeType.Line);
 		shapeRenderer.setColor(Color.GREEN);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/CpuSpriteBatchTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/CpuSpriteBatchTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.Texture.TextureFilter;
@@ -68,7 +67,7 @@ public class CpuSpriteBatchTest extends GdxTest {
 
 		stage = new Stage(new ExtendViewport(500, 500), batch);
 
-		Gdx.input.setInputProcessor(stage);
+		input.setInputProcessor(stage);
 
 		texture = new Texture("data/bobargb8888-32x32.png");
 		texture.setFilter(TextureFilter.Linear, TextureFilter.Linear);
@@ -119,7 +118,7 @@ public class CpuSpriteBatchTest extends GdxTest {
 	public void render () {
 		ScreenUtils.clear(0.5f, 0.5f, 0.5f, 1);
 
-		stage.act(Gdx.graphics.getDeltaTime());
+		stage.act(graphics.getDeltaTime());
 		stage.draw();
 
 		long now = TimeUtils.nanoTime();
@@ -128,7 +127,7 @@ public class CpuSpriteBatchTest extends GdxTest {
 		if (now - sampleStartTime > 1000000000) {
 			if (sampleStartTime != 0) {
 				int renderCalls = ((SpriteBatch)stage.getBatch()).renderCalls;
-				Gdx.app.log("CpuSpriteBatch", "FPS: " + sampleFrames + ", render calls: " + renderCalls);
+				app.log("CpuSpriteBatch", "FPS: " + sampleFrames + ", render calls: " + renderCalls);
 			}
 			sampleStartTime = now;
 			sampleFrames = 0;

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/CullTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/CullTest.java
@@ -19,7 +19,6 @@ package com.badlogic.gdx.tests;
 import java.util.Random;
 
 import com.badlogic.gdx.ApplicationListener;
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input.Keys;
 import com.badlogic.gdx.graphics.Camera;
 import com.badlogic.gdx.graphics.Color;
@@ -52,8 +51,8 @@ public class CullTest extends GdxTest implements ApplicationListener {
 		ModelBuilder builder = new ModelBuilder();
 		sphere = builder.createSphere(2f, 2f, 2f, 16, 16, new Material(new ColorAttribute(ColorAttribute.Diffuse, Color.WHITE)),
 			Usage.Position | Usage.Normal);
-		// cam = new PerspectiveCamera(45, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
-		cam = new OrthographicCamera(45, 45 * (Gdx.graphics.getWidth() / (float)Gdx.graphics.getHeight()));
+		// cam = new PerspectiveCamera(45, graphics.getWidth(), graphics.getHeight());
+		cam = new OrthographicCamera(45, 45 * (graphics.getWidth() / (float)graphics.getHeight()));
 
 		cam.near = 1;
 		cam.far = 200;
@@ -68,13 +67,13 @@ public class CullTest extends GdxTest implements ApplicationListener {
 
 		batch = new SpriteBatch();
 		font = new BitmapFont();
-		// Gdx.graphics.setVSync(true);
-		// Gdx.app.log("CullTest", "" + Gdx.graphics.getBufferFormat().toString());
+		// graphics.setVSync(true);
+		// app.log("CullTest", "" + graphics.getBufferFormat().toString());
 	}
 
 	@Override
 	public void render () {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20;
 
 		gl.glClearColor(0, 0, 0, 0);
 		gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
@@ -96,12 +95,12 @@ public class CullTest extends GdxTest implements ApplicationListener {
 		}
 		modelBatch.end();
 
-		if (Gdx.input.isKeyPressed(Keys.A)) cam.rotate(20 * Gdx.graphics.getDeltaTime(), 0, 1, 0);
-		if (Gdx.input.isKeyPressed(Keys.D)) cam.rotate(-20 * Gdx.graphics.getDeltaTime(), 0, 1, 0);
+		if (input.isKeyPressed(Keys.A)) cam.rotate(20 * graphics.getDeltaTime(), 0, 1, 0);
+		if (input.isKeyPressed(Keys.D)) cam.rotate(-20 * graphics.getDeltaTime(), 0, 1, 0);
 
 		gl.glDisable(GL20.GL_DEPTH_TEST);
 		batch.begin();
-		font.draw(batch, "visible: " + visible + "/100" + ", fps: " + Gdx.graphics.getFramesPerSecond(), 0, 20);
+		font.draw(batch, "visible: " + visible + "/100" + ", fps: " + graphics.getFramesPerSecond(), 0, 20);
 		batch.end();
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/CursorTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/CursorTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Cursor;
 import com.badlogic.gdx.graphics.Pixmap;
@@ -35,18 +34,18 @@ public class CursorTest extends GdxTest {
 
 	public void create () {
 
-		Pixmap pixmap1 = new Pixmap(Gdx.files.internal("data/bobargb8888-32x32.png"));
-		cursor1 = Gdx.graphics.newCursor(pixmap1, 16, 16);
+		Pixmap pixmap1 = new Pixmap(files.internal("data/bobargb8888-32x32.png"));
+		cursor1 = graphics.newCursor(pixmap1, 16, 16);
 
 		Pixmap pixmap2 = new Pixmap(32, 32, Format.RGBA8888);
 		pixmap2.setColor(Color.RED);
 		pixmap2.fillCircle(16, 16, 8);
-		cursor2 = Gdx.graphics.newCursor(pixmap2, 16, 16);
+		cursor2 = graphics.newCursor(pixmap2, 16, 16);
 
 		Pixmap pixmap3 = new Pixmap(32, 32, Format.RGBA8888);
 		pixmap3.setColor(Color.BLUE);
 		pixmap3.fillCircle(16, 16, 8);
-		cursor3 = Gdx.graphics.newCursor(pixmap3, 16, 16);
+		cursor3 = graphics.newCursor(pixmap3, 16, 16);
 
 	}
 
@@ -54,14 +53,14 @@ public class CursorTest extends GdxTest {
 		// set the clear color and clear the screen.
 		ScreenUtils.clear(1, 1, 1, 1);
 
-		if (Gdx.input.isTouched()) {
-			Gdx.graphics.setCursor(cursor1);
+		if (input.isTouched()) {
+			graphics.setCursor(cursor1);
 		} else {
 			cursorActive = !cursorActive;
 			if (cursorActive) {
-				Gdx.graphics.setCursor(cursor2);
+				graphics.setCursor(cursor2);
 			} else {
-				Gdx.graphics.setCursor(cursor3);
+				graphics.setCursor(cursor3);
 			}
 		}
 	}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/CustomShaderSpriteBatchTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/CustomShaderSpriteBatchTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
@@ -32,15 +31,15 @@ public class CustomShaderSpriteBatchTest extends GdxTest {
 	public void create () {
 		batch = new SpriteBatch(10);
 		ShaderProgram.pedantic = false;
-		shader = new ShaderProgram(Gdx.files.internal("data/shaders/batch.vert").readString(),
-			Gdx.files.internal("data/shaders/batch.frag").readString());
+		shader = new ShaderProgram(files.internal("data/shaders/batch.vert").readString(),
+			files.internal("data/shaders/batch.frag").readString());
 		batch.setShader(shader);
 		texture = new Texture("data/badlogic.jpg");
 	}
 
 	@Override
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		batch.begin();
 		batch.draw(texture, 0, 0);
 		batch.end();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/DecalTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/DecalTest.java
@@ -18,7 +18,6 @@ package com.badlogic.gdx.tests;
 
 import java.util.LinkedList;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Camera;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.OrthographicCamera;
@@ -48,29 +47,29 @@ public class DecalTest extends GdxTest {
 
 	@Override
 	public void create () {
-		Gdx.gl.glEnable(GL20.GL_DEPTH_TEST);
-		Gdx.gl.glDepthFunc(GL20.GL_LESS);
+		gl.glEnable(GL20.GL_DEPTH_TEST);
+		gl.glDepthFunc(GL20.GL_LESS);
 
-		egg = new Texture(Gdx.files.internal("data/egg.png"));
+		egg = new Texture(files.internal("data/egg.png"));
 		egg.setFilter(Texture.TextureFilter.Linear, Texture.TextureFilter.Linear);
 		egg.setWrap(Texture.TextureWrap.ClampToEdge, Texture.TextureWrap.ClampToEdge);
-		wheel = new Texture(Gdx.files.internal("data/sys.png"));
+		wheel = new Texture(files.internal("data/sys.png"));
 		wheel.setFilter(Texture.TextureFilter.Linear, Texture.TextureFilter.Linear);
 		wheel.setWrap(Texture.TextureWrap.ClampToEdge, Texture.TextureWrap.ClampToEdge);
 
-		w = Gdx.graphics.getWidth() / 0.8f;
-		h = Gdx.graphics.getHeight() / 0.8f;
+		w = graphics.getWidth() / 0.8f;
+		h = graphics.getHeight() / 0.8f;
 		for (int i = 0; i < INITIAL_RENDERED; i++) {
 			toRender.add(makeDecal());
 		}
-		cam = new OrthographicCamera(Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+		cam = new OrthographicCamera(graphics.getWidth(), graphics.getHeight());
 		cam.near = 0.1f;
 		cam.far = 10f;
 		cam.position.set(0, 0, 0.1f);
 		cam.direction.set(0, 0, -1f);
 		batch = new DecalBatch(new CameraGroupStrategy(cam));
 
-		Gdx.gl.glClearColor(1, 1, 0, 1);
+		gl.glClearColor(1, 1, 0, 1);
 	}
 
 	@Override
@@ -82,9 +81,9 @@ public class DecalTest extends GdxTest {
 
 	@Override
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
 
-		float elapsed = Gdx.graphics.getDeltaTime();
+		float elapsed = graphics.getDeltaTime();
 		float scale = timePassed > 0.5 ? 1 - timePassed / 2 : 0.5f + timePassed / 2;
 
 		for (Decal decal : toRender) {
@@ -122,8 +121,8 @@ public class DecalTest extends GdxTest {
 
 	@Override
 	public void resize (int width, int height) {
-		w = Gdx.graphics.getWidth() / 0.8f;
-		h = Gdx.graphics.getHeight() / 0.8f;
+		w = graphics.getWidth() / 0.8f;
+		h = graphics.getHeight() / 0.8f;
 		cam = new OrthographicCamera(width, height);
 		cam.near = 0.1f;
 		cam.far = 10f;

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/DelaunayTriangulatorTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/DelaunayTriangulatorTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.InputAdapter;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
@@ -42,7 +41,7 @@ public class DelaunayTriangulatorTest extends GdxTest {
 		triangulate();
 		System.out.println(seed);
 
-		Gdx.input.setInputProcessor(new InputAdapter() {
+		input.setInputProcessor(new InputAdapter() {
 			public boolean touchDown (int screenX, int screenY, int pointer, int button) {
 				seed = MathUtils.random.nextLong();
 				System.out.println(seed);
@@ -75,14 +74,14 @@ public class DelaunayTriangulatorTest extends GdxTest {
 			} while (points.contains(value));
 			points.add(value);
 		}
-		points.add(Gdx.input.getX());
-		points.add(Gdx.graphics.getHeight() - Gdx.input.getY());
+		points.add(input.getX());
+		points.add(graphics.getHeight() - input.getY());
 
 		triangles = trianglulator.computeTriangles(points, false);
 	}
 
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 
 		renderer.setColor(Color.RED);
 		renderer.begin(ShapeType.Filled);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/DeltaTimeTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/DeltaTimeTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.tests.utils.GdxTest;
 import com.badlogic.gdx.utils.TimeUtils;
 
@@ -35,6 +34,6 @@ public class DeltaTimeTest extends GdxTest {
 		float deltaTime = (frameTime - lastFrameTime) / 1000000000.0f;
 		lastFrameTime = frameTime;
 
-		Gdx.app.log("DeltaTimeTest", "delta: " + deltaTime + ", gdx delta: " + Gdx.graphics.getDeltaTime());
+		app.log("DeltaTimeTest", "delta: " + deltaTime + ", gdx delta: " + graphics.getDeltaTime());
 	}
 }

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/DeviceInfoTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/DeviceInfoTest.java
@@ -23,9 +23,9 @@ public class DeviceInfoTest extends GdxTest {
 	@Override
 	public void create () {
 		/*
-		 * DeviceInfo info = Gdx.app.getDeviceInfo(); int[] keys = info.keys(); int cnt = 0; for (int i = 0; i < keys.length; i++) {
-		 * int key = keys[i]; Gdx.app.log("DeviceInfo", "key = "+key+"; value = "+info.value(key)); cnt++; }
-		 * Gdx.app.log("DeviceInfo", "Total of "+cnt+" values");
+		 * DeviceInfo info = app.getDeviceInfo(); int[] keys = info.keys(); int cnt = 0; for (int i = 0; i < keys.length; i++) {
+		 * int key = keys[i]; app.log("DeviceInfo", "key = "+key+"; value = "+info.value(key)); cnt++; }
+		 * app.log("DeviceInfo", "Total of "+cnt+" values");
 		 */
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/DirtyRenderingTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/DirtyRenderingTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.tests.utils.GdxTest;
 import com.badlogic.gdx.utils.ScreenUtils;
@@ -29,28 +28,28 @@ public class DirtyRenderingTest extends GdxTest {
 	@Override
 	public void create () {
 		// disable continuous rendering
-		Gdx.graphics.setContinuousRendering(false);
-		Gdx.app.log("DirtyRenderingTest", "created");
+		graphics.setContinuousRendering(false);
+		app.log("DirtyRenderingTest", "created");
 	}
 
 	@Override
 	public void resume () {
-		Gdx.app.log("DirtyRenderingTest", "resumed");
+		app.log("DirtyRenderingTest", "resumed");
 	}
 
 	@Override
 	public void resize (int width, int height) {
-		Gdx.app.log("DirtyRenderingTest", "resized");
+		app.log("DirtyRenderingTest", "resized");
 	}
 
 	@Override
 	public void pause () {
-		Gdx.app.log("DirtyRenderingTest", "paused");
+		app.log("DirtyRenderingTest", "paused");
 	}
 
 	@Override
 	public void dispose () {
-		Gdx.app.log("DirtyRenderingTest", "disposed");
+		app.log("DirtyRenderingTest", "disposed");
 	}
 
 	@Override

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/DownloadTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/DownloadTest.java
@@ -1,7 +1,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.Texture;
@@ -30,7 +29,7 @@ public class DownloadTest extends GdxTest {
 
 			@Override
 			public void downloadFailed (Throwable t) {
-				Gdx.app.log("EmptyDownloadTest", "Failed, trying next", t);
+				app.log("EmptyDownloadTest", "Failed, trying next", t);
 				if (urls.notEmpty()) {
 					Pixmap.downloadFromUrl(urls.removeFirst(), this);
 				}
@@ -40,7 +39,7 @@ public class DownloadTest extends GdxTest {
 
 	@Override
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		batch.begin();
 		if (texture != null) batch.draw(texture, 0, 0);
 		batch.end();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/DpiTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/DpiTest.java
@@ -1,7 +1,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
@@ -19,12 +18,12 @@ public class DpiTest extends GdxTest {
 
 	@Override
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		batch.begin();
 		font.draw(batch,
-			"Density: " + Gdx.graphics.getDensity() + "\n" + "PPC-x: " + Gdx.graphics.getPpcX() + "\n" + "PPC-y: "
-				+ Gdx.graphics.getPpcY() + "\n" + "PPI-x: " + Gdx.graphics.getPpiX() + "\n" + "PPI-y: " + Gdx.graphics.getPpiY(),
-			0, Gdx.graphics.getHeight());
+			"Density: " + graphics.getDensity() + "\n" + "PPC-x: " + graphics.getPpcX() + "\n" + "PPC-y: "
+				+ graphics.getPpcY() + "\n" + "PPI-x: " + graphics.getPpiX() + "\n" + "PPI-y: " + graphics.getPpiY(),
+			0, graphics.getHeight());
 		batch.end();
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/DragAndDropTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/DragAndDropTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Texture;
@@ -39,7 +38,7 @@ public class DragAndDropTest extends GdxTest {
 
 	public void create () {
 		stage = new Stage();
-		Gdx.input.setInputProcessor(stage);
+		input.setInputProcessor(stage);
 
 		final Skin skin = new Skin();
 		skin.add("default", new LabelStyle(new BitmapFont(), Color.WHITE));
@@ -107,8 +106,8 @@ public class DragAndDropTest extends GdxTest {
 	}
 
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-		stage.act(Gdx.graphics.getDeltaTime());
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		stage.act(graphics.getDeltaTime());
 		stage.draw();
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ETC1Test.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ETC1Test.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.graphics.Pixmap;
@@ -40,9 +39,9 @@ public class ETC1Test extends GdxTest {
 	@Override
 	public void create () {
 		font = new BitmapFont();
-		camera = new OrthographicCamera(Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+		camera = new OrthographicCamera(graphics.getWidth(), graphics.getHeight());
 		controller = new OrthoCamController(camera);
-		Gdx.input.setInputProcessor(controller);
+		input.setInputProcessor(controller);
 
 		Pixmap pixmap = new Pixmap(32, 32, Format.RGB565);
 		pixmap.setColor(1, 0, 0, 1);
@@ -63,7 +62,7 @@ public class ETC1Test extends GdxTest {
 
 	@Override
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 
 		camera.update();
 
@@ -73,9 +72,9 @@ public class ETC1Test extends GdxTest {
 		batch.draw(img1, 0, 0);
 		batch.end();
 
-		batch.getProjectionMatrix().setToOrtho2D(0, 0, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+		batch.getProjectionMatrix().setToOrtho2D(0, 0, graphics.getWidth(), graphics.getHeight());
 		batch.begin();
-		font.draw(batch, "fps: " + Gdx.graphics.getFramesPerSecond(), 0, 30);
+		font.draw(batch, "fps: " + graphics.getFramesPerSecond(), 0, 30);
 		batch.end();
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/EarClippingTriangulatorTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/EarClippingTriangulatorTest.java
@@ -120,7 +120,7 @@ public class EarClippingTriangulatorTest {
 // casesX = (int)Math.ceil(Math.sqrt(testCases.size()));
 // casesY = (int)Math.ceil((float)testCases.size() / casesX);
 //
-// Gdx.input.setInputProcessor(new InputAdapter() {
+// input.setInputProcessor(new InputAdapter() {
 // @Override
 // public boolean keyDown (int keycode) {
 // switch (keycode) {
@@ -143,27 +143,27 @@ public class EarClippingTriangulatorTest {
 //
 // @Override
 // public void render () {
-// Gdx.gl.glClearColor(1, 1, 1, 1);
-// Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+// gl.glClearColor(1, 1, 1, 1);
+// gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 //
-// int w = Gdx.graphics.getWidth();
-// int h = Gdx.graphics.getHeight();
-// Gdx.gl20.glViewport(0, 0, w, h);
+// int w = graphics.getWidth();
+// int h = graphics.getHeight();
+// gl20.glViewport(0, 0, w, h);
 //
 // final float M = 0.1f;
-// Gdx.gl10.glMatrixMode(GL10.GL_PROJECTION);
-// Gdx.gl10.glLoadIdentity();
-// Gdx.gl10.glOrthof(-M, casesX * (1 + M), -M, casesY * (1 + M), -1, 1);
-// Gdx.gl10.glMatrixMode(GL10.GL_MODELVIEW);
-// Gdx.gl10.glLoadIdentity();
+// gl10.glMatrixMode(GL10.GL_PROJECTION);
+// gl10.glLoadIdentity();
+// gl10.glOrthof(-M, casesX * (1 + M), -M, casesY * (1 + M), -1, 1);
+// gl10.glMatrixMode(GL10.GL_MODELVIEW);
+// gl10.glLoadIdentity();
 //
 // int x = 0;
 // int y = 0;
 // for (TestCase testCase : testCases) {
-// Gdx.gl10.glPushMatrix();
-// Gdx.gl10.glTranslatef(x * (1 + M), y * (1 + M), 0);
+// gl10.glPushMatrix();
+// gl10.glTranslatef(x * (1 + M), y * (1 + M), 0);
 // testCase.render();
-// Gdx.gl10.glPopMatrix();
+// gl10.glPopMatrix();
 //
 // x++;
 // if (x >= casesX) {
@@ -307,17 +307,17 @@ public class EarClippingTriangulatorTest {
 // }
 //
 // public void render () {
-// Gdx.gl10.glScalef(1 / boundingRect.width, 1 / boundingRect.height, 1);
-// Gdx.gl10.glTranslatef(-boundingRect.x, -boundingRect.y, 0);
+// gl10.glScalef(1 / boundingRect.width, 1 / boundingRect.height, 1);
+// gl10.glTranslatef(-boundingRect.x, -boundingRect.y, 0);
 //
 // interiorMesh.render(GL10.GL_TRIANGLES);
 //
-// Gdx.gl10.glColor4f(0.4f, 0.4f, 0.4f, 1.0f);
-// Gdx.gl10.glLineWidth(1.0f);
+// gl10.glColor4f(0.4f, 0.4f, 0.4f, 1.0f);
+// gl10.glLineWidth(1.0f);
 // triangleOutlineMesh.render(GL10.GL_LINES);
 //
-// Gdx.gl10.glColor4f(0.3f, 0.0f, 0.0f, 1.0f);
-// Gdx.gl10.glLineWidth(2.0f);
+// gl10.glColor4f(0.3f, 0.0f, 0.0f, 1.0f);
+// gl10.glLineWidth(2.0f);
 // polygonMesh.render(GL10.GL_LINE_LOOP);
 // }
 //

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/EdgeDetectionTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/EdgeDetectionTest.java
@@ -18,7 +18,6 @@ package com.badlogic.gdx.tests;
 
 import java.util.Arrays;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.FPSLogger;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.PerspectiveCamera;
@@ -56,22 +55,22 @@ public class EdgeDetectionTest extends GdxTest {
 	public void create () {
 		ShaderProgram.pedantic = false;
 		/*
-		 * shader = new ShaderProgram(Gdx.files.internal("data/shaders/default.vert").readString(), Gdx.files.internal(
-		 * "data/shaders/depthtocolor.frag").readString()); if (!shader.isCompiled()) { Gdx.app.log("EdgeDetectionTest",
+		 * shader = new ShaderProgram(files.internal("data/shaders/default.vert").readString(), files.internal(
+		 * "data/shaders/depthtocolor.frag").readString()); if (!shader.isCompiled()) { app.log("EdgeDetectionTest",
 		 * "couldn't compile scene shader: " + shader.getLog()); }
 		 */
-		batchShader = new ShaderProgram(Gdx.files.internal("data/shaders/batch.vert").readString(),
-			Gdx.files.internal("data/shaders/convolution.frag").readString());
+		batchShader = new ShaderProgram(files.internal("data/shaders/batch.vert").readString(),
+			files.internal("data/shaders/convolution.frag").readString());
 		if (!batchShader.isCompiled()) {
-			Gdx.app.log("EdgeDetectionTest", "couldn't compile post-processing shader: " + batchShader.getLog());
+			app.log("EdgeDetectionTest", "couldn't compile post-processing shader: " + batchShader.getLog());
 		}
 
 		ObjLoader objLoader = new ObjLoader();
-		scene = objLoader.loadModel(Gdx.files.internal("data/scene.obj"));
+		scene = objLoader.loadModel(files.internal("data/scene.obj"));
 		sceneInstance = new ModelInstance(scene);
 		modelBatch = new ModelBatch();
-		fbo = new FrameBuffer(Format.RGB565, Gdx.graphics.getWidth(), Gdx.graphics.getHeight(), true);
-		cam = new PerspectiveCamera(67, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+		fbo = new FrameBuffer(Format.RGB565, graphics.getWidth(), graphics.getHeight(), true);
+		cam = new PerspectiveCamera(67, graphics.getWidth(), graphics.getHeight());
 		cam.position.set(0, 0, 10);
 		cam.lookAt(0, 0, 0);
 		cam.far = 30;
@@ -95,24 +94,24 @@ public class EdgeDetectionTest extends GdxTest {
 		int idx = 0;
 		for (int y = -1; y <= 1; y++) {
 			for (int x = -1; x <= 1; x++) {
-				offsets[idx++] = x / (float)Gdx.graphics.getWidth();
-				offsets[idx++] = y / (float)Gdx.graphics.getHeight();
+				offsets[idx++] = x / (float)graphics.getWidth();
+				offsets[idx++] = y / (float)graphics.getHeight();
 			}
 		}
 		System.out.println(Arrays.toString(offsets));
 	}
 
 	public void render () {
-		angle += 45 * Gdx.graphics.getDeltaTime();
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
+		angle += 45 * graphics.getDeltaTime();
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
 
 		cam.update();
 		matrix.setToRotation(0, 1, 0, angle);
 		cam.combined.mul(matrix);
 
 		fbo.begin();
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
-		Gdx.gl.glEnable(GL20.GL_DEPTH_TEST);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
+		gl.glEnable(GL20.GL_DEPTH_TEST);
 		modelBatch.begin(cam);
 		modelBatch.render(sceneInstance);
 		modelBatch.end();
@@ -123,7 +122,7 @@ public class EdgeDetectionTest extends GdxTest {
 		batchShader.setUniformi("u_filterSize", filter.length);
 		batchShader.setUniform1fv("u_filter", filter, 0, filter.length);
 		batchShader.setUniform2fv("u_offsets", offsets, 0, offsets.length);
-		batch.draw(fboRegion, 0, 0, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+		batch.draw(fboRegion, 0, 0, graphics.getWidth(), graphics.getHeight());
 		batch.end();
 		logger.log();
 	}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ExitTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ExitTest.java
@@ -16,23 +16,22 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.tests.utils.GdxTest;
 
 public class ExitTest extends GdxTest {
 
 	@Override
 	public void render () {
-		if (Gdx.input.justTouched()) Gdx.app.exit();
+		if (input.justTouched()) app.exit();
 	}
 
 	@Override
 	public void pause () {
-		Gdx.app.log("ExitTest", "paused");
+		app.log("ExitTest", "paused");
 	}
 
 	@Override
 	public void dispose () {
-		Gdx.app.log("ExitTest", "disposed");
+		app.log("ExitTest", "disposed");
 	}
 }

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ExternalMusicTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ExternalMusicTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.audio.Music;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.tests.utils.GdxTest;
@@ -29,12 +28,12 @@ public class ExternalMusicTest extends GdxTest {
 	@Override
 	public void create () {
 		// copy an internal mp3 to the external storage
-		FileHandle src = Gdx.files.internal("data/8.12.mp3");
-		FileHandle dst = Gdx.files.external("8.12.mp3");
+		FileHandle src = files.internal("data/8.12.mp3");
+		FileHandle dst = files.external("8.12.mp3");
 		src.copyTo(dst);
 
 		// create a music instance and start playback
-		music = Gdx.audio.newMusic(dst);
+		music = audio.newMusic(dst);
 		music.play();
 	}
 
@@ -43,6 +42,6 @@ public class ExternalMusicTest extends GdxTest {
 		music.stop();
 		music.dispose();
 		// delete the copy on the external storage
-		Gdx.files.external("8.12.mp3").delete();
+		files.external("8.12.mp3").delete();
 	}
 }

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/FilesTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/FilesTest.java
@@ -24,7 +24,6 @@ import java.io.OutputStreamWriter;
 import java.util.Arrays;
 
 import com.badlogic.gdx.Application.ApplicationType;
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
@@ -41,15 +40,15 @@ public class FilesTest extends GdxTest {
 
 	@Override
 	public void create () {
-		font = new BitmapFont(Gdx.files.internal("data/lsans-15.fnt"), false);
+		font = new BitmapFont(files.internal("data/lsans-15.fnt"), false);
 		batch = new SpriteBatch();
 
-		if (Gdx.files.isExternalStorageAvailable()) {
+		if (files.isExternalStorageAvailable()) {
 			message += "External storage available\n";
-			message += "External storage path: " + Gdx.files.getExternalStoragePath() + "\n";
+			message += "External storage path: " + files.getExternalStoragePath() + "\n";
 
 			try {
-				InputStream in = Gdx.files.internal("data/cube.obj").read();
+				InputStream in = files.internal("data/cube.obj").read();
 				StreamUtils.closeQuietly(in);
 				message += "Open internal success\n";
 			} catch (Throwable e) {
@@ -58,7 +57,7 @@ public class FilesTest extends GdxTest {
 
 			BufferedWriter out = null;
 			try {
-				out = new BufferedWriter(new OutputStreamWriter(Gdx.files.external("test.txt").write(false)));
+				out = new BufferedWriter(new OutputStreamWriter(files.external("test.txt").write(false)));
 				out.write("test");
 				message += "Write external success\n";
 			} catch (GdxRuntimeException ex) {
@@ -70,7 +69,7 @@ public class FilesTest extends GdxTest {
 			}
 
 			try {
-				InputStream in = Gdx.files.external("test.txt").read();
+				InputStream in = files.external("test.txt").read();
 				StreamUtils.closeQuietly(in);
 				message += "Open external success\n";
 			} catch (Throwable e) {
@@ -79,7 +78,7 @@ public class FilesTest extends GdxTest {
 
 			BufferedReader in = null;
 			try {
-				in = new BufferedReader(new InputStreamReader(Gdx.files.external("test.txt").read()));
+				in = new BufferedReader(new InputStreamReader(files.external("test.txt").read()));
 				if (!in.readLine().equals("test"))
 					message += "Read result wrong\n";
 				else
@@ -92,17 +91,17 @@ public class FilesTest extends GdxTest {
 				StreamUtils.closeQuietly(in);
 			}
 
-			if (!Gdx.files.external("test.txt").delete()) message += "Couldn't delete externalstorage/test.txt";
+			if (!files.external("test.txt").delete()) message += "Couldn't delete externalstorage/test.txt";
 		} else {
 			message += "External storage not available";
 		}
-		if (Gdx.files.isLocalStorageAvailable()) {
+		if (files.isLocalStorageAvailable()) {
 			message += "Local storage available\n";
-			message += "Local storage path: " + Gdx.files.getLocalStoragePath() + "\n";
+			message += "Local storage path: " + files.getLocalStoragePath() + "\n";
 
 			BufferedWriter out = null;
 			try {
-				out = new BufferedWriter(new OutputStreamWriter(Gdx.files.local("test.txt").write(false)));
+				out = new BufferedWriter(new OutputStreamWriter(files.local("test.txt").write(false)));
 				out.write("test");
 				message += "Write local success\n";
 			} catch (GdxRuntimeException ex) {
@@ -114,7 +113,7 @@ public class FilesTest extends GdxTest {
 			}
 
 			try {
-				InputStream in = Gdx.files.local("test.txt").read();
+				InputStream in = files.local("test.txt").read();
 				StreamUtils.closeQuietly(in);
 				message += "Open local success\n";
 			} catch (Throwable e) {
@@ -123,7 +122,7 @@ public class FilesTest extends GdxTest {
 
 			BufferedReader in = null;
 			try {
-				in = new BufferedReader(new InputStreamReader(Gdx.files.local("test.txt").read()));
+				in = new BufferedReader(new InputStreamReader(files.local("test.txt").read()));
 				if (!in.readLine().equals("test"))
 					message += "Read result wrong\n";
 				else
@@ -137,7 +136,7 @@ public class FilesTest extends GdxTest {
 			}
 
 			try {
-				byte[] testBytes = Gdx.files.local("test.txt").readBytes();
+				byte[] testBytes = files.local("test.txt").readBytes();
 				if (Arrays.equals("test".getBytes(), testBytes))
 					message += "Read into byte array success\n";
 				else
@@ -146,12 +145,12 @@ public class FilesTest extends GdxTest {
 				message += "Couldn't read localstorage/test.txt\n" + e.getMessage() + "\n";
 			}
 
-			if (!Gdx.files.local("test.txt").delete()) message += "Couldn't delete localstorage/test.txt";
+			if (!files.local("test.txt").delete()) message += "Couldn't delete localstorage/test.txt";
 		}
 		try {
 			testClasspath();
 			testInternal();
-			if (!(Gdx.app.getType() == ApplicationType.WebGL)) {
+			if (!(app.getType() == ApplicationType.WebGL)) {
 				testExternal();
 				testAbsolute();
 				testLocal();
@@ -163,8 +162,8 @@ public class FilesTest extends GdxTest {
 
 	private void testClasspath () throws IOException {
 		// no classpath support on ios
-		if (Gdx.app.getType() == ApplicationType.iOS) return;
-		FileHandle handle = Gdx.files.classpath("com/badlogic/gdx/utils/lsans-15.png");
+		if (app.getType() == ApplicationType.iOS) return;
+		FileHandle handle = files.classpath("com/badlogic/gdx/utils/lsans-15.png");
 		if (!handle.exists()) fail();
 		if (handle.isDirectory()) fail();
 		try {
@@ -182,7 +181,7 @@ public class FilesTest extends GdxTest {
 			fail();
 		} catch (Exception ignored) {
 		}
-		FileHandle dir = Gdx.files.classpath("com/badlogic/gdx/utils");
+		FileHandle dir = files.classpath("com/badlogic/gdx/utils");
 		if (dir.isDirectory()) fail();
 		FileHandle child = dir.child("lsans-15.fnt");
 		if (!child.name().equals("lsans-15.fnt")) fail();
@@ -193,7 +192,7 @@ public class FilesTest extends GdxTest {
 	}
 
 	private void testInternal () throws IOException {
-		FileHandle handle = Gdx.files.internal("data/badlogic.jpg");
+		FileHandle handle = files.internal("data/badlogic.jpg");
 		if (!handle.exists()) fail("Couldn't find internal file");
 		if (handle.isDirectory()) fail("Internal file shouldn't be a directory");
 		try {
@@ -202,7 +201,7 @@ public class FilesTest extends GdxTest {
 		} catch (Exception expected) {
 		}
 		if (handle.list().length != 0) fail("File length shouldn't be 0");
-		if (Gdx.app.getType() != ApplicationType.Android) {
+		if (app.getType() != ApplicationType.Android) {
 			if (!handle.parent().exists()) fail("Parent doesn't exist");
 		}
 		try {
@@ -210,22 +209,22 @@ public class FilesTest extends GdxTest {
 			fail();
 		} catch (Exception ignored) {
 		}
-		FileHandle dir = Gdx.files.internal("data");
-		if (Gdx.app.getType() != ApplicationType.Android) {
+		FileHandle dir = files.internal("data");
+		if (app.getType() != ApplicationType.Android) {
 			if (!dir.exists()) fail();
 		}
 		if (!dir.isDirectory()) fail();
 		if (dir.list().length == 0) fail();
-		Gdx.app.log("FilesTest", "Files in data: " + Arrays.toString(dir.list()) + " (" + dir.list().length + ")");
+		app.log("FilesTest", "Files in data: " + Arrays.toString(dir.list()) + " (" + dir.list().length + ")");
 		FileHandle child = dir.child("badlogic.jpg");
 		if (!child.name().equals("badlogic.jpg")) fail();
 		if (!child.nameWithoutExtension().equals("badlogic")) fail();
 		if (!child.extension().equals("jpg")) fail();
-		if (Gdx.app.getType() != ApplicationType.Android) {
+		if (app.getType() != ApplicationType.Android) {
 			if (!child.parent().exists()) fail();
 		}
-		if (!(Gdx.app.getType() == ApplicationType.WebGL)) {
-			FileHandle copy = Gdx.files.external("badlogic.jpg-copy");
+		if (!(app.getType() == ApplicationType.WebGL)) {
+			FileHandle copy = files.external("badlogic.jpg-copy");
 			copy.delete();
 			if (copy.exists()) fail();
 			handle.copyTo(copy);
@@ -240,7 +239,7 @@ public class FilesTest extends GdxTest {
 
 	private void testExternal () throws IOException {
 		String path = "meow";
-		FileHandle handle = Gdx.files.external(path);
+		FileHandle handle = files.external(path);
 		handle.delete();
 		if (handle.exists()) fail();
 		if (handle.isDirectory()) fail();
@@ -269,13 +268,13 @@ public class FilesTest extends GdxTest {
 		output.close();
 		if (!handle.exists()) fail();
 		if (handle.length() != 3) fail();
-		FileHandle copy = Gdx.files.external(path + "-copy");
+		FileHandle copy = files.external(path + "-copy");
 		copy.delete();
 		if (copy.exists()) fail();
 		handle.copyTo(copy);
 		if (!copy.exists()) fail();
 		if (copy.length() != 3) fail();
-		FileHandle move = Gdx.files.external(path + "-move");
+		FileHandle move = files.external(path + "-move");
 		move.delete();
 		if (move.exists()) fail();
 		copy.moveTo(move);
@@ -309,8 +308,8 @@ public class FilesTest extends GdxTest {
 	}
 
 	private void testAbsolute () throws IOException {
-		String path = new File(Gdx.files.getExternalStoragePath(), "meow").getAbsolutePath();
-		FileHandle handle = Gdx.files.absolute(path);
+		String path = new File(files.getExternalStoragePath(), "meow").getAbsolutePath();
+		FileHandle handle = files.absolute(path);
 		handle.delete();
 		if (handle.exists()) fail();
 		if (handle.isDirectory()) fail();
@@ -339,13 +338,13 @@ public class FilesTest extends GdxTest {
 		output.close();
 		if (!handle.exists()) fail();
 		if (handle.length() != 3) fail();
-		FileHandle copy = Gdx.files.absolute(path + "-copy");
+		FileHandle copy = files.absolute(path + "-copy");
 		copy.delete();
 		if (copy.exists()) fail();
 		handle.copyTo(copy);
 		if (!copy.exists()) fail();
 		if (copy.length() != 3) fail();
-		FileHandle move = Gdx.files.absolute(path + "-move");
+		FileHandle move = files.absolute(path + "-move");
 		move.delete();
 		if (move.exists()) fail();
 		copy.moveTo(move);
@@ -380,7 +379,7 @@ public class FilesTest extends GdxTest {
 
 	private void testLocal () throws IOException {
 		String path = "meow";
-		FileHandle handle = Gdx.files.local(path);
+		FileHandle handle = files.local(path);
 		handle.delete();
 		if (handle.exists()) fail();
 		if (handle.isDirectory()) fail();
@@ -409,13 +408,13 @@ public class FilesTest extends GdxTest {
 		output.close();
 		if (!handle.exists()) fail();
 		if (handle.length() != 3) fail();
-		FileHandle copy = Gdx.files.local(path + "-copy");
+		FileHandle copy = files.local(path + "-copy");
 		copy.delete();
 		if (copy.exists()) fail();
 		handle.copyTo(copy);
 		if (!copy.exists()) fail();
 		if (copy.length() != 3) fail();
-		FileHandle move = Gdx.files.local(path + "-move");
+		FileHandle move = files.local(path + "-move");
 		move.delete();
 		if (move.exists()) fail();
 		copy.moveTo(move);
@@ -458,9 +457,9 @@ public class FilesTest extends GdxTest {
 
 	@Override
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		batch.begin();
-		font.draw(batch, message, 20, Gdx.graphics.getHeight() - 20);
+		font.draw(batch, message, 20, graphics.getHeight() - 20);
 		batch.end();
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/FilterPerformanceTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/FilterPerformanceTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.InputAdapter;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Texture;
@@ -45,9 +44,9 @@ public class FilterPerformanceTest extends GdxTest {
 
 	void setTextureFilter (int filter) {
 		atlas.findRegion("map").getTexture().bind();
-		Gdx.gl.glTexParameterf(GL20.GL_TEXTURE_2D, GL20.GL_TEXTURE_MIN_FILTER, filters[filter]);
+		gl.glTexParameterf(GL20.GL_TEXTURE_2D, GL20.GL_TEXTURE_MIN_FILTER, filters[filter]);
 		texture.bind();
-		Gdx.gl.glTexParameterf(GL20.GL_TEXTURE_2D, GL20.GL_TEXTURE_MIN_FILTER, filters[filter]);
+		gl.glTexParameterf(GL20.GL_TEXTURE_2D, GL20.GL_TEXTURE_MIN_FILTER, filters[filter]);
 	}
 
 	void setModeString () {
@@ -59,17 +58,17 @@ public class FilterPerformanceTest extends GdxTest {
 		sceneMatrix = new Matrix4().setToOrtho2D(0, 0, 480, 320);
 		textMatrix = new Matrix4().setToOrtho2D(0, 0, 480, 320);
 
-		atlas = new TextureAtlas(Gdx.files.internal("data/issue_pack"), Gdx.files.internal("data/"));
-		texture = new Texture(Gdx.files.internal("data/resource1.jpg"), true);
+		atlas = new TextureAtlas(files.internal("data/issue_pack"), files.internal("data/"));
+		texture = new Texture(files.internal("data/resource1.jpg"), true);
 		texture.setFilter(TextureFilter.MipMap, TextureFilter.Nearest);
 		setTextureFilter(0);
 		setModeString();
 
 		sprite = atlas.createSprite("map");
 		sprite2 = new Sprite(texture, 0, 0, 855, 480);
-		font = new BitmapFont(Gdx.files.internal("data/font.fnt"), Gdx.files.internal("data/font.png"), false);
+		font = new BitmapFont(files.internal("data/font.fnt"), files.internal("data/font.png"), false);
 
-		Gdx.input.setInputProcessor(new InputAdapter() {
+		input.setInputProcessor(new InputAdapter() {
 			public boolean touchDown (int x, int y, int pointer, int newParam) {
 				mode++;
 				if (mode == filters.length * 2) mode = 0;
@@ -89,7 +88,7 @@ public class FilterPerformanceTest extends GdxTest {
 	}
 
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 
 		batch.setProjectionMatrix(sceneMatrix);
 		batch.begin();
@@ -98,7 +97,7 @@ public class FilterPerformanceTest extends GdxTest {
 
 		batch.setProjectionMatrix(textMatrix);
 		batch.begin();
-		font.draw(batch, modeString + " fps:" + Gdx.graphics.getFramesPerSecond(), 26, 65);
+		font.draw(batch, modeString + " fps:" + graphics.getFramesPerSecond(), 26, 65);
 		batch.end();
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/FloatTextureTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/FloatTextureTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Mesh;
 import com.badlogic.gdx.graphics.OrthographicCamera;
@@ -105,13 +104,13 @@ public class FloatTextureTest extends GdxTest {
 		shader = new ShaderProgram(vertexShader, fragmentShader);
 		createQuad();
 
-		screenCamera = new OrthographicCamera(Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+		screenCamera = new OrthographicCamera(graphics.getWidth(), graphics.getHeight());
 		createScreenQuad();
 	}
 
 	public void render () {
-		Gdx.gl20.glViewport(0, 0, Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight());
-		Gdx.gl20.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl20.glViewport(0, 0, graphics.getBackBufferWidth(), graphics.getBackBufferHeight());
+		gl20.glClear(GL20.GL_COLOR_BUFFER_BIT);
 
 		fb.begin();
 		fbshader.bind();
@@ -153,7 +152,7 @@ public class FloatTextureTest extends GdxTest {
 
 		Vector3 vec0 = new Vector3(0, 0, 0);
 		screenCamera.unproject(vec0);
-		Vector3 vec1 = new Vector3(Gdx.graphics.getWidth(), Gdx.graphics.getHeight(), 0);
+		Vector3 vec1 = new Vector3(graphics.getWidth(), graphics.getHeight(), 0);
 		screenCamera.unproject(vec1);
 		screenQuad.setVertices(new float[] {vec0.x, vec0.y, 0, 1, 1, 1, 1, 0, 1, vec1.x, vec0.y, 0, 1, 1, 1, 1, 1, 1, vec1.x,
 			vec1.y, 0, 1, 1, 1, 1, 1, 0, vec0.x, vec1.y, 0, 1, 1, 1, 1, 0, 0});

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/FrameBufferTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/FrameBufferTest.java
@@ -28,7 +28,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Graphics;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
@@ -57,9 +56,9 @@ public class FrameBufferTest extends GdxTest {
 	@Override
 	public void render () {
 		frameBuffer.begin();
-		Gdx.gl20.glViewport(0, 0, frameBuffer.getWidth(), frameBuffer.getHeight());
-		Gdx.gl20.glClearColor(0f, 1f, 0f, 1);
-		Gdx.gl20.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl20.glViewport(0, 0, frameBuffer.getWidth(), frameBuffer.getHeight());
+		gl20.glClearColor(0f, 1f, 0f, 1);
+		gl20.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		texture.bind();
 		meshShader.bind();
 		meshShader.setUniformi("u_texture", 0);
@@ -67,37 +66,37 @@ public class FrameBufferTest extends GdxTest {
 		frameBuffer.end();
 
 		stencilFrameBuffer.begin();
-		Gdx.gl20.glViewport(0, 0, frameBuffer.getWidth(), frameBuffer.getHeight());
-		Gdx.gl20.glClearColor(1f, 1f, 0f, 1);
-		Gdx.gl20.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_STENCIL_BUFFER_BIT);
+		gl20.glViewport(0, 0, frameBuffer.getWidth(), frameBuffer.getHeight());
+		gl20.glClearColor(1f, 1f, 0f, 1);
+		gl20.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_STENCIL_BUFFER_BIT);
 
-		Gdx.gl20.glEnable(GL20.GL_STENCIL_TEST);
+		gl20.glEnable(GL20.GL_STENCIL_TEST);
 
-		Gdx.gl20.glColorMask(false, false, false, false);
-		Gdx.gl20.glDepthMask(false);
-		Gdx.gl20.glStencilFunc(GL20.GL_NEVER, 1, 0xFF);
-		Gdx.gl20.glStencilOp(GL20.GL_REPLACE, GL20.GL_KEEP, GL20.GL_KEEP);
+		gl20.glColorMask(false, false, false, false);
+		gl20.glDepthMask(false);
+		gl20.glStencilFunc(GL20.GL_NEVER, 1, 0xFF);
+		gl20.glStencilOp(GL20.GL_REPLACE, GL20.GL_KEEP, GL20.GL_KEEP);
 
-		Gdx.gl20.glStencilMask(0xFF);
-		Gdx.gl20.glClear(GL20.GL_STENCIL_BUFFER_BIT);
+		gl20.glStencilMask(0xFF);
+		gl20.glClear(GL20.GL_STENCIL_BUFFER_BIT);
 
 		meshShader.bind();
 		stencilMesh.render(meshShader, GL20.GL_TRIANGLES);
 
-		Gdx.gl20.glColorMask(true, true, true, true);
-		Gdx.gl20.glDepthMask(true);
-		Gdx.gl20.glStencilMask(0x00);
-		Gdx.gl20.glStencilFunc(GL20.GL_EQUAL, 1, 0xFF);
+		gl20.glColorMask(true, true, true, true);
+		gl20.glDepthMask(true);
+		gl20.glStencilMask(0x00);
+		gl20.glStencilFunc(GL20.GL_EQUAL, 1, 0xFF);
 
 		meshShader.bind();
 		mesh.render(meshShader, GL20.GL_TRIANGLES);
 
-		Gdx.gl20.glDisable(GL20.GL_STENCIL_TEST);
+		gl20.glDisable(GL20.GL_STENCIL_TEST);
 		stencilFrameBuffer.end();
 
-		Gdx.gl20.glViewport(0, 0, Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight());
-		Gdx.gl20.glClearColor(0.2f, 0.2f, 0.2f, 1);
-		Gdx.gl20.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl20.glViewport(0, 0, graphics.getBackBufferWidth(), graphics.getBackBufferHeight());
+		gl20.glClearColor(0.2f, 0.2f, 0.2f, 1);
+		gl20.glClear(GL20.GL_COLOR_BUFFER_BIT);
 
 		spriteBatch.begin();
 		spriteBatch.draw(frameBuffer.getColorBufferTexture(), 0, 0, 256, 256, 0, 0, frameBuffer.getColorBufferTexture().getWidth(),
@@ -122,12 +121,12 @@ public class FrameBufferTest extends GdxTest {
 			new VertexAttribute(Usage.ColorPacked, 4, "a_Color"), new VertexAttribute(Usage.TextureCoordinates, 2, "a_texCoords"));
 		stencilMesh.setVertices(new float[] {-0.5f, 0.5f, 0, c1, 0, 0, 0.5f, 0.5f, 0, c2, 1, 0, 0, -0.5f, 0, c3, 0.5f, 1});
 
-		texture = new Texture(Gdx.files.internal("data/badlogic.jpg"));
+		texture = new Texture(files.internal("data/badlogic.jpg"));
 
 		spriteBatch = new SpriteBatch();
 		frameBuffer = new FrameBuffer(Format.RGB565, 128, 128, false);
 		stencilFrameBuffer = new FrameBuffer(Format.RGB565, 128, 128, false, true);
-		createShader(Gdx.graphics);
+		createShader(graphics);
 	}
 
 	private void createShader (Graphics graphics) {

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/FramebufferToTextureTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/FramebufferToTextureTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.PerspectiveCamera;
@@ -49,15 +48,15 @@ public class FramebufferToTextureTest extends GdxTest {
 
 	@Override
 	public void create () {
-		texture = new Texture(Gdx.files.internal("data/badlogic.jpg"), true);
+		texture = new Texture(files.internal("data/badlogic.jpg"), true);
 		texture.setFilter(TextureFilter.MipMap, TextureFilter.Linear);
 		ObjLoader objLoader = new ObjLoader();
-		mesh = objLoader.loadModel(Gdx.files.internal("data/cube.obj"));
+		mesh = objLoader.loadModel(files.internal("data/cube.obj"));
 		mesh.materials.get(0).set(new TextureAttribute(TextureAttribute.Diffuse, texture));
 		modelInstance = new ModelInstance(mesh);
 		modelBatch = new ModelBatch();
 
-		cam = new PerspectiveCamera(67, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+		cam = new PerspectiveCamera(67, graphics.getWidth(), graphics.getHeight());
 		cam.position.set(3, 3, 3);
 		cam.direction.set(-1, -1, -1);
 		batch = new SpriteBatch();
@@ -66,19 +65,19 @@ public class FramebufferToTextureTest extends GdxTest {
 
 	@Override
 	public void render () {
-		Gdx.gl.glViewport(0, 0, Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight());
-		Gdx.gl.glClearColor(clearColor.r, clearColor.g, clearColor.b, clearColor.a);
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
-		Gdx.gl.glEnable(GL20.GL_DEPTH_TEST);
+		gl.glViewport(0, 0, graphics.getBackBufferWidth(), graphics.getBackBufferHeight());
+		gl.glClearColor(clearColor.r, clearColor.g, clearColor.b, clearColor.a);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
+		gl.glEnable(GL20.GL_DEPTH_TEST);
 
 		cam.update();
 
-		modelInstance.transform.rotate(Vector3.Y, 45 * Gdx.graphics.getDeltaTime());
+		modelInstance.transform.rotate(Vector3.Y, 45 * graphics.getDeltaTime());
 		modelBatch.begin(cam);
 		modelBatch.render(modelInstance);
 		modelBatch.end();
 
-		if (Gdx.input.justTouched() || fbTexture == null) {
+		if (input.justTouched() || fbTexture == null) {
 			if (fbTexture != null) fbTexture.getTexture().dispose();
 			fbTexture = ScreenUtils.getFrameBufferTexture();
 		}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/FullscreenTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/FullscreenTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Graphics.DisplayMode;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Texture;
@@ -35,12 +34,12 @@ public class FullscreenTest extends GdxTest {
 	public void create () {
 		batch = new SpriteBatch();
 		font = new BitmapFont();
-		tex = new Texture(Gdx.files.internal("data/badlogic.jpg"));
-		DisplayMode[] modes = Gdx.graphics.getDisplayModes();
+		tex = new Texture(files.internal("data/badlogic.jpg"));
+		DisplayMode[] modes = graphics.getDisplayModes();
 		for (DisplayMode mode : modes) {
 			System.out.println(mode);
 		}
-		Gdx.app.log("FullscreenTest", Gdx.graphics.getBufferFormat().toString());
+		app.log("FullscreenTest", graphics.getBufferFormat().toString());
 	}
 
 	@Override
@@ -53,22 +52,22 @@ public class FullscreenTest extends GdxTest {
 		ScreenUtils.clear(0, 0, 0, 1);
 
 		batch.begin();
-		batch.setColor(Gdx.input.getX() < Gdx.graphics.getSafeInsetLeft()
-			|| Gdx.input.getX() + tex.getWidth() > Gdx.graphics.getWidth() - Gdx.graphics.getSafeInsetRight() ? Color.RED
+		batch.setColor(input.getX() < graphics.getSafeInsetLeft()
+			|| input.getX() + tex.getWidth() > graphics.getWidth() - graphics.getSafeInsetRight() ? Color.RED
 				: Color.WHITE);
-		batch.draw(tex, Gdx.input.getX(), Gdx.graphics.getHeight() - Gdx.input.getY());
-		font.draw(batch, "" + Gdx.graphics.getWidth() + ", " + Gdx.graphics.getHeight(), 0, 20);
+		batch.draw(tex, input.getX(), graphics.getHeight() - input.getY());
+		font.draw(batch, "" + graphics.getWidth() + ", " + graphics.getHeight(), 0, 20);
 		batch.end();
 
-		if (Gdx.input.justTouched()) {
+		if (input.justTouched()) {
 			if (fullscreen) {
-				Gdx.graphics.setWindowedMode(480, 320);
-				batch.getProjectionMatrix().setToOrtho2D(0, 0, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
-				Gdx.gl.glViewport(0, 0, Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight());
+				graphics.setWindowedMode(480, 320);
+				batch.getProjectionMatrix().setToOrtho2D(0, 0, graphics.getWidth(), graphics.getHeight());
+				gl.glViewport(0, 0, graphics.getBackBufferWidth(), graphics.getBackBufferHeight());
 				fullscreen = false;
 			} else {
 				DisplayMode m = null;
-				for (DisplayMode mode : Gdx.graphics.getDisplayModes()) {
+				for (DisplayMode mode : graphics.getDisplayModes()) {
 					if (m == null) {
 						m = mode;
 					} else {
@@ -78,9 +77,9 @@ public class FullscreenTest extends GdxTest {
 					}
 				}
 
-				Gdx.graphics.setFullscreenMode(Gdx.graphics.getDisplayMode());
-				batch.getProjectionMatrix().setToOrtho2D(0, 0, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
-				Gdx.gl.glViewport(0, 0, Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight());
+				graphics.setFullscreenMode(graphics.getDisplayMode());
+				batch.getProjectionMatrix().setToOrtho2D(0, 0, graphics.getWidth(), graphics.getHeight());
+				gl.glViewport(0, 0, graphics.getBackBufferWidth(), graphics.getBackBufferHeight());
 				fullscreen = true;
 			}
 		}
@@ -88,18 +87,18 @@ public class FullscreenTest extends GdxTest {
 
 	@Override
 	public void resize (int width, int height) {
-		Gdx.app.log("FullscreenTest", "resized: " + width + ", " + height);
-		Gdx.app.log("FullscreenTest", "safe insets: " + Gdx.graphics.getSafeInsetLeft() + "/" + Gdx.graphics.getSafeInsetRight());
+		app.log("FullscreenTest", "resized: " + width + ", " + height);
+		app.log("FullscreenTest", "safe insets: " + graphics.getSafeInsetLeft() + "/" + graphics.getSafeInsetRight());
 		batch.getProjectionMatrix().setToOrtho2D(0, 0, width, height);
 	}
 
 	@Override
 	public void pause () {
-		Gdx.app.log("FullscreenTest", "paused");
+		app.log("FullscreenTest", "paused");
 	}
 
 	@Override
 	public void dispose () {
-		Gdx.app.log("FullscreenTest", "disposed");
+		app.log("FullscreenTest", "disposed");
 	}
 }

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/GLES30Test.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/GLES30Test.java
@@ -1,7 +1,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
@@ -17,14 +16,14 @@ public class GLES30Test extends GdxTest {
 
 	@Override
 	public void create () {
-		Gdx.app.log("GLES30Test", "GL_VERSION = " + Gdx.gl.glGetString(GL20.GL_VERSION));
+		app.log("GLES30Test", "GL_VERSION = " + gl.glGetString(GL20.GL_VERSION));
 		batch = new SpriteBatch();
-		texture = new Texture(Gdx.files.internal("data/badlogic.jpg"));
-		shaderProgram = new ShaderProgram(Gdx.files.internal("data/shaders/gles30sprite.vert"),
-			Gdx.files.internal("data/shaders/gles30sprite.frag"));
-		Gdx.app.log("GLES30Test", shaderProgram.getLog());
+		texture = new Texture(files.internal("data/badlogic.jpg"));
+		shaderProgram = new ShaderProgram(files.internal("data/shaders/gles30sprite.vert"),
+			files.internal("data/shaders/gles30sprite.frag"));
+		app.log("GLES30Test", shaderProgram.getLog());
 		if (shaderProgram.isCompiled()) {
-			Gdx.app.log("GLES30Test", "Shader compiled");
+			app.log("GLES30Test", "Shader compiled");
 			batch.setShader(shaderProgram);
 		}
 	}
@@ -34,7 +33,7 @@ public class GLES30Test extends GdxTest {
 		ScreenUtils.clear(0, 0, 0, 1);
 
 		batch.begin();
-		batch.draw(texture, 0, 0, Gdx.graphics.getWidth() / 2f, Gdx.graphics.getHeight() / 2f);
+		batch.draw(texture, 0, 0, graphics.getWidth() / 2f, graphics.getHeight() / 2f);
 		batch.end();
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/GLProfilerErrorTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/GLProfilerErrorTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.profiling.GLProfiler;
 import com.badlogic.gdx.graphics.profiling.GLErrorListener;
@@ -49,9 +48,9 @@ public class GLProfilerErrorTest extends GdxTest {
 	public void create () {
 		batch = new SpriteBatch();
 		font = new BitmapFont();
-		Gdx.input.setInputProcessor(this);
+		input.setInputProcessor(this);
 
-		glProfiler = new GLProfiler(Gdx.graphics);
+		glProfiler = new GLProfiler(graphics);
 	}
 
 	@Override
@@ -63,19 +62,19 @@ public class GLProfilerErrorTest extends GdxTest {
 		if (makeGlError) {
 			makeGlError = false;
 			try {
-				Gdx.gl.glClear(42); // Random invalid value, will raise GL_INVALID_VALUE (0x501, 1281)
+				gl.glClear(42); // Random invalid value, will raise GL_INVALID_VALUE (0x501, 1281)
 			} catch (GdxRuntimeException glError) {
 				if ("GLProfiler: Got gl error GL_INVALID_VALUE".equals(glError.getMessage())) {
 					message = "Got expected exception.";
 				} else {
 					message = "Got GdxRuntimeException (correct) but with unexpected message: " + glError.getMessage();
 				}
-				Gdx.app.log("GLProfilerTest", "Caught exception: ", glError);
+				app.log("GLProfilerTest", "Caught exception: ", glError);
 			}
 		}
 
 		int x = 10;
-		int y = Gdx.graphics.getHeight() - 10;
+		int y = graphics.getHeight() - 10;
 		y -= font.draw(batch, "e - Enable debugging\n" + "d - Disable debugging\n" + "l - Test log error listener\n"
 			+ "t - Test throw error listener\n" + "c - Test custom listener\n\n" + "Expected error: GL_INVALID_VALUE (0x501, 1281)",
 			x, y).height;

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/GWTLossyPremultipliedAlphaTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/GWTLossyPremultipliedAlphaTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.Texture;
@@ -35,12 +34,12 @@ public class GWTLossyPremultipliedAlphaTest extends GdxTest {
 	public void create () {
 		batch = new SpriteBatch();
 		// Load a texture with premultiplied alpha
-		FileTextureData data = new FileTextureData(Gdx.files.internal("data/premultiplied_alpha_test.png"), null, null, false);
+		FileTextureData data = new FileTextureData(files.internal("data/premultiplied_alpha_test.png"), null, null, false);
 		goodTexture = new Texture(data);
 
 		// Load the texture again. But this time, force the GWT implementation of Pixmap to move to a Canvas representation of the
 		// image
-		Pixmap pixmap = new Pixmap(Gdx.files.internal("data/premultiplied_alpha_test.png"));
+		Pixmap pixmap = new Pixmap(files.internal("data/premultiplied_alpha_test.png"));
 		pixmap.getPixel(0, 0);
 		FileTextureData data1 = new FileTextureData(null, pixmap, null, false);
 		badTexture = new Texture(data1);
@@ -51,10 +50,10 @@ public class GWTLossyPremultipliedAlphaTest extends GdxTest {
 
 		batch.begin();
 		batch.setBlendFunction(GL20.GL_ONE, GL20.GL_ONE_MINUS_SRC_ALPHA);
-		batch.draw(badTexture, 0, Gdx.graphics.getHeight(), Gdx.graphics.getWidth() * 0.5f, -Gdx.graphics.getHeight());
+		batch.draw(badTexture, 0, graphics.getHeight(), graphics.getWidth() * 0.5f, -graphics.getHeight());
 
-		batch.draw(goodTexture, Gdx.graphics.getWidth() * 0.5f, Gdx.graphics.getHeight(), Gdx.graphics.getWidth() * 0.5f,
-			-Gdx.graphics.getHeight());
+		batch.draw(goodTexture, graphics.getWidth() * 0.5f, graphics.getHeight(), graphics.getWidth() * 0.5f,
+			-graphics.getHeight());
 
 		batch.end();
 	}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/Gdx2DTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/Gdx2DTest.java
@@ -19,7 +19,6 @@ package com.badlogic.gdx.tests;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Pixmap.Format;
@@ -37,7 +36,7 @@ public class Gdx2DTest extends GdxTest {
 	Texture textureFromPixmap (Gdx2DPixmap pixmap) {
 		Texture texture = new Texture(pixmap.getWidth(), pixmap.getHeight(), Format.RGB565);
 		texture.bind();
-		Gdx.gl.glTexImage2D(GL20.GL_TEXTURE_2D, 0, pixmap.getGLInternalFormat(), pixmap.getWidth(), pixmap.getHeight(), 0,
+		gl.glTexImage2D(GL20.GL_TEXTURE_2D, 0, pixmap.getGLInternalFormat(), pixmap.getWidth(), pixmap.getHeight(), 0,
 			pixmap.getGLFormat(), pixmap.getGLType(), pixmap.getPixels());
 		return texture;
 	}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/GestureDetectorTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/GestureDetectorTest.java
@@ -17,7 +17,6 @@
 package com.badlogic.gdx.tests;
 
 import com.badlogic.gdx.ApplicationListener;
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.graphics.Texture;
@@ -47,19 +46,19 @@ public class GestureDetectorTest extends GdxTest implements ApplicationListener 
 
 		@Override
 		public boolean tap (float x, float y, int count, int button) {
-			Gdx.app.log("GestureDetectorTest", "tap at " + x + ", " + y + ", count: " + count);
+			app.log("GestureDetectorTest", "tap at " + x + ", " + y + ", count: " + count);
 			return false;
 		}
 
 		@Override
 		public boolean longPress (float x, float y) {
-			Gdx.app.log("GestureDetectorTest", "long press at " + x + ", " + y);
+			app.log("GestureDetectorTest", "long press at " + x + ", " + y);
 			return false;
 		}
 
 		@Override
 		public boolean fling (float velocityX, float velocityY, int button) {
-			Gdx.app.log("GestureDetectorTest", "fling " + velocityX + ", " + velocityY);
+			app.log("GestureDetectorTest", "fling " + velocityX + ", " + velocityY);
 			flinging = true;
 			velX = camera.zoom * velocityX * 0.5f;
 			velY = camera.zoom * velocityY * 0.5f;
@@ -68,14 +67,14 @@ public class GestureDetectorTest extends GdxTest implements ApplicationListener 
 
 		@Override
 		public boolean pan (float x, float y, float deltaX, float deltaY) {
-			// Gdx.app.log("GestureDetectorTest", "pan at " + x + ", " + y);
+			// app.log("GestureDetectorTest", "pan at " + x + ", " + y);
 			camera.position.add(-deltaX * camera.zoom, deltaY * camera.zoom, 0);
 			return false;
 		}
 
 		@Override
 		public boolean panStop (float x, float y, int pointer, int button) {
-			Gdx.app.log("GestureDetectorTest", "pan stop at " + x + ", " + y);
+			app.log("GestureDetectorTest", "pan stop at " + x + ", " + y);
 			return false;
 		}
 
@@ -97,7 +96,7 @@ public class GestureDetectorTest extends GdxTest implements ApplicationListener 
 			if (flinging) {
 				velX *= 0.98f;
 				velY *= 0.98f;
-				camera.position.add(-velX * Gdx.graphics.getDeltaTime(), velY * Gdx.graphics.getDeltaTime(), 0);
+				camera.position.add(-velX * graphics.getDeltaTime(), velY * graphics.getDeltaTime(), 0);
 				if (Math.abs(velX) < 0.01f) velX = 0;
 				if (Math.abs(velY) < 0.01f) velY = 0;
 			}
@@ -112,15 +111,15 @@ public class GestureDetectorTest extends GdxTest implements ApplicationListener 
 	public void create () {
 		texture = new Texture("data/stones.jpg");
 		batch = new SpriteBatch();
-		camera = new OrthographicCamera(Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+		camera = new OrthographicCamera(graphics.getWidth(), graphics.getHeight());
 		controller = new CameraController();
 		gestureDetector = new GestureDetector(20, 40, 0.5f, 2, 0.15f, controller);
-		Gdx.input.setInputProcessor(gestureDetector);
+		input.setInputProcessor(gestureDetector);
 	}
 
 	@Override
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		controller.update();
 		camera.update();
 		batch.setProjectionMatrix(camera.combined);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/GroupCullingTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/GroupCullingTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.g2d.Batch;
 import com.badlogic.gdx.scenes.scene2d.Stage;
@@ -37,13 +36,13 @@ public class GroupCullingTest extends GdxTest {
 
 	public void create () {
 		stage = new Stage();
-		Gdx.input.setInputProcessor(stage);
+		input.setInputProcessor(stage);
 
 		root = new Table();
 		root.setFillParent(true);
 		stage.addActor(root);
 
-		skin = new Skin(Gdx.files.internal("data/uiskin.json"));
+		skin = new Skin(files.internal("data/uiskin.json"));
 
 		Table labels = new Table();
 		root.add(new ScrollPane(labels, skin)).grow();
@@ -73,9 +72,9 @@ public class GroupCullingTest extends GdxTest {
 	}
 
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		drawn = 0;
-		stage.act(Gdx.graphics.getDeltaTime());
+		stage.act(graphics.getDeltaTime());
 		stage.draw();
 		drawnLabel.setText("Drawn: " + drawn + "/" + count);
 		drawnLabel.invalidateHierarchy();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/GroupFadeTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/GroupFadeTest.java
@@ -21,7 +21,6 @@ import static com.badlogic.gdx.scenes.scene2d.actions.Actions.fadeOut;
 import static com.badlogic.gdx.scenes.scene2d.actions.Actions.forever;
 import static com.badlogic.gdx.scenes.scene2d.actions.Actions.sequence;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
@@ -36,7 +35,7 @@ public class GroupFadeTest extends GdxTest {
 
 	@Override
 	public void create () {
-		texture = new Texture(Gdx.files.internal("data/badlogicsmall.jpg"));
+		texture = new Texture(files.internal("data/badlogicsmall.jpg"));
 		stage = new Stage();
 
 		for (int i = 0; i < 100; i++) {
@@ -52,8 +51,8 @@ public class GroupFadeTest extends GdxTest {
 
 	@Override
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-		stage.act(Gdx.graphics.getDeltaTime());
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		stage.act(graphics.getDeltaTime());
 		stage.draw();
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/GroupTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/GroupTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.Batch;
@@ -60,9 +59,9 @@ public class GroupTest extends GdxTest {
 		renderer = new ShapeRenderer();
 
 		stage = new Stage(new ScreenViewport());
-		Gdx.input.setInputProcessor(stage);
+		input.setInputProcessor(stage);
 
-		region = new TextureRegion(new Texture(Gdx.files.internal("data/group-debug.png")));
+		region = new TextureRegion(new Texture(files.internal("data/group-debug.png")));
 
 		group2 = new TestGroup("group2");
 		group2.setTransform(true);
@@ -75,7 +74,7 @@ public class GroupTest extends GdxTest {
 		LabelStyle style = new LabelStyle();
 		style.font = new BitmapFont();
 
-		Texture texture = new Texture(Gdx.files.internal("data/badlogic.jpg"));
+		Texture texture = new Texture(files.internal("data/badlogic.jpg"));
 
 		horiz = new HorizontalGroup().pad(10, 20, 30, 40).top().space(5).reverse();
 		for (int i = 1; i <= 15; i++) {
@@ -123,7 +122,7 @@ public class GroupTest extends GdxTest {
 	public void render () {
 
 		horiz.setVisible(true);
-		horiz.setWidth(Gdx.input.getX() - horiz.getX());
+		horiz.setWidth(input.getX() - horiz.getX());
 		// horiz.setWidth(200);
 		horiz.setHeight(100);
 		horiz.fill();
@@ -133,13 +132,13 @@ public class GroupTest extends GdxTest {
 		horizWrap.setVisible(true);
 		horizWrap.fill();
 		horizWrap.expand();
-		horizWrap.setWidth(Gdx.input.getX() - horizWrap.getX());
+		horizWrap.setWidth(input.getX() - horizWrap.getX());
 		// horizWrap.setHeight(horizWrap.getPrefHeight());
 		horizWrap.setHeight(200);
 
-		vert.setHeight(Gdx.graphics.getHeight() - Gdx.input.getY() - vert.getY());
+		vert.setHeight(graphics.getHeight() - input.getY() - vert.getY());
 		// vert.setWidth(200);
-		vertWrap.setHeight(Gdx.graphics.getHeight() - Gdx.input.getY() - vertWrap.getY());
+		vertWrap.setHeight(graphics.getHeight() - input.getY() - vertWrap.getY());
 // vertWrap.setWidth(vertWrap.getPrefWidth());
 		vertWrap.setWidth(200);
 
@@ -161,14 +160,14 @@ public class GroupTest extends GdxTest {
 		renderer.begin(ShapeType.Filled);
 		if (MathUtils.randomBoolean()) { // So we see when they are drawn on top of each other (which should be always).
 			renderer.setColor(Color.GREEN);
-			renderer.circle(group1.toScreenCoordinates.x, Gdx.graphics.getHeight() - group1.toScreenCoordinates.y, 5);
+			renderer.circle(group1.toScreenCoordinates.x, graphics.getHeight() - group1.toScreenCoordinates.y, 5);
 			renderer.setColor(Color.RED);
-			renderer.circle(group1.localToParentCoordinates.x, Gdx.graphics.getHeight() - group1.localToParentCoordinates.y, 5);
+			renderer.circle(group1.localToParentCoordinates.x, graphics.getHeight() - group1.localToParentCoordinates.y, 5);
 		} else {
 			renderer.setColor(Color.RED);
-			renderer.circle(group1.localToParentCoordinates.x, Gdx.graphics.getHeight() - group1.localToParentCoordinates.y, 5);
+			renderer.circle(group1.localToParentCoordinates.x, graphics.getHeight() - group1.localToParentCoordinates.y, 5);
 			renderer.setColor(Color.GREEN);
-			renderer.circle(group1.toScreenCoordinates.x, Gdx.graphics.getHeight() - group1.toScreenCoordinates.y, 5);
+			renderer.circle(group1.toScreenCoordinates.x, graphics.getHeight() - group1.toScreenCoordinates.y, 5);
 		}
 		renderer.end();
 	}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/HexagonalTiledMapTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/HexagonalTiledMapTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
@@ -41,17 +40,17 @@ public class HexagonalTiledMapTest extends GdxTest {
 	@Override
 	public void create () {
 		super.create();
-		float w = Gdx.graphics.getWidth();
-		float h = Gdx.graphics.getHeight();
+		float w = graphics.getWidth();
+		float h = graphics.getHeight();
 
 		camera = new OrthographicCamera();
 		camera.setToOrtho(false, (w / h) * 480, 480);
 		camera.update();
 
 		cameraController = new OrthoCamController(camera);
-		Gdx.input.setInputProcessor(cameraController);
+		input.setInputProcessor(cameraController);
 
-		hexture = new Texture(Gdx.files.internal("data/maps/tiled/hex/hexes.png"));
+		hexture = new Texture(files.internal("data/maps/tiled/hex/hexes.png"));
 		TextureRegion[][] hexes = TextureRegion.split(hexture, 112, 97);
 		map = new TiledMap();
 		MapLayers layers = map.getLayers();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/I18NMessageTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/I18NMessageTest.java
@@ -19,7 +19,6 @@ package com.badlogic.gdx.tests;
 import java.util.Date;
 import java.util.Locale;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
@@ -51,7 +50,7 @@ public class I18NMessageTest extends GdxTest {
 		I18NBundle.setSimpleFormatter(false);
 
 		try {
-			FileHandle bfh = Gdx.files.internal("data/i18n/message1");
+			FileHandle bfh = files.internal("data/i18n/message1");
 			rb_root = I18NBundle.createBundle(bfh, Locale.ROOT);
 			rb_default = I18NBundle.createBundle(bfh);
 			rb_en = I18NBundle.createBundle(bfh, new Locale("en", "US"));
@@ -74,12 +73,12 @@ public class I18NMessageTest extends GdxTest {
 			println(getParametricMessage("it", rb_it));
 			println(getParametricMessage("unsupported", rb_unsupported));
 
-			Gdx.app.log("", message);
+			app.log("", message);
 
 		} catch (Throwable t) {
 			message = "FAILED: " + t.getMessage() + "\n";
 			message += t.getClass();
-			Gdx.app.error(I18NMessageTest.class.getSimpleName(), "Error", t);
+			app.error(I18NMessageTest.class.getSimpleName(), "Error", t);
 		}
 	}
 
@@ -98,9 +97,9 @@ public class I18NMessageTest extends GdxTest {
 
 	@Override
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		batch.begin();
-		font.draw(batch, message, 20, Gdx.graphics.getHeight() - 20);
+		font.draw(batch, message, 20, graphics.getHeight() - 20);
 		batch.end();
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/I18NSimpleMessageTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/I18NSimpleMessageTest.java
@@ -19,7 +19,6 @@ package com.badlogic.gdx.tests;
 import java.util.Date;
 import java.util.Locale;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
@@ -51,7 +50,7 @@ public class I18NSimpleMessageTest extends GdxTest {
 		I18NBundle.setSimpleFormatter(true);
 
 		try {
-			FileHandle bfh = Gdx.files.internal("data/i18n/message2");
+			FileHandle bfh = files.internal("data/i18n/message2");
 			rb_root = I18NBundle.createBundle(bfh, Locale.ROOT);
 			rb_default = I18NBundle.createBundle(bfh);
 			rb_en = I18NBundle.createBundle(bfh, new Locale("en", "US"));
@@ -74,12 +73,12 @@ public class I18NSimpleMessageTest extends GdxTest {
 			println(getParametricMessage("it", rb_it));
 			println(getParametricMessage("unsupported", rb_unsupported));
 
-			Gdx.app.log("", message);
+			app.log("", message);
 
 		} catch (Throwable t) {
 			message = "FAILED: " + t.getMessage() + "\n";
 			message += t.getClass();
-			Gdx.app.error(I18NSimpleMessageTest.class.getSimpleName(), "Error", t);
+			app.error(I18NSimpleMessageTest.class.getSimpleName(), "Error", t);
 		}
 	}
 
@@ -98,9 +97,9 @@ public class I18NSimpleMessageTest extends GdxTest {
 
 	@Override
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		batch.begin();
-		font.draw(batch, message, 20, Gdx.graphics.getHeight() - 20);
+		font.draw(batch, message, 20, graphics.getHeight() - 20);
 		batch.end();
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ImageScaleTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ImageScaleTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.scenes.scene2d.ui.Image;
@@ -30,7 +29,7 @@ public class ImageScaleTest extends GdxTest {
 
 	public void create () {
 		stage = new Stage();
-		Gdx.input.setInputProcessor(stage);
+		input.setInputProcessor(stage);
 
 		texture = new Texture("data/group-debug.png");
 		Image image = new Image(texture);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ImageTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ImageTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.scenes.scene2d.Stage;
@@ -35,13 +34,13 @@ public class ImageTest extends GdxTest {
 
 	@Override
 	public void create () {
-		skin = new Skin(Gdx.files.internal("data/uiskin.json"));
-		image2 = new TextureRegion(new Texture(Gdx.files.internal("data/badlogic.jpg")));
+		skin = new Skin(files.internal("data/uiskin.json"));
+		image2 = new TextureRegion(new Texture(files.internal("data/badlogic.jpg")));
 		ui = new Stage();
-		Gdx.input.setInputProcessor(ui);
+		input.setInputProcessor(ui);
 
 		root = new Table();
-		root.setSize(Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+		root.setSize(graphics.getWidth(), graphics.getHeight());
 		ui.addActor(root);
 		root.debug();
 
@@ -60,7 +59,7 @@ public class ImageTest extends GdxTest {
 	@Override
 	public void render () {
 		ScreenUtils.clear(0.2f, 0.2f, 0.2f, 1);
-		ui.act(Math.min(Gdx.graphics.getDeltaTime(), 1 / 30f));
+		ui.act(Math.min(graphics.getDeltaTime(), 1 / 30f));
 		ui.draw();
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ImmediateModeRendererTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ImmediateModeRendererTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.glutils.ImmediateModeRenderer;
@@ -36,8 +35,8 @@ public class ImmediateModeRendererTest extends GdxTest {
 
 	@Override
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-		Gdx.gl.glEnable(GL20.GL_TEXTURE_2D);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl.glEnable(GL20.GL_TEXTURE_2D);
 		texture.bind();
 		renderer.begin(projMatrix, GL20.GL_TRIANGLES);
 		renderer.texCoord(0, 0);
@@ -55,6 +54,6 @@ public class ImmediateModeRendererTest extends GdxTest {
 	@Override
 	public void create () {
 		renderer = new ImmediateModeRenderer20(false, true, 1);
-		texture = new Texture(Gdx.files.internal("data/badlogic.jpg"));
+		texture = new Texture(files.internal("data/badlogic.jpg"));
 	}
 }

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/IndexBufferObjectShaderTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/IndexBufferObjectShaderTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Texture;
@@ -45,15 +44,15 @@ public class IndexBufferObjectShaderTest extends GdxTest {
 	public void render () {
 // System.out.println( "render");
 
-		Gdx.gl.glViewport(0, 0, Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight());
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl.glViewport(0, 0, graphics.getBackBufferWidth(), graphics.getBackBufferHeight());
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 
 		shader.bind();
 		shader.setUniformi("u_texture", 0);
 		texture.bind();
 		vbo.bind(shader);
 		ibo.bind();
-		Gdx.gl20.glDrawElements(GL20.GL_TRIANGLES, 3, GL20.GL_UNSIGNED_SHORT, 0);
+		gl20.glDrawElements(GL20.GL_TRIANGLES, 3, GL20.GL_UNSIGNED_SHORT, 0);
 		ibo.unbind();
 		vbo.unbind(shader);
 	}
@@ -80,7 +79,7 @@ public class IndexBufferObjectShaderTest extends GdxTest {
 		ibo = new IndexBufferObject(true, 3);
 		ibo.setIndices(new short[] {0, 1, 2}, 0, 3);
 
-		texture = new Texture(Gdx.files.internal("data/badlogic.jpg"));
+		texture = new Texture(files.internal("data/badlogic.jpg"));
 	}
 
 	@Override

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/InputTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/InputTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input.Buttons;
 import com.badlogic.gdx.Input.Keys;
 import com.badlogic.gdx.InputProcessor;
@@ -26,89 +25,89 @@ public class InputTest extends GdxTest implements InputProcessor {
 
 	@Override
 	public void create () {
-// Gdx.input = new RemoteInput();
-		Gdx.input.setInputProcessor(this);
-// Gdx.input.setCursorCatched(true);
+// input = new RemoteInput();
+		input.setInputProcessor(this);
+// input.setCursorCatched(true);
 //
-// Gdx.input.getTextInput(new Input.TextInputListener() {
+// input.getTextInput(new Input.TextInputListener() {
 // @Override
 // public void input(String text) {
-// Gdx.app.log("Input test", "Input value: " + text);
+// app.log("Input test", "Input value: " + text);
 // }
 //
 // @Override
 // public void canceled() {
-// Gdx.app.log("Input test", "Canceled input text");
+// app.log("Input test", "Canceled input text");
 // }
 // }, "Title", "Text", "Placeholder");
 	}
 
 	@Override
 	public void render () {
-		if (Gdx.input.justTouched()) {
-			Gdx.app.log("Input Test", "just touched, button: " + (Gdx.input.isButtonPressed(Buttons.LEFT) ? "left " : "")
-				+ (Gdx.input.isButtonPressed(Buttons.MIDDLE) ? "middle " : "")
-				+ (Gdx.input.isButtonPressed(Buttons.RIGHT) ? "right" : "") + (Gdx.input.isButtonPressed(Buttons.BACK) ? "back" : "")
-				+ (Gdx.input.isButtonPressed(Buttons.FORWARD) ? "forward" : ""));
+		if (input.justTouched()) {
+			app.log("Input Test", "just touched, button: " + (input.isButtonPressed(Buttons.LEFT) ? "left " : "")
+				+ (input.isButtonPressed(Buttons.MIDDLE) ? "middle " : "")
+				+ (input.isButtonPressed(Buttons.RIGHT) ? "right" : "") + (input.isButtonPressed(Buttons.BACK) ? "back" : "")
+				+ (input.isButtonPressed(Buttons.FORWARD) ? "forward" : ""));
 		}
 
 		for (int i = 0; i < 10; i++) {
-			if (Gdx.input.getDeltaX(i) != 0 || Gdx.input.getDeltaY(i) != 0) {
-				Gdx.app.log("Input Test", "delta[" + i + "]: " + Gdx.input.getDeltaX(i) + ", " + Gdx.input.getDeltaY(i));
+			if (input.getDeltaX(i) != 0 || input.getDeltaY(i) != 0) {
+				app.log("Input Test", "delta[" + i + "]: " + input.getDeltaX(i) + ", " + input.getDeltaY(i));
 			}
 		}
-// Gdx.input.setCursorPosition(Gdx.graphics.getWidth() / 2, Gdx.graphics.getHeight() / 2);
-// if(Gdx.input.isTouched()) {
-// Gdx.app.log("Input Test", "is touched");
+// input.setCursorPosition(graphics.getWidth() / 2, graphics.getHeight() / 2);
+// if(input.isTouched()) {
+// app.log("Input Test", "is touched");
 // }
 	}
 
 	@Override
 	public boolean keyDown (int keycode) {
-		Gdx.app.log("Input Test", "key down: " + keycode);
-		if (keycode == Keys.G) Gdx.input.setCursorCatched(!Gdx.input.isCursorCatched());
+		app.log("Input Test", "key down: " + keycode);
+		if (keycode == Keys.G) input.setCursorCatched(!input.isCursorCatched());
 		return false;
 	}
 
 	@Override
 	public boolean keyTyped (char character) {
-		Gdx.app.log("Input Test", "key typed: '" + character + "'");
+		app.log("Input Test", "key typed: '" + character + "'");
 		return false;
 	}
 
 	@Override
 	public boolean keyUp (int keycode) {
-		Gdx.app.log("Input Test", "key up: " + keycode);
+		app.log("Input Test", "key up: " + keycode);
 		return false;
 	}
 
 	@Override
 	public boolean touchDown (int x, int y, int pointer, int button) {
-		Gdx.app.log("Input Test", "touch down: " + x + ", " + y + ", button: " + getButtonString(button));
+		app.log("Input Test", "touch down: " + x + ", " + y + ", button: " + getButtonString(button));
 		return false;
 	}
 
 	@Override
 	public boolean touchDragged (int x, int y, int pointer) {
-		Gdx.app.log("Input Test", "touch dragged: " + x + ", " + y + ", pointer: " + pointer);
+		app.log("Input Test", "touch dragged: " + x + ", " + y + ", pointer: " + pointer);
 		return false;
 	}
 
 	@Override
 	public boolean touchUp (int x, int y, int pointer, int button) {
-		Gdx.app.log("Input Test", "touch up: " + x + ", " + y + ", button: " + getButtonString(button));
+		app.log("Input Test", "touch up: " + x + ", " + y + ", button: " + getButtonString(button));
 		return false;
 	}
 
 	@Override
 	public boolean mouseMoved (int x, int y) {
-		Gdx.app.log("Input Test", "touch moved: " + x + ", " + y);
+		app.log("Input Test", "touch moved: " + x + ", " + y);
 		return false;
 	}
 
 	@Override
 	public boolean scrolled (float amountX, float amountY) {
-		Gdx.app.log("Input Test", "scrolled: " + amountY);
+		app.log("Input Test", "scrolled: " + amountY);
 		return false;
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/IntegerBitmapFontTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/IntegerBitmapFontTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.graphics.g2d.BitmapFontCache;
@@ -36,7 +35,7 @@ public class IntegerBitmapFontTest extends GdxTest {
 
 	public void create () {
 		TextureAtlas textureAtlas = new TextureAtlas("data/pack.atlas");
-		font = new BitmapFont(Gdx.files.internal("data/verdana39.fnt"), textureAtlas.findRegion("verdana39"), false);
+		font = new BitmapFont(files.internal("data/verdana39.fnt"), textureAtlas.findRegion("verdana39"), false);
 		singleLineCache = new BitmapFontCache(font, true);
 		multiLineCache = new BitmapFontCache(font, true);
 		singleLineCacheNonInteger = new BitmapFontCache(font, false);
@@ -52,7 +51,7 @@ public class IntegerBitmapFontTest extends GdxTest {
 	}
 
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		batch.begin();
 		font.setUseIntegerPositions(false);
 		font.setColor(1, 0, 0, 1);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/InterpolationTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/InterpolationTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input.Keys;
 import com.badlogic.gdx.InputAdapter;
 import com.badlogic.gdx.InputMultiplexer;
@@ -76,10 +75,10 @@ public class InterpolationTest extends GdxTest {
 
 	@Override
 	public void create () {
-		Gdx.gl.glClearColor(.3f, .3f, .3f, 1);
+		gl.glClearColor(.3f, .3f, .3f, 1);
 		renderer = new ShapeRenderer();
 
-		skin = new Skin(Gdx.files.internal("data/uiskin.json"));
+		skin = new Skin(files.internal("data/uiskin.json"));
 
 		stage = new Stage(new ScreenViewport());
 		resetPositions();
@@ -118,9 +117,9 @@ public class InterpolationTest extends GdxTest {
 		table.add(scroll).expandX().left().width(100);
 		stage.addActor(table);
 
-		Gdx.input.setInputProcessor(new InputMultiplexer(new InputAdapter() {
+		input.setInputProcessor(new InputMultiplexer(new InputAdapter() {
 			public boolean scrolled (float amountX, float amountY) {
-				if (!Gdx.input.isKeyPressed(Keys.CONTROL_LEFT)) return false;
+				if (!input.isKeyPressed(Keys.CONTROL_LEFT)) return false;
 				duration -= amountY / 15f;
 				duration = MathUtils.clamp(duration, 0, Float.POSITIVE_INFINITY);
 				return true;
@@ -139,9 +138,9 @@ public class InterpolationTest extends GdxTest {
 	}
 
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 
-		float bottomLeftX = Gdx.graphics.getWidth() / 2 - graphSize / 2, bottomLeftY = Gdx.graphics.getHeight() / 2 - graphSize / 2;
+		float bottomLeftX = graphics.getWidth() / 2 - graphSize / 2, bottomLeftY = graphics.getHeight() / 2 - graphSize / 2;
 
 		// only show up to two decimals
 		String text = String.valueOf(duration);
@@ -163,7 +162,7 @@ public class InterpolationTest extends GdxTest {
 			lastX = x;
 			lastY = y;
 		}
-		time += Gdx.graphics.getDeltaTime();
+		time += graphics.getDeltaTime();
 		if (time > duration) {
 			time = Float.NaN; // stop "walking"
 			startPosition.set(targetPosition); // set startPosition to targetPosition for next click

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/IntersectorOverlapConvexPolygonsTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/IntersectorOverlapConvexPolygonsTest.java
@@ -2,7 +2,6 @@
 package com.badlogic.gdx.tests;
 
 import com.badlogic.gdx.Application;
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.OrthographicCamera;
@@ -34,7 +33,7 @@ public class IntersectorOverlapConvexPolygonsTest extends GdxTest {
 
 	@Override
 	public void create () {
-		Gdx.app.setLogLevel(Application.LOG_DEBUG);
+		app.setLogLevel(Application.LOG_DEBUG);
 		camera = new OrthographicCamera();
 		camera.setToOrtho(false);
 		camera.position.set(0, 0, 0);
@@ -53,29 +52,29 @@ public class IntersectorOverlapConvexPolygonsTest extends GdxTest {
 	}
 
 	private void update (float deltaTime) {
-		if (Gdx.input.isKeyJustPressed(Input.Keys.SPACE)) {
+		if (input.isKeyJustPressed(Input.Keys.SPACE)) {
 			Intersector.overlapConvexPolygons(shape1, shape2, mtv);
 			float x = shape1.getX() + (mtv.normal.x * mtv.depth);
 			float y = shape1.getY() + (mtv.normal.y * mtv.depth);
 			shape1.setPosition(x, y);
-			Gdx.app.debug(TAG, mtv.normal + " " + mtv.depth);
+			app.debug(TAG, mtv.normal + " " + mtv.depth);
 		}
-		if (Gdx.input.isButtonPressed(Input.Buttons.LEFT)) {
-			mouseCoords.set(Gdx.input.getX(), Gdx.input.getY(), 0);
+		if (input.isButtonPressed(Input.Buttons.LEFT)) {
+			mouseCoords.set(input.getX(), input.getY(), 0);
 			camera.unproject(mouseCoords);
 			shape1.setPosition(mouseCoords.x, mouseCoords.y);
 			boolean overlaps = Intersector.overlapConvexPolygons(shape1, shape2, mtv);
-			Gdx.app.debug(TAG, mtv.normal + " " + mtv.depth + " overlaps: " + overlaps + " " + mouseCoords);
-		} else if (Gdx.input.isButtonJustPressed(Input.Buttons.RIGHT)) {
+			app.debug(TAG, mtv.normal + " " + mtv.depth + " overlaps: " + overlaps + " " + mouseCoords);
+		} else if (input.isButtonJustPressed(Input.Buttons.RIGHT)) {
 			shape1.rotate(90);
 			boolean overlaps = Intersector.overlapConvexPolygons(shape1, shape2, mtv);
-			Gdx.app.debug(TAG, mtv.normal + " " + mtv.depth + " overlaps: " + overlaps);
+			app.debug(TAG, mtv.normal + " " + mtv.depth + " overlaps: " + overlaps);
 		}
 	}
 
 	@Override
 	public void render () {
-		update(Gdx.graphics.getDeltaTime());
+		update(graphics.getDeltaTime());
 		camera.update();
 		ScreenUtils.clear(0f, 0f, 0f, 0f, true);
 		shapeRenderer.setProjectionMatrix(camera.combined);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/InverseKinematicsTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/InverseKinematicsTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
@@ -55,7 +54,7 @@ public class InverseKinematicsTest extends GdxTest {
 
 	@Override
 	public void create () {
-		float aspect = Gdx.graphics.getWidth() / (float)Gdx.graphics.getHeight();
+		float aspect = graphics.getWidth() / (float)graphics.getHeight();
 		camera = new OrthographicCamera(15 * aspect, 15);
 		camera.update();
 		renderer = new ShapeRenderer();
@@ -73,12 +72,12 @@ public class InverseKinematicsTest extends GdxTest {
 
 	@Override
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 
 		camera.update();
 		renderer.setProjectionMatrix(camera.combined);
 
-		if (Gdx.input.isTouched()) camera.unproject(globalCoords.set(Gdx.input.getX(), Gdx.input.getY(), 0));
+		if (input.isTouched()) camera.unproject(globalCoords.set(input.getX(), input.getY(), 0));
 		solveFakeIK(globalCoords);
 		renderBones();
 	}
@@ -100,7 +99,7 @@ public class InverseKinematicsTest extends GdxTest {
 	}
 
 	public void solveFakeIK (Vector3 target) {
-		float gravity = Gdx.graphics.getDeltaTime() * GRAVITY;
+		float gravity = graphics.getDeltaTime() * GRAVITY;
 
 		endPoint.set(target);
 		bones[0].position.set(endPoint);
@@ -116,7 +115,7 @@ public class InverseKinematicsTest extends GdxTest {
 
 			float x = endPoint.x - diff.x;
 			float y = endPoint.y - diff.y;
-			float delta = Gdx.graphics.getDeltaTime();
+			float delta = graphics.getDeltaTime();
 			bones[i + 1].inertia.add((bones[i + 1].position.x - x) * delta, (bones[i + 1].position.y - y) * delta, 0).scl(0.99f);
 			bones[i + 1].position.set(x, y, 0);
 		}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/IsometricTileTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/IsometricTileTest.java
@@ -18,7 +18,6 @@ package com.badlogic.gdx.tests;
 
 import java.util.Random;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.graphics.Texture;
@@ -53,10 +52,10 @@ public class IsometricTileTest extends GdxTest {
 	public void create () {
 		cam = new OrthographicCamera(480, 320);
 		camController = new OrthoCamController(cam);
-		Gdx.input.setInputProcessor(camController);
+		input.setInputProcessor(camController);
 
 		renderer = new ShapeRenderer();
-		texture = new Texture(Gdx.files.internal("data/isotile.png"));
+		texture = new Texture(files.internal("data/isotile.png"));
 
 		Random rand = new Random();
 		for (int i = 0; i < LAYERS; i++) {
@@ -93,8 +92,8 @@ public class IsometricTileTest extends GdxTest {
 		ScreenUtils.clear(0.7f, 0.7f, 0.7f, 1f);
 		cam.update();
 
-		Gdx.gl.glEnable(GL20.GL_BLEND);
-		Gdx.gl.glBlendFunc(GL20.GL_SRC_ALPHA, GL20.GL_ONE_MINUS_SRC_ALPHA);
+		gl.glEnable(GL20.GL_BLEND);
+		gl.glBlendFunc(GL20.GL_SRC_ALPHA, GL20.GL_ONE_MINUS_SRC_ALPHA);
 		for (int i = 0; i < LAYERS; i++) {
 			SpriteCache cache = caches[i];
 			cache.setProjectionMatrix(cam.combined);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/KTXTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/KTXTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.InputMultiplexer;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Cubemap;
@@ -95,7 +94,7 @@ public class KTXTest extends GdxTest {
 			+ "}\n";
 		modelBatch = new ModelBatch(new DefaultShaderProvider(new Config(cubemapVS, cubemapFS)));
 
-		cubemap = new Cubemap(new KTXTextureData(Gdx.files.internal("data/cubemap.zktx"), true));
+		cubemap = new Cubemap(new KTXTextureData(files.internal("data/cubemap.zktx"), true));
 		cubemap.setFilter(TextureFilter.MipMapLinearLinear, TextureFilter.Linear);
 
 		environment = new Environment();
@@ -103,7 +102,7 @@ public class KTXTest extends GdxTest {
 		environment.add(new DirectionalLight().set(0.8f, 0.8f, 0.8f, -0.5f, -1.0f, -0.8f));
 		environment.set(new CubemapAttribute(CubemapAttribute.EnvironmentMap, cubemap));
 
-		perspectiveCamera = new PerspectiveCamera(67, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+		perspectiveCamera = new PerspectiveCamera(67, graphics.getWidth(), graphics.getHeight());
 		perspectiveCamera.position.set(10f, 10f, 10f);
 		perspectiveCamera.lookAt(0, 0, 0);
 		perspectiveCamera.near = 0.1f;
@@ -115,7 +114,7 @@ public class KTXTest extends GdxTest {
 			Usage.Position | Usage.Normal);
 		instance = new ModelInstance(model);
 
-		Gdx.input.setInputProcessor(new InputMultiplexer(this, inputController = new CameraInputController(perspectiveCamera)));
+		input.setInputProcessor(new InputMultiplexer(this, inputController = new CameraInputController(perspectiveCamera)));
 
 		// 2D texture test
 		String etc1aVS = "" //
@@ -148,7 +147,7 @@ public class KTXTest extends GdxTest {
 			+ "   gl_FragColor = vec4(col, alpha) * v_color;\n"//
 			+ "}\n";//
 		etc1aShader = new ShaderProgram(etc1aVS, etc1aFS);
-		orthoCamera = new OrthographicCamera(Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+		orthoCamera = new OrthographicCamera(graphics.getWidth(), graphics.getHeight());
 		image = new Texture("data/egg.zktx");
 		batch = new SpriteBatch(100, etc1aShader);
 
@@ -156,15 +155,15 @@ public class KTXTest extends GdxTest {
 
 	@Override
 	public void render () {
-		time += Gdx.graphics.getDeltaTime();
+		time += graphics.getDeltaTime();
 		inputController.update();
-		int gw = Gdx.graphics.getWidth(), gh = Gdx.graphics.getHeight();
+		int gw = graphics.getWidth(), gh = graphics.getHeight();
 		int pw = gw > gh ? gw / 2 : gw, ph = gw > gh ? gh : gh / 2;
 
 		ScreenUtils.clear(0, 0, 0, 1, true);
 
 		// cubemap
-		Gdx.gl.glViewport(gw - pw, gh - ph, pw, ph);
+		gl.glViewport(gw - pw, gh - ph, pw, ph);
 		perspectiveCamera.viewportWidth = pw;
 		perspectiveCamera.viewportHeight = ph;
 		perspectiveCamera.update();
@@ -173,7 +172,7 @@ public class KTXTest extends GdxTest {
 		modelBatch.end();
 
 		// 2D texture with alpha & ETC1
-		Gdx.gl.glViewport(0, 0, pw, ph);
+		gl.glViewport(0, 0, pw, ph);
 		orthoCamera.viewportWidth = pw;
 		orthoCamera.viewportHeight = ph;
 		orthoCamera.update();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/KinematicBodyTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/KinematicBodyTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.math.Vector2;
@@ -56,8 +55,8 @@ public class KinematicBodyTest extends GdxTest {
 	}
 
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-		world.step(Math.min(0.032f, Gdx.graphics.getDeltaTime()), 3, 4);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		world.step(Math.min(0.032f, graphics.getDeltaTime()), 3, 4);
 		cam.update();
 		renderer.render(world, cam.combined);
 	}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/LabelScaleTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/LabelScaleTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.Stage;
@@ -35,9 +34,9 @@ public class LabelScaleTest extends GdxTest {
 	@Override
 	public void create () {
 		batch = new SpriteBatch();
-		skin = new Skin(Gdx.files.internal("data/uiskin.json"));
+		skin = new Skin(files.internal("data/uiskin.json"));
 		stage = new Stage();
-		Gdx.input.setInputProcessor(stage);
+		input.setInputProcessor(stage);
 
 		Table table = new Table();
 		stage.addActor(table);
@@ -67,7 +66,7 @@ public class LabelScaleTest extends GdxTest {
 	public void render () {
 		ScreenUtils.clear(0.2f, 0.2f, 0.2f, 1);
 
-		stage.act(Math.min(Gdx.graphics.getDeltaTime(), 1 / 30f));
+		stage.act(Math.min(graphics.getDeltaTime(), 1 / 30f));
 		stage.draw();
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/LabelTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/LabelTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Texture.TextureFilter;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
@@ -46,12 +45,12 @@ public class LabelTest extends GdxTest {
 	public void create () {
 		batch = new SpriteBatch();
 		renderer = new ShapeRenderer();
-		skin = new Skin(Gdx.files.internal("data/uiskin.json"));
+		skin = new Skin(files.internal("data/uiskin.json"));
 		skin.getAtlas().getTextures().iterator().next().setFilter(TextureFilter.Nearest, TextureFilter.Nearest);
 		skin.getFont("default-font").getData().markupEnabled = true;
 		skin.getFont("default-font").getData().setScale(scale);
 		stage = new Stage(new ScreenViewport());
-		Gdx.input.setInputProcessor(stage);
+		input.setInputProcessor(stage);
 
 		// skin.getFont("default-font").getData().getGlyph('T').xoffset = -20;
 		skin.getFont("default-font").getData().getGlyph('B').setKerning('B', -5);
@@ -122,7 +121,7 @@ public class LabelTest extends GdxTest {
 	public void render () {
 		ScreenUtils.clear(0.2f, 0.2f, 0.2f, 1);
 
-		stage.act(Math.min(Gdx.graphics.getDeltaTime(), 1 / 30f));
+		stage.act(Math.min(graphics.getDeltaTime(), 1 / 30f));
 		stage.draw();
 
 		float x = 40, y = 15 + 20 * scale;

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/LifeCycleTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/LifeCycleTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.tests.utils.GdxTest;
 
@@ -27,32 +26,32 @@ public class LifeCycleTest extends GdxTest {
 
 	@Override
 	public void dispose () {
-		Gdx.app.log("Test", "app destroyed");
+		app.log("Test", "app destroyed");
 	}
 
 	@Override
 	public void pause () {
-		Gdx.app.log("Test", "app paused");
+		app.log("Test", "app paused");
 	}
 
 	@Override
 	public void resume () {
-		Gdx.app.log("Test", "app resumed");
+		app.log("Test", "app resumed");
 	}
 
 	@Override
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 	}
 
 	@Override
 	public void create () {
-		Gdx.app.log("Test", "app created: " + Gdx.graphics.getWidth() + "x" + Gdx.graphics.getHeight());
+		app.log("Test", "app created: " + graphics.getWidth() + "x" + graphics.getHeight());
 	}
 
 	@Override
 	public void resize (int width, int height) {
-		Gdx.app.log("Test",
-			"app resized: " + width + "x" + height + ", Graphics says: " + Gdx.graphics.getWidth() + "x" + Gdx.graphics.getHeight());
+		app.log("Test",
+			"app resized: " + width + "x" + height + ", Graphics says: " + graphics.getWidth() + "x" + graphics.getHeight());
 	}
 }

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/MatrixJNITest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/MatrixJNITest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.math.Matrix4;
 import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.tests.utils.GdxTest;
@@ -86,44 +85,44 @@ public class MatrixJNITest extends GdxTest {
 		for (int i = 0; i < 1000000; i++) {
 			mata.mul(matb);
 		}
-		Gdx.app.log("MatrixJNITest", "java matrix * matrix took: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
+		app.log("MatrixJNITest", "java matrix * matrix took: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
 
 		start = TimeUtils.nanoTime();
 		for (int i = 0; i < 1000000; i++) {
 			Matrix4.mul(mata.val, matb.val);
 		}
-		Gdx.app.log("MatrixJNITest", "jni matrix * matrix took: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
+		app.log("MatrixJNITest", "jni matrix * matrix took: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
 
 		Vector3 vec = new Vector3();
 		start = TimeUtils.nanoTime();
 		for (int i = 0; i < 500000; i++) {
 			vec.mul(mata);
 		}
-		Gdx.app.log("MatrixJNITest", "java vecs * matrix took: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
+		app.log("MatrixJNITest", "java vecs * matrix took: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
 
 		float[] fvec = new float[3];
 		start = TimeUtils.nanoTime();
 		for (int i = 0; i < 500000; i++) {
 			Matrix4.mulVec(mata.val, fvec);
 		}
-		Gdx.app.log("MatrixJNITest", "jni vecs * matrix took: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
+		app.log("MatrixJNITest", "jni vecs * matrix took: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
 
 		float[] fvecs = new float[3 * 500000];
 		start = TimeUtils.nanoTime();
 		Matrix4.mulVec(mata.val, fvecs, 0, 500000, 3);
-		Gdx.app.log("MatrixJNITest", "jni bulk vecs * matrix took: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
+		app.log("MatrixJNITest", "jni bulk vecs * matrix took: " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
 
 		start = TimeUtils.nanoTime();
 		for (int i = 0; i < 1000000; i++) {
 			mata.inv();
 		}
-		Gdx.app.log("MatrixJNITest", "java inv(matrix): " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
+		app.log("MatrixJNITest", "java inv(matrix): " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
 
 		start = TimeUtils.nanoTime();
 		for (int i = 0; i < 1000000; i++) {
 			Matrix4.inv(mata.val);
 		}
-		Gdx.app.log("MatrixJNITest", "jni inv(matrix): " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
+		app.log("MatrixJNITest", "jni inv(matrix): " + (TimeUtils.nanoTime() - start) / 1000000000.0f);
 	}
 
 	private void check (Vector3 vec, float[] fvec) {

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/MeshShaderTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/MeshShaderTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Mesh;
@@ -49,8 +48,8 @@ public class MeshShaderTest extends GdxTest {
 
 		shader = new ShaderProgram(vertexShader, fragmentShader);
 		if (shader.isCompiled() == false) {
-			Gdx.app.log("ShaderTest", shader.getLog());
-			Gdx.app.exit();
+			app.log("ShaderTest", shader.getLog());
+			app.exit();
 		}
 
 		mesh = new Mesh(true, 4, 6, VertexAttribute.Position(), VertexAttribute.ColorUnpacked(), VertexAttribute.TexCoords(0));
@@ -66,7 +65,7 @@ public class MeshShaderTest extends GdxTest {
 			Color.WHITE_FLOAT_BITS, toSingleFloat(0, 0)});
 		meshCustomVA.setIndices(new short[] {0, 1, 2, 2, 3, 0});
 
-		texture = new Texture(Gdx.files.internal("data/bobrgb888-32x32.png"));
+		texture = new Texture(files.internal("data/bobrgb888-32x32.png"));
 	}
 
 	private static float toSingleFloat (float u, float v) {
@@ -79,17 +78,17 @@ public class MeshShaderTest extends GdxTest {
 
 	@Override
 	public void render () {
-		angle += Gdx.graphics.getDeltaTime() * 45;
+		angle += graphics.getDeltaTime() * 45;
 		matrix.setToRotation(axis, angle);
 
-		Mesh meshToDraw = Gdx.input.isButtonPressed(0) ? meshCustomVA : mesh;
+		Mesh meshToDraw = input.isButtonPressed(0) ? meshCustomVA : mesh;
 
-		Gdx.gl20.glViewport(0, 0, Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight());
-		Gdx.gl20.glClearColor(0.2f, 0.2f, 0.2f, 1);
-		Gdx.gl20.glClear(GL20.GL_COLOR_BUFFER_BIT);
-		Gdx.gl20.glEnable(GL20.GL_TEXTURE_2D);
-		Gdx.gl20.glEnable(GL20.GL_BLEND);
-		Gdx.gl20.glBlendFunc(GL20.GL_SRC_ALPHA, GL20.GL_ONE_MINUS_SRC_ALPHA);
+		gl20.glViewport(0, 0, graphics.getBackBufferWidth(), graphics.getBackBufferHeight());
+		gl20.glClearColor(0.2f, 0.2f, 0.2f, 1);
+		gl20.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl20.glEnable(GL20.GL_TEXTURE_2D);
+		gl20.glEnable(GL20.GL_BLEND);
+		gl20.glBlendFunc(GL20.GL_SRC_ALPHA, GL20.GL_ONE_MINUS_SRC_ALPHA);
 		texture.bind();
 		shader.bind();
 		shader.setUniformMatrix("u_worldView", matrix);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/MipMapTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/MipMapTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.InputMultiplexer;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Mesh;
@@ -56,7 +55,7 @@ public class MipMapTest extends GdxTest {
 
 	@Override
 	public void create () {
-		camera = new PerspectiveCamera(67, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+		camera = new PerspectiveCamera(67, graphics.getWidth(), graphics.getHeight());
 		camera.position.set(0, 1.5f, 1.5f);
 		camera.lookAt(0, 0, 0);
 		camera.update();
@@ -67,25 +66,25 @@ public class MipMapTest extends GdxTest {
 		mesh.setVertices(new float[] {-1, 0, 1, 0, 1, 1, 0, 1, 1, 1, 1, 0, -1, 1, 0, -1, 0, -1, 0, 0,});
 		mesh.setIndices(new short[] {0, 1, 2, 3});
 
-		shader = new ShaderProgram(Gdx.files.internal("data/shaders/flattex-vert.glsl").readString(),
-			Gdx.files.internal("data/shaders/flattex-frag.glsl").readString());
+		shader = new ShaderProgram(files.internal("data/shaders/flattex-vert.glsl").readString(),
+			files.internal("data/shaders/flattex-frag.glsl").readString());
 		if (!shader.isCompiled()) throw new GdxRuntimeException("shader error: " + shader.getLog());
 
-		textureHW = new Texture(Gdx.files.internal("data/badlogic.jpg"), Format.RGB565, true);
+		textureHW = new Texture(files.internal("data/badlogic.jpg"), Format.RGB565, true);
 		MipMapGenerator.setUseHardwareMipMap(false);
-		textureSW = new Texture(Gdx.files.internal("data/badlogic.jpg"), Format.RGB565, true);
+		textureSW = new Texture(files.internal("data/badlogic.jpg"), Format.RGB565, true);
 		currTexture = textureHW;
 
 		createUI();
 
 		multiplexer = new InputMultiplexer();
-		Gdx.input.setInputProcessor(multiplexer);
+		input.setInputProcessor(multiplexer);
 		multiplexer.addProcessor(ui);
 		multiplexer.addProcessor(controller);
 	}
 
 	private void createUI () {
-		skin = new Skin(Gdx.files.internal("data/uiskin.json"));
+		skin = new Skin(files.internal("data/uiskin.json"));
 		ui = new Stage();
 
 		String[] filters = new String[TextureFilter.values().length];
@@ -113,7 +112,7 @@ public class MipMapTest extends GdxTest {
 
 	@Override
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 
 		camera.update();
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/MultitouchTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/MultitouchTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input.Peripheral;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
@@ -41,18 +40,18 @@ public class MultitouchTest extends GdxTest {
 
 	@Override
 	public void render () {
-		Gdx.gl.glViewport(0, 0, Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight());
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl.glViewport(0, 0, graphics.getBackBufferWidth(), graphics.getBackBufferHeight());
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		camera.update();
 		renderer.setProjectionMatrix(camera.combined);
 		renderer.begin(ShapeType.Filled);
-		int size = Math.max(Gdx.graphics.getWidth(), Gdx.graphics.getHeight()) / 10;
+		int size = Math.max(graphics.getWidth(), graphics.getHeight()) / 10;
 		for (int i = 0; i < 10; i++) {
-			if (!Gdx.input.isTouched(i)) continue;
-			viewport.unproject(tp.set(Gdx.input.getX(i), Gdx.input.getY(i)));
+			if (!input.isTouched(i)) continue;
+			viewport.unproject(tp.set(input.getX(i), input.getY(i)));
 			Color color = colors[i % colors.length];
 			renderer.setColor(color);
-			float sSize = size * Gdx.input.getPressure(i);
+			float sSize = size * input.getPressure(i);
 			renderer.triangle(tp.x, tp.y + sSize, tp.x + sSize, tp.y - sSize, tp.x - sSize, tp.y - sSize);
 		}
 		renderer.end();
@@ -60,11 +59,11 @@ public class MultitouchTest extends GdxTest {
 
 	@Override
 	public void create () {
-		Gdx.app.log("Multitouch", "multitouch supported: " + Gdx.input.isPeripheralAvailable(Peripheral.MultitouchScreen));
+		app.log("Multitouch", "multitouch supported: " + input.isPeripheralAvailable(Peripheral.MultitouchScreen));
 		renderer = new ShapeRenderer();
 		camera = new OrthographicCamera();
 		viewport = new ScreenViewport(camera);
-		Gdx.input.setInputProcessor(this);
+		input.setInputProcessor(this);
 	}
 
 	@Override

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/MusicTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/MusicTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.audio.Music;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Texture;
@@ -66,7 +65,7 @@ public class MusicTest extends GdxTest {
 		batch = new SpriteBatch();
 
 		stage = new Stage(new ExtendViewport(600, 480));
-		Skin skin = new Skin(Gdx.files.internal("data/uiskin.json"));
+		Skin skin = new Skin(files.internal("data/uiskin.json"));
 
 		Table sliderTable = new Table();
 		label = new Label("", skin);
@@ -142,7 +141,7 @@ public class MusicTest extends GdxTest {
 		stage.addActor(table);
 		stage.addActor(footerTable);
 
-		Gdx.input.setInputProcessor(stage);
+		input.setInputProcessor(stage);
 	}
 
 	void setSong (Song song) {
@@ -152,23 +151,23 @@ public class MusicTest extends GdxTest {
 		switch (song) {
 		default:
 		case MP3_CLOCK:
-			music = Gdx.audio.newMusic(Gdx.files.internal("data/60bpm.mp3"));
+			music = audio.newMusic(files.internal("data/60bpm.mp3"));
 			songDuration = 5 * 60 + 4;
 			break;
 		case MP3:
-			music = Gdx.audio.newMusic(Gdx.files.internal("data/8.12.mp3"));
+			music = audio.newMusic(files.internal("data/8.12.mp3"));
 			songDuration = 183;
 			break;
 		case OGG:
-			music = Gdx.audio.newMusic(Gdx.files.internal("data/8.12.ogg"));
+			music = audio.newMusic(files.internal("data/8.12.ogg"));
 			songDuration = 183;
 			break;
 		case WAV:
-			music = Gdx.audio.newMusic(Gdx.files.internal("data/8.12.loop.wav"));
+			music = audio.newMusic(files.internal("data/8.12.loop.wav"));
 			songDuration = 4;
 			break;
 		case PCM8:
-			music = Gdx.audio.newMusic(Gdx.files.internal("data/8.12.loop-8bit.wav"));
+			music = audio.newMusic(files.internal("data/8.12.loop-8bit.wav"));
 			songDuration = 4;
 			break;
 		}
@@ -184,7 +183,7 @@ public class MusicTest extends GdxTest {
 
 	@Override
 	public void resume () {
-		System.out.println(Gdx.graphics.getDeltaTime());
+		System.out.println(graphics.getDeltaTime());
 	}
 
 	@Override
@@ -200,7 +199,7 @@ public class MusicTest extends GdxTest {
 		stage.draw();
 
 // if(music.isPlaying()){
-// time += Gdx.graphics.getDeltaTime();
+// time += graphics.getDeltaTime();
 // System.out.println("realtime: " + time + " music time: " + currentPosition);
 // }
 	}
@@ -212,6 +211,6 @@ public class MusicTest extends GdxTest {
 	}
 
 	private Drawable getDrawable (String path) {
-		return new TextureRegionDrawable(new TextureRegion(new Texture(Gdx.files.internal(path))));
+		return new TextureRegionDrawable(new TextureRegion(new Texture(files.internal(path))));
 	}
 }

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/NativeInputTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/NativeInputTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input.OnscreenKeyboardType;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.input.NativeInputConfiguration;
@@ -49,14 +48,14 @@ public class NativeInputTest extends GdxTest {
 
 	public void create () {
 		stage = new Stage();
-		skin = new Skin(Gdx.files.internal("data/uiskin.json"));
+		skin = new Skin(files.internal("data/uiskin.json"));
 
 		Table table = new Table();
 		table.addListener(new ClickListener() {
 			@Override
 			public void clicked (InputEvent event, float x, float y) {
 				if (!event.isStopped()) {
-					Gdx.input.closeTextInputField(false);
+					input.closeTextInputField(false);
 				}
 				super.clicked(event, x, y);
 			}
@@ -106,8 +105,8 @@ public class NativeInputTest extends GdxTest {
 		openInput.addListener(new ClickListener() {
 			@Override
 			public void clicked (InputEvent event, float x, float y) {
-				if (Gdx.input.isTextInputFieldOpened()) {
-					Gdx.input.closeTextInputField(false, (confirmative) -> {
+				if (input.isTextInputFieldOpened()) {
+					input.closeTextInputField(false, (confirmative) -> {
 						openNativeInputField();
 						return true;
 					});
@@ -148,7 +147,7 @@ public class NativeInputTest extends GdxTest {
 
 		stage.addActor(table);
 
-		Gdx.input.setInputProcessor(stage);
+		input.setInputProcessor(stage);
 	}
 
 	public void openNativeInputField () {
@@ -185,15 +184,15 @@ public class NativeInputTest extends GdxTest {
 		});
 		try {
 			configuration.validate();
-			Gdx.input.openTextInputField(configuration);
+			input.openTextInputField(configuration);
 		} catch (IllegalArgumentException e) {
 			resultArea.setText(e.getMessage());
 		}
 	}
 
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-		stage.act(Gdx.graphics.getDeltaTime());
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		stage.act(graphics.getDeltaTime());
 		stage.draw();
 	}
 }

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/NinePatchTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/NinePatchTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.graphics.Pixmap;
@@ -160,12 +159,12 @@ public class NinePatchTest extends GdxTest {
 
 	@Override
 	public void render () {
-		final int screenWidth = Gdx.graphics.getWidth();
-		final int screenHeight = Gdx.graphics.getHeight();
+		final int screenWidth = graphics.getWidth();
+		final int screenHeight = graphics.getHeight();
 
 		ScreenUtils.clear(0, 0, 0, 0);
 
-		timePassed += Gdx.graphics.getDeltaTime();
+		timePassed += graphics.getDeltaTime();
 
 		b.begin();
 		final int sz = ninePatches.size;
@@ -210,7 +209,7 @@ public class NinePatchTest extends GdxTest {
 
 	@Override
 	public void resize (int width, int height) {
-		float ratio = ((float)Gdx.graphics.getWidth() / (float)Gdx.graphics.getHeight());
+		float ratio = ((float)graphics.getWidth() / (float)graphics.getHeight());
 		int h = 10;
 		int w = (int)(h * ratio);
 		camera = new OrthographicCamera(w, h);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/NoncontinuousRenderingTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/NoncontinuousRenderingTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Graphics;
 import com.badlogic.gdx.graphics.Camera;
 import com.badlogic.gdx.graphics.Color;
@@ -61,15 +60,15 @@ public class NoncontinuousRenderingTest extends GdxTest {
 		texture = new Texture("data/badlogic.jpg");
 		region = new TextureRegion(texture);
 		stage = new Stage(new ScreenViewport(), batch);
-		Gdx.input.setInputProcessor(stage);
+		input.setInputProcessor(stage);
 
-		skin = new Skin(Gdx.files.internal("data/uiskin.json"));
-		skin.add("default", font = new BitmapFont(Gdx.files.internal("data/lsans-32.fnt"), false));
+		skin = new Skin(files.internal("data/uiskin.json"));
+		skin.add("default", font = new BitmapFont(files.internal("data/lsans-32.fnt"), false));
 
 		populateTable();
 
-		Gdx.graphics.setContinuousRendering(false);
-		Gdx.graphics.requestRendering();
+		graphics.setContinuousRendering(false);
+		graphics.requestRendering();
 	}
 
 	void nextColor () {
@@ -80,7 +79,7 @@ public class NoncontinuousRenderingTest extends GdxTest {
 
 	@Override
 	public void render () {
-		float delta = Math.min(Gdx.graphics.getDeltaTime(), 1 / 30f);
+		float delta = Math.min(graphics.getDeltaTime(), 1 / 30f);
 		elapsed += delta;
 		float value = elapsed % 1f;
 		value = value < 0.5f ? Interpolation.fade.apply(2 * value) : 1 - Interpolation.fade.apply(2 * value - 1);
@@ -89,18 +88,18 @@ public class NoncontinuousRenderingTest extends GdxTest {
 		synchronized (this) {
 			switch (colorCycle) {
 			case 0:
-				Gdx.gl.glClearColor(value, 0, 0, 1);
+				gl.glClearColor(value, 0, 0, 1);
 				break;
 			case 1:
-				Gdx.gl.glClearColor(0, value, 0, 1);
+				gl.glClearColor(0, value, 0, 1);
 				break;
 			case 2:
-				Gdx.gl.glClearColor(0, 0, value, 1);
+				gl.glClearColor(0, 0, value, 1);
 				break;
 			}
 		}
 
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 
 		Camera cam = stage.getCamera();
 		batch.setProjectionMatrix(cam.combined);
@@ -124,8 +123,8 @@ public class NoncontinuousRenderingTest extends GdxTest {
 		Button button0 = new TextButton("Toggle continuous rendering", skin, "toggle");
 		button0.addListener(new ChangeListener() {
 			public void changed (ChangeEvent event, Actor actor) {
-				boolean continuous = Gdx.graphics.isContinuousRendering();
-				Gdx.graphics.setContinuousRendering(!continuous);
+				boolean continuous = graphics.isContinuousRendering();
+				graphics.setContinuousRendering(!continuous);
 			}
 		});
 		root.add(button0).row();
@@ -141,9 +140,9 @@ public class NoncontinuousRenderingTest extends GdxTest {
 						} catch (InterruptedException ignored) {
 						}
 						nextColor();
-						Gdx.app.postRunnable(new Runnable() {
+						app.postRunnable(new Runnable() {
 							public void run () {
-								Gdx.app.log(str1, "Posted runnable to Gdx.app");
+								app.log(str1, "Posted runnable to app");
 							}
 						});
 					}
@@ -157,7 +156,7 @@ public class NoncontinuousRenderingTest extends GdxTest {
 		Button button2 = new TextButton(str2, skin);
 		button2.addListener(new ChangeListener() {
 			public void changed (ChangeEvent event, Actor actor) {
-				final Graphics graphics = Gdx.graphics; // caching necessary to ensure call on this window
+				final Graphics graphics = NoncontinuousRenderingTest.this.graphics; // caching necessary to ensure call on this window
 				new Thread(new Runnable() {
 					public void run () {
 						try {
@@ -166,7 +165,7 @@ public class NoncontinuousRenderingTest extends GdxTest {
 						}
 						nextColor();
 						graphics.requestRendering();
-						Gdx.app.log(str2, "Called Gdx.graphics.requestRendering()");
+						app.log(str2, "Called graphics.requestRendering()");
 					}
 				}).start();
 
@@ -181,9 +180,9 @@ public class NoncontinuousRenderingTest extends GdxTest {
 				Timer.schedule(new Task() {
 					public void run () {
 						nextColor();
-						Gdx.app.postRunnable(new Runnable() {
+						app.postRunnable(new Runnable() {
 							public void run () {
-								Gdx.app.log(str3, "Posted runnable to Gdx.app");
+								app.log(str3, "Posted runnable to app");
 							}
 						});
 					}
@@ -199,7 +198,7 @@ public class NoncontinuousRenderingTest extends GdxTest {
 				stage.addAction(Actions.sequence(Actions.delay(2), Actions.run(new Runnable() {
 					public void run () {
 						nextColor();
-						Gdx.app.log(str4, "RunnableAction executed");
+						app.log(str4, "RunnableAction executed");
 					}
 				})));
 			}
@@ -210,7 +209,7 @@ public class NoncontinuousRenderingTest extends GdxTest {
 		Button button5 = new TextButton(str5, skin);
 		button5.addListener(new ChangeListener() {
 			public void changed (ChangeEvent event, Actor actor) {
-				final Graphics graphics = Gdx.graphics; // caching necessary to ensure call on this window
+				final Graphics graphics = NoncontinuousRenderingTest.this.graphics; // caching necessary to ensure call on this window
 				new Thread(new Runnable() {
 					public void run () {
 						for (int i = 0; i < 2; i++) {
@@ -221,7 +220,7 @@ public class NoncontinuousRenderingTest extends GdxTest {
 							nextColor();
 							boolean continuous = graphics.isContinuousRendering();
 							graphics.setContinuousRendering(!continuous);
-							Gdx.app.log(str5, "Toggled continuous");
+							app.log(str5, "Toggled continuous");
 						}
 					}
 				}).start();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/OnscreenKeyboardTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/OnscreenKeyboardTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.InputProcessor;
 import com.badlogic.gdx.Input.OnscreenKeyboardType;
 import com.badlogic.gdx.graphics.GL20;
@@ -35,18 +34,18 @@ public class OnscreenKeyboardTest extends GdxTest implements InputProcessor {
 		batch = new SpriteBatch();
 		font = new BitmapFont();
 		text = "";
-		Gdx.input.setInputProcessor(this);
+		input.setInputProcessor(this);
 	}
 
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		batch.begin();
-		font.draw(batch, "input [" + type + "]: " + text, 0, Gdx.graphics.getHeight());
+		font.draw(batch, "input [" + type + "]: " + text, 0, graphics.getHeight());
 		batch.end();
 
-		if (Gdx.input.justTouched()) {
+		if (input.justTouched()) {
 			type = OnscreenKeyboardType.values()[(type.ordinal() + 1) % OnscreenKeyboardType.values().length];
-			Gdx.input.setOnscreenKeyboardVisible(true, type);
+			input.setOnscreenKeyboardVisible(true, type);
 		}
 	}
 
@@ -66,7 +65,7 @@ public class OnscreenKeyboardTest extends GdxTest implements InputProcessor {
 		if (character == '\b' && text.length() >= 1) {
 			text = text.substring(0, text.length() - 1);
 		} else if (character == '\n') {
-			Gdx.input.setOnscreenKeyboardVisible(false);
+			input.setOnscreenKeyboardVisible(false);
 		} else {
 			text += character;
 		}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ParallaxTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ParallaxTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
@@ -60,7 +59,7 @@ public class ParallaxTest extends GdxTest {
 
 	@Override
 	public void create () {
-		Texture texture = new Texture(Gdx.files.internal("data/layers.png"));
+		Texture texture = new Texture(files.internal("data/layers.png"));
 		layers = new TextureRegion[3];
 		layers[0] = new TextureRegion(texture, 0, 0, 542, 363);
 		layers[1] = new TextureRegion(texture, 0, 363, 1024, 149);
@@ -68,9 +67,9 @@ public class ParallaxTest extends GdxTest {
 
 		camera = new ParallaxCamera(480, 320);
 		controller = new OrthoCamController(camera);
-		Gdx.input.setInputProcessor(controller);
+		input.setInputProcessor(controller);
 		batch = new SpriteBatch();
-		font = new BitmapFont(Gdx.files.internal("data/lsans-15.fnt"), false);
+		font = new BitmapFont(files.internal("data/lsans-15.fnt"), false);
 	}
 
 	@Override
@@ -131,9 +130,9 @@ public class ParallaxTest extends GdxTest {
 		batch.end();
 
 		// draw fps
-		batch.getProjectionMatrix().setToOrtho2D(0, 0, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+		batch.getProjectionMatrix().setToOrtho2D(0, 0, graphics.getWidth(), graphics.getHeight());
 		batch.begin();
-		font.draw(batch, "fps: " + Gdx.graphics.getFramesPerSecond(), 0, 30);
+		font.draw(batch, "fps: " + graphics.getFramesPerSecond(), 0, 30);
 		batch.end();
 	}
 }

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ParticleEmitterChangeSpriteTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ParticleEmitterChangeSpriteTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.InputAdapter;
 import com.badlogic.gdx.InputProcessor;
 import com.badlogic.gdx.graphics.GL20;
@@ -53,8 +52,8 @@ public class ParticleEmitterChangeSpriteTest extends GdxTest {
 		}
 
 		effect = new ParticleEffect();
-		effect.load(Gdx.files.internal("data/test.p"), Gdx.files.internal("data"));
-		effect.setPosition(Gdx.graphics.getWidth() / 2, Gdx.graphics.getHeight() / 2);
+		effect.load(files.internal("data/test.p"), files.internal("data"));
+		effect.setPosition(graphics.getWidth() / 2, graphics.getHeight() / 2);
 		// Of course, a ParticleEffect is normally just used, without messing around with its emitters.
 		emitters = new Array(effect.getEmitters());
 		effect.getEmitters().clear();
@@ -63,7 +62,7 @@ public class ParticleEmitterChangeSpriteTest extends GdxTest {
 		inputProcessor = new InputAdapter() {
 
 			public boolean touchDragged (int x, int y, int pointer) {
-				effect.setPosition(x, Gdx.graphics.getHeight() - y);
+				effect.setPosition(x, graphics.getHeight() - y);
 				return false;
 			}
 
@@ -75,7 +74,7 @@ public class ParticleEmitterChangeSpriteTest extends GdxTest {
 			}
 		};
 
-		Gdx.input.setInputProcessor(inputProcessor);
+		input.setInputProcessor(inputProcessor);
 	}
 
 	@Override
@@ -86,16 +85,16 @@ public class ParticleEmitterChangeSpriteTest extends GdxTest {
 	}
 
 	public void render () {
-		spriteBatch.getProjectionMatrix().setToOrtho2D(0, 0, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
-		float delta = Gdx.graphics.getDeltaTime();
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		spriteBatch.getProjectionMatrix().setToOrtho2D(0, 0, graphics.getWidth(), graphics.getHeight());
+		float delta = graphics.getDeltaTime();
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		spriteBatch.begin();
 		effect.draw(spriteBatch, delta);
 		spriteBatch.end();
 		fpsCounter += delta;
 		if (fpsCounter > 3) {
 			fpsCounter = 0;
-			Gdx.app.log("libgdx", "current sprite: " + currentSprite + ", FPS: " + Gdx.graphics.getFramesPerSecond());
+			app.log("libgdx", "current sprite: " + currentSprite + ", FPS: " + graphics.getFramesPerSecond());
 		}
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ParticleEmitterTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ParticleEmitterTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.InputAdapter;
 import com.badlogic.gdx.InputProcessor;
@@ -41,8 +40,8 @@ public class ParticleEmitterTest extends GdxTest {
 		spriteBatch = new SpriteBatch();
 
 		effect = new ParticleEffect();
-		effect.load(Gdx.files.internal("data/test.p"), Gdx.files.internal("data"));
-		effect.setPosition(Gdx.graphics.getWidth() / 2, Gdx.graphics.getHeight() / 2);
+		effect.load(files.internal("data/test.p"), files.internal("data"));
+		effect.setPosition(graphics.getWidth() / 2, graphics.getHeight() / 2);
 		// Of course, a ParticleEffect is normally just used, without messing around with its emitters.
 		emitters = new Array(effect.getEmitters());
 		effect.getEmitters().clear();
@@ -51,12 +50,12 @@ public class ParticleEmitterTest extends GdxTest {
 		inputProcessor = new InputAdapter() {
 
 			public boolean touchDragged (int x, int y, int pointer) {
-				effect.setPosition(x, Gdx.graphics.getHeight() - y);
+				effect.setPosition(x, graphics.getHeight() - y);
 				return false;
 			}
 
 			public boolean touchDown (int x, int y, int pointer, int newParam) {
-				// effect.setPosition(x, Gdx.graphics.getHeight() - y);
+				// effect.setPosition(x, graphics.getHeight() - y);
 				ParticleEmitter emitter = emitters.get(emitterIndex);
 				particleCount += 100;
 				System.out.println(particleCount);
@@ -100,7 +99,7 @@ public class ParticleEmitterTest extends GdxTest {
 			}
 		};
 
-		Gdx.input.setInputProcessor(inputProcessor);
+		input.setInputProcessor(inputProcessor);
 	}
 
 	@Override
@@ -110,9 +109,9 @@ public class ParticleEmitterTest extends GdxTest {
 	}
 
 	public void render () {
-		spriteBatch.getProjectionMatrix().setToOrtho2D(0, 0, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
-		float delta = Gdx.graphics.getDeltaTime();
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		spriteBatch.getProjectionMatrix().setToOrtho2D(0, 0, graphics.getWidth(), graphics.getHeight());
+		float delta = graphics.getDeltaTime();
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		spriteBatch.begin();
 		effect.draw(spriteBatch, delta);
 		spriteBatch.end();
@@ -120,7 +119,7 @@ public class ParticleEmitterTest extends GdxTest {
 		if (fpsCounter > 3) {
 			fpsCounter = 0;
 			int activeCount = emitters.get(emitterIndex).getActiveCount();
-			Gdx.app.log("libGDX", activeCount + "/" + particleCount + " particles, FPS: " + Gdx.graphics.getFramesPerSecond());
+			app.log("libGDX", activeCount + "/" + particleCount + " particles, FPS: " + graphics.getFramesPerSecond());
 		}
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ParticleEmittersTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ParticleEmittersTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.InputAdapter;
 import com.badlogic.gdx.InputMultiplexer;
 import com.badlogic.gdx.InputProcessor;
@@ -57,8 +56,8 @@ public class ParticleEmittersTest extends GdxTest {
 		spriteBatch = new SpriteBatch();
 
 		effect = new ParticleEffect();
-		effect.load(Gdx.files.internal("data/singleTextureAllAdditive.p"), Gdx.files.internal("data"));
-		effect.setPosition(Gdx.graphics.getWidth() / 2, Gdx.graphics.getHeight() / 2);
+		effect.load(files.internal("data/singleTextureAllAdditive.p"), files.internal("data"));
+		effect.setPosition(graphics.getWidth() / 2, graphics.getHeight() / 2);
 		effectPool = new ParticleEffectPool(effect, 20, 20);
 
 		setupUI();
@@ -66,14 +65,14 @@ public class ParticleEmittersTest extends GdxTest {
 		InputProcessor inputProcessor = new InputAdapter() {
 
 			public boolean touchDragged (int x, int y, int pointer) {
-				if (latestEffect != null) latestEffect.setPosition(x, Gdx.graphics.getHeight() - y);
+				if (latestEffect != null) latestEffect.setPosition(x, graphics.getHeight() - y);
 				return false;
 			}
 
 			public boolean touchDown (int x, int y, int pointer, int newParam) {
 				latestEffect = effectPool.obtain();
 				latestEffect.setEmittersCleanUpBlendFunction(!skipCleanup.isChecked());
-				latestEffect.setPosition(x, Gdx.graphics.getHeight() - y);
+				latestEffect.setPosition(x, graphics.getHeight() - y);
 				effects.add(latestEffect);
 
 				return false;
@@ -85,7 +84,7 @@ public class ParticleEmittersTest extends GdxTest {
 		multiplexer.addProcessor(ui);
 		multiplexer.addProcessor(inputProcessor);
 
-		Gdx.input.setInputProcessor(multiplexer);
+		input.setInputProcessor(multiplexer);
 	}
 
 	@Override
@@ -101,9 +100,9 @@ public class ParticleEmittersTest extends GdxTest {
 
 	public void render () {
 		ui.act();
-		spriteBatch.getProjectionMatrix().setToOrtho2D(0, 0, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
-		float delta = Gdx.graphics.getDeltaTime();
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		spriteBatch.getProjectionMatrix().setToOrtho2D(0, 0, graphics.getWidth(), graphics.getHeight());
+		float delta = graphics.getDeltaTime();
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		spriteBatch.begin();
 		for (ParticleEffect e : effects)
 			e.draw(spriteBatch, delta);
@@ -111,9 +110,9 @@ public class ParticleEmittersTest extends GdxTest {
 		fpsCounter += delta;
 		if (fpsCounter > 3) {
 			fpsCounter = 0;
-			String log = effects.size + " particle effects, FPS: " + Gdx.graphics.getFramesPerSecond() + ", Render calls: "
+			String log = effects.size + " particle effects, FPS: " + graphics.getFramesPerSecond() + ", Render calls: "
 				+ spriteBatch.renderCalls;
-			Gdx.app.log("libGDX", log);
+			app.log("libGDX", log);
 			logLabel.setText(log);
 		}
 		ui.draw();
@@ -125,7 +124,7 @@ public class ParticleEmittersTest extends GdxTest {
 
 	private void setupUI () {
 		ui = new Stage(new ExtendViewport(640, 480));
-		Skin skin = new Skin(Gdx.files.internal("data/uiskin.json"));
+		Skin skin = new Skin(files.internal("data/uiskin.json"));
 		skipCleanup = new CheckBox("Skip blend function clean-up", skin);
 		skipCleanup.addListener(listener);
 		logLabel = new Label("", skin.get(LabelStyle.class));

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/PathTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/PathTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.Sprite;
@@ -55,16 +54,16 @@ public class PathTest extends GdxTest {
 	public void create () {
 		renderer = new ImmediateModeRenderer20(false, false, 0);
 		spriteBatch = new SpriteBatch();
-		obj = new Sprite(new Texture(Gdx.files.internal("data/badlogicsmall.jpg")));
+		obj = new Sprite(new Texture(files.internal("data/badlogicsmall.jpg")));
 		obj.setSize(40, 40);
 		obj.setOriginCenter();
-		obj2 = new Sprite(new Texture(Gdx.files.internal("data/bobrgb888-32x32.png")));
+		obj2 = new Sprite(new Texture(files.internal("data/bobrgb888-32x32.png")));
 		obj2.setSize(40, 40);
 		obj2.setOriginCenter();
-		ZIGZAG_SCALE = Gdx.graphics.getDensity() * 96; // 96DP
+		ZIGZAG_SCALE = graphics.getDensity() * 96; // 96DP
 
-		float w = Gdx.graphics.getWidth() - obj.getWidth();
-		float h = Gdx.graphics.getHeight() - obj.getHeight();
+		float w = graphics.getWidth() - obj.getWidth();
+		float h = graphics.getHeight() - obj.getHeight();
 
 		paths.add(new Bezier<Vector2>(new Vector2(0, 0), new Vector2(w, h)));
 		paths.add(new Bezier<Vector2>(new Vector2(0, 0), new Vector2(0, h), new Vector2(w, h)));
@@ -80,7 +79,7 @@ public class PathTest extends GdxTest {
 		pathLength = paths.get(currentPath).approxLength(500);
 		avg_speed = speed * pathLength;
 
-		Gdx.input.setInputProcessor(this);
+		input.setInputProcessor(this);
 	}
 
 	final Vector2 tmpV = new Vector2();
@@ -96,10 +95,10 @@ public class PathTest extends GdxTest {
 		ScreenUtils.clear(0.7f, 0.7f, 0.7f, 1);
 
 		if (wait > 0)
-			wait -= Gdx.graphics.getDeltaTime();
+			wait -= graphics.getDeltaTime();
 		else {
-			t += speed * Gdx.graphics.getDeltaTime();
-			zt += zspeed * Gdx.graphics.getDeltaTime();
+			t += speed * graphics.getDeltaTime();
+			zt += zspeed * graphics.getDeltaTime();
 			while (t >= 1f) {
 				currentPath = (currentPath + 1) % paths.size;
 				pathLength = paths.get(currentPath).approxLength(500);
@@ -122,7 +121,7 @@ public class PathTest extends GdxTest {
 			paths.get(currentPath).derivativeAt(tmpV2, t);
 
 			paths.get(currentPath).derivativeAt(tmpV3, t2);
-			t2 += avg_speed * Gdx.graphics.getDeltaTime() / tmpV3.len();
+			t2 += avg_speed * graphics.getDeltaTime() / tmpV3.len();
 
 			paths.get(currentPath).valueAt(tmpV4, t2);
 			// obj.setRotation(tmpV2.angle());
@@ -157,7 +156,7 @@ public class PathTest extends GdxTest {
 	}
 
 	private void touch (int x, int y) {
-		t = paths.get(currentPath).locate(tmpV.set(x, Gdx.graphics.getHeight() - y));
+		t = paths.get(currentPath).locate(tmpV.set(x, graphics.getHeight() - y));
 		paths.get(currentPath).valueAt(tmpV, t);
 		obj.setPosition(tmpV.x, tmpV.y);
 		wait = 0.2f;

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/PixelPerfectTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/PixelPerfectTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.graphics.Pixmap;
@@ -42,12 +41,12 @@ public class PixelPerfectTest extends GdxTest {
 		tex = new Texture(pixmap);
 		batch = new SpriteBatch();
 		cam = new OrthographicCamera();
-		cam.setToOrtho(false, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+		cam.setToOrtho(false, graphics.getWidth(), graphics.getHeight());
 	}
 
 	@Override
 	public void resize (int width, int height) {
-		cam.setToOrtho(false, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+		cam.setToOrtho(false, graphics.getWidth(), graphics.getHeight());
 	}
 
 	@Override

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/PixelsPerInchTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/PixelsPerInchTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
@@ -31,20 +30,20 @@ public class PixelsPerInchTest extends GdxTest {
 
 	@Override
 	public void create () {
-		font = new BitmapFont(Gdx.files.internal("data/lsans-15.fnt"), false);
+		font = new BitmapFont(files.internal("data/lsans-15.fnt"), false);
 		batch = new SpriteBatch();
-		texture = new Texture(Gdx.files.internal("data/badlogicsmall.jpg"));
+		texture = new Texture(files.internal("data/badlogicsmall.jpg"));
 	}
 
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 
 		batch.begin();
-		float width = (int)(Gdx.graphics.getPpcX() * 2);
-		float height = (int)(Gdx.graphics.getPpcY() * 1);
+		float width = (int)(graphics.getPpcX() * 2);
+		float height = (int)(graphics.getPpcY() * 1);
 		batch.draw(texture, 10, 100, width, height, 0, 0, 64, 32, false, false);
-		font.draw(batch, "button is 2x1 cm (" + width + "x" + height + "px), ppi: (" + Gdx.graphics.getPpiX() + ","
-			+ Gdx.graphics.getPpiY() + "), ppc: (" + Gdx.graphics.getPpcX() + "," + Gdx.graphics.getPpcY() + ")", 10, 50);
+		font.draw(batch, "button is 2x1 cm (" + width + "x" + height + "px), ppi: (" + graphics.getPpiX() + ","
+			+ graphics.getPpiY() + "), ppc: (" + graphics.getPpcX() + "," + graphics.getPpcY() + ")", 10, 50);
 		batch.end();
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/PixmapBlendingTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/PixmapBlendingTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.Sprite;
@@ -36,12 +35,12 @@ public class PixmapBlendingTest extends GdxTest {
 		spriteBatch = new SpriteBatch();
 
 		Matrix4 transform = new Matrix4();
-		transform.setToTranslation(0, Gdx.graphics.getHeight(), 0);
+		transform.setToTranslation(0, graphics.getHeight(), 0);
 		transform.mul(new Matrix4().setToScaling(1, -1, 1));
 		spriteBatch.setTransformMatrix(transform);
 
-		pixS1 = new Pixmap(Gdx.files.internal("data/test4.png"));
-		pixS2 = new Pixmap(Gdx.files.internal("data/test3.png"));
+		pixS1 = new Pixmap(files.internal("data/test4.png"));
+		pixS2 = new Pixmap(files.internal("data/test3.png"));
 		pixD = new Pixmap(512, 1024, Pixmap.Format.RGBA8888);
 
 		pixD.setBlending(Pixmap.Blending.SourceOver);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/PixmapPackerIOTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/PixmapPackerIOTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.InputAdapter;
 import com.badlogic.gdx.graphics.Color;
@@ -55,17 +54,17 @@ public class PixmapPackerIOTest extends GdxTest {
 		batch = new SpriteBatch();
 		shapeRenderer = new ShapeRenderer();
 
-		camera = new OrthographicCamera(Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
-		camera.position.set(Gdx.graphics.getWidth() / 2, Gdx.graphics.getHeight() / 2, 0);
+		camera = new OrthographicCamera(graphics.getWidth(), graphics.getHeight());
+		camera.position.set(graphics.getWidth() / 2, graphics.getHeight() / 2, 0);
 		camera.update();
 
-		skin = new Skin(Gdx.files.internal("data/uiskin.json"));
+		skin = new Skin(files.internal("data/uiskin.json"));
 
-		Pixmap pixmap1 = new Pixmap(Gdx.files.internal("data/badlogic.jpg"));
-		Pixmap pixmap2 = new Pixmap(Gdx.files.internal("data/particle-fire.png"));
-		Pixmap pixmap3 = new Pixmap(Gdx.files.internal("data/isotile.png"));
-		Pixmap pixmap4 = new Pixmap(Gdx.files.internal("data/textfield.9.png"));
-		Pixmap pixmap5 = new Pixmap(Gdx.files.internal("data/badlogic-with-whitespace.png"));
+		Pixmap pixmap1 = new Pixmap(files.internal("data/badlogic.jpg"));
+		Pixmap pixmap2 = new Pixmap(files.internal("data/particle-fire.png"));
+		Pixmap pixmap3 = new Pixmap(files.internal("data/isotile.png"));
+		Pixmap pixmap4 = new Pixmap(files.internal("data/textfield.9.png"));
+		Pixmap pixmap5 = new Pixmap(files.internal("data/badlogic-with-whitespace.png"));
 
 		PixmapPacker packer = new PixmapPacker(1024, 1024, Format.RGBA8888, 8, false, true, true,
 			new PixmapPacker.GuillotineStrategy());
@@ -79,7 +78,7 @@ public class PixmapPackerIOTest extends GdxTest {
 		}
 
 		atlas = packer.generateTextureAtlas(TextureFilter.Nearest, TextureFilter.Nearest, false);
-		Gdx.app.log("PixmapPackerTest", "Number of initial textures: " + atlas.getTextures().size);
+		app.log("PixmapPackerTest", "Number of initial textures: " + atlas.getTextures().size);
 
 		packer.setPackToTexture(true);
 
@@ -100,8 +99,8 @@ public class PixmapPackerIOTest extends GdxTest {
 		packer.updateTextureAtlas(atlas, TextureFilter.Nearest, TextureFilter.Nearest, false);
 		textureRegions = new Array<TextureRegion>();
 		packer.updateTextureRegions(textureRegions, TextureFilter.Nearest, TextureFilter.Nearest, false);
-		Gdx.app.log("PixmapPackerTest", "Number of updated textures: " + atlas.getTextures().size);
-		Gdx.input.setInputProcessor(new InputAdapter() {
+		app.log("PixmapPackerTest", "Number of updated textures: " + atlas.getTextures().size);
+		input.setInputProcessor(new InputAdapter() {
 			@Override
 			public boolean keyDown (int keycode) {
 				if (keycode >= Input.Keys.NUM_0 && keycode <= Input.Keys.NUM_9) {
@@ -122,12 +121,12 @@ public class PixmapPackerIOTest extends GdxTest {
 		try {
 			PixmapPackerIO.SaveParameters saveParameters = new PixmapPackerIO.SaveParameters();
 			saveParameters.format = PixmapPackerIO.ImageFormat.PNG;
-			pixmapPackerIO.save(Gdx.files.local("pixmapPackerTest.atlas"), packer, saveParameters);
+			pixmapPackerIO.save(files.local("pixmapPackerTest.atlas"), packer, saveParameters);
 		} catch (IOException e) {
 			e.printStackTrace();
 		}
 
-		TextureAtlas loaded = new TextureAtlas(Gdx.files.local("pixmapPackerTest.atlas"));
+		TextureAtlas loaded = new TextureAtlas(files.local("pixmapPackerTest.atlas"));
 		for (int i = 0; i < loaded.getRegions().size; i++) {
 			final TextureAtlas.AtlasRegion atlasRegion = loaded.getRegions().get(i);
 			compare(atlas, atlasRegion);
@@ -175,7 +174,7 @@ public class PixmapPackerIOTest extends GdxTest {
 	@Override
 	public void render () {
 		ScreenUtils.clear(0.2f, 0.2f, 0.2f, 1);
-		int size = Math.min(Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+		int size = Math.min(graphics.getWidth(), graphics.getHeight());
 		int quarterSize = (int)(size / 4f);
 		batch.begin();
 		batch.draw(textureRegions.get(pageToShow), 0, 0, size, size);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/PixmapPackerTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/PixmapPackerTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.InputAdapter;
 import com.badlogic.gdx.graphics.Color;
@@ -56,17 +55,17 @@ public class PixmapPackerTest extends GdxTest {
 		batch = new SpriteBatch();
 		shapeRenderer = new ShapeRenderer();
 
-		camera = new OrthographicCamera(Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
-		camera.position.set(Gdx.graphics.getWidth() / 2, Gdx.graphics.getHeight() / 2, 0);
+		camera = new OrthographicCamera(graphics.getWidth(), graphics.getHeight());
+		camera.position.set(graphics.getWidth() / 2, graphics.getHeight() / 2, 0);
 		camera.update();
 
-		skin = new Skin(Gdx.files.internal("data/uiskin.json"));
+		skin = new Skin(files.internal("data/uiskin.json"));
 
-		Pixmap pixmap1 = new Pixmap(Gdx.files.internal("data/badlogic.jpg"));
-		Pixmap pixmap2 = new Pixmap(Gdx.files.internal("data/particle-fire.png"));
-		Pixmap pixmap3 = new Pixmap(Gdx.files.internal("data/isotile.png"));
-		Pixmap pixmap4 = new Pixmap(Gdx.files.internal("data/textfield.9.png"));
-		Pixmap pixmap5 = new Pixmap(Gdx.files.internal("data/badlogic-with-whitespace.png"));
+		Pixmap pixmap1 = new Pixmap(files.internal("data/badlogic.jpg"));
+		Pixmap pixmap2 = new Pixmap(files.internal("data/particle-fire.png"));
+		Pixmap pixmap3 = new Pixmap(files.internal("data/isotile.png"));
+		Pixmap pixmap4 = new Pixmap(files.internal("data/textfield.9.png"));
+		Pixmap pixmap5 = new Pixmap(files.internal("data/badlogic-with-whitespace.png"));
 
 		PixmapPacker packer = new PixmapPacker(1024, 1024, Format.RGBA8888, 8, false, true, true,
 			new PixmapPacker.GuillotineStrategy());
@@ -80,7 +79,7 @@ public class PixmapPackerTest extends GdxTest {
 		}
 
 		atlas = packer.generateTextureAtlas(TextureFilter.Nearest, TextureFilter.Nearest, false);
-		Gdx.app.log("PixmapPackerTest", "Number of initial textures: " + atlas.getTextures().size);
+		app.log("PixmapPackerTest", "Number of initial textures: " + atlas.getTextures().size);
 
 		packer.setPackToTexture(true);
 
@@ -108,8 +107,8 @@ public class PixmapPackerTest extends GdxTest {
 
 		textureRegions = new Array<TextureRegion>();
 		packer.updateTextureRegions(textureRegions, TextureFilter.Nearest, TextureFilter.Nearest, false);
-		Gdx.app.log("PixmapPackerTest", "Number of updated textures: " + atlas.getTextures().size);
-		Gdx.input.setInputProcessor(new InputAdapter() {
+		app.log("PixmapPackerTest", "Number of updated textures: " + atlas.getTextures().size);
+		input.setInputProcessor(new InputAdapter() {
 			@Override
 			public boolean keyDown (int keycode) {
 				if (keycode >= Input.Keys.NUM_0 && keycode <= Input.Keys.NUM_9) {
@@ -131,7 +130,7 @@ public class PixmapPackerTest extends GdxTest {
 	@Override
 	public void render () {
 		ScreenUtils.clear(0.2f, 0.2f, 0.2f, 1);
-		int size = Math.min(Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+		int size = Math.min(graphics.getWidth(), graphics.getHeight());
 		int quarterSize = (int)(size / 4f);
 		batch.begin();
 		batch.draw(textureRegions.get(pageToShow), 0, 0, size, size);
@@ -144,7 +143,7 @@ public class PixmapPackerTest extends GdxTest {
 		shapeRenderer.rect(0, 0, size, size);
 		shapeRenderer.end();
 
-		stateTime += Gdx.graphics.getDeltaTime();
+		stateTime += graphics.getDeltaTime();
 	}
 
 	@Override

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/PngTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/PngTest.java
@@ -17,7 +17,6 @@
 package com.badlogic.gdx.tests;
 
 import java.io.IOException;
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Pixmap;
@@ -33,21 +32,21 @@ public class PngTest extends GdxTest {
 
 	public void create () {
 		batch = new SpriteBatch();
-		badlogic = new Texture(Gdx.files.internal("data/badlogic.jpg"));
+		badlogic = new Texture(files.internal("data/badlogic.jpg"));
 	}
 
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		batch.begin();
 		if (screenshot == null) {
-			int width = Gdx.graphics.getWidth(), height = Gdx.graphics.getHeight();
+			int width = graphics.getWidth(), height = graphics.getHeight();
 			for (int i = 0; i < 100; i++)
 				batch.draw(badlogic, MathUtils.random(width), MathUtils.random(height));
 			batch.flush();
 
 			FileHandle file = FileHandle.tempFile("screenshot-");
 			System.out.println(file.file().getAbsolutePath());
-			Pixmap pixmap = Pixmap.createFromFrameBuffer(0, 0, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+			Pixmap pixmap = Pixmap.createFromFrameBuffer(0, 0, graphics.getWidth(), graphics.getHeight());
 			try {
 				PNG writer = new PNG((int)(pixmap.getWidth() * pixmap.getHeight() * 1.5f));
 				// writer.setCompression(Deflater.NO_COMPRESSION);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/PolygonRegionTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/PolygonRegionTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.graphics.Texture;
@@ -46,22 +45,22 @@ public class PolygonRegionTest extends GdxTest {
 
 	@Override
 	public void create () {
-		texture = new Texture(Gdx.files.internal("data/tree.png"));
+		texture = new Texture(files.internal("data/tree.png"));
 
 		PolygonRegionLoader loader = new PolygonRegionLoader();
-		region = loader.load(new TextureRegion(texture), Gdx.files.internal("data/tree.psh"));
+		region = loader.load(new TextureRegion(texture), files.internal("data/tree.psh"));
 
 		// create a region from an arbitrary set of vertices (a triangle in this case)
 		region2 = new PolygonRegion(new TextureRegion(texture), new float[] {0, 0, 100, 100, 0, 100}, new short[] {0, 1, 2});
 
-		camera = new OrthographicCamera(Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+		camera = new OrthographicCamera(graphics.getWidth(), graphics.getHeight());
 		camera.position.x = 0;
 		camera.position.y = 0;
 
 		batch = new PolygonSpriteBatch();
 		debugRenderer = new PolygonRegionDebugRenderer();
 
-		Gdx.input.setInputProcessor(this);
+		input.setInputProcessor(this);
 	}
 
 	@Override

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/PolygonSpriteTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/PolygonSpriteTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.graphics.Texture;
@@ -47,10 +46,10 @@ public class PolygonSpriteTest extends GdxTest {
 
 	@Override
 	public void create () {
-		texture = new Texture(Gdx.files.internal("data/tree.png"));
+		texture = new Texture(files.internal("data/tree.png"));
 
 		PolygonRegionLoader loader = new PolygonRegionLoader();
-		region = loader.load(new TextureRegion(texture), Gdx.files.internal("data/tree.psh"));
+		region = loader.load(new TextureRegion(texture), files.internal("data/tree.psh"));
 
 		renderer = new ShapeRenderer();
 
@@ -81,8 +80,8 @@ public class PolygonSpriteTest extends GdxTest {
 
 		for (int i = 0; i < sprites.size; i++) {
 			PolygonSprite sprite = sprites.get(i);
-			sprite.rotate(45 * Gdx.graphics.getDeltaTime());
-			sprite.translateX(10 * Gdx.graphics.getDeltaTime());
+			sprite.rotate(45 * graphics.getDeltaTime());
+			sprite.translateX(10 * graphics.getDeltaTime());
 
 			if (sprite.getX() > 450) sprite.setX(-50);
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/PreferencesTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/PreferencesTest.java
@@ -16,14 +16,13 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Preferences;
 import com.badlogic.gdx.tests.utils.GdxTest;
 import com.badlogic.gdx.utils.GdxRuntimeException;
 
 public class PreferencesTest extends GdxTest {
 	public void create () {
-		Preferences prefs = Gdx.app.getPreferences(".test");
+		Preferences prefs = app.getPreferences(".test");
 		if (prefs.contains("bool")) {
 			if (prefs.getBoolean("bool") != true) throw new GdxRuntimeException("bool failed");
 			if (prefs.getInteger("int") != 1234) throw new GdxRuntimeException("int failed");

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ProjectTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ProjectTest.java
@@ -18,7 +18,6 @@ package com.badlogic.gdx.tests;
 
 import java.util.Random;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input.Keys;
 import com.badlogic.gdx.graphics.Camera;
 import com.badlogic.gdx.graphics.Color;
@@ -50,9 +49,9 @@ public class ProjectTest extends GdxTest {
 	@Override
 	public void create () {
 		ObjLoader objLoader = new ObjLoader();
-		sphere = objLoader.loadModel(Gdx.files.internal("data/sphere.obj"));
+		sphere = objLoader.loadModel(files.internal("data/sphere.obj"));
 		sphere.materials.get(0).set(new ColorAttribute(ColorAttribute.Diffuse, Color.WHITE));
-		cam = new PerspectiveCamera(45, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+		cam = new PerspectiveCamera(45, graphics.getWidth(), graphics.getHeight());
 		cam.far = 200;
 		Random rand = new Random();
 		for (int i = 0; i < instances.length; i++) {
@@ -61,15 +60,15 @@ public class ProjectTest extends GdxTest {
 		}
 		batch = new SpriteBatch();
 		font = new BitmapFont();
-		logo = new TextureRegion(new Texture(Gdx.files.internal("data/badlogicsmall.jpg")));
+		logo = new TextureRegion(new Texture(files.internal("data/badlogicsmall.jpg")));
 		modelBatch = new ModelBatch();
 	}
 
 	@Override
 	public void render () {
 
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
-		Gdx.gl.glEnable(GL20.GL_DEPTH_TEST);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
+		gl.glEnable(GL20.GL_DEPTH_TEST);
 
 		cam.update();
 
@@ -88,10 +87,10 @@ public class ProjectTest extends GdxTest {
 		}
 		modelBatch.end();
 
-		if (Gdx.input.isKeyPressed(Keys.A)) cam.rotate(20 * Gdx.graphics.getDeltaTime(), 0, 1, 0);
-		if (Gdx.input.isKeyPressed(Keys.D)) cam.rotate(-20 * Gdx.graphics.getDeltaTime(), 0, 1, 0);
+		if (input.isKeyPressed(Keys.A)) cam.rotate(20 * graphics.getDeltaTime(), 0, 1, 0);
+		if (input.isKeyPressed(Keys.D)) cam.rotate(-20 * graphics.getDeltaTime(), 0, 1, 0);
 
-		Gdx.gl.glDisable(GL20.GL_DEPTH_TEST);
+		gl.glDisable(GL20.GL_DEPTH_TEST);
 		batch.begin();
 		for (int i = 0; i < instances.length; i++) {
 			instances[i].transform.getTranslation(tmp);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ProjectiveTextureTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ProjectiveTextureTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.InputMultiplexer;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
@@ -74,7 +73,7 @@ public class ProjectiveTextureTest extends GdxTest {
 
 		multiplexer.addProcessor(ui);
 		multiplexer.addProcessor(controller);
-		Gdx.input.setInputProcessor(multiplexer);
+		input.setInputProcessor(multiplexer);
 
 		// renderer = new ImmediateModeRenderer20(false, true, 0);
 	}
@@ -85,16 +84,16 @@ public class ProjectiveTextureTest extends GdxTest {
 		plane.setVertices(new float[] {-10, -1, 10, 0, 1, 0, 10, -1, 10, 0, 1, 0, 10, -1, -10, 0, 1, 0, -10, -1, -10, 0, 1, 0});
 		plane.setIndices(new short[] {3, 2, 1, 1, 0, 3});
 
-		texture = new Texture(Gdx.files.internal("data/badlogic.jpg"), Format.RGB565, true);
+		texture = new Texture(files.internal("data/badlogic.jpg"), Format.RGB565, true);
 		texture.setFilter(TextureFilter.MipMap, TextureFilter.Nearest);
 
-		cam = new PerspectiveCamera(67, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+		cam = new PerspectiveCamera(67, graphics.getWidth(), graphics.getHeight());
 		cam.position.set(0, 5, 10);
 		cam.lookAt(0, 0, 0);
 		cam.update();
 		controller = new PerspectiveCamController(cam);
 
-		projector = new PerspectiveCamera(67, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+		projector = new PerspectiveCamera(67, graphics.getWidth(), graphics.getHeight());
 		projector.position.set(2, 3, 2);
 		projector.lookAt(0, 0, 0);
 		projector.normalizeUp();
@@ -103,7 +102,7 @@ public class ProjectiveTextureTest extends GdxTest {
 
 	public void setupUI () {
 		ui = new Stage();
-		skin = new Skin(Gdx.files.internal("data/uiskin.json"));
+		skin = new Skin(files.internal("data/uiskin.json"));
 		TextButton reload = new TextButton("Reload Shaders", skin.get(TextButtonStyle.class));
 		camera = new SelectBox(skin.get(SelectBoxStyle.class));
 		camera.setItems("Camera", "Light");
@@ -119,10 +118,10 @@ public class ProjectiveTextureTest extends GdxTest {
 
 		reload.addListener(new ClickListener() {
 			public void clicked (InputEvent event, float x, float y) {
-				ShaderProgram prog = new ShaderProgram(Gdx.files.internal("data/shaders/projtex-vert.glsl").readString(),
-					Gdx.files.internal("data/shaders/projtex-frag.glsl").readString());
+				ShaderProgram prog = new ShaderProgram(files.internal("data/shaders/projtex-vert.glsl").readString(),
+					files.internal("data/shaders/projtex-frag.glsl").readString());
 				if (prog.isCompiled() == false) {
-					Gdx.app.log("GLSL ERROR", "Couldn't reload shaders:\n" + prog.getLog());
+					app.log("GLSL ERROR", "Couldn't reload shaders:\n" + prog.getLog());
 				} else {
 					projTexShader.dispose();
 					projTexShader = prog;
@@ -133,17 +132,17 @@ public class ProjectiveTextureTest extends GdxTest {
 
 	public void setupShaders () {
 		ShaderProgram.pedantic = false;
-		projTexShader = new ShaderProgram(Gdx.files.internal("data/shaders/projtex-vert.glsl").readString(),
-			Gdx.files.internal("data/shaders/projtex-frag.glsl").readString());
+		projTexShader = new ShaderProgram(files.internal("data/shaders/projtex-vert.glsl").readString(),
+			files.internal("data/shaders/projtex-frag.glsl").readString());
 		if (!projTexShader.isCompiled()) throw new GdxRuntimeException("Couldn't compile shader: " + projTexShader.getLog());
 	}
 
 	@Override
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
-		Gdx.gl.glEnable(GL20.GL_DEPTH_TEST);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
+		gl.glEnable(GL20.GL_DEPTH_TEST);
 
-		angle += Gdx.graphics.getDeltaTime() * 20.0f;
+		angle += graphics.getDeltaTime() * 20.0f;
 		cubeTrans.setToRotation(Vector3.Y, angle);
 
 		cam.update();
@@ -165,7 +164,7 @@ public class ProjectiveTextureTest extends GdxTest {
 			 */
 		}
 
-		fps.setText("fps: " + Gdx.graphics.getFramesPerSecond());
+		fps.setText("fps: " + graphics.getFramesPerSecond());
 		ui.act();
 		ui.draw();
 	}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/QuadTreeFloatNearestTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/QuadTreeFloatNearestTest.java
@@ -1,7 +1,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
@@ -29,11 +28,11 @@ public class QuadTreeFloatNearestTest extends GdxTest {
 	}
 
 	public void render () {
-		float x = Gdx.input.getX(), y = Gdx.graphics.getHeight() - Gdx.input.getY();
+		float x = input.getX(), y = graphics.getHeight() - input.getY();
 		results.clear();
 		boolean found = q.nearest(x, y, results);
 
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		shapes.begin(ShapeType.Line);
 		draw(q);
 		shapes.setColor(Color.GREEN);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/QuadTreeFloatTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/QuadTreeFloatTest.java
@@ -1,7 +1,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
@@ -29,11 +28,11 @@ public class QuadTreeFloatTest extends GdxTest {
 	}
 
 	public void render () {
-		float radius = 50, x = Gdx.input.getX(), y = Gdx.graphics.getHeight() - Gdx.input.getY();
+		float radius = 50, x = input.getX(), y = graphics.getHeight() - input.getY();
 		results.clear();
 		q.query(x, y, radius, results);
 
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		shapes.begin(ShapeType.Line);
 		draw(q);
 		shapes.setColor(Color.GREEN);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ReflectionCorrectnessTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ReflectionCorrectnessTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.tests.utils.GdxTest;
 import com.badlogic.gdx.utils.reflect.ClassReflection;
 
@@ -201,7 +200,7 @@ public class ReflectionCorrectnessTest extends GdxTest {
 
 	public void doTest (final Class c, Expectation e) {
 
-		Gdx.app.log("ClassReflectionTest", "Name of class: " + c.getName());
+		app.log("ClassReflectionTest", "Name of class: " + c.getName());
 
 		boolean isArray = ClassReflection.isArray(c);
 		expectResult(e.isArray, isArray, "value of is Array");

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ReflectionTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ReflectionTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
@@ -94,9 +93,9 @@ public class ReflectionTest extends GdxTest {
 
 	@Override
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		batch.begin();
-		font.draw(batch, message, 20, Gdx.graphics.getHeight() - 20);
+		font.draw(batch, message, 20, graphics.getHeight() - 20);
 		batch.end();
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/RotationTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/RotationTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
@@ -31,7 +30,7 @@ public class RotationTest extends GdxTest {
 
 	@Override
 	public void create () {
-		texture = new Texture(Gdx.files.internal("data/black_marked_0.png"));
+		texture = new Texture(files.internal("data/black_marked_0.png"));
 		region = new TextureRegion(texture);
 		batch = new SpriteBatch();
 		batch.getTransformMatrix().setToTranslation(30.5f, 30.5f, 0);
@@ -39,7 +38,7 @@ public class RotationTest extends GdxTest {
 
 	@Override
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		batch.begin();
 		batch.draw(texture, 0, 0);
 		batch.draw(region, 128, 0, 64, 64, 128, 128, 1, 1, 90);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/Scene2dTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/Scene2dTest.java
@@ -18,7 +18,6 @@ package com.badlogic.gdx.tests;
 
 import static com.badlogic.gdx.scenes.scene2d.actions.Actions.*;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Texture;
@@ -51,7 +50,7 @@ public class Scene2dTest extends GdxTest {
 
 	public void create () {
 		stage = new Stage();
-		Gdx.input.setInputProcessor(stage);
+		input.setInputProcessor(stage);
 
 		final TextureRegion region = new TextureRegion(new Texture("data/badlogic.jpg"));
 		final Actor actor = new Actor() {
@@ -76,7 +75,7 @@ public class Scene2dTest extends GdxTest {
 			}
 		});
 
-		Skin skin = new Skin(Gdx.files.internal("data/uiskin.json"));
+		Skin skin = new Skin(files.internal("data/uiskin.json"));
 
 		VerticalGroup g = new VerticalGroup().space(5).reverse().pad(5).fill();
 		for (int i = 0; i < 10; i++)
@@ -210,8 +209,8 @@ public class Scene2dTest extends GdxTest {
 
 	public void render () {
 		// System.out.println(meow.getValue());
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-		stage.act(Gdx.graphics.getDeltaTime());
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		stage.act(graphics.getDeltaTime());
 		stage.draw();
 
 		stage.getBatch().begin();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ScrollPane2Test.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ScrollPane2Test.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.scenes.scene2d.InputEvent;
 import com.badlogic.gdx.scenes.scene2d.InputListener;
@@ -34,9 +33,9 @@ public class ScrollPane2Test extends GdxTest {
 
 	public void create () {
 		stage = new Stage();
-		Gdx.input.setInputProcessor(stage);
+		input.setInputProcessor(stage);
 
-		skin = new Skin(Gdx.files.internal("data/uiskin.json"));
+		skin = new Skin(files.internal("data/uiskin.json"));
 
 		ScrollPane pane2 = new ScrollPane(new Image(new Texture("data/group-debug.png")), skin);
 		pane2.setScrollingDisabled(false, true);
@@ -67,11 +66,11 @@ public class ScrollPane2Test extends GdxTest {
 			// This sizes the pane to the size of it's contents.
 			pane.pack();
 			// Then the height is hardcoded, leaving the pane the width of it's contents.
-			pane.setHeight(Gdx.graphics.getHeight());
+			pane.setHeight(graphics.getHeight());
 		} else {
 			// This shows a hardcoded size.
 			pane.setWidth(300);
-			pane.setHeight(Gdx.graphics.getHeight());
+			pane.setHeight(graphics.getHeight());
 		}
 
 		stage.addActor(pane);
@@ -79,7 +78,7 @@ public class ScrollPane2Test extends GdxTest {
 
 	public void render () {
 		ScreenUtils.clear(0, 0, 0, 1);
-		stage.act(Gdx.graphics.getDeltaTime());
+		stage.act(graphics.getDeltaTime());
 		stage.draw();
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ScrollPaneScrollBarsTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ScrollPaneScrollBarsTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.Stage;
@@ -39,13 +38,13 @@ public class ScrollPaneScrollBarsTest extends GdxTest {
 	private Table bottomLeft, bottomRight, topLeft, topRight, horizOnlyTop, horizOnlyBottom, vertOnlyLeft, vertOnlyRight;
 
 	public void create () {
-		float width = Gdx.graphics.getWidth();
-		float height = Gdx.graphics.getHeight();
+		float width = graphics.getWidth();
+		float height = graphics.getHeight();
 		float btnWidth = 200;
 		float btnHeight = 40;
 		stage = new Stage();
-		Skin skin = new Skin(Gdx.files.internal("data/uiskin.json"));
-		Gdx.input.setInputProcessor(stage);
+		Skin skin = new Skin(files.internal("data/uiskin.json"));
+		input.setInputProcessor(stage);
 
 		final TextButton fadeBtn = new TextButton("Fade: " + doFade, skin);
 		fadeBtn.setSize(btnWidth, btnHeight);
@@ -78,7 +77,7 @@ public class ScrollPaneScrollBarsTest extends GdxTest {
 			}
 		});
 
-		// Gdx.graphics.setVSync(false);
+		// graphics.setVSync(false);
 
 		float gap = 8;
 		float x = gap;
@@ -235,14 +234,14 @@ public class ScrollPaneScrollBarsTest extends GdxTest {
 	}
 
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-		stage.act(Gdx.graphics.getDeltaTime());
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		stage.act(graphics.getDeltaTime());
 		stage.draw();
 	}
 
 	public void resize (int width, int height) {
 		stage.getViewport().update(width, height, true);
-		// Gdx.gl.glViewport(100, 100, width - 200, height - 200);
+		// gl.glViewport(100, 100, width - 200, height - 200);
 		// stage.setViewport(800, 600, false, 100, 100, width - 200, height - 200);
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ScrollPaneTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ScrollPaneTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.InputEvent;
@@ -39,10 +38,10 @@ public class ScrollPaneTest extends GdxTest {
 
 	public void create () {
 		stage = new Stage();
-		Skin skin = new Skin(Gdx.files.internal("data/uiskin.json"));
-		Gdx.input.setInputProcessor(stage);
+		Skin skin = new Skin(files.internal("data/uiskin.json"));
+		input.setInputProcessor(stage);
 
-		// Gdx.graphics.setVSync(false);
+		// graphics.setVSync(false);
 
 		container = new Table();
 		stage.addActor(container);
@@ -120,15 +119,15 @@ public class ScrollPaneTest extends GdxTest {
 	}
 
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-		stage.act(Gdx.graphics.getDeltaTime());
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		stage.act(graphics.getDeltaTime());
 		stage.draw();
 	}
 
 	public void resize (int width, int height) {
 		stage.getViewport().update(width, height, true);
 
-		// Gdx.gl.glViewport(100, 100, width - 200, height - 200);
+		// gl.glViewport(100, 100, width - 200, height - 200);
 		// stage.setViewport(800, 600, false, 100, 100, width - 200, height - 200);
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ScrollPaneTextAreaTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ScrollPaneTextAreaTest.java
@@ -1,7 +1,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.scenes.scene2d.ui.ScrollPane;
@@ -20,8 +19,8 @@ public class ScrollPaneTextAreaTest extends GdxTest {
 	@Override
 	public void create () {
 		stage = new Stage(new ScreenViewport());
-		skin = new Skin(Gdx.files.internal("data/uiskin.json"));
-		Gdx.input.setInputProcessor(stage);
+		skin = new Skin(files.internal("data/uiskin.json"));
+		input.setInputProcessor(stage);
 
 		Table container = new Table();
 		stage.addActor(container);
@@ -79,8 +78,8 @@ public class ScrollPaneTextAreaTest extends GdxTest {
 			scrollPane.scrollTo(0, textArea.getHeight() - textArea.getCursorY(), 0, textArea.getStyle().font.getLineHeight());
 		}
 
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-		stage.act(Gdx.graphics.getDeltaTime());
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		stage.act(graphics.getDeltaTime());
 		stage.draw();
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ScrollPaneWithDynamicScrolling.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ScrollPaneWithDynamicScrolling.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.Stage;
@@ -37,8 +36,8 @@ public class ScrollPaneWithDynamicScrolling extends GdxTest {
 
 	public void create () {
 		stage = new Stage();
-		Skin skin = new Skin(Gdx.files.internal("data/uiskin.json"));
-		Gdx.input.setInputProcessor(stage);
+		Skin skin = new Skin(files.internal("data/uiskin.json"));
+		input.setInputProcessor(stage);
 
 		dynamicLabel = new Label("Chat box begin here", skin);
 
@@ -71,8 +70,8 @@ public class ScrollPaneWithDynamicScrolling extends GdxTest {
 	}
 
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-		stage.act(Gdx.graphics.getDeltaTime());
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		stage.act(graphics.getDeltaTime());
 		stage.draw();
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/SensorTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/SensorTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Texture;
@@ -89,7 +88,7 @@ public class SensorTest extends BaseG3dTest {
 		tmpUp.set(cam.up);
 		tmpDirection.set(cam.direction);
 
-		Input input = Gdx.input;
+		Input input = this.input;
 		tmpRotation.setEulerAngles(-input.getAzimuth(), -input.getPitch(), -input.getRoll());
 
 		cam.position.set(5, 10, 5);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ShaderMultitextureTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ShaderMultitextureTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Mesh;
 import com.badlogic.gdx.graphics.Pixmap;
@@ -87,13 +86,13 @@ public class ShaderMultitextureTest extends GdxTest {
 	}
 
 	public void render () {
-		Gdx.gl20.glViewport(0, 0, Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight());
-		Gdx.gl20.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl20.glViewport(0, 0, graphics.getBackBufferWidth(), graphics.getBackBufferHeight());
+		gl20.glClear(GL20.GL_COLOR_BUFFER_BIT);
 
-		Gdx.gl20.glActiveTexture(GL20.GL_TEXTURE0);
+		gl20.glActiveTexture(GL20.GL_TEXTURE0);
 		texture.bind();
 
-		Gdx.gl20.glActiveTexture(GL20.GL_TEXTURE1);
+		gl20.glActiveTexture(GL20.GL_TEXTURE1);
 		texture2.bind();
 
 		shader.bind();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ShapeRendererAlphaTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ShapeRendererAlphaTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
@@ -35,10 +34,10 @@ public class ShapeRendererAlphaTest extends GdxTest {
 
 	@Override
 	public void render () {
-		Gdx.gl.glClearColor(1, 1, 1, 1);
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-		Gdx.gl.glEnable(GL20.GL_BLEND);
-		Gdx.gl.glBlendFunc(GL20.GL_SRC_ALPHA, GL20.GL_ONE_MINUS_SRC_ALPHA);
+		gl.glClearColor(1, 1, 1, 1);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl.glEnable(GL20.GL_BLEND);
+		gl.glBlendFunc(GL20.GL_SRC_ALPHA, GL20.GL_ONE_MINUS_SRC_ALPHA);
 
 		renderer.begin(ShapeType.Line);
 		renderer.setColor(1, 0, 0, 0.5f);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ShapeRendererTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ShapeRendererTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input.Keys;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
@@ -39,18 +38,18 @@ public class ShapeRendererTest extends GdxTest {
 
 	public void create () {
 		renderer = new ShapeRenderer();
-		cam = new PerspectiveCamera(47, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+		cam = new PerspectiveCamera(47, graphics.getWidth(), graphics.getHeight());
 		cam.position.set(0, 0, 2);
 		cam.near = 0.1f;
 		controller = new PerspectiveCamController(cam);
-		Gdx.input.setInputProcessor(controller);
+		input.setInputProcessor(controller);
 		batch = new SpriteBatch();
-		font = new BitmapFont(Gdx.files.internal("data/lsans-15.fnt"), false);
+		font = new BitmapFont(files.internal("data/lsans-15.fnt"), false);
 	}
 
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
-		Gdx.gl.glEnable(GL20.GL_DEPTH_TEST);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
+		gl.glEnable(GL20.GL_DEPTH_TEST);
 		cam.update();
 		renderer.setProjectionMatrix(cam.combined);
 		renderer.identity();
@@ -67,7 +66,7 @@ public class ShapeRendererTest extends GdxTest {
 
 		renderer.end();
 
-		if (Gdx.input.isKeyPressed(Keys.F)) {
+		if (input.isKeyPressed(Keys.F)) {
 			renderer.begin(ShapeType.Filled);
 
 			renderer.setColor(Color.RED);
@@ -122,7 +121,7 @@ public class ShapeRendererTest extends GdxTest {
 		}
 
 		batch.begin();
-		font.draw(batch, "fps: " + Gdx.graphics.getFramesPerSecond(), 0, 20);
+		font.draw(batch, "fps: " + graphics.getFramesPerSecond(), 0, 20);
 		batch.end();
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ShortSoundTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ShortSoundTest.java
@@ -1,14 +1,13 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.tests.utils.GdxTest;
 
 public class ShortSoundTest extends GdxTest {
 
 	@Override
 	public void create () {
-		Gdx.audio.newSound(Gdx.files.internal("data/tic.ogg")).play();
+		audio.newSound(files.internal("data/tic.ogg")).play();
 	}
 
 }

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/SimpleAnimationTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/SimpleAnimationTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.Animation;
@@ -43,8 +42,8 @@ public class SimpleAnimationTest extends GdxTest {
 
 	@Override
 	public void create () {
-		Gdx.input.setInputProcessor(this);
-		texture = new Texture(Gdx.files.internal("data/animation.png"));
+		input.setInputProcessor(this);
+		texture = new Texture(files.internal("data/animation.png"));
 		TextureRegion[][] regions = TextureRegion.split(texture, 32, 48);
 		TextureRegion[] downWalkReg = regions[0];
 		TextureRegion[] leftWalkReg = regions[1];
@@ -64,8 +63,8 @@ public class SimpleAnimationTest extends GdxTest {
 
 	@Override
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-		currentFrameTime += Gdx.graphics.getDeltaTime();
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		currentFrameTime += graphics.getDeltaTime();
 
 		spriteBatch.begin();
 		TextureRegion frame = currentWalk.getKeyFrame(currentFrameTime, true);
@@ -76,7 +75,7 @@ public class SimpleAnimationTest extends GdxTest {
 	@Override
 	public boolean touchDown (int x, int y, int pointer, int button) {
 		position.x = x;
-		position.y = Gdx.graphics.getHeight() - y;
+		position.y = graphics.getHeight() - y;
 		return true;
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/SimpleDecalTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/SimpleDecalTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.FPSLogger;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.PerspectiveCamera;
@@ -41,21 +40,21 @@ public class SimpleDecalTest extends GdxTest {
 	FPSLogger logger = new FPSLogger();
 
 	public void create () {
-		float width = Gdx.graphics.getWidth();
-		float height = Gdx.graphics.getHeight();
+		float width = graphics.getWidth();
+		float height = graphics.getHeight();
 
-		camera = new PerspectiveCamera(45, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+		camera = new PerspectiveCamera(45, graphics.getWidth(), graphics.getHeight());
 		camera.near = 1;
 		camera.far = 300;
 		camera.position.set(0, 0, 5);
 		controller = new PerspectiveCamController(camera);
 
-		Gdx.input.setInputProcessor(controller);
+		input.setInputProcessor(controller);
 		batch = new DecalBatch(new CameraGroupStrategy(camera));
 
-		TextureRegion[] textures = {new TextureRegion(new Texture(Gdx.files.internal("data/egg.png"))),
-			new TextureRegion(new Texture(Gdx.files.internal("data/sys.png"))),
-			new TextureRegion(new Texture(Gdx.files.internal("data/badlogic.jpg")))};
+		TextureRegion[] textures = {new TextureRegion(new Texture(files.internal("data/egg.png"))),
+			new TextureRegion(new Texture(files.internal("data/sys.png"))),
+			new TextureRegion(new Texture(files.internal("data/badlogic.jpg")))};
 
 		Decal decal = Decal.newDecal(1, 1, textures[1]);
 		decal.setPosition(0, 0, 0);
@@ -83,7 +82,7 @@ public class SimpleDecalTest extends GdxTest {
 
 	public void render () {
 		ScreenUtils.clear(Color.DARK_GRAY, true);
-		Gdx.gl.glEnable(GL20.GL_DEPTH_TEST);
+		gl.glEnable(GL20.GL_DEPTH_TEST);
 
 		camera.update();
 		for (int i = 0; i < decals.size; i++) {

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/SimpleStageCullingTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/SimpleStageCullingTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.graphics.Texture;
@@ -113,10 +112,10 @@ public class SimpleStageCullingTest extends GdxTest {
 		stage = new Stage();
 		;
 		camController = new OrthoCamController((OrthographicCamera)stage.getCamera()); // we know it's an ortho cam at this point!
-		Gdx.input.setInputProcessor(camController);
+		input.setInputProcessor(camController);
 
 		// load a dummy texture
-		texture = new Texture(Gdx.files.internal("data/badlogicsmall.jpg"));
+		texture = new Texture(files.internal("data/badlogicsmall.jpg"));
 
 		// populate the stage with some actors and groups.
 		for (int i = 0; i < 5000; i++) {
@@ -128,11 +127,11 @@ public class SimpleStageCullingTest extends GdxTest {
 
 		// we also want to output the number of visible actors, so we need a SpriteBatch and a BitmapFont
 		batch = new SpriteBatch();
-		font = new BitmapFont(Gdx.files.internal("data/lsans-15.fnt"), false);
+		font = new BitmapFont(files.internal("data/lsans-15.fnt"), false);
 	}
 
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		stage.draw();
 
 		// check how many actors are visible.
@@ -143,7 +142,7 @@ public class SimpleStageCullingTest extends GdxTest {
 		}
 
 		batch.begin();
-		font.draw(batch, "Visible: " + numVisible + ", fps: " + Gdx.graphics.getFramesPerSecond(), 20, 30);
+		font.draw(batch, "Visible: " + numVisible + ", fps: " + graphics.getFramesPerSecond(), 20, 30);
 		batch.end();
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/SoftKeyboardTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/SoftKeyboardTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.InputAdapter;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
@@ -42,7 +41,7 @@ public class SoftKeyboardTest extends GdxTest {
 		// we register an InputAdapter to listen for the keyboard
 		// input. The on-screen keyboard might only generate
 		// "key typed" events, depending on the backend.
-		Gdx.input.setInputProcessor(new InputAdapter() {
+		input.setInputProcessor(new InputAdapter() {
 			@Override
 			public boolean keyTyped (char character) {
 				// convert \r to \n
@@ -62,14 +61,14 @@ public class SoftKeyboardTest extends GdxTest {
 
 	@Override
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		batch.begin();
-		font.draw(batch, textBuffer, 0, Gdx.graphics.getHeight() - 20);
+		font.draw(batch, textBuffer, 0, graphics.getHeight() - 20);
 		batch.end();
 
 		// bring up the keyboard if we touch the screen
-		if (Gdx.input.justTouched()) {
-			Gdx.input.setOnscreenKeyboardVisible(true);
+		if (input.justTouched()) {
+			input.setOnscreenKeyboardVisible(true);
 			textBuffer = new SimpleCharSequence();
 		}
 	}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/SortedSpriteTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/SortedSpriteTest.java
@@ -18,7 +18,6 @@ package com.badlogic.gdx.tests;
 
 import java.util.Comparator;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.Sprite;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
@@ -99,7 +98,7 @@ public class SortedSpriteTest extends GdxTest {
 		for (int i = 0; i < 100; i++) {
 			// create the sprite and set a random position
 			MySprite sprite = new MySprite(texture);
-			sprite.setPosition(MathUtils.random() * Gdx.graphics.getWidth(), MathUtils.random() * Gdx.graphics.getHeight());
+			sprite.setPosition(MathUtils.random() * graphics.getWidth(), MathUtils.random() * graphics.getHeight());
 
 			// create a random z coordinate in the range 0-1
 			sprite.z = MathUtils.random();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/SoundTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/SoundTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.audio.Sound;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.scenes.scene2d.Actor;
@@ -49,7 +48,7 @@ public class SoundTest extends GdxTest {
 	@Override
 	public void create () {
 
-		skin = new Skin(Gdx.files.internal("data/uiskin.json"));
+		skin = new Skin(files.internal("data/uiskin.json"));
 		ui = new Stage(new FitViewport(640, 400));
 		final SelectBox<String> soundSelector = new SelectBox<String>(skin);
 		soundSelector.setItems(FILENAMES);
@@ -141,12 +140,12 @@ public class SoundTest extends GdxTest {
 				panValue.setText("" + pan.getValue());
 			}
 		});
-		Gdx.input.setInputProcessor(ui);
+		input.setInputProcessor(ui);
 	}
 
 	protected void setSound (String fileName) {
 		if (sound != null) sound.dispose();
-		sound = Gdx.audio.newSound(Gdx.files.internal("data").child(fileName));
+		sound = audio.newSound(files.internal("data").child(fileName));
 	}
 
 	@Override
@@ -156,8 +155,8 @@ public class SoundTest extends GdxTest {
 
 	@Override
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-		ui.act(Gdx.graphics.getDeltaTime());
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		ui.act(graphics.getDeltaTime());
 		ui.draw();
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/SpriteBatchOriginScaleTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/SpriteBatchOriginScaleTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
@@ -46,8 +45,8 @@ public class SpriteBatchOriginScaleTest extends GdxTest {
 
 		renderer.begin(ShapeType.Line);
 		renderer.setColor(1, 1, 1, 1);
-		renderer.line(0, 100, Gdx.graphics.getWidth(), 100);
-		renderer.line(100, 0, 100, Gdx.graphics.getHeight());
+		renderer.line(0, 100, graphics.getWidth(), 100);
+		renderer.line(100, 0, 100, graphics.getHeight());
 		renderer.end();
 
 		batch.begin();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/SpriteBatchPerformanceTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/SpriteBatchPerformanceTest.java
@@ -17,7 +17,6 @@
 package com.badlogic.gdx.tests;
 
 import com.badlogic.gdx.Application;
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Mesh;
 import com.badlogic.gdx.graphics.Texture;
@@ -52,14 +51,14 @@ public class SpriteBatchPerformanceTest extends GdxTest {
 
 	@Override
 	public void create () {
-		texture = new Texture(Gdx.files.internal("data/badlogic.jpg"));
+		texture = new Texture(files.internal("data/badlogic.jpg"));
 		spriteBatch = new SpriteBatch(8191);
 		bitmapFont = new BitmapFont();
 
-		if (Gdx.graphics.isGL30Available()) {
+		if (graphics.isGL30Available()) {
 			perfTests.add(new PerfTest(Mesh.VertexDataType.VertexBufferObjectWithVAO));
 
-			if (Gdx.app.getType() != Application.ApplicationType.Desktop) {
+			if (app.getType() != Application.ApplicationType.Desktop) {
 				perfTests.add(new PerfTest(Mesh.VertexDataType.VertexBufferObject));
 			}
 		} else {
@@ -67,7 +66,7 @@ public class SpriteBatchPerformanceTest extends GdxTest {
 			perfTests.add(new PerfTest(Mesh.VertexDataType.VertexBufferObject));
 		}
 
-		GLProfiler glProfiler = new GLProfiler(Gdx.graphics);
+		GLProfiler glProfiler = new GLProfiler(graphics);
 		glProfiler.setListener(new GLErrorListener() {
 			@Override
 			public void onError (int error) {
@@ -80,9 +79,9 @@ public class SpriteBatchPerformanceTest extends GdxTest {
 
 	@Override
 	public void render () {
-		Gdx.gl20.glViewport(0, 0, Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight());
-		Gdx.gl20.glClearColor(0.2f, 0.2f, 0.2f, 1);
-		Gdx.gl20.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl20.glViewport(0, 0, graphics.getBackBufferWidth(), graphics.getBackBufferHeight());
+		gl20.glClearColor(0.2f, 0.2f, 0.2f, 1);
+		gl20.glClear(GL20.GL_COLOR_BUFFER_BIT);
 
 		int draws = 100;
 		int spritesToFill = 8190;
@@ -91,7 +90,7 @@ public class SpriteBatchPerformanceTest extends GdxTest {
 			SpriteBatch.overrideVertexType = perfTest.vertexDataType;
 
 			SpriteBatch testingBatch = new SpriteBatch(8191);
-			Gdx.gl.glFlush();
+			gl.glFlush();
 			testingBatch.begin();
 			for (int i = 0; i < draws; i++) {
 				for (int j = 0; j < spritesToFill; j++) {
@@ -100,7 +99,7 @@ public class SpriteBatchPerformanceTest extends GdxTest {
 
 				long beforeFlush = System.nanoTime();
 				testingBatch.flush();
-				Gdx.gl.glFlush();
+				gl.glFlush();
 				long afterFlush = System.nanoTime();
 
 				perfTest.counter.addValue(afterFlush - beforeFlush);
@@ -108,7 +107,7 @@ public class SpriteBatchPerformanceTest extends GdxTest {
 
 			testingBatch.end();
 			testingBatch.dispose();
-			Gdx.gl.glFlush();
+			gl.glFlush();
 		}
 
 		spriteBatch.begin();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/SpriteBatchRotationTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/SpriteBatchRotationTest.java
@@ -18,7 +18,6 @@ package com.badlogic.gdx.tests;
 
 import java.nio.IntBuffer;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
@@ -35,7 +34,7 @@ public class SpriteBatchRotationTest extends GdxTest {
 
 	@Override
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		spriteBatch.begin();
 		spriteBatch.draw(texture, 16, 10, 16, 16, 32, 32, 1, 1, 0, 0, 0, texture.getWidth(), texture.getHeight(), false, false);
 		spriteBatch.draw(texture, 64, 10, 32, 32, 0, 0, texture.getWidth(), texture.getHeight(), false, false);
@@ -50,8 +49,8 @@ public class SpriteBatchRotationTest extends GdxTest {
 			false);
 
 		spriteBatch.end();
-		angle += 20 * Gdx.graphics.getDeltaTime();
-		scale += vScale * Gdx.graphics.getDeltaTime();
+		angle += 20 * graphics.getDeltaTime();
+		scale += vScale * graphics.getDeltaTime();
 		if (scale > 2) {
 			vScale = -vScale;
 			scale = 2;
@@ -66,6 +65,6 @@ public class SpriteBatchRotationTest extends GdxTest {
 	@Override
 	public void create () {
 		spriteBatch = new SpriteBatch();
-		texture = new Texture(Gdx.files.internal("data/test.png"));
+		texture = new Texture(files.internal("data/test.png"));
 	}
 }

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/SpriteBatchShaderTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/SpriteBatchShaderTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Mesh;
@@ -47,7 +46,7 @@ public class SpriteBatchShaderTest extends GdxTest {
 
 	@Override
 	public void render () {
-		GL20 gl = Gdx.gl20;
+		GL20 gl = gl20;
 		gl.glClearColor(0.7f, 0.7f, 0.7f, 1);
 		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 
@@ -84,7 +83,7 @@ public class SpriteBatchShaderTest extends GdxTest {
 		end = (TimeUtils.nanoTime() - start) / 1000000000.0f;
 
 		if (TimeUtils.nanoTime() - startTime > 1000000000) {
-			Gdx.app.log("SpriteBatch", "fps: " + frames + ", render calls: " + spriteBatch.renderCalls + ", " + begin + ", " + draw1
+			app.log("SpriteBatch", "fps: " + frames + ", render calls: " + spriteBatch.renderCalls + ", " + begin + ", " + draw1
 				+ ", " + draw2 + ", " + drawText + ", " + end);
 			frames = 0;
 			startTime = TimeUtils.nanoTime();
@@ -95,7 +94,7 @@ public class SpriteBatchShaderTest extends GdxTest {
 	@Override
 	public void create () {
 		spriteBatch = new SpriteBatch();
-		texture = new Texture(Gdx.files.internal("data/badlogicsmall.jpg"));
+		texture = new Texture(files.internal("data/badlogicsmall.jpg"));
 
 		Pixmap pixmap = new Pixmap(32, 32, Format.RGB565);
 		pixmap.setColor(1, 1, 0, 0.7f);
@@ -104,10 +103,10 @@ public class SpriteBatchShaderTest extends GdxTest {
 		pixmap.dispose();
 
 		for (int i = 0; i < coords.length; i += 2) {
-			coords[i] = (int)(Math.random() * Gdx.graphics.getWidth());
-			coords[i + 1] = (int)(Math.random() * Gdx.graphics.getHeight());
-			coords2[i] = (int)(Math.random() * Gdx.graphics.getWidth());
-			coords2[i + 1] = (int)(Math.random() * Gdx.graphics.getHeight());
+			coords[i] = (int)(Math.random() * graphics.getWidth());
+			coords[i + 1] = (int)(Math.random() * graphics.getHeight());
+			coords2[i] = (int)(Math.random() * graphics.getWidth());
+			coords2[i + 1] = (int)(Math.random() * graphics.getHeight());
 		}
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/SpriteBatchTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/SpriteBatchTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.InputProcessor;
 import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.Pixmap.Format;
@@ -63,8 +62,8 @@ public class SpriteBatchTest extends GdxTest implements InputProcessor {
 		float draw2 = 0;
 		float drawText = 0;
 
-		angle += ROTATION_SPEED * Gdx.graphics.getDeltaTime();
-		scale += SCALE_SPEED * Gdx.graphics.getDeltaTime();
+		angle += ROTATION_SPEED * graphics.getDeltaTime();
+		scale += SCALE_SPEED * graphics.getDeltaTime();
 		if (scale < 0.5f) {
 			scale = 0.5f;
 			SCALE_SPEED = 1;
@@ -93,7 +92,7 @@ public class SpriteBatchTest extends GdxTest implements InputProcessor {
 // spriteBatch.drawText(font, "Question?", 100, 300, Color.RED);
 // spriteBatch.drawText(font, "and another this is a test", 200, 100, Color.WHITE);
 // spriteBatch.drawText(font, "all hail and another this is a test", 200, 200, Color.WHITE);
-// spriteBatch.drawText(font, "normal fps: " + Gdx.graphics.getFramesPerSecond(), 10, 30, Color.RED);
+// spriteBatch.drawText(font, "normal fps: " + graphics.getFramesPerSecond(), 10, 30, Color.RED);
 		drawText = (TimeUtils.nanoTime() - start) / 1000000000.0f;
 
 		start = TimeUtils.nanoTime();
@@ -101,7 +100,7 @@ public class SpriteBatchTest extends GdxTest implements InputProcessor {
 		end = (TimeUtils.nanoTime() - start) / 1000000000.0f;
 
 		if (TimeUtils.nanoTime() - startTime > 1000000000) {
-			Gdx.app.log("SpriteBatch", "fps: " + frames + ", render calls: " + spriteBatch.renderCalls + ", " + begin + ", " + draw1
+			app.log("SpriteBatch", "fps: " + frames + ", render calls: " + spriteBatch.renderCalls + ", " + begin + ", " + draw1
 				+ ", " + draw2 + ", " + drawText + ", " + end);
 			frames = 0;
 			startTime = TimeUtils.nanoTime();
@@ -123,8 +122,8 @@ public class SpriteBatchTest extends GdxTest implements InputProcessor {
 		spriteBatch.begin();
 		begin = (TimeUtils.nanoTime() - start) / 1000000000.0f;
 
-		float angleInc = ROTATION_SPEED * Gdx.graphics.getDeltaTime();
-		scale += SCALE_SPEED * Gdx.graphics.getDeltaTime();
+		float angleInc = ROTATION_SPEED * graphics.getDeltaTime();
+		scale += SCALE_SPEED * graphics.getDeltaTime();
 		if (scale < 0.5f) {
 			scale = 0.5f;
 			SCALE_SPEED = 1;
@@ -154,7 +153,7 @@ public class SpriteBatchTest extends GdxTest implements InputProcessor {
 // spriteBatch.drawText(font, "Question?", 100, 300, Color.RED);
 // spriteBatch.drawText(font, "and another this is a test", 200, 100, Color.WHITE);
 // spriteBatch.drawText(font, "all hail and another this is a test", 200, 200, Color.WHITE);
-// spriteBatch.drawText(font, "Sprite fps: " + Gdx.graphics.getFramesPerSecond(), 10, 30, Color.RED);
+// spriteBatch.drawText(font, "Sprite fps: " + graphics.getFramesPerSecond(), 10, 30, Color.RED);
 		drawText = (TimeUtils.nanoTime() - start) / 1000000000.0f;
 
 		start = TimeUtils.nanoTime();
@@ -162,7 +161,7 @@ public class SpriteBatchTest extends GdxTest implements InputProcessor {
 		end = (TimeUtils.nanoTime() - start) / 1000000000.0f;
 
 		if (TimeUtils.nanoTime() - startTime > 1000000000) {
-			Gdx.app.log("SpriteBatch", "fps: " + frames + ", render calls: " + spriteBatch.renderCalls + ", " + begin + ", " + draw1
+			app.log("SpriteBatch", "fps: " + frames + ", render calls: " + spriteBatch.renderCalls + ", " + begin + ", " + draw1
 				+ ", " + draw2 + ", " + drawText + ", " + end);
 			frames = 0;
 			startTime = TimeUtils.nanoTime();
@@ -174,7 +173,7 @@ public class SpriteBatchTest extends GdxTest implements InputProcessor {
 	public void create () {
 		spriteBatch = new SpriteBatch(1000);
 
-		Pixmap pixmap = new Pixmap(Gdx.files.internal("data/badlogicsmall.jpg"));
+		Pixmap pixmap = new Pixmap(files.internal("data/badlogicsmall.jpg"));
 		texture = new Texture(32, 32, Format.RGB565);
 		texture.setFilter(TextureFilter.Linear, TextureFilter.Linear);
 		texture.draw(pixmap, 0, 0);
@@ -187,14 +186,14 @@ public class SpriteBatchTest extends GdxTest implements InputProcessor {
 		pixmap.dispose();
 
 		for (int i = 0; i < sprites.length; i += 6) {
-			sprites[i] = (int)(Math.random() * (Gdx.graphics.getWidth() - 32));
-			sprites[i + 1] = (int)(Math.random() * (Gdx.graphics.getHeight() - 32));
+			sprites[i] = (int)(Math.random() * (graphics.getWidth() - 32));
+			sprites[i + 1] = (int)(Math.random() * (graphics.getHeight() - 32));
 			sprites[i + 2] = 0;
 			sprites[i + 3] = 0;
 			sprites[i + 4] = 32;
 			sprites[i + 5] = 32;
-			sprites2[i] = (int)(Math.random() * (Gdx.graphics.getWidth() - 32));
-			sprites2[i + 1] = (int)(Math.random() * (Gdx.graphics.getHeight() - 32));
+			sprites2[i] = (int)(Math.random() * (graphics.getWidth() - 32));
+			sprites2[i + 1] = (int)(Math.random() * (graphics.getHeight() - 32));
 			sprites2[i + 2] = 0;
 			sprites2[i + 3] = 0;
 			sprites2[i + 4] = 32;
@@ -202,8 +201,8 @@ public class SpriteBatchTest extends GdxTest implements InputProcessor {
 		}
 
 		for (int i = 0; i < SPRITES * 2; i++) {
-			int x = (int)(Math.random() * (Gdx.graphics.getWidth() - 32));
-			int y = (int)(Math.random() * (Gdx.graphics.getHeight() - 32));
+			int x = (int)(Math.random() * (graphics.getWidth() - 32));
+			int y = (int)(Math.random() * (graphics.getHeight() - 32));
 
 			if (i >= SPRITES)
 				sprites3[i] = new Sprite(texture2, 32, 32);
@@ -213,12 +212,12 @@ public class SpriteBatchTest extends GdxTest implements InputProcessor {
 			sprites3[i].setOrigin(16, 16);
 		}
 
-		Gdx.input.setInputProcessor(this);
+		input.setInputProcessor(this);
 	}
 
 	@Override
 	public void resize (int width, int height) {
-		Gdx.app.log("SpriteBatchTest", "resized: " + width + ", " + height);
+		app.log("SpriteBatchTest", "resized: " + width + ", " + height);
 	}
 
 	@Override

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/SpriteCacheOffsetTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/SpriteCacheOffsetTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.InputProcessor;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Texture;
@@ -32,7 +31,7 @@ public class SpriteCacheOffsetTest extends GdxTest implements InputProcessor {
 	private Texture texture;
 
 	public void create () {
-		texture = new Texture(Gdx.files.internal("data/badlogicsmall.jpg"));
+		texture = new Texture(files.internal("data/badlogicsmall.jpg"));
 		Sprite sprite = new Sprite(texture);
 		sprite.setSize(tileSize, tileSize);
 
@@ -49,7 +48,7 @@ public class SpriteCacheOffsetTest extends GdxTest implements InputProcessor {
 	}
 
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		cache.begin();
 		for (int y = 1; y < tileMapHeight - 1; y++)
 			cache.draw(y, 1, tileMapWidth - 2);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/SpriteCacheTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/SpriteCacheTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.InputProcessor;
 import com.badlogic.gdx.graphics.Pixmap;
@@ -72,7 +71,7 @@ public class SpriteCacheTest extends GdxTest implements InputProcessor {
 		end = (TimeUtils.nanoTime() - start) / 1000000000.0f;
 
 		if (TimeUtils.nanoTime() - startTime > 1000000000) {
-// Gdx.app.log( "SpriteBatch", "fps: " + frames + ", render calls: " + spriteBatch.renderCalls + ", " + begin + ", " + draw1 +
+// app.log( "SpriteBatch", "fps: " + frames + ", render calls: " + spriteBatch.renderCalls + ", " + begin + ", " + draw1 +
 // ", " + draw2 + ", " + drawText + ", " + end );
 			frames = 0;
 			startTime = TimeUtils.nanoTime();
@@ -102,7 +101,7 @@ public class SpriteCacheTest extends GdxTest implements InputProcessor {
 		end = (TimeUtils.nanoTime() - start) / 1000000000.0f;
 
 		if (TimeUtils.nanoTime() - startTime > 1000000000) {
-// Gdx.app.log( "SpriteBatch", "fps: " + frames + ", render calls: " + spriteBatch.renderCalls + ", " + begin + ", " + draw1 +
+// app.log( "SpriteBatch", "fps: " + frames + ", render calls: " + spriteBatch.renderCalls + ", " + begin + ", " + draw1 +
 // ", " + draw2 + ", " + drawText + ", " + end );
 			frames = 0;
 			startTime = TimeUtils.nanoTime();
@@ -114,7 +113,7 @@ public class SpriteCacheTest extends GdxTest implements InputProcessor {
 	public void create () {
 		spriteCache = new SpriteCache(1000, true);
 
-		texture = new Texture(Gdx.files.internal("data/badlogicsmall.jpg"));
+		texture = new Texture(files.internal("data/badlogicsmall.jpg"));
 		texture.setFilter(TextureFilter.Linear, TextureFilter.Linear);
 
 		Pixmap pixmap = new Pixmap(32, 32, Format.RGBA8888);
@@ -128,14 +127,14 @@ public class SpriteCacheTest extends GdxTest implements InputProcessor {
 		Sprite[] sprites3 = new Sprite[SPRITES * 2];
 
 		for (int i = 0; i < sprites.length; i += 6) {
-			sprites[i] = (int)(Math.random() * (Gdx.graphics.getWidth() - 32));
-			sprites[i + 1] = (int)(Math.random() * (Gdx.graphics.getHeight() - 32));
+			sprites[i] = (int)(Math.random() * (graphics.getWidth() - 32));
+			sprites[i + 1] = (int)(Math.random() * (graphics.getHeight() - 32));
 			sprites[i + 2] = 0;
 			sprites[i + 3] = 0;
 			sprites[i + 4] = 32;
 			sprites[i + 5] = 32;
-			sprites2[i] = (int)(Math.random() * (Gdx.graphics.getWidth() - 32));
-			sprites2[i + 1] = (int)(Math.random() * (Gdx.graphics.getHeight() - 32));
+			sprites2[i] = (int)(Math.random() * (graphics.getWidth() - 32));
+			sprites2[i + 1] = (int)(Math.random() * (graphics.getHeight() - 32));
 			sprites2[i + 2] = 0;
 			sprites2[i + 3] = 0;
 			sprites2[i + 4] = 32;
@@ -143,8 +142,8 @@ public class SpriteCacheTest extends GdxTest implements InputProcessor {
 		}
 
 		for (int i = 0; i < SPRITES * 2; i++) {
-			int x = (int)(Math.random() * (Gdx.graphics.getWidth() - 32));
-			int y = (int)(Math.random() * (Gdx.graphics.getHeight() - 32));
+			int x = (int)(Math.random() * (graphics.getWidth() - 32));
+			int y = (int)(Math.random() * (graphics.getHeight() - 32));
 
 			if (i >= SPRITES)
 				sprites3[i] = new Sprite(texture2, 32, 32);
@@ -179,7 +178,7 @@ public class SpriteCacheTest extends GdxTest implements InputProcessor {
 		}
 		spriteCacheID = spriteCache.endCache();
 
-		Gdx.input.setInputProcessor(this);
+		input.setInputProcessor(this);
 	}
 
 	@Override

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/StageDebugTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/StageDebugTest.java
@@ -18,7 +18,6 @@ package com.badlogic.gdx.tests;
 
 import static com.badlogic.gdx.scenes.scene2d.actions.Actions.*;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.Batch;
@@ -51,7 +50,7 @@ public class StageDebugTest extends GdxTest {
 	public void create () {
 		textureRegion = new TextureRegion(new Texture("data/badlogic.jpg"));
 
-		Gdx.input.setInputProcessor(this);
+		input.setInputProcessor(this);
 
 		stage1 = new Stage();
 		stage1.getCamera().position.set(100, 100, 0);
@@ -74,7 +73,7 @@ public class StageDebugTest extends GdxTest {
 		group.debugAll();
 
 		stage2 = new Stage();
-		Skin skin = new Skin(Gdx.files.internal("data/uiskin.json"));
+		Skin skin = new Skin(files.internal("data/uiskin.json"));
 
 		TextButton shortButton = new TextButton("Button short", skin);
 		shortButton.debug();
@@ -101,7 +100,7 @@ public class StageDebugTest extends GdxTest {
 
 	@Override
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
 		stage.act();
 		stage.draw();
 	}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/StagePerformanceTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/StagePerformanceTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
@@ -52,7 +51,7 @@ public class StagePerformanceTest extends GdxTest {
 		regions = new TextureRegion[8 * 8];
 		sprites = new Sprite[24 * 12];
 
-		texture = new Texture(Gdx.files.internal("data/badlogic.jpg"));
+		texture = new Texture(files.internal("data/badlogic.jpg"));
 		for (int y = 0; y < 8; y++) {
 			for (int x = 0; x < 8; x++) {
 				regions[x + y * 8] = new TextureRegion(texture, x * 32, y * 32, 32, 32);
@@ -75,15 +74,15 @@ public class StagePerformanceTest extends GdxTest {
 
 	@Override
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 
 		if (useStage) {
-			stage.act(Gdx.graphics.getDeltaTime());
+			stage.act(graphics.getDeltaTime());
 			stage.getBatch().disableBlending();
 			Group root = stage.getRoot();
 			Array<Actor> actors = root.getChildren();
 // for(int i = 0; i < actors.size(); i++) {
-// actors.get(i).rotation += 45 * Gdx.graphics.getDeltaTime();
+// actors.get(i).rotation += 45 * graphics.getDeltaTime();
 // }
 			stage.draw();
 		} else {
@@ -92,7 +91,7 @@ public class StagePerformanceTest extends GdxTest {
 			batch.disableBlending();
 			batch.begin();
 			for (int i = 0; i < sprites.length; i++) {
-// sprites[i].rotate(45 * Gdx.graphics.getDeltaTime());
+// sprites[i].rotate(45 * graphics.getDeltaTime());
 				sprites[i].draw(batch);
 			}
 			batch.end();
@@ -103,10 +102,10 @@ public class StagePerformanceTest extends GdxTest {
 		batch.begin();
 		font.setColor(0, 0, 1, 1);
 		font.getData().setScale(2);
-		font.draw(batch, "fps: " + Gdx.graphics.getFramesPerSecond() + (useStage ? ", stage" : "sprite"), 10, 40);
+		font.draw(batch, "fps: " + graphics.getFramesPerSecond() + (useStage ? ", stage" : "sprite"), 10, 40);
 		batch.end();
 
-		if (Gdx.input.justTouched()) {
+		if (input.justTouched()) {
 			useStage = !useStage;
 		}
 	}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/StageTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/StageTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.InputProcessor;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Texture;
@@ -62,9 +61,9 @@ public class StageTest extends GdxTest implements InputProcessor {
 
 	@Override
 	public void create () {
-		texture = new Texture(Gdx.files.internal("data/badlogicsmall.jpg"));
+		texture = new Texture(files.internal("data/badlogicsmall.jpg"));
 		texture.setFilter(TextureFilter.Linear, TextureFilter.Linear);
-		font = new BitmapFont(Gdx.files.internal("data/lsans-15.fnt"), false);
+		font = new BitmapFont(files.internal("data/lsans-15.fnt"), false);
 
 		stage = new Stage(new ScreenViewport());
 
@@ -79,7 +78,7 @@ public class StageTest extends GdxTest implements InputProcessor {
 			stage.addActor(group);
 		}
 
-		uiTexture = new Texture(Gdx.files.internal("data/ui.png"));
+		uiTexture = new Texture(files.internal("data/ui.png"));
 		uiTexture.setFilter(TextureFilter.Linear, TextureFilter.Linear);
 		ui = new Stage(new ScreenViewport());
 
@@ -151,7 +150,7 @@ public class StageTest extends GdxTest implements InputProcessor {
 		ui.addActor(fps);
 
 		renderer = new ShapeRenderer();
-		Gdx.input.setInputProcessor(this);
+		input.setInputProcessor(this);
 	}
 
 	private void fillGroup (Group group, Texture texture) {
@@ -172,11 +171,11 @@ public class StageTest extends GdxTest implements InputProcessor {
 
 	@Override
 	public void render () {
-		Gdx.gl.glViewport(0, 0, Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight());
+		gl.glViewport(0, 0, graphics.getBackBufferWidth(), graphics.getBackBufferHeight());
 		ScreenUtils.clear(0.2f, 0.2f, 0.2f, 1);
 
-		if (Gdx.input.isTouched()) {
-			stage.screenToStageCoordinates(stageCoords.set(Gdx.input.getX(), Gdx.input.getY()));
+		if (input.isTouched()) {
+			stage.screenToStageCoordinates(stageCoords.set(input.getX(), input.getY()));
 			Actor actor = stage.hit(stageCoords.x, stageCoords.y, true);
 			if (actor != null)
 				actor.setColor((float)Math.random(), (float)Math.random(), (float)Math.random(), 0.5f + 0.5f * (float)Math.random());
@@ -186,10 +185,10 @@ public class StageTest extends GdxTest implements InputProcessor {
 		int len = actors.size;
 		if (rotateSprites) {
 			for (int i = 0; i < len; i++)
-				actors.get(i).rotateBy(Gdx.graphics.getDeltaTime() * 10);
+				actors.get(i).rotateBy(graphics.getDeltaTime() * 10);
 		}
 
-		scale += vScale * Gdx.graphics.getDeltaTime();
+		scale += vScale * graphics.getDeltaTime();
 		if (scale > 1) {
 			scale = 1;
 			vScale = -vScale;
@@ -203,7 +202,7 @@ public class StageTest extends GdxTest implements InputProcessor {
 		for (int i = 0; i < len; i++) {
 			Actor sprite = sprites.get(i);
 			if (rotateSprites)
-				sprite.rotateBy(-40 * Gdx.graphics.getDeltaTime());
+				sprite.rotateBy(-40 * graphics.getDeltaTime());
 			else
 				sprite.setRotation(0);
 
@@ -225,7 +224,7 @@ public class StageTest extends GdxTest implements InputProcessor {
 		}
 		renderer.end();
 
-		fps.setText("fps: " + Gdx.graphics.getFramesPerSecond() + ", actors " + sprites.size + ", groups " + sprites.size);
+		fps.setText("fps: " + graphics.getFramesPerSecond() + ", actors " + sprites.size + ", groups " + sprites.size);
 		ui.draw();
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/SystemCursorTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/SystemCursorTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Cursor;
 import com.badlogic.gdx.scenes.scene2d.Actor;
@@ -37,9 +36,9 @@ public class SystemCursorTest extends GdxTest {
 	public void create () {
 		super.create();
 		stage = new Stage(new ScreenViewport());
-		skin = new Skin(Gdx.files.internal("data/uiskin.json"));
+		skin = new Skin(files.internal("data/uiskin.json"));
 
-		Gdx.input.setInputProcessor(stage);
+		input.setInputProcessor(stage);
 
 		Table table = new Table();
 		table.setFillParent(true);
@@ -50,7 +49,7 @@ public class SystemCursorTest extends GdxTest {
 			button.addListener(new ChangeListener() {
 				@Override
 				public void changed (ChangeEvent event, Actor actor) {
-					Gdx.graphics.setSystemCursor(cursor);
+					graphics.setSystemCursor(cursor);
 				}
 			});
 			table.add(button).row();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TableLayoutTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TableLayoutTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
@@ -37,8 +36,8 @@ public class TableLayoutTest extends GdxTest {
 
 	public void create () {
 		stage = new Stage();
-		Gdx.input.setInputProcessor(stage);
-		Skin skin = new Skin(Gdx.files.internal("data/uiskin.json"));
+		input.setInputProcessor(stage);
+		Skin skin = new Skin(files.internal("data/uiskin.json"));
 
 		Label nameLabel = new Label("Name:", skin);
 		TextField nameText = new TextField("", skin);
@@ -88,8 +87,8 @@ public class TableLayoutTest extends GdxTest {
 	}
 
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-		stage.act(Gdx.graphics.getDeltaTime());
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		stage.act(graphics.getDeltaTime());
 		stage.draw();
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TableTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TableTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.Batch;
 import com.badlogic.gdx.graphics.g2d.NinePatch;
@@ -42,11 +41,11 @@ public class TableTest extends GdxTest {
 	@Override
 	public void create () {
 		stage = new Stage();
-		Gdx.input.setInputProcessor(stage);
+		input.setInputProcessor(stage);
 
-		skin = new Skin(Gdx.files.internal("data/uiskin.json"));
+		skin = new Skin(files.internal("data/uiskin.json"));
 
-		texture = new Texture(Gdx.files.internal("data/badlogic.jpg"));
+		texture = new Texture(files.internal("data/badlogic.jpg"));
 		TextureRegion region = new TextureRegion(texture);
 
 		NinePatch patch = skin.getPatch("default-round");
@@ -105,7 +104,7 @@ public class TableTest extends GdxTest {
 	public void render () {
 		ScreenUtils.clear(0.2f, 0.2f, 0.2f, 1);
 
-		stage.act(Math.min(Gdx.graphics.getDeltaTime(), 1 / 30f));
+		stage.act(Math.min(graphics.getDeltaTime(), 1 / 30f));
 		stage.draw();
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TextAreaTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TextAreaTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.scenes.scene2d.Stage;
@@ -33,8 +32,8 @@ public class TextAreaTest extends GdxTest {
 	@Override
 	public void create () {
 		stage = new Stage();
-		Gdx.input.setInputProcessor(stage);
-		skin = new Skin(Gdx.files.internal("data/uiskin.json"));
+		input.setInputProcessor(stage);
+		skin = new Skin(files.internal("data/uiskin.json"));
 		skin.getFont("default-font").setFixedWidthGlyphs("0123456789");
 		TextArea textArea = new TextArea("Text Area\n1111111111\n0123456789\nEssentially, a text field\nwith\nmultiple\nlines.\n"
 			+ "It can even handle very loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong lines.",
@@ -52,16 +51,16 @@ public class TextAreaTest extends GdxTest {
 		stage.addActor(textArea);
 		stage.addActor(textField);
 
-		Gdx.input.setCatchKey(Input.Keys.TAB, true);
+		input.setCatchKey(Input.Keys.TAB, true);
 	}
 
 	@Override
 	public void render () {
 		ScreenUtils.clear(0.2f, 0.2f, 0.2f, 1);
 		stage.draw();
-		Gdx.app.log("X", "FPS: " + Gdx.graphics.getFramesPerSecond());
+		app.log("X", "FPS: " + graphics.getFramesPerSecond());
 		SpriteBatch spriteBatch = (SpriteBatch)stage.getBatch();
-		Gdx.app.log("X", "render calls: " + spriteBatch.totalRenderCalls);
+		app.log("X", "render calls: " + spriteBatch.totalRenderCalls);
 		spriteBatch.totalRenderCalls = 0;
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TextAreaTest2.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TextAreaTest2.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.scenes.scene2d.ui.Skin;
@@ -32,8 +31,8 @@ public class TextAreaTest2 extends GdxTest {
 	@Override
 	public void create () {
 		stage = new Stage();
-		Gdx.input.setInputProcessor(stage);
-		skin = new Skin(Gdx.files.internal("data/uiskin.json"));
+		input.setInputProcessor(stage);
+		skin = new Skin(files.internal("data/uiskin.json"));
 
 		// Create a string that perfectly fills the float array used in the textarea float array
 		FloatArray dummyArray = new FloatArray();
@@ -56,9 +55,9 @@ public class TextAreaTest2 extends GdxTest {
 	public void render () {
 		ScreenUtils.clear(0.2f, 0.2f, 0.2f, 1);
 		stage.draw();
-		Gdx.app.log("X", "FPS: " + Gdx.graphics.getFramesPerSecond());
+		app.log("X", "FPS: " + graphics.getFramesPerSecond());
 		SpriteBatch spriteBatch = (SpriteBatch)stage.getBatch();
-		Gdx.app.log("X", "render calls: " + spriteBatch.totalRenderCalls);
+		app.log("X", "render calls: " + spriteBatch.totalRenderCalls);
 		spriteBatch.totalRenderCalls = 0;
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TextAreaTest3.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TextAreaTest3.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.scenes.scene2d.Actor;
@@ -46,7 +45,7 @@ public class TextAreaTest3 extends GdxTest {
 
 	@Override
 	public void create () {
-		skin = new Skin(Gdx.files.internal("data/uiskin.json"));
+		skin = new Skin(files.internal("data/uiskin.json"));
 		// default font in the skin has line height == text height, so its impossible to see updated selection/cursor rendering
 		styleDefault = skin.get(TextField.TextFieldStyle.class);
 		// nearest so its easier to see whats going on
@@ -55,20 +54,20 @@ public class TextAreaTest3 extends GdxTest {
 		printMetrics("default", styleDefault.font);
 
 		styleLSans15 = new TextField.TextFieldStyle(styleDefault);
-		styleLSans15.font = new BitmapFont(Gdx.files.internal("data/lsans-15.fnt"), Gdx.files.internal("data/lsans-15_00.png"),
+		styleLSans15.font = new BitmapFont(files.internal("data/lsans-15.fnt"), files.internal("data/lsans-15_00.png"),
 			false);
 		printMetrics("lsans15", styleLSans15.font);
 
 		styleLSans32 = new TextField.TextFieldStyle(styleDefault);
-		styleLSans32.font = new BitmapFont(Gdx.files.internal("data/lsans-32.fnt"), Gdx.files.internal("data/lsans-32.png"), false);
+		styleLSans32.font = new BitmapFont(files.internal("data/lsans-32.fnt"), files.internal("data/lsans-32.png"), false);
 		printMetrics("lsans32", styleLSans32.font);
 
 		styleFont = new TextField.TextFieldStyle(styleDefault);
-		styleFont.font = new BitmapFont(Gdx.files.internal("data/font.fnt"), Gdx.files.internal("data/font.png"), false);
+		styleFont.font = new BitmapFont(files.internal("data/font.fnt"), files.internal("data/font.png"), false);
 		printMetrics("font", styleFont.font);
 
 		stage = new Stage();
-		Gdx.input.setInputProcessor(stage);
+		input.setInputProcessor(stage);
 		// easier to test this with proper layout
 		Table root = new Table();
 		root.setFillParent(true);
@@ -112,7 +111,7 @@ public class TextAreaTest3 extends GdxTest {
 		BitmapFont.BitmapFontData data = font.getData();
 		float textHeight = data.capHeight - data.descent;
 		float textFieldHeight = data.capHeight - data.descent * 2;
-		Gdx.app.log(name, "line height = " + data.lineHeight + ", text height = " + textHeight + ", text field height = "
+		app.log(name, "line height = " + data.lineHeight + ", text height = " + textHeight + ", text field height = "
 			+ textFieldHeight + ", cap height = " + data.capHeight + ", descent = " + data.descent);
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TextAreaTest4.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TextAreaTest4.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.scenes.scene2d.ui.*;
@@ -35,8 +34,8 @@ public class TextAreaTest4 extends GdxTest {
 	@Override
 	public void create () {
 		stage = new Stage();
-		Gdx.input.setInputProcessor(stage);
-		skin = new Skin(Gdx.files.internal("data/uiskin.json"));
+		input.setInputProcessor(stage);
+		skin = new Skin(files.internal("data/uiskin.json"));
 
 		textArea = new TextArea("Line 1\nLine 2\n0123456789\nABCDEFGHIJ", skin);
 		textArea.setBounds(20, 20, 300, 200);
@@ -46,7 +45,7 @@ public class TextAreaTest4 extends GdxTest {
 			public void changed (ChangeEvent event, Actor actor) {
 				if (cancelled) {
 					event.cancel();
-					Gdx.app.log("Test", "ChangeEvent Cancelled.");
+					app.log("Test", "ChangeEvent Cancelled.");
 				}
 			}
 		});
@@ -82,7 +81,7 @@ public class TextAreaTest4 extends GdxTest {
 	@Override
 	public void render () {
 		ScreenUtils.clear(0.2f, 0.2f, 0.2f, 1);
-		stage.act(Gdx.graphics.getDeltaTime());
+		stage.act(graphics.getDeltaTime());
 		updateStatus();
 		stage.draw();
 	}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TextButtonTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TextButtonTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.scenes.scene2d.Stage;
@@ -32,12 +31,12 @@ public class TextButtonTest extends GdxTest {
 	@Override
 	public void create () {
 		stage = new Stage();
-		Gdx.input.setInputProcessor(stage);
-		skin = new Skin(Gdx.files.internal("data/uiskin.json"));
+		input.setInputProcessor(stage);
+		skin = new Skin(files.internal("data/uiskin.json"));
 		for (int i = 0; i < 1; i++) {
 			TextButton t = new TextButton("Button" + i, skin);
-			t.setX(MathUtils.random(0, Gdx.graphics.getWidth()));
-			t.setY(MathUtils.random(0, Gdx.graphics.getHeight()));
+			t.setX(MathUtils.random(0, graphics.getWidth()));
+			t.setY(MathUtils.random(0, graphics.getHeight()));
 			t.setWidth(MathUtils.random(50, 200));
 			t.setHeight(MathUtils.random(0, 100));
 			stage.addActor(t);
@@ -48,9 +47,9 @@ public class TextButtonTest extends GdxTest {
 	public void render () {
 		ScreenUtils.clear(0.2f, 0.2f, 0.2f, 1);
 		stage.draw();
-		Gdx.app.log("X", "FPS: " + Gdx.graphics.getFramesPerSecond());
+		app.log("X", "FPS: " + graphics.getFramesPerSecond());
 		SpriteBatch spriteBatch = (SpriteBatch)stage.getBatch();
-		Gdx.app.log("X", "render calls: " + spriteBatch.totalRenderCalls);
+		app.log("X", "render calls: " + spriteBatch.totalRenderCalls);
 		spriteBatch.totalRenderCalls = 0;
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TextFieldTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TextFieldTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.scenes.scene2d.ui.*;
@@ -35,8 +34,8 @@ public class TextFieldTest extends GdxTest {
 	@Override
 	public void create () {
 		stage = new Stage();
-		Gdx.input.setInputProcessor(stage);
-		skin = new Skin(Gdx.files.internal("data/uiskin.json"));
+		input.setInputProcessor(stage);
+		skin = new Skin(files.internal("data/uiskin.json"));
 
 		textField = new TextField("0123456789ABCDEFGHIJ", skin);
 		textField.setBounds(20, 20, 300, 30);
@@ -46,7 +45,7 @@ public class TextFieldTest extends GdxTest {
 			public void changed (ChangeEvent event, Actor actor) {
 				if (cancelled) {
 					event.cancel();
-					Gdx.app.log("Test", "ChangeEvent Cancelled.");
+					app.log("Test", "ChangeEvent Cancelled.");
 				}
 			}
 		});
@@ -82,7 +81,7 @@ public class TextFieldTest extends GdxTest {
 	@Override
 	public void render () {
 		ScreenUtils.clear(0.2f, 0.2f, 0.2f, 1);
-		stage.act(Gdx.graphics.getDeltaTime());
+		stage.act(graphics.getDeltaTime());
 		updateStatus();
 		stage.draw();
 	}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TextInputDialogTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TextInputDialogTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.Input.TextInputListener;
 import com.badlogic.gdx.graphics.GL20;
@@ -37,13 +36,13 @@ public class TextInputDialogTest extends GdxTest {
 	}
 
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		batch.begin();
 		font.draw(batch, message, 10, 40);
 		batch.end();
 
-		if (Gdx.input.justTouched()) {
-			Gdx.input.getTextInput(new TextInputListener() {
+		if (input.justTouched()) {
+			input.getTextInput(new TextInputListener() {
 				@Override
 				public void input (String text) {
 					message = "message: " + text + ", type: " + Input.OnscreenKeyboardType.values()[inputType]

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TextureAtlasTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TextureAtlasTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input.Keys;
 import com.badlogic.gdx.InputAdapter;
 import com.badlogic.gdx.graphics.GL20;
@@ -45,8 +44,8 @@ public class TextureAtlasTest extends GdxTest {
 		batch = new SpriteBatch();
 		renderer = new ShapeRenderer();
 
-		atlas = new TextureAtlas(Gdx.files.internal("data/pack.atlas"));
-		jumpAtlas = new TextureAtlas(Gdx.files.internal("data/jump.txt"));
+		atlas = new TextureAtlas(files.internal("data/pack.atlas"));
+		jumpAtlas = new TextureAtlas(files.internal("data/jump.txt"));
 
 		jumpAnimation = new Animation<TextureRegion>(0.25f, jumpAtlas.findRegions("ALIEN_JUMP_"));
 
@@ -64,11 +63,11 @@ public class TextureAtlasTest extends GdxTest {
 		star = atlas.createSprite("particle-star");
 		star.setPosition(10, 70);
 
-		font = new BitmapFont(Gdx.files.internal("data/font.fnt"), atlas.findRegion("font"), false);
+		font = new BitmapFont(files.internal("data/font.fnt"), atlas.findRegion("font"), false);
 
-		Gdx.gl.glClearColor(0, 1, 0, 1);
+		gl.glClearColor(0, 1, 0, 1);
 
-		Gdx.input.setInputProcessor(new InputAdapter() {
+		input.setInputProcessor(new InputAdapter() {
 			public boolean keyUp (int keycode) {
 				if (keycode == Keys.UP) {
 					badlogicSmall.flip(false, true);
@@ -85,8 +84,8 @@ public class TextureAtlasTest extends GdxTest {
 	}
 
 	public void render () {
-		time += Gdx.graphics.getDeltaTime();
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		time += graphics.getDeltaTime();
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 
 		renderer.begin(ShapeType.Line);
 		renderer.rect(10, 10, 256, 256);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TextureDataTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TextureDataTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
@@ -29,12 +28,12 @@ public class TextureDataTest extends GdxTest {
 
 	public void create () {
 		spriteBatch = new SpriteBatch();
-// texture = new Texture(new PixmapTextureData(new Pixmap(Gdx.files.internal("data/t8890.png")), null, false, true));
-		texture = new Texture(new FileTextureData(Gdx.files.internal("data/t8890.png"), null, null, false));
+// texture = new Texture(new PixmapTextureData(new Pixmap(files.internal("data/t8890.png")), null, false, true));
+		texture = new Texture(new FileTextureData(files.internal("data/t8890.png"), null, null, false));
 	}
 
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		spriteBatch.begin();
 		spriteBatch.draw(texture, 100, 100);
 		spriteBatch.end();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TextureDownloadTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TextureDownloadTest.java
@@ -20,7 +20,6 @@ import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.Pixmap.Blending;
 import com.badlogic.gdx.graphics.Texture;
@@ -80,7 +79,7 @@ public class TextureDownloadTest extends GdxTest {
 					potPixmap.setBlending(Blending.None);
 					potPixmap.drawPixmap(pixmap, 0, 0, 0, 0, pixmap.getWidth(), pixmap.getHeight());
 					pixmap.dispose();
-					Gdx.app.postRunnable(new Runnable() {
+					app.postRunnable(new Runnable() {
 						@Override
 						public void run () {
 							image = new TextureRegion(new Texture(potPixmap), 0, 0, originalWidth, originalHeight);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TextureFormatTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TextureFormatTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.Pixmap.Format;
 import com.badlogic.gdx.graphics.Texture;
@@ -32,7 +31,7 @@ public class TextureFormatTest extends GdxTest {
 
 	@Override
 	public void create () {
-		FileHandle file = Gdx.files.internal("data/bobargb8888-32x32.png");
+		FileHandle file = files.internal("data/bobargb8888-32x32.png");
 		nonMipMapped[0] = new Texture(file, Format.Alpha, false);
 		nonMipMapped[1] = new Texture(file, Format.LuminanceAlpha, false);
 		nonMipMapped[2] = new Texture(file, Format.RGB888, false);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TideMapAssetManagerTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TideMapAssetManagerTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.assets.AssetManager;
 import com.badlogic.gdx.assets.loaders.resolvers.InternalFileHandleResolver;
 import com.badlogic.gdx.graphics.OrthographicCamera;
@@ -42,8 +41,8 @@ public class TideMapAssetManagerTest extends GdxTest {
 
 	@Override
 	public void create () {
-		float w = Gdx.graphics.getWidth();
-		float h = Gdx.graphics.getHeight();
+		float w = graphics.getWidth();
+		float h = graphics.getHeight();
 
 		camera = new OrthographicCamera();
 		camera.setToOrtho(false, (w / h) * 10, 10);
@@ -51,7 +50,7 @@ public class TideMapAssetManagerTest extends GdxTest {
 		camera.update();
 
 		cameraController = new OrthoCamController(camera);
-		Gdx.input.setInputProcessor(cameraController);
+		input.setInputProcessor(cameraController);
 
 		font = new BitmapFont();
 		batch = new SpriteBatch();
@@ -71,7 +70,7 @@ public class TideMapAssetManagerTest extends GdxTest {
 		renderer.setView(camera);
 		renderer.render();
 		batch.begin();
-		font.draw(batch, "FPS: " + Gdx.graphics.getFramesPerSecond(), 10, 20);
+		font.draw(batch, "FPS: " + graphics.getFramesPerSecond(), 10, 20);
 		batch.end();
 	}
 }

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TideMapDirectLoaderTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TideMapDirectLoaderTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
@@ -39,15 +38,15 @@ public class TideMapDirectLoaderTest extends GdxTest {
 
 	@Override
 	public void create () {
-		float w = Gdx.graphics.getWidth();
-		float h = Gdx.graphics.getHeight();
+		float w = graphics.getWidth();
+		float h = graphics.getHeight();
 
 		camera = new OrthographicCamera();
 		camera.setToOrtho(false, (w / h) * 10, 10);
 		camera.update();
 
 		cameraController = new OrthoCamController(camera);
-		Gdx.input.setInputProcessor(cameraController);
+		input.setInputProcessor(cameraController);
 
 		font = new BitmapFont();
 		batch = new SpriteBatch();
@@ -63,7 +62,7 @@ public class TideMapDirectLoaderTest extends GdxTest {
 		renderer.setView(camera);
 		renderer.render();
 		batch.begin();
-		font.draw(batch, "FPS: " + Gdx.graphics.getFramesPerSecond(), 10, 20);
+		font.draw(batch, "FPS: " + graphics.getFramesPerSecond(), 10, 20);
 		batch.end();
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TileTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TileTest.java
@@ -18,7 +18,6 @@ package com.badlogic.gdx.tests;
 
 import java.util.Random;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.graphics.Texture;
@@ -46,9 +45,9 @@ public class TileTest extends GdxTest {
 		cam = new OrthographicCamera(480, 320);
 		cam.position.set(WIDTH * 32 / 2, HEIGHT * 32 / 2, 0);
 		camController = new OrthoCamController(cam);
-		Gdx.input.setInputProcessor(camController);
+		input.setInputProcessor(camController);
 
-		texture = new Texture(Gdx.files.internal("data/tiles.png"));
+		texture = new Texture(files.internal("data/tiles.png"));
 
 		Random rand = new Random();
 		for (int i = 0; i < LAYERS; i++) {
@@ -69,11 +68,11 @@ public class TileTest extends GdxTest {
 
 	@Override
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		cam.update();
 
-		Gdx.gl.glEnable(GL20.GL_BLEND);
-		Gdx.gl.glBlendFunc(GL20.GL_SRC_ALPHA, GL20.GL_ONE_MINUS_SRC_ALPHA);
+		gl.glEnable(GL20.GL_BLEND);
+		gl.glBlendFunc(GL20.GL_SRC_ALPHA, GL20.GL_ONE_MINUS_SRC_ALPHA);
 		for (int i = 0; i < LAYERS; i++) {
 			SpriteCache cache = caches[i];
 			cache.setProjectionMatrix(cam.combined);
@@ -85,7 +84,7 @@ public class TileTest extends GdxTest {
 		}
 
 		if (TimeUtils.nanoTime() - startTime >= 1000000000) {
-			Gdx.app.log("TileTest", "fps: " + Gdx.graphics.getFramesPerSecond());
+			app.log("TileTest", "fps: " + graphics.getFramesPerSecond());
 			startTime = TimeUtils.nanoTime();
 		}
 	}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledDrawableTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledDrawableTest.java
@@ -1,7 +1,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.graphics.g2d.Batch;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
@@ -27,13 +26,13 @@ public class TiledDrawableTest extends GdxTest {
 	public void create () {
 		stage = new Stage();
 		batch = new SpriteBatch();
-		font = new BitmapFont(Gdx.files.internal("data/lsans-15.fnt"), false);
+		font = new BitmapFont(files.internal("data/lsans-15.fnt"), false);
 
 		// Must be a texture atlas so uv is not just 0 and 1
-		atlas = new TextureAtlas(Gdx.files.internal("data/testAtlas.atlas"));
+		atlas = new TextureAtlas(files.internal("data/testAtlas.atlas"));
 		tiledDrawable = new TiledDrawable(atlas.findRegion("tileTester"));
 
-		Gdx.input.setInputProcessor(this);
+		input.setInputProcessor(this);
 	}
 
 	@Override
@@ -51,8 +50,8 @@ public class TiledDrawableTest extends GdxTest {
 		final float spacingX = 80;
 		final float bottomSpacing = 60;
 		final float spacingY = 40;
-		float inputX = Gdx.input.getX();
-		float inputY = Gdx.graphics.getHeight() - Gdx.input.getY();
+		float inputX = input.getX();
+		float inputY = graphics.getHeight() - input.getY();
 
 		final float clusterWidth = Math.max(13, (inputX - leftSpacingX - (2 * spacingX)) / 3f);
 		final float clusterHeight = Math.max(13, (inputY - bottomSpacing - (2 * spacingY)) / 3f);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapAnimationLoadingTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapAnimationLoadingTest.java
@@ -18,7 +18,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
@@ -45,8 +44,8 @@ public class TiledMapAnimationLoadingTest extends GdxTest {
 
 	@Override
 	public void create () {
-		float w = Gdx.graphics.getWidth();
-		float h = Gdx.graphics.getHeight();
+		float w = graphics.getWidth();
+		float h = graphics.getHeight();
 
 		camera = new OrthographicCamera();
 		camera.setToOrtho(false, (w / h) * 512, 512);
@@ -54,7 +53,7 @@ public class TiledMapAnimationLoadingTest extends GdxTest {
 		camera.update();
 
 		cameraController = new OrthoCamController(camera);
-		Gdx.input.setInputProcessor(cameraController);
+		input.setInputProcessor(cameraController);
 
 		font = new BitmapFont();
 		batch = new SpriteBatch();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapAssetManagerTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapAssetManagerTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.assets.AssetManager;
 import com.badlogic.gdx.assets.loaders.resolvers.InternalFileHandleResolver;
 import com.badlogic.gdx.graphics.OrthographicCamera;
@@ -63,8 +62,8 @@ public class TiledMapAssetManagerTest extends GdxTest {
 
 	@Override
 	public void create () {
-		float w = Gdx.graphics.getWidth();
-		float h = Gdx.graphics.getHeight();
+		float w = graphics.getWidth();
+		float h = graphics.getHeight();
 
 		camera = new OrthographicCamera();
 		camera.setToOrtho(false, (w / h) * 10, 10);
@@ -72,7 +71,7 @@ public class TiledMapAssetManagerTest extends GdxTest {
 		camera.update();
 
 		cameraController = new OrthoCamController(camera);
-		Gdx.input.setInputProcessor(cameraController);
+		input.setInputProcessor(cameraController);
 
 		font = new BitmapFont();
 		batch = new SpriteBatch();
@@ -85,25 +84,25 @@ public class TiledMapAssetManagerTest extends GdxTest {
 		renderer = new IsometricTiledMapRenderer(map, 1f / 64f);
 
 		String mapCustomValue = map.getProperties().get(MAP_PROPERTY_NAME, String.class);
-		Gdx.app.log("TiledMapAssetManagerTest", "Property : " + MAP_PROPERTY_NAME + ", Value : " + mapCustomValue);
+		app.log("TiledMapAssetManagerTest", "Property : " + MAP_PROPERTY_NAME + ", Value : " + mapCustomValue);
 		if (!MAP_PROPERTY_VALUE.equals(mapCustomValue)) {
 			throw new RuntimeException("Failed to get map properties");
 		}
 
 		boolean boolCustomValue = map.getProperties().get(BOOL_PROPERTY_NAME, Boolean.class);
-		Gdx.app.log("TiledMapAssetManagerTest", "Property : " + BOOL_PROPERTY_NAME + ", Value : " + boolCustomValue);
+		app.log("TiledMapAssetManagerTest", "Property : " + BOOL_PROPERTY_NAME + ", Value : " + boolCustomValue);
 		if (boolCustomValue != BOOL_PROPERTY_VALUE) {
 			throw new RuntimeException("Failed to get boolean map properties");
 		}
 
 		int intCustomValue = map.getProperties().get(INT_PROPERTY_NAME, Integer.class);
-		Gdx.app.log("TiledMapAssetManagerTest", "Property : " + INT_PROPERTY_NAME + ", Value : " + intCustomValue);
+		app.log("TiledMapAssetManagerTest", "Property : " + INT_PROPERTY_NAME + ", Value : " + intCustomValue);
 		if (intCustomValue != INT_PROPERTY_VALUE) {
 			throw new RuntimeException("Failed to get int map properties");
 		}
 
 		float floatCustomValue = map.getProperties().get(FLOAT_PROPERTY_NAME, Float.class);
-		Gdx.app.log("TiledMapAssetManagerTest", "Property : " + FLOAT_PROPERTY_NAME + ", Value : " + floatCustomValue);
+		app.log("TiledMapAssetManagerTest", "Property : " + FLOAT_PROPERTY_NAME + ", Value : " + floatCustomValue);
 		if (floatCustomValue != FLOAT_PROPERTY_VALUE) {
 			throw new RuntimeException("Failed to get float map properties");
 		}
@@ -134,7 +133,7 @@ public class TiledMapAssetManagerTest extends GdxTest {
 		renderer.setView(camera);
 		renderer.render();
 		batch.begin();
-		font.draw(batch, "FPS: " + Gdx.graphics.getFramesPerSecond(), 10, 20);
+		font.draw(batch, "FPS: " + graphics.getFramesPerSecond(), 10, 20);
 		batch.end();
 	}
 }

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapAtlasAssetManagerTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapAtlasAssetManagerTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.assets.AssetDescriptor;
 import com.badlogic.gdx.assets.AssetErrorListener;
@@ -53,8 +52,8 @@ public class TiledMapAtlasAssetManagerTest extends GdxTest {
 
 	@Override
 	public void create () {
-		float w = Gdx.graphics.getWidth();
-		float h = Gdx.graphics.getHeight();
+		float w = graphics.getWidth();
+		float h = graphics.getHeight();
 
 		camera = new OrthographicCamera();
 		camera.setToOrtho(false, (w / h) * 10, 10);
@@ -62,7 +61,7 @@ public class TiledMapAtlasAssetManagerTest extends GdxTest {
 		camera.update();
 
 		cameraController = new OrthoCamController(camera);
-		Gdx.input.setInputProcessor(cameraController);
+		input.setInputProcessor(cameraController);
 
 		font = new BitmapFont();
 		batch = new SpriteBatch();
@@ -95,20 +94,20 @@ public class TiledMapAtlasAssetManagerTest extends GdxTest {
 			map = assetManager.get(fileName);
 			renderer = new OrthogonalTiledMapRenderer(map, 1f / 32f);
 		} else if (renderer != null) {
-			if (Gdx.input.isKeyJustPressed(Input.Keys.NUM_1)) {
+			if (input.isKeyJustPressed(Input.Keys.NUM_1)) {
 				if (mapType != 0) {
 					mapType = 0;
 					map = assetManager.get(fileName);
 					renderer = new OrthogonalTiledMapRenderer(map, 1f / 32f);
 				}
-			} else if (Gdx.input.isKeyJustPressed(Input.Keys.NUM_2)) {
+			} else if (input.isKeyJustPressed(Input.Keys.NUM_2)) {
 				if (mapType != 1) {
 					if (renderer instanceof Disposable) ((Disposable)renderer).dispose();
 					mapType = 1;
 					map = assetManager.get(fileNameWithImageLayers);
 					renderer = new OrthogonalTiledMapRenderer(map, 1f / 32f);
 				}
-			} else if (Gdx.input.isKeyJustPressed(Input.Keys.NUM_3)) {
+			} else if (input.isKeyJustPressed(Input.Keys.NUM_3)) {
 				if (mapType != 2) {
 					if (renderer instanceof Disposable) ((Disposable)renderer).dispose();
 					mapType = 2;
@@ -123,7 +122,7 @@ public class TiledMapAtlasAssetManagerTest extends GdxTest {
 
 		batch.begin();
 		if (errorMessage != null) font.draw(batch, "ERROR (OK if running in GWT): " + errorMessage, 10, 50);
-		font.draw(batch, "FPS: " + Gdx.graphics.getFramesPerSecond(), 10, 20);
+		font.draw(batch, "FPS: " + graphics.getFramesPerSecond(), 10, 20);
 		font.draw(batch, "Press keys 1, 2 and 3 to toggle between a map with packed imagelayers.", 170, 20);
 		batch.end();
 	}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapAtlasDirectLoaderTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapAtlasDirectLoaderTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
@@ -39,15 +38,15 @@ public class TiledMapAtlasDirectLoaderTest extends GdxTest {
 
 	@Override
 	public void create () {
-		float w = Gdx.graphics.getWidth();
-		float h = Gdx.graphics.getHeight();
+		float w = graphics.getWidth();
+		float h = graphics.getHeight();
 
 		camera = new OrthographicCamera();
 		camera.setToOrtho(false, (w / h) * 10, 10);
 		camera.update();
 
 		cameraController = new OrthoCamController(camera);
-		Gdx.input.setInputProcessor(cameraController);
+		input.setInputProcessor(cameraController);
 
 		font = new BitmapFont();
 		batch = new SpriteBatch();
@@ -63,7 +62,7 @@ public class TiledMapAtlasDirectLoaderTest extends GdxTest {
 		renderer.setView(camera);
 		renderer.render();
 		batch.begin();
-		font.draw(batch, "FPS: " + Gdx.graphics.getFramesPerSecond(), 10, 20);
+		font.draw(batch, "FPS: " + graphics.getFramesPerSecond(), 10, 20);
 		batch.end();
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapDirectLoaderTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapDirectLoaderTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
@@ -39,15 +38,15 @@ public class TiledMapDirectLoaderTest extends GdxTest {
 
 	@Override
 	public void create () {
-		float w = Gdx.graphics.getWidth();
-		float h = Gdx.graphics.getHeight();
+		float w = graphics.getWidth();
+		float h = graphics.getHeight();
 
 		camera = new OrthographicCamera();
 		camera.setToOrtho(false, (w / h) * 10, 10);
 		camera.update();
 
 		cameraController = new OrthoCamController(camera);
-		Gdx.input.setInputProcessor(cameraController);
+		input.setInputProcessor(cameraController);
 
 		font = new BitmapFont();
 		batch = new SpriteBatch();
@@ -63,7 +62,7 @@ public class TiledMapDirectLoaderTest extends GdxTest {
 		renderer.setView(camera);
 		renderer.render();
 		batch.begin();
-		font.draw(batch, "FPS: " + Gdx.graphics.getFramesPerSecond(), 10, 20);
+		font.draw(batch, "FPS: " + graphics.getFramesPerSecond(), 10, 20);
 		batch.end();
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapGWTAtlasAssetManagerTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapGWTAtlasAssetManagerTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.assets.AssetDescriptor;
 import com.badlogic.gdx.assets.AssetErrorListener;
@@ -53,8 +52,8 @@ public class TiledMapGWTAtlasAssetManagerTest extends GdxTest {
 
 	@Override
 	public void create () {
-		float w = Gdx.graphics.getWidth();
-		float h = Gdx.graphics.getHeight();
+		float w = graphics.getWidth();
+		float h = graphics.getHeight();
 
 		camera = new OrthographicCamera();
 		camera.setToOrtho(false, (w / h) * 10, 10);
@@ -62,7 +61,7 @@ public class TiledMapGWTAtlasAssetManagerTest extends GdxTest {
 		camera.update();
 
 		cameraController = new OrthoCamController(camera);
-		Gdx.input.setInputProcessor(cameraController);
+		input.setInputProcessor(cameraController);
 
 		font = new BitmapFont();
 		batch = new SpriteBatch();
@@ -95,20 +94,20 @@ public class TiledMapGWTAtlasAssetManagerTest extends GdxTest {
 			map = assetManager.get(fileName);
 			renderer = new OrthogonalTiledMapRenderer(map, 1f / 32f);
 		} else if (renderer != null) {
-			if (Gdx.input.isKeyJustPressed(Input.Keys.NUM_1)) {
+			if (input.isKeyJustPressed(Input.Keys.NUM_1)) {
 				if (mapType != 0) {
 					mapType = 0;
 					map = assetManager.get(fileName);
 					renderer = new OrthogonalTiledMapRenderer(map, 1f / 32f);
 				}
-			} else if (Gdx.input.isKeyJustPressed(Input.Keys.NUM_2)) {
+			} else if (input.isKeyJustPressed(Input.Keys.NUM_2)) {
 				if (mapType != 1) {
 					if (renderer instanceof Disposable) ((Disposable)renderer).dispose();
 					mapType = 1;
 					map = assetManager.get(fileNameWithImageLayers);
 					renderer = new OrthogonalTiledMapRenderer(map, 1f / 32f);
 				}
-			} else if (Gdx.input.isKeyJustPressed(Input.Keys.NUM_3)) {
+			} else if (input.isKeyJustPressed(Input.Keys.NUM_3)) {
 				if (mapType != 2) {
 					if (renderer instanceof Disposable) ((Disposable)renderer).dispose();
 					mapType = 2;
@@ -123,7 +122,7 @@ public class TiledMapGWTAtlasAssetManagerTest extends GdxTest {
 
 		batch.begin();
 		if (errorMessage != null) font.draw(batch, "ERROR: " + errorMessage, 10, 50);
-		font.draw(batch, "FPS: " + Gdx.graphics.getFramesPerSecond(), 10, 20);
+		font.draw(batch, "FPS: " + graphics.getFramesPerSecond(), 10, 20);
 		font.draw(batch, "Press keys 1, 2 and 3 to toggle between a map with packed imagelayers.", 170, 20);
 		batch.end();
 	}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapGroupLayerTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapGroupLayerTest.java
@@ -1,7 +1,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.assets.AssetDescriptor;
 import com.badlogic.gdx.assets.AssetErrorListener;
 import com.badlogic.gdx.assets.AssetManager;
@@ -33,8 +32,8 @@ public class TiledMapGroupLayerTest extends GdxTest {
 
 	@Override
 	public void create () {
-		float w = Gdx.graphics.getWidth();
-		float h = Gdx.graphics.getHeight();
+		float w = graphics.getWidth();
+		float h = graphics.getHeight();
 
 		camera = new OrthographicCamera();
 		camera.setToOrtho(false, (w / h) * 10, 10);
@@ -42,7 +41,7 @@ public class TiledMapGroupLayerTest extends GdxTest {
 		camera.update();
 
 		cameraController = new OrthoCamController(camera);
-		Gdx.input.setInputProcessor(cameraController);
+		input.setInputProcessor(cameraController);
 
 		font = new BitmapFont();
 		batch = new SpriteBatch();
@@ -81,7 +80,7 @@ public class TiledMapGroupLayerTest extends GdxTest {
 			font.draw(batch, "ERROR (OK if running in GWT): " + errorMessage, 10, 50);
 			System.out.println(errorMessage);
 		}
-		font.draw(batch, "FPS: " + Gdx.graphics.getFramesPerSecond(), 10, 20);
+		font.draw(batch, "FPS: " + graphics.getFramesPerSecond(), 10, 20);
 		batch.end();
 	}
 }

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapGroupLayerWithImagelayerTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapGroupLayerWithImagelayerTest.java
@@ -1,7 +1,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.assets.AssetDescriptor;
 import com.badlogic.gdx.assets.AssetErrorListener;
 import com.badlogic.gdx.assets.AssetManager;
@@ -30,8 +29,8 @@ public class TiledMapGroupLayerWithImagelayerTest extends GdxTest {
 
 	@Override
 	public void create () {
-		float w = Gdx.graphics.getWidth();
-		float h = Gdx.graphics.getHeight();
+		float w = graphics.getWidth();
+		float h = graphics.getHeight();
 
 		camera = new OrthographicCamera();
 		camera.setToOrtho(false, (w / h) * 10, 10);
@@ -39,7 +38,7 @@ public class TiledMapGroupLayerWithImagelayerTest extends GdxTest {
 		camera.update();
 
 		cameraController = new OrthoCamController(camera);
-		Gdx.input.setInputProcessor(cameraController);
+		input.setInputProcessor(cameraController);
 
 		font = new BitmapFont();
 		batch = new SpriteBatch();
@@ -78,7 +77,7 @@ public class TiledMapGroupLayerWithImagelayerTest extends GdxTest {
 			font.draw(batch, "ERROR (OK if running in GWT): " + errorMessage, 10, 50);
 			System.out.println(errorMessage);
 		}
-		font.draw(batch, "FPS: " + Gdx.graphics.getFramesPerSecond(), 10, 20);
+		font.draw(batch, "FPS: " + graphics.getFramesPerSecond(), 10, 20);
 		batch.end();
 	}
 }

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapImageLayerRepeatTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapImageLayerRepeatTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.assets.AssetManager;
 import com.badlogic.gdx.assets.loaders.resolvers.InternalFileHandleResolver;
@@ -53,8 +52,8 @@ public class TiledMapImageLayerRepeatTest extends GdxTest {
 
 	@Override
 	public void create () {
-		float w = Gdx.graphics.getWidth();
-		float h = Gdx.graphics.getHeight();
+		float w = graphics.getWidth();
+		float h = graphics.getHeight();
 
 		camera = new OrthographicCamera();
 		camera.setToOrtho(false, (w / h) * 10, 10);
@@ -62,7 +61,7 @@ public class TiledMapImageLayerRepeatTest extends GdxTest {
 		camera.update();
 
 		cameraController = new OrthoCamController(camera);
-		Gdx.input.setInputProcessor(cameraController);
+		input.setInputProcessor(cameraController);
 
 		font = new BitmapFont();
 		batch = new SpriteBatch();
@@ -83,14 +82,14 @@ public class TiledMapImageLayerRepeatTest extends GdxTest {
 
 	@Override
 	public void render () {
-		if (Gdx.input.isKeyJustPressed(Input.Keys.NUM_1)) {
+		if (input.isKeyJustPressed(Input.Keys.NUM_1)) {
 			if (mapType != 0) {
 				if (renderer instanceof Disposable) ((Disposable)renderer).dispose();
 				mapType = 0;
 				map = assetManager.get(MAP_ORTHO);
 				renderer = new OrthogonalTiledMapRenderer(map, 1f / 64f);
 			}
-		} else if (Gdx.input.isKeyJustPressed(Input.Keys.NUM_2)) {
+		} else if (input.isKeyJustPressed(Input.Keys.NUM_2)) {
 			if (mapType != 1) {
 				if (renderer instanceof Disposable) ((Disposable)renderer).dispose();
 				mapType = 1;
@@ -98,28 +97,28 @@ public class TiledMapImageLayerRepeatTest extends GdxTest {
 				renderer = new OrthoCachedTiledMapRenderer(map, 1f / 32f);
 				((OrthoCachedTiledMapRenderer)renderer).setBlending(true);
 			}
-		} else if (Gdx.input.isKeyJustPressed(Input.Keys.NUM_3)) {
+		} else if (input.isKeyJustPressed(Input.Keys.NUM_3)) {
 			if (mapType != 2) {
 				if (renderer instanceof Disposable) ((Disposable)renderer).dispose();
 				mapType = 2;
 				map = assetManager.get(MAP_ISO);
 				renderer = new IsometricTiledMapRenderer(map, 1f / 64f);
 			}
-		} else if (Gdx.input.isKeyJustPressed(Input.Keys.NUM_4)) {
+		} else if (input.isKeyJustPressed(Input.Keys.NUM_4)) {
 			if (mapType != 3) {
 				if (renderer instanceof Disposable) ((Disposable)renderer).dispose();
 				mapType = 3;
 				map = assetManager.get(MAP_ISO_STAG);
 				renderer = new IsometricStaggeredTiledMapRenderer(map, 1f / 48f);
 			}
-		} else if (Gdx.input.isKeyJustPressed(Input.Keys.NUM_5)) {
+		} else if (input.isKeyJustPressed(Input.Keys.NUM_5)) {
 			if (mapType != 4) {
 				if (renderer instanceof Disposable) ((Disposable)renderer).dispose();
 				mapType = 4;
 				map = assetManager.get(MAP_HEX_X);
 				renderer = new HexagonalTiledMapRenderer(map, 1f / 128f);
 			}
-		} else if (Gdx.input.isKeyJustPressed(Input.Keys.NUM_6)) {
+		} else if (input.isKeyJustPressed(Input.Keys.NUM_6)) {
 			if (mapType != 5) {
 				if (renderer instanceof Disposable) ((Disposable)renderer).dispose();
 				mapType = 5;
@@ -150,9 +149,9 @@ public class TiledMapImageLayerRepeatTest extends GdxTest {
 		shapeRenderer.end();
 
 		batch.begin();
-		font.draw(batch, "FPS: " + Gdx.graphics.getFramesPerSecond(), 10, 20);
-		font.draw(batch, "Switch type with 1-6", Gdx.graphics.getHeight() - 100, 50);
-		font.draw(batch, renderer.getClass().getSimpleName(), Gdx.graphics.getHeight() - 100, 20);
+		font.draw(batch, "FPS: " + graphics.getFramesPerSecond(), 10, 20);
+		font.draw(batch, "Switch type with 1-6", graphics.getHeight() - 100, 50);
+		font.draw(batch, renderer.getClass().getSimpleName(), graphics.getHeight() - 100, 20);
 		batch.end();
 	}
 }

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapJsonAtlasAssetManagerTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapJsonAtlasAssetManagerTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.assets.AssetDescriptor;
 import com.badlogic.gdx.assets.AssetErrorListener;
@@ -55,8 +54,8 @@ public class TiledMapJsonAtlasAssetManagerTest extends GdxTest {
 
 	@Override
 	public void create () {
-		float w = Gdx.graphics.getWidth();
-		float h = Gdx.graphics.getHeight();
+		float w = graphics.getWidth();
+		float h = graphics.getHeight();
 
 		camera = new OrthographicCamera();
 		camera.setToOrtho(false, (w / h) * 10, 10);
@@ -64,7 +63,7 @@ public class TiledMapJsonAtlasAssetManagerTest extends GdxTest {
 		camera.update();
 
 		cameraController = new OrthoCamController(camera);
-		Gdx.input.setInputProcessor(cameraController);
+		input.setInputProcessor(cameraController);
 
 		font = new BitmapFont();
 		batch = new SpriteBatch();
@@ -98,13 +97,13 @@ public class TiledMapJsonAtlasAssetManagerTest extends GdxTest {
 			map = assetManager.get(fileName);
 			renderer = new OrthogonalTiledMapRenderer(map, 1f / 32f);
 		} else if (renderer != null) {
-			if (Gdx.input.isKeyJustPressed(Input.Keys.NUM_1)) {
+			if (input.isKeyJustPressed(Input.Keys.NUM_1)) {
 				if (mapType != 0) {
 					mapType = 0;
 					map = assetManager.get(fileName);
 					renderer = new OrthogonalTiledMapRenderer(map, 1f / 32f);
 				}
-			} else if (Gdx.input.isKeyJustPressed(Input.Keys.NUM_2)) {
+			} else if (input.isKeyJustPressed(Input.Keys.NUM_2)) {
 				if (mapType != 1) {
 					if (renderer instanceof Disposable) ((Disposable)renderer).dispose();
 					mapType = 1;
@@ -119,7 +118,7 @@ public class TiledMapJsonAtlasAssetManagerTest extends GdxTest {
 
 		batch.begin();
 		if (errorMessage != null) font.draw(batch, "ERROR (OK if running in GWT): " + errorMessage, 10, 50);
-		font.draw(batch, "FPS: " + Gdx.graphics.getFramesPerSecond(), 10, 20);
+		font.draw(batch, "FPS: " + graphics.getFramesPerSecond(), 10, 20);
 		font.draw(batch, "Press keys 1 and 2 to toggle between a map with packed imagelayers.", 170, 20);
 		batch.end();
 	}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapJsonFormatTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapJsonFormatTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.assets.AssetManager;
 import com.badlogic.gdx.assets.loaders.resolvers.InternalFileHandleResolver;
@@ -55,8 +54,8 @@ public class TiledMapJsonFormatTest extends GdxTest {
 
 	@Override
 	public void create () {
-		float w = Gdx.graphics.getWidth();
-		float h = Gdx.graphics.getHeight();
+		float w = graphics.getWidth();
+		float h = graphics.getHeight();
 
 		camera = new OrthographicCamera();
 		camera.setToOrtho(false, (w / h) * 10, 10);
@@ -64,7 +63,7 @@ public class TiledMapJsonFormatTest extends GdxTest {
 		camera.update();
 
 		cameraController = new OrthoCamController(camera);
-		Gdx.input.setInputProcessor(cameraController);
+		input.setInputProcessor(cameraController);
 
 		font = new BitmapFont();
 		batch = new SpriteBatch();
@@ -86,14 +85,14 @@ public class TiledMapJsonFormatTest extends GdxTest {
 
 	@Override
 	public void render () {
-		if (Gdx.input.isKeyJustPressed(Input.Keys.NUM_1)) {
+		if (input.isKeyJustPressed(Input.Keys.NUM_1)) {
 			if (mapType != 0) {
 				if (renderer instanceof Disposable) ((Disposable)renderer).dispose();
 				mapType = 0;
 				map = assetManager.get(MAP_ORTHO);
 				renderer = new OrthogonalTiledMapRenderer(map, 1f / 32f);
 			}
-		} else if (Gdx.input.isKeyJustPressed(Input.Keys.NUM_2)) {
+		} else if (input.isKeyJustPressed(Input.Keys.NUM_2)) {
 			if (mapType != 1) {
 				if (renderer instanceof Disposable) ((Disposable)renderer).dispose();
 				mapType = 1;
@@ -101,35 +100,35 @@ public class TiledMapJsonFormatTest extends GdxTest {
 				renderer = new OrthoCachedTiledMapRenderer(map, 1f / 32f);
 				((OrthoCachedTiledMapRenderer)renderer).setBlending(true);
 			}
-		} else if (Gdx.input.isKeyJustPressed(Input.Keys.NUM_3)) {
+		} else if (input.isKeyJustPressed(Input.Keys.NUM_3)) {
 			if (mapType != 2) {
 				if (renderer instanceof Disposable) ((Disposable)renderer).dispose();
 				mapType = 2;
 				map = assetManager.get(MAP_ISO);
 				renderer = new IsometricTiledMapRenderer(map, 1f / 48f);
 			}
-		} else if (Gdx.input.isKeyJustPressed(Input.Keys.NUM_4)) {
+		} else if (input.isKeyJustPressed(Input.Keys.NUM_4)) {
 			if (mapType != 3) {
 				if (renderer instanceof Disposable) ((Disposable)renderer).dispose();
 				mapType = 3;
 				map = assetManager.get(MAP_ISO_STAG);
 				renderer = new IsometricStaggeredTiledMapRenderer(map, 1f / 48f);
 			}
-		} else if (Gdx.input.isKeyJustPressed(Input.Keys.NUM_5)) {
+		} else if (input.isKeyJustPressed(Input.Keys.NUM_5)) {
 			if (mapType != 4) {
 				if (renderer instanceof Disposable) ((Disposable)renderer).dispose();
 				mapType = 4;
 				map = assetManager.get(MAP_HEX_X);
 				renderer = new HexagonalTiledMapRenderer(map, 1f / 48f);
 			}
-		} else if (Gdx.input.isKeyJustPressed(Input.Keys.NUM_6)) {
+		} else if (input.isKeyJustPressed(Input.Keys.NUM_6)) {
 			if (mapType != 5) {
 				if (renderer instanceof Disposable) ((Disposable)renderer).dispose();
 				mapType = 5;
 				map = assetManager.get(MAP_HEX_Y);
 				renderer = new HexagonalTiledMapRenderer(map, 1f / 48f);
 			}
-		} else if (Gdx.input.isKeyJustPressed(Input.Keys.NUM_7)) {
+		} else if (input.isKeyJustPressed(Input.Keys.NUM_7)) {
 			if (mapType != 6) {
 				if (renderer instanceof Disposable) ((Disposable)renderer).dispose();
 				mapType = 6;
@@ -164,9 +163,9 @@ public class TiledMapJsonFormatTest extends GdxTest {
 		shapeRenderer.end();
 
 		batch.begin();
-		font.draw(batch, "FPS: " + Gdx.graphics.getFramesPerSecond(), 10, 20);
-		font.draw(batch, "Switch type with 1-7", Gdx.graphics.getHeight() - 100, 50);
-		font.draw(batch, renderer.getClass().getSimpleName(), Gdx.graphics.getHeight() - 100, 20);
+		font.draw(batch, "FPS: " + graphics.getFramesPerSecond(), 10, 20);
+		font.draw(batch, "Switch type with 1-7", graphics.getHeight() - 100, 50);
+		font.draw(batch, renderer.getClass().getSimpleName(), graphics.getHeight() - 100, 20);
 		batch.end();
 	}
 }

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapJsonObjectLoadingTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapJsonObjectLoadingTest.java
@@ -18,7 +18,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
@@ -53,8 +52,8 @@ public class TiledMapJsonObjectLoadingTest extends GdxTest {
 
 	@Override
 	public void create () {
-		float w = Gdx.graphics.getWidth();
-		float h = Gdx.graphics.getHeight();
+		float w = graphics.getWidth();
+		float h = graphics.getHeight();
 
 		camera = new OrthographicCamera();
 		camera.setToOrtho(false, (w / h) * 512, 512);
@@ -62,7 +61,7 @@ public class TiledMapJsonObjectLoadingTest extends GdxTest {
 		camera.update();
 
 		cameraController = new OrthoCamController(camera);
-		Gdx.input.setInputProcessor(cameraController);
+		input.setInputProcessor(cameraController);
 
 		font = new BitmapFont();
 		textMapObjectFont = new BitmapFont();
@@ -98,7 +97,7 @@ public class TiledMapJsonObjectLoadingTest extends GdxTest {
 		shapeRenderer.setProjectionMatrix(camera.combined);
 		batch.setProjectionMatrix(camera.combined);
 		shapeRenderer.setColor(Color.BLUE);
-		Gdx.gl20.glLineWidth(2);
+		gl20.glLineWidth(2);
 		MapLayer layer = map.getLayers().get("Objects");
 		AnimatedTiledMapTile.updateAnimationBaseTime();
 		for (MapObject mapObject : layer.getObjects()) {
@@ -190,7 +189,7 @@ public class TiledMapJsonObjectLoadingTest extends GdxTest {
 			}
 		}
 		batch.begin();
-		font.draw(batch, "FPS: " + Gdx.graphics.getFramesPerSecond() + "\n" + loadingStatus, 20, 500);
+		font.draw(batch, "FPS: " + graphics.getFramesPerSecond() + "\n" + loadingStatus, 20, 500);
 		batch.end();
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapLayerOffsetTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapLayerOffsetTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.assets.AssetManager;
 import com.badlogic.gdx.assets.loaders.resolvers.InternalFileHandleResolver;
@@ -57,8 +56,8 @@ public class TiledMapLayerOffsetTest extends GdxTest {
 
 	@Override
 	public void create () {
-		float w = Gdx.graphics.getWidth();
-		float h = Gdx.graphics.getHeight();
+		float w = graphics.getWidth();
+		float h = graphics.getHeight();
 
 		camera = new OrthographicCamera();
 		camera.setToOrtho(false, (w / h) * 10, 10);
@@ -66,7 +65,7 @@ public class TiledMapLayerOffsetTest extends GdxTest {
 		camera.update();
 
 		cameraController = new OrthoCamController(camera);
-		Gdx.input.setInputProcessor(cameraController);
+		input.setInputProcessor(cameraController);
 
 		font = new BitmapFont();
 		batch = new SpriteBatch();
@@ -87,14 +86,14 @@ public class TiledMapLayerOffsetTest extends GdxTest {
 
 	@Override
 	public void render () {
-		if (Gdx.input.isKeyJustPressed(Input.Keys.NUM_1)) {
+		if (input.isKeyJustPressed(Input.Keys.NUM_1)) {
 			if (mapType != 0) {
 				if (renderer instanceof Disposable) ((Disposable)renderer).dispose();
 				mapType = 0;
 				map = assetManager.get(MAP_ORTHO);
 				renderer = new OrthogonalTiledMapRenderer(map, 1f / 32f);
 			}
-		} else if (Gdx.input.isKeyJustPressed(Input.Keys.NUM_2)) {
+		} else if (input.isKeyJustPressed(Input.Keys.NUM_2)) {
 			if (mapType != 1) {
 				if (renderer instanceof Disposable) ((Disposable)renderer).dispose();
 				mapType = 1;
@@ -102,28 +101,28 @@ public class TiledMapLayerOffsetTest extends GdxTest {
 				renderer = new OrthoCachedTiledMapRenderer(map, 1f / 32f);
 				((OrthoCachedTiledMapRenderer)renderer).setBlending(true);
 			}
-		} else if (Gdx.input.isKeyJustPressed(Input.Keys.NUM_3)) {
+		} else if (input.isKeyJustPressed(Input.Keys.NUM_3)) {
 			if (mapType != 2) {
 				if (renderer instanceof Disposable) ((Disposable)renderer).dispose();
 				mapType = 2;
 				map = assetManager.get(MAP_ISO);
 				renderer = new IsometricTiledMapRenderer(map, 1f / 48f);
 			}
-		} else if (Gdx.input.isKeyJustPressed(Input.Keys.NUM_4)) {
+		} else if (input.isKeyJustPressed(Input.Keys.NUM_4)) {
 			if (mapType != 3) {
 				if (renderer instanceof Disposable) ((Disposable)renderer).dispose();
 				mapType = 3;
 				map = assetManager.get(MAP_ISO_STAG);
 				renderer = new IsometricStaggeredTiledMapRenderer(map, 1f / 48f);
 			}
-		} else if (Gdx.input.isKeyJustPressed(Input.Keys.NUM_5)) {
+		} else if (input.isKeyJustPressed(Input.Keys.NUM_5)) {
 			if (mapType != 4) {
 				if (renderer instanceof Disposable) ((Disposable)renderer).dispose();
 				mapType = 4;
 				map = assetManager.get(MAP_HEX_X);
 				renderer = new HexagonalTiledMapRenderer(map, 1f / 48f);
 			}
-		} else if (Gdx.input.isKeyJustPressed(Input.Keys.NUM_6)) {
+		} else if (input.isKeyJustPressed(Input.Keys.NUM_6)) {
 			if (mapType != 5) {
 				if (renderer instanceof Disposable) ((Disposable)renderer).dispose();
 				mapType = 5;
@@ -158,9 +157,9 @@ public class TiledMapLayerOffsetTest extends GdxTest {
 		shapeRenderer.end();
 
 		batch.begin();
-		font.draw(batch, "FPS: " + Gdx.graphics.getFramesPerSecond(), 10, 20);
-		font.draw(batch, "Switch type with 1-6", Gdx.graphics.getHeight() - 100, 50);
-		font.draw(batch, renderer.getClass().getSimpleName(), Gdx.graphics.getHeight() - 100, 20);
+		font.draw(batch, "FPS: " + graphics.getFramesPerSecond(), 10, 20);
+		font.draw(batch, "Switch type with 1-6", graphics.getHeight() - 100, 50);
+		font.draw(batch, renderer.getClass().getSimpleName(), graphics.getHeight() - 100, 20);
 		batch.end();
 	}
 }

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapLayerTintOpacityTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapLayerTintOpacityTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.assets.AssetManager;
 import com.badlogic.gdx.assets.loaders.resolvers.InternalFileHandleResolver;
@@ -56,8 +55,8 @@ public class TiledMapLayerTintOpacityTest extends GdxTest {
 
 	@Override
 	public void create () {
-		float w = Gdx.graphics.getWidth();
-		float h = Gdx.graphics.getHeight();
+		float w = graphics.getWidth();
+		float h = graphics.getHeight();
 
 		camera = new OrthographicCamera();
 		camera.setToOrtho(false, (w / h) * 10, 10);
@@ -65,7 +64,7 @@ public class TiledMapLayerTintOpacityTest extends GdxTest {
 		camera.update();
 
 		cameraController = new OrthoCamController(camera);
-		Gdx.input.setInputProcessor(cameraController);
+		input.setInputProcessor(cameraController);
 
 		font = new BitmapFont();
 		batch = new SpriteBatch();
@@ -88,14 +87,14 @@ public class TiledMapLayerTintOpacityTest extends GdxTest {
 
 	@Override
 	public void render () {
-		if (Gdx.input.isKeyJustPressed(Input.Keys.NUM_1)) {
+		if (input.isKeyJustPressed(Input.Keys.NUM_1)) {
 			if (mapType != 0) {
 				if (renderer instanceof Disposable) ((Disposable)renderer).dispose();
 				mapType = 0;
 				map = assetManager.get(MAP_ORTHO);
 				renderer = new OrthogonalTiledMapRenderer(map, 1f / 32f);
 			}
-		} else if (Gdx.input.isKeyJustPressed(Input.Keys.NUM_2)) {
+		} else if (input.isKeyJustPressed(Input.Keys.NUM_2)) {
 			if (mapType != 1) {
 				if (renderer instanceof Disposable) ((Disposable)renderer).dispose();
 				mapType = 1;
@@ -103,35 +102,35 @@ public class TiledMapLayerTintOpacityTest extends GdxTest {
 				renderer = new OrthoCachedTiledMapRenderer(map, 1f / 32f);
 				((OrthoCachedTiledMapRenderer)renderer).setBlending(true);
 			}
-		} else if (Gdx.input.isKeyJustPressed(Input.Keys.NUM_3)) {
+		} else if (input.isKeyJustPressed(Input.Keys.NUM_3)) {
 			if (mapType != 2) {
 				if (renderer instanceof Disposable) ((Disposable)renderer).dispose();
 				mapType = 2;
 				map = assetManager.get(MAP_ISO);
 				renderer = new IsometricTiledMapRenderer(map, 1f / 64f);
 			}
-		} else if (Gdx.input.isKeyJustPressed(Input.Keys.NUM_4)) {
+		} else if (input.isKeyJustPressed(Input.Keys.NUM_4)) {
 			if (mapType != 3) {
 				if (renderer instanceof Disposable) ((Disposable)renderer).dispose();
 				mapType = 3;
 				map = assetManager.get(MAP_ISO_STAG);
 				renderer = new IsometricStaggeredTiledMapRenderer(map, 1f / 64f);
 			}
-		} else if (Gdx.input.isKeyJustPressed(Input.Keys.NUM_5)) {
+		} else if (input.isKeyJustPressed(Input.Keys.NUM_5)) {
 			if (mapType != 4) {
 				if (renderer instanceof Disposable) ((Disposable)renderer).dispose();
 				mapType = 4;
 				map = assetManager.get(MAP_HEX);
 				renderer = new HexagonalTiledMapRenderer(map, 1f / 128f);
 			}
-		} else if (Gdx.input.isKeyJustPressed(Input.Keys.NUM_6)) {
+		} else if (input.isKeyJustPressed(Input.Keys.NUM_6)) {
 			if (mapType != 5) {
 				if (renderer instanceof Disposable) ((Disposable)renderer).dispose();
 				mapType = 5;
 				map = assetManager.get(MAP_ORTHO_W_IMG);
 				renderer = new OrthogonalTiledMapRenderer(map, 1f / 32f);
 			}
-		} else if (Gdx.input.isKeyJustPressed(Input.Keys.NUM_7)) {
+		} else if (input.isKeyJustPressed(Input.Keys.NUM_7)) {
 			if (mapType != 6) {
 				if (renderer instanceof Disposable) ((Disposable)renderer).dispose();
 				mapType = 6;
@@ -162,9 +161,9 @@ public class TiledMapLayerTintOpacityTest extends GdxTest {
 		shapeRenderer.end();
 
 		batch.begin();
-		font.draw(batch, "FPS: " + Gdx.graphics.getFramesPerSecond(), 10, 20);
-		font.draw(batch, "Switch type with 1-7", Gdx.graphics.getHeight() - 100, 50);
-		font.draw(batch, renderer.getClass().getSimpleName(), Gdx.graphics.getHeight() - 100, 20);
+		font.draw(batch, "FPS: " + graphics.getFramesPerSecond(), 10, 20);
+		font.draw(batch, "Switch type with 1-7", graphics.getHeight() - 100, 50);
+		font.draw(batch, renderer.getClass().getSimpleName(), graphics.getHeight() - 100, 20);
 		batch.end();
 	}
 }

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapModifiedExternalTilesetTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapModifiedExternalTilesetTest.java
@@ -1,7 +1,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
@@ -23,8 +22,8 @@ public class TiledMapModifiedExternalTilesetTest extends GdxTest {
 
 	@Override
 	public void create () {
-		float w = Gdx.graphics.getWidth();
-		float h = Gdx.graphics.getHeight();
+		float w = graphics.getWidth();
+		float h = graphics.getHeight();
 
 		camera = new OrthographicCamera();
 		camera.setToOrtho(false, (w / h) * 10, 10);
@@ -32,7 +31,7 @@ public class TiledMapModifiedExternalTilesetTest extends GdxTest {
 		camera.update();
 
 		cameraController = new OrthoCamController(camera);
-		Gdx.input.setInputProcessor(cameraController);
+		input.setInputProcessor(cameraController);
 
 		font = new BitmapFont();
 		batch = new SpriteBatch();
@@ -52,7 +51,7 @@ public class TiledMapModifiedExternalTilesetTest extends GdxTest {
 		renderer.setView(camera);
 		renderer.render();
 		batch.begin();
-		font.draw(batch, "FPS: " + Gdx.graphics.getFramesPerSecond(), 10, 20);
+		font.draw(batch, "FPS: " + graphics.getFramesPerSecond(), 10, 20);
 		batch.end();
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapObjectLoadingTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapObjectLoadingTest.java
@@ -18,7 +18,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
@@ -58,8 +57,8 @@ public class TiledMapObjectLoadingTest extends GdxTest {
 
 	@Override
 	public void create () {
-		float w = Gdx.graphics.getWidth();
-		float h = Gdx.graphics.getHeight();
+		float w = graphics.getWidth();
+		float h = graphics.getHeight();
 
 		camera = new OrthographicCamera();
 		camera.setToOrtho(false, (w / h) * 512, 512);
@@ -67,7 +66,7 @@ public class TiledMapObjectLoadingTest extends GdxTest {
 		camera.update();
 
 		cameraController = new OrthoCamController(camera);
-		Gdx.input.setInputProcessor(cameraController);
+		input.setInputProcessor(cameraController);
 
 		font = new BitmapFont();
 		textMapObjectFont = new BitmapFont();
@@ -103,7 +102,7 @@ public class TiledMapObjectLoadingTest extends GdxTest {
 		shapeRenderer.setProjectionMatrix(camera.combined);
 		batch.setProjectionMatrix(camera.combined);
 		shapeRenderer.setColor(Color.BLUE);
-		Gdx.gl20.glLineWidth(2);
+		gl20.glLineWidth(2);
 		MapLayer layer = map.getLayers().get("Objects");
 		AnimatedTiledMapTile.updateAnimationBaseTime();
 		for (MapObject mapObject : layer.getObjects()) {
@@ -196,7 +195,7 @@ public class TiledMapObjectLoadingTest extends GdxTest {
 		}
 
 		batch.begin();
-		font.draw(batch, "FPS: " + Gdx.graphics.getFramesPerSecond() + "\n" + loadingStatus, 20, 500);
+		font.draw(batch, "FPS: " + graphics.getFramesPerSecond() + "\n" + loadingStatus, 20, 500);
 		batch.end();
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapObjectPropertyTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapObjectPropertyTest.java
@@ -3,7 +3,6 @@ package com.badlogic.gdx.tests;
 
 import java.util.Iterator;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
@@ -42,7 +41,7 @@ public class TiledMapObjectPropertyTest extends GdxTest {
 			TmxMapLoader loader = new TmxMapLoader();
 			// run multiple times to ensure reloading map works correctly
 			for (int i = 0; i < 3; i++) {
-				Gdx.app.log("-------------------------------------", "Running test " + (i + 1) + "/3\n");
+				app.log("-------------------------------------", "Running test " + (i + 1) + "/3\n");
 
 				StringBuilder builder = new StringBuilder();
 				builder.append("Expected results:\n").append("- Object with id 1 should have \"object\" props:\n")
@@ -52,10 +51,10 @@ public class TiledMapObjectPropertyTest extends GdxTest {
 					.append("- Object with id 3 should have \"object\" props:\n").append("\t- Points_To_ID_2 = id: 2\n")
 					.append("- Object with id 4 should have \"object\" props:\n").append("\t- Points_To_ID_1 = id: 1\n")
 					.append("- Objects with id's 5 and 6 should have \"object\" props:\n").append("\t- Placeholder = 0\n");
-				Gdx.app.log("TiledMapObjectPropertyTest", builder.toString());
+				app.log("TiledMapObjectPropertyTest", builder.toString());
 
-				float w = Gdx.graphics.getWidth();
-				float h = Gdx.graphics.getHeight();
+				float w = graphics.getWidth();
+				float h = graphics.getHeight();
 
 				camera = new OrthographicCamera();
 				camera.setToOrtho(false, (w / h) * 512, 512);
@@ -63,7 +62,7 @@ public class TiledMapObjectPropertyTest extends GdxTest {
 				camera.update();
 
 				OrthoCamController cameraController = new OrthoCamController(camera);
-				Gdx.input.setInputProcessor(cameraController);
+				input.setInputProcessor(cameraController);
 
 				map = loader.load("data/maps/tiled-objects/test-object-properties.tmx");
 
@@ -89,7 +88,7 @@ public class TiledMapObjectPropertyTest extends GdxTest {
 					builder.append("\n\t").append(entry.key).append(" -> ").append(entry.value);
 				}
 				builder.append("\n}\n");
-				Gdx.app.log("TiledMapObjectPropertyTest", builder.toString());
+				app.log("TiledMapObjectPropertyTest", builder.toString());
 
 				for (MapObject object1 : objects) {
 					int id = object1.getProperties().get("id", Integer.class);
@@ -156,10 +155,10 @@ public class TiledMapObjectPropertyTest extends GdxTest {
 						builder.append("\t\t").append(key).append(" -> ").append(value).append("\n");
 					}
 				}
-				Gdx.app.log("TiledMapObjectPropertyTest", builder.toString());
+				app.log("TiledMapObjectPropertyTest", builder.toString());
 			}
 		} catch (Exception e) {
-			Gdx.app.error("TiledMapObjectPropertyTest", "Failed to run test!", e);
+			app.error("TiledMapObjectPropertyTest", "Failed to run test!", e);
 			e.printStackTrace();
 			error = true;
 		}
@@ -168,8 +167,8 @@ public class TiledMapObjectPropertyTest extends GdxTest {
 	@Override
 	public void render () {
 		if (error) {
-			Gdx.app.error("TiledMapObjectPropertyTest", "Failed to run test!");
-			Gdx.app.exit();
+			app.error("TiledMapObjectPropertyTest", "Failed to run test!");
+			app.exit();
 		}
 
 		ScreenUtils.clear(0.55f, 0.55f, 0.55f, 1f);
@@ -181,7 +180,7 @@ public class TiledMapObjectPropertyTest extends GdxTest {
 		batch.setProjectionMatrix(camera.combined);
 
 		shapeRenderer.setColor(Color.BLUE);
-		Gdx.gl20.glLineWidth(2);
+		gl20.glLineWidth(2);
 		for (MapObject object : objects) {
 			if (!object.isVisible()) continue;
 			if (object instanceof RectangleMapObject) {

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapPropertiesTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapPropertiesTest.java
@@ -1,7 +1,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.maps.MapObject;
 import com.badlogic.gdx.maps.MapProperties;
@@ -50,10 +49,10 @@ public class TiledMapPropertiesTest extends GdxTest {
 		try {
 			verifyTiledMap(tiledMap);
 		} catch (Exception e) {
-			Gdx.app.error(LOG_TAG, "Verification of tiledmap properties failed", e);
+			app.error(LOG_TAG, "Verification of tiledmap properties failed", e);
 			return;
 		}
-		Gdx.app.log(LOG_TAG, "TMJ properties successfully verified!");
+		app.log(LOG_TAG, "TMJ properties successfully verified!");
 
 		// verify TMX
 		tiledMap.dispose();
@@ -64,10 +63,10 @@ public class TiledMapPropertiesTest extends GdxTest {
 		try {
 			verifyTiledMap(tiledMap);
 		} catch (Exception e) {
-			Gdx.app.error(LOG_TAG, "Verification of tiledmap properties failed", e);
+			app.error(LOG_TAG, "Verification of tiledmap properties failed", e);
 			return;
 		}
-		Gdx.app.log(LOG_TAG, "TMX properties successfully verified!");
+		app.log(LOG_TAG, "TMX properties successfully verified!");
 
 		success = true;
 	}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapTemplateObjectLoadingTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapTemplateObjectLoadingTest.java
@@ -18,7 +18,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.OrthographicCamera;
@@ -64,8 +63,8 @@ public class TiledMapTemplateObjectLoadingTest extends GdxTest {
 
 	@Override
 	public void create () {
-		float w = Gdx.graphics.getWidth();
-		float h = Gdx.graphics.getHeight();
+		float w = graphics.getWidth();
+		float h = graphics.getHeight();
 
 		camera = new OrthographicCamera();
 		camera.setToOrtho(false, (w / h) * 520, 520);
@@ -74,7 +73,7 @@ public class TiledMapTemplateObjectLoadingTest extends GdxTest {
 		camera.update();
 
 		cameraController = new OrthoCamController(camera);
-		Gdx.input.setInputProcessor(cameraController);
+		input.setInputProcessor(cameraController);
 
 		stringBuilder = new StringBuilder();
 		font = new BitmapFont();
@@ -103,12 +102,12 @@ public class TiledMapTemplateObjectLoadingTest extends GdxTest {
 
 	@Override
 	public void render () {
-		if (Gdx.input.isKeyJustPressed(Input.Keys.NUM_1)) {
+		if (input.isKeyJustPressed(Input.Keys.NUM_1)) {
 			if (mapType != 0) {
 				mapType = 0;
 				map = tmxMapLoader.load(TMX_TESTMAP);
 			}
-		} else if (Gdx.input.isKeyJustPressed(Input.Keys.NUM_2)) {
+		} else if (input.isKeyJustPressed(Input.Keys.NUM_2)) {
 			if (mapType != 1) {
 				mapType = 1;
 				map = tmjMapLoader.load(TMJ_TESTMAP);
@@ -125,7 +124,7 @@ public class TiledMapTemplateObjectLoadingTest extends GdxTest {
 			shapeRenderer.setColor(Color.RED);
 		}
 
-		Gdx.gl20.glLineWidth(2);
+		gl20.glLineWidth(2);
 		MapLayer layer = map.getLayers().get("Objects");
 		AnimatedTiledMapTile.updateAnimationBaseTime();
 		for (MapObject mapObject : layer.getObjects()) {
@@ -339,7 +338,7 @@ public class TiledMapTemplateObjectLoadingTest extends GdxTest {
 			}
 		}
 
-		font.draw(batch, "FPS: " + Gdx.graphics.getFramesPerSecond() + "\n" + loadingStatus, 20, 1470);
+		font.draw(batch, "FPS: " + graphics.getFramesPerSecond() + "\n" + loadingStatus, 20, 1470);
 		batch.end();
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapUniversalLoaderTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TiledMapUniversalLoaderTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.assets.AssetManager;
 import com.badlogic.gdx.assets.loaders.resolvers.InternalFileHandleResolver;
@@ -55,8 +54,8 @@ public class TiledMapUniversalLoaderTest extends GdxTest {
 
 	@Override
 	public void create () {
-		float w = Gdx.graphics.getWidth();
-		float h = Gdx.graphics.getHeight();
+		float w = graphics.getWidth();
+		float h = graphics.getHeight();
 
 		camera = new OrthographicCamera();
 		camera.setToOrtho(false, (w / h) * 10, 10);
@@ -64,7 +63,7 @@ public class TiledMapUniversalLoaderTest extends GdxTest {
 		camera.update();
 
 		cameraController = new OrthoCamController(camera);
-		Gdx.input.setInputProcessor(cameraController);
+		input.setInputProcessor(cameraController);
 
 		font = new BitmapFont();
 		batch = new SpriteBatch();
@@ -105,49 +104,49 @@ public class TiledMapUniversalLoaderTest extends GdxTest {
 
 	@Override
 	public void render () {
-		if (Gdx.input.isKeyJustPressed(Input.Keys.NUM_1)) {
+		if (input.isKeyJustPressed(Input.Keys.NUM_1)) {
 			if (mapType != 0) {
 				if (renderer instanceof Disposable) ((Disposable)renderer).dispose();
 				mapType = 0;
 				map = assetManager.get(MAP_TMX);
 				renderer = new IsometricTiledMapRenderer(map, 1f / 64f);
 			}
-		} else if (Gdx.input.isKeyJustPressed(Input.Keys.NUM_2)) {
+		} else if (input.isKeyJustPressed(Input.Keys.NUM_2)) {
 			if (mapType != 1) {
 				if (renderer instanceof Disposable) ((Disposable)renderer).dispose();
 				mapType = 1;
 				map = assetManager.get(MAP_TMX_2);
 				renderer = new OrthogonalTiledMapRenderer(map, 1f / 32f);
 			}
-		} else if (Gdx.input.isKeyJustPressed(Input.Keys.NUM_3)) {
+		} else if (input.isKeyJustPressed(Input.Keys.NUM_3)) {
 			if (mapType != 2) {
 				if (renderer instanceof Disposable) ((Disposable)renderer).dispose();
 				mapType = 2;
 				map = assetManager.get(MAP_TMJ);
 				renderer = new HexagonalTiledMapRenderer(map, 1f / 64f);
 			}
-		} else if (Gdx.input.isKeyJustPressed(Input.Keys.NUM_4)) {
+		} else if (input.isKeyJustPressed(Input.Keys.NUM_4)) {
 			if (mapType != 3) {
 				if (renderer instanceof Disposable) ((Disposable)renderer).dispose();
 				mapType = 3;
 				map = assetManager.get(MAP_ATLAS_TMX);
 				renderer = new OrthogonalTiledMapRenderer(map, 1f / 32f);
 			}
-		} else if (Gdx.input.isKeyJustPressed(Input.Keys.NUM_5)) {
+		} else if (input.isKeyJustPressed(Input.Keys.NUM_5)) {
 			if (mapType != 4) {
 				if (renderer instanceof Disposable) ((Disposable)renderer).dispose();
 				mapType = 4;
 				map = assetManager.get(MAP_ATLAS_TMJ);
 				renderer = new OrthogonalTiledMapRenderer(map, 1f / 16f);
 			}
-		} else if (Gdx.input.isKeyJustPressed(Input.Keys.NUM_6)) {
+		} else if (input.isKeyJustPressed(Input.Keys.NUM_6)) {
 			if (mapType != 5) {
 				if (renderer instanceof Disposable) ((Disposable)renderer).dispose();
 				mapType = 5;
 				map = assetManager.get(MAP_TMJ_2);
 				renderer = new OrthogonalTiledMapRenderer(map, 1f / 32f);
 			}
-		} else if (Gdx.input.isKeyJustPressed(Input.Keys.NUM_7)) {
+		} else if (input.isKeyJustPressed(Input.Keys.NUM_7)) {
 			if (mapType != 6) {
 				if (renderer instanceof Disposable) ((Disposable)renderer).dispose();
 				mapType = 6;
@@ -178,9 +177,9 @@ public class TiledMapUniversalLoaderTest extends GdxTest {
 		shapeRenderer.end();
 
 		batch.begin();
-		font.draw(batch, "FPS: " + Gdx.graphics.getFramesPerSecond(), 10, 20);
-		font.draw(batch, "Switch type with 1-7", Gdx.graphics.getHeight() - 100, 50);
-		font.draw(batch, renderer.getClass().getSimpleName(), Gdx.graphics.getHeight() - 100, 20);
+		font.draw(batch, "FPS: " + graphics.getFramesPerSecond(), 10, 20);
+		font.draw(batch, "Switch type with 1-7", graphics.getHeight() - 100, 50);
+		font.draw(batch, renderer.getClass().getSimpleName(), graphics.getHeight() - 100, 20);
 		batch.end();
 	}
 }

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TimerTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TimerTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.tests.utils.GdxTest;
 import com.badlogic.gdx.utils.Timer;
 import com.badlogic.gdx.utils.Timer.Task;
@@ -26,7 +25,7 @@ public class TimerTest extends GdxTest {
 
 	@Override
 	public void create () {
-		Gdx.app.log("TimerTest", "Starting tests...");
+		app.log("TimerTest", "Starting tests...");
 		testOnce();
 		testRepeat();
 		testCancelPosted();
@@ -44,11 +43,11 @@ public class TimerTest extends GdxTest {
 
 	public void render () {
 		if (time < 2) {
-			time += Gdx.graphics.getDeltaTime();
+			time += graphics.getDeltaTime();
 			if (time >= 2) {
 				if (testCount != expectedTests)
 					throw new RuntimeException("Some tests did not run: " + testCount + " != " + expectedTests);
-				Gdx.app.log("TimerTest", "SUCCESS! " + testCount + " tests passed.");
+				app.log("TimerTest", "SUCCESS! " + testCount + " tests passed.");
 				repeatTask.cancel();
 			}
 		}
@@ -58,7 +57,7 @@ public class TimerTest extends GdxTest {
 		Task task = Timer.schedule(new Task() {
 			@Override
 			public void run () {
-				Gdx.app.log("TimerTest", "testOnce");
+				app.log("TimerTest", "testOnce");
 				testCount++;
 			}
 		}, 1);
@@ -71,7 +70,7 @@ public class TimerTest extends GdxTest {
 
 			@Override
 			public void run () {
-				Gdx.app.log("TimerTest", "testRepeat");
+				app.log("TimerTest", "testRepeat");
 				if (++count <= 2) testCount++;
 			}
 		}, 1, 1);
@@ -90,7 +89,7 @@ public class TimerTest extends GdxTest {
 		assertNotScheduled(task);
 		task.cancel(); // The posted task should not execute.
 		assertNotScheduled(task);
-		Gdx.app.log("TimerTest", "testCancelPosted");
+		app.log("TimerTest", "testCancelPosted");
 		testCount++;
 	}
 
@@ -111,7 +110,7 @@ public class TimerTest extends GdxTest {
 		assertNotScheduled(task);
 		task.cancel(); // The twice posted task should not execute.
 		assertNotScheduled(task);
-		Gdx.app.log("TimerTest", "testCancelPostedTwice");
+		app.log("TimerTest", "testCancelPostedTwice");
 		testCount++;
 	}
 
@@ -122,7 +121,7 @@ public class TimerTest extends GdxTest {
 			@Override
 			public void run () {
 				if (++count != 1) throw new RuntimeException("Rescheduled task should only run once.");
-				Gdx.app.log("TimerTest", "testCancelPostedReschedule");
+				app.log("TimerTest", "testCancelPostedReschedule");
 				testCount++;
 			}
 		}, 0.01f);
@@ -145,7 +144,7 @@ public class TimerTest extends GdxTest {
 		}, 1);
 		assertScheduled(task);
 		timer.stop();
-		Gdx.app.log("TimerTest", "testStop");
+		app.log("TimerTest", "testStop");
 		testCount++;
 	}
 
@@ -154,7 +153,7 @@ public class TimerTest extends GdxTest {
 		Task task = timer.scheduleTask(new Task() {
 			@Override
 			public void run () {
-				Gdx.app.log("TimerTest", "testStopStart");
+				app.log("TimerTest", "testStopStart");
 				testCount++;
 			}
 		}, 0.200f);
@@ -171,7 +170,7 @@ public class TimerTest extends GdxTest {
 		Task task = timer.scheduleTask(new Task() {
 			@Override
 			public void run () {
-				Gdx.app.log("TimerTest", "testDelay");
+				app.log("TimerTest", "testDelay");
 				testCount++;
 			}
 		}, 0.200f);
@@ -192,7 +191,7 @@ public class TimerTest extends GdxTest {
 		assertScheduled(task);
 		timer.clear();
 		assertNotScheduled(task);
-		Gdx.app.log("TimerTest", "testClear");
+		app.log("TimerTest", "testClear");
 		testCount++;
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TouchpadTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TouchpadTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.scenes.scene2d.ui.Skin;
@@ -29,9 +28,9 @@ public class TouchpadTest extends GdxTest {
 
 	public void create () {
 		stage = new Stage();
-		Gdx.input.setInputProcessor(stage);
+		input.setInputProcessor(stage);
 
-		Skin skin = new Skin(Gdx.files.internal("data/uiskin.json"));
+		Skin skin = new Skin(files.internal("data/uiskin.json"));
 
 		touchpad = new Touchpad(20, skin);
 		touchpad.setBounds(15, 15, 100, 100);
@@ -40,8 +39,8 @@ public class TouchpadTest extends GdxTest {
 
 	public void render () {
 		// System.out.println(touchpad.getKnobPercentX() + " " + touchpad.getKnobPercentY());
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-		stage.act(Gdx.graphics.getDeltaTime());
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		stage.act(graphics.getDeltaTime());
 		stage.draw();
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/TreeTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/TreeTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.scenes.scene2d.InputEvent;
@@ -45,9 +44,9 @@ public class TreeTest extends GdxTest {
 
 	public void create () {
 		stage = new Stage();
-		Gdx.input.setInputProcessor(stage);
+		input.setInputProcessor(stage);
 
-		skin = new Skin(Gdx.files.internal("data/uiskin.json"));
+		skin = new Skin(files.internal("data/uiskin.json"));
 
 		label = new Label("", skin);
 		stage.addActor(label);
@@ -100,8 +99,8 @@ public class TreeTest extends GdxTest {
 
 	public void render () {
 		// System.out.println(meow.getValue());
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-		stage.act(Gdx.graphics.getDeltaTime());
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		stage.act(graphics.getDeltaTime());
 		stage.draw();
 
 		label.setText(tree.toString());

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/UBJsonTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/UBJsonTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.tests.utils.GdxTest;
 import com.badlogic.gdx.utils.JsonValue;
 import com.badlogic.gdx.utils.UBJsonReader;
@@ -36,7 +35,7 @@ public class UBJsonTest extends GdxTest {
 	public void create () {
 		try {
 
-			UBJsonWriter uw = new UBJsonWriter(Gdx.files.external(fn).write(false));
+			UBJsonWriter uw = new UBJsonWriter(files.external(fn).write(false));
 			uw.object();
 			uw.set(longString, longString);
 			uw.set("0floats", new float[] {});
@@ -64,19 +63,19 @@ public class UBJsonTest extends GdxTest {
 			uw.close();
 			UBJsonReader ur = new UBJsonReader();
 			ur.oldFormat = false;
-			JsonValue v = ur.parse(Gdx.files.external(fn));
-			Gdx.app.log("UBJsonTest", "result = \n" + v.toString());
+			JsonValue v = ur.parse(files.external(fn));
+			app.log("UBJsonTest", "result = \n" + v.toString());
 			performanceTest();
-			Gdx.app.log("UBJsonTest", "Test succeeded");
+			app.log("UBJsonTest", "Test succeeded");
 		} catch (Throwable t) {
-			Gdx.app.error("UBJsonTest", "Test failed", t);
+			app.error("UBJsonTest", "Test failed", t);
 		}
 	}
 
 	private void performanceTest () throws Exception {
-		Gdx.app.log("UBJsonTest", "--- performanceTest ---");
+		app.log("UBJsonTest", "--- performanceTest ---");
 		long start = System.currentTimeMillis();
-		UBJsonWriter uw = new UBJsonWriter(Gdx.files.external(fn).write(false, 8192));
+		UBJsonWriter uw = new UBJsonWriter(files.external(fn).write(false, 8192));
 		uw.object();
 		uw.set("0floats", new float[] {});
 		uw.set("3floats", new float[] {1, 2, 3.456789f});
@@ -98,12 +97,12 @@ public class UBJsonTest extends GdxTest {
 		uw.pop();
 		uw.close();
 
-		Gdx.app.log("UBJsonTest", "Writing the test file took " + (System.currentTimeMillis() - start) + "ms");
-		Gdx.app.log("UBJsonTest", "File size is " + Gdx.files.external(fn).length());
+		app.log("UBJsonTest", "Writing the test file took " + (System.currentTimeMillis() - start) + "ms");
+		app.log("UBJsonTest", "File size is " + files.external(fn).length());
 		UBJsonReader ur = new UBJsonReader();
 		ur.oldFormat = false;
 		start = System.currentTimeMillis();
-		ur.parse(Gdx.files.external(fn));
-		Gdx.app.log("UBJsonTest", "Parsing the test file took " + (System.currentTimeMillis() - start) + "ms");
+		ur.parse(files.external(fn));
+		app.log("UBJsonTest", "Parsing the test file took " + (System.currentTimeMillis() - start) + "ms");
 	}
 }

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/UISimpleTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/UISimpleTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.Pixmap.Format;
@@ -43,7 +42,7 @@ public class UISimpleTest extends GdxTest {
 	public void create () {
 		batch = new SpriteBatch();
 		stage = new Stage();
-		Gdx.input.setInputProcessor(stage);
+		input.setInputProcessor(stage);
 
 		// A skin can be loaded via JSON or defined programmatically, either is fine. Using a skin is optional but strongly
 		// recommended solely for the convenience of getting a texture, region, etc as a drawable, tinted drawable, etc.
@@ -94,7 +93,7 @@ public class UISimpleTest extends GdxTest {
 	@Override
 	public void render () {
 		ScreenUtils.clear(0.2f, 0.2f, 0.2f, 1);
-		stage.act(Math.min(Gdx.graphics.getDeltaTime(), 1 / 30f));
+		stage.act(Math.min(graphics.getDeltaTime(), 1 / 30f));
 		stage.draw();
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/UITest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/UITest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input.Keys;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
@@ -65,16 +64,16 @@ public class UITest extends GdxTest {
 
 	@Override
 	public void create () {
-		skin = new Skin(Gdx.files.internal("data/uiskin.json"));
-		texture1 = new Texture(Gdx.files.internal("data/badlogicsmall.jpg"));
-		texture2 = new Texture(Gdx.files.internal("data/badlogic.jpg"));
+		skin = new Skin(files.internal("data/uiskin.json"));
+		texture1 = new Texture(files.internal("data/badlogicsmall.jpg"));
+		texture2 = new Texture(files.internal("data/badlogic.jpg"));
 		TextureRegion image = new TextureRegion(texture1);
 		TextureRegion imageFlipped = new TextureRegion(image);
 		imageFlipped.flip(true, true);
 		TextureRegion image2 = new TextureRegion(texture2);
-		// stage = new Stage(Gdx.graphics.getWidth(), Gdx.graphics.getHeight(), false, new PolygonSpriteBatch());
+		// stage = new Stage(graphics.getWidth(), graphics.getHeight(), false, new PolygonSpriteBatch());
 		stage = new Stage(new ScreenViewport());
-		Gdx.input.setInputProcessor(stage);
+		input.setInputProcessor(stage);
 
 		// stage.setDebugAll(true);
 
@@ -184,7 +183,7 @@ public class UITest extends GdxTest {
 
 		slider.addListener(new ChangeListener() {
 			public void changed (ChangeEvent event, Actor actor) {
-				Gdx.app.log("UITest", "slider: " + slider.getValue());
+				app.log("UITest", "slider: " + slider.getValue());
 			}
 		});
 
@@ -201,7 +200,7 @@ public class UITest extends GdxTest {
 
 		checkBox.addListener(new ChangeListener() {
 			public void changed (ChangeEvent event, Actor actor) {
-				Gdx.graphics.setContinuousRendering(checkBox.isChecked());
+				graphics.setContinuousRendering(checkBox.isChecked());
 			}
 		});
 	}
@@ -210,9 +209,9 @@ public class UITest extends GdxTest {
 	public void render () {
 		ScreenUtils.clear(0.2f, 0.2f, 0.2f, 1);
 
-		fpsLabel.setText("fps: " + Gdx.graphics.getFramesPerSecond());
+		fpsLabel.setText("fps: " + graphics.getFramesPerSecond());
 
-		stage.act(Math.min(Gdx.graphics.getDeltaTime(), 1 / 30f));
+		stage.act(Math.min(graphics.getDeltaTime(), 1 / 30f));
 		stage.draw();
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/UtfFontTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/UtfFontTest.java
@@ -1,7 +1,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
@@ -16,12 +15,12 @@ public class UtfFontTest extends GdxTest {
 	@Override
 	public void create () {
 		batch = new SpriteBatch();
-		font = new BitmapFont(Gdx.files.internal("data/utf-font.fnt"));
+		font = new BitmapFont(files.internal("data/utf-font.fnt"));
 	}
 
 	@Override
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		batch.begin();
 
 		// https://github.com/libgdx/libgdx/pull/6501#issuecomment-821749417

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/Vector2dTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/Vector2dTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
@@ -82,7 +81,7 @@ public class Vector2dTest extends GdxTest {
 		renderer.setColor(Color.YELLOW);
 		renderVectorAt(0, 0, sum);
 
-		final float changeRate = Gdx.graphics.getDeltaTime();
+		final float changeRate = graphics.getDeltaTime();
 		renderer.setColor(Color.WHITE);
 
 		renderVectorAt(2, 2, rotating);
@@ -100,7 +99,7 @@ public class Vector2dTest extends GdxTest {
 			lerpTarget.set(-1.0f + MathUtils.random(2.0f), -1.0f + MathUtils.random(2.0f)).nor();
 		}
 
-		timePassed += Gdx.graphics.getDeltaTime();
+		timePassed += graphics.getDeltaTime();
 		renderVectorAt(-4, 0, lerping2);
 		lerping2.set(lerpStart2);
 		lerping2.interpolate(lerpTarget2, MathUtils.clamp(timePassed / DURATION, 0, 1), interpolator);
@@ -119,7 +118,7 @@ public class Vector2dTest extends GdxTest {
 
 	@Override
 	public void resize (int width, int height) {
-		float ratio = ((float)Gdx.graphics.getWidth() / (float)Gdx.graphics.getHeight());
+		float ratio = ((float)graphics.getWidth() / (float)graphics.getHeight());
 		int h = 10;
 		int w = (int)(h * ratio);
 		camera = new OrthographicCamera(w, h);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/VertexBufferObjectShaderTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/VertexBufferObjectShaderTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Texture;
@@ -45,9 +44,9 @@ public class VertexBufferObjectShaderTest extends GdxTest {
 
 	@Override
 	public void render () {
-		GL20 gl = Gdx.gl20;
-		gl.glViewport(0, 0, Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight());
-		Gdx.gl.glClearColor(0.7f, 0, 0, 1);
+		GL20 gl = gl20;
+		gl.glViewport(0, 0, graphics.getBackBufferWidth(), graphics.getBackBufferHeight());
+		gl.glClearColor(0.7f, 0, 0, 1);
 		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 
 		shader.bind();
@@ -88,7 +87,7 @@ public class VertexBufferObjectShaderTest extends GdxTest {
 		//@on
 
 		shader = new ShaderProgram(vertexShader, fragmentShader);
-		if (Gdx.gl30 != null) {
+		if (gl30 != null) {
 			vbo = new VertexBufferObjectWithVAO(true, 3, new VertexAttribute(VertexAttributes.Usage.Position, 2, "a_position"),
 				new VertexAttribute(VertexAttributes.Usage.TextureCoordinates, 2, "a_texCoords"),
 				new VertexAttribute(VertexAttributes.Usage.ColorPacked, 4, "a_color"));
@@ -104,7 +103,7 @@ public class VertexBufferObjectShaderTest extends GdxTest {
 		indices = new IndexBufferObject(3);
 		indices.setIndices(new short[] {0, 1, 2}, 0, 3);
 
-		texture = new Texture(Gdx.files.internal("data/badlogic.jpg"));
+		texture = new Texture(files.internal("data/badlogic.jpg"));
 	}
 
 	@Override

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/VibratorTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/VibratorTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
@@ -41,8 +40,8 @@ public class VibratorTest extends GdxTest {
 	public void create () {
 		batch = new SpriteBatch();
 		stage = new Stage();
-		skin = new Skin(Gdx.files.internal("data/uiskin.json"));
-		Gdx.input.setInputProcessor(stage);
+		skin = new Skin(files.internal("data/uiskin.json"));
+		input.setInputProcessor(stage);
 
 		// Create a table that fills the screen. Everything else will go inside this table.
 		Table table = new Table();
@@ -54,7 +53,7 @@ public class VibratorTest extends GdxTest {
 		button.addListener(new ChangeListener() {
 			@Override
 			public void changed (ChangeEvent event, Actor actor) {
-				Gdx.input.vibrate(50);
+				input.vibrate(50);
 			}
 		});
 		final Button buttonVibrateAmplitude = getButton("Vibrate \n Amplitude \n Random");
@@ -63,8 +62,8 @@ public class VibratorTest extends GdxTest {
 			public void changed (ChangeEvent event, Actor actor) {
 				int randomLength = MathUtils.random(10, 200);
 				int randomAmplitude = MathUtils.random(0, 255);
-				Gdx.input.vibrate(randomLength, randomAmplitude, fallbackCheckbox.isChecked());
-				Gdx.app.log("VibratorTest", "Length: " + randomLength + "ms, Amplitude: " + randomAmplitude);
+				input.vibrate(randomLength, randomAmplitude, fallbackCheckbox.isChecked());
+				app.log("VibratorTest", "Length: " + randomLength + "ms, Amplitude: " + randomAmplitude);
 			}
 		});
 		final Button buttonVibrateType = getButton("Vibrate \n Type \n Random");
@@ -73,8 +72,8 @@ public class VibratorTest extends GdxTest {
 			public void changed (ChangeEvent event, Actor actor) {
 				Input.VibrationType vibrationType = Input.VibrationType.values()[MathUtils.random(0,
 					Input.VibrationType.values().length - 1)];
-				Gdx.input.vibrate(vibrationType);
-				Gdx.app.log("VibratorTest", "VibrationType: " + vibrationType.name());
+				input.vibrate(vibrationType);
+				app.log("VibratorTest", "VibrationType: " + vibrationType.name());
 			}
 		});
 
@@ -96,8 +95,8 @@ public class VibratorTest extends GdxTest {
 
 	@Override
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-		stage.act(Math.min(Gdx.graphics.getDeltaTime(), 1 / 30f));
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		stage.act(Math.min(graphics.getDeltaTime(), 1 / 30f));
 		stage.draw();
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ViewportTest1.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ViewportTest1.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.InputAdapter;
 import com.badlogic.gdx.InputMultiplexer;
@@ -47,7 +46,7 @@ public class ViewportTest1 extends GdxTest {
 
 	public void create () {
 		stage = new Stage();
-		Skin skin = new Skin(Gdx.files.internal("data/uiskin.json"));
+		Skin skin = new Skin(files.internal("data/uiskin.json"));
 
 		label = new Label("", skin);
 
@@ -67,14 +66,14 @@ public class ViewportTest1 extends GdxTest {
 		stage.setViewport(viewports.first());
 		label.setText(names.first());
 
-		Gdx.input.setInputProcessor(new InputMultiplexer(new InputAdapter() {
+		input.setInputProcessor(new InputMultiplexer(new InputAdapter() {
 			public boolean keyDown (int keycode) {
 				if (keycode == Input.Keys.SPACE) {
 					int index = (viewports.indexOf(stage.getViewport(), true) + 1) % viewports.size;
 					label.setText(names.get(index));
 					Viewport viewport = viewports.get(index);
 					stage.setViewport(viewport);
-					resize(Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+					resize(graphics.getWidth(), graphics.getHeight());
 				}
 				return false;
 			}
@@ -84,7 +83,7 @@ public class ViewportTest1 extends GdxTest {
 	public void render () {
 		stage.act();
 
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		stage.draw();
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ViewportTest2.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ViewportTest2.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.InputAdapter;
 import com.badlogic.gdx.graphics.GL20;
@@ -65,13 +64,13 @@ public class ViewportTest2 extends GdxTest {
 		names = ViewportTest1.getViewportNames();
 		name = names.first();
 
-		Gdx.input.setInputProcessor(new InputAdapter() {
+		input.setInputProcessor(new InputAdapter() {
 			public boolean keyDown (int keycode) {
 				if (keycode == Input.Keys.SPACE) {
 					int index = (viewports.indexOf(viewport, true) + 1) % viewports.size;
 					name = names.get(index);
 					viewport = viewports.get(index);
-					resize(Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+					resize(graphics.getWidth(), graphics.getHeight());
 				}
 				return false;
 			}
@@ -82,7 +81,7 @@ public class ViewportTest2 extends GdxTest {
 		batch.setProjectionMatrix(camera.projection);
 		batch.setTransformMatrix(camera.view);
 
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		batch.begin();
 		// draw a white background so we are able to see the black bars
 		batch.setColor(1, 1, 1, 1);
@@ -97,8 +96,8 @@ public class ViewportTest2 extends GdxTest {
 		if (viewport instanceof ScalingViewport) {
 			// This shows how to set the viewport to the whole screen and draw within the black bars.
 			ScalingViewport scalingViewport = (ScalingViewport)viewport;
-			int screenWidth = Gdx.graphics.getWidth();
-			int screenHeight = Gdx.graphics.getHeight();
+			int screenWidth = graphics.getWidth();
+			int screenHeight = graphics.getHeight();
 			HdpiUtils.glViewport(0, 0, screenWidth, screenHeight);
 			batch.getProjectionMatrix().idt().setToOrtho2D(0, 0, screenWidth, screenHeight);
 			batch.getTransformMatrix().idt();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/ViewportTest3.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/ViewportTest3.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.InputAdapter;
 import com.badlogic.gdx.graphics.Color;
@@ -81,13 +80,13 @@ public class ViewportTest3 extends GdxTest {
 		boxInstance.transform.rotate(1, 0, 0, 30);
 		boxInstance.transform.rotate(0, 1, 0, 30);
 
-		Gdx.input.setInputProcessor(new InputAdapter() {
+		input.setInputProcessor(new InputAdapter() {
 			public boolean keyDown (int keycode) {
 				if (keycode == Input.Keys.SPACE) {
 					int index = (viewports.indexOf(viewport, true) + 1) % viewports.size;
 					name = names.get(index);
 					viewport = viewports.get(index);
-					resize(Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+					resize(graphics.getWidth(), graphics.getHeight());
 				}
 				return false;
 			}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/YDownTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/YDownTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.OrthographicCamera;
@@ -49,14 +48,14 @@ public class YDownTest extends GdxTest {
 	public void create () {
 		// a bitmap font to draw some text, note that we
 		// pass true to the constructor, which flips glyphs on y
-		font = new BitmapFont(Gdx.files.internal("data/lsans-15.fnt"), true);
+		font = new BitmapFont(files.internal("data/lsans-15.fnt"), true);
 
 		// a texture region, note the flipping on y again
 		region = new TextureRegion(new Texture("data/badlogic.jpg"));
 		region.flip(false, true);
 
 		// a texture atlas, note the boolean
-		atlas = new TextureAtlas(Gdx.files.internal("data/pack.atlas"), true);
+		atlas = new TextureAtlas(files.internal("data/pack.atlas"), true);
 
 		// a sprite, created from a region in the atlas
 		sprite = atlas.createSprite("badlogicsmall");
@@ -80,7 +79,7 @@ public class YDownTest extends GdxTest {
 		stage.addActor(image);
 
 		// finally we write up the stage as the input process and call it a day.
-		Gdx.input.setInputProcessor(stage);
+		input.setInputProcessor(stage);
 	}
 
 	@Override
@@ -93,7 +92,7 @@ public class YDownTest extends GdxTest {
 	public void render () {
 		// clear the screen, update the camera and make the sprite batch
 		// use its matrices.
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		camera.update();
 		batch.setProjectionMatrix(camera.combined);
 
@@ -112,11 +111,11 @@ public class YDownTest extends GdxTest {
 		sprite.setColor(Color.RED);
 		sprite.draw(batch);
 		// finally we draw our current touch/mouse coordinates
-		font.draw(batch, Gdx.input.getX() + ", " + Gdx.input.getY(), 0, 0);
+		font.draw(batch, input.getX() + ", " + input.getY(), 0, 0);
 		batch.end();
 
 		// tell the stage to act and draw itself
-		stage.act(Gdx.graphics.getDeltaTime());
+		stage.act(graphics.getDeltaTime());
 		stage.draw();
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/bench/TiledMapBench.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/bench/TiledMapBench.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests.bench;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.assets.AssetManager;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.graphics.Texture;
@@ -48,21 +47,21 @@ public class TiledMapBench extends GdxTest {
 
 	@Override
 	public void create () {
-		float w = Gdx.graphics.getWidth();
-		float h = Gdx.graphics.getHeight();
+		float w = graphics.getWidth();
+		float h = graphics.getHeight();
 
 		camera = new OrthographicCamera();
 		camera.setToOrtho(false, (w / h) * 320, 320);
 		camera.update();
 
 		cameraController = new OrthoCamController(camera);
-		Gdx.input.setInputProcessor(cameraController);
+		input.setInputProcessor(cameraController);
 
 		font = new BitmapFont();
 		batch = new SpriteBatch();
 
 		{
-			tiles = new Texture(Gdx.files.internal("data/maps/tiled/tiles.png"));
+			tiles = new Texture(files.internal("data/maps/tiled/tiles.png"));
 			TextureRegion[][] splitTiles = TextureRegion.split(tiles, 32, 32);
 			map = new TiledMap();
 			MapLayers layers = map.getLayers();
@@ -92,7 +91,7 @@ public class TiledMapBench extends GdxTest {
 		renderer.setView(camera);
 		renderer.render();
 		batch.begin();
-		font.draw(batch, "FPS: " + Gdx.graphics.getFramesPerSecond(), 10, 20);
+		font.draw(batch, "FPS: " + graphics.getFramesPerSecond(), 10, 20);
 		batch.end();
 	}
 }

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/box2d/BodyTypes.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/box2d/BodyTypes.java
@@ -161,7 +161,7 @@ public class BodyTypes extends Box2DTest {
 
 		// if (renderer.batch != null) {
 		// renderer.batch.begin();
-		// // renderer.batch.drawText(renderer.font, "Keys: (d) dynamic, (s) static, (k) kinematic", 0, Gdx.app.getGraphics()
+		// // renderer.batch.drawText(renderer.font, "Keys: (d) dynamic, (s) static, (k) kinematic", 0, app.getGraphics()
 		// // .getHeight(), Color.WHITE);
 		// renderer.batch.end();
 		// }

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/box2d/Box2DTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/box2d/Box2DTest.java
@@ -28,8 +28,6 @@
 
 package com.badlogic.gdx.tests.box2d;
 
-import com.badlogic.gdx.ApplicationListener;
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.InputProcessor;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.OrthographicCamera;
@@ -46,12 +44,13 @@ import com.badlogic.gdx.physics.box2d.QueryCallback;
 import com.badlogic.gdx.physics.box2d.World;
 import com.badlogic.gdx.physics.box2d.joints.MouseJoint;
 import com.badlogic.gdx.physics.box2d.joints.MouseJointDef;
+import com.badlogic.gdx.tests.utils.GdxTest;
 import com.badlogic.gdx.utils.TimeUtils;
 
 /** Base class for all Box2D Testbed tests, all subclasses must implement the createWorld() method.
  * 
  * @author badlogicgames@gmail.com */
-public abstract class Box2DTest implements ApplicationListener, InputProcessor {
+public abstract class Box2DTest extends GdxTest implements InputProcessor {
 	/** the camera **/
 	protected OrthographicCamera camera;
 
@@ -82,12 +81,12 @@ public abstract class Box2DTest implements ApplicationListener, InputProcessor {
 	public void render () {
 		// update the world with a fixed time step
 		long startTime = TimeUtils.nanoTime();
-		world.step(Gdx.app.getGraphics().getDeltaTime(), 3, 3);
+		world.step(graphics.getDeltaTime(), 3, 3);
 		float updateTime = (TimeUtils.nanoTime() - startTime) / 1000000000.0f;
 
 		startTime = TimeUtils.nanoTime();
 		// clear the screen and setup the projection matrix
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		camera.update();
 
 		// render the world using the debug renderer
@@ -95,7 +94,7 @@ public abstract class Box2DTest implements ApplicationListener, InputProcessor {
 		float renderTime = (TimeUtils.nanoTime() - startTime) / 1000000000.0f;
 
 		batch.begin();
-		font.draw(batch, "fps:" + Gdx.graphics.getFramesPerSecond() + ", update: " + updateTime + ", render: " + renderTime, 0, 20);
+		font.draw(batch, "fps:" + graphics.getFramesPerSecond() + ", update: " + updateTime + ", render: " + renderTime, 0, 20);
 		batch.end();
 	}
 
@@ -126,7 +125,7 @@ public abstract class Box2DTest implements ApplicationListener, InputProcessor {
 		createWorld(world);
 
 		batch = new SpriteBatch();
-		font = new BitmapFont(Gdx.files.internal("data/lsans-15.fnt"), false);
+		font = new BitmapFont(files.internal("data/lsans-15.fnt"), false);
 	}
 
 	@Override

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/box2d/ContactListenerTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/box2d/ContactListenerTest.java
@@ -31,7 +31,6 @@ package com.badlogic.gdx.tests.box2d;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.physics.box2d.Body;
 import com.badlogic.gdx.physics.box2d.BodyDef;
@@ -183,7 +182,7 @@ public class ContactListenerTest extends Box2DTest implements ContactListener {
 
 		final Body toRemove = contact.getFixtureA().getBody().getType() == BodyType.DynamicBody ? contact.getFixtureA().getBody()
 			: contact.getFixtureB().getBody();
-		Gdx.app.postRunnable(new Runnable() {
+		app.postRunnable(new Runnable() {
 			@Override
 			public void run () {
 				world.destroyBody(toRemove);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/box2d/Prismatic.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/box2d/Prismatic.java
@@ -100,10 +100,10 @@ public class Prismatic extends Box2DTest {
 		// if (renderer.batch != null) {
 		// renderer.batch.begin();
 		// // renderer.batch.drawText(renderer.font, "Keys: (l) limits, (m) motors, (s) speed", 0,
-// Gdx.app.getGraphics().getHeight(),
+// app.getGraphics().getHeight(),
 // // Color.WHITE);
 // // renderer.batch.drawText(renderer.font, "Motor Force = " + m_joint.getMotorForce(), 0,
-// // Gdx.app.getGraphics().getHeight() - 15, Color.WHITE);
+// // app.getGraphics().getHeight() - 15, Color.WHITE);
 // renderer.batch.end();
 // }
 	}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/box2d/VerticalStack.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/box2d/VerticalStack.java
@@ -132,7 +132,7 @@ public class VerticalStack extends Box2DTest {
 
 		// if (renderer.batch != null) {
 		// renderer.batch.begin();
-		// // renderer.batch.drawText(renderer.font, "Press: (,) to launch a bullet", 0, Gdx.app.getGraphics().getHeight(),
+		// // renderer.batch.drawText(renderer.font, "Press: (,) to launch a bullet", 0, app.getGraphics().getHeight(),
 		// // Color.WHITE);
 		// renderer.batch.end();
 		// }

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/BasicBulletTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/BasicBulletTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests.bullet;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.PerspectiveCamera;
@@ -80,8 +79,8 @@ public class BasicBulletTest extends BulletTest {
 		lights.add(new DirectionalLight().set(0.8f, 0.8f, 0.8f, -0.5f, -1f, -0.7f));
 
 		// Set up the camera
-		final float width = Gdx.graphics.getWidth();
-		final float height = Gdx.graphics.getHeight();
+		final float width = graphics.getWidth();
+		final float height = graphics.getHeight();
 		if (width > height)
 			camera = new PerspectiveCamera(67f, 3f * width / height, 3f);
 		else
@@ -152,14 +151,14 @@ public class BasicBulletTest extends BulletTest {
 
 	@Override
 	public void render () {
-		Gdx.gl.glViewport(0, 0, Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight());
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
+		gl.glViewport(0, 0, graphics.getBackBufferWidth(), graphics.getBackBufferHeight());
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
 
-		fpsCounter.put(Gdx.graphics.getFramesPerSecond());
+		fpsCounter.put(graphics.getFramesPerSecond());
 
 		performanceCounter.tick();
 		performanceCounter.start();
-		((btDynamicsWorld)collisionWorld).stepSimulation(Gdx.graphics.getDeltaTime(), 5);
+		((btDynamicsWorld)collisionWorld).stepSimulation(graphics.getDeltaTime(), 5);
 		performanceCounter.stop();
 
 		int c = motionStates.size;

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/BasicShapesTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/BasicShapesTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests.bullet;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.VertexAttributes.Usage;
 import com.badlogic.gdx.graphics.g3d.Material;
@@ -35,7 +34,7 @@ public class BasicShapesTest extends BaseBulletTest {
 	public void create () {
 		super.create();
 
-		final Texture texture = new Texture(Gdx.files.internal("data/badlogic.jpg"));
+		final Texture texture = new Texture(files.internal("data/badlogic.jpg"));
 		disposables.add(texture);
 		final Material material = new Material(TextureAttribute.createDiffuse(texture), ColorAttribute.createSpecular(1, 1, 1, 1),
 			FloatAttribute.createShininess(8f));

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/BulletTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/BulletTest.java
@@ -16,16 +16,15 @@
 
 package com.badlogic.gdx.tests.bullet;
 
-import com.badlogic.gdx.ApplicationListener;
-import com.badlogic.gdx.InputAdapter;
 import com.badlogic.gdx.graphics.PerspectiveCamera;
 import com.badlogic.gdx.input.GestureDetector.GestureListener;
 import com.badlogic.gdx.math.FloatCounter;
 import com.badlogic.gdx.math.Vector2;
+import com.badlogic.gdx.tests.utils.GdxTest;
 import com.badlogic.gdx.utils.PerformanceCounter;
 
 /** @author xoppa */
-public class BulletTest extends InputAdapter implements ApplicationListener, GestureListener {
+public class BulletTest extends GdxTest implements GestureListener {
 	public StringBuilder performance = new StringBuilder();
 	public String instructions = "Tap to shoot\nLong press to toggle debug mode\nSwipe for next test\nCtrl+drag to rotate\nScroll to zoom";
 	public PerformanceCounter performanceCounter = new PerformanceCounter(this.getClass().getSimpleName());

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/CharacterTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/CharacterTest.java
@@ -1,7 +1,6 @@
 
 package com.badlogic.gdx.tests.bullet;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input.Keys;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.VertexAttributes.Usage;
@@ -65,7 +64,7 @@ public class CharacterTest extends BaseBulletTest {
 
 		// Create a visual representation of the character (note that we don't use the physics part of BulletEntity, we'll do that
 		// manually)
-		final Texture texture = new Texture(Gdx.files.internal("data/badlogic.jpg"));
+		final Texture texture = new Texture(files.internal("data/badlogic.jpg"));
 		disposables.add(texture);
 		final Material material = new Material(TextureAttribute.createDiffuse(texture), ColorAttribute.createSpecular(1, 1, 1, 1),
 			FloatAttribute.createShininess(8f));
@@ -107,11 +106,11 @@ public class CharacterTest extends BaseBulletTest {
 	@Override
 	public void update () {
 		// If the left or right key is pressed, rotate the character and update its physics update accordingly.
-		if (Gdx.input.isKeyPressed(Keys.LEFT)) {
+		if (input.isKeyPressed(Keys.LEFT)) {
 			characterTransform.rotate(0, 1, 0, 5f);
 			ghostObject.setWorldTransform(characterTransform);
 		}
-		if (Gdx.input.isKeyPressed(Keys.RIGHT)) {
+		if (input.isKeyPressed(Keys.RIGHT)) {
 			characterTransform.rotate(0, 1, 0, -5f);
 			ghostObject.setWorldTransform(characterTransform);
 		}
@@ -119,10 +118,10 @@ public class CharacterTest extends BaseBulletTest {
 		characterDirection.set(-1, 0, 0).rot(characterTransform).nor();
 		// Set the walking direction accordingly (either forward or backward)
 		walkDirection.set(0, 0, 0);
-		if (Gdx.input.isKeyPressed(Keys.UP)) walkDirection.add(characterDirection);
-		if (Gdx.input.isKeyPressed(Keys.DOWN))
+		if (input.isKeyPressed(Keys.UP)) walkDirection.add(characterDirection);
+		if (input.isKeyPressed(Keys.DOWN))
 			walkDirection.add(-characterDirection.x, -characterDirection.y, -characterDirection.z);
-		walkDirection.scl(4f * Gdx.graphics.getDeltaTime());
+		walkDirection.scl(4f * graphics.getDeltaTime());
 		// And update the character controller
 		characterController.setWalkDirection(walkDirection);
 		// Now we can update the world as normally

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/CollisionWorldTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/CollisionWorldTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests.bullet;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.g3d.Model;
 import com.badlogic.gdx.math.Matrix4;
@@ -95,7 +94,7 @@ public class CollisionWorldTest extends BaseBulletTest {
 	@Override
 	public void render () {
 		movingBox.transform.val[Matrix4.M03] = movingBox.transform.val[Matrix4.M13] = movingBox.transform.val[Matrix4.M23] = 0f;
-		movingBox.transform.rotate(Vector3.Y, Gdx.graphics.getDeltaTime() * 45f);
+		movingBox.transform.rotate(Vector3.Y, graphics.getDeltaTime() * 45f);
 		movingBox.transform.translate(-5f, 1f, 0f);
 		movingBox.body.setWorldTransform(movingBox.transform);
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/ConvexHullDistanceTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/ConvexHullDistanceTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests.bullet;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Mesh;
 import com.badlogic.gdx.graphics.g3d.Model;
@@ -45,7 +44,7 @@ public class ConvexHullDistanceTest extends BaseBulletTest {
 	public void create () {
 		super.create();
 
-		final Model carModel = objLoader.loadModel(Gdx.files.internal("data/car.obj"));
+		final Model carModel = objLoader.loadModel(files.internal("data/car.obj"));
 		disposables.add(carModel);
 		carModel.materials.get(0).clear();
 		carModel.materials.get(0).set(ColorAttribute.createDiffuse(Color.WHITE), ColorAttribute.createSpecular(Color.WHITE));

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/ConvexHullTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/ConvexHullTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests.bullet;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Mesh;
 import com.badlogic.gdx.graphics.g3d.Model;
@@ -31,7 +30,7 @@ public class ConvexHullTest extends BaseBulletTest {
 	public void create () {
 		super.create();
 
-		final Model carModel = objLoader.loadModel(Gdx.files.internal("data/car.obj"));
+		final Model carModel = objLoader.loadModel(files.internal("data/car.obj"));
 		disposables.add(carModel);
 		carModel.materials.get(0).clear();
 		carModel.materials.get(0).set(ColorAttribute.createDiffuse(Color.WHITE), ColorAttribute.createSpecular(Color.WHITE));

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/FrustumCullingTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/FrustumCullingTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests.bullet;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.PerspectiveCamera;
@@ -190,7 +189,7 @@ public class FrustumCullingTest extends BaseBulletTest {
 
 	@Override
 	public void render () {
-		final float dt = Gdx.graphics.getDeltaTime();
+		final float dt = graphics.getDeltaTime();
 		frustumEntity.transform.idt();
 		frustumEntity.transform.rotate(Vector3.X, angleX = (angleX + dt * SPEED_X) % 360);
 		frustumEntity.transform.rotate(Vector3.Y, angleY = (angleY + dt * SPEED_Y) % 360);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/GimpactTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/GimpactTest.java
@@ -1,7 +1,6 @@
 
 package com.badlogic.gdx.tests.bullet;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.g3d.Model;
 import com.badlogic.gdx.graphics.g3d.attributes.ColorAttribute;
@@ -19,7 +18,7 @@ public class GimpactTest extends BaseBulletTest {
 	public void create () {
 		super.create();
 
-		final Model chassisModel = objLoader.loadModel(Gdx.files.internal("data/car.obj"));
+		final Model chassisModel = objLoader.loadModel(files.internal("data/car.obj"));
 		disposables.add(chassisModel);
 		chassisModel.materials.get(0).clear();
 		chassisModel.materials.get(0).set(ColorAttribute.createDiffuse(Color.RED), ColorAttribute.createSpecular(Color.WHITE));

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/HeightFieldTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/HeightFieldTest.java
@@ -1,7 +1,6 @@
 
 package com.badlogic.gdx.tests.bullet;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Pixmap;
@@ -36,7 +35,7 @@ public class HeightFieldTest extends BaseBulletTest {
 	public void create () {
 		super.create();
 
-		texture = new Texture(Gdx.files.internal("data/badlogic.jpg"));
+		texture = new Texture(files.internal("data/badlogic.jpg"));
 		disposables.add(texture);
 
 		createSpheres();
@@ -45,7 +44,7 @@ public class HeightFieldTest extends BaseBulletTest {
 
 	private void createTerrain (float size, float heightScale) {
 		// Create the height field model
-		Pixmap data = new Pixmap(Gdx.files.internal("data/g3d/heightmap.png"));
+		Pixmap data = new Pixmap(files.internal("data/g3d/heightmap.png"));
 		field = new HeightField(true, data, true, VertexAttributes.Usage.Position | VertexAttributes.Usage.Normal
 			| VertexAttributes.Usage.ColorUnpacked | VertexAttributes.Usage.TextureCoordinates);
 		data.dispose();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/ImportTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/ImportTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests.bullet;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.assets.loaders.ModelLoader;
 import com.badlogic.gdx.graphics.g3d.Model;
 import com.badlogic.gdx.graphics.g3d.ModelInstance;
@@ -62,11 +61,11 @@ public class ImportTest extends BaseBulletTest {
 		super.create();
 
 		ModelLoader g3djLoader = new G3dModelLoader(new JsonReader());
-		model = g3djLoader.loadModel(Gdx.files.internal("data/g3d/btscene1.g3dj"));
+		model = g3djLoader.loadModel(files.internal("data/g3d/btscene1.g3dj"));
 		disposables.add(model);
 
 		importer = new MyImporter((btDynamicsWorld)world.collisionWorld);
-		importer.loadFile(Gdx.files.internal("data/g3d/btscene1.bullet"));
+		importer.loadFile(files.internal("data/g3d/btscene1.bullet"));
 
 		camera.position.set(10f, 15f, 20f);
 		camera.up.set(0, 1, 0);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/InternalTickTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/InternalTickTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests.bullet;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.physics.bullet.collision.btCollisionObjectArray;
 import com.badlogic.gdx.physics.bullet.dynamics.InternalTickCallback;
 import com.badlogic.gdx.physics.bullet.dynamics.btDynamicsWorld;
@@ -89,7 +88,7 @@ public class InternalTickTest extends BaseBulletTest {
 	public void render () {
 		super.render();
 		if (internalTickCallback == null) return;
-		if ((toggleTime += Gdx.graphics.getDeltaTime()) > 1.0f) {
+		if ((toggleTime += graphics.getDeltaTime()) > 1.0f) {
 			toggleTime -= 1.0f;
 			if (toggleAttach)
 				internalTickCallback.detach();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/KinematicTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/KinematicTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests.bullet;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.physics.bullet.collision.Collision;
@@ -60,7 +59,7 @@ public class KinematicTest extends BaseBulletTest {
 
 	@Override
 	public void render () {
-		angle = angle + Gdx.graphics.getDeltaTime() * 360f / 5f;
+		angle = angle + graphics.getDeltaTime() * 360f / 5f;
 		kinematicBox3.transform.idt().rotate(Vector3.Y, 360f - 2f * angle).translate(position3);
 
 		if (angle >= 360f) {

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/MeshShapeTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/MeshShapeTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests.bullet;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.VertexAttributes.Usage;
 import com.badlogic.gdx.graphics.g3d.Material;
@@ -42,7 +41,7 @@ public class MeshShapeTest extends BaseBulletTest {
 		sphereConstructor.bodyInfo.setRestitution(1f);
 		world.addConstructor("sphere", sphereConstructor);
 
-		final Model sceneModel = objLoader.loadModel(Gdx.files.internal("data/scene.obj"));
+		final Model sceneModel = objLoader.loadModel(files.internal("data/scene.obj"));
 		disposables.add(sceneModel);
 		final BulletConstructor sceneConstructor = new BulletConstructor(sceneModel, 0f,
 			new btBvhTriangleMeshShape(sceneModel.meshParts));

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/OcclusionCullingTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/OcclusionCullingTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests.bullet;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.assets.AssetManager;
 import com.badlogic.gdx.graphics.Camera;
 import com.badlogic.gdx.graphics.Color;
@@ -163,10 +162,10 @@ public class OcclusionCullingTest extends BaseBulletTest {
 
 	@Override
 	public void create () {
-		Gdx.input.setOnscreenKeyboardVisible(true);
+		input.setOnscreenKeyboardVisible(true);
 		super.create();
 
-		glProfiler = new GLProfiler(Gdx.graphics);
+		glProfiler = new GLProfiler(graphics);
 		glProfiler.enable();
 
 		StringBuilder sb = new StringBuilder();
@@ -293,7 +292,7 @@ public class OcclusionCullingTest extends BaseBulletTest {
 
 	@Override
 	public void dispose () {
-		Gdx.input.setOnscreenKeyboardVisible(false);
+		input.setOnscreenKeyboardVisible(false);
 		glProfiler.disable();
 		visibleEntities.clear();
 		rng.setSeed(0);
@@ -425,7 +424,7 @@ public class OcclusionCullingTest extends BaseBulletTest {
 		super.update();
 		// Transform the frustum camera
 		if ((state & PAUSE_FRUSTUM_CAM) == PAUSE_FRUSTUM_CAM) return;
-		final float dt = Gdx.graphics.getDeltaTime();
+		final float dt = graphics.getDeltaTime();
 		frustumInstance.transform.idt().rotate(Vector3.Y, frustumCamAngleY = (frustumCamAngleY + dt * FRUSTUM_ANG_SPEED) % 360);
 		frustumCam.direction.set(0, 0, -1);
 		frustumCam.up.set(Vector3.Y);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/PairCacheTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/PairCacheTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests.bullet;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.PerspectiveCamera;
 import com.badlogic.gdx.graphics.g3d.Model;
@@ -113,7 +112,7 @@ public class PairCacheTest extends BaseBulletTest {
 
 	@Override
 	public void render () {
-		final float dt = Gdx.graphics.getDeltaTime();
+		final float dt = graphics.getDeltaTime();
 		ghostEntity.transform.idt();
 		ghostEntity.transform.rotate(Vector3.X, angleX = (angleX + dt * SPEED_X) % 360);
 		ghostEntity.transform.rotate(Vector3.Y, angleY = (angleY + dt * SPEED_Y) % 360);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/SoftBodyTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/SoftBodyTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests.bullet;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Mesh;
@@ -121,7 +120,7 @@ public class SoftBodyTest extends BaseBulletTest {
 			verts[i * vertSize + uvOffset + 1] = (verts[i * vertSize + 2] - z0) / (z1 - z0);
 		}
 		mesh.setVertices(verts);
-		texture = new Texture(Gdx.files.internal("data/badlogic.jpg"));
+		texture = new Texture(files.internal("data/badlogic.jpg"));
 
 		ModelBuilder builder = new ModelBuilder();
 		builder.begin();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/SoftMeshTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/SoftMeshTest.java
@@ -18,7 +18,6 @@ package com.badlogic.gdx.tests.bullet;
 
 import java.nio.ShortBuffer;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.VertexAttributes.Usage;
 import com.badlogic.gdx.graphics.g3d.Model;
 import com.badlogic.gdx.graphics.g3d.model.MeshPart;
@@ -72,7 +71,7 @@ public class SoftMeshTest extends BaseBulletTest {
 			0.25f + 0.5f * (float)Math.random(), 1f);
 
 		// Note: not every model is suitable for a one on one translation with a soft body, a better model might be added later.
-		model = objLoader.loadModel(Gdx.files.internal("data/wheel.obj"));
+		model = objLoader.loadModel(files.internal("data/wheel.obj"));
 		MeshPart meshPart = model.nodes.get(0).parts.get(0).meshPart;
 
 		meshPart.mesh.scale(6, 6, 6);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/TriangleRaycastTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/TriangleRaycastTest.java
@@ -19,7 +19,6 @@ package com.badlogic.gdx.tests.bullet;
 import java.nio.FloatBuffer;
 import java.nio.ShortBuffer;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Mesh;
 import com.badlogic.gdx.graphics.VertexAttributes;
@@ -110,7 +109,7 @@ public class TriangleRaycastTest extends BaseBulletTest {
 
 		shapeRenderer = new ShapeRenderer();
 
-		model = objLoader.loadModel(Gdx.files.internal("data/scene.obj"));
+		model = objLoader.loadModel(files.internal("data/scene.obj"));
 		model.materials.get(0).clear();
 		model.materials.get(0).set(ColorAttribute.createDiffuse(Color.WHITE), ColorAttribute.createSpecular(Color.WHITE));
 
@@ -136,7 +135,7 @@ public class TriangleRaycastTest extends BaseBulletTest {
 	@Override
 	public void render () {
 		super.render();
-		Gdx.gl.glLineWidth(5);
+		gl.glLineWidth(5);
 		shapeRenderer.setProjectionMatrix(camera.combined);
 		shapeRenderer.begin(ShapeRenderer.ShapeType.Line);
 		shapeRenderer.setColor(1, 0, 0, 1f);
@@ -144,7 +143,7 @@ public class TriangleRaycastTest extends BaseBulletTest {
 		shapeRenderer.line(selectedTriangleVertices[1], selectedTriangleVertices[2]);
 		shapeRenderer.line(selectedTriangleVertices[2], selectedTriangleVertices[0]);
 		shapeRenderer.end();
-		Gdx.gl.glLineWidth(1);
+		gl.glLineWidth(1);
 	}
 
 	@Override

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/VehicleTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/VehicleTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests.bullet;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input.Keys;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Texture;
@@ -62,16 +61,16 @@ public class VehicleTest extends BaseBulletTest {
 		super.create();
 		instructions = "Tap to shoot\nArrow keys to drive\nR to reset\nLong press to toggle debug mode\nSwipe for next test";
 
-		final Model chassisModel = objLoader.loadModel(Gdx.files.internal("data/car.obj"));
+		final Model chassisModel = objLoader.loadModel(files.internal("data/car.obj"));
 		disposables.add(chassisModel);
 		chassisModel.materials.get(0).clear();
 		chassisModel.materials.get(0).set(ColorAttribute.createDiffuse(Color.RED), ColorAttribute.createSpecular(Color.WHITE));
-		final Model wheelModel = objLoader.loadModel(Gdx.files.internal("data/wheel.obj"));
+		final Model wheelModel = objLoader.loadModel(files.internal("data/wheel.obj"));
 		disposables.add(wheelModel);
 		wheelModel.materials.get(0).clear();
 		wheelModel.materials.get(0).set(ColorAttribute.createDiffuse(Color.BLACK), ColorAttribute.createSpecular(Color.WHITE),
 			FloatAttribute.createShininess(128));
-		Texture checkboard = new Texture(Gdx.files.internal("data/g3d/checkboard.png"));
+		Texture checkboard = new Texture(files.internal("data/g3d/checkboard.png"));
 		final Model largeGroundModel = modelBuilder.createBox(200f, 2f, 200f,
 			new Material(TextureAttribute.createDiffuse(checkboard), ColorAttribute.createSpecular(Color.WHITE),
 				FloatAttribute.createShininess(16f)),
@@ -128,7 +127,7 @@ public class VehicleTest extends BaseBulletTest {
 
 	@Override
 	public void update () {
-		final float delta = Gdx.graphics.getDeltaTime();
+		final float delta = graphics.getDeltaTime();
 		float angle = currentAngle;
 		if (rightPressed) {
 			if (angle > 0f) angle = 0f;

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/conformance/AudioSoundAndMusicIsolationTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/conformance/AudioSoundAndMusicIsolationTest.java
@@ -1,7 +1,6 @@
 
 package com.badlogic.gdx.tests.conformance;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.audio.Music;
 import com.badlogic.gdx.audio.Sound;
 import com.badlogic.gdx.math.MathUtils;
@@ -18,15 +17,15 @@ public class AudioSoundAndMusicIsolationTest extends GdxTest {
 
 	@Override
 	public void create () {
-		sound = Gdx.audio.newSound(Gdx.files.getFileHandle("data/shotgun.ogg", FileType.Internal));
-		music = Gdx.audio.newMusic(Gdx.files.internal("data/8.12.loop.wav"));
+		sound = audio.newSound(files.getFileHandle("data/shotgun.ogg", FileType.Internal));
+		music = audio.newMusic(files.internal("data/8.12.loop.wav"));
 
 		soundID = sound.play();
 	}
 
 	@Override
 	public void render () {
-		time += Gdx.graphics.getDeltaTime();
+		time += graphics.getDeltaTime();
 		if (time > 5 && !music.isPlaying()) {
 			music.play();
 		}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/conformance/DisplayModeTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/conformance/DisplayModeTest.java
@@ -18,7 +18,6 @@ package com.badlogic.gdx.tests.conformance;
 
 import java.util.Arrays;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Graphics.DisplayMode;
 import com.badlogic.gdx.tests.utils.GdxTest;
 
@@ -26,18 +25,18 @@ public class DisplayModeTest extends GdxTest {
 
 	@Override
 	public void create () {
-		DisplayMode displayMode = Gdx.graphics.getDisplayMode();
-		DisplayMode displayModeForMonitor = Gdx.graphics.getDisplayMode(Gdx.graphics.getMonitor());
-		DisplayMode[] displayModes = Gdx.graphics.getDisplayModes();
-		DisplayMode[] displayModesForMonitor = Gdx.graphics.getDisplayModes(Gdx.graphics.getMonitor());
+		DisplayMode displayMode = graphics.getDisplayMode();
+		DisplayMode displayModeForMonitor = graphics.getDisplayMode(graphics.getMonitor());
+		DisplayMode[] displayModes = graphics.getDisplayModes();
+		DisplayMode[] displayModesForMonitor = graphics.getDisplayModes(graphics.getMonitor());
 
-		Gdx.app.log("DisplayModeTest", "Display mode (using Gdx.graphics.getDisplayMode() ) : " + displayMode);
-		Gdx.app.log("DisplayModeTest",
-			"Display mode (using Gdx.graphics.getDisplayMode(Gdx.graphics.getMonitor()) ) : " + Arrays.toString(displayModes));
-		Gdx.app.log("DisplayModeTest",
-			"Display mode (using Gdx.graphics.getDisplayModes() ) : " + Arrays.toString(displayModesForMonitor));
-		Gdx.app.log("DisplayModeTest",
-			"Display mode (using Gdx.graphics.getDisplayModes(Gdx.graphics.getMonitor()) ): " + displayModeForMonitor);
+		app.log("DisplayModeTest", "Display mode (using graphics.getDisplayMode() ) : " + displayMode);
+		app.log("DisplayModeTest",
+			"Display mode (using graphics.getDisplayMode(graphics.getMonitor()) ) : " + Arrays.toString(displayModes));
+		app.log("DisplayModeTest",
+			"Display mode (using graphics.getDisplayModes() ) : " + Arrays.toString(displayModesForMonitor));
+		app.log("DisplayModeTest",
+			"Display mode (using graphics.getDisplayModes(graphics.getMonitor()) ): " + displayModeForMonitor);
 		assertDisplayModeEquals(displayMode, displayModeForMonitor);
 		assertDisplayModesEquals(displayModes, displayModesForMonitor);
 	}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/examples/MoveSpriteExample.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/examples/MoveSpriteExample.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests.examples;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
@@ -39,7 +38,7 @@ public class MoveSpriteExample extends GdxTest {
 
 		// load the sprite's texture. note: usually you have more than
 		// one sprite in a texture, see {@see TextureAtlas} and {@see TextureRegion}.
-		texture = new Texture(Gdx.files.internal("data/bobargb8888-32x32.png"));
+		texture = new Texture(files.internal("data/bobargb8888-32x32.png"));
 
 		// create an {@link OrthographicCamera} which is used to transform
 		// touch coordinates to world coordinates.
@@ -61,11 +60,11 @@ public class MoveSpriteExample extends GdxTest {
 		batch.end();
 
 		// if a finger is down, set the sprite's x/y coordinate.
-		if (Gdx.input.isTouched()) {
+		if (input.isTouched()) {
 			// the unproject method takes a Vector3 in window coordinates (origin in
 			// upper left corner, y-axis pointing down) and transforms it to world
 			// coordinates.
-			camera.unproject(spritePosition.set(Gdx.input.getX(), Gdx.input.getY(), 0));
+			camera.unproject(spritePosition.set(input.getX(), input.getY(), 0));
 		}
 	}
 }

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/extensions/FreeTypeAtlasTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/extensions/FreeTypeAtlasTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests.extensions;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.graphics.Pixmap.Format;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
@@ -94,12 +93,12 @@ public class FreeTypeAtlasTest extends GdxTest {
 	public void render () {
 		ScreenUtils.clear(0.2f, 0.2f, 0.2f, 1);
 
-		camera.setToOrtho(false, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+		camera.setToOrtho(false, graphics.getWidth(), graphics.getHeight());
 		batch.setProjectionMatrix(camera.combined);
 		batch.begin();
 
 		float x = 10;
-		float y = Gdx.graphics.getHeight() - 10;
+		float y = graphics.getHeight() - 10;
 
 		int renderCalls = 0;
 
@@ -157,7 +156,7 @@ public class FreeTypeAtlasTest extends GdxTest {
 		// for each style...
 		for (FontStyle style : FontStyle.values()) {
 			// get the file for this style
-			FreeTypeFontGenerator gen = new FreeTypeFontGenerator(Gdx.files.internal(style.path));
+			FreeTypeFontGenerator gen = new FreeTypeFontGenerator(files.internal(style.path));
 
 			// For each size...
 			for (FontSize size : FontSize.values()) {

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/extensions/FreeTypeDisposeTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/extensions/FreeTypeDisposeTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests.extensions;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.graphics.g2d.freetype.FreeTypeFontGenerator;
@@ -32,12 +31,12 @@ public class FreeTypeDisposeTest extends GdxTest {
 	}
 
 	public void render () {
-		if (Gdx.input.justTouched()) {
+		if (input.justTouched()) {
 			for (int i = 0; i < 10; i++) {
 				if (font != null) {
 					font.dispose();
 				}
-				FileHandle fontFile = Gdx.files.internal("data/lsans.ttf");
+				FileHandle fontFile = files.internal("data/lsans.ttf");
 				FreeTypeFontGenerator generator = new FreeTypeFontGenerator(fontFile);
 
 				FreeTypeFontParameter parameter = new FreeTypeFontParameter();
@@ -48,8 +47,8 @@ public class FreeTypeDisposeTest extends GdxTest {
 			}
 			for (int i = 0; i < 10; i++)
 				System.gc();
-			Gdx.app.log("FreeTypeDisposeTest", "generated 10 fonts");
-			Gdx.app.log("FreeTypeDisposeTest", Gdx.app.getJavaHeap() + ", " + Gdx.app.getNativeHeap());
+			app.log("FreeTypeDisposeTest", "generated 10 fonts");
+			app.log("FreeTypeDisposeTest", app.getJavaHeap() + ", " + app.getNativeHeap());
 		}
 	}
 }

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/extensions/FreeTypeFontLoaderTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/extensions/FreeTypeFontLoaderTest.java
@@ -1,7 +1,6 @@
 
 package com.badlogic.gdx.tests.extensions;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.assets.AssetManager;
 import com.badlogic.gdx.assets.loaders.FileHandleResolver;
 import com.badlogic.gdx.assets.loaders.resolvers.InternalFileHandleResolver;
@@ -49,7 +48,7 @@ public class FreeTypeFontLoaderTest extends GdxTest {
 
 	@Override
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		if (manager.update(16) && manager.isLoaded("size10.ttf")) {
 			batch.begin();
 			manager.get("size10.ttf", BitmapFont.class).draw(batch, "First font!", 20, 20);
@@ -58,7 +57,7 @@ public class FreeTypeFontLoaderTest extends GdxTest {
 			batch.end();
 		}
 
-		if (Gdx.input.justTouched() && manager.isLoaded("size10.ttf")) {
+		if (input.justTouched() && manager.isLoaded("size10.ttf")) {
 			// unload all the things and check if they really get disposed properly
 			manager.unload("size10.ttf");
 			manager.finishLoading();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/extensions/FreeTypeIncrementalTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/extensions/FreeTypeIncrementalTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests.extensions;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
@@ -45,7 +44,7 @@ public class FreeTypeIncrementalTest extends GdxTest {
 
 		FreeTypeFontGenerator.setMaxTextureSize(128);
 
-		generator = new FreeTypeFontGenerator(Gdx.files.internal("data/lsans.ttf"));
+		generator = new FreeTypeFontGenerator(files.internal("data/lsans.ttf"));
 
 		FreeTypeFontParameter param = new FreeTypeFontParameter();
 		param.incremental = true;
@@ -66,17 +65,17 @@ public class FreeTypeIncrementalTest extends GdxTest {
 	}
 
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 
 		// Draw rects.
 		shapes.begin(ShapeType.Line);
-		float x = 0, y = Gdx.graphics.getHeight() - font.getRegion().getRegionHeight() - 1;
+		float x = 0, y = graphics.getHeight() - font.getRegion().getRegionHeight() - 1;
 		for (int i = 0, n = font.getRegions().size; i < n; i++) {
 			TextureRegion region = font.getRegions().get(i);
 			shapes.rect(x, y, region.getRegionWidth(), region.getRegionHeight());
 			x += region.getRegionWidth() + 2;
 		}
-		shapes.rect(10, 250, Gdx.graphics.getWidth() - 20, -240);
+		shapes.rect(10, 250, graphics.getWidth() - 20, -240);
 		shapes.end();
 
 		batch.begin();
@@ -90,7 +89,7 @@ public class FreeTypeIncrementalTest extends GdxTest {
 		font.draw(batch, "hello world", 100, 300);
 		font.draw(batch, "动画能给游戏带来生机和灵气。我们相信创作一段美妙的动画，不仅需要强大的软件工具，更需要一套牛 B 的工作流程。" //
 			+ "Spine专注于此，为您创建惊艳的骨骼动画，并将其整合到游戏当中，提供了一套高效的工作流程。", 10, 250, //
-			Gdx.graphics.getWidth() - 20, Align.left, true);
+			graphics.getWidth() - 20, Align.left, true);
 		batch.end();
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/extensions/FreeTypeMetricsTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/extensions/FreeTypeMetricsTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests.extensions;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.graphics.g2d.GlyphLayout;
@@ -44,7 +43,7 @@ public class FreeTypeMetricsTest extends GdxTest {
 		FreeTypeFontParameter parameter = new FreeTypeFontParameter();
 		parameter.size = 60;
 
-		FreeTypeFontGenerator generator = new FreeTypeFontGenerator(Gdx.files.internal("data/lsans.ttf"));
+		FreeTypeFontGenerator generator = new FreeTypeFontGenerator(files.internal("data/lsans.ttf"));
 		font = generator.generateFont(parameter);
 		generator.dispose();
 
@@ -54,9 +53,9 @@ public class FreeTypeMetricsTest extends GdxTest {
 
 	@Override
 	public void render () {
-		// red.a = (red.a + Gdx.graphics.getDeltaTime() * 0.1f) % 1;
+		// red.a = (red.a + graphics.getDeltaTime() * 0.1f) % 1;
 
-		int viewHeight = Gdx.graphics.getHeight();
+		int viewHeight = graphics.getHeight();
 
 		ScreenUtils.clear(1, 1, 1, 1);
 		spriteBatch.begin();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/extensions/FreeTypePackTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/extensions/FreeTypePackTest.java
@@ -18,7 +18,6 @@ package com.badlogic.gdx.tests.extensions;
 
 import java.util.EnumMap;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.graphics.Pixmap.Format;
 import com.badlogic.gdx.graphics.Texture.TextureFilter;
@@ -97,12 +96,12 @@ public class FreeTypePackTest extends GdxTest {
 	public void render () {
 		ScreenUtils.clear(0.2f, 0.2f, 0.2f, 1);
 
-		camera.setToOrtho(false, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+		camera.setToOrtho(false, graphics.getWidth(), graphics.getHeight());
 		batch.setProjectionMatrix(camera.combined);
 		batch.begin();
 
 		float x = 10;
-		float y = Gdx.graphics.getHeight() - 10;
+		float y = graphics.getHeight() - 10;
 
 		int renderCalls = 0;
 
@@ -165,7 +164,7 @@ public class FreeTypePackTest extends GdxTest {
 		// for each style...
 		for (FontStyle style : FontStyle.values()) {
 			// get the file for this style
-			FreeTypeFontGenerator gen = new FreeTypeFontGenerator(Gdx.files.internal(style.path));
+			FreeTypeFontGenerator gen = new FreeTypeFontGenerator(files.internal(style.path));
 
 			// For each size...
 			for (FontSize size : FontSize.values()) {

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/extensions/FreeTypeTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/extensions/FreeTypeTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests.extensions;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.OrthographicCamera;
@@ -43,8 +42,8 @@ public class FreeTypeTest extends GdxTest {
 			cam.update();
 			batch.setProjectionMatrix(cam.combined);
 		}
-		font = new BitmapFont(Gdx.files.internal("data/lsans-15.fnt"), flip);
-		FileHandle fontFile = Gdx.files.internal("data/lsans.ttf");
+		font = new BitmapFont(files.internal("data/lsans-15.fnt"), flip);
+		FileHandle fontFile = files.internal("data/lsans.ttf");
 
 		FreeTypeFontGenerator generator = new FreeTypeFontGenerator(fontFile);
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/extensions/InternationalFontsTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/extensions/InternationalFontsTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests.extensions;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
@@ -48,7 +47,7 @@ public class InternationalFontsTest extends GdxTest {
 
 	@Override
 	public void create () {
-		FreeTypeFontGenerator generator = new FreeTypeFontGenerator(Gdx.files.internal("data/unbom.ttf"));
+		FreeTypeFontGenerator generator = new FreeTypeFontGenerator(files.internal("data/unbom.ttf"));
 
 		FreeTypeFontParameter parameter = new FreeTypeFontParameter();
 		parameter.size = 18;
@@ -59,26 +58,26 @@ public class InternationalFontsTest extends GdxTest {
 
 		parameter.characters = FreeTypeFontGenerator.DEFAULT_CHARS;
 
-		generator = new FreeTypeFontGenerator(Gdx.files.internal("data/russkij.ttf"));
+		generator = new FreeTypeFontGenerator(files.internal("data/russkij.ttf"));
 		cyrillicFont = generator.generateFont(parameter);
 		generator.dispose();
 
 		parameter.characters = "วรณยุ�?ต์";
 
-		generator = new FreeTypeFontGenerator(Gdx.files.internal("data/garuda.ttf"));
+		generator = new FreeTypeFontGenerator(files.internal("data/garuda.ttf"));
 		thaiFont = generator.generateFont(parameter);
 		generator.dispose();
 
 		batch = new SpriteBatch();
 
 		cam = new OrthographicCamera();
-		cam.setToOrtho(false, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+		cam.setToOrtho(false, graphics.getWidth(), graphics.getHeight());
 		cam.update();
 	}
 
 	@Override
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 
 		batch.setProjectionMatrix(cam.combined);
 		batch.begin();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g2d/ProgressiveJPEGTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g2d/ProgressiveJPEGTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests.g2d;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.Texture.TextureFilter;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
@@ -37,7 +36,7 @@ public class ProgressiveJPEGTest extends GdxTest {
 	public void create () {
 		batch = new SpriteBatch();
 
-		texture = new Texture(Gdx.files.internal("data/g2d/progressive-libgdx.jpg"));
+		texture = new Texture(files.internal("data/g2d/progressive-libgdx.jpg"));
 		texture.setFilter(TextureFilter.Linear, TextureFilter.Linear);
 		drawable = new TextureRegionDrawable(new TextureRegion(texture));
 	}
@@ -47,7 +46,7 @@ public class ProgressiveJPEGTest extends GdxTest {
 		ScreenUtils.clear(1, 1, 1, 1);
 
 		batch.begin();
-		drawable.draw(batch, 0, 0, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+		drawable.draw(batch, 0, 0, graphics.getWidth(), graphics.getHeight());
 		batch.end();
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/Animation3DTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/Animation3DTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests.g3d;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input.Keys;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Texture;
@@ -116,19 +115,19 @@ public class Animation3DTest extends BaseG3dHudTest {
 	@Override
 	public void render () {
 		if (character != null) {
-			animation.update(Gdx.graphics.getDeltaTime());
-			if (Gdx.input.isKeyPressed(Keys.UP)) {
+			animation.update(graphics.getDeltaTime());
+			if (input.isKeyPressed(Keys.UP)) {
 				if (!animation.inAction) {
-					trTmp.idt().lerp(trForward, Gdx.graphics.getDeltaTime() / animation.current.animation.duration);
+					trTmp.idt().lerp(trForward, graphics.getDeltaTime() / animation.current.animation.duration);
 					character.transform.mul(trTmp.toMatrix4(tmpMatrix));
 				}
 				if (status != walk) {
 					animation.animate("Walk", -1, 1f, null, 0.2f);
 					status = walk;
 				}
-			} else if (Gdx.input.isKeyPressed(Keys.DOWN)) {
+			} else if (input.isKeyPressed(Keys.DOWN)) {
 				if (!animation.inAction) {
-					trTmp.idt().lerp(trBackward, Gdx.graphics.getDeltaTime() / animation.current.animation.duration);
+					trTmp.idt().lerp(trBackward, graphics.getDeltaTime() / animation.current.animation.duration);
 					character.transform.mul(trTmp.toMatrix4(tmpMatrix));
 				}
 				if (status != back) {
@@ -139,17 +138,17 @@ public class Animation3DTest extends BaseG3dHudTest {
 				animation.animate("Idle", -1, 1f, null, 0.2f);
 				status = idle;
 			}
-			if (Gdx.input.isKeyPressed(Keys.RIGHT) && (status == walk || status == back) && !animation.inAction) {
-				trTmp.idt().lerp(trRight, Gdx.graphics.getDeltaTime() / animation.current.animation.duration);
+			if (input.isKeyPressed(Keys.RIGHT) && (status == walk || status == back) && !animation.inAction) {
+				trTmp.idt().lerp(trRight, graphics.getDeltaTime() / animation.current.animation.duration);
 				character.transform.mul(trTmp.toMatrix4(tmpMatrix));
-			} else if (Gdx.input.isKeyPressed(Keys.LEFT) && (status == walk || status == back) && !animation.inAction) {
-				trTmp.idt().lerp(trLeft, Gdx.graphics.getDeltaTime() / animation.current.animation.duration);
+			} else if (input.isKeyPressed(Keys.LEFT) && (status == walk || status == back) && !animation.inAction) {
+				trTmp.idt().lerp(trLeft, graphics.getDeltaTime() / animation.current.animation.duration);
 				character.transform.mul(trTmp.toMatrix4(tmpMatrix));
 			}
-			if (Gdx.input.isKeyPressed(Keys.SPACE) && !animation.inAction) {
+			if (input.isKeyPressed(Keys.SPACE) && !animation.inAction) {
 				animation.action("Attack", 1, 1f, null, 0.2f);
 			}
-			if (Gdx.input.isKeyJustPressed(Keys.Z)) ship.parts.get(0).enabled = !ship.parts.get(0).enabled;
+			if (input.isKeyJustPressed(Keys.Z)) ship.parts.get(0).enabled = !ship.parts.get(0).enabled;
 		}
 
 		if (character != null) {
@@ -201,7 +200,7 @@ public class Animation3DTest extends BaseG3dHudTest {
 			animation.animate("Idle", -1, 1f, null, 0.2f);
 			status = idle;
 			for (Animation anim : character.animations)
-				Gdx.app.log("Test", anim.id);
+				app.log("Test", anim.id);
 			// Now attach the node of another model at the tip of this knights sword:
 			ship = assets.get("data/g3d/ship.obj", Model.class).nodes.get(0).copy();
 			ship.detach();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/AnisotropyTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/AnisotropyTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests.g3d;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.PerspectiveCamera;
@@ -35,16 +34,16 @@ public class AnisotropyTest extends GdxTest {
 
 	@Override
 	public void create () {
-		Gdx.gl.glEnable(GL20.GL_DEPTH_TEST);
-		Gdx.gl.glDepthFunc(GL20.GL_LESS);
+		gl.glEnable(GL20.GL_DEPTH_TEST);
+		gl.glDepthFunc(GL20.GL_LESS);
 
-		brick = new Texture(Gdx.files.internal("data/g3d/materials/brick_diffuse_01.png"), true);
+		brick = new Texture(files.internal("data/g3d/materials/brick_diffuse_01.png"), true);
 		brick.setFilter(Texture.TextureFilter.MipMapLinearLinear, Texture.TextureFilter.Linear);
 		brick.setWrap(Texture.TextureWrap.Repeat, Texture.TextureWrap.Repeat);
 
 		batch = new SpriteBatch();
 
-		Gdx.gl.glClearColor(0, 0.2f, 0.2f, 1);
+		gl.glClearColor(0, 0.2f, 0.2f, 1);
 	}
 
 	@Override
@@ -57,14 +56,14 @@ public class AnisotropyTest extends GdxTest {
 		targetAnisotropicLevel *= 2;
 		if (targetAnisotropicLevel > 16) targetAnisotropicLevel = 1;
 		float value = brick.setAnisotropicFilter(targetAnisotropicLevel);
-		Gdx.app.log("anisotropic value", Float.toString(value));
+		app.log("anisotropic value", Float.toString(value));
 	}
 
 	@Override
 	public void render () {
-		if (Gdx.input.isKeyJustPressed(Input.Keys.SPACE)) changeAnisotropy();
+		if (input.isKeyJustPressed(Input.Keys.SPACE)) changeAnisotropy();
 
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
 		batch.setProjectionMatrix(cam.combined);
 		batch.begin();
 		for (int i = 0; i < 5; i++) {

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/BaseG3dHudTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/BaseG3dHudTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests.g3d;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.InputMultiplexer;
 import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.math.Matrix4;
@@ -61,14 +60,14 @@ public abstract class BaseG3dHudTest extends BaseG3dTest {
 
 		createHUD();
 
-		Gdx.input.setInputProcessor(new InputMultiplexer(hud, this, inputController));
+		input.setInputProcessor(new InputMultiplexer(hud, this, inputController));
 	}
 
 	protected void createHUD () {
 		hud = new Stage(new ScalingViewport(Scaling.fit, PREF_HUDWIDTH, PREF_HUDHEIGHT));
 		hudWidth = hud.getWidth();
 		hudHeight = hud.getHeight();
-		skin = new Skin(Gdx.files.internal("data/uiskin.json"));
+		skin = new Skin(files.internal("data/uiskin.json"));
 
 		final List<String> modelsList = new List(skin);
 		modelsList.setItems(models);
@@ -131,7 +130,7 @@ public abstract class BaseG3dHudTest extends BaseG3dTest {
 	protected abstract void onModelClicked (final String name);
 
 	protected void getStatus (final StringBuilder stringBuilder) {
-		stringBuilder.append("FPS: ").append(Gdx.graphics.getFramesPerSecond());
+		stringBuilder.append("FPS: ").append(graphics.getFramesPerSecond());
 		if (loading) stringBuilder.append(" loading...");
 	}
 
@@ -141,9 +140,9 @@ public abstract class BaseG3dHudTest extends BaseG3dTest {
 	public void render () {
 		transform.idt();
 		if (rotateCheckBox.isChecked())
-			transform.rotate(Vector3.Y, rotation = (rotation + rotationSpeed * Gdx.graphics.getDeltaTime()) % 360);
+			transform.rotate(Vector3.Y, rotation = (rotation + rotationSpeed * graphics.getDeltaTime()) % 360);
 		if (moveCheckBox.isChecked()) {
-			movement = (movement + moveSpeed * Gdx.graphics.getDeltaTime()) % 1f;
+			movement = (movement + moveSpeed * graphics.getDeltaTime()) % 1f;
 			final float sm = MathUtils.sin(movement * MathUtils.PI2);
 			final float cm = MathUtils.cos(movement * MathUtils.PI2);
 			transform.trn(0, moveRadius * cm, moveRadius * sm);
@@ -154,7 +153,7 @@ public abstract class BaseG3dHudTest extends BaseG3dTest {
 		stringBuilder.setLength(0);
 		getStatus(stringBuilder);
 		fpsLabel.setText(stringBuilder);
-		hud.act(Gdx.graphics.getDeltaTime());
+		hud.act(graphics.getDeltaTime());
 		hud.draw();
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/BaseG3dTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/BaseG3dTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests.g3d;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.assets.AssetManager;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
@@ -51,7 +50,7 @@ public abstract class BaseG3dTest extends GdxTest {
 
 		modelBatch = new ModelBatch();
 
-		cam = new PerspectiveCamera(67, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+		cam = new PerspectiveCamera(67, graphics.getWidth(), graphics.getHeight());
 		cam.position.set(10f, 10f, 10f);
 		cam.lookAt(0, 0, 0);
 		cam.near = 0.1f;
@@ -60,7 +59,7 @@ public abstract class BaseG3dTest extends GdxTest {
 
 		createAxes();
 
-		Gdx.input.setInputProcessor(inputController = new CameraInputController(cam));
+		input.setInputProcessor(inputController = new CameraInputController(cam));
 	}
 
 	final float GRID_MIN = -10f;

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/Basic3DSceneTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/Basic3DSceneTest.java
@@ -17,7 +17,6 @@
 package com.badlogic.gdx.tests.g3d;
 
 import com.badlogic.gdx.ApplicationListener;
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.assets.AssetManager;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.PerspectiveCamera;
@@ -53,7 +52,7 @@ public class Basic3DSceneTest extends GdxTest implements ApplicationListener {
 		lights.set(new ColorAttribute(ColorAttribute.AmbientLight, 0.4f, 0.4f, 0.4f, 1.f));
 		lights.add(new DirectionalLight().set(0.8f, 0.8f, 0.8f, -1f, -0.8f, -0.2f));
 
-		cam = new PerspectiveCamera(67, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+		cam = new PerspectiveCamera(67, graphics.getWidth(), graphics.getHeight());
 		cam.position.set(0f, 7f, 10f);
 		cam.lookAt(0, 0, 0);
 		cam.near = 0.1f;
@@ -61,7 +60,7 @@ public class Basic3DSceneTest extends GdxTest implements ApplicationListener {
 		cam.update();
 
 		camController = new CameraInputController(cam);
-		Gdx.input.setInputProcessor(camController);
+		input.setInputProcessor(camController);
 
 		assets = new AssetManager();
 		assets.load("data/g3d/invaders.g3dj", Model.class);
@@ -103,8 +102,8 @@ public class Basic3DSceneTest extends GdxTest implements ApplicationListener {
 		if (loading && assets.update(16)) doneLoading();
 		camController.update();
 
-		Gdx.gl.glViewport(0, 0, Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight());
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
+		gl.glViewport(0, 0, graphics.getBackBufferWidth(), graphics.getBackBufferHeight());
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
 
 		modelBatch.begin(cam);
 		for (ModelInstance instance : instances)

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/Basic3DTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/Basic3DTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests.g3d;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.InputMultiplexer;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
@@ -50,7 +49,7 @@ public class Basic3DTest extends GdxTest {
 		environment.set(new ColorAttribute(ColorAttribute.AmbientLight, .4f, .4f, .4f, 1f));
 		environment.add(new DirectionalLight().set(0.8f, 0.8f, 0.8f, -1f, -0.8f, -0.2f));
 
-		cam = new PerspectiveCamera(67, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+		cam = new PerspectiveCamera(67, graphics.getWidth(), graphics.getHeight());
 		cam.position.set(10f, 10f, 10f);
 		cam.lookAt(0, 0, 0);
 		cam.near = 1f;
@@ -62,15 +61,15 @@ public class Basic3DTest extends GdxTest {
 			Usage.Position | Usage.Normal);
 		instance = new ModelInstance(model);
 
-		Gdx.input.setInputProcessor(new InputMultiplexer(this, inputController = new CameraInputController(cam)));
+		input.setInputProcessor(new InputMultiplexer(this, inputController = new CameraInputController(cam)));
 	}
 
 	@Override
 	public void render () {
 		inputController.update();
 
-		Gdx.gl.glViewport(0, 0, Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight());
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
+		gl.glViewport(0, 0, graphics.getBackBufferWidth(), graphics.getBackBufferHeight());
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
 
 		modelBatch.begin(cam);
 		modelBatch.render(instance, environment);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/Benchmark3DTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/Benchmark3DTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests.g3d;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input.Keys;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.g3d.Environment;
@@ -60,7 +59,7 @@ public class Benchmark3DTest extends BaseG3dHudTest {
 	public void create () {
 		super.create();
 
-		glProfiler = new GLProfiler(Gdx.graphics);
+		glProfiler = new GLProfiler(graphics);
 		glProfiler.enable();
 
 		randomizeLights();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/FogTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/FogTest.java
@@ -17,7 +17,6 @@
 package com.badlogic.gdx.tests.g3d;
 
 import com.badlogic.gdx.ApplicationListener;
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.InputMultiplexer;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.PerspectiveCamera;
@@ -50,7 +49,7 @@ public class FogTest extends GdxTest implements ApplicationListener {
 		environment.set(new ColorAttribute(ColorAttribute.Fog, 0.13f, 0.13f, 0.13f, 1f));
 		environment.add(new DirectionalLight().set(0.8f, 0.8f, 0.8f, -1f, -0.8f, -0.2f));
 
-		cam = new PerspectiveCamera(67, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+		cam = new PerspectiveCamera(67, graphics.getWidth(), graphics.getHeight());
 		cam.position.set(30f, 10f, 30f);
 		cam.lookAt(0, 0, 0);
 		cam.near = 0.1f;
@@ -62,7 +61,7 @@ public class FogTest extends GdxTest implements ApplicationListener {
 			Usage.Position | Usage.Normal);
 		instance = new ModelInstance(model);
 
-		Gdx.input.setInputProcessor(new InputMultiplexer(this, inputController = new CameraInputController(cam)));
+		input.setInputProcessor(new InputMultiplexer(this, inputController = new CameraInputController(cam)));
 	}
 
 	@Override
@@ -72,7 +71,7 @@ public class FogTest extends GdxTest implements ApplicationListener {
 
 		inputController.update();
 
-		Gdx.gl.glViewport(0, 0, Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight());
+		gl.glViewport(0, 0, graphics.getBackBufferWidth(), graphics.getBackBufferHeight());
 
 		ScreenUtils.clear(0.13f, 0.13f, 0.13f, 1, true);
 
@@ -85,7 +84,7 @@ public class FogTest extends GdxTest implements ApplicationListener {
 
 	private void animate () {
 
-		delta = Gdx.graphics.getDeltaTime();
+		delta = graphics.getDeltaTime();
 
 		instance.transform.val[14] += delta * 4 * dir;
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/FrameBufferCubemapTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/FrameBufferCubemapTest.java
@@ -1,7 +1,6 @@
 
 package com.badlogic.gdx.tests.g3d;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Cubemap;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.PerspectiveCamera;
@@ -39,15 +38,15 @@ public class FrameBufferCubemapTest extends Basic3DSceneTest {
 		cubemap = fb.getColorBufferTexture();
 
 		ObjLoader objLoader = new ObjLoader();
-		cubeMesh = objLoader.loadModel(Gdx.files.internal("data/cube.obj"));
+		cubeMesh = objLoader.loadModel(files.internal("data/cube.obj"));
 		cubeInstance = new ModelInstance(cubeMesh);
 
-		cubeBatch = new ModelBatch(Gdx.files.internal("data/shaders/cubemap-vert.glsl"),
-			Gdx.files.internal("data/shaders/cubemap-frag.glsl"));
+		cubeBatch = new ModelBatch(files.internal("data/shaders/cubemap-vert.glsl"),
+			files.internal("data/shaders/cubemap-frag.glsl"));
 
 		cubeInstance.materials.get(0).set(new CubemapAttribute(CubemapAttribute.EnvironmentMap, cubemap));
 
-		camCube = new PerspectiveCamera(67, Gdx.graphics.getWidth() * 0.5f, Gdx.graphics.getHeight() * 0.5f);
+		camCube = new PerspectiveCamera(67, graphics.getWidth() * 0.5f, graphics.getHeight() * 0.5f);
 		camCube.position.set(0f, 2f, 2f);
 		camCube.lookAt(0, 0, 0);
 		camCube.near = 1f;
@@ -62,8 +61,8 @@ public class FrameBufferCubemapTest extends Basic3DSceneTest {
 	}
 
 	public void renderScene () {
-		Gdx.gl.glViewport(0, 0, Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight());
-		Gdx.gl.glDisable(GL20.GL_SCISSOR_TEST);
+		gl.glViewport(0, 0, graphics.getBackBufferWidth(), graphics.getBackBufferHeight());
+		gl.glDisable(GL20.GL_SCISSOR_TEST);
 
 		// Render scene to screen
 		super.render();
@@ -92,21 +91,21 @@ public class FrameBufferCubemapTest extends Basic3DSceneTest {
 	float yaw, pitch, roll;
 
 	public void renderCube () {
-		int w = Gdx.graphics.getBackBufferWidth();
-		int h = Gdx.graphics.getBackBufferHeight();
+		int w = graphics.getBackBufferWidth();
+		int h = graphics.getBackBufferHeight();
 		int x = (int)(w - w * 0.5f);
 		int y = (int)(h - h * 0.5f);
 		w *= 0.5f;
 		h *= 0.5f;
 
-		Gdx.gl.glViewport(x, y, w, h);
-		Gdx.gl.glEnable(GL20.GL_SCISSOR_TEST);
-		Gdx.gl.glScissor(x, y, w, h);
-		Gdx.gl.glClearColor(1, 1, 1, 1);
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
+		gl.glViewport(x, y, w, h);
+		gl.glEnable(GL20.GL_SCISSOR_TEST);
+		gl.glScissor(x, y, w, h);
+		gl.glClearColor(1, 1, 1, 1);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
 
-		pitch += 25 * Gdx.graphics.getDeltaTime();
-		yaw += 45 * Gdx.graphics.getDeltaTime();
+		pitch += 25 * graphics.getDeltaTime();
+		yaw += 45 * graphics.getDeltaTime();
 		cubeInstance.transform.setFromEulerAngles(yaw, pitch, roll);
 		cubeBatch.begin(camCube);
 		cubeBatch.render(cubeInstance);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/HeightMapTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/HeightMapTest.java
@@ -1,7 +1,6 @@
 
 package com.badlogic.gdx.tests.g3d;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.Texture;
@@ -32,10 +31,10 @@ public class HeightMapTest extends BaseG3dTest {
 		environment.set(new ColorAttribute(ColorAttribute.AmbientLight, 0.4f, 0.4f, 0.4f, 1.f));
 		environment.add(new DirectionalLight().set(0.8f, 0.8f, 0.8f, -0.5f, -1.0f, -0.8f));
 
-		texture = new Texture(Gdx.files.internal("data/badlogic.jpg"));
+		texture = new Texture(files.internal("data/badlogic.jpg"));
 
 		int w = 20, h = 20;
-		Pixmap data = new Pixmap(Gdx.files.internal("data/g3d/heightmap.png"));
+		Pixmap data = new Pixmap(files.internal("data/g3d/heightmap.png"));
 		field = new HeightField(true, data, true, Usage.Position | Usage.Normal | Usage.ColorUnpacked | Usage.TextureCoordinates);
 		data.dispose();
 		field.corner00.set(-10f, 0, -10f);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/LightsTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/LightsTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests.g3d;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.VertexAttributes.Usage;
 import com.badlogic.gdx.graphics.g3d.Material;
 import com.badlogic.gdx.graphics.g3d.Model;
@@ -67,7 +66,7 @@ public class LightsTest extends ModelTest {
 
 	@Override
 	protected void render (ModelBatch batch, Array<ModelInstance> instances) {
-		final float delta = Gdx.graphics.getDeltaTime();
+		final float delta = graphics.getDeltaTime();
 		dirLight.direction.rotate(Vector3.X, delta * 45f);
 		dirLight.direction.rotate(Vector3.Y, delta * 25f);
 		dirLight.direction.rotate(Vector3.Z, delta * 33f);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/MaterialEmissiveTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/MaterialEmissiveTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests.g3d;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.*;
 import com.badlogic.gdx.graphics.VertexAttributes.Usage;
 import com.badlogic.gdx.graphics.g3d.*;
@@ -58,8 +57,8 @@ public class MaterialEmissiveTest extends GdxTest {
 
 	@Override
 	public void create () {
-		diffuseTexture = new Texture(Gdx.files.internal("data/badlogic.jpg"), true);
-		emissiveTexture = new Texture(Gdx.files.internal("data/particle-star.png"), true);
+		diffuseTexture = new Texture(files.internal("data/badlogic.jpg"), true);
+		emissiveTexture = new Texture(files.internal("data/particle-star.png"), true);
 
 		// Create material attributes. Each material can contain x-number of attributes.
 		diffuseTextureAttribute = new TextureAttribute(TextureAttribute.Diffuse, diffuseTexture);
@@ -96,20 +95,20 @@ public class MaterialEmissiveTest extends GdxTest {
 		camera.direction.set(0, 0, -1);
 		camera.update();
 
-		Gdx.input.setInputProcessor(this);
+		input.setInputProcessor(this);
 	}
 
 	private float counter = 0.f;
 
 	@Override
 	public void render () {
-		counter = (counter + Gdx.graphics.getDeltaTime()) % 1.f;
+		counter = (counter + graphics.getDeltaTime()) % 1.f;
 		blendingAttribute.opacity = 0.25f + Math.abs(0.5f - counter);
 
-		Gdx.gl.glViewport(0, 0, Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight());
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
+		gl.glViewport(0, 0, graphics.getBackBufferWidth(), graphics.getBackBufferHeight());
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
 
-		modelInstance.transform.rotate(Vector3.Y, 30 * Gdx.graphics.getDeltaTime());
+		modelInstance.transform.rotate(Vector3.Y, 30 * graphics.getDeltaTime());
 		modelBatch.begin(camera);
 		modelBatch.render(background);
 		modelBatch.render(modelInstance, environment);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/MaterialTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/MaterialTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests.g3d;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Camera;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
@@ -56,7 +55,7 @@ public class MaterialTest extends GdxTest {
 
 	@Override
 	public void create () {
-		texture = new Texture(Gdx.files.internal("data/badlogic.jpg"), true);
+		texture = new Texture(files.internal("data/badlogic.jpg"), true);
 
 		// Create material attributes. Each material can contain x-number of attributes.
 		textureAttribute = new TextureAttribute(TextureAttribute.Diffuse, texture);
@@ -85,20 +84,20 @@ public class MaterialTest extends GdxTest {
 		camera.direction.set(0, 0, -1);
 		camera.update();
 
-		Gdx.input.setInputProcessor(this);
+		input.setInputProcessor(this);
 	}
 
 	private float counter = 0.f;
 
 	@Override
 	public void render () {
-		counter = (counter + Gdx.graphics.getDeltaTime()) % 1.f;
+		counter = (counter + graphics.getDeltaTime()) % 1.f;
 		blendingAttribute.opacity = 0.25f + Math.abs(0.5f - counter);
 
-		Gdx.gl.glViewport(0, 0, Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight());
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
+		gl.glViewport(0, 0, graphics.getBackBufferWidth(), graphics.getBackBufferHeight());
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
 
-		modelInstance.transform.rotate(Vector3.Y, 30 * Gdx.graphics.getDeltaTime());
+		modelInstance.transform.rotate(Vector3.Y, 30 * graphics.getDeltaTime());
 		modelBatch.begin(camera);
 		modelBatch.render(background);
 		modelBatch.render(modelInstance);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/MeshBuilderTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/MeshBuilderTest.java
@@ -1,7 +1,6 @@
 
 package com.badlogic.gdx.tests.g3d;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Mesh;
@@ -36,7 +35,7 @@ public class MeshBuilderTest extends BaseG3dHudTest {
 
 		modelsWindow.setVisible(false);
 
-		Texture texture = new Texture(Gdx.files.internal("data/badlogic.jpg"));
+		Texture texture = new Texture(files.internal("data/badlogic.jpg"));
 
 		Material material = new Material(TextureAttribute.createDiffuse(texture));
 		Material solidMaterial = new Material();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/ModelLoaderTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/ModelLoaderTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests.g3d;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.assets.AssetManager;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.PerspectiveCamera;
@@ -36,7 +35,7 @@ public class ModelLoaderTest extends GdxTest {
 
 	@Override
 	public void create () {
-		camera = new PerspectiveCamera(67, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+		camera = new PerspectiveCamera(67, graphics.getWidth(), graphics.getHeight());
 		camera.position.set(0, 0, 5);
 		camera.near = 1;
 		camera.far = 100;
@@ -56,7 +55,7 @@ public class ModelLoaderTest extends GdxTest {
 
 	@Override
 	public void render () {
-		if ((instance != null) && ((counter += Gdx.graphics.getDeltaTime()) >= 1f)) {
+		if ((instance != null) && ((counter += graphics.getDeltaTime()) >= 1f)) {
 			counter = 0f;
 			instance = null;
 			assets.unload("data/g3d/cube.g3dj");
@@ -64,9 +63,9 @@ public class ModelLoaderTest extends GdxTest {
 			assets.finishLoading();
 		}
 
-		Gdx.gl.glClearColor(0.2f, 0.2f, 0.2f, 1);
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
-		Gdx.gl.glEnable(GL20.GL_DEPTH_TEST);
+		gl.glClearColor(0.2f, 0.2f, 0.2f, 1);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
+		gl.glEnable(GL20.GL_DEPTH_TEST);
 
 		if (assets.update(16)) {
 			doneLoading();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/ModelTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/ModelTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests.g3d;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input.Keys;
 import com.badlogic.gdx.graphics.g3d.Environment;
 import com.badlogic.gdx.graphics.g3d.Model;
@@ -57,7 +56,7 @@ public class ModelTest extends BaseG3dHudTest {
 	@Override
 	protected void render (ModelBatch batch, Array<ModelInstance> instances) {
 		for (ObjectMap.Entry<ModelInstance, AnimationController> e : animationControllers.entries())
-			e.value.update(Gdx.graphics.getDeltaTime());
+			e.value.update(graphics.getDeltaTime());
 		batch.render(instances, environment);
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/ParticleControllerInfluencerSingleTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/ParticleControllerInfluencerSingleTest.java
@@ -1,7 +1,6 @@
 
 package com.badlogic.gdx.tests.g3d;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g3d.Environment;
 import com.badlogic.gdx.graphics.g3d.ModelBatch;
@@ -156,9 +155,9 @@ public class ParticleControllerInfluencerSingleTest extends BaseG3dTest {
 	protected void render (ModelBatch batch, Array<ModelInstance> instances) {
 		if (emitters.size > 0) {
 			// Update
-			float delta = Gdx.graphics.getDeltaTime();
+			float delta = graphics.getDeltaTime();
 			builder.delete(0, builder.length());
-			builder.append(Gdx.graphics.getFramesPerSecond());
+			builder.append(graphics.getFramesPerSecond());
 			fpsLabel.setText(builder);
 			ui.act(delta);
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/ParticleControllerTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/ParticleControllerTest.java
@@ -1,7 +1,6 @@
 
 package com.badlogic.gdx.tests.g3d;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g3d.Environment;
 import com.badlogic.gdx.graphics.g3d.ModelBatch;
@@ -178,9 +177,9 @@ public class ParticleControllerTest extends BaseG3dTest {
 	protected void render (ModelBatch batch, Array<ModelInstance> instances) {
 		if (emitters.size > 0) {
 			// Update
-			float delta = Gdx.graphics.getDeltaTime();
+			float delta = graphics.getDeltaTime();
 			builder.delete(0, builder.length());
-			builder.append(Gdx.graphics.getFramesPerSecond());
+			builder.append(graphics.getFramesPerSecond());
 			fpsLabel.setText(builder);
 			ui.act(delta);
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/PolarAccelerationTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/PolarAccelerationTest.java
@@ -1,7 +1,6 @@
 
 package com.badlogic.gdx.tests.g3d;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g3d.Environment;
 import com.badlogic.gdx.graphics.g3d.ModelBatch;
@@ -138,9 +137,9 @@ public class PolarAccelerationTest extends BaseG3dTest {
 	protected void render (ModelBatch batch, Array<ModelInstance> instances) {
 		if (emitters.size > 0) {
 			// Update
-			float delta = Gdx.graphics.getDeltaTime();
+			float delta = graphics.getDeltaTime();
 			builder.delete(0, builder.length());
-			builder.append(Gdx.graphics.getFramesPerSecond());
+			builder.append(graphics.getFramesPerSecond());
 			fpsLabel.setText(builder);
 			ui.act(delta);
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/ShadowMappingTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/ShadowMappingTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests.g3d;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.PerspectiveCamera;
@@ -54,7 +53,7 @@ public class ShadowMappingTest extends GdxTest {
 			.add((shadowLight = new DirectionalShadowLight(1024, 1024, 30f, 30f, 1f, 100f)).set(0.8f, 0.8f, 0.8f, -1f, -.8f, -.2f));
 		environment.shadowMap = shadowLight;
 
-		cam = new PerspectiveCamera(67, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+		cam = new PerspectiveCamera(67, graphics.getWidth(), graphics.getHeight());
 		cam.position.set(0f, 7f, 10f);
 		cam.lookAt(0, 0, 0);
 		cam.near = 1f;
@@ -74,16 +73,16 @@ public class ShadowMappingTest extends GdxTest {
 
 		shadowBatch = new ModelBatch(new DepthShaderProvider());
 
-		Gdx.input.setInputProcessor(camController = new CameraInputController(cam));
+		input.setInputProcessor(camController = new CameraInputController(cam));
 	}
 
 	@Override
 	public void render () {
 		camController.update();
 
-		Gdx.gl.glViewport(0, 0, Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight());
-		Gdx.gl.glClearColor(0, 0, 0, 1);
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
+		gl.glViewport(0, 0, graphics.getBackBufferWidth(), graphics.getBackBufferHeight());
+		gl.glClearColor(0, 0, 0, 1);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
 
 		shadowLight.begin(Vector3.Zero, cam.direction);
 		shadowBatch.begin(shadowLight.getCamera());

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/ShadowMappingTextureTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/ShadowMappingTextureTest.java
@@ -1,7 +1,6 @@
 
 package com.badlogic.gdx.tests.g3d;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.PerspectiveCamera;
 import com.badlogic.gdx.graphics.Texture;
@@ -43,7 +42,7 @@ public class ShadowMappingTextureTest extends GdxTest {
 			.add((shadowLight = new DirectionalShadowLight(1024, 1024, 30f, 30f, 1f, 100f)).set(0.8f, 0.8f, 0.8f, 1f, -.1f, -.2f));
 		environment.shadowMap = shadowLight;
 
-		cam = new PerspectiveCamera(67, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+		cam = new PerspectiveCamera(67, graphics.getWidth(), graphics.getHeight());
 		cam.position.set(0f, 7f, 10f);
 		cam.lookAt(0, 0, 0);
 		cam.near = 1f;
@@ -56,7 +55,7 @@ public class ShadowMappingTextureTest extends GdxTest {
 
 		MeshPartBuilder mpb = modelBuilder.part("parts", GL20.GL_TRIANGLES,
 			Usage.Position | Usage.Normal | Usage.ColorUnpacked | Usage.TextureCoordinates, new Material(
-				TextureAttribute.createDiffuse(new Texture(Gdx.files.internal("data/animation.png"))), new BlendingAttribute(1)));
+				TextureAttribute.createDiffuse(new Texture(files.internal("data/animation.png"))), new BlendingAttribute(1)));
 
 		mpb.setColor(1f, 1f, 1f, 1f);
 		mpb.sphere(2f, 2f, 2f, 10, 10);
@@ -72,16 +71,16 @@ public class ShadowMappingTextureTest extends GdxTest {
 
 		shadowBatch = new ModelBatch(new DepthShaderProvider());
 
-		Gdx.input.setInputProcessor(camController = new CameraInputController(cam));
+		input.setInputProcessor(camController = new CameraInputController(cam));
 	}
 
 	@Override
 	public void render () {
 		camController.update();
 
-		Gdx.gl.glViewport(0, 0, Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight());
-		Gdx.gl.glClearColor(0, 0, 0, 1);
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
+		gl.glViewport(0, 0, graphics.getBackBufferWidth(), graphics.getBackBufferHeight());
+		gl.glClearColor(0, 0, 0, 1);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
 
 		instance2.transform.setToTranslation(4, 0, 0);
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/SkeletonTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/SkeletonTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests.g3d;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input.Keys;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
@@ -61,7 +60,7 @@ public class SkeletonTest extends BaseG3dHudTest {
 	@Override
 	protected void render (ModelBatch batch, Array<ModelInstance> instances) {
 		for (ObjectMap.Entry<ModelInstance, AnimationController> e : animationControllers.entries())
-			e.value.update(Gdx.graphics.getDeltaTime());
+			e.value.update(graphics.getDeltaTime());
 		for (final ModelInstance instance : instances)
 			renderSkeleton(instance);
 		batch.render(instances);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/TangentialAccelerationTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/TangentialAccelerationTest.java
@@ -1,7 +1,6 @@
 
 package com.badlogic.gdx.tests.g3d;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g3d.Environment;
 import com.badlogic.gdx.graphics.g3d.ModelBatch;
@@ -138,9 +137,9 @@ public class TangentialAccelerationTest extends BaseG3dTest {
 	protected void render (ModelBatch batch, Array<ModelInstance> instances) {
 		if (emitters.size > 0) {
 			// Update
-			float delta = Gdx.graphics.getDeltaTime();
+			float delta = graphics.getDeltaTime();
 			builder.delete(0, builder.length());
-			builder.append(Gdx.graphics.getFramesPerSecond());
+			builder.append(graphics.getFramesPerSecond());
 			fpsLabel.setText(builder);
 			ui.act(delta);
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/TextureArrayTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/TextureArrayTest.java
@@ -17,7 +17,6 @@
 package com.badlogic.gdx.tests.g3d;
 
 import com.badlogic.gdx.Application;
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
@@ -54,37 +53,37 @@ public class TextureArrayTest extends GdxTest {
 
 	@Override
 	public void create () {
-		glProfiler = new GLProfiler(Gdx.graphics);
+		glProfiler = new GLProfiler(graphics);
 		glProfiler.enable();
 
-		ShaderProgram.prependVertexCode = Gdx.app.getType().equals(Application.ApplicationType.Desktop)
+		ShaderProgram.prependVertexCode = app.getType().equals(Application.ApplicationType.Desktop)
 			? "#version 140\n #extension GL_EXT_texture_array : enable\n"
 			: "#version 300 es\n";
-		ShaderProgram.prependFragmentCode = Gdx.app.getType().equals(Application.ApplicationType.Desktop)
+		ShaderProgram.prependFragmentCode = app.getType().equals(Application.ApplicationType.Desktop)
 			? "#version 140\n #extension GL_EXT_texture_array : enable\n"
 			: "#version 300 es\n";
 
 		String[] texPaths = new String[] {"data/g3d/materials/Searing Gorge.jpg", "data/g3d/materials/Lava Cracks.jpg",
 			"data/g3d/materials/Deep Fire.jpg"};
 
-		camera = new PerspectiveCamera(67, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+		camera = new PerspectiveCamera(67, graphics.getWidth(), graphics.getHeight());
 		camera.position.set(8, 10f, 20f);
 		camera.lookAt(10, 0, 10);
 		camera.up.set(0, 1, 0);
 		camera.update();
 		cameraController = new FirstPersonCameraController(camera);
-		Gdx.input.setInputProcessor(cameraController);
+		input.setInputProcessor(cameraController);
 
 		FileHandle[] texFiles = new FileHandle[texPaths.length];
 		for (int i = 0; i < texPaths.length; i++) {
-			texFiles[i] = Gdx.files.internal(texPaths[i]);
+			texFiles[i] = files.internal(texPaths[i]);
 		}
 
 		textureArray = new TextureArray(true, texFiles);
 		textureArray.setWrap(Texture.TextureWrap.Repeat, Texture.TextureWrap.Repeat);
 		textureArray.setFilter(TextureFilter.MipMapLinearLinear, TextureFilter.Linear);
-		shaderProgram = new ShaderProgram(Gdx.files.internal("data/shaders/texturearray.vert"),
-			Gdx.files.internal("data/shaders/texturearray.frag"));
+		shaderProgram = new ShaderProgram(files.internal("data/shaders/texturearray.vert"),
+			files.internal("data/shaders/texturearray.frag"));
 		System.out.println(shaderProgram.getLog());
 
 		int vertexStride = 6;
@@ -92,7 +91,7 @@ public class TextureArrayTest extends GdxTest {
 		terrain = new Mesh(false, vertexCount * 6, 0, new VertexAttributes(VertexAttribute.Position(),
 			new VertexAttribute(VertexAttributes.Usage.TextureCoordinates, 3, ShaderProgram.TEXCOORD_ATTRIBUTE + 0)));
 
-		Pixmap data = new Pixmap(Gdx.files.internal("data/g3d/heightmap.png"));
+		Pixmap data = new Pixmap(files.internal("data/g3d/heightmap.png"));
 		float[] vertices = new float[vertexCount * vertexStride * 6];
 		int idx = 0;
 		for (int i = 0; i < 100 - 1; i++) {
@@ -127,12 +126,12 @@ public class TextureArrayTest extends GdxTest {
 
 	@Override
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
-		Gdx.gl.glEnable(GL20.GL_DEPTH_TEST);
-		Gdx.gl.glDepthFunc(GL20.GL_LEQUAL);
-		Gdx.gl.glCullFace(GL20.GL_BACK);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
+		gl.glEnable(GL20.GL_DEPTH_TEST);
+		gl.glDepthFunc(GL20.GL_LEQUAL);
+		gl.glCullFace(GL20.GL_BACK);
 
-		modelView.translate(10f, 0, 10f).rotate(0, 1f, 0, 2f * Gdx.graphics.getDeltaTime()).translate(-10f, 0, -10f);
+		modelView.translate(10f, 0, 10f).rotate(0, 1f, 0, 2f * graphics.getDeltaTime()).translate(-10f, 0, -10f);
 
 		cameraController.update();
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/TextureRegion3DTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/TextureRegion3DTest.java
@@ -1,7 +1,6 @@
 
 package com.badlogic.gdx.tests.g3d;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.InputMultiplexer;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.PerspectiveCamera;
@@ -37,9 +36,9 @@ public class TextureRegion3DTest extends GdxTest {
 
 	@Override
 	public void create () {
-		Gdx.gl.glClearColor(0.2f, 0.3f, 1.0f, 0.f);
+		gl.glClearColor(0.2f, 0.3f, 1.0f, 0.f);
 
-		atlas = new TextureAtlas(Gdx.files.internal("data/testpack"));
+		atlas = new TextureAtlas(files.internal("data/testpack"));
 		regions = atlas.getRegions();
 
 		modelBatch = new ModelBatch(new DefaultShaderProvider());
@@ -48,7 +47,7 @@ public class TextureRegion3DTest extends GdxTest {
 		environment.set(new ColorAttribute(ColorAttribute.AmbientLight, .4f, .4f, .4f, 1f));
 		environment.add(new DirectionalLight().set(0.8f, 0.8f, 0.8f, -1f, -0.8f, -0.2f));
 
-		cam = new PerspectiveCamera(67, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+		cam = new PerspectiveCamera(67, graphics.getWidth(), graphics.getHeight());
 		cam.position.set(10f, 10f, 10f);
 		cam.lookAt(0, 0, 0);
 		cam.near = 0.1f;
@@ -62,21 +61,21 @@ public class TextureRegion3DTest extends GdxTest {
 		instance = new ModelInstance(model);
 		attribute = instance.materials.get(0).get(TextureAttribute.class, TextureAttribute.Diffuse);
 
-		Gdx.input.setInputProcessor(new InputMultiplexer(this, inputController = new CameraInputController(cam)));
+		input.setInputProcessor(new InputMultiplexer(this, inputController = new CameraInputController(cam)));
 	}
 
 	@Override
 	public void render () {
 		inputController.update();
-		if ((time += Gdx.graphics.getDeltaTime()) >= 1f) {
+		if ((time += graphics.getDeltaTime()) >= 1f) {
 			time -= 1f;
 			index = (index + 1) % regions.size;
 			attribute.set(regions.get(index));
-			Gdx.app.log("TextureRegion3DTest", "Current region = " + regions.get(index).name);
+			app.log("TextureRegion3DTest", "Current region = " + regions.get(index).name);
 		}
 
-		Gdx.gl.glViewport(0, 0, Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight());
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
+		gl.glViewport(0, 0, graphics.getBackBufferWidth(), graphics.getBackBufferHeight());
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
 
 		modelBatch.begin(cam);
 		modelBatch.render(instance, environment);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/utils/DefaultTextureBinderTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/utils/DefaultTextureBinderTest.java
@@ -3,7 +3,6 @@ package com.badlogic.gdx.tests.g3d.utils;
 
 import java.nio.IntBuffer;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Pixmap.Format;
 import com.badlogic.gdx.graphics.Texture;
@@ -72,9 +71,9 @@ public class DefaultTextureBinderTest extends GdxTest {
 
 	private void assertBinding (int... b) {
 		for (int i = 0; i < b.length; i++) {
-			Gdx.gl.glActiveTexture(GL20.GL_TEXTURE0 + i);
+			gl.glActiveTexture(GL20.GL_TEXTURE0 + i);
 			IntBuffer buffer = BufferUtils.newIntBuffer(16);
-			Gdx.gl.glGetIntegerv(GL20.GL_TEXTURE_BINDING_2D, buffer);
+			gl.glGetIntegerv(GL20.GL_TEXTURE_BINDING_2D, buffer);
 			int tex = buffer.get(0);
 			int textureID = map.get(tex, -1);
 			if (textureID != b[i]) {
@@ -85,9 +84,9 @@ public class DefaultTextureBinderTest extends GdxTest {
 
 	private void printBindings (int n) {
 		for (int i = 0; i < n; i++) {
-			Gdx.gl.glActiveTexture(GL20.GL_TEXTURE0 + i);
+			gl.glActiveTexture(GL20.GL_TEXTURE0 + i);
 			IntBuffer buffer = BufferUtils.newIntBuffer(16);
-			Gdx.gl.glGetIntegerv(GL20.GL_TEXTURE_BINDING_2D, buffer);
+			gl.glGetIntegerv(GL20.GL_TEXTURE_BINDING_2D, buffer);
 			int tex = buffer.get(0);
 			int textureID = map.get(tex, -1);
 			System.out.println("UNIT " + i + " texture " + textureID);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/voxel/VoxelTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/g3d/voxel/VoxelTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests.g3d.voxel;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.PerspectiveCamera;
 import com.badlogic.gdx.graphics.Texture;
@@ -48,17 +47,17 @@ public class VoxelTest extends GdxTest {
 		font = new BitmapFont();
 		modelBatch = new ModelBatch();
 		DefaultShader.defaultCullFace = GL20.GL_FRONT;
-		camera = new PerspectiveCamera(67, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+		camera = new PerspectiveCamera(67, graphics.getWidth(), graphics.getHeight());
 		camera.near = 0.5f;
 		camera.far = 1000;
 		controller = new FirstPersonCameraController(camera);
-		Gdx.input.setInputProcessor(controller);
+		input.setInputProcessor(controller);
 
 		lights = new Environment();
 		lights.set(new ColorAttribute(ColorAttribute.AmbientLight, 0.4f, 0.4f, 0.4f, 1.f));
 		lights.add(new DirectionalLight().set(1, 1, 1, 0, -1, 0));
 
-		Texture texture = new Texture(Gdx.files.internal("data/g3d/tiles.png"));
+		Texture texture = new Texture(files.internal("data/g3d/tiles.png"));
 		TextureRegion[][] tiles = TextureRegion.split(texture, 32, 32);
 
 		MathUtils.random.setSeed(0);
@@ -79,7 +78,7 @@ public class VoxelTest extends GdxTest {
 		controller.update();
 
 		spriteBatch.begin();
-		font.draw(spriteBatch, "fps: " + Gdx.graphics.getFramesPerSecond() + ", #visible chunks: " + voxelWorld.renderedChunks + "/"
+		font.draw(spriteBatch, "fps: " + graphics.getFramesPerSecond() + ", #visible chunks: " + voxelWorld.renderedChunks + "/"
 			+ voxelWorld.numChunks, 0, 20);
 		spriteBatch.end();
 	}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gles2/GlTexImage2D.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gles2/GlTexImage2D.java
@@ -19,7 +19,6 @@ package com.badlogic.gdx.tests.gles2;
 import java.nio.FloatBuffer;
 import java.nio.ByteBuffer;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.glutils.ShaderProgram;
@@ -82,7 +81,7 @@ public class GlTexImage2D extends GdxTest {
 		 * check if OpenGL context needs to be reloaded; checking only texture should be sufficient; but i guess this check is
 		 * redundant
 		 */
-		if (!Gdx.gl20.glIsTexture(texture)) {
+		if (!gl20.glIsTexture(texture)) {
 			reload();
 		}
 
@@ -91,55 +90,55 @@ public class GlTexImage2D extends GdxTest {
 			textureColorData.put(colorComponent, (byte)(textureColorData.get(colorComponent) + 1));
 		}
 		textureColorData.rewind();
-		Gdx.gl20.glActiveTexture(GL20.GL_TEXTURE1);
-		Gdx.gl20.glTexImage2D(GL20.GL_TEXTURE_2D, 0, GL20.GL_RGB, 2, 2, 0, GL20.GL_RGB, GL20.GL_UNSIGNED_BYTE, textureColorData);
-		Gdx.gl20.glActiveTexture(GL20.GL_TEXTURE0);
+		gl20.glActiveTexture(GL20.GL_TEXTURE1);
+		gl20.glTexImage2D(GL20.GL_TEXTURE_2D, 0, GL20.GL_RGB, 2, 2, 0, GL20.GL_RGB, GL20.GL_UNSIGNED_BYTE, textureColorData);
+		gl20.glActiveTexture(GL20.GL_TEXTURE0);
 
 		/* init drawing */
-		Gdx.gl20.glViewport(0, 0, Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight());
-		Gdx.gl20.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl20.glViewport(0, 0, graphics.getBackBufferWidth(), graphics.getBackBufferHeight());
+		gl20.glClear(GL20.GL_COLOR_BUFFER_BIT);
 
 		/* draw texture built from bytes */
-		Gdx.gl20.glBindBuffer(GL20.GL_ARRAY_BUFFER, vertsBuffer);
-		Gdx.gl20.glVertexAttribPointer(shader.getAttributeLocation("vPosition"), 2, GL20.GL_FLOAT, false, 0, 0);
+		gl20.glBindBuffer(GL20.GL_ARRAY_BUFFER, vertsBuffer);
+		gl20.glVertexAttribPointer(shader.getAttributeLocation("vPosition"), 2, GL20.GL_FLOAT, false, 0, 0);
 		shader.setUniformi("uTex2d", 1);
-		Gdx.gl20.glDrawArrays(GL20.GL_TRIANGLE_FAN, 0, 4);
+		gl20.glDrawArrays(GL20.GL_TRIANGLE_FAN, 0, 4);
 
 		/* draw pixmap */
-		Gdx.gl20.glBindBuffer(GL20.GL_ARRAY_BUFFER, pixmapBuffer);
-		Gdx.gl20.glVertexAttribPointer(shader.getAttributeLocation("vPosition"), 2, GL20.GL_FLOAT, false, 0, 0);
+		gl20.glBindBuffer(GL20.GL_ARRAY_BUFFER, pixmapBuffer);
+		gl20.glVertexAttribPointer(shader.getAttributeLocation("vPosition"), 2, GL20.GL_FLOAT, false, 0, 0);
 		shader.setUniformi("uTex2d", 2);
-		Gdx.gl20.glDrawArrays(GL20.GL_TRIANGLE_FAN, 0, 4);
+		gl20.glDrawArrays(GL20.GL_TRIANGLE_FAN, 0, 4);
 
 	}
 
 	private void reload () {
 
 		/* common */
-		Gdx.gl20.glPixelStorei(GL20.GL_UNPACK_ALIGNMENT, 1);
+		gl20.glPixelStorei(GL20.GL_UNPACK_ALIGNMENT, 1);
 
 		/* generate texture */
-		texture = Gdx.gl20.glGenTexture();
-		Gdx.gl20.glActiveTexture(GL20.GL_TEXTURE1);
-		Gdx.gl20.glBindTexture(GL20.GL_TEXTURE_2D, texture);
-		Gdx.gl20.glTexParameteri(GL20.GL_TEXTURE_2D, GL20.GL_TEXTURE_WRAP_S, GL20.GL_CLAMP_TO_EDGE);
-		Gdx.gl20.glTexParameteri(GL20.GL_TEXTURE_2D, GL20.GL_TEXTURE_WRAP_T, GL20.GL_CLAMP_TO_EDGE);
-		Gdx.gl20.glTexParameteri(GL20.GL_TEXTURE_2D, GL20.GL_TEXTURE_MAG_FILTER, GL20.GL_LINEAR);
-		Gdx.gl20.glTexParameteri(GL20.GL_TEXTURE_2D, GL20.GL_TEXTURE_MIN_FILTER, GL20.GL_LINEAR);
-		Gdx.gl20.glTexImage2D(GL20.GL_TEXTURE_2D, 0, GL20.GL_RGB, 2, 2, 0, GL20.GL_RGB, GL20.GL_UNSIGNED_BYTE, textureColorData);
+		texture = gl20.glGenTexture();
+		gl20.glActiveTexture(GL20.GL_TEXTURE1);
+		gl20.glBindTexture(GL20.GL_TEXTURE_2D, texture);
+		gl20.glTexParameteri(GL20.GL_TEXTURE_2D, GL20.GL_TEXTURE_WRAP_S, GL20.GL_CLAMP_TO_EDGE);
+		gl20.glTexParameteri(GL20.GL_TEXTURE_2D, GL20.GL_TEXTURE_WRAP_T, GL20.GL_CLAMP_TO_EDGE);
+		gl20.glTexParameteri(GL20.GL_TEXTURE_2D, GL20.GL_TEXTURE_MAG_FILTER, GL20.GL_LINEAR);
+		gl20.glTexParameteri(GL20.GL_TEXTURE_2D, GL20.GL_TEXTURE_MIN_FILTER, GL20.GL_LINEAR);
+		gl20.glTexImage2D(GL20.GL_TEXTURE_2D, 0, GL20.GL_RGB, 2, 2, 0, GL20.GL_RGB, GL20.GL_UNSIGNED_BYTE, textureColorData);
 
 		/* load pixmap to verify that pixmap was not broken */
-		pixmapCheck = new Pixmap(Gdx.files.internal("data/walkanim.png"));
+		pixmapCheck = new Pixmap(files.internal("data/walkanim.png"));
 
 		/* generate texture for pixmap */
-		pixmapTexture = Gdx.gl20.glGenTexture();
-		Gdx.gl20.glActiveTexture(GL20.GL_TEXTURE2);
-		Gdx.gl20.glBindTexture(GL20.GL_TEXTURE_2D, pixmapTexture);
-		Gdx.gl20.glTexParameteri(GL20.GL_TEXTURE_2D, GL20.GL_TEXTURE_WRAP_S, GL20.GL_CLAMP_TO_EDGE);
-		Gdx.gl20.glTexParameteri(GL20.GL_TEXTURE_2D, GL20.GL_TEXTURE_WRAP_T, GL20.GL_CLAMP_TO_EDGE);
-		Gdx.gl20.glTexParameteri(GL20.GL_TEXTURE_2D, GL20.GL_TEXTURE_MAG_FILTER, GL20.GL_LINEAR);
-		Gdx.gl20.glTexParameteri(GL20.GL_TEXTURE_2D, GL20.GL_TEXTURE_MIN_FILTER, GL20.GL_LINEAR);
-		Gdx.gl20.glTexImage2D(GL20.GL_TEXTURE_2D, 0, GL20.GL_RGBA, pixmapCheck.getWidth(), pixmapCheck.getHeight(), 0, GL20.GL_RGBA,
+		pixmapTexture = gl20.glGenTexture();
+		gl20.glActiveTexture(GL20.GL_TEXTURE2);
+		gl20.glBindTexture(GL20.GL_TEXTURE_2D, pixmapTexture);
+		gl20.glTexParameteri(GL20.GL_TEXTURE_2D, GL20.GL_TEXTURE_WRAP_S, GL20.GL_CLAMP_TO_EDGE);
+		gl20.glTexParameteri(GL20.GL_TEXTURE_2D, GL20.GL_TEXTURE_WRAP_T, GL20.GL_CLAMP_TO_EDGE);
+		gl20.glTexParameteri(GL20.GL_TEXTURE_2D, GL20.GL_TEXTURE_MAG_FILTER, GL20.GL_LINEAR);
+		gl20.glTexParameteri(GL20.GL_TEXTURE_2D, GL20.GL_TEXTURE_MIN_FILTER, GL20.GL_LINEAR);
+		gl20.glTexImage2D(GL20.GL_TEXTURE_2D, 0, GL20.GL_RGBA, pixmapCheck.getWidth(), pixmapCheck.getHeight(), 0, GL20.GL_RGBA,
 			GL20.GL_UNSIGNED_BYTE, pixmapCheck.getPixels());
 
 		/* set shader */
@@ -147,27 +146,27 @@ public class GlTexImage2D extends GdxTest {
 		shader.bind();
 
 		/* set vertices */
-		vertsBuffer = Gdx.gl20.glGenBuffer();
-		Gdx.gl20.glBindBuffer(GL20.GL_ARRAY_BUFFER, vertsBuffer);
-		Gdx.gl20.glBufferData(GL20.GL_ARRAY_BUFFER, 8 * 4, verticesData, GL20.GL_STATIC_DRAW);
+		vertsBuffer = gl20.glGenBuffer();
+		gl20.glBindBuffer(GL20.GL_ARRAY_BUFFER, vertsBuffer);
+		gl20.glBufferData(GL20.GL_ARRAY_BUFFER, 8 * 4, verticesData, GL20.GL_STATIC_DRAW);
 
 		/* set pixmap verts */
-		pixmapBuffer = Gdx.gl20.glGenBuffer();
-		Gdx.gl20.glBindBuffer(GL20.GL_ARRAY_BUFFER, pixmapBuffer);
-		Gdx.gl20.glBufferData(GL20.GL_ARRAY_BUFFER, 8 * 4, pixmapVerticesData, GL20.GL_STATIC_DRAW);
+		pixmapBuffer = gl20.glGenBuffer();
+		gl20.glBindBuffer(GL20.GL_ARRAY_BUFFER, pixmapBuffer);
+		gl20.glBufferData(GL20.GL_ARRAY_BUFFER, 8 * 4, pixmapVerticesData, GL20.GL_STATIC_DRAW);
 
 		/* set uvs */
-		uvBuffer = Gdx.gl20.glGenBuffer();
-		Gdx.gl20.glBindBuffer(GL20.GL_ARRAY_BUFFER, uvBuffer);
-		Gdx.gl20.glBufferData(GL20.GL_ARRAY_BUFFER, 8 * 4, uvData, GL20.GL_STATIC_DRAW);
-		Gdx.gl20.glVertexAttribPointer(shader.getAttributeLocation("vTexCoords"), 2, GL20.GL_FLOAT, false, 0, 0);
+		uvBuffer = gl20.glGenBuffer();
+		gl20.glBindBuffer(GL20.GL_ARRAY_BUFFER, uvBuffer);
+		gl20.glBufferData(GL20.GL_ARRAY_BUFFER, 8 * 4, uvData, GL20.GL_STATIC_DRAW);
+		gl20.glVertexAttribPointer(shader.getAttributeLocation("vTexCoords"), 2, GL20.GL_FLOAT, false, 0, 0);
 
 		/* finalize setup */
-		Gdx.gl20.glEnableVertexAttribArray(shader.getAttributeLocation("vPosition"));
-		Gdx.gl20.glEnableVertexAttribArray(shader.getAttributeLocation("vTexCoords"));
+		gl20.glEnableVertexAttribArray(shader.getAttributeLocation("vPosition"));
+		gl20.glEnableVertexAttribArray(shader.getAttributeLocation("vTexCoords"));
 
-		Gdx.gl20.glActiveTexture(GL20.GL_TEXTURE0);
-		Gdx.gl20.glBindBuffer(GL20.GL_ARRAY_BUFFER, 0);
+		gl20.glActiveTexture(GL20.GL_TEXTURE0);
+		gl20.glBindBuffer(GL20.GL_ARRAY_BUFFER, 0);
 	}
 
 	@Override
@@ -182,15 +181,15 @@ public class GlTexImage2D extends GdxTest {
 
 	@Override
 	public void dispose () {
-		Gdx.gl20.glDisableVertexAttribArray(shader.getAttributeLocation("vPosition"));
-		Gdx.gl20.glDisableVertexAttribArray(shader.getAttributeLocation("vTexCoords"));
+		gl20.glDisableVertexAttribArray(shader.getAttributeLocation("vPosition"));
+		gl20.glDisableVertexAttribArray(shader.getAttributeLocation("vTexCoords"));
 
-		Gdx.gl20.glDeleteBuffer(vertsBuffer);
-		Gdx.gl20.glDeleteBuffer(pixmapBuffer);
-		Gdx.gl20.glDeleteBuffer(uvBuffer);
+		gl20.glDeleteBuffer(vertsBuffer);
+		gl20.glDeleteBuffer(pixmapBuffer);
+		gl20.glDeleteBuffer(uvBuffer);
 
-		Gdx.gl20.glDeleteTexture(texture);
-		Gdx.gl20.glDeleteTexture(pixmapTexture);
+		gl20.glDeleteTexture(texture);
+		gl20.glDeleteTexture(pixmapTexture);
 
 		shader.dispose();
 		pixmapCheck.dispose();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gles2/HelloTriangle.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gles2/HelloTriangle.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests.gles2;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Mesh;
 import com.badlogic.gdx.graphics.VertexAttribute;
@@ -44,8 +43,8 @@ public class HelloTriangle extends GdxTest {
 
 	@Override
 	public void render () {
-		Gdx.gl20.glViewport(0, 0, Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight());
-		Gdx.gl20.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl20.glViewport(0, 0, graphics.getBackBufferWidth(), graphics.getBackBufferHeight());
+		gl20.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		shader.bind();
 		mesh.render(shader, GL20.GL_TRIANGLES);
 	}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gles2/MipMap2D.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gles2/MipMap2D.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests.gles2;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Mesh;
 import com.badlogic.gdx.graphics.Pixmap;
@@ -81,19 +80,19 @@ public class MipMap2D extends GdxTest {
 	}
 
 	public void render () {
-		Gdx.gl20.glViewport(0, 0, Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight());
-		Gdx.gl20.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl20.glViewport(0, 0, graphics.getBackBufferWidth(), graphics.getBackBufferHeight());
+		gl20.glClear(GL20.GL_COLOR_BUFFER_BIT);
 
-		Gdx.gl20.glActiveTexture(GL20.GL_TEXTURE0);
+		gl20.glActiveTexture(GL20.GL_TEXTURE0);
 		texture.bind();
 		shader.bind();
 		shader.setUniformf("s_texture", 0);
 
-		Gdx.gl20.glTexParameteri(GL20.GL_TEXTURE_2D, GL20.GL_TEXTURE_MIN_FILTER, GL20.GL_NEAREST);
+		gl20.glTexParameteri(GL20.GL_TEXTURE_2D, GL20.GL_TEXTURE_MIN_FILTER, GL20.GL_NEAREST);
 		shader.setUniformf("u_offset", -0.6f);
 		mesh.render(shader, GL20.GL_TRIANGLES);
 
-		Gdx.gl20.glTexParameteri(GL20.GL_TEXTURE_2D, GL20.GL_TEXTURE_MIN_FILTER, GL20.GL_LINEAR_MIPMAP_LINEAR);
+		gl20.glTexParameteri(GL20.GL_TEXTURE_2D, GL20.GL_TEXTURE_MIN_FILTER, GL20.GL_LINEAR_MIPMAP_LINEAR);
 		shader.setUniformf("u_offset", 0.6f);
 		mesh.render(shader, GL20.GL_TRIANGLES);
 	}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gles2/SimpleVertexShader.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gles2/SimpleVertexShader.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests.gles2;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Mesh;
 import com.badlogic.gdx.graphics.VertexAttributes.Usage;
@@ -62,19 +61,19 @@ public class SimpleVertexShader extends GdxTest {
 
 	@Override
 	public void render () {
-		angle += Gdx.graphics.getDeltaTime() * 40.0f;
-		float aspect = Gdx.graphics.getWidth() / (float)Gdx.graphics.getHeight();
+		angle += graphics.getDeltaTime() * 40.0f;
+		float aspect = graphics.getWidth() / (float)graphics.getHeight();
 		projection.setToProjection(1.0f, 20.0f, 60.0f, aspect);
 		view.idt().trn(0, 0, -2.0f);
 		model.setToRotation(axis, angle);
 		combined.set(projection).mul(view).mul(model);
 
-		Gdx.gl20.glViewport(0, 0, Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight());
-		Gdx.gl20.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl20.glViewport(0, 0, graphics.getBackBufferWidth(), graphics.getBackBufferHeight());
+		gl20.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		shader.bind();
 		shader.setUniformMatrix("u_mvpMatrix", combined);
 		mesh.render(shader, GL20.GL_TRIANGLES);
 
-		Gdx.app.log("angle", "" + angle);
+		app.log("angle", "" + angle);
 	}
 }

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gles2/VertexArrayTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gles2/VertexArrayTest.java
@@ -20,7 +20,6 @@ import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.ShortBuffer;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Mesh;
 import com.badlogic.gdx.graphics.Mesh.VertexDataType;
@@ -71,7 +70,7 @@ public class VertexArrayTest extends GdxTest {
 	@Override
 	public void render () {
 		boolean log = false;
-		if (Gdx.input.justTouched()) {
+		if (input.justTouched()) {
 			testCase = (testCase + 1) % testCases.length;
 			log = true;
 		}
@@ -79,11 +78,11 @@ public class VertexArrayTest extends GdxTest {
 		int offset = testCases[testCase][1];
 		int count = testCases[testCase][2];
 		if (log) {
-			Gdx.app.log("VertexArrayTest", "mode: " + mode + ", offset: " + offset + ", count: " + count);
+			app.log("VertexArrayTest", "mode: " + mode + ", offset: " + offset + ", count: " + count);
 		}
 
-		Gdx.gl20.glViewport(0, 0, Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight());
-		Gdx.gl20.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl20.glViewport(0, 0, graphics.getBackBufferWidth(), graphics.getBackBufferHeight());
+		gl20.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		shader.bind();
 		mesh.bind(shader);
 
@@ -104,10 +103,10 @@ public class VertexArrayTest extends GdxTest {
 		}
 
 		if (log) {
-			Gdx.app.log("VertexArrayTest", "position: " + buffer.position());
+			app.log("VertexArrayTest", "position: " + buffer.position());
 		}
 
-		Gdx.gl20.glDrawElements(GL20.GL_TRIANGLES, count, type, buffer);
+		gl20.glDrawElements(GL20.GL_TRIANGLES, count, type, buffer);
 		buffer.position(0);
 		mesh.unbind(shader);
 	}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gles3/GL30FrameBufferMultisampleMRTTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gles3/GL30FrameBufferMultisampleMRTTest.java
@@ -17,7 +17,6 @@
 package com.badlogic.gdx.tests.gles3;
 
 import com.badlogic.gdx.Application;
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.GL30;
@@ -59,21 +58,21 @@ public class GL30FrameBufferMultisampleMRTTest extends GdxTest {
 
 		batch = new SpriteBatch();
 
-		ShaderProgram.prependVertexCode = Gdx.app.getType().equals(Application.ApplicationType.Desktop)
+		ShaderProgram.prependVertexCode = app.getType().equals(Application.ApplicationType.Desktop)
 			? "#version 140\n #extension GL_ARB_explicit_attrib_location : enable\n"
 			: "#version 300 es\n";
-		ShaderProgram.prependFragmentCode = Gdx.app.getType().equals(Application.ApplicationType.Desktop)
+		ShaderProgram.prependFragmentCode = app.getType().equals(Application.ApplicationType.Desktop)
 			? "#version 140\n #extension GL_ARB_explicit_attrib_location : enable\n"
 			: "#version 300 es\n";
 
-		shader = new ShaderProgram(Gdx.files.internal("data/shaders/shape-renderer-mrt-vert.glsl").readString(),
-			Gdx.files.internal("data/shaders/shape-renderer-mrt-frag.glsl").readString());
+		shader = new ShaderProgram(files.internal("data/shaders/shape-renderer-mrt-vert.glsl").readString(),
+			files.internal("data/shaders/shape-renderer-mrt-frag.glsl").readString());
 
 		if (shader.isCompiled()) {
-			Gdx.app.log("GL30FrameBufferMultisampleMRTTest", "Shader compiled successfully");
+			app.log("GL30FrameBufferMultisampleMRTTest", "Shader compiled successfully");
 		} else {
-			Gdx.app.error("GL30FrameBufferMultisampleMRTTest", "Shader compilation failed: " + shader.getLog());
-			Gdx.app.exit();
+			app.error("GL30FrameBufferMultisampleMRTTest", "Shader compilation failed: " + shader.getLog());
+			app.exit();
 		}
 		shapes = new ShapeRenderer(3, shader);
 
@@ -91,7 +90,7 @@ public class GL30FrameBufferMultisampleMRTTest extends GdxTest {
 	@Override
 	public void render () {
 
-		Gdx.gl.glEnable(GL20.GL_DEPTH_TEST);
+		gl.glEnable(GL20.GL_DEPTH_TEST);
 		ScreenUtils.clear(Color.CLEAR, true);
 		batch.getProjectionMatrix().setToOrtho2D(0, 0, 2, 3);
 
@@ -133,6 +132,6 @@ public class GL30FrameBufferMultisampleMRTTest extends GdxTest {
 		batch.draw(fbo.getTextureAttachments().get(2), 1, 2, 1, 1, 0, 0, 1, 1);
 		batch.end();
 
-		Gdx.gl.glDisable(GL20.GL_DEPTH_TEST);
+		gl.glDisable(GL20.GL_DEPTH_TEST);
 	}
 }

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gles3/InstancedRenderingSpriteTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gles3/InstancedRenderingSpriteTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests.gles3;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL30;
 import com.badlogic.gdx.graphics.Mesh;
 import com.badlogic.gdx.graphics.Texture;
@@ -55,7 +54,7 @@ public class InstancedRenderingSpriteTest extends GdxTest {
 
 	@Override
 	public void create () {
-		if (Gdx.gl30 == null) {
+		if (gl30 == null) {
 			throw new GdxRuntimeException("GLES 3.0 profile required for this test");
 		}
 
@@ -63,8 +62,8 @@ public class InstancedRenderingSpriteTest extends GdxTest {
 		String ofs = ShaderProgram.prependFragmentCode;
 		ShaderProgram.prependVertexCode = "#version 300 es\n";
 		ShaderProgram.prependFragmentCode = "#version 300 es\n";
-		shader = new ShaderProgram(Gdx.files.internal("data/shaders/sprite-instanced.vert"),
-			Gdx.files.internal("data/shaders/sprite-instanced.frag"));
+		shader = new ShaderProgram(files.internal("data/shaders/sprite-instanced.vert"),
+			files.internal("data/shaders/sprite-instanced.frag"));
 		if (!shader.isCompiled()) {
 			throw new GdxRuntimeException("Shader compile error: " + shader.getLog());
 		}
@@ -95,7 +94,7 @@ public class InstancedRenderingSpriteTest extends GdxTest {
 		((Buffer)offsets).position(0);
 		mesh.setInstanceData(offsets);
 
-		texture = new Texture(Gdx.files.internal("data/badlogic.jpg"));
+		texture = new Texture(files.internal("data/badlogic.jpg"));
 		sprite = new Sprite(texture);
 		sprite.setSize(1, 1);
 		sprite.setPosition(5, 5);
@@ -104,7 +103,7 @@ public class InstancedRenderingSpriteTest extends GdxTest {
 
 		batch = new SpriteBatch();
 
-		glProfiler = new GLProfiler(Gdx.graphics);
+		glProfiler = new GLProfiler(graphics);
 		glProfiler.enable();
 	}
 
@@ -138,7 +137,7 @@ public class InstancedRenderingSpriteTest extends GdxTest {
 
 		int drawCalls = glProfiler.getDrawCalls();
 
-		System.out.println("Draw Calls: " + drawCalls + " and " + Gdx.graphics.getFramesPerSecond() + " FPS");
+		System.out.println("Draw Calls: " + drawCalls + " and " + graphics.getFramesPerSecond() + " FPS");
 	}
 
 	@Override

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gles3/InstancedRenderingTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gles3/InstancedRenderingTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests.gles3;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL30;
 import com.badlogic.gdx.graphics.Mesh;
 import com.badlogic.gdx.graphics.VertexAttribute;
@@ -42,7 +41,7 @@ public class InstancedRenderingTest extends GdxTest {
 
 	@Override
 	public void create () {
-		if (Gdx.gl30 == null) {
+		if (gl30 == null) {
 			throw new GdxRuntimeException("GLES 3.0 profile required for this test");
 		}
 
@@ -50,8 +49,8 @@ public class InstancedRenderingTest extends GdxTest {
 		String ofs = ShaderProgram.prependFragmentCode;
 		ShaderProgram.prependVertexCode = "#version 300 es\n";
 		ShaderProgram.prependFragmentCode = "#version 300 es\n";
-		shader = new ShaderProgram(Gdx.files.internal("data/shaders/instanced-rendering.vert"),
-			Gdx.files.internal("data/shaders/instanced-rendering.frag"));
+		shader = new ShaderProgram(files.internal("data/shaders/instanced-rendering.vert"),
+			files.internal("data/shaders/instanced-rendering.frag"));
 		if (!shader.isCompiled()) {
 			throw new GdxRuntimeException("Shader compile error: " + shader.getLog());
 		}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gles3/ModelInstancedRenderingTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gles3/ModelInstancedRenderingTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests.gles3;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Mesh;
 import com.badlogic.gdx.graphics.OrthographicCamera;
@@ -50,7 +49,7 @@ public class ModelInstancedRenderingTest extends GdxTest {
 
 	@Override
 	public void create () {
-		if (Gdx.gl30 == null) {
+		if (gl30 == null) {
 			throw new GdxRuntimeException("GLES 3.0 profile required for this test");
 		}
 
@@ -87,8 +86,8 @@ public class ModelInstancedRenderingTest extends GdxTest {
 			public void init () {
 				ShaderProgram.prependVertexCode = "#version 300 es\n";
 				ShaderProgram.prependFragmentCode = "#version 300 es\n";
-				program = new ShaderProgram(Gdx.files.internal("data/shaders/instanced-rendering.vert"),
-					Gdx.files.internal("data/shaders/instanced-rendering.frag"));
+				program = new ShaderProgram(files.internal("data/shaders/instanced-rendering.vert"),
+					files.internal("data/shaders/instanced-rendering.frag"));
 				if (!program.isCompiled()) {
 					throw new GdxRuntimeException("Shader compile error: " + program.getLog());
 				}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gles3/NonPowerOfTwoTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gles3/NonPowerOfTwoTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests.gles3;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.tests.utils.GdxTest;
@@ -32,7 +31,7 @@ public class NonPowerOfTwoTest extends GdxTest {
 	@Override
 	public void create () {
 		batch = new SpriteBatch();
-		texture = new Texture(Gdx.files.internal("data/heightmap.png"), true);
+		texture = new Texture(files.internal("data/heightmap.png"), true);
 		texture.setFilter(Texture.TextureFilter.MipMapLinearNearest, Texture.TextureFilter.Linear);
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gles3/UniformBufferObjectsTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gles3/UniformBufferObjectsTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests.gles3;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL30;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
@@ -61,42 +60,42 @@ public class UniformBufferObjectsTest extends GdxTest {
 	public void create () {
 		random = new RandomXS128();
 		batch = new SpriteBatch();
-		texture = new Texture(Gdx.files.internal("data/badlogic.jpg"));
+		texture = new Texture(files.internal("data/badlogic.jpg"));
 		texture.setFilter(Texture.TextureFilter.Linear, Texture.TextureFilter.Linear);
 
-		shaderProgram = new ShaderProgram(Gdx.files.internal("data/shaders/ubo.vert"), Gdx.files.internal("data/shaders/ubo.frag"));
+		shaderProgram = new ShaderProgram(files.internal("data/shaders/ubo.vert"), files.internal("data/shaders/ubo.frag"));
 
-		Gdx.app.log("UniformBufferObjectsTest", shaderProgram.getLog());
+		app.log("UniformBufferObjectsTest", shaderProgram.getLog());
 		if (shaderProgram.isCompiled()) {
-			Gdx.app.log("UniformBufferObjectsTest", "Shader compiled");
+			app.log("UniformBufferObjectsTest", "Shader compiled");
 			batch.setShader(shaderProgram);
 		}
 
 		IntBuffer tmpBuffer = BufferUtils.newIntBuffer(16);
 
 		// Get the block index for the uniform block
-		int blockIndex = Gdx.gl30.glGetUniformBlockIndex(shaderProgram.getHandle(), "u_bufferBlock");
+		int blockIndex = gl30.glGetUniformBlockIndex(shaderProgram.getHandle(), "u_bufferBlock");
 
 		// Use the index to get the active block uniform count
-		Gdx.gl30.glGetActiveUniformBlockiv(shaderProgram.getHandle(), blockIndex, GL30.GL_UNIFORM_BLOCK_ACTIVE_UNIFORMS, tmpBuffer);
+		gl30.glGetActiveUniformBlockiv(shaderProgram.getHandle(), blockIndex, GL30.GL_UNIFORM_BLOCK_ACTIVE_UNIFORMS, tmpBuffer);
 		int activeUniforms = tmpBuffer.get(0);
 
 		tmpBuffer.clear();
-		Gdx.gl30.glGenBuffers(1, tmpBuffer);
+		gl30.glGenBuffers(1, tmpBuffer);
 		int bufferHandle = tmpBuffer.get(0);
 
-		Gdx.gl.glBindBuffer(GL30.GL_UNIFORM_BUFFER, bufferHandle);
-		Gdx.gl.glBufferData(GL30.GL_UNIFORM_BUFFER, 16, uniformBuffer, GL30.GL_STATIC_DRAW);
+		gl.glBindBuffer(GL30.GL_UNIFORM_BUFFER, bufferHandle);
+		gl.glBufferData(GL30.GL_UNIFORM_BUFFER, 16, uniformBuffer, GL30.GL_STATIC_DRAW);
 
 		int bindingPoint = 0;
 		// Use the index to bind to a binding point, then bind the buffer
-		Gdx.gl30.glUniformBlockBinding(shaderProgram.getHandle(), blockIndex, bindingPoint);
-		Gdx.gl30.glBindBufferBase(GL30.GL_UNIFORM_BUFFER, bindingPoint, bufferHandle);
+		gl30.glUniformBlockBinding(shaderProgram.getHandle(), blockIndex, bindingPoint);
+		gl30.glBindBufferBase(GL30.GL_UNIFORM_BUFFER, bindingPoint, bufferHandle);
 
 		// UI
-		skin = new Skin(Gdx.files.internal("data/uiskin.json"));
+		skin = new Skin(files.internal("data/uiskin.json"));
 		stage = new Stage(new ScreenViewport());
-		Gdx.input.setInputProcessor(stage);
+		input.setInputProcessor(stage);
 
 		table = new Table();
 		table.add(new Label("Block Uniforms (2 is expected):" + activeUniforms, skin)).row();
@@ -107,7 +106,7 @@ public class UniformBufferObjectsTest extends GdxTest {
 	@Override
 	public void render () {
 		ScreenUtils.clear(0, 0, 0, 1);
-		elapsedTime += Gdx.graphics.getDeltaTime();
+		elapsedTime += graphics.getDeltaTime();
 
 		if (elapsedTime > 2f) {
 			elapsedTime = 0;
@@ -117,19 +116,19 @@ public class UniformBufferObjectsTest extends GdxTest {
 		}
 
 		// Update the colors
-		uniformBuffer.put(0, Interpolation.smooth.apply(uniformBuffer.get(0), lerpToR, Gdx.graphics.getDeltaTime() * 2));// ColorBuffer.R
-		uniformBuffer.put(1, Interpolation.smooth.apply(uniformBuffer.get(1), lerpToG, Gdx.graphics.getDeltaTime() * 2));// ColorBuffer.G
-		uniformBuffer.put(2, Interpolation.smooth.apply(uniformBuffer.get(2), lerpToB, Gdx.graphics.getDeltaTime() * 2));// ColorBuffer.B
+		uniformBuffer.put(0, Interpolation.smooth.apply(uniformBuffer.get(0), lerpToR, graphics.getDeltaTime() * 2));// ColorBuffer.R
+		uniformBuffer.put(1, Interpolation.smooth.apply(uniformBuffer.get(1), lerpToG, graphics.getDeltaTime() * 2));// ColorBuffer.G
+		uniformBuffer.put(2, Interpolation.smooth.apply(uniformBuffer.get(2), lerpToB, graphics.getDeltaTime() * 2));// ColorBuffer.B
 
 		// Update the positions
-		uniformBuffer.put(4, Interpolation.smooth.apply(uniformBuffer.get(4), lerpToR, Gdx.graphics.getDeltaTime() * 2));// Position.X
-		uniformBuffer.put(5, Interpolation.smooth.apply(uniformBuffer.get(5), lerpToG, Gdx.graphics.getDeltaTime() * 2));// Position.Y
+		uniformBuffer.put(4, Interpolation.smooth.apply(uniformBuffer.get(4), lerpToR, graphics.getDeltaTime() * 2));// Position.X
+		uniformBuffer.put(5, Interpolation.smooth.apply(uniformBuffer.get(5), lerpToG, graphics.getDeltaTime() * 2));// Position.Y
 
 		// Update the buffer data store
-		Gdx.gl30.glBufferSubData(GL30.GL_UNIFORM_BUFFER, 0, uniformBuffer.capacity() * 4, uniformBuffer);
+		gl30.glBufferSubData(GL30.GL_UNIFORM_BUFFER, 0, uniformBuffer.capacity() * 4, uniformBuffer);
 
 		batch.begin();
-		batch.draw(texture, 0, 0, Gdx.graphics.getWidth() / 2f, Gdx.graphics.getHeight() / 2f);
+		batch.draw(texture, 0, 0, graphics.getWidth() / 2f, graphics.getHeight() / 2f);
 		batch.end();
 
 		stage.act();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gles31/GL31IndirectDrawingIndexedTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gles31/GL31IndirectDrawingIndexedTest.java
@@ -18,7 +18,6 @@ package com.badlogic.gdx.tests.gles31;
 
 import java.nio.IntBuffer;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.GL30;
@@ -68,7 +67,7 @@ public class GL31IndirectDrawingIndexedTest extends GdxTest {
 
 	@Override
 	public void create () {
-		drawCommands = Gdx.gl.glGenBuffer();
+		drawCommands = gl.glGenBuffer();
 		IntBuffer buffer = BufferUtils.newIntBuffer(commandInts * nbCommands);
 		buffer.put(new int[] { //
 			3, // count
@@ -87,9 +86,9 @@ public class GL31IndirectDrawingIndexedTest extends GdxTest {
 		});
 		buffer.flip();
 
-		Gdx.gl.glBindBuffer(GL31.GL_DRAW_INDIRECT_BUFFER, drawCommands);
-		Gdx.gl.glBufferData(GL31.GL_DRAW_INDIRECT_BUFFER, nbCommands * commandStride, buffer, GL30.GL_DYNAMIC_DRAW);
-		Gdx.gl.glBindBuffer(GL31.GL_DRAW_INDIRECT_BUFFER, 0);
+		gl.glBindBuffer(GL31.GL_DRAW_INDIRECT_BUFFER, drawCommands);
+		gl.glBufferData(GL31.GL_DRAW_INDIRECT_BUFFER, nbCommands * commandStride, buffer, GL30.GL_DYNAMIC_DRAW);
+		gl.glBindBuffer(GL31.GL_DRAW_INDIRECT_BUFFER, 0);
 
 		mesh = new Mesh(true, 4, 6, VertexAttribute.Position(), VertexAttribute.ColorUnpacked());
 		mesh.setVertices(new float[] { //
@@ -111,12 +110,12 @@ public class GL31IndirectDrawingIndexedTest extends GdxTest {
 	public void dispose () {
 		shader.dispose();
 		mesh.dispose();
-		Gdx.gl.glDeleteBuffer(drawCommands);
+		gl.glDeleteBuffer(drawCommands);
 	}
 
 	@Override
 	public void render () {
-		time += Gdx.graphics.getDeltaTime();
+		time += graphics.getDeltaTime();
 		int commandIndex = (int)time % nbCommands;
 
 		ScreenUtils.clear(Color.CLEAR, true);
@@ -127,8 +126,8 @@ public class GL31IndirectDrawingIndexedTest extends GdxTest {
 
 		mesh.bind(shader);
 
-		Gdx.gl.glBindBuffer(GL31.GL_DRAW_INDIRECT_BUFFER, drawCommands);
-		Gdx.gl31.glDrawElementsIndirect(GL20.GL_TRIANGLES, GL20.GL_UNSIGNED_SHORT, commandStride * commandIndex);
+		gl.glBindBuffer(GL31.GL_DRAW_INDIRECT_BUFFER, drawCommands);
+		gl31.glDrawElementsIndirect(GL20.GL_TRIANGLES, GL20.GL_UNSIGNED_SHORT, commandStride * commandIndex);
 		mesh.unbind(shader);
 	}
 }

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gles31/GL31IndirectDrawingNonIndexedTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gles31/GL31IndirectDrawingNonIndexedTest.java
@@ -18,7 +18,6 @@ package com.badlogic.gdx.tests.gles31;
 
 import java.nio.IntBuffer;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.GL30;
@@ -69,7 +68,7 @@ public class GL31IndirectDrawingNonIndexedTest extends GdxTest {
 	@Override
 	public void create () {
 
-		drawCommands = Gdx.gl.glGenBuffer();
+		drawCommands = gl.glGenBuffer();
 		IntBuffer buffer = BufferUtils.newIntBuffer(commandInts * nbCommands);
 		buffer.put(new int[] { //
 			3, // count
@@ -86,9 +85,9 @@ public class GL31IndirectDrawingNonIndexedTest extends GdxTest {
 		});
 		buffer.flip();
 
-		Gdx.gl.glBindBuffer(GL31.GL_DRAW_INDIRECT_BUFFER, drawCommands);
-		Gdx.gl.glBufferData(GL31.GL_DRAW_INDIRECT_BUFFER, nbCommands * commandStride, buffer, GL30.GL_DYNAMIC_DRAW);
-		Gdx.gl.glBindBuffer(GL31.GL_DRAW_INDIRECT_BUFFER, 0);
+		gl.glBindBuffer(GL31.GL_DRAW_INDIRECT_BUFFER, drawCommands);
+		gl.glBufferData(GL31.GL_DRAW_INDIRECT_BUFFER, nbCommands * commandStride, buffer, GL30.GL_DYNAMIC_DRAW);
+		gl.glBindBuffer(GL31.GL_DRAW_INDIRECT_BUFFER, 0);
 
 		mesh = new Mesh(true, 6, 0, VertexAttribute.Position(), VertexAttribute.ColorUnpacked());
 		mesh.setVertices(new float[] { //
@@ -109,12 +108,12 @@ public class GL31IndirectDrawingNonIndexedTest extends GdxTest {
 	public void dispose () {
 		shader.dispose();
 		mesh.dispose();
-		Gdx.gl.glDeleteBuffer(drawCommands);
+		gl.glDeleteBuffer(drawCommands);
 	}
 
 	@Override
 	public void render () {
-		time += Gdx.graphics.getDeltaTime();
+		time += graphics.getDeltaTime();
 		int commandIndex = (int)time % nbCommands;
 
 		ScreenUtils.clear(Color.CLEAR, true);
@@ -125,8 +124,8 @@ public class GL31IndirectDrawingNonIndexedTest extends GdxTest {
 
 		mesh.bind(shader);
 
-		Gdx.gl.glBindBuffer(GL31.GL_DRAW_INDIRECT_BUFFER, drawCommands);
-		Gdx.gl31.glDrawArraysIndirect(GL20.GL_TRIANGLES, commandStride * commandIndex);
+		gl.glBindBuffer(GL31.GL_DRAW_INDIRECT_BUFFER, drawCommands);
+		gl31.glDrawArraysIndirect(GL20.GL_TRIANGLES, commandStride * commandIndex);
 		mesh.unbind(shader);
 	}
 }

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gles31/GL31ProgramIntrospectionTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gles31/GL31ProgramIntrospectionTest.java
@@ -39,19 +39,19 @@ public class GL31ProgramIntrospectionTest extends GdxTest {
 
 		IntBuffer int1 = BufferUtils.newIntBuffer(1);
 
-		Gdx.gl31.glGetProgramInterfaceiv(program, GL31.GL_UNIFORM, GL31.GL_ACTIVE_RESOURCES, int1);
+		gl31.glGetProgramInterfaceiv(program, GL31.GL_UNIFORM, GL31.GL_ACTIVE_RESOURCES, int1);
 		int nbRes = int1.get();
 
 		for (int i = 0; i < nbRes; i++) {
-			String name = Gdx.gl31.glGetProgramResourceName(program, GL31.GL_UNIFORM, i);
-			Gdx.app.log("Gdx", name);
+			String name = gl31.glGetProgramResourceName(program, GL31.GL_UNIFORM, i);
+			app.log("Gdx", name);
 		}
 
-		int u_texture_index = Gdx.gl31.glGetProgramResourceIndex(program, GL31.GL_UNIFORM, "u_texture");
-		Gdx.app.log("Gdx", "u_texture: index:" + u_texture_index);
+		int u_texture_index = gl31.glGetProgramResourceIndex(program, GL31.GL_UNIFORM, "u_texture");
+		app.log("Gdx", "u_texture: index:" + u_texture_index);
 
-		int resLoc = Gdx.gl31.glGetProgramResourceLocation(program, GL31.GL_UNIFORM, "u_texture");
-		Gdx.app.log("Gdx", "u_texture: loc:" + resLoc);
+		int resLoc = gl31.glGetProgramResourceLocation(program, GL31.GL_UNIFORM, "u_texture");
+		app.log("Gdx", "u_texture: loc:" + resLoc);
 
 		IntBuffer props = BufferUtils.newIntBuffer(16);
 		props.put(GL31.GL_TYPE);
@@ -64,7 +64,7 @@ public class GL31ProgramIntrospectionTest extends GdxTest {
 
 		IntBuffer results = BufferUtils.newIntBuffer(16);
 
-		Gdx.gl31.glGetProgramResourceiv(program, GL31.GL_UNIFORM, u_texture_index, props, int1, results);
+		gl31.glGetProgramResourceiv(program, GL31.GL_UNIFORM, u_texture_index, props, int1, results);
 		int count = int1.get();
 		if (count == 4) {
 			int type = results.get();
@@ -72,9 +72,9 @@ public class GL31ProgramIntrospectionTest extends GdxTest {
 			boolean vs = results.get() == GL20.GL_TRUE;
 			boolean fs = results.get() == GL20.GL_TRUE;
 			boolean sampler2D = type == GL20.GL_SAMPLER_2D;
-			Gdx.app.log("Gdx", "u_texture: sampler2D:" + sampler2D + " " + loc + " vertex:" + vs + " fragment:" + fs);
+			app.log("Gdx", "u_texture: sampler2D:" + sampler2D + " " + loc + " vertex:" + vs + " fragment:" + fs);
 		} else {
-			Gdx.app.error("Gdx", "result count mismatch");
+			app.error("Gdx", "result count mismatch");
 		}
 
 		shader.dispose();

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gles32/GL32AdvancedBlendingTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gles32/GL32AdvancedBlendingTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests.gles32;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.GL32;
@@ -50,7 +49,7 @@ public class GL32AdvancedBlendingTest extends GdxTest {
 	int mode = 0;
 
 	public void create () {
-		texture = new Texture(Gdx.files.internal("data/badlogic.jpg"));
+		texture = new Texture(files.internal("data/badlogic.jpg"));
 		batch = new SpriteBatch();
 		batch.getProjectionMatrix().setToOrtho2D(0, 0, 1, 1);
 	}
@@ -63,7 +62,7 @@ public class GL32AdvancedBlendingTest extends GdxTest {
 
 	@Override
 	public void render () {
-		if (Gdx.input.justTouched()) {
+		if (input.justTouched()) {
 			mode = (mode + 1) % modes.length;
 		}
 
@@ -74,11 +73,11 @@ public class GL32AdvancedBlendingTest extends GdxTest {
 
 		batch.flush();
 
-		Gdx.gl.glBlendEquation(modes[mode]);
+		gl.glBlendEquation(modes[mode]);
 		batch.draw(texture, 0, 0, .5f, .5f);
 
 		batch.end();
 
-		Gdx.gl.glBlendEquation(GL20.GL_FUNC_ADD);
+		gl.glBlendEquation(GL20.GL_FUNC_ADD);
 	}
 }

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gles32/GL32MultipleRenderTargetsBlendingTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gles32/GL32MultipleRenderTargetsBlendingTest.java
@@ -119,7 +119,7 @@ public class GL32MultipleRenderTargetsBlendingTest extends GdxTest {
 		fbo = builder.build();
 
 		String prefix;
-		if (Gdx.app.getType() == ApplicationType.Desktop) {
+		if (app.getType() == ApplicationType.Desktop) {
 			prefix = "#version 150\n";
 		} else {
 			prefix = "#version 300 es\n";
@@ -139,8 +139,8 @@ public class GL32MultipleRenderTargetsBlendingTest extends GdxTest {
 		batch = new SpriteBatch();
 
 		for (int i = 0; i < fbo.getTextureAttachments().size; i++) {
-			boolean enabled = Gdx.gl32.glIsEnabledi(GL20.GL_BLEND, i);
-			Gdx.app.log("Gdx", "#" + i + " blending: " + enabled);
+			boolean enabled = gl32.glIsEnabledi(GL20.GL_BLEND, i);
+			app.log("Gdx", "#" + i + " blending: " + enabled);
 		}
 	}
 
@@ -157,32 +157,32 @@ public class GL32MultipleRenderTargetsBlendingTest extends GdxTest {
 	public void render () {
 
 		// Configure blending for individual render target
-		Gdx.gl32.glEnablei(GL20.GL_BLEND, 0);
-		Gdx.gl32.glBlendFuncSeparatei(0, GL20.GL_SRC_ALPHA, GL20.GL_ONE_MINUS_SRC_ALPHA, GL20.GL_ONE, GL20.GL_ONE);
+		gl32.glEnablei(GL20.GL_BLEND, 0);
+		gl32.glBlendFuncSeparatei(0, GL20.GL_SRC_ALPHA, GL20.GL_ONE_MINUS_SRC_ALPHA, GL20.GL_ONE, GL20.GL_ONE);
 
-		Gdx.gl32.glEnablei(GL20.GL_BLEND, 1);
-		Gdx.gl32.glBlendFunci(1, GL20.GL_SRC_ALPHA, GL20.GL_ONE);
+		gl32.glEnablei(GL20.GL_BLEND, 1);
+		gl32.glBlendFunci(1, GL20.GL_SRC_ALPHA, GL20.GL_ONE);
 
-		Gdx.gl32.glDisablei(GL20.GL_BLEND, 2);
+		gl32.glDisablei(GL20.GL_BLEND, 2);
 
-		Gdx.gl32.glEnablei(GL20.GL_BLEND, 3);
-		Gdx.gl32.glBlendFunci(3, GL20.GL_SRC_ALPHA, GL20.GL_ONE);
-		Gdx.gl32.glBlendEquationi(3, GL20.GL_FUNC_SUBTRACT);
+		gl32.glEnablei(GL20.GL_BLEND, 3);
+		gl32.glBlendFunci(3, GL20.GL_SRC_ALPHA, GL20.GL_ONE);
+		gl32.glBlendEquationi(3, GL20.GL_FUNC_SUBTRACT);
 
-		Gdx.gl32.glDisablei(GL20.GL_BLEND, 4);
-		Gdx.gl32.glColorMaski(4, true, false, false, false);
+		gl32.glDisablei(GL20.GL_BLEND, 4);
+		gl32.glColorMaski(4, true, false, false, false);
 
-		Gdx.gl32.glEnablei(GL20.GL_BLEND, 5);
-		Gdx.gl32.glBlendFunci(5, GL20.GL_SRC_ALPHA, GL20.GL_ONE);
-		Gdx.gl32.glBlendEquationSeparatei(5, GL20.GL_FUNC_SUBTRACT, GL20.GL_FUNC_ADD);
+		gl32.glEnablei(GL20.GL_BLEND, 5);
+		gl32.glBlendFunci(5, GL20.GL_SRC_ALPHA, GL20.GL_ONE);
+		gl32.glBlendEquationSeparatei(5, GL20.GL_FUNC_SUBTRACT, GL20.GL_FUNC_ADD);
 
-		Gdx.gl32.glEnablei(GL20.GL_BLEND, 6);
-		Gdx.gl32.glBlendFunci(6, GL20.GL_SRC_ALPHA, GL20.GL_ONE_MINUS_SRC_ALPHA);
-		Gdx.gl32.glBlendEquationSeparatei(6, GL32.GL_FUNC_REVERSE_SUBTRACT, GL20.GL_FUNC_ADD);
+		gl32.glEnablei(GL20.GL_BLEND, 6);
+		gl32.glBlendFunci(6, GL20.GL_SRC_ALPHA, GL20.GL_ONE_MINUS_SRC_ALPHA);
+		gl32.glBlendEquationSeparatei(6, GL32.GL_FUNC_REVERSE_SUBTRACT, GL20.GL_FUNC_ADD);
 
-		Gdx.gl32.glEnablei(GL20.GL_BLEND, 7);
-		Gdx.gl32.glBlendFunci(7, GL20.GL_SRC_ALPHA, GL20.GL_ONE_MINUS_SRC_ALPHA);
-		Gdx.gl32.glBlendEquationSeparatei(7, GL32.GL_MAX, GL20.GL_FUNC_ADD);
+		gl32.glEnablei(GL20.GL_BLEND, 7);
+		gl32.glBlendFunci(7, GL20.GL_SRC_ALPHA, GL20.GL_ONE_MINUS_SRC_ALPHA);
+		gl32.glBlendEquationSeparatei(7, GL32.GL_MAX, GL20.GL_FUNC_ADD);
 
 		// render into MRT fbo
 		fbo.begin();
@@ -198,10 +198,10 @@ public class GL32MultipleRenderTargetsBlendingTest extends GdxTest {
 
 		// reset GL state
 		for (int i = 0; i < 8; i++) {
-			Gdx.gl32.glDisablei(GL20.GL_BLEND, i);
-			Gdx.gl32.glBlendEquationi(i, GL20.GL_FUNC_ADD);
-			Gdx.gl32.glBlendFunci(i, GL20.GL_SRC_ALPHA, GL20.GL_ONE_MINUS_SRC_ALPHA);
-			Gdx.gl32.glColorMaski(i, true, true, true, true);
+			gl32.glDisablei(GL20.GL_BLEND, i);
+			gl32.glBlendEquationi(i, GL20.GL_FUNC_ADD);
+			gl32.glBlendFunci(i, GL20.GL_SRC_ALPHA, GL20.GL_ONE_MINUS_SRC_ALPHA);
+			gl32.glColorMaski(i, true, true, true, true);
 		}
 
 		// Display render targets

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gles32/GL32OffsetElementsTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gles32/GL32OffsetElementsTest.java
@@ -18,7 +18,6 @@ package com.badlogic.gdx.tests.gles32;
 
 import java.nio.ShortBuffer;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Mesh;
@@ -87,7 +86,7 @@ public class GL32OffsetElementsTest extends GdxTest {
 
 	@Override
 	public void render () {
-		time += Gdx.graphics.getDeltaTime();
+		time += graphics.getDeltaTime();
 
 		int baseVertex = ((int)time) % 3;
 
@@ -98,7 +97,7 @@ public class GL32OffsetElementsTest extends GdxTest {
 		shader.setUniformMatrix("u_projTrans", transform);
 
 		mesh.bind(shader);
-		Gdx.gl32.glDrawElementsBaseVertex(GL20.GL_TRIANGLES, 6, GL20.GL_UNSIGNED_SHORT, indices, baseVertex);
+		gl32.glDrawElementsBaseVertex(GL20.GL_TRIANGLES, 6, GL20.GL_UNSIGNED_SHORT, indices, baseVertex);
 		mesh.unbind(shader);
 	}
 }

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtBinaryTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtBinaryTest.java
@@ -19,7 +19,6 @@ package com.badlogic.gdx.tests.gwt;
 import java.io.DataInputStream;
 import java.io.IOException;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.tests.utils.GdxTest;
 import com.badlogic.gdx.utils.ScreenUtils;
@@ -29,7 +28,7 @@ public class GwtBinaryTest extends GdxTest {
 
 	@Override
 	public void create () {
-		FileHandle handle = Gdx.files.internal("data/lsans.ttf");
+		FileHandle handle = files.internal("data/lsans.ttf");
 		bytes = new byte[(int)handle.length()];
 		DataInputStream in = new DataInputStream(handle.read());
 		for (int i = 0; i < 100; i++) {

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtInputTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtInputTest.java
@@ -34,70 +34,70 @@ public class GwtInputTest extends GdxTest {
 	@Override
 	public void create () {
 		renderer = new ShapeRenderer();
-		Gdx.input.setInputProcessor(this);
-		Gdx.app.setLogLevel(Application.LOG_DEBUG);
-		Gdx.input.setCursorCatched(true);
+		input.setInputProcessor(this);
+		app.setLogLevel(Application.LOG_DEBUG);
+		input.setCursorCatched(true);
 	}
 
 	@Override
 	public void render () {
 		ScreenUtils.clear(0, 0, 0, 1);
 		renderer.begin(ShapeType.Filled);
-		if (Gdx.input.isTouched())
+		if (input.isTouched())
 			renderer.setColor(Color.RED);
 		else
 			renderer.setColor(Color.GREEN);
-		renderer.rect(Gdx.input.getX() - 15, Gdx.graphics.getHeight() - Gdx.input.getY() - 15, 30, 30);
+		renderer.rect(input.getX() - 15, graphics.getHeight() - input.getY() - 15, 30, 30);
 		renderer.rect(x, y, 30, 30);
 		renderer.end();
 
-		if (Gdx.input.isKeyPressed(Keys.ALT_LEFT)) {
-			Gdx.app.log("GwtInputTest", "key pressed: " + "ALT_LEFT");
+		if (input.isKeyPressed(Keys.ALT_LEFT)) {
+			app.log("GwtInputTest", "key pressed: " + "ALT_LEFT");
 		}
-		if (Gdx.input.isKeyPressed(Keys.CONTROL_LEFT)) {
-			Gdx.app.log("GwtInputTest", "key pressed: " + "CTRL_LEFT");
+		if (input.isKeyPressed(Keys.CONTROL_LEFT)) {
+			app.log("GwtInputTest", "key pressed: " + "CTRL_LEFT");
 		}
-		if (Gdx.input.isKeyPressed(Keys.LEFT)) {
+		if (input.isKeyPressed(Keys.LEFT)) {
 			x -= 1;
 		}
 
-		if (Gdx.input.isKeyPressed(Keys.RIGHT)) {
+		if (input.isKeyPressed(Keys.RIGHT)) {
 			x += 1;
 		}
 
-		if (Gdx.input.isKeyPressed(Keys.UP)) {
+		if (input.isKeyPressed(Keys.UP)) {
 			y += 1;
 		}
 
-		if (Gdx.input.isKeyPressed(Keys.DOWN)) {
+		if (input.isKeyPressed(Keys.DOWN)) {
 			y -= 1;
 		}
-		if (Gdx.input.isButtonJustPressed(Input.Buttons.LEFT)) {
-			Gdx.app.log("GwtInputTest", "button pressed: LEFT");
+		if (input.isButtonJustPressed(Input.Buttons.LEFT)) {
+			app.log("GwtInputTest", "button pressed: LEFT");
 		}
-		if (Gdx.input.isButtonJustPressed(Input.Buttons.MIDDLE)) {
-			Gdx.app.log("GwtInputTest", "button pressed: MIDDLE");
+		if (input.isButtonJustPressed(Input.Buttons.MIDDLE)) {
+			app.log("GwtInputTest", "button pressed: MIDDLE");
 		}
-		if (Gdx.input.isButtonJustPressed(Input.Buttons.RIGHT)) {
-			Gdx.app.log("GwtInputTest", "button pressed: RIGHT");
+		if (input.isButtonJustPressed(Input.Buttons.RIGHT)) {
+			app.log("GwtInputTest", "button pressed: RIGHT");
 		}
 	}
 
 	@Override
 	public boolean keyDown (int keycode) {
-		Gdx.app.log("GdxInputTest", "key down: " + keycode);
+		app.log("GdxInputTest", "key down: " + keycode);
 		return super.keyDown(keycode);
 	}
 
 	@Override
 	public boolean keyTyped (char character) {
-		Gdx.app.log("GdxInputTest", "key typed: '" + character + "'");
+		app.log("GdxInputTest", "key typed: '" + character + "'");
 		return false;
 	}
 
 	@Override
 	public boolean keyUp (int keycode) {
-		Gdx.app.log("GdxInputTest", "key up: " + keycode);
+		app.log("GdxInputTest", "key up: " + keycode);
 		return false;
 	}
 }

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtTest.java
@@ -19,7 +19,6 @@ package com.badlogic.gdx.tests.gwt;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Preferences;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
@@ -57,38 +56,38 @@ public class GwtTest extends GdxTest {
 
 	@Override
 	public void create () {
-		Preferences pref = Gdx.app.getPreferences("test");
+		Preferences pref = app.getPreferences("test");
 		boolean resultb = pref.getBoolean("test");
 		int resulti = pref.getInteger("test");
 
-		shader = new ShaderProgram(Gdx.files.internal("data/shaders/shader-vs.glsl"),
-			Gdx.files.internal("data/shaders/shader-fs.glsl"));
+		shader = new ShaderProgram(files.internal("data/shaders/shader-vs.glsl"),
+			files.internal("data/shaders/shader-fs.glsl"));
 		if (!shader.isCompiled()) throw new GdxRuntimeException(shader.getLog());
 		mesh = new Mesh(VertexDataType.VertexBufferObject, true, 6, 0, VertexAttribute.Position(), VertexAttribute.TexCoords(0));
 		mesh.setVertices(new float[] {-0.5f, -0.5f, 0, 0, 1, 0.5f, -0.5f, 0, 1, 1, 0.5f, 0.5f, 0, 1, 0, 0.5f, 0.5f, 0, 1, 0, -0.5f,
 			0.5f, 0, 0, 0, -0.5f, -0.5f, 0, 0, 1});
 
-		texture = new Texture(new Pixmap(Gdx.files.internal("data/badlogic.jpg")), true);
+		texture = new Texture(new Pixmap(files.internal("data/badlogic.jpg")), true);
 		texture.setFilter(TextureFilter.MipMap, TextureFilter.Linear);
 
-		String params = Gdx.files.internal("data/gwttestparams.txt").readString();
+		String params = files.internal("data/gwttestparams.txt").readString();
 		numSprites = Integer.parseInt(params);
 
 		batch = new SpriteBatch();
 		positions = new ArrayList<Vector2>();
 		for (int i = 0; i < numSprites; i++) {
-			positions.add(new Vector2(MathUtils.random() * Gdx.graphics.getWidth(), MathUtils.random() * Gdx.graphics.getHeight()));
+			positions.add(new Vector2(MathUtils.random() * graphics.getWidth(), MathUtils.random() * graphics.getHeight()));
 		}
 		sprite = new Sprite(texture);
 		sprite.setSize(64, 64);
 		sprite.setOrigin(32, 32);
 
-		font = new BitmapFont(Gdx.files.internal("data/lsans-15.fnt"), false);
+		font = new BitmapFont(files.internal("data/lsans-15.fnt"), false);
 		cache = font.newFontCache();
 		cache.setColor(Color.RED);
 		cache.setText("This is a Test", 0, 0);
 
-		atlas = new TextureAtlas(Gdx.files.internal("data/pack.atlas"));
+		atlas = new TextureAtlas(files.internal("data/pack.atlas"));
 	}
 
 	@Override
@@ -102,13 +101,13 @@ public class GwtTest extends GdxTest {
 
 		batch.begin();
 		batch.draw(atlas.findRegion("font"), 0, 100);
-		sprite.rotate(Gdx.graphics.getDeltaTime() * 45);
+		sprite.rotate(graphics.getDeltaTime() * 45);
 		for (Vector2 position : positions) {
 			sprite.setPosition(position.x, position.y);
 			sprite.draw(batch);
 		}
 		font.draw(batch,
-			"fps:" + Gdx.graphics.getFramesPerSecond() + ", delta: " + Gdx.graphics.getDeltaTime() + ", #sprites: " + numSprites, 0,
+			"fps:" + graphics.getFramesPerSecond() + ", delta: " + graphics.getDeltaTime() + ", #sprites: " + numSprites, 0,
 			30);
 		cache.setPosition(200, 200);
 		cache.draw(batch);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtWindowModeTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/gwt/GwtWindowModeTest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests.gwt;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.scenes.scene2d.InputEvent;
 import com.badlogic.gdx.scenes.scene2d.Stage;
@@ -34,41 +33,41 @@ public class GwtWindowModeTest extends GdxTest {
 
 	public void create () {
 		stage = new Stage();
-		Gdx.input.setInputProcessor(stage);
-		Skin skin = new Skin(Gdx.files.internal("data/uiskin.json"));
+		input.setInputProcessor(stage);
+		Skin skin = new Skin(files.internal("data/uiskin.json"));
 
 		changeModeButton = new TextButton(windowedInstructions, skin);
-		changeModeButton.setSize(Gdx.graphics.getWidth() / 2, Gdx.graphics.getHeight() / 2);
-		changeModeButton.setPosition(Gdx.graphics.getWidth() / 4, Gdx.graphics.getHeight() / 4);
+		changeModeButton.setSize(graphics.getWidth() / 2, graphics.getHeight() / 2);
+		changeModeButton.setPosition(graphics.getWidth() / 4, graphics.getHeight() / 4);
 		stage.addActor(changeModeButton);
 
 		changeModeButton.addListener(new ClickListener() {
 			@Override
 			public void clicked (InputEvent event, float x, float y) {
 				super.clicked(event, x, y);
-				if (!Gdx.graphics.isFullscreen()) {
-					Gdx.graphics.setFullscreenMode(Gdx.graphics.getDisplayMode());
+				if (!graphics.isFullscreen()) {
+					graphics.setFullscreenMode(graphics.getDisplayMode());
 				} else {
-					Gdx.graphics.setWindowedMode(Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+					graphics.setWindowedMode(graphics.getWidth(), graphics.getHeight());
 				}
 			}
 		});
-		if (!Gdx.graphics.supportsDisplayModeChange()) {
+		if (!graphics.supportsDisplayModeChange()) {
 			changeModeButton.setDisabled(true);
 			changeModeButton.setText(notSupported);
 		}
 	}
 
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-		stage.act(Gdx.graphics.getDeltaTime());
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		stage.act(graphics.getDeltaTime());
 		stage.draw();
 	}
 
 	public void resize (int width, int height) {
 		stage.getViewport().update(width, height, true);
-		if (Gdx.graphics.supportsDisplayModeChange()) {
-			if (Gdx.graphics.isFullscreen()) {
+		if (graphics.supportsDisplayModeChange()) {
+			if (graphics.isFullscreen()) {
 				changeModeButton.setText(fullScreenInstructions);
 			} else {
 				changeModeButton.setText(windowedInstructions);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/math/CollisionPlaygroundTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/math/CollisionPlaygroundTest.java
@@ -17,7 +17,6 @@
 package com.badlogic.gdx.tests.math;
 
 import com.badlogic.gdx.ApplicationListener;
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.InputMultiplexer;
 import com.badlogic.gdx.graphics.Color;
@@ -75,7 +74,7 @@ public class CollisionPlaygroundTest extends GdxTest implements ApplicationListe
 
 	@Override
 	public void create () {
-		font = new BitmapFont(Gdx.files.internal("data/lsans-15.fnt"), false);
+		font = new BitmapFont(files.internal("data/lsans-15.fnt"), false);
 		batch = new SpriteBatch();
 		modelBatch = new ModelBatch();
 
@@ -84,7 +83,7 @@ public class CollisionPlaygroundTest extends GdxTest implements ApplicationListe
 		InputMultiplexer inputMultiplexer = new InputMultiplexer();
 		inputMultiplexer.addProcessor(cameraController);
 		inputMultiplexer.addProcessor(this);
-		Gdx.input.setInputProcessor(inputMultiplexer);
+		input.setInputProcessor(inputMultiplexer);
 	}
 
 	private void setupScene () {
@@ -108,7 +107,7 @@ public class CollisionPlaygroundTest extends GdxTest implements ApplicationListe
 	}
 
 	private void setupCamera () {
-		camera = new PerspectiveCamera(60f, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+		camera = new PerspectiveCamera(60f, graphics.getWidth(), graphics.getHeight());
 		camera.near = 0.01f;
 		camera.far = 100f;
 		camera.position.set(0, 5, 0);
@@ -116,7 +115,7 @@ public class CollisionPlaygroundTest extends GdxTest implements ApplicationListe
 		camera.update();
 		cameraController = new CameraInputController(camera);
 
-		collisionCamera = new PerspectiveCamera(60f, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+		collisionCamera = new PerspectiveCamera(60f, graphics.getWidth(), graphics.getHeight());
 		collisionCamera.near = 0.01f;
 		collisionCamera.far = 3f;
 		collisionCamera.position.set(1, 0, 0);
@@ -126,13 +125,13 @@ public class CollisionPlaygroundTest extends GdxTest implements ApplicationListe
 
 	@Override
 	public void render () {
-		Gdx.gl.glClearColor(0, 0, 0, 0);
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
+		gl.glClearColor(0, 0, 0, 0);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
 
 		// Draw FPS
-		batch.getProjectionMatrix().setToOrtho2D(0, 0, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+		batch.getProjectionMatrix().setToOrtho2D(0, 0, graphics.getWidth(), graphics.getHeight());
 		batch.begin();
-		font.draw(batch, "fps: " + Gdx.graphics.getFramesPerSecond(), 0, 30);
+		font.draw(batch, "fps: " + graphics.getFramesPerSecond(), 0, 30);
 		font.draw(batch, "seed: " + seed, 0, 50);
 		batch.end();
 
@@ -148,7 +147,7 @@ public class CollisionPlaygroundTest extends GdxTest implements ApplicationListe
 	}
 
 	private void checkCollision () {
-		Ray ray = camera.getPickRay(Gdx.input.getX(), Gdx.input.getY());
+		Ray ray = camera.getPickRay(input.getX(), input.getY());
 
 		for (Shape shape : shapes) {
 			if (shape.isColliding(ray)) {

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/math/OctreeTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/math/OctreeTest.java
@@ -17,7 +17,6 @@
 package com.badlogic.gdx.tests.math;
 
 import com.badlogic.gdx.ApplicationListener;
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
@@ -73,7 +72,7 @@ public class OctreeTest extends GdxTest implements ApplicationListener {
 		lights.set(new ColorAttribute(ColorAttribute.AmbientLight, 0.4f, 0.4f, 0.4f, 1.f));
 		lights.add(new DirectionalLight().set(0.8f, 0.8f, 0.8f, -1f, -0.8f, -0.2f));
 
-		cam = new PerspectiveCamera(67, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+		cam = new PerspectiveCamera(67, graphics.getWidth(), graphics.getHeight());
 		cam.position.set(0f, 0f, 15f);
 		cam.lookAt(0, 0, 1);
 		cam.near = 0.1f;
@@ -81,7 +80,7 @@ public class OctreeTest extends GdxTest implements ApplicationListener {
 		cam.update(true);
 
 		camController = new FirstPersonCameraController(cam);
-		Gdx.input.setInputProcessor(this);
+		input.setInputProcessor(this);
 
 		Vector3 min = new Vector3(-AREA_SIZE / 2, -AREA_SIZE / 2, -AREA_SIZE / 2);
 		Vector3 max = new Vector3(AREA_SIZE / 2, AREA_SIZE / 2, AREA_SIZE / 2);
@@ -119,14 +118,14 @@ public class OctreeTest extends GdxTest implements ApplicationListener {
 	public void render () {
 		camController.update();
 
-		Gdx.gl.glViewport(0, 0, Gdx.graphics.getBackBufferWidth(), Gdx.graphics.getBackBufferHeight());
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
+		gl.glViewport(0, 0, graphics.getBackBufferWidth(), graphics.getBackBufferHeight());
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
 
 		modelBatch.begin(cam);
 
 		octree.query(cam.frustum, tmpResult);
 		for (GameObject gameObject : tmpResult) {
-			Gdx.app.log("", "Rendering: " + tmpResult.size);
+			app.log("", "Rendering: " + tmpResult.size);
 			modelBatch.render(gameObject.instance, lights);
 			modelBatch.render(gameObject.boxEdges);
 		}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/math/collision/OrientedBoundingBoxTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/math/collision/OrientedBoundingBoxTest.java
@@ -17,7 +17,6 @@
 package com.badlogic.gdx.tests.math.collision;
 
 import com.badlogic.gdx.ApplicationListener;
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.InputMultiplexer;
 import com.badlogic.gdx.graphics.Color;
@@ -63,7 +62,7 @@ public class OrientedBoundingBoxTest extends GdxTest implements ApplicationListe
 
 	@Override
 	public void create () {
-		font = new BitmapFont(Gdx.files.internal("data/lsans-15.fnt"), false);
+		font = new BitmapFont(files.internal("data/lsans-15.fnt"), false);
 		batch = new SpriteBatch();
 		modelBatch = new ModelBatch();
 
@@ -72,7 +71,7 @@ public class OrientedBoundingBoxTest extends GdxTest implements ApplicationListe
 		InputMultiplexer inputMultiplexer = new InputMultiplexer();
 		inputMultiplexer.addProcessor(cameraController);
 		inputMultiplexer.addProcessor(this);
-		Gdx.input.setInputProcessor(inputMultiplexer);
+		input.setInputProcessor(inputMultiplexer);
 	}
 
 	private void setupScene () {
@@ -91,7 +90,7 @@ public class OrientedBoundingBoxTest extends GdxTest implements ApplicationListe
 	}
 
 	private void setupCamera () {
-		camera = new PerspectiveCamera(60f, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+		camera = new PerspectiveCamera(60f, graphics.getWidth(), graphics.getHeight());
 		camera.near = 0.01f;
 		camera.far = 100f;
 		camera.position.set(0, 5, -2);
@@ -103,13 +102,13 @@ public class OrientedBoundingBoxTest extends GdxTest implements ApplicationListe
 
 	@Override
 	public void render () {
-		Gdx.gl.glClearColor(0, 0, 0, 0);
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
+		gl.glClearColor(0, 0, 0, 0);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
 
 		// Draw FPS
-		batch.getProjectionMatrix().setToOrtho2D(0, 0, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+		batch.getProjectionMatrix().setToOrtho2D(0, 0, graphics.getWidth(), graphics.getHeight());
 		batch.begin();
-		font.draw(batch, "fps: " + Gdx.graphics.getFramesPerSecond(), 0, 30);
+		font.draw(batch, "fps: " + graphics.getFramesPerSecond(), 0, 30);
 		font.draw(batch, "seed: " + seed, 0, 50);
 		batch.end();
 
@@ -126,7 +125,7 @@ public class OrientedBoundingBoxTest extends GdxTest implements ApplicationListe
 	}
 
 	private void checkCollision () {
-		Ray ray = camera.getPickRay(Gdx.input.getX(), Gdx.input.getY());
+		Ray ray = camera.getPickRay(input.getX(), input.getY());
 
 		// Reset all boxes
 		for (Box box : boxes) {

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/net/HttpRequestExample.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/net/HttpRequestExample.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests.net;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Net.HttpMethods;
 import com.badlogic.gdx.Net.HttpRequest;
 import com.badlogic.gdx.Net.HttpResponse;
@@ -30,20 +29,20 @@ public class HttpRequestExample extends GdxTest {
 	public void create () {
 		HttpRequest request = new HttpRequest(HttpMethods.GET);
 		request.setUrl("https://raw.githubusercontent.com/libgdx/libgdx/master/AUTHORS");
-		Gdx.net.sendHttpRequest(request, new HttpResponseListener() {
+		net.sendHttpRequest(request, new HttpResponseListener() {
 			@Override
 			public void handleHttpResponse (HttpResponse httpResponse) {
-				Gdx.app.log("HttpRequestExample", "response: " + httpResponse.getResultAsString());
+				app.log("HttpRequestExample", "response: " + httpResponse.getResultAsString());
 			}
 
 			@Override
 			public void failed (Throwable t) {
-				Gdx.app.error("HttpRequestExample", "something went wrong", t);
+				app.error("HttpRequestExample", "something went wrong", t);
 			}
 
 			@Override
 			public void cancelled () {
-				Gdx.app.log("HttpRequestExample", "cancelled");
+				app.log("HttpRequestExample", "cancelled");
 			}
 		});
 	}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/net/NetAPITest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/net/NetAPITest.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests.net;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Net;
 import com.badlogic.gdx.Net.HttpRequest;
 import com.badlogic.gdx.Net.HttpResponse;
@@ -74,17 +73,17 @@ public class NetAPITest extends GdxTest implements HttpResponseListener {
 	@Override
 	public void create () {
 		batch = new SpriteBatch();
-		skin = new Skin(Gdx.files.internal("data/uiskin.json"));
+		skin = new Skin(files.internal("data/uiskin.json"));
 		font = new BitmapFont();
 		stage = new Stage();
-		Gdx.input.setInputProcessor(stage);
+		input.setInputProcessor(stage);
 
 		{
 			statusLabel = new Label("", skin);
 			statusLabel.setWrap(true);
-			statusLabel.setWidth(Gdx.graphics.getWidth() * 0.96f);
+			statusLabel.setWidth(graphics.getWidth() * 0.96f);
 			statusLabel.setAlignment(Align.center);
-			statusLabel.setPosition(Gdx.graphics.getWidth() * 0.5f - statusLabel.getWidth() * 0.5f, 30f);
+			statusLabel.setPosition(graphics.getWidth() * 0.5f - statusLabel.getWidth() * 0.5f, 30f);
 			statusLabel.setColor(Color.CYAN);
 			stage.addActor(statusLabel);
 		}
@@ -113,7 +112,7 @@ public class NetAPITest extends GdxTest implements HttpResponseListener {
 					else if (clickedButton == btnDownloadError)
 						url = "https://libgdx.com/doesnotexist";
 					else if (clickedButton == btnOpenUri) {
-						Gdx.net.openURI("https://libgdx.com");
+						net.openURI("https://libgdx.com");
 						return;
 					} else {
 						url = "https://httpbin.org/post";
@@ -124,7 +123,7 @@ public class NetAPITest extends GdxTest implements HttpResponseListener {
 					httpRequest = new HttpRequest(httpMethod);
 					httpRequest.setUrl(url);
 					httpRequest.setContent(requestContent);
-					Gdx.net.sendHttpRequest(httpRequest, NetAPITest.this);
+					net.sendHttpRequest(httpRequest, NetAPITest.this);
 
 					statusLabel.setText("Downloading data from " + httpRequest.getUrl());
 				}
@@ -135,15 +134,15 @@ public class NetAPITest extends GdxTest implements HttpResponseListener {
 				public void clicked (InputEvent event, float x, float y) {
 					super.clicked(event, x, y);
 					if (httpRequest != null) {
-						Gdx.net.cancelHttpRequest(httpRequest);
-						Gdx.app.log("NetAPITest", "Cancelling request " + httpRequest.getUrl());
+						net.cancelHttpRequest(httpRequest);
+						app.log("NetAPITest", "Cancelling request " + httpRequest.getUrl());
 						statusLabel.setText("Cancelling request " + httpRequest.getUrl());
 					}
 				}
 			};
 
 			btnCancel = new TextButton("Cancel", skin);
-			btnCancel.setPosition(Gdx.graphics.getWidth() * 0.10f, 60f);
+			btnCancel.setPosition(graphics.getWidth() * 0.10f, 60f);
 			btnCancel.addListener(cancelListener);
 			stage.addActor(btnCancel);
 
@@ -186,7 +185,7 @@ public class NetAPITest extends GdxTest implements HttpResponseListener {
 
 		final int statusCode = httpResponse.getStatus().getStatusCode();
 		// We are not in main thread right now so we need to post to main thread for ui updates
-		Gdx.app.postRunnable(new Runnable() {
+		app.postRunnable(new Runnable() {
 			@Override
 			public void run () {
 				statusLabel.setText("HTTP Request status: " + statusCode);
@@ -195,14 +194,14 @@ public class NetAPITest extends GdxTest implements HttpResponseListener {
 		});
 
 		if (statusCode != 200) {
-			Gdx.app.log("NetAPITest", "An error ocurred since statusCode is not OK");
+			app.log("NetAPITest", "An error ocurred since statusCode is not OK");
 			setText(httpResponse);
 			return;
 		}
 
 		if (clickedButton == btnDownloadImage) {
 			final byte[] rawImageBytes = httpResponse.getResult();
-			Gdx.app.postRunnable(new Runnable() {
+			app.postRunnable(new Runnable() {
 				public void run () {
 					Pixmap pixmap = new Pixmap(rawImageBytes, 0, rawImageBytes.length);
 					texture = new Texture(pixmap);
@@ -210,13 +209,13 @@ public class NetAPITest extends GdxTest implements HttpResponseListener {
 			});
 
 		} else if (clickedButton == btnDownloadLarge) {
-			Gdx.app.postRunnable(new Runnable() {
+			app.postRunnable(new Runnable() {
 				public void run () {
 					text = "Retrieving large file...";
 				}
 			});
 			final byte[] rawFileBytes = httpResponse.getResult();
-			Gdx.app.postRunnable(new Runnable() {
+			app.postRunnable(new Runnable() {
 				public void run () {
 					text = "Retrieved large file: " + rawFileBytes.length;
 				}
@@ -229,7 +228,7 @@ public class NetAPITest extends GdxTest implements HttpResponseListener {
 
 	void setText (HttpResponse httpResponse) {
 		final String newText = httpResponse.getResultAsString();
-		Gdx.app.postRunnable(new Runnable() {
+		app.postRunnable(new Runnable() {
 			public void run () {
 				text = newText;
 			}
@@ -265,15 +264,15 @@ public class NetAPITest extends GdxTest implements HttpResponseListener {
 
 		if (texture != null) {
 			batch.begin();
-			batch.draw(texture, Gdx.graphics.getWidth() * 0.5f - texture.getWidth() * 0.5f, 100f);
+			batch.draw(texture, graphics.getWidth() * 0.5f - texture.getWidth() * 0.5f, 100f);
 			batch.end();
 		} else if (text != null) {
 			batch.begin();
-			font.draw(batch, text, 10, Gdx.graphics.getHeight() - 10);
+			font.draw(batch, text, 10, graphics.getHeight() - 10);
 			batch.end();
 		}
 
-		stage.act(Gdx.graphics.getDeltaTime());
+		stage.act(graphics.getDeltaTime());
 		stage.draw();
 	}
 
@@ -284,10 +283,10 @@ public class NetAPITest extends GdxTest implements HttpResponseListener {
 
 	@Override
 	public void cancelled () {
-		Gdx.app.postRunnable(new Runnable() {
+		app.postRunnable(new Runnable() {
 			public void run () {
 				setButtonDisabled(false);
-				Gdx.app.log("NetAPITest", "HTTP request cancelled");
+				app.log("NetAPITest", "HTTP request cancelled");
 				statusLabel.setText("HTTP request cancelled");
 			}
 		});

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/net/OpenBrowserExample.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/net/OpenBrowserExample.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests.net;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.tests.utils.GdxTest;
 
 /** Demonstrates how to open a browser and load a specific URL.
@@ -24,6 +23,6 @@ import com.badlogic.gdx.tests.utils.GdxTest;
 public class OpenBrowserExample extends GdxTest {
 	@Override
 	public void create () {
-		Gdx.net.openURI("https://libgdx.com");
+		net.openURI("https://libgdx.com");
 	}
 }

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/net/PingPongSocketExample.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/net/PingPongSocketExample.java
@@ -20,7 +20,6 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Net.Protocol;
 import com.badlogic.gdx.net.ServerSocket;
 import com.badlogic.gdx.net.ServerSocketHints;
@@ -42,16 +41,16 @@ public class PingPongSocketExample extends GdxTest {
 			@Override
 			public void run () {
 				ServerSocketHints hints = new ServerSocketHints();
-				ServerSocket server = Gdx.net.newServerSocket(Protocol.TCP, "localhost", 9999, hints);
+				ServerSocket server = net.newServerSocket(Protocol.TCP, "localhost", 9999, hints);
 				// wait for the next client connection
 				Socket client = server.accept(null);
 				// read message and send it back
 				try {
 					String message = new BufferedReader(new InputStreamReader(client.getInputStream())).readLine();
-					Gdx.app.log("PingPongSocketExample", "got client message: " + message);
+					app.log("PingPongSocketExample", "got client message: " + message);
 					client.getOutputStream().write("PONG\n".getBytes());
 				} catch (IOException e) {
-					Gdx.app.log("PingPongSocketExample", "an error occured", e);
+					app.log("PingPongSocketExample", "an error occured", e);
 				}
 			}
 		}).start();
@@ -59,13 +58,13 @@ public class PingPongSocketExample extends GdxTest {
 		// create the client send a message, then wait for the
 		// server to reply
 		SocketHints hints = new SocketHints();
-		Socket client = Gdx.net.newClientSocket(Protocol.TCP, "localhost", 9999, hints);
+		Socket client = net.newClientSocket(Protocol.TCP, "localhost", 9999, hints);
 		try {
 			client.getOutputStream().write("PING\n".getBytes());
 			String response = new BufferedReader(new InputStreamReader(client.getInputStream())).readLine();
-			Gdx.app.log("PingPongSocketExample", "got server message: " + response);
+			app.log("PingPongSocketExample", "got server message: " + response);
 		} catch (IOException e) {
-			Gdx.app.log("PingPongSocketExample", "an error occured", e);
+			app.log("PingPongSocketExample", "an error occured", e);
 		}
 	}
 }

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/superkoalio/SuperKoalio.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/superkoalio/SuperKoalio.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.tests.superkoalio;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input.Keys;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.OrthographicCamera;
@@ -125,7 +124,7 @@ public class SuperKoalio extends GdxTest {
 		ScreenUtils.clear(0.7f, 0.7f, 1.0f, 1);
 
 		// get the delta time
-		float deltaTime = Gdx.graphics.getDeltaTime();
+		float deltaTime = graphics.getDeltaTime();
 
 		// update the koala (process input, collision detection, position update)
 		updateKoala(deltaTime);
@@ -154,25 +153,25 @@ public class SuperKoalio extends GdxTest {
 		koala.stateTime += deltaTime;
 
 		// check input and apply to velocity & state
-		if ((Gdx.input.isKeyPressed(Keys.SPACE) || isTouched(0.5f, 1)) && koala.grounded) {
+		if ((input.isKeyPressed(Keys.SPACE) || isTouched(0.5f, 1)) && koala.grounded) {
 			koala.velocity.y += Koala.JUMP_VELOCITY;
 			koala.state = Koala.State.Jumping;
 			koala.grounded = false;
 		}
 
-		if (Gdx.input.isKeyPressed(Keys.LEFT) || Gdx.input.isKeyPressed(Keys.A) || isTouched(0, 0.25f)) {
+		if (input.isKeyPressed(Keys.LEFT) || input.isKeyPressed(Keys.A) || isTouched(0, 0.25f)) {
 			koala.velocity.x = -Koala.MAX_VELOCITY;
 			if (koala.grounded) koala.state = Koala.State.Walking;
 			koala.facesRight = false;
 		}
 
-		if (Gdx.input.isKeyPressed(Keys.RIGHT) || Gdx.input.isKeyPressed(Keys.D) || isTouched(0.25f, 0.5f)) {
+		if (input.isKeyPressed(Keys.RIGHT) || input.isKeyPressed(Keys.D) || isTouched(0.25f, 0.5f)) {
 			koala.velocity.x = Koala.MAX_VELOCITY;
 			if (koala.grounded) koala.state = Koala.State.Walking;
 			koala.facesRight = true;
 		}
 
-		if (Gdx.input.isKeyJustPressed(Keys.B)) debug = !debug;
+		if (input.isKeyJustPressed(Keys.B)) debug = !debug;
 
 		// apply gravity if we are falling
 		koala.velocity.add(0, GRAVITY);
@@ -259,8 +258,8 @@ public class SuperKoalio extends GdxTest {
 		// Check for touch inputs between startX and endX
 		// startX/endX are given between 0 (left edge of the screen) and 1 (right edge of the screen)
 		for (int i = 0; i < 2; i++) {
-			float x = Gdx.input.getX(i) / (float)Gdx.graphics.getWidth();
-			if (Gdx.input.isTouched(i) && (x >= startX && x <= endX)) {
+			float x = input.getX(i) / (float)graphics.getWidth();
+			if (input.isTouched(i) && (x >= startX && x <= endX)) {
 				return true;
 			}
 		}

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTest.java
@@ -28,10 +28,60 @@
 
 package com.badlogic.gdx.tests.utils;
 
+import com.badlogic.gdx.Application;
 import com.badlogic.gdx.ApplicationListener;
+import com.badlogic.gdx.Audio;
+import com.badlogic.gdx.Files;
+import com.badlogic.gdx.Graphics;
+import com.badlogic.gdx.Input;
 import com.badlogic.gdx.InputAdapter;
+import com.badlogic.gdx.Net;
+import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.GL30;
+import com.badlogic.gdx.graphics.GL31;
+import com.badlogic.gdx.graphics.GL32;
 
 public abstract class GdxTest extends InputAdapter implements ApplicationListener {
+	/** Set by {@link #create(Application)}; prefer these over {@link com.badlogic.gdx.Gdx} statics. */
+	protected Application app;
+	protected Graphics graphics;
+	protected Audio audio;
+	protected Input input;
+	protected Files files;
+	protected Net net;
+	protected GL20 gl;
+	protected GL20 gl20;
+	protected GL30 gl30;
+	protected GL31 gl31;
+	protected GL32 gl32;
+
+	@Override
+	public void create (Application app) {
+		bind(app);
+		create();
+	}
+
+	/** Binds module fields from the given application (also used when a test is started from a collection UI). */
+	public void bind (Application app) {
+		this.app = app;
+		this.graphics = app.getGraphics();
+		this.audio = app.getAudio();
+		this.input = app.getInput();
+		this.files = app.getFiles();
+		this.net = app.getNet();
+		refreshGl();
+	}
+
+	/** Refresh GL aliases from {@link #graphics} (e.g. after context recreation). */
+	protected void refreshGl () {
+		if (graphics == null) return;
+		gl32 = graphics.getGL32();
+		gl31 = gl32 != null ? gl32 : graphics.getGL31();
+		gl30 = gl31 != null ? gl31 : graphics.getGL30();
+		gl20 = gl30 != null ? gl30 : graphics.getGL20();
+		gl = gl20;
+	}
+
 	public void create () {
 	}
 

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTestWrapper.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTestWrapper.java
@@ -23,19 +23,19 @@ public class GdxTestWrapper implements ApplicationListener {
 	}
 
 	@Override
-	public void create (Application app) {
+	public void create (Application application) {
 		if (logGLErrors) {
-			app.log("GLProfiler", "profiler enabled");
-			GLProfiler profiler = new GLProfiler(app.getGraphics());
+			application.log("GLProfiler", "profiler enabled");
+			GLProfiler profiler = new GLProfiler(application.getGraphics());
 			profiler.setListener(new GLErrorListener() {
 				@Override
 				public void onError (int error) {
-					app.error("GLProfiler", "error " + error);
+					application.error("GLProfiler", "error " + error);
 				}
 			});
 			profiler.enable();
 		}
-		this.app.create(app);
+		app.create(application);
 	}
 
 	@Override

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTestWrapper.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/GdxTestWrapper.java
@@ -1,6 +1,7 @@
 
 package com.badlogic.gdx.tests.utils;
 
+import com.badlogic.gdx.Application;
 import com.badlogic.gdx.ApplicationListener;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.profiling.GLErrorListener;
@@ -18,18 +19,23 @@ public class GdxTestWrapper implements ApplicationListener {
 
 	@Override
 	public void create () {
+		create(Gdx.app);
+	}
+
+	@Override
+	public void create (Application app) {
 		if (logGLErrors) {
-			Gdx.app.log("GLProfiler", "profiler enabled");
-			GLProfiler profiler = new GLProfiler(Gdx.graphics);
+			app.log("GLProfiler", "profiler enabled");
+			GLProfiler profiler = new GLProfiler(app.getGraphics());
 			profiler.setListener(new GLErrorListener() {
 				@Override
 				public void onError (int error) {
-					Gdx.app.error("GLProfiler", "error " + error);
+					app.error("GLProfiler", "error " + error);
 				}
 			});
 			profiler.enable();
 		}
-		app.create();
+		this.app.create(app);
 	}
 
 	@Override

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/IssueTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/utils/IssueTest.java
@@ -1,7 +1,6 @@
 
 package com.badlogic.gdx.tests.utils;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
@@ -22,7 +21,7 @@ public class IssueTest extends GdxTest {
 
 	@Override
 	public void render () {
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+		gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 		batch.begin();
 		batch.draw(img, 0, 0);
 		batch.draw(img2, 512, 0);


### PR DESCRIPTION
Gdx stays. The goal of this PR is to stop *requiring* it for core GL/resources.
  Backends still assign `Gdx.*`. Existing no-arg / old constructors keep working by defaulting to `Gdx.graphics` (etc.). New APIs take an explicit `Graphics` (and adapters bind `graphics` / `audio` /
  `input` / `files` / `net` / `gl*`) so call sites can avoid the static facade when they want to.
  ## What’s in this PR
 - API Addition: ScreenUtils/Pixmap.createFromFrameBuffer/ShapeRenderer/ImmediateModeRenderer20 and custom TextureData types take Graphics; existing APIs use Gdx.graphics.
- API Addition: RenderContext/DefaultTextureBinder/HdpiUtils/MipMapGenerator APIs that take Graphics; existing APIs use Gdx.graphics.
- API Addition: SpriteBatch/PolygonSpriteBatch/SpriteCache constructors that take Graphics; existing constructors use Gdx.graphics.
- API Addition: GLFrameBuffer/FrameBuffer/FloatFrameBuffer/FrameBufferCubemap constructors and builders that take Graphics; existing APIs use Gdx.graphics.
- API Addition: Mesh and Vertex/Index/Instance buffer object constructors that take Graphics; existing constructors use Gdx.graphics.
- API Addition: GLTexture/Texture/Cubemap/TextureArray/Texture3D constructors that take Graphics; existing constructors use Gdx.graphics.
- API Addition: ShaderProgram constructors that take Graphics; existing constructors use Gdx.graphics.
- API Change: Managed GL resources (ShaderProgram, Texture, Cubemap, TextureArray, Texture3D, Mesh, GLFrameBuffer) are keyed by Graphics instead of Application.
- API Addition: ApplicationListener#create(Application); backends call it, default delegates to create().
- API Addition: ApplicationAdapter/Game bind graphics/audio/input/files/net/gl* from create(Application).
  ## Non-goals (this PR)
  - Deleting `Gdx`
  - Stopping backends from assigning `Gdx.*`
  - Forcing every call site off `Gdx` in one change