### PR TITLE
Fix DefaultAndroidInput delta reset

### DIFF
--- a/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/DefaultAndroidInput.java
+++ b/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/DefaultAndroidInput.java
@@ -487,10 +487,8 @@ public class DefaultAndroidInput extends AbstractInput implements AndroidInput, 
 			}
 
 			if (touchEvents.isEmpty()) {
-				for (int i = 0; i < deltaX.length; i++) {
-					deltaX[0] = 0;
-					deltaY[0] = 0;
-				}
+				Arrays.fill(deltaX, 0);
+				Arrays.fill(deltaY, 0);
 			}
 
 			keyEvents.clear();


### PR DESCRIPTION
The existing implementation iterates over all indices but only resets
`deltaX[0]` and `deltaY[0]`.

Based on the discussion in #7837, this appears to be a long-standing
typo. Replace the loop with `Arrays.fill()` to reset all pointer deltas.

I'm opening this as a draft pending clarification of the intended behavior.