### PR TITLE
Deduplicate ANGLE EGL window creation fallback in Lwjgl3Application

### DIFF
--- a/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
+++ b/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3Application.java
@@ -510,30 +510,14 @@ public class Lwjgl3Application implements Lwjgl3ApplicationBase {
 			GLFW.glfwWindowHint(GLFW.GLFW_OPENGL_DEBUG_CONTEXT, GLFW.GLFW_TRUE);
 		}
 
-		long windowHandle = 0;
-
+		long windowHandle;
 		if (config.fullscreenMode != null) {
 			GLFW.glfwWindowHint(GLFW.GLFW_REFRESH_RATE, config.fullscreenMode.refreshRate);
-			windowHandle = GLFW.glfwCreateWindow(config.fullscreenMode.width, config.fullscreenMode.height, config.title,
+			windowHandle = createGlfwWindowHandle(config, config.fullscreenMode.width, config.fullscreenMode.height,
 				config.fullscreenMode.getMonitor(), sharedContextWindow);
-
-			// On Ubuntu >= 22.04 with Nvidia GPU drivers and X11 display server there's a bug with EGL Context API
-			// If the windows creation has failed for this reason try to create it again with the native context
-			if (windowHandle == 0 && config.glEmulation == Lwjgl3ApplicationConfiguration.GLEmulation.ANGLE_GLES20) {
-				GLFW.glfwWindowHint(GLFW.GLFW_CONTEXT_CREATION_API, GLFW.GLFW_NATIVE_CONTEXT_API);
-				windowHandle = GLFW.glfwCreateWindow(config.fullscreenMode.width, config.fullscreenMode.height, config.title,
-					config.fullscreenMode.getMonitor(), sharedContextWindow);
-			}
 		} else {
 			GLFW.glfwWindowHint(GLFW.GLFW_DECORATED, config.windowDecorated ? GLFW.GLFW_TRUE : GLFW.GLFW_FALSE);
-			windowHandle = GLFW.glfwCreateWindow(config.windowWidth, config.windowHeight, config.title, 0, sharedContextWindow);
-
-			// On Ubuntu >= 22.04 with Nvidia GPU drivers and X11 display server there's a bug with EGL Context API
-			// If the windows creation has failed for this reason try to create it again with the native context
-			if (windowHandle == 0 && config.glEmulation == Lwjgl3ApplicationConfiguration.GLEmulation.ANGLE_GLES20) {
-				GLFW.glfwWindowHint(GLFW.GLFW_CONTEXT_CREATION_API, GLFW.GLFW_NATIVE_CONTEXT_API);
-				windowHandle = GLFW.glfwCreateWindow(config.windowWidth, config.windowHeight, config.title, 0, sharedContextWindow);
-			}
+			windowHandle = createGlfwWindowHandle(config, config.windowWidth, config.windowHeight, 0, sharedContextWindow);
 		}
 		if (windowHandle == 0) {
 			throw new GdxRuntimeException("Couldn't create window");
@@ -606,6 +590,18 @@ public class Lwjgl3Application implements Lwjgl3ApplicationBase {
 			setGLDebugMessageControl(GLDebugMessageSeverity.NOTIFICATION, false);
 		}
 
+		return windowHandle;
+	}
+
+	private static long createGlfwWindowHandle (Lwjgl3ApplicationConfiguration config, int width, int height, long monitor,
+		long sharedContextWindow) {
+		long windowHandle = GLFW.glfwCreateWindow(width, height, config.title, monitor, sharedContextWindow);
+		// On Ubuntu >= 22.04 with Nvidia GPU drivers and X11 display server there's a bug with EGL Context API.
+		// If window creation failed for this reason, try again with the native context.
+		if (windowHandle == 0 && config.glEmulation == Lwjgl3ApplicationConfiguration.GLEmulation.ANGLE_GLES20) {
+			GLFW.glfwWindowHint(GLFW.GLFW_CONTEXT_CREATION_API, GLFW.GLFW_NATIVE_CONTEXT_API);
+			windowHandle = GLFW.glfwCreateWindow(width, height, config.title, monitor, sharedContextWindow);
+		}
 		return windowHandle;
 	}
 


### PR DESCRIPTION
Fullscreen and windowed paths shared the same Ubuntu/Nvidia ANGLE retry; extract createGlfwWindowHandle so the workaround lives in one place.