### PR TITLE
Add overloads for btRigidBody methods

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,7 +107,7 @@ allprojects {
 		lineEndings 'UNIX'
 
 		java {
-			target 'src/**/*.java', 'test/**/*.java', 'generator/**/*.java'
+			target 'src/**/*.java', 'test/**/*.java', 'generator/**/*.java', 'jni/swig-src/**/*.java'
 			removeUnusedImports()
 			eclipse().configFile new File(rootProject.projectDir.absolutePath, 'eclipse-formatter.xml')
 		}

--- a/extensions/gdx-bullet/jni/swig-src/dynamics/com/badlogic/gdx/physics/bullet/dynamics/DynamicsJNI.java
+++ b/extensions/gdx-bullet/jni/swig-src/dynamics/com/badlogic/gdx/physics/bullet/dynamics/DynamicsJNI.java
@@ -215,7 +215,7 @@ public class DynamicsJNI {
 
 	public final static native Vector3 btRigidBody_getLinearVelocity (long jarg1, btRigidBody jarg1_);
 
-	public final static native Vector3 btRigidBody_getAngularVelocity (long jarg1, btRigidBody jarg1_);
+	public final static native Vector3 btRigidBody_getAngularVelocity__SWIG_0 (long jarg1, btRigidBody jarg1_);
 
 	public final static native void btRigidBody_setLinearVelocity (long jarg1, btRigidBody jarg1_, Vector3 jarg2);
 
@@ -298,6 +298,8 @@ public class DynamicsJNI {
 
 	public final static native long new_btRigidBody__SWIG_2 (boolean jarg1, float jarg2, long jarg3, btMotionState jarg3_,
 		long jarg4, btCollisionShape jarg4_);
+
+	public final static native void btRigidBody_getAngularVelocity__SWIG_1 (long jarg1, btRigidBody jarg1_, Vector3 jarg2);
 
 	public final static native void btRigidBodyFloatData_collisionObjectData_set (long jarg1, btRigidBodyFloatData jarg1_,
 		long jarg2, btCollisionObjectFloatData jarg2_);

--- a/extensions/gdx-bullet/jni/swig-src/dynamics/com/badlogic/gdx/physics/bullet/dynamics/DynamicsJNI.java
+++ b/extensions/gdx-bullet/jni/swig-src/dynamics/com/badlogic/gdx/physics/bullet/dynamics/DynamicsJNI.java
@@ -153,7 +153,7 @@ public class DynamicsJNI {
 
 	public final static native void btRigidBody_setGravity (long jarg1, btRigidBody jarg1_, Vector3 jarg2);
 
-	public final static native Vector3 btRigidBody_getGravity (long jarg1, btRigidBody jarg1_);
+	public final static native Vector3 btRigidBody_getGravity__SWIG_0 (long jarg1, btRigidBody jarg1_);
 
 	public final static native void btRigidBody_setDamping (long jarg1, btRigidBody jarg1_, float jarg2, float jarg3);
 
@@ -169,7 +169,7 @@ public class DynamicsJNI {
 
 	public final static native void btRigidBody_setMassProps (long jarg1, btRigidBody jarg1_, float jarg2, Vector3 jarg3);
 
-	public final static native Vector3 btRigidBody_getLinearFactor (long jarg1, btRigidBody jarg1_);
+	public final static native Vector3 btRigidBody_getLinearFactor__SWIG_0 (long jarg1, btRigidBody jarg1_);
 
 	public final static native void btRigidBody_setLinearFactor (long jarg1, btRigidBody jarg1_, Vector3 jarg2);
 
@@ -183,11 +183,11 @@ public class DynamicsJNI {
 
 	public final static native void btRigidBody_applyCentralForce (long jarg1, btRigidBody jarg1_, Vector3 jarg2);
 
-	public final static native Vector3 btRigidBody_getTotalForce (long jarg1, btRigidBody jarg1_);
+	public final static native Vector3 btRigidBody_getTotalForce__SWIG_0 (long jarg1, btRigidBody jarg1_);
 
-	public final static native Vector3 btRigidBody_getTotalTorque (long jarg1, btRigidBody jarg1_);
+	public final static native Vector3 btRigidBody_getTotalTorque__SWIG_0 (long jarg1, btRigidBody jarg1_);
 
-	public final static native Vector3 btRigidBody_getInvInertiaDiagLocal (long jarg1, btRigidBody jarg1_);
+	public final static native Vector3 btRigidBody_getInvInertiaDiagLocal__SWIG_0 (long jarg1, btRigidBody jarg1_);
 
 	public final static native void btRigidBody_setInvInertiaDiagLocal (long jarg1, btRigidBody jarg1_, Vector3 jarg2);
 
@@ -207,13 +207,13 @@ public class DynamicsJNI {
 
 	public final static native void btRigidBody_updateInertiaTensor (long jarg1, btRigidBody jarg1_);
 
-	public final static native Vector3 btRigidBody_getCenterOfMassPosition (long jarg1, btRigidBody jarg1_);
+	public final static native Vector3 btRigidBody_getCenterOfMassPosition__SWIG_0 (long jarg1, btRigidBody jarg1_);
 
 	public final static native Quaternion btRigidBody_getOrientation (long jarg1, btRigidBody jarg1_);
 
-	public final static native Matrix4 btRigidBody_getCenterOfMassTransform (long jarg1, btRigidBody jarg1_);
+	public final static native Matrix4 btRigidBody_getCenterOfMassTransform__SWIG_0 (long jarg1, btRigidBody jarg1_);
 
-	public final static native Vector3 btRigidBody_getLinearVelocity (long jarg1, btRigidBody jarg1_);
+	public final static native Vector3 btRigidBody_getLinearVelocity__SWIG_0 (long jarg1, btRigidBody jarg1_);
 
 	public final static native Vector3 btRigidBody_getAngularVelocity__SWIG_0 (long jarg1, btRigidBody jarg1_);
 
@@ -262,7 +262,7 @@ public class DynamicsJNI {
 
 	public final static native void btRigidBody_setAngularFactor__SWIG_1 (long jarg1, btRigidBody jarg1_, float jarg2);
 
-	public final static native Vector3 btRigidBody_getAngularFactor (long jarg1, btRigidBody jarg1_);
+	public final static native Vector3 btRigidBody_getAngularFactor__SWIG_0 (long jarg1, btRigidBody jarg1_);
 
 	public final static native boolean btRigidBody_isInWorld (long jarg1, btRigidBody jarg1_);
 
@@ -299,7 +299,25 @@ public class DynamicsJNI {
 	public final static native long new_btRigidBody__SWIG_2 (boolean jarg1, float jarg2, long jarg3, btMotionState jarg3_,
 		long jarg4, btCollisionShape jarg4_);
 
+	public final static native void btRigidBody_getLinearVelocity__SWIG_1 (long jarg1, btRigidBody jarg1_, Vector3 jarg2);
+
 	public final static native void btRigidBody_getAngularVelocity__SWIG_1 (long jarg1, btRigidBody jarg1_, Vector3 jarg2);
+
+	public final static native void btRigidBody_getLinearFactor__SWIG_1 (long jarg1, btRigidBody jarg1_, Vector3 jarg2);
+
+	public final static native void btRigidBody_getAngularFactor__SWIG_1 (long jarg1, btRigidBody jarg1_, Vector3 jarg2);
+
+	public final static native void btRigidBody_getGravity__SWIG_1 (long jarg1, btRigidBody jarg1_, Vector3 jarg2);
+
+	public final static native void btRigidBody_getTotalForce__SWIG_1 (long jarg1, btRigidBody jarg1_, Vector3 jarg2);
+
+	public final static native void btRigidBody_getTotalTorque__SWIG_1 (long jarg1, btRigidBody jarg1_, Vector3 jarg2);
+
+	public final static native void btRigidBody_getInvInertiaDiagLocal__SWIG_1 (long jarg1, btRigidBody jarg1_, Vector3 jarg2);
+
+	public final static native void btRigidBody_getCenterOfMassPosition__SWIG_1 (long jarg1, btRigidBody jarg1_, Vector3 jarg2);
+
+	public final static native void btRigidBody_getCenterOfMassTransform__SWIG_1 (long jarg1, btRigidBody jarg1_, Matrix4 jarg2);
 
 	public final static native void btRigidBodyFloatData_collisionObjectData_set (long jarg1, btRigidBodyFloatData jarg1_,
 		long jarg2, btCollisionObjectFloatData jarg2_);

--- a/extensions/gdx-bullet/jni/swig-src/dynamics/com/badlogic/gdx/physics/bullet/dynamics/btRigidBody.java
+++ b/extensions/gdx-bullet/jni/swig-src/dynamics/com/badlogic/gdx/physics/bullet/dynamics/btRigidBody.java
@@ -525,7 +525,7 @@ public class btRigidBody extends btCollisionObject {
 	}
 
 	public Vector3 getAngularVelocity () {
-		return DynamicsJNI.btRigidBody_getAngularVelocity(swigCPtr, this);
+		return DynamicsJNI.btRigidBody_getAngularVelocity__SWIG_0(swigCPtr, this);
 	}
 
 	public void setLinearVelocity (Vector3 lin_vel) {
@@ -677,6 +677,10 @@ public class btRigidBody extends btCollisionObject {
 	private btRigidBody (boolean dummy, float mass, btMotionState motionState, btCollisionShape collisionShape) {
 		this(DynamicsJNI.new_btRigidBody__SWIG_2(dummy, mass, btMotionState.getCPtr(motionState), motionState,
 			btCollisionShape.getCPtr(collisionShape), collisionShape), true);
+	}
+
+	public void getAngularVelocity (Vector3 out) {
+		DynamicsJNI.btRigidBody_getAngularVelocity__SWIG_1(swigCPtr, this, out);
 	}
 
 }

--- a/extensions/gdx-bullet/jni/swig-src/dynamics/com/badlogic/gdx/physics/bullet/dynamics/btRigidBody.java
+++ b/extensions/gdx-bullet/jni/swig-src/dynamics/com/badlogic/gdx/physics/bullet/dynamics/btRigidBody.java
@@ -401,7 +401,7 @@ public class btRigidBody extends btCollisionObject {
 	}
 
 	public Vector3 getGravity () {
-		return DynamicsJNI.btRigidBody_getGravity(swigCPtr, this);
+		return DynamicsJNI.btRigidBody_getGravity__SWIG_0(swigCPtr, this);
 	}
 
 	public void setDamping (float lin_damping, float ang_damping) {
@@ -433,7 +433,7 @@ public class btRigidBody extends btCollisionObject {
 	}
 
 	public Vector3 getLinearFactor () {
-		return DynamicsJNI.btRigidBody_getLinearFactor(swigCPtr, this);
+		return DynamicsJNI.btRigidBody_getLinearFactor__SWIG_0(swigCPtr, this);
 	}
 
 	public void setLinearFactor (Vector3 linearFactor) {
@@ -461,15 +461,15 @@ public class btRigidBody extends btCollisionObject {
 	}
 
 	public Vector3 getTotalForce () {
-		return DynamicsJNI.btRigidBody_getTotalForce(swigCPtr, this);
+		return DynamicsJNI.btRigidBody_getTotalForce__SWIG_0(swigCPtr, this);
 	}
 
 	public Vector3 getTotalTorque () {
-		return DynamicsJNI.btRigidBody_getTotalTorque(swigCPtr, this);
+		return DynamicsJNI.btRigidBody_getTotalTorque__SWIG_0(swigCPtr, this);
 	}
 
 	public Vector3 getInvInertiaDiagLocal () {
-		return DynamicsJNI.btRigidBody_getInvInertiaDiagLocal(swigCPtr, this);
+		return DynamicsJNI.btRigidBody_getInvInertiaDiagLocal__SWIG_0(swigCPtr, this);
 	}
 
 	public void setInvInertiaDiagLocal (Vector3 diagInvInertia) {
@@ -509,7 +509,7 @@ public class btRigidBody extends btCollisionObject {
 	}
 
 	public Vector3 getCenterOfMassPosition () {
-		return DynamicsJNI.btRigidBody_getCenterOfMassPosition(swigCPtr, this);
+		return DynamicsJNI.btRigidBody_getCenterOfMassPosition__SWIG_0(swigCPtr, this);
 	}
 
 	public Quaternion getOrientation () {
@@ -517,11 +517,11 @@ public class btRigidBody extends btCollisionObject {
 	}
 
 	public Matrix4 getCenterOfMassTransform () {
-		return DynamicsJNI.btRigidBody_getCenterOfMassTransform(swigCPtr, this);
+		return DynamicsJNI.btRigidBody_getCenterOfMassTransform__SWIG_0(swigCPtr, this);
 	}
 
 	public Vector3 getLinearVelocity () {
-		return DynamicsJNI.btRigidBody_getLinearVelocity(swigCPtr, this);
+		return DynamicsJNI.btRigidBody_getLinearVelocity__SWIG_0(swigCPtr, this);
 	}
 
 	public Vector3 getAngularVelocity () {
@@ -615,7 +615,7 @@ public class btRigidBody extends btCollisionObject {
 	}
 
 	public Vector3 getAngularFactor () {
-		return DynamicsJNI.btRigidBody_getAngularFactor(swigCPtr, this);
+		return DynamicsJNI.btRigidBody_getAngularFactor__SWIG_0(swigCPtr, this);
 	}
 
 	public boolean isInWorld () {
@@ -679,8 +679,44 @@ public class btRigidBody extends btCollisionObject {
 			btCollisionShape.getCPtr(collisionShape), collisionShape), true);
 	}
 
+	public void getLinearVelocity (Vector3 out) {
+		DynamicsJNI.btRigidBody_getLinearVelocity__SWIG_1(swigCPtr, this, out);
+	}
+
 	public void getAngularVelocity (Vector3 out) {
 		DynamicsJNI.btRigidBody_getAngularVelocity__SWIG_1(swigCPtr, this, out);
+	}
+
+	public void getLinearFactor (Vector3 out) {
+		DynamicsJNI.btRigidBody_getLinearFactor__SWIG_1(swigCPtr, this, out);
+	}
+
+	public void getAngularFactor (Vector3 out) {
+		DynamicsJNI.btRigidBody_getAngularFactor__SWIG_1(swigCPtr, this, out);
+	}
+
+	public void getGravity (Vector3 out) {
+		DynamicsJNI.btRigidBody_getGravity__SWIG_1(swigCPtr, this, out);
+	}
+
+	public void getTotalForce (Vector3 out) {
+		DynamicsJNI.btRigidBody_getTotalForce__SWIG_1(swigCPtr, this, out);
+	}
+
+	public void getTotalTorque (Vector3 out) {
+		DynamicsJNI.btRigidBody_getTotalTorque__SWIG_1(swigCPtr, this, out);
+	}
+
+	public void getInvInertiaDiagLocal (Vector3 out) {
+		DynamicsJNI.btRigidBody_getInvInertiaDiagLocal__SWIG_1(swigCPtr, this, out);
+	}
+
+	public void getCenterOfMassPosition (Vector3 out) {
+		DynamicsJNI.btRigidBody_getCenterOfMassPosition__SWIG_1(swigCPtr, this, out);
+	}
+
+	public void getCenterOfMassTransform (Matrix4 out) {
+		DynamicsJNI.btRigidBody_getCenterOfMassTransform__SWIG_1(swigCPtr, this, out);
 	}
 
 }

--- a/extensions/gdx-bullet/jni/swig-src/dynamics/dynamics_wrap.cpp
+++ b/extensions/gdx-bullet/jni/swig-src/dynamics/dynamics_wrap.cpp
@@ -1890,8 +1890,35 @@ SWIGINTERN btRigidBody *new_btRigidBody__SWIG_0(bool dummy,btRigidBody::btRigidB
 SWIGINTERN btRigidBody *new_btRigidBody__SWIG_1(bool dummy,btScalar mass,btMotionState *motionState,btCollisionShape *collisionShape,btVector3 const &localInertia=btVector3(0,0,0)){
 		return new btRigidBody(mass, motionState, collisionShape, localInertia);
 	}
+SWIGINTERN void btRigidBody_getLinearVelocity__SWIG_1(btRigidBody *self,btVector3 &out){
+        out = self->getLinearVelocity();
+    }
 SWIGINTERN void btRigidBody_getAngularVelocity__SWIG_1(btRigidBody *self,btVector3 &out){
 		out = self->getAngularVelocity();
+	}
+SWIGINTERN void btRigidBody_getLinearFactor__SWIG_1(btRigidBody *self,btVector3 &out){
+		out = self->getLinearFactor();
+	}
+SWIGINTERN void btRigidBody_getAngularFactor__SWIG_1(btRigidBody *self,btVector3 &out){
+        out = self->getAngularFactor();
+    }
+SWIGINTERN void btRigidBody_getGravity__SWIG_1(btRigidBody *self,btVector3 &out){
+		out = self->getGravity();
+	}
+SWIGINTERN void btRigidBody_getTotalForce__SWIG_1(btRigidBody *self,btVector3 &out){
+		out = self->getTotalForce();
+	}
+SWIGINTERN void btRigidBody_getTotalTorque__SWIG_1(btRigidBody *self,btVector3 &out){
+		out = self->getTotalTorque();
+	}
+SWIGINTERN void btRigidBody_getInvInertiaDiagLocal__SWIG_1(btRigidBody *self,btVector3 &out){
+		out = self->getInvInertiaDiagLocal();
+	}
+SWIGINTERN void btRigidBody_getCenterOfMassPosition__SWIG_1(btRigidBody *self,btVector3 &out){
+		out = self->getCenterOfMassPosition();
+	}
+SWIGINTERN void btRigidBody_getCenterOfMassTransform__SWIG_1(btRigidBody *self,btTransform &out){
+		out = self->getCenterOfMassTransform();
 	}
 
 #include <BulletDynamics/ConstraintSolver/btTypedConstraint.h>
@@ -2953,7 +2980,7 @@ SWIGEXPORT void JNICALL Java_com_badlogic_gdx_physics_bullet_dynamics_DynamicsJN
 }
 
 
-SWIGEXPORT jobject JNICALL Java_com_badlogic_gdx_physics_bullet_dynamics_DynamicsJNI_btRigidBody_1getGravity(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_) {
+SWIGEXPORT jobject JNICALL Java_com_badlogic_gdx_physics_bullet_dynamics_DynamicsJNI_btRigidBody_1getGravity_1_1SWIG_10(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_) {
   jobject jresult = 0 ;
   btRigidBody *arg1 = (btRigidBody *) 0 ;
   btVector3 *result = 0 ;
@@ -3075,7 +3102,7 @@ SWIGEXPORT void JNICALL Java_com_badlogic_gdx_physics_bullet_dynamics_DynamicsJN
 }
 
 
-SWIGEXPORT jobject JNICALL Java_com_badlogic_gdx_physics_bullet_dynamics_DynamicsJNI_btRigidBody_1getLinearFactor(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_) {
+SWIGEXPORT jobject JNICALL Java_com_badlogic_gdx_physics_bullet_dynamics_DynamicsJNI_btRigidBody_1getLinearFactor_1_1SWIG_10(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_) {
   jobject jresult = 0 ;
   btRigidBody *arg1 = (btRigidBody *) 0 ;
   btVector3 *result = 0 ;
@@ -3183,7 +3210,7 @@ SWIGEXPORT void JNICALL Java_com_badlogic_gdx_physics_bullet_dynamics_DynamicsJN
 }
 
 
-SWIGEXPORT jobject JNICALL Java_com_badlogic_gdx_physics_bullet_dynamics_DynamicsJNI_btRigidBody_1getTotalForce(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_) {
+SWIGEXPORT jobject JNICALL Java_com_badlogic_gdx_physics_bullet_dynamics_DynamicsJNI_btRigidBody_1getTotalForce_1_1SWIG_10(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_) {
   jobject jresult = 0 ;
   btRigidBody *arg1 = (btRigidBody *) 0 ;
   btVector3 *result = 0 ;
@@ -3199,7 +3226,7 @@ SWIGEXPORT jobject JNICALL Java_com_badlogic_gdx_physics_bullet_dynamics_Dynamic
 }
 
 
-SWIGEXPORT jobject JNICALL Java_com_badlogic_gdx_physics_bullet_dynamics_DynamicsJNI_btRigidBody_1getTotalTorque(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_) {
+SWIGEXPORT jobject JNICALL Java_com_badlogic_gdx_physics_bullet_dynamics_DynamicsJNI_btRigidBody_1getTotalTorque_1_1SWIG_10(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_) {
   jobject jresult = 0 ;
   btRigidBody *arg1 = (btRigidBody *) 0 ;
   btVector3 *result = 0 ;
@@ -3215,7 +3242,7 @@ SWIGEXPORT jobject JNICALL Java_com_badlogic_gdx_physics_bullet_dynamics_Dynamic
 }
 
 
-SWIGEXPORT jobject JNICALL Java_com_badlogic_gdx_physics_bullet_dynamics_DynamicsJNI_btRigidBody_1getInvInertiaDiagLocal(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_) {
+SWIGEXPORT jobject JNICALL Java_com_badlogic_gdx_physics_bullet_dynamics_DynamicsJNI_btRigidBody_1getInvInertiaDiagLocal_1_1SWIG_10(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_) {
   jobject jresult = 0 ;
   btRigidBody *arg1 = (btRigidBody *) 0 ;
   btVector3 *result = 0 ;
@@ -3374,7 +3401,7 @@ SWIGEXPORT void JNICALL Java_com_badlogic_gdx_physics_bullet_dynamics_DynamicsJN
 }
 
 
-SWIGEXPORT jobject JNICALL Java_com_badlogic_gdx_physics_bullet_dynamics_DynamicsJNI_btRigidBody_1getCenterOfMassPosition(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_) {
+SWIGEXPORT jobject JNICALL Java_com_badlogic_gdx_physics_bullet_dynamics_DynamicsJNI_btRigidBody_1getCenterOfMassPosition_1_1SWIG_10(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_) {
   jobject jresult = 0 ;
   btRigidBody *arg1 = (btRigidBody *) 0 ;
   btVector3 *result = 0 ;
@@ -3406,7 +3433,7 @@ SWIGEXPORT jobject JNICALL Java_com_badlogic_gdx_physics_bullet_dynamics_Dynamic
 }
 
 
-SWIGEXPORT jobject JNICALL Java_com_badlogic_gdx_physics_bullet_dynamics_DynamicsJNI_btRigidBody_1getCenterOfMassTransform(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_) {
+SWIGEXPORT jobject JNICALL Java_com_badlogic_gdx_physics_bullet_dynamics_DynamicsJNI_btRigidBody_1getCenterOfMassTransform_1_1SWIG_10(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_) {
   jobject jresult = 0 ;
   btRigidBody *arg1 = (btRigidBody *) 0 ;
   btTransform *result = 0 ;
@@ -3422,7 +3449,7 @@ SWIGEXPORT jobject JNICALL Java_com_badlogic_gdx_physics_bullet_dynamics_Dynamic
 }
 
 
-SWIGEXPORT jobject JNICALL Java_com_badlogic_gdx_physics_bullet_dynamics_DynamicsJNI_btRigidBody_1getLinearVelocity(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_) {
+SWIGEXPORT jobject JNICALL Java_com_badlogic_gdx_physics_bullet_dynamics_DynamicsJNI_btRigidBody_1getLinearVelocity_1_1SWIG_10(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_) {
   jobject jresult = 0 ;
   btRigidBody *arg1 = (btRigidBody *) 0 ;
   btVector3 *result = 0 ;
@@ -3790,7 +3817,7 @@ SWIGEXPORT void JNICALL Java_com_badlogic_gdx_physics_bullet_dynamics_DynamicsJN
 }
 
 
-SWIGEXPORT jobject JNICALL Java_com_badlogic_gdx_physics_bullet_dynamics_DynamicsJNI_btRigidBody_1getAngularFactor(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_) {
+SWIGEXPORT jobject JNICALL Java_com_badlogic_gdx_physics_bullet_dynamics_DynamicsJNI_btRigidBody_1getAngularFactor_1_1SWIG_10(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_) {
   jobject jresult = 0 ;
   btRigidBody *arg1 = (btRigidBody *) 0 ;
   btVector3 *result = 0 ;
@@ -4049,6 +4076,22 @@ SWIGEXPORT jlong JNICALL Java_com_badlogic_gdx_physics_bullet_dynamics_DynamicsJ
 }
 
 
+SWIGEXPORT void JNICALL Java_com_badlogic_gdx_physics_bullet_dynamics_DynamicsJNI_btRigidBody_1getLinearVelocity_1_1SWIG_11(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_, jobject jarg2) {
+  btRigidBody *arg1 = (btRigidBody *) 0 ;
+  btVector3 *arg2 = 0 ;
+  
+  (void)jenv;
+  (void)jcls;
+  (void)jarg1_;
+  arg1 = *(btRigidBody **)&jarg1; 
+  btVector3 local_arg2;
+  gdx_setbtVector3FromVector3(jenv, local_arg2, jarg2);
+  arg2 = &local_arg2;
+  gdxAutoCommitVector3 auto_commit_arg2(jenv, jarg2, &local_arg2);
+  btRigidBody_getLinearVelocity__SWIG_1(arg1,*arg2);
+}
+
+
 SWIGEXPORT void JNICALL Java_com_badlogic_gdx_physics_bullet_dynamics_DynamicsJNI_btRigidBody_1getAngularVelocity_1_1SWIG_11(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_, jobject jarg2) {
   btRigidBody *arg1 = (btRigidBody *) 0 ;
   btVector3 *arg2 = 0 ;
@@ -4062,6 +4105,134 @@ SWIGEXPORT void JNICALL Java_com_badlogic_gdx_physics_bullet_dynamics_DynamicsJN
   arg2 = &local_arg2;
   gdxAutoCommitVector3 auto_commit_arg2(jenv, jarg2, &local_arg2);
   btRigidBody_getAngularVelocity__SWIG_1(arg1,*arg2);
+}
+
+
+SWIGEXPORT void JNICALL Java_com_badlogic_gdx_physics_bullet_dynamics_DynamicsJNI_btRigidBody_1getLinearFactor_1_1SWIG_11(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_, jobject jarg2) {
+  btRigidBody *arg1 = (btRigidBody *) 0 ;
+  btVector3 *arg2 = 0 ;
+  
+  (void)jenv;
+  (void)jcls;
+  (void)jarg1_;
+  arg1 = *(btRigidBody **)&jarg1; 
+  btVector3 local_arg2;
+  gdx_setbtVector3FromVector3(jenv, local_arg2, jarg2);
+  arg2 = &local_arg2;
+  gdxAutoCommitVector3 auto_commit_arg2(jenv, jarg2, &local_arg2);
+  btRigidBody_getLinearFactor__SWIG_1(arg1,*arg2);
+}
+
+
+SWIGEXPORT void JNICALL Java_com_badlogic_gdx_physics_bullet_dynamics_DynamicsJNI_btRigidBody_1getAngularFactor_1_1SWIG_11(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_, jobject jarg2) {
+  btRigidBody *arg1 = (btRigidBody *) 0 ;
+  btVector3 *arg2 = 0 ;
+  
+  (void)jenv;
+  (void)jcls;
+  (void)jarg1_;
+  arg1 = *(btRigidBody **)&jarg1; 
+  btVector3 local_arg2;
+  gdx_setbtVector3FromVector3(jenv, local_arg2, jarg2);
+  arg2 = &local_arg2;
+  gdxAutoCommitVector3 auto_commit_arg2(jenv, jarg2, &local_arg2);
+  btRigidBody_getAngularFactor__SWIG_1(arg1,*arg2);
+}
+
+
+SWIGEXPORT void JNICALL Java_com_badlogic_gdx_physics_bullet_dynamics_DynamicsJNI_btRigidBody_1getGravity_1_1SWIG_11(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_, jobject jarg2) {
+  btRigidBody *arg1 = (btRigidBody *) 0 ;
+  btVector3 *arg2 = 0 ;
+  
+  (void)jenv;
+  (void)jcls;
+  (void)jarg1_;
+  arg1 = *(btRigidBody **)&jarg1; 
+  btVector3 local_arg2;
+  gdx_setbtVector3FromVector3(jenv, local_arg2, jarg2);
+  arg2 = &local_arg2;
+  gdxAutoCommitVector3 auto_commit_arg2(jenv, jarg2, &local_arg2);
+  btRigidBody_getGravity__SWIG_1(arg1,*arg2);
+}
+
+
+SWIGEXPORT void JNICALL Java_com_badlogic_gdx_physics_bullet_dynamics_DynamicsJNI_btRigidBody_1getTotalForce_1_1SWIG_11(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_, jobject jarg2) {
+  btRigidBody *arg1 = (btRigidBody *) 0 ;
+  btVector3 *arg2 = 0 ;
+  
+  (void)jenv;
+  (void)jcls;
+  (void)jarg1_;
+  arg1 = *(btRigidBody **)&jarg1; 
+  btVector3 local_arg2;
+  gdx_setbtVector3FromVector3(jenv, local_arg2, jarg2);
+  arg2 = &local_arg2;
+  gdxAutoCommitVector3 auto_commit_arg2(jenv, jarg2, &local_arg2);
+  btRigidBody_getTotalForce__SWIG_1(arg1,*arg2);
+}
+
+
+SWIGEXPORT void JNICALL Java_com_badlogic_gdx_physics_bullet_dynamics_DynamicsJNI_btRigidBody_1getTotalTorque_1_1SWIG_11(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_, jobject jarg2) {
+  btRigidBody *arg1 = (btRigidBody *) 0 ;
+  btVector3 *arg2 = 0 ;
+  
+  (void)jenv;
+  (void)jcls;
+  (void)jarg1_;
+  arg1 = *(btRigidBody **)&jarg1; 
+  btVector3 local_arg2;
+  gdx_setbtVector3FromVector3(jenv, local_arg2, jarg2);
+  arg2 = &local_arg2;
+  gdxAutoCommitVector3 auto_commit_arg2(jenv, jarg2, &local_arg2);
+  btRigidBody_getTotalTorque__SWIG_1(arg1,*arg2);
+}
+
+
+SWIGEXPORT void JNICALL Java_com_badlogic_gdx_physics_bullet_dynamics_DynamicsJNI_btRigidBody_1getInvInertiaDiagLocal_1_1SWIG_11(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_, jobject jarg2) {
+  btRigidBody *arg1 = (btRigidBody *) 0 ;
+  btVector3 *arg2 = 0 ;
+  
+  (void)jenv;
+  (void)jcls;
+  (void)jarg1_;
+  arg1 = *(btRigidBody **)&jarg1; 
+  btVector3 local_arg2;
+  gdx_setbtVector3FromVector3(jenv, local_arg2, jarg2);
+  arg2 = &local_arg2;
+  gdxAutoCommitVector3 auto_commit_arg2(jenv, jarg2, &local_arg2);
+  btRigidBody_getInvInertiaDiagLocal__SWIG_1(arg1,*arg2);
+}
+
+
+SWIGEXPORT void JNICALL Java_com_badlogic_gdx_physics_bullet_dynamics_DynamicsJNI_btRigidBody_1getCenterOfMassPosition_1_1SWIG_11(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_, jobject jarg2) {
+  btRigidBody *arg1 = (btRigidBody *) 0 ;
+  btVector3 *arg2 = 0 ;
+  
+  (void)jenv;
+  (void)jcls;
+  (void)jarg1_;
+  arg1 = *(btRigidBody **)&jarg1; 
+  btVector3 local_arg2;
+  gdx_setbtVector3FromVector3(jenv, local_arg2, jarg2);
+  arg2 = &local_arg2;
+  gdxAutoCommitVector3 auto_commit_arg2(jenv, jarg2, &local_arg2);
+  btRigidBody_getCenterOfMassPosition__SWIG_1(arg1,*arg2);
+}
+
+
+SWIGEXPORT void JNICALL Java_com_badlogic_gdx_physics_bullet_dynamics_DynamicsJNI_btRigidBody_1getCenterOfMassTransform_1_1SWIG_11(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_, jobject jarg2) {
+  btRigidBody *arg1 = (btRigidBody *) 0 ;
+  btTransform *arg2 = 0 ;
+  
+  (void)jenv;
+  (void)jcls;
+  (void)jarg1_;
+  arg1 = *(btRigidBody **)&jarg1; 
+  btTransform local_arg2;
+  gdx_setbtTransformFromMatrix4(jenv, local_arg2, jarg2);
+  arg2 = &local_arg2;
+  gdxAutoCommitMatrix4 auto_commit_arg2(jenv, jarg2, &local_arg2);
+  btRigidBody_getCenterOfMassTransform__SWIG_1(arg1,*arg2);
 }
 
 

--- a/extensions/gdx-bullet/jni/swig-src/dynamics/dynamics_wrap.cpp
+++ b/extensions/gdx-bullet/jni/swig-src/dynamics/dynamics_wrap.cpp
@@ -132,7 +132,7 @@ template <typename T> T SwigValueInit() {
 
 /* calling conventions for Windows */
 #ifndef SWIGSTDCALL
-# if defined(_WIN32) || defined(__WIN32__)
+# if defined(_WIN32) || defined(__WIN32__) || defined(__CYGWIN__)
 #   define SWIGSTDCALL __stdcall
 # else
 #   define SWIGSTDCALL
@@ -1890,6 +1890,9 @@ SWIGINTERN btRigidBody *new_btRigidBody__SWIG_0(bool dummy,btRigidBody::btRigidB
 SWIGINTERN btRigidBody *new_btRigidBody__SWIG_1(bool dummy,btScalar mass,btMotionState *motionState,btCollisionShape *collisionShape,btVector3 const &localInertia=btVector3(0,0,0)){
 		return new btRigidBody(mass, motionState, collisionShape, localInertia);
 	}
+SWIGINTERN void btRigidBody_getAngularVelocity__SWIG_1(btRigidBody *self,btVector3 &out){
+		out = self->getAngularVelocity();
+	}
 
 #include <BulletDynamics/ConstraintSolver/btTypedConstraint.h>
 
@@ -3435,7 +3438,7 @@ SWIGEXPORT jobject JNICALL Java_com_badlogic_gdx_physics_bullet_dynamics_Dynamic
 }
 
 
-SWIGEXPORT jobject JNICALL Java_com_badlogic_gdx_physics_bullet_dynamics_DynamicsJNI_btRigidBody_1getAngularVelocity(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_) {
+SWIGEXPORT jobject JNICALL Java_com_badlogic_gdx_physics_bullet_dynamics_DynamicsJNI_btRigidBody_1getAngularVelocity_1_1SWIG_10(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_) {
   jobject jresult = 0 ;
   btRigidBody *arg1 = (btRigidBody *) 0 ;
   btVector3 *result = 0 ;
@@ -4043,6 +4046,22 @@ SWIGEXPORT jlong JNICALL Java_com_badlogic_gdx_physics_bullet_dynamics_DynamicsJ
   result = (btRigidBody *)new_btRigidBody__SWIG_1(arg1,arg2,arg3,arg4);
   *(btRigidBody **)&jresult = result; 
   return jresult;
+}
+
+
+SWIGEXPORT void JNICALL Java_com_badlogic_gdx_physics_bullet_dynamics_DynamicsJNI_btRigidBody_1getAngularVelocity_1_1SWIG_11(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_, jobject jarg2) {
+  btRigidBody *arg1 = (btRigidBody *) 0 ;
+  btVector3 *arg2 = 0 ;
+  
+  (void)jenv;
+  (void)jcls;
+  (void)jarg1_;
+  arg1 = *(btRigidBody **)&jarg1; 
+  btVector3 local_arg2;
+  gdx_setbtVector3FromVector3(jenv, local_arg2, jarg2);
+  arg2 = &local_arg2;
+  gdxAutoCommitVector3 auto_commit_arg2(jenv, jarg2, &local_arg2);
+  btRigidBody_getAngularVelocity__SWIG_1(arg1,*arg2);
 }
 
 

--- a/extensions/gdx-bullet/jni/swig/dynamics/btRigidBody.i
+++ b/extensions/gdx-bullet/jni/swig/dynamics/btRigidBody.i
@@ -120,9 +120,47 @@
 	btRigidBody(bool dummy, btScalar mass, btMotionState* motionState, btCollisionShape* collisionShape, const btVector3& localInertia=btVector3(0,0,0)) {
 		return new btRigidBody(mass, motionState, collisionShape, localInertia);
 	}
+
+	void getLinearVelocity(btVector3 & out) {
+        out = $self->getLinearVelocity();
+    }
+
 	void getAngularVelocity(btVector3 & out) {
 		out = $self->getAngularVelocity();
 	}
+
+	void getLinearFactor(btVector3 & out) {
+		out = $self->getLinearFactor();
+	}
+
+	void getAngularFactor(btVector3 & out) {
+        out = $self->getAngularFactor();
+    }
+
+	void getGravity(btVector3 & out) {
+		out = $self->getGravity();
+	}
+
+	void getTotalForce(btVector3 & out) {
+		out = $self->getTotalForce();
+	}
+
+	void getTotalTorque(btVector3 & out) {
+		out = $self->getTotalTorque();
+	}
+
+	void getInvInertiaDiagLocal(btVector3 & out) {
+		out = $self->getInvInertiaDiagLocal();
+	}
+
+	void getCenterOfMassPosition(btVector3 & out) {
+		out = $self->getCenterOfMassPosition();
+	}
+
+	void getCenterOfMassTransform(btTransform & out) {
+		out = $self->getCenterOfMassTransform();
+	}
+
 };
 
 %typemap(javacode) btRigidBody %{

--- a/extensions/gdx-bullet/jni/swig/dynamics/btRigidBody.i
+++ b/extensions/gdx-bullet/jni/swig/dynamics/btRigidBody.i
@@ -120,6 +120,9 @@
 	btRigidBody(bool dummy, btScalar mass, btMotionState* motionState, btCollisionShape* collisionShape, const btVector3& localInertia=btVector3(0,0,0)) {
 		return new btRigidBody(mass, motionState, collisionShape, localInertia);
 	}
+	void getAngularVelocity(btVector3 & out) {
+		out = $self->getAngularVelocity();
+	}
 };
 
 %typemap(javacode) btRigidBody %{

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/VehicleTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/VehicleTest.java
@@ -176,7 +176,7 @@ public class VehicleTest extends BaseBulletTest {
 	}
 
 	@Override
-	public void render() {
+	public void render () {
 		super.render();
 		Vector3 tmpU = vehicle.getRigidBody().getAngularVelocity();
 		vehicle.getRigidBody().getAngularVelocity(tmpV);

--- a/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/VehicleTest.java
+++ b/tests/gdx-tests/src/com/badlogic/gdx/tests/bullet/VehicleTest.java
@@ -176,6 +176,15 @@ public class VehicleTest extends BaseBulletTest {
 	}
 
 	@Override
+	public void render() {
+		super.render();
+		Vector3 tmpU = vehicle.getRigidBody().getAngularVelocity();
+		vehicle.getRigidBody().getAngularVelocity(tmpV);
+		performance.append(", Angular Velocity (value): ").append(String.format("%+.3f", tmpU.len()));
+		performance.append(", Angular Velocity (ref): ").append(String.format("%+.3f", tmpV.len()));
+	}
+
+	@Override
 	public boolean tap (float x, float y, int count, int button) {
 		shoot(x, y);
 		return true;


### PR DESCRIPTION
Add additional overloads for usual btRigidBody methods like `getLinearVelocity()`, which instead of creating and returning new instances, take one in as a parameter and mutate it.