### PR TITLE
Add Json#getUsePrototypes().

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,6 @@
 [1.14.3]
 - API Addition: add() with 5-8 parameters for arrays.
+- API Addition: Json#getUsePrototypes(), so a Json.Serializable can restore the setting it changed.
 - API Removal: Removed LwjglApplet (Java applets are obsolete). ApplicationType.Applet is deprecated.
 - iOS: Made iOS Preferences flush() implementation atomic (see #7833)
 

--- a/gdx/src/com/badlogic/gdx/utils/Json.java
+++ b/gdx/src/com/badlogic/gdx/utils/Json.java
@@ -157,6 +157,11 @@ public class Json {
 		this.usePrototypes = usePrototypes;
 	}
 
+	/** @see #setUsePrototypes(boolean) */
+	public boolean getUsePrototypes () {
+		return usePrototypes;
+	}
+
 	/** Sets the type of elements in a collection. When the element type is known, the class for each element in the collection
 	 * does not need to be written unless different from the element type. */
 	public void setElementType (Class type, String fieldName, Class elementType) {


### PR DESCRIPTION
A Json.Serializable#write(Json) implementation is handed the writer but cannot read its usePrototypes setting back, so code that flips the flag for a single field has no way to restore what the caller had. The symmetric getter already exists for ignoreUnknownFields.