### PR TITLE
TexturePacker: reject duplicatePadding with padding < 2.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,7 @@
 - API Addition: Json#getUsePrototypes(), so a Json.Serializable can restore the setting it changed.
 - API Removal: Removed LwjglApplet (Java applets are obsolete). ApplicationType.Applet is deprecated.
 - iOS: Made iOS Preferences flush() implementation atomic (see #7833)
+- API Change: TexturePacker now throws if duplicatePadding is true and paddingX or paddingY is less than 2. Padding is the whole gap between two adjacent images, so half of it is duplicated on each side and a padding of 1 duplicated nothing at all, silently.
 
 [1.14.2]
 - [BREAKING CHANGE] Revert InputMultiplexer and set addAll return types that were breaking changes in 1.14.1. #7805

--- a/extensions/gdx-tools/src/com/badlogic/gdx/tools/texturepacker/TexturePacker.java
+++ b/extensions/gdx-tools/src/com/badlogic/gdx/tools/texturepacker/TexturePacker.java
@@ -78,6 +78,13 @@ public class TexturePacker {
 				throw new RuntimeException("If mod4 is true, maxHeight must be evenly divisible by 4: " + settings.maxHeight);
 		}
 
+		if (settings.duplicatePadding) {
+			if (settings.paddingX < 2)
+				throw new RuntimeException("If duplicatePadding is true, paddingX must be >= 2: " + settings.paddingX);
+			if (settings.paddingY < 2)
+				throw new RuntimeException("If duplicatePadding is true, paddingY must be >= 2: " + settings.paddingY);
+		}
+
 		if (settings.grid)
 			packer = new GridPacker(settings);
 		else
@@ -900,6 +907,9 @@ public class TexturePacker {
 		public boolean multipleOfFour;
 		public int paddingX = 2, paddingY = 2;
 		public boolean edgePadding = true;
+		/** If true, the edge pixels of each image are duplicated into the padding, so filtering does not sample transparent pixels.
+		 * {@link #paddingX} and {@link #paddingY} are the whole gap between two adjacent images, so each image duplicates only half
+		 * of it on each side, rounded down. Requires padding of 2 or more. */
 		public boolean duplicatePadding = false;
 		public boolean rotation;
 		public int minWidth = 16, minHeight = 16;


### PR DESCRIPTION
`duplicatePadding` exists so that a region's edge texels survive filtering. When `paddingX`/`paddingY` is 1, it silently does nothing.

### The problem

`padding` is the whole gap between two adjacent images, not a per-side margin — `MaxRectsPacker` adds it to a rect once. So each image duplicates `padding / 2` texels outward, and the two rings meet exactly in the middle.

At `padding = 1`, `padding / 2` is 0, so every duplication loop in `writeImages()` has an empty body, and `edgePadding` collapses the same way. The atlas still packs, the regions still have their 1 texel gap — and the gap is empty. Bilinear sampling and any seam-clamping shader then read transparent alpha just outside each region, and every sprite edge picks up a fringe.

Nothing warns about this. The setting is on and inert, the failure is invisible at pack time, and it surfaces only as fringing in the finished game.

### Why not just duplicate more

The halving is correct and this PR does not touch it. `plot()` is an unconditional `setRGB`, so duplicating the full padding instead would have neighbours overwrite each other's ring, and a region would sample its neighbour's colour — worse than the current failure. A 1 texel gap cannot hold one duplicated texel for each of its two neighbours, so `padding = 1` can never work with `duplicatePadding`. The fix is to say so rather than to change the arithmetic.

### The change

The check goes in the `TexturePacker(File, Settings)` constructor, directly below the existing `pot` and `multipleOfFour` blocks, which already reject settings the packer cannot honour:

```java
if (settings.duplicatePadding) {
    if (settings.paddingX < 2)
        throw new RuntimeException("If duplicatePadding is true, paddingX must be >= 2: " + settings.paddingX);
    if (settings.paddingY < 2)
        throw new RuntimeException("If duplicatePadding is true, paddingY must be >= 2: " + settings.paddingY);
}
```

It also adds a javadoc line to the `duplicatePadding` field noting that `padding` is the total gap between two neighbouring images and that only `padding / 2` is duplicated per side — the part that cannot be inferred from the field name.

Nothing in the repository is affected: `tests/gdx-tests-android/assets-raw/skin/pack.json` sets `duplicatePadding: false`, and `TiledMapPacker` uses padding 2 with duplication enabled. `CHANGES` has an entry under 1.14.3.

### One thing worth your call

This turns a silent no-op into a hard failure, so a project currently packing with `padding = 1` and `duplicatePadding` on will now fail instead of quietly producing fringed atlases. That is exactly the population that has the bug and no way to notice it, which is the argument for throwing — and it matches the neighbouring `pot` / `multipleOfFour` checks. If you would rather not break those builds, the same information as a `System.err` warning is still a strict improvement over silence, and I am happy to change it.

(@tommyettinger: maybe also interesting for "com.github.tommyettinger:libgdx-texturepacker")
