### PR TITLE
Draw a GlyphLayout with a tint in a single pass

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,5 @@
 [1.14.3]
+- API Addition: BitmapFont#draw and BitmapFontCache#addText/setText overloads that take a tint for a GlyphLayout. The tint is applied while the glyph vertices are built, avoiding the second pass over the vertices done by BitmapFontCache#tint.
 - API Addition: add() with 5-8 parameters for arrays.
 - API Addition: Json#getUsePrototypes(), so a Json.Serializable can restore the setting it changed.
 - API Removal: Removed LwjglApplet (Java applets are obsolete). ApplicationType.Applet is deprecated.

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFont.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFont.java
@@ -39,6 +39,7 @@ import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.Disposable;
 import com.badlogic.gdx.utils.FloatArray;
 import com.badlogic.gdx.utils.GdxRuntimeException;
+import com.badlogic.gdx.utils.Null;
 import com.badlogic.gdx.utils.StreamUtils;
 
 /** Renders bitmap fonts. The font consists of 2 files: an image file or {@link TextureRegion} containing the glyphs and a file in
@@ -231,6 +232,19 @@ public class BitmapFont implements Disposable {
 	public void draw (Batch batch, GlyphLayout layout, float x, float y) {
 		cache.clear();
 		cache.addText(layout, x, y);
+		cache.draw(batch);
+	}
+
+	/** Draws text at the specified position, multiplying the color of each glyph by the specified tint.
+	 * <p>
+	 * The tint is applied while the glyph vertices are built, so drawing a layout that fades or flashes costs a single pass over
+	 * the vertices rather than the two needed by {@link BitmapFontCache#tint(Color)}. Note the color of the {@link Batch} does not
+	 * affect cached text.
+	 * @param tint May be null to draw the glyphs with the colors of the layout, unmodified.
+	 * @see BitmapFontCache#addText(GlyphLayout, float, float, Color) */
+	public void draw (Batch batch, GlyphLayout layout, float x, float y, @Null Color tint) {
+		cache.clear();
+		cache.addText(layout, x, y, tint);
 		cache.draw(batch);
 	}
 

--- a/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFontCache.java
+++ b/gdx/src/com/badlogic/gdx/graphics/g2d/BitmapFontCache.java
@@ -24,6 +24,7 @@ import com.badlogic.gdx.utils.Align;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.FlushablePool;
 import com.badlogic.gdx.utils.IntArray;
+import com.badlogic.gdx.utils.Null;
 import com.badlogic.gdx.utils.NumberUtils;
 
 import java.util.Arrays;
@@ -112,7 +113,10 @@ public class BitmapFontCache {
 		}
 	}
 
-	/** Tints all text currently in the cache. Does not affect subsequently added text. */
+	/** Tints all text currently in the cache. Does not affect subsequently added text.
+	 * <p>
+	 * This is a second pass over the vertices. When the text is added just to be drawn tinted, it is more efficient to pass the
+	 * tint to {@link #addText(GlyphLayout, float, float, Color)} or {@link #setText(GlyphLayout, float, float, Color)}. */
 	public void tint (Color tint) {
 		float newTint = tint.toFloatBits();
 		if (currentTint == newTint) return;
@@ -308,6 +312,7 @@ public class BitmapFontCache {
 	public void clear () {
 		x = 0;
 		y = 0;
+		currentTint = Color.WHITE_FLOAT_BITS;
 		pooledLayouts.flush();
 		layouts.clear();
 		glyphCount = 0;
@@ -376,7 +381,7 @@ public class BitmapFontCache {
 		tempGlyphCount = new int[pageCount];
 	}
 
-	private void addToCache (GlyphLayout layout, float x, float y) {
+	private void addToCache (GlyphLayout layout, float x, float y, @Null Color tint) {
 		int runCount = layout.runs.size;
 		if (runCount == 0) return;
 
@@ -396,7 +401,13 @@ public class BitmapFontCache {
 			float gx = x + run.x, gy = y + run.y;
 			for (int ii = 0, nn = run.glyphs.size; ii < nn; ii++) {
 				if (glyphIndex++ == nextColorGlyphIndex) {
-					lastColorFloatBits = NumberUtils.intToFloatColor(colors.get(++colorsIndex));
+					int abgr = colors.get(++colorsIndex);
+					if (tint == null)
+						lastColorFloatBits = NumberUtils.intToFloatColor(abgr);
+					else {
+						Color.abgr8888ToColor(tempColor, abgr);
+						lastColorFloatBits = tempColor.mul(tint).toFloatBits();
+					}
 					nextColorGlyphIndex = ++colorsIndex < colors.size ? colors.get(colorsIndex) : -1;
 				}
 				gx += xAdvances[ii];
@@ -404,7 +415,13 @@ public class BitmapFontCache {
 			}
 		}
 
-		currentTint = Color.WHITE_FLOAT_BITS; // Cached glyphs have changed, reset the current tint.
+		// Cached glyphs have changed, reset the current tint. Glyphs added with a tint have it baked into their vertices, so from
+		// then until the cache is cleared the tint of the cached text is unknown. NaN is never equal to the tint passed to tint(),
+		// which ensures tint() is not skipped for those glyphs.
+		if (tint != null || Float.isNaN(currentTint))
+			currentTint = Float.NaN;
+		else
+			currentTint = Color.WHITE_FLOAT_BITS;
 	}
 
 	private void addGlyph (Glyph glyph, float x, float y, float color) {
@@ -491,6 +508,13 @@ public class BitmapFontCache {
 		addText(layout, x, y);
 	}
 
+	/** Clears any cached glyphs and adds the specified glyphs, tinted.
+	 * @see #addText(GlyphLayout, float, float, Color) */
+	public void setText (GlyphLayout layout, float x, float y, @Null Color tint) {
+		clear();
+		addText(layout, x, y, tint);
+	}
+
 	/** Adds glyphs for the specified text.
 	 * @see #addText(CharSequence, float, float, int, int, float, int, boolean, String) */
 	public GlyphLayout addText (CharSequence str, float x, float y) {
@@ -530,9 +554,20 @@ public class BitmapFontCache {
 	}
 
 	/** Adds the specified glyphs.
-	 * @param layout The cache keeps the layout until cleared or new text is set. The layout should not be modified before then. */
+	 * @param layout The cache keeps the layout until cleared or new text is set. The layout should not be modified before then.
+	 * @see #addText(GlyphLayout, float, float, Color) */
 	public void addText (GlyphLayout layout, float x, float y) {
-		addToCache(layout, x, y + font.data.ascent);
+		addToCache(layout, x, y + font.data.ascent, null);
+	}
+
+	/** Adds the specified glyphs, multiplying the color of each glyph by the specified tint.
+	 * <p>
+	 * The tint is applied while the glyph vertices are built, once per color run, so this is more efficient than adding the glyphs
+	 * and then calling {@link #tint(Color)}, which is a second pass over every vertex.
+	 * @param layout The cache keeps the layout until cleared or new text is set. The layout should not be modified before then.
+	 * @param tint May be null to add the glyphs with the colors of the layout, unmodified. */
+	public void addText (GlyphLayout layout, float x, float y, @Null Color tint) {
+		addToCache(layout, x, y + font.data.ascent, tint);
 	}
 
 	/** Returns the x position of the cached string, relative to the position when the string was cached. */

--- a/gdx/test/com/badlogic/gdx/graphics/g2d/BitmapFontCacheTest.java
+++ b/gdx/test/com/badlogic/gdx/graphics/g2d/BitmapFontCacheTest.java
@@ -1,0 +1,180 @@
+
+package com.badlogic.gdx.graphics.g2d;
+
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.g2d.BitmapFont.BitmapFontData;
+import com.badlogic.gdx.graphics.g2d.BitmapFont.Glyph;
+import com.badlogic.gdx.utils.Array;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/** Headless tests for tinting a {@link GlyphLayout} while it is added to a {@link BitmapFontCache}.
+ *
+ * <p>
+ * The vertices produced by {@link BitmapFontCache#addText(GlyphLayout, float, float, Color)} must be identical to those produced
+ * by adding the text and then calling {@link BitmapFontCache#tint(Color)}. */
+public class BitmapFontCacheTest {
+	static private final String CHARS = "abcdefghijklmnopqrstuvwxyz";
+	static private final float X = 12.4f, Y = 30.7f;
+
+	@Test
+	public void nullTintIsUnchanged () {
+		for (boolean integer : new boolean[] {false, true}) {
+			BitmapFont font = newFont(integer, 1);
+			GlyphLayout layout = new GlyphLayout(font, "[RED]abc[]defghi");
+
+			BitmapFontCache expected = new BitmapFontCache(font, integer);
+			expected.setText(layout, X, Y);
+
+			BitmapFontCache actual = new BitmapFontCache(font, integer);
+			actual.setText(layout, X, Y, null);
+
+			assertVerticesEqual(expected, actual);
+		}
+	}
+
+	@Test
+	public void whiteTintIsUnchanged () {
+		for (boolean integer : new boolean[] {false, true}) {
+			BitmapFont font = newFont(integer, 1);
+			GlyphLayout layout = new GlyphLayout(font, "[RED]abc[]defghi");
+
+			BitmapFontCache expected = new BitmapFontCache(font, integer);
+			expected.setText(layout, X, Y);
+
+			BitmapFontCache actual = new BitmapFontCache(font, integer);
+			actual.setText(layout, X, Y, Color.WHITE);
+
+			assertVerticesEqual(expected, actual);
+		}
+	}
+
+	@Test
+	public void tintMatchesTintAfterAdd () {
+		Color tint = new Color(0.75f, 1, 0.5f, 0.4f);
+		for (String text : new String[] {"abcdefghi", "[RED]abc[]def[#4080c0aa]ghi"}) {
+			for (boolean integer : new boolean[] {false, true}) {
+				BitmapFont font = newFont(integer, 1);
+				GlyphLayout layout = new GlyphLayout(font, text);
+
+				BitmapFontCache expected = new BitmapFontCache(font, integer);
+				expected.setText(layout, X, Y);
+				float[] untinted = copyVertices(expected, 0);
+				expected.tint(tint);
+
+				BitmapFontCache actual = new BitmapFontCache(font, integer);
+				actual.setText(layout, X, Y, tint);
+
+				assertVerticesEqual(expected, actual);
+				// Guard against both paths being no-ops.
+				assertFalse("tint did not change any vertex color", equalVertices(untinted, expected, 0));
+			}
+		}
+	}
+
+	@Test
+	public void multiPageTintMatchesTintAfterAdd () {
+		Color tint = new Color(1, 1, 1, 0.25f);
+		BitmapFont font = newFont(false, 3);
+		GlyphLayout layout = new GlyphLayout(font, "[RED]abc[]defghijkl");
+
+		BitmapFontCache expected = new BitmapFontCache(font, false);
+		expected.setText(layout, X, Y);
+		expected.tint(tint);
+
+		BitmapFontCache actual = new BitmapFontCache(font, false);
+		actual.setText(layout, X, Y, tint);
+
+		assertEquals(3, actual.getPageCount());
+		for (int page = 0; page < 3; page++)
+			assertTrue("page " + page + " has no glyphs", actual.getVertexCount(page) > 0);
+		assertVerticesEqual(expected, actual);
+	}
+
+	/** A tint applied while adding must not let a later {@link BitmapFontCache#tint(Color)} be skipped, not even when untinted
+	 * text is added after it. */
+	@Test
+	public void tintAfterAddIsNotSkipped () {
+		BitmapFont font = newFont(false, 1);
+		GlyphLayout layout = new GlyphLayout(font, "abcdefghi");
+
+		BitmapFontCache expected = new BitmapFontCache(font, false);
+		expected.addText(layout, X, Y);
+		expected.addText(layout, X, Y - 20);
+
+		BitmapFontCache actual = new BitmapFontCache(font, false);
+		actual.addText(layout, X, Y, new Color(1, 1, 1, 0.5f));
+		actual.addText(layout, X, Y - 20);
+		actual.tint(Color.WHITE);
+
+		assertVerticesEqual(expected, actual);
+	}
+
+	// --- helpers ---
+
+	/** Creates a font with hand made glyphs, so no texture and no GL context are needed. */
+	static private BitmapFont newFont (boolean integer, int pageCount) {
+		BitmapFontData data = new BitmapFontData();
+		data.markupEnabled = true;
+		// A non integer scale, so integer positions actually round.
+		data.scaleX = 1.37f;
+		data.scaleY = 0.83f;
+		data.capHeight = 8;
+		data.ascent = -1.5f;
+		data.descent = -3;
+		data.lineHeight = 16;
+		data.down = -16;
+		data.xHeight = 6;
+		data.spaceXadvance = 5;
+
+		Array<TextureRegion> regions = new Array();
+		for (int i = 0; i < pageCount; i++)
+			regions.add(new TextureRegion());
+
+		// The glyphs are added after construction, so BitmapFont#load doesn't need a texture to compute the UVs.
+		BitmapFont font = new BitmapFont(data, regions, integer);
+		for (int i = 0, n = CHARS.length(); i < n; i++) {
+			Glyph glyph = new Glyph();
+			glyph.id = CHARS.charAt(i);
+			glyph.width = 5 + i % 4;
+			glyph.height = 7 + i % 3;
+			glyph.xoffset = i % 3;
+			glyph.yoffset = -(i % 5);
+			glyph.xadvance = 6 + i % 4;
+			glyph.page = i % pageCount;
+			glyph.u = i / 64f;
+			glyph.v = i / 32f;
+			glyph.u2 = glyph.u + 0.01f;
+			glyph.v2 = glyph.v + 0.02f;
+			data.setGlyph(glyph.id, glyph);
+		}
+		return font;
+	}
+
+	static private float[] copyVertices (BitmapFontCache cache, int page) {
+		float[] vertices = new float[cache.getVertexCount(page)];
+		System.arraycopy(cache.getVertices(page), 0, vertices, 0, vertices.length);
+		return vertices;
+	}
+
+	static private boolean equalVertices (float[] vertices, BitmapFontCache cache, int page) {
+		if (vertices.length != cache.getVertexCount(page)) return false;
+		float[] cacheVertices = cache.getVertices(page);
+		for (int i = 0, n = vertices.length; i < n; i++)
+			if (vertices[i] != cacheVertices[i]) return false;
+		return true;
+	}
+
+	static private void assertVerticesEqual (BitmapFontCache expected, BitmapFontCache actual) {
+		assertEquals("page count", expected.getPageCount(), actual.getPageCount());
+		for (int page = 0, n = expected.getPageCount(); page < n; page++) {
+			int count = expected.getVertexCount(page);
+			assertEquals("page " + page + " vertex count", count, actual.getVertexCount(page));
+			float[] expectedVertices = expected.getVertices(page), actualVertices = actual.getVertices(page);
+			for (int i = 0; i < count; i++)
+				assertEquals("page " + page + " vertex " + i, expectedVertices[i], actualVertices[i], 0);
+		}
+	}
+}


### PR DESCRIPTION
Tinting cached text currently requires two full passes over the glyph vertices: BitmapFontCache#addText builds them, then #tint walks every layout, run and glyph again to rewrite the color of all four vertices of each glyph. Text that moves and fades every frame, which cannot reuse the cache, pays both passes on every frame. The color of the Batch is no help here, since Batch#draw(Texture, float[], int, int) copies the vertices verbatim.

This adds the tint to the pass that is already there:

  BitmapFont#draw(Batch, GlyphLayout, float, float, Color)
  BitmapFontCache#addText(GlyphLayout, float, float, Color)
  BitmapFontCache#setText(GlyphLayout, float, float, Color)

The tint is multiplied into the color once per color run rather than once per glyph, markup colors keep working, and a null tint leaves the existing behavior untouched.

Since a tint applied while adding is baked into the vertices, the tint of the cached text is no longer known afterwards, so #tint is never skipped for that text.

Adds headless tests comparing the vertices of both paths float for float, for plain and markup text, with integer positions on and off, and for a multi page font.